### PR TITLE
cog1 medbay redesign

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -272,6 +272,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"abs" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "abu" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -48346,12 +48354,18 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxR" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
 /obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxS" = (
@@ -50158,6 +50172,10 @@
 	dir = 8;
 	tag = ""
 	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -50245,6 +50263,9 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
@@ -53632,6 +53653,17 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
+"hje" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "hjt" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -54367,6 +54399,17 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"imI" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/cdc)
 "imT" = (
 /obj/landmark/start{
 	name = "Security Assistant"
@@ -54896,6 +54939,9 @@
 /area/station/engine/core)
 "jmw" = (
 /obj/storage/secure/closet/animal,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -57312,6 +57358,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/sortingRoom)
 "mRI" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/west,
 /area/station/medical/staff)
 "mSv" = (
@@ -58098,6 +58147,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/station/engine/hotloop)
+"nYd" = (
+/obj/item/clothing/suit/bedsheet,
+/obj/stool/bed/moveable,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "nYv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59024,6 +59081,9 @@
 "pnt" = (
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "poA" = (
@@ -59073,6 +59133,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"ptZ" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "pui" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -60531,6 +60598,9 @@
 /obj/machinery/light,
 /obj/stool/chair/office{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -63182,6 +63252,20 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"uOp" = (
+/obj/overlay{
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm1";
+	layer = 10;
+	name = "palm tree"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "uQi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -63740,6 +63824,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/eastwest,
 /area/station/medical/staff)
 "vxN" = (
@@ -63871,6 +63958,11 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
+"vGI" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "vHi" = (
 /obj/cable/brown{
 	icon_state = "1-2"
@@ -65184,6 +65276,9 @@
 "xzu" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "xAi" = (
@@ -99767,11 +99862,11 @@ fLo
 fLo
 fLo
 fLo
-mwV
-mwV
-mwV
-mwV
-mwV
+ptZ
+abs
+hje
+abs
+vGI
 cxe
 cxe
 cxe
@@ -100078,8 +100173,8 @@ pTr
 mOn
 cyr
 cyA
-cyr
-cxf
+nYd
+dJr
 aao
 aay
 cyX
@@ -100379,7 +100474,7 @@ fib
 cxe
 tgU
 cxp
-cxp
+uMP
 ryS
 cxe
 adC
@@ -100681,7 +100776,7 @@ fLo
 cxe
 cxC
 guM
-cyB
+imI
 cxe
 cxe
 adC
@@ -104602,7 +104697,7 @@ ilc
 aKZ
 cxq
 cNC
-cDv
+uOp
 jmw
 nVQ
 cxf

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -105646,7 +105646,7 @@ cmo
 sIb
 coH
 cpG
-cqI
+csu
 cvc
 csE
 cwH

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -13403,7 +13403,15 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aKZ" = (
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/obj/machinery/disposal/morgue,
+/obj/disposalpipe/trunk/morgue{
+	dir = 1
+	},
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "aLa" = (
 /obj/cable{
@@ -29585,14 +29593,6 @@
 	dir = 6
 	},
 /area/station/turret_protected/ai_upload_foyer)
-"bAx" = (
-/obj/storage/secure/closet/medical/anesthetic,
-/obj/machinery/light/small{
-	dir = 1;
-	status = 2
-	},
-/turf/simulated/floor/red,
-/area/station/medical/medbay/surgery)
 "bAz" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -29685,21 +29685,6 @@
 	dir = 4
 	},
 /area/station/quartermaster/refinery)
-"bAP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/medical/medbay/surgery)
 "bAQ" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -30072,9 +30057,10 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/turf/simulated/floor/redwhite{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "bBM" = (
 /obj/item/device/radio/intercom{
@@ -45923,22 +45909,9 @@
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay)
-"cqH" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/window/reinforced{
-	dir = 2
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
 "cqI" = (
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/obj/window/reinforced{
-	dir = 2
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -45948,9 +45921,6 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
-	},
-/obj/window/reinforced{
-	dir = 2
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -45965,9 +45935,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cqL" = (
@@ -45977,9 +45944,6 @@
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/window/reinforced{
-	dir = 2
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
@@ -46241,146 +46205,22 @@
 	},
 /area/station/medical/medbay)
 "crG" = (
-/obj/table/auto,
-/obj/item/device/radio/headset/medical{
-	pixel_x = -6;
-	pixel_y = -5
-	},
-/obj/item/device/radio/headset/medical{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/window/reinforced{
+/obj/stool/chair{
 	dir = 8
 	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = 12;
-	pixel_y = 11
-	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = 11;
-	pixel_y = 5
-	},
-/obj/item/device/light/flashlight/penlight{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
-/area/station/medical/medbay/surgery)
-"crH" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/redwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/surgery)
-"crI" = (
-/obj/machinery/atmospherics/pipe/simple,
-/obj/storage/secure/closet/medical/chemical,
-/turf/simulated/floor/redwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/surgery)
-"crJ" = (
-/obj/table/auto,
-/obj/item/clothing/suit/straight_jacket{
-	pixel_x = -10;
-	pixel_y = 7
-	},
-/obj/item/clothing/suit/straight_jacket{
-	pixel_x = -8;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/iv_drip/saline{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/syringe/haloperidol{
-	pixel_x = 1;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/syringe/haloperidol{
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/syringe/haloperidol{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/blindfold{
-	pixel_y = -4
-	},
-/obj/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/redwhite{
-	dir = 5
-	},
-/area/station/medical/medbay/surgery)
-"crK" = (
-/obj/rack,
-/obj/item/storage/box/stma_kit{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/bio_suit/paramedic{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/bio_suit/paramedic{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/medical{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/storage/belt/medical{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/turf/simulated/floor/red,
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "crM" = (
-/obj/storage/secure/closet/medical/medicine,
+/obj/wingrille_spawn/auto,
 /obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/red,
-/area/station/medical/medbay/surgery)
-"crN" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/computer3/generic/med_data,
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "crO" = (
+/obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
-/obj/storage/secure/closet/fridge/blood,
-/turf/simulated/floor/redwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/surgery)
-"crP" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/redwhite{
-	dir = 5
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "crQ" = (
-/obj/window/reinforced{
-	dir = 8
-	},
 /obj/window/reinforced{
 	dir = 4
 	},
@@ -46587,114 +46427,104 @@
 /area/station/medical/medbay)
 "csu" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
+/obj/machinery/light,
+/turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "csv" = (
-/obj/window/reinforced{
+/obj/stool/chair{
 	dir = 8
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/clothing/suit/bedsheet,
-/obj/stool/bed/moveable,
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
-"csw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/iv_stand,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "csx" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/storage/secure/closet/medical/anesthetic,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/white,
+/turf/simulated/floor/redwhite{
+	dir = 9
+	},
 /area/station/medical/medbay/surgery)
 "csy" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/window/reinforced{
-	dir = 4
-	},
-/obj/item/clothing/suit/bedsheet,
-/obj/stool/bed/moveable,
+/obj/storage/secure/closet/medical/medicine,
+/obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/redwhite{
-	dir = 4
+	dir = 5
 	},
 /area/station/medical/medbay/surgery)
 "csz" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
-	},
-/turf/simulated/floor,
+/obj/machinery/computer3/generic/med_data,
+/obj/item/device/radio/intercom/medical,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "csA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/turf/simulated/floor,
+/obj/machinery/vending/medical,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "csB" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/rack,
+/obj/item/storage/box/stma_kit{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/storage/belt/medical{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/storage/belt/medical{
+	pixel_x = 4;
+	pixel_y = -1
 	},
 /obj/machinery/atmospherics/pipe/simple,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 5
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "csC" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
+/obj/storage/secure/closet/fridge/blood,
 /turf/simulated/floor/redwhite{
-	dir = 8
+	dir = 9
 	},
 /area/station/medical/medbay/surgery)
 "csD" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/white,
+/turf/simulated/floor/redwhite{
+	dir = 5
+	},
 /area/station/medical/medbay/surgery)
 "csE" = (
-/turf/simulated/floor/redwhite{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pharmacy";
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "csF" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/door/window/westright{
-	name = "Operating Room";
-	req_access_txt = null
+/turf/simulated/floor/bluewhite{
+	dir = 9
 	},
-/obj/access_spawn/medical,
-/turf/simulated/floor,
 /area/station/medical/medbay/cloner)
 "csG" = (
 /obj/decal/tile_edge/stripe/big{
@@ -46704,7 +46534,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
-	dir = 9
+	dir = 1
 	},
 /area/station/medical/medbay/cloner)
 "csH" = (
@@ -46746,9 +46576,6 @@
 "csN" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
 	},
 /obj/stool/chair/comfy/wheelchair{
 	dir = 8
@@ -47004,38 +46831,62 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
-/obj/machinery/light{
-	dir = 4
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
 /area/station/medical/medbay)
 "ctu" = (
-/obj/window/reinforced{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/item/clothing/suit/bedsheet,
-/obj/stool/bed/moveable,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"ctv" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Operating Theatre"
+	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/medbay/surgery)
+"ctw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
-"ctv" = (
-/obj/iv_stand,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
-"ctw" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "ctx" = (
-/obj/window/reinforced{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/item/clothing/suit/bedsheet,
-/obj/stool/bed/moveable,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -47059,13 +46910,22 @@
 	},
 /area/station/crew_quarters/info)
 "ctz" = (
-/obj/machinery/optable,
-/turf/simulated/floor/bot,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "ctA" = (
-/obj/machinery/atmospherics/pipe/simple,
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
@@ -47310,46 +47170,50 @@
 	},
 /area/station/medical/medbay)
 "cuh" = (
-/obj/machinery/door/window/westright{
-	name = "Operating Room";
-	req_access_txt = null
-	},
-/obj/access_spawn/medical,
-/turf/simulated/floor/redwhite{
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/area/station/medical/medbay/surgery)
-"cui" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
-"cuj" = (
-/obj/machinery/door/window/eastleft{
-	name = "Operating Room";
-	req_access_txt = null
+/area/station/medical/medbay)
+"cui" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Operating Theatre"
 	},
 /obj/access_spawn/medical,
-/turf/simulated/floor/redwhite{
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/medbay/surgery)
+"cuj" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/redwhite{
+	dir = 6
 	},
 /area/station/medical/medbay/surgery)
 "cuk" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/machinery/drainage,
+/obj/iv_stand,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cul" = (
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor,
-/area/station/medical/medbay/surgery)
-"cum" = (
-/obj/table/auto,
-/obj/machinery/defib_mount,
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
+/obj/machinery/optable,
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/bot,
 /area/station/medical/medbay/surgery)
 "cuo" = (
 /turf/simulated/floor/blue/checker,
@@ -47555,49 +47419,56 @@
 "cuY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/research)
-"cvb" = (
-/obj/machinery/door/window/westleft{
-	desc = "5";
-	name = "Operating Room";
-	req_access_txt = null
-	},
-/obj/access_spawn/medical,
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
 "cvc" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 4;
-	icon_state = "on";
-	on = 1
-	},
-/turf/simulated/floor/white,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
 "cvd" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
+/obj/table/auto,
+/obj/item/device/radio/headset/medical{
+	pixel_x = -6;
+	pixel_y = -5
 	},
-/turf/simulated/floor/white,
+/obj/item/device/radio/headset/medical{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 12;
+	pixel_y = 11
+	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 11;
+	pixel_y = 5
+	},
+/obj/item/device/light/flashlight/penlight{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "cve" = (
-/obj/machinery/door/window/eastright{
-	name = "Operating Room";
-	req_access_txt = null
-	},
-/obj/access_spawn/medical,
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "cvf" = (
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "on";
 	on = 1
+	},
+/obj/landmark/start{
+	name = "Test Subject"
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
@@ -47626,21 +47497,7 @@
 /area/station/crew_quarters/info)
 "cvh" = (
 /obj/table/auto,
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = 9
-	},
-/obj/item/clothing/mask/surgical_shield{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/clothing/mask/surgical_shield{
-	pixel_x = -5;
-	pixel_y = 8
-	},
+/obj/machinery/defib_mount,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -47733,51 +47590,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/medsci)
-"cvB" = (
-/obj/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/cold_sink/freezer/cryo/east,
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
 "cvC" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4;
-	level = 2
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/redwhite{
+	dir = 9
 	},
-/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cvD" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
+/turf/simulated/floor/redwhite{
+	dir = 1
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cvE" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/redwhite{
-	dir = 4
+	dir = 5
 	},
-/area/station/medical/medbay/surgery)
-"cvF" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cvG" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "cvH" = (
 /obj/storage/cart/trash,
@@ -47872,79 +47704,82 @@
 "cvX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tech)
-"cvY" = (
+"cvZ" = (
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/wrench{
+	pixel_x = 4;
+	pixel_y = 1
+	},
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 6;
 	level = 2
-	},
-/obj/window/reinforced{
-	dir = 8
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/area/station/medical/medbay/surgery)
-"cvZ" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4;
-	level = 2
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cwa" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
-"cwb" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10;
-	level = 2
-	},
-/obj/window/reinforced{
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/medical/medbay/surgery)
 "cwc" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 10
+	dir = 8
 	},
+/obj/machinery/drainage,
+/obj/iv_stand,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwd" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor,
+/obj/machinery/optable,
+/obj/item/robodefibrillator,
+/obj/item/paper/book/from_file/medical_surgery_guide,
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/bot,
 /area/station/medical/medbay/surgery)
 "cwe" = (
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 6
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwf" = (
+/obj/surgery_tray,
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -47954,7 +47789,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
 /area/station/medical/medbay/surgery)
 "cwi" = (
 /obj/disposalpipe/segment/mail{
@@ -48128,39 +47965,22 @@
 	},
 /area/station/medical/medbay)
 "cwF" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/junction{
-	dir = 1
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cwG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
-/obj/stool/chair{
-	dir = 8
-	},
 /obj/machinery/bot/secbot,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cwH" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 1;
-	pipe_direction = 4
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cwI" = (
 /obj/surgery_tray,
@@ -48192,53 +48012,31 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "cwJ" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
 	},
-/obj/machinery/light,
-/obj/table/reinforced/auto,
-/obj/item/weldingtool{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/wrench{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/item/paper/cryo{
-	pixel_x = -13;
-	pixel_y = 4
-	},
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cwK" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 1;
-	pipe_direction = 8
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/southwest{
+	level = 2
 	},
 /turf/simulated/floor/redwhite{
-	dir = 6
+	dir = 4
 	},
 /area/station/medical/medbay/surgery)
 "cwL" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 8
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
 	},
-/turf/simulated/floor/red,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwM" = (
-/obj/machinery/disposal/morgue,
-/obj/disposalpipe/trunk/morgue{
-	dir = 1
-	},
-/turf/simulated/floor/red,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwN" = (
 /obj/stool/chair/couch{
@@ -48254,76 +48052,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
-"cwO" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/beaker/large/antitox{
-	pixel_x = -10;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/glass/beaker/large/epinephrine{
-	pixel_x = -7;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/beaker/large/burn{
-	pixel_x = -4;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/beaker/large/brute{
-	pixel_x = -1;
-	pixel_y = 12
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/storage/firstaid/oxygen{
-	pixel_x = -11;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
-/area/station/medical/medbay/surgery)
 "cwP" = (
-/obj/table/auto,
-/obj/item/clothing/gloves/latex{
-	pixel_x = -12;
-	pixel_y = -4
+/turf/simulated/floor/redwhite{
+	dir = 4
 	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/surgical{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 13;
-	pixel_y = 11
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/item/device/reagentscanner{
-	pixel_x = -15;
-	pixel_y = 10
-	},
-/turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "cwQ" = (
-/turf/simulated/floor/redwhite{
-	dir = 6
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cwR" = (
 /obj/item/device/radio/intercom/medical{
@@ -48477,25 +48219,25 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxo" = (
-/obj/machinery/autoclave,
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/treatment)
 "cxp" = (
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxq" = (
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/medical/research)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/dome)
 "cxr" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_normal"
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Monkey Pen";
+	req_access_txt = null
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/medical/research)
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/delivery,
+/area/station/medical/dome)
 "cxs" = (
 /obj/cable,
 /obj/cable{
@@ -48503,7 +48245,7 @@
 	},
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/medical/dome)
 "cxt" = (
 /obj/storage/closet/biohazard,
 /obj/machinery/light{
@@ -48513,9 +48255,15 @@
 /turf/simulated/floor/bot/white,
 /area/station/medical/cdc)
 "cxw" = (
-/obj/machinery/centrifuge,
+/obj/machinery/atmospherics/pipe/simple,
+/obj/blind_switch/area/east{
+	pixel_y = -6
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = 6
+	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/treatment)
 "cxA" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -48567,82 +48315,18 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "cxF" = (
-/obj/table/auto,
-/obj/item/bloodslide{
-	pixel_x = -7;
-	pixel_y = 11
-	},
-/obj/item/bloodslide{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/bloodslide{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/bloodslide{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/bloodslide{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/bloodslide{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/bloodslide{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/bloodslide{
-	pixel_x = 7;
-	pixel_y = 1
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/treatment)
 "cxG" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = 9;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/vial{
-	pixel_x = 2;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
-"cxH" = (
-/obj/storage/secure/closet/animal,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/medical/research)
+/area/station/medical/medbay/treatment)
 "cxJ" = (
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/white,
@@ -48655,16 +48339,21 @@
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxQ" = (
-/obj/table/auto,
-/obj/machinery/microscope,
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
-"cxR" = (
-/obj/stool/chair/office{
-	dir = 8
+/obj/stool/bed/moveable,
+/obj/item/clothing/suit/bedsheet,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/treatment)
+"cxR" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/obj/machinery/light,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "cxS" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -48686,10 +48375,17 @@
 /area/station/medical/cdc)
 "cxY" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -48697,31 +48393,22 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/stool/chair/office,
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cya" = (
-/obj/stool/chair/office{
-	dir = 1
-	},
+/obj/disposalpipe/segment/mail,
 /obj/machinery/light{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/redwhite{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
-"cyb" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/medical/research)
+/area/station/medical/medbay/surgery)
 "cyd" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment,
@@ -48729,10 +48416,12 @@
 /turf/simulated/floor/bot,
 /area/station/hallway/secondary/exit)
 "cyf" = (
-/obj/stool/chair/office{
-	dir = 4
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/white,
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cyi" = (
 /obj/table/auto,
@@ -48789,13 +48478,45 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyl" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay)
 "cym" = (
-/obj/machinery/light,
+/obj/table/auto,
+/obj/item/bloodslide{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/obj/item/bloodslide{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/bloodslide{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/bloodslide{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/bloodslide{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/bloodslide{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/bloodslide{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/bloodslide{
+	pixel_x = 7;
+	pixel_y = 1
+	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyn" = (
@@ -48805,12 +48526,18 @@
 	},
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/medical/dome)
 "cyp" = (
-/turf/simulated/floor/stairs{
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/area/station/medical/cdc)
+/turf/simulated/floor/bluewhite{
+	dir = 4
+	},
+/area/station/medical/medbay)
 "cyr" = (
 /obj/item/clothing/suit/bedsheet,
 /obj/stool/bed/moveable,
@@ -48825,16 +48552,13 @@
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyu" = (
-/obj/cable,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
+/area/station/medical/medbay/surgery)
 "cyv" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -48843,14 +48567,13 @@
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyx" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "cyy" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -48911,15 +48634,11 @@
 /turf/simulated/floor/plating,
 /area/station/janitor/supply)
 "cyH" = (
-/obj/cable{
-	icon_state = "0-2"
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/redwhite{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
+/area/station/medical/medbay/surgery)
 "cyI" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -48971,30 +48690,20 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyQ" = (
-/obj/item/clothing/suit/bedsheet,
+/obj/table/auto,
+/obj/machinery/microscope,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/stool/bed/moveable,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyR" = (
-/obj/cable,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
+/obj/storage/secure/closet/medical/chemical,
+/turf/simulated/floor/red,
+/area/station/medical/medbay/surgery)
 "cyU" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/medbay/cloner)
 "cyV" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -50177,29 +49886,6 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/hallway/secondary/exit)
 "cCS" = (
-/obj/surgery_tray,
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -50227,10 +49913,10 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/hallway/secondary/exit)
 "cCX" = (
-/obj/machinery/optable,
-/obj/item/robodefibrillator,
-/obj/item/paper/book/from_file/medical_surgery_guide,
-/turf/simulated/floor/bot,
+/obj/landmark/start{
+	name = "Test Subject"
+	},
+/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cCZ" = (
 /obj/table/auto,
@@ -50275,67 +49961,54 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cDk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/drainage,
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
+	dir = 9
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cDm" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cDn" = (
-/obj/machinery/drainage,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cDo" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
+/turf/simulated/floor/redwhite{
+	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "cDv" = (
-/obj/machinery/drainage,
+/obj/overlay{
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm1";
+	layer = 10;
+	name = "palm tree"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "cDx" = (
 /obj/table/wood/auto,
 /obj/machinery/light/small,
@@ -50371,13 +50044,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "cFh" = (
-/obj/machinery/centrifuge,
-/obj/machinery/light{
+/obj/storage/secure/closet/medical,
+/obj/machinery/firealarm{
 	dir = 8;
-	tag = ""
+	pixel_x = -24
 	},
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/treatment)
 "cFm" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -50481,12 +50154,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "cNC" = (
-/obj/overlay{
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm1";
-	layer = 10;
-	name = "palm tree"
-	},
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -50494,7 +50161,7 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "cNP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/cable/brown{
@@ -50574,6 +50241,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
+"cTz" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "cUw" = (
 /obj/item/device/radio/intercom/botany{
 	dir = 1
@@ -50697,6 +50371,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"ddE" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "dgj" = (
 /obj/machinery/launcher_loader/south{
 	door_delay = 5
@@ -50710,16 +50388,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "dhj" = (
-/obj/overlay{
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm1";
-	layer = 10;
-	name = "palm tree"
-	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "diC" = (
 /obj/storage/secure/closet/security/armory,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -50968,6 +50640,36 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"dvC" = (
+/obj/table/auto,
+/obj/item/clothing/gloves/latex{
+	pixel_x = -12;
+	pixel_y = -4
+	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/device/reagentscanner{
+	pixel_x = -15;
+	pixel_y = 10
+	},
+/turf/simulated/floor/redwhite{
+	dir = 6
+	},
+/area/station/medical/medbay/surgery)
 "dwx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51166,10 +50868,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "dJr" = (
-/obj/submachine/chef_sink{
-	dir = 8
-	},
-/turf/simulated/floor/bot/white,
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "dJQ" = (
 /obj/item/device/radio/intercom/botany,
@@ -51314,14 +51015,18 @@
 	icon_state = "Stairs_wide"
 	},
 /area/station/security/main)
-"dUE" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Monkey Pen";
-	req_access_txt = null
+"dSS" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/access_spawn/medical,
-/obj/firedoor_spawn,
-/turf/simulated/floor/blue,
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
+"dUE" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/white,
 /area/station/medical/research)
 "dUT" = (
 /obj/table/auto,
@@ -52142,6 +51847,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"eTb" = (
+/obj/machinery/autoclave,
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "eTE" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -52831,8 +52540,42 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "fPv" = (
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker/large/antitox{
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/beaker/large/epinephrine{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/large/burn{
+	pixel_x = -4;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/beaker/large/brute{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = -11;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
 /area/station/medical/medbay/surgery)
 "fQF" = (
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -53145,6 +52888,15 @@
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
+"gfX" = (
+/obj/machinery/atmospherics/unary/cryo_cell{
+	dir = 1;
+	pipe_direction = 1
+	},
+/turf/simulated/floor/redwhite{
+	dir = 6
+	},
+/area/station/medical/medbay/surgery)
 "git" = (
 /turf/simulated/floor/stairs,
 /area/station/hangar/catering{
@@ -53502,7 +53254,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/stool/chair/comfy/wheelchair{
 	dir = 8
 	},
@@ -53636,19 +53387,25 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "gLK" = (
-/obj/machinery/light,
-/obj/table/auto,
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 4
+	},
+/area/station/medical/medbay)
 "gNp" = (
-/obj/cable{
-	icon_state = "0-8"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pathology Lab";
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/pathology,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "gNJ" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -54103,15 +53860,26 @@
 	},
 /area/station/medical/medbay)
 "hzC" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/table/auto,
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 10;
+	pixel_y = 8
 	},
-/obj/cable{
-	icon_state = "0-2"
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 9
 	},
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
+/obj/item/clothing/mask/surgical_shield{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/surgical_shield{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/simulated/floor/redwhite{
+	dir = 8
+	},
+/area/station/medical/medbay/surgery)
 "hzO" = (
 /obj/stool/chair,
 /obj/cable{
@@ -54382,6 +54150,11 @@
 /obj/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/routing/sortingRoom)
+"hTs" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "hTA" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -54579,32 +54352,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "ilc" = (
-/obj/table/auto,
-/obj/item/storage/box/stma_kit{
-	pixel_x = -9;
-	pixel_y = 12
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
 	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = 5;
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/machinery/light,
-/obj/item/device/radio/intercom/medical{
-	dir = 1
-	},
-/turf/simulated/floor/red,
+/obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "ill" = (
 /obj/cable{
@@ -54635,6 +54388,14 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/security/detectives_office)
+"inJ" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/stairs{
+	dir = 4
+	},
+/area/station/medical/cdc)
 "iod" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment,
@@ -54744,10 +54505,6 @@
 "iCV" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -54970,6 +54727,13 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
+"iXU" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "iZi" = (
 /obj/cable/brown{
 	icon_state = "1-2"
@@ -55094,6 +54858,16 @@
 /obj/machinery/phone/wall,
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
+"jkY" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "jlv" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -55120,6 +54894,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"jmw" = (
+/obj/storage/secure/closet/animal,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "jmy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55142,30 +54922,38 @@
 /area/station/hangar/main)
 "jne" = (
 /obj/table/auto,
-/obj/machinery/light,
-/obj/bedsheetbin{
-	pixel_x = 7;
-	pixel_y = 9
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = -8;
+	pixel_y = 11
 	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr";
-	pixel_x = -5;
-	pixel_y = 13
+/obj/item/reagent_containers/glass/vial{
+	pixel_y = 11
 	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr";
-	pixel_x = -6;
-	pixel_y = 8
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 8;
+	pixel_y = 11
 	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr";
+/obj/item/reagent_containers/glass/vial{
 	pixel_x = -7;
-	pixel_y = 4
+	pixel_y = 6
 	},
-/obj/item/clothing/glasses/spectro{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 1;
+	pixel_y = 6
 	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/machinery/light,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "jnq" = (
@@ -55815,7 +55603,7 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
@@ -56024,6 +55812,10 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
+"ktW" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "kuI" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -56087,18 +55879,11 @@
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "kzw" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Quarantine 2";
-	req_access_txt = null
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/pathology,
 /turf/simulated/floor/white,
-/area/station/medical/cdc)
+/area/station/medical/medbay/surgery)
 "kAj" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -56697,6 +56482,10 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
+"lBD" = (
+/obj/machinery/centrifuge,
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "lBT" = (
 /obj/machinery/door/airlock/pyro/security{
 	aiControlDisabled = 1;
@@ -56973,7 +56762,7 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "mcM" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light,
@@ -57243,6 +57032,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"myb" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "myo" = (
 /obj/grille/catwalk,
 /obj/cable/yellow{
@@ -57578,6 +57373,15 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/sortingRoom)
+"mWh" = (
+/obj/table/auto,
+/obj/machinery/microscope,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "mWr" = (
 /obj/storage/closet/emergency,
 /turf/unsimulated/floor{
@@ -57752,6 +57556,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"nji" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/cdc)
 "njO" = (
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/maintenance/northeast)
@@ -58054,6 +57866,19 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"nKV" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment)
 "nLg" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -58205,6 +58030,22 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/storage/hydroponics)
+"nVQ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/storage/secure/closet/animal,
+/obj/machinery/light{
+	dir = 8;
+	tag = ""
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "nWe" = (
 /obj/cable/brown{
 	icon_state = "1-2"
@@ -58296,6 +58137,9 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
+"nZV" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/medbay/treatment)
 "oaq" = (
 /obj/decal/poster/wallsign/hazard_electrical{
 	pixel_y = 32
@@ -58502,6 +58346,36 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
+"owm" = (
+/obj/table/auto,
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/iv_drip/saline{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_y = -4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "owD" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
@@ -58510,15 +58384,8 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "owN" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pathology Lab";
-	req_access_txt = null
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/pathology,
-/turf/simulated/floor/delivery/white,
-/area/station/medical/cdc)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/medbay/surgery)
 "oxf" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/power_monitor/smes{
@@ -58582,6 +58449,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
+"oDz" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/red,
+/area/station/medical/medbay/surgery)
 "oFI" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -59116,7 +58993,7 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "pkL" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -59144,6 +59021,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
+"pnt" = (
+/obj/stool/bed/moveable,
+/obj/item/clothing/suit/bedsheet,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "poA" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
@@ -59759,6 +59641,12 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
+"quY" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "qva" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
@@ -59922,7 +59810,7 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/medical/research)
+/area/station/medical/dome)
 "qBG" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -60662,6 +60550,14 @@
 /obj/machinery/vending/cola/red,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"rBL" = (
+/obj/landmark/spawner{
+	name = "monkeyspawn_normal"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "rCz" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
@@ -60797,6 +60693,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"rJL" = (
+/obj/machinery/atmospherics/unary/cold_sink/freezer/cryo/east{
+	dir = 1
+	},
+/turf/simulated/floor/redwhite,
+/area/station/medical/medbay/surgery)
 "rKQ" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
@@ -60867,6 +60769,18 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"rOb" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "rOi" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail,
@@ -60889,6 +60803,14 @@
 /obj/access_spawn/research_foyer,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"rPz" = (
+/obj/submachine/chef_sink,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/bot/white,
+/area/station/medical/cdc)
 "rQC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
@@ -61011,6 +60933,11 @@
 	dir = 4
 	},
 /area/station/solar/south)
+"sbg" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "scA" = (
 /obj/decal/tile_edge/stripe/corner/big2{
 	dir = 9
@@ -61380,6 +61307,16 @@
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
+"srw" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/red,
+/area/station/medical/medbay/surgery)
 "srJ" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/lawrack{
@@ -61974,13 +61911,38 @@
 /turf/simulated/floor/red/side,
 /area/station/bridge)
 "tdI" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 6
+/obj/table/auto,
+/obj/item/storage/box/stma_kit{
+	pixel_x = -9;
+	pixel_y = 12
 	},
-/turf/simulated/floor/redwhite{
-	dir = 4
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 5;
+	pixel_y = 16
 	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "tdV" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -62846,6 +62808,18 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/lobby)
+"umi" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Monkey Pen";
+	req_access_txt = null
+	},
+/obj/access_spawn/pathology,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/delivery,
+/area/station/medical/cdc)
 "umE" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -62871,14 +62845,18 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "unF" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Monkey Pen";
-	req_access_txt = null
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
 	},
-/obj/access_spawn/pathology,
-/turf/simulated/floor/delivery,
-/area/station/medical/cdc)
+/obj/machinery/atmospherics/unary/cryo_cell{
+	dir = 1;
+	pipe_direction = 1
+	},
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
+/area/station/medical/medbay/surgery)
 "unV" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -63016,6 +62994,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"uBk" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	icon_state = "on";
+	on = 1
+	},
+/obj/landmark/start{
+	name = "Test Subject"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "uCf" = (
 /obj/storage/secure/closet/brig_automatic/minibrig,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -63582,6 +63571,13 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
+"vnp" = (
+/obj/machinery/atmospherics/pipe/simple,
+/obj/machinery/door/airlock/pyro/medical,
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
+/turf/simulated/floor/blue,
+/area/station/medical/medbay/treatment)
 "vnq" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs/wood/wide{
@@ -63674,6 +63670,9 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/market)
+"vts" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/medbay/treatment)
 "vuo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -64237,10 +64236,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "wfB" = (
-/obj/machinery/light_switch{
-	name = "N light switch";
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "wfH" = (
@@ -64751,6 +64747,16 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"wQD" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "wQU" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -65175,6 +65181,11 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
+"xzu" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "xAi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -101564,7 +101575,7 @@ crC
 crC
 krl
 son
-fLo
+mky
 jyy
 nWf
 jyy
@@ -102167,11 +102178,11 @@ cqF
 crE
 crE
 crE
-crE
+cyl
 crE
 crE
 cqF
-cwF
+crE
 nFw
 cxl
 cxl
@@ -102467,10 +102478,10 @@ cBP
 cAX
 cqG
 crF
-csu
+crF
 ctt
-crF
-crF
+cyp
+gLK
 gEK
 iCV
 csN
@@ -102480,8 +102491,8 @@ eLp
 cxE
 kck
 cxY
-cyl
-cyu
+cxp
+cxp
 gps
 jMV
 cxe
@@ -102772,19 +102783,19 @@ crG
 csv
 ctu
 cuh
-cvb
-cvB
-cvY
+cvc
 cwH
+cwH
+cwH
+owN
+vts
+vts
+vts
+nKV
 cxe
-cxe
-cxe
-cxe
-cxP
-cxp
 cym
-cxe
-kzw
+cxp
+cxX
 cxC
 cxe
 aar
@@ -103069,23 +103080,23 @@ cih
 cih
 coG
 cpG
-cqH
-crH
-csw
+cqI
+cvc
+cvc
 ctv
 cui
 cvc
 cvC
 cvZ
 cDo
-cxe
+unF
 cxo
 cFh
 cxF
 cxQ
-cxp
-cxp
 cxe
+mWh
+cxV
 cxX
 jne
 cxe
@@ -103370,24 +103381,24 @@ ckP
 cmk
 gWV
 coH
-cpH
+cpG
 cqI
-crI
+cwH
 csx
 ctw
-ctw
+cyu
 cvd
 cvD
 cwa
 cwJ
-cxf
-cxp
-cxp
-cxp
+rJL
+sbg
+owm
+uBk
 cxR
+cxe
+lBD
 cxp
-cxp
-hzC
 cxZ
 cyQ
 cyB
@@ -103674,24 +103685,24 @@ umZ
 coI
 cpI
 cqJ
-crJ
+cwH
 csy
 ctx
 cuj
 cve
 cvE
-cwb
+cwP
 cwK
-cxf
+gfX
+hTs
+ddE
+quY
+xzu
+cxe
+eTb
 cxp
-cxp
-cxp
-cxp
-cxp
-cxp
-gNp
-cxp
-cyr
+cxX
+lBD
 bCw
 adC
 aah
@@ -103975,25 +103986,25 @@ cmm
 tTc
 coH
 cpG
-cqH
-crK
+csu
+cvc
 csz
 cDk
 cuk
-cuk
+cDn
 cDn
 cwc
 cwL
-cxe
-cxo
+srw
+vnp
 cxw
 cxG
-cxQ
-cya
+pnt
+cxe
+rPz
 cxp
-gNp
-cxp
-cyr
+dSS
+eTb
 bCw
 adC
 aah
@@ -104277,8 +104288,8 @@ cmn
 cih
 coJ
 cpG
-cqH
-bAx
+cqI
+cvc
 csA
 ctz
 cul
@@ -104286,17 +104297,17 @@ cvf
 cCX
 cwd
 cwM
+oDz
+nZV
+nZV
+iXU
+cTz
 cxe
-cxf
-cxf
-cxf
-cxf
 cxe
-owN
 gNp
-cxp
+cxe
 cyf
-bCw
+nji
 adC
 aah
 adC
@@ -104579,26 +104590,26 @@ cih
 cih
 coK
 cpH
-cqI
+cwF
 crM
 csB
 ctA
-ctA
+cwe
 cDm
-cvF
+cwe
 cwe
 ilc
 aKZ
 cxq
 cNC
-cxH
-cxH
+cDv
+jmw
+nVQ
 cxf
-cyp
-cxP
+inJ
 dJr
-gLK
-bCw
+aap
+acW
 adC
 aah
 adC
@@ -104882,25 +104893,25 @@ dGP
 coL
 cpJ
 cqK
-crN
+cwH
 csC
 cCS
-cum
-cvh
-cCS
 cwf
-cwO
+cvh
+hzC
+cwf
+cCS
 fPv
-cxq
-cxr
-cxq
-cxr
+ktW
+dhj
+rBL
+dhj
+rBL
 cxe
-unF
+umi
 cxe
-cyH
-cyR
-cyU
+aah
+adC
 adC
 aah
 adC
@@ -105186,23 +105197,23 @@ cpG
 cqL
 crO
 csD
-csD
-csD
-csD
-csD
+cya
+cyH
+cyH
+cyH
 cwg
 cwP
-fPv
-cxq
-cxq
-cxq
-cxq
-cyb
-cxq
+dvC
+ktW
+dhj
+dhj
+dhj
+dhj
+rBL
 cyx
-wtE
-aap
-acW
+rOb
+aah
+adC
 adC
 aah
 adC
@@ -105485,24 +105496,24 @@ cmo
 sIb
 coH
 cpG
-cqH
-crP
+cqI
+cvc
 csE
-bAP
-csE
+cwH
+cyR
 tdI
-csE
+kzw
 bBK
 cwQ
 dUE
 cxr
-cxq
+rBL
 dhj
 cDv
-cxr
-cxq
+myb
+dhj
 lZY
-wtE
+wQD
 aah
 adC
 adC
@@ -105791,7 +105802,7 @@ cqM
 crQ
 csF
 cvG
-cvG
+cyU
 cng
 nLg
 cwi
@@ -105799,10 +105810,10 @@ ctD
 ctD
 ctD
 ctD
-cxq
-cxq
+dhj
+dhj
 pkK
-qLY
+jkY
 cxs
 cyn
 aaG
@@ -106101,10 +106112,10 @@ cuo
 cuo
 vql
 ctD
-cxq
-cxq
-cxr
-wtE
+dhj
+dhj
+rBL
+wQD
 aap
 aaq
 acW
@@ -106403,10 +106414,10 @@ cuo
 hjc
 hvo
 ctD
-cxq
-cxq
+dhj
+dhj
 qBE
-wtE
+wQD
 aah
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45964,6 +45964,9 @@
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/big,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cqO" = (
@@ -45980,9 +45983,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/clonepod,
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/railing/orange,
 /turf/simulated/floor/bot,
 /area/station/medical/medbay/cloner)
@@ -46224,6 +46224,9 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crR" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/stairs{
 	icon_state = "medstairs_alone"
 	},
@@ -46239,15 +46242,6 @@
 "crT" = (
 /obj/machinery/computer/cloning,
 /obj/item/paper/Cloning,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -46255,6 +46249,15 @@
 	tag = ""
 	},
 /obj/decal/stage_edge/alt,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crU" = (
@@ -46520,6 +46523,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 9
@@ -53457,9 +53463,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/pathology,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "gNJ" = (
@@ -56590,6 +56593,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
+"lDv" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/research)
 "lEV" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -60110,6 +60120,9 @@
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "qMw" = (
@@ -64170,6 +64183,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -105958,7 +105974,7 @@ cwi
 ctD
 ctD
 ctD
-ctD
+lDv
 dhj
 dgt
 pkK
@@ -106260,7 +106276,7 @@ cwj
 cuo
 cuo
 vql
-ctD
+lDv
 dhj
 dhj
 rBL
@@ -106562,7 +106578,7 @@ cwj
 cuo
 hjc
 hvo
-ctD
+lDv
 dhj
 dhj
 qBE

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -48496,7 +48496,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cyj" = (
-/obj/machinery/vending/pathology,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -64364,6 +64363,7 @@
 /area/station/maintenance/disposal)
 "wfB" = (
 /obj/machinery/light_switch/north,
+/obj/machinery/vending/pathology,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "wfH" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -272,14 +272,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"abs" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/medical/staff)
 "abu" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -26248,6 +26240,14 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
+"bqu" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "bqv" = (
 /obj/storage/crate,
 /obj/item/device/analyzer/healthanalyzer{
@@ -46221,12 +46221,12 @@
 "crM" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "crO" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "crQ" = (
 /obj/window/reinforced{
@@ -46524,15 +46524,13 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
-/turf/simulated/floor/red,
+/turf/simulated/floor/delivery,
 /area/station/medical/medbay/surgery)
 "csF" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 9
-	},
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "csG" = (
 /obj/decal/tile_edge/stripe/big{
@@ -46542,7 +46540,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite{
-	dir = 1
+	dir = 9
 	},
 /area/station/medical/medbay/cloner)
 "csH" = (
@@ -46924,6 +46922,9 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "ctA" = (
@@ -46934,6 +46935,9 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
@@ -47506,6 +47510,9 @@
 "cvh" = (
 /obj/table/auto,
 /obj/machinery/defib_mount,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -47617,7 +47624,7 @@
 /area/station/medical/medbay/surgery)
 "cvG" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
 "cvH" = (
 /obj/storage/cart/trash,
@@ -47787,6 +47794,9 @@
 	},
 /obj/item/suture{
 	pixel_y = 5
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -47988,7 +47998,7 @@
 /area/station/medical/medbay)
 "cwH" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "cwI" = (
 /obj/surgery_tray,
@@ -48072,6 +48082,9 @@
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 6
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -48229,7 +48242,7 @@
 "cxo" = (
 /obj/window_blinds/cog2/left,
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "cxp" = (
 /turf/simulated/floor/white,
@@ -48244,6 +48257,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/delivery,
 /area/station/medical/dome)
 "cxs" = (
@@ -48354,18 +48370,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxR" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
 /obj/machinery/light,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxS" = (
@@ -49900,6 +49910,9 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/hallway/secondary/exit)
 "cCS" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -49984,6 +49997,9 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cDm" = (
@@ -50013,16 +50029,13 @@
 	},
 /area/station/medical/medbay/surgery)
 "cDv" = (
-/obj/overlay{
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm1";
-	layer = 10;
-	name = "palm tree"
+/obj/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
+/turf/simulated/floor/redwhite{
+	dir = 8
 	},
-/area/station/medical/dome)
+/area/station/medical/medbay/surgery)
 "cDx" = (
 /obj/table/wood/auto,
 /obj/machinery/light/small,
@@ -50174,7 +50187,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -50263,9 +50276,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
@@ -50408,6 +50418,17 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
+"dgt" = (
+/obj/overlay{
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm1";
+	layer = 10;
+	name = "palm tree"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "dhj" = (
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -51046,6 +51067,9 @@
 "dUE" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -53653,17 +53677,6 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
-"hje" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/medical/staff)
 "hjt" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -53907,6 +53920,9 @@
 /obj/item/clothing/mask/surgical_shield{
 	pixel_x = -5;
 	pixel_y = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -54185,7 +54201,7 @@
 "hTs" = (
 /obj/window_blinds/cog2/right,
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "hTA" = (
 /obj/disposalpipe/segment{
@@ -54399,17 +54415,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"imI" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/cdc)
 "imT" = (
 /obj/landmark/start{
 	name = "Security Assistant"
@@ -54545,6 +54550,17 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
+"iBp" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/cdc)
 "iCV" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54939,9 +54955,6 @@
 /area/station/engine/core)
 "jmw" = (
 /obj/storage/secure/closet/animal,
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -55637,6 +55650,14 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/mining/staff_room)
+"kca" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "kck" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58147,14 +58168,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/station/engine/hotloop)
-"nYd" = (
-/obj/item/clothing/suit/bedsheet,
-/obj/stool/bed/moveable,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/cdc)
 "nYv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59081,9 +59094,6 @@
 "pnt" = (
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "poA" = (
@@ -59133,13 +59143,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
-"ptZ" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/staff)
 "pui" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -59982,6 +59985,11 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
+"qHM" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "qIm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61006,7 +61014,7 @@
 "sbg" = (
 /obj/window_blinds/cog2/middle,
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "scA" = (
 /obj/decal/tile_edge/stripe/corner/big2{
@@ -62083,6 +62091,14 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"tlD" = (
+/obj/item/clothing/suit/bedsheet,
+/obj/stool/bed/moveable,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/cdc)
 "tlJ" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -62327,6 +62343,13 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
+"tKF" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "tLW" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -62519,6 +62542,14 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/janitor/office)
+"tWR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/surgery)
 "tWU" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start{
@@ -63252,20 +63283,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
-"uOp" = (
-/obj/overlay{
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm1";
-	layer = 10;
-	name = "palm tree"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/medical/dome)
 "uQi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -63958,11 +63975,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
-"vGI" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/medical/staff)
 "vHi" = (
 /obj/cable/brown{
 	icon_state = "1-2"
@@ -64063,6 +64075,17 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/security/main)
+"vOu" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/medical/staff)
 "vOV" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -64119,6 +64142,17 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"vUI" = (
+/obj/landmark/spawner{
+	name = "monkeyspawn_normal"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/medical/dome)
 "vXz" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Catering Storage"
@@ -65276,9 +65310,6 @@
 "xzu" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "xAi" = (
@@ -99862,11 +99893,11 @@ fLo
 fLo
 fLo
 fLo
-ptZ
-abs
-hje
-abs
-vGI
+tKF
+bqu
+vOu
+bqu
+qHM
 cxe
 cxe
 cxe
@@ -100173,7 +100204,7 @@ pTr
 mOn
 cyr
 cyA
-nYd
+tlD
 dJr
 aao
 aay
@@ -100776,7 +100807,7 @@ fLo
 cxe
 cxC
 guM
-imI
+iBp
 cxe
 cxe
 adC
@@ -104697,7 +104728,7 @@ ilc
 aKZ
 cxq
 cNC
-uOp
+rBL
 jmw
 nVQ
 cxf
@@ -104995,13 +105026,13 @@ cwf
 cvh
 hzC
 cwf
-cCS
+cDv
 fPv
 ktW
+kca
+dgt
 dhj
-rBL
 dhj
-rBL
 cxe
 umi
 cxe
@@ -105297,12 +105328,12 @@ cyH
 cyH
 cyH
 cwg
-cwP
+tWR
 dvC
 ktW
+kca
 dhj
-dhj
-dhj
+rBL
 dhj
 rBL
 cyx
@@ -105602,9 +105633,9 @@ bBK
 cwQ
 dUE
 cxr
-rBL
+vUI
 dhj
-cDv
+dhj
 myb
 dhj
 lZY
@@ -105906,7 +105937,7 @@ ctD
 ctD
 ctD
 dhj
-dhj
+dgt
 pkK
 jkY
 cxs

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -46429,7 +46429,6 @@
 	dir = 4
 	},
 /obj/railing/orange,
-/obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "csx" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -48219,8 +48219,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxo" = (
-/obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxp" = (
@@ -54151,8 +54151,8 @@
 /turf/simulated/floor/plating,
 /area/station/routing/sortingRoom)
 "hTs" = (
-/obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "hTA" = (
@@ -60934,8 +60934,8 @@
 	},
 /area/station/solar/south)
 "sbg" = (
-/obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "scA" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45143,16 +45143,12 @@
 /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat{
 	pixel_x = 4
 	},
-/obj/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
+/obj/decal/stage_edge/alt,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "coT" = (
 /obj/machinery/camera{
@@ -45959,10 +45955,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
 /obj/machinery/manufacturer/medical,
+/obj/railing/orange,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cqN" = (
@@ -45976,9 +45970,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
+/obj/railing/orange,
 /turf/simulated/floor/bluewhite{
 	dir = 6
 	},
@@ -45988,12 +45980,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/clonepod,
-/obj/window/reinforced{
-	dir = 2
-	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/railing/orange,
 /turf/simulated/floor/bot,
 /area/station/medical/medbay/cloner)
 "cqQ" = (
@@ -46003,20 +45993,18 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
+/obj/railing/orange,
 /turf/simulated/floor/bluewhite{
 	dir = 10
 	},
 /area/station/medical/medbay)
 "cqR" = (
-/obj/decal/tile_edge/stripe/big,
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/tile_edge/stripe/big,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cqS" = (
@@ -46026,9 +46014,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/window/reinforced{
-	dir = 2
-	},
+/obj/railing/orange,
 /turf/simulated/floor/bluewhite{
 	dir = 6
 	},
@@ -46229,15 +46215,13 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "crQ" = (
-/obj/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/obj/decal/stage_edge/alt,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crR" = (
 /turf/simulated/floor/stairs{
@@ -46246,13 +46230,11 @@
 /area/station/medical/medbay/cloner)
 "crS" = (
 /obj/machinery/clone_scanner,
-/obj/window/reinforced{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/bot,
+/obj/decal/stage_edge/alt,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crT" = (
 /obj/machinery/computer/cloning,
@@ -46272,17 +46254,16 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/bot,
+/obj/decal/stage_edge/alt,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crU" = (
 /obj/machinery/clonegrinder,
-/obj/window/reinforced{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/bot,
+/obj/decal/stage_edge/alt,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay/cloner)
 "crV" = (
 /obj/disposalpipe/segment,
@@ -46447,6 +46428,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/railing/orange,
+/obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "csx" = (
@@ -46844,6 +46827,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -46852,13 +46838,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/stairs/medical/wide/other{
+	dir = 8
+	},
 /area/station/medical/medbay)
 "ctv" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -47182,13 +47167,12 @@
 	},
 /area/station/medical/medbay)
 "cuh" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/stairs/medical/wide{
+	dir = 8
+	},
 /area/station/medical/medbay)
 "cui" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -48051,10 +48035,16 @@
 	dir = 10
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwM" = (
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwN" = (
@@ -48280,12 +48270,17 @@
 /turf/simulated/floor/bot/white,
 /area/station/medical/cdc)
 "cxw" = (
-/obj/machinery/atmospherics/pipe/simple,
 /obj/blind_switch/area/east{
 	pixel_y = -6
 	},
 /obj/machinery/light_switch/east{
 	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -48342,13 +48337,13 @@
 "cxF" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxG" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -48364,15 +48359,18 @@
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "cxQ" = (
-/obj/stool/bed/moveable,
-/obj/item/clothing/suit/bedsheet,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/treatment)
+/obj/disposalpipe/segment/morgue,
+/obj/decal/tile_edge/stripe/big{
+	dir = 6;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 4
+	},
+/area/station/medical/medbay)
 "cxR" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
@@ -48556,6 +48554,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
@@ -50032,6 +50033,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -50404,6 +50408,9 @@
 /area/station/engine/core)
 "ddE" = (
 /obj/machinery/vending/medical,
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "dgj" = (
@@ -53435,6 +53442,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 5;
+	icon_state = "xtra_bigstripe-corner2"
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -54405,6 +54416,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "ill" = (
@@ -57944,9 +57958,6 @@
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "nLg" = (
@@ -58443,6 +58454,9 @@
 	},
 /obj/item/clothing/glasses/blindfold{
 	pixel_y = -4
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -59712,8 +59726,8 @@
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "quY" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -61392,6 +61406,9 @@
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
@@ -63097,12 +63114,15 @@
 /area/station/hallway/secondary/exit)
 "uBk" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 4;
+	dir = 1;
 	icon_state = "on";
 	on = 1
 	},
 /obj/landmark/start{
 	name = "Test Subject"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -63677,6 +63697,9 @@
 /obj/machinery/door/airlock/pyro/medical,
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "vnq" = (
@@ -102605,7 +102628,7 @@ cBP
 cAX
 cqG
 crF
-crF
+cxQ
 ctt
 cyp
 gLK
@@ -103220,7 +103243,7 @@ unF
 cxo
 cFh
 cxF
-cxQ
+pnt
 cxe
 mWh
 cxV

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -47733,6 +47733,7 @@
 	pixel_x = -6;
 	pixel_y = 1
 	},
+/obj/item/paper/cryo,
 /obj/item/wrench{
 	pixel_x = 4;
 	pixel_y = 1

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -54454,7 +54454,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/stairs{
-	dir = 4
+	dir = 8
 	},
 /area/station/medical/cdc)
 "iod" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Redesigns the operating theatre to use thick windows and doors
* makes the monkey run a little more perilous by moving a toolbox within reach of mischievous monkey hands
* Squish down patho space that was under-utilized
* Adds a treatment center room with blinds and an opaque door for hiding away in/crime/containing patients
* make monkey dome a little bigger
* fix some minor map bugs
![image](https://user-images.githubusercontent.com/33204415/191074297-667097af-0dad-40fc-a670-57ed1bd525c8.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* shake things up


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)The cog1 medbay has had some alterations made to its layout
```
