### PR TITLE
Stun cane battery can no longer be swapped and cant be recharged, stun cane now comes with disruptor cell

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1304,6 +1304,11 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	charge = 100
 	max_charge = 100
 
+/obj/item/ammo/power_cell/self_charging/disruptor/bad
+	name = "Power Cell - Slowcharge Plus"
+	desc = "An upgraded radioisotope power cell to support additional capacity. Holds 100 PU"
+	recharge_rate = 2.5
+
 /obj/item/ammo/power_cell/self_charging/ntso_baton
 	name = "Power Cell - NTSO Stun Baton"
 	desc = "A self-contained radioisotope power cell that slowly recharges an internal capacitor. Holds 100PU."

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -346,7 +346,8 @@
 	icon_off = "stuncane"
 	item_on = "cane"
 	item_off = "cane"
-	cell_type = /obj/item/ammo/power_cell
+	cell_type = /obj/item/ammo/power_cell/self_charging/disruptor/bad
+	can_swap_cell = 0
 	mats = list("MET-3"=10, "CON-2"=10, "gem"=1, "gold"=1)
 
 /obj/item/baton/classic


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stun cane's cell is unswappable and non rechargable, however its cell has been swapped for a disruptor cell.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change is two fold, currently you can make a matsci cell to ignore the downsides of the stun cane. The lack of being able to fit it into a recharger means that using the baton has a high opportunity cost as you have to wait for it to recharge. This change should make the stun cane more geared towards self defense and less useful for valid hunting. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Stun cane is now unswappable and no longer fits into rechargers, however it now has a disruptor power cell.
```
