### PR TITLE
Removes AA from regional director.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1508,7 +1508,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/random/director
 	name = "Regional Director"
-	receives_miranda = 1
 	cant_spawn_as_rev = 1
 	wages = PAY_EXECUTIVE
 
@@ -1525,7 +1524,9 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 	New()
 		..()
-		src.access = get_all_accesses()
+		src.access = get_access("VIP")
+		src.access += get_access("Janitor")
+		return
 
 /datum/job/special/random/diplomat
 	name = "Diplomat"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr gives Regional Director VIP + Janitor access instead of All access, also removes miranda from them because it doesnt really fit them. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Regional directors can oftentimes fall into one of two camps, first camp is looting caps locker/handing out AA, second camp is using there security access and AA to play as security (except act far worse then a security officer). In short regional directors can act a lot like the worst kinds of hops. This change fixes these issues with this job and moves em more towards a more generic gimmick job.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Regional Director's access has been severely reduced.
```
