### PR TITLE
Legless fix

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -277,6 +277,13 @@
 		if(!owner.ear_disability)
 			owner.bioHolder.AddEffect("deaf", 0, 0, 0, 1)
 
+/datum/trait/nolegs
+	name = "Stumped"
+	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair out of the goodness of their heart. (due to regulations)"
+	id = "nolegs"
+	icon_state = "placeholder"
+	category = list("body")
+	points = 0
 // LANGUAGE - Yellow Border
 
 /datum/trait/swedish
@@ -512,12 +519,7 @@
 	icon_state = "placeholder"
 	points = 0
 
-/datum/trait/nolegs
-	name = "Stumped"
-	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair out of the goodness of their heart. (due to regulations)"
-	id = "nolegs"
-	icon_state = "placeholder"
-	points = 0
+
 
 // Skill - White Border
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR 
Changes category of stumped trait



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10817 and easier to find.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)golferjoe
(+)Moved "stumped" trait from uncategorized to body
```
