### PR TITLE
Allow the Relay to convert a much larger part of the station

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -1,6 +1,10 @@
 /////////////////////////////////////////////////////////////////////////////////
 // RELAY
 /////////////////////////////////////////////////////////////////////////////////
+
+// Important: Reduce size of max_conv_radius if you are planning on viewing
+// variables of the relay, otherwise it will take a long time to load
+
 /obj/flock_structure/relay
 	icon = 'icons/misc/featherzone-160x160.dmi'
 	icon_state = "structure-relay"
@@ -11,7 +15,7 @@
 	build_time = 30
 	health = 600 //same as a nukie nuke * 4 because nuke has /4 damage resist
 	uses_health_icon = FALSE
-	resourcecost = 750
+	resourcecost = 10
 	bound_width = 160
 	bound_height = 160
 	pixel_x = -64
@@ -22,6 +26,8 @@
 	layer = EFFECTS_LAYER_BASE //big spooky thing needs to render over everything
 	plane = PLANE_NOSHADOW_ABOVE
 	var/conversion_radius = 1
+	var/max_conv_radius = 100
+	var/list/turfs_to_convert = null
 	var/last_time_sound_played_in_seconds = 0
 	var/sound_length_in_seconds = 27
 	var/charge_time_length = 360 // in seconds
@@ -56,6 +62,19 @@
 		msg = radioGarbleText(msg, 7)
 		command_alert(msg, sound_to_play = 'sound/misc/announcement_1.ogg', alert_origin = ALERT_ANOMALY)
 
+	turfs_to_convert = list()
+	var/turf/center = get_turf(src)
+	for (var/turf/T as anything in block(locate(max(center.x - src.max_conv_radius, 1), max(center.y - src.max_conv_radius, 1), center.z), locate(min(center.x + src.max_conv_radius, world.maxx), min(center.y + src.max_conv_radius, world.maxy), center.z)))
+		LAGCHECK(LAG_LOW)
+		if (!flockTurfAllowed(T))
+			continue
+		var/dist = round(GET_EUCLIDEAN_DIST(center, T))
+		if (dist > src.max_conv_radius)
+			continue
+		if (!("[dist]" in turfs_to_convert))
+			turfs_to_convert["[dist]"] = list()
+		turfs_to_convert["[dist]"] |= T
+
 /obj/flock_structure/relay/disposing()
 	var/mob/living/intangible/flock/flockmind/F = src.flock?.flockmind
 	logTheThing(LOG_GAMEMODE, src, "Flock relay[src.flock ? " belonging to flock [src.flock.name]" : ""] is destroyed at [log_loc(src)].")
@@ -78,7 +97,7 @@
 		return "<b><i>BROADCASTING IN PROGRESS</i></b>"
 
 /obj/flock_structure/relay/process()
-	if (src.conversion_radius <= 20)
+	if (src.conversion_radius <= length(src.turfs_to_convert))
 		src.convert_turfs()
 		src.conversion_radius++
 
@@ -105,11 +124,10 @@
 		boutput(M, "<span class='flocksay bold'>You hear something unworldly coming from the <i>[dir2text(get_dir(M, center_loc))]</i>!</span>")
 
 /obj/flock_structure/relay/proc/convert_turfs()
-	var/list/turfs = circular_range(get_turf(src), src.conversion_radius)
 	SPAWN(0)
-		for (var/turf/T as anything in turfs)
+		for (var/turf/T as anything in src?.turfs_to_convert["[src.conversion_radius]"])
+			LAGCHECK(LAG_LOW)
 			if (istype(T, /turf/simulated) && !isfeathertile(T))
-				LAGCHECK(LAG_LOW)
 				src?.flock?.claimTurf(flock_convert_turf(T))
 
 /obj/flock_structure/relay/proc/unleash_the_signal()


### PR DESCRIPTION
[GAME MODES][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR increases the Relay radial conversion to a radius of 100 tiles.

At the end of conversion process, placing the Relay at the middle of the map on Cogmap 2:
![image](https://user-images.githubusercontent.com/53062374/190880789-88a4bffc-5c02-4f31-9105-04f6f0a7cfd1.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Thought it would be cool to make the radius larger.