### PR TITLE
Kondaru map fixes: maint spawners, magnet double-turfs, misc.

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -2557,7 +2557,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
+/area/station/crew_quarters/clown{
+	name = "Clowntainment"
+	})
 "ahn" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -3007,7 +3009,9 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
+/area/station/crew_quarters/clown{
+	name = "Clowntainment"
+	})
 "ait" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/radio/news_office)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -356,22 +356,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/space)
-"aba" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 4;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/mining/magnet)
 "abb" = (
 /obj/lattice{
 	dir = 1;
@@ -450,7 +434,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -475,22 +458,6 @@
 /turf/space,
 /turf/space,
 /area/space)
-"abo" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 8;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/mining/magnet)
 "abp" = (
 /obj/cable{
 	d1 = 4;
@@ -1564,6 +1531,7 @@
 /area/station/hangar/main)
 "aef" = (
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aeg" = (
@@ -1744,6 +1712,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/chapel/sanctuary)
 "aeF" = (
@@ -1941,6 +1910,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/chapel/sanctuary)
 "afp" = (
@@ -2351,6 +2321,7 @@
 	name = "Pod Bay"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 9
 	},
@@ -2374,6 +2345,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_we"
 	},
@@ -2585,9 +2557,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/clown{
-	name = "Clowntainment"
-	})
+/area/station/maintenance/northwest)
 "ahn" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -2904,6 +2874,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
 "ahZ" = (
@@ -3036,9 +3007,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/clown{
-	name = "Clowntainment"
-	})
+/area/station/maintenance/northwest)
 "ait" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/radio/news_office)
@@ -3051,6 +3020,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/radio/news_office)
 "aiv" = (
@@ -3059,6 +3029,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aiy" = (
@@ -3406,6 +3377,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ajx" = (
@@ -3430,6 +3402,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ajA" = (
@@ -3815,6 +3788,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aky" = (
@@ -3919,6 +3893,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -3955,6 +3930,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "akO" = (
@@ -5049,6 +5025,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "anI" = (
@@ -5133,6 +5110,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/utility)
 "anW" = (
@@ -5994,6 +5972,7 @@
 "aqv" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/radio/news_office)
 "aqw" = (
@@ -6045,6 +6024,7 @@
 "aqE" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/machinery/atmospherics/pipe/simple,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aqF" = (
@@ -7577,6 +7557,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "avB" = (
@@ -7981,6 +7962,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "awI" = (
@@ -8531,6 +8513,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "ayl" = (
@@ -10067,6 +10050,7 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/west)
 "aCb" = (
@@ -13068,6 +13052,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "aKm" = (
@@ -13499,6 +13484,7 @@
 "aLL" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aLM" = (
@@ -13527,6 +13513,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aLQ" = (
@@ -14425,6 +14412,7 @@
 /area/station/maintenance/west)
 "aPp" = (
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aPq" = (
@@ -15428,6 +15416,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
 "aSg" = (
@@ -15832,6 +15821,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aTu" = (
@@ -15975,6 +15965,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "aTN" = (
@@ -16014,6 +16005,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aTZ" = (
@@ -16253,6 +16245,7 @@
 "aUO" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aUQ" = (
@@ -16454,6 +16447,7 @@
 "aVn" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/quarters_north)
 "aVp" = (
@@ -16462,6 +16456,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aVx" = (
@@ -19014,6 +19009,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/north)
 "bei" = (
@@ -19435,6 +19431,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "bfX" = (
@@ -24020,6 +24017,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bvM" = (
@@ -25208,6 +25206,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "bAh" = (
@@ -25487,6 +25486,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner/south)
 "bBD" = (
@@ -26274,6 +26274,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "bDI" = (
@@ -26298,6 +26299,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bDN" = (
@@ -26402,6 +26404,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bEa" = (
@@ -26725,6 +26728,7 @@
 /area/station/crew_quarters/md)
 "bEU" = (
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bEV" = (
@@ -27265,6 +27269,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/south)
 "bGx" = (
@@ -31399,6 +31404,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bSN" = (
@@ -31477,9 +31483,9 @@
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
+	dir = 8;
+	name = "Loading Chute Cover"
 	},
-/obj/access_spawn/cargo,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -32145,6 +32151,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bVk" = (
@@ -32272,6 +32279,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bWa" = (
@@ -32430,6 +32438,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bWt" = (
@@ -32667,6 +32676,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bXV" = (
@@ -32850,6 +32860,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bYL" = (
@@ -34564,6 +34575,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "cel" = (
@@ -40586,6 +40598,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "dXt" = (
@@ -41848,6 +41861,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "fhx" = (
@@ -42180,6 +42194,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/red/checker,
 /area/station/maintenance/central)
 "fsR" = (
@@ -44375,6 +44390,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "hrS" = (
@@ -44763,6 +44779,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/sw)
 "hSs" = (
@@ -45366,7 +45383,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -48944,6 +48960,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "mlf" = (
@@ -49606,6 +49623,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "mSD" = (
@@ -51085,6 +51103,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
@@ -51669,6 +51688,7 @@
 /obj/cable{
 	icon_state = "1-6"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "oUk" = (
@@ -53269,6 +53289,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/greenblack,
 /area/station/garden/aviary)
 "qpS" = (
@@ -54086,6 +54107,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "reX" = (
@@ -54915,6 +54937,7 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "rZC" = (
@@ -59736,6 +59759,7 @@
 /area/station/security/checkpoint/escape)
 "wBw" = (
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
 /turf/simulated/floor/red/checker,
 /area/station/maintenance/central)
 "wBS" = (
@@ -106306,7 +106330,7 @@ aLI
 aML
 aaa
 ach
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -106320,7 +106344,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 aaa
 bgm
 bfg
@@ -106608,7 +106632,7 @@ aLJ
 azW
 aay
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -106622,7 +106646,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 ree
 gxN
 ree
@@ -106910,7 +106934,7 @@ aLK
 auL
 nRo
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -106924,7 +106948,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 ree
 gxN
 ree
@@ -107212,7 +107236,7 @@ aaX
 aaY
 abg
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -107226,7 +107250,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 ree
 gxN
 ree
@@ -107514,7 +107538,7 @@ aaf
 aMN
 aad
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -107528,7 +107552,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 tOE
 fXT
 tOE
@@ -107816,7 +107840,7 @@ acO
 aBj
 aaa
 aaO
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -107830,7 +107854,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 oUa
 ury
 tWL
@@ -108118,7 +108142,7 @@ acO
 aaa
 aaa
 acb
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -108132,7 +108156,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 qoc
 mLb
 juf
@@ -108420,7 +108444,7 @@ aaf
 aay
 aay
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -108434,7 +108458,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 iuC
 mLb
 tOE
@@ -108722,7 +108746,7 @@ aaf
 aad
 aad
 aaf
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -108736,7 +108760,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 tzN
 ury
 tWL
@@ -109024,7 +109048,7 @@ acO
 aaa
 aaa
 ach
-aba
+aea
 aQJ
 aQJ
 aQJ
@@ -109038,7 +109062,7 @@ aQJ
 aQJ
 aQJ
 aQJ
-abo
+aeV
 juf
 xQB
 juf
@@ -109326,7 +109350,7 @@ acO
 aaa
 aaa
 ach
-aba
+aea
 abe
 abe
 abe
@@ -109340,7 +109364,7 @@ abe
 abe
 abe
 abe
-abo
+aeV
 ree
 gxN
 ree


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
major:
removes double-turfs in magnet containment area
adds maint access spawners to maint doors

minor: 
renames & removes cargo-specific access for the 'Loading Chute Cover' door in cargo (like medical's chute-loading door, now)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
map consistency & quality