### PR TITLE
Let's revolutionaries see undisguised heads.

### DIFF
--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -750,6 +750,7 @@
 	var/see_wizards = 0
 	var/see_revs = 0
 	var/see_heads = 0
+	var/see_heads_sometimes = FALSE
 	var/see_xmas = 0
 	var/see_zombies = 0
 	var/see_special = 0 // Just a pass-through. Game mode-specific stuff is handled further down in the proc.
@@ -768,6 +769,8 @@
 			var/list/datum/mind/RR = R.revolutionaries
 			if (src.mind in (HR + RR))
 				see_revs = 1
+			if (src.mind in RR)
+				see_heads_sometimes = TRUE
 			if (src.mind in HR)
 				see_heads = 1
 		else if (istype(ticker.mode, /datum/game_mode/spy))
@@ -942,6 +945,14 @@
 				if (M.current)
 					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
+		if (see_heads_sometimes)
+			for (var/datum/mind/M in heads)
+				var/mob/living/carbon/human/H
+				if (M.current && H.face_visible())
+					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
+					can_see.Add(I)
+
+
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))
 		var/datum/game_mode/nuclear/N = ticker.mode

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -750,6 +750,7 @@
 	var/see_wizards = 0
 	var/see_revs = 0
 	var/see_heads = 0
+	var/see_heads_sometimes = FALSE
 	var/see_xmas = 0
 	var/see_zombies = 0
 	var/see_special = 0 // Just a pass-through. Game mode-specific stuff is handled further down in the proc.
@@ -768,6 +769,9 @@
 			var/list/datum/mind/RR = R.revolutionaries
 			if (src.mind in (HR + RR))
 				see_revs = 1
+			if (src.mind in RR)
+				see_heads_sometimes = TRUE
+			if (src.mind in HR)
 				see_heads = 1
 		else if (istype(ticker.mode, /datum/game_mode/spy))
 			var/datum/game_mode/spy/S = ticker.mode
@@ -816,7 +820,7 @@
 	if (remove)
 		return
 
-	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
+	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_heads_sometimes && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
 		src.last_overlay_refresh = world.time
 		return
 
@@ -939,6 +943,12 @@
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
+					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
+					can_see.Add(I)
+		if (see_heads_sometimes)
+			for (var/datum/mind/M in heads)
+				var/mob/living/carbon/human/H
+				if (M.current && H.face_visible())
 					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -750,7 +750,6 @@
 	var/see_wizards = 0
 	var/see_revs = 0
 	var/see_heads = 0
-	var/see_heads_sometimes = FALSE
 	var/see_xmas = 0
 	var/see_zombies = 0
 	var/see_special = 0 // Just a pass-through. Game mode-specific stuff is handled further down in the proc.
@@ -769,9 +768,6 @@
 			var/list/datum/mind/RR = R.revolutionaries
 			if (src.mind in (HR + RR))
 				see_revs = 1
-			if (src.mind in RR)
-				see_heads_sometimes = TRUE
-			if (src.mind in HR)
 				see_heads = 1
 		else if (istype(ticker.mode, /datum/game_mode/spy))
 			var/datum/game_mode/spy/S = ticker.mode
@@ -820,7 +816,7 @@
 	if (remove)
 		return
 
-	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_heads_sometimes && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
+	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
 		src.last_overlay_refresh = world.time
 		return
 
@@ -943,12 +939,6 @@
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
-					can_see.Add(I)
-		if (see_heads_sometimes)
-			for (var/datum/mind/M in heads)
-				var/mob/living/carbon/human/H
-				if (M.current && H.face_visible())
 					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -820,7 +820,7 @@
 	if (remove)
 		return
 
-	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
+	if (!see_traitors && !see_nukeops && !see_wizards && !see_revs && !see_heads && !see_heads_sometimes && !see_xmas && !see_zombies && !see_special && !see_everything && gang_to_see == null && PWT_to_see == null && !V && !VT)
 		src.last_overlay_refresh = world.time
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAMEMODE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr is a draft due to being unable to test this on local.

This pr makes it so that revs can see who is a head of staff if they are undisguised.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Heads of staff currently can currently walk past a group of revs in plain clothes without drawing their attention due to remembering who is a head of staff being somewhat difficult during a rev round. This helps to let revs know who is a head of staff.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Converted revolutionaries can now see who is a head of staff if they are undisguised.
```
