### PR TITLE
Removes sec access + miranda from inspector

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1473,7 +1473,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/special/random/inspector
 	name = "Inspector"
 	wages = PAY_IMPORTANT
-	receives_miranda = 1
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	slot_back = list(/obj/item/storage/backpack/withO2)

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -406,7 +406,7 @@
 
 /obj/item/clothing/suit/armor/NT
 	name = "armored nanotrasen jacket"
-	desc = "An armored jacket worn by NanoTrasen security commanders."
+	desc = "An armored jacket given by nanotrasen for when their bureaucrats inevitably get shoved into hostile situations."
 	icon_state = "ntarmor"
 	item_state = "ntarmor"
 	body_parts_covered = TORSO

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -372,7 +372,7 @@
 		if("Club member")
 			return list(access_special_club)
 		if("Inspector", "Communications Officer")
-			return list(access_security, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
+			return list(access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_emergency_storage, access_eva, access_heads, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch, access_pathology,
 						access_researchfoyer, access_artlab, access_telesci, access_robotdepot)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr removes the miranda ability and security access from inspectors. Also changes the description of the inspectors coat to fit them better.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Inspector isnt security, having them have these things I think sends the wrong message, nor do they help much with the gimmicl of the job.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Inspector no longer has security access
```
