### PR TITLE
Increases freeze cooling amount

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1599,7 +1599,7 @@ datum
 					M.reagents.del_reagent("chocolate")
 					M.reagents.del_reagent("freeze")
 				if(M.bodytemperature > 0)
-					M.bodytemperature=max(M.bodytemperature-(10 * mult),0)
+					M.bodytemperature=max(M.bodytemperature-(15 * mult),0)
 				if(probmult(10))
 					boutput(M, pick("<span class='notice'><i>Brrr...</i></span>","<span class='notice'><i>Isn't it a bit chilly in here?</i></span>","<span class='notice'><i>Who left an airlock open?</i></span>"))
 				if(probmult(15))

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1599,7 +1599,7 @@ datum
 					M.reagents.del_reagent("chocolate")
 					M.reagents.del_reagent("freeze")
 				if(M.bodytemperature > 0)
-					M.bodytemperature=max(M.bodytemperature-(15 * mult),0)
+					M.bodytemperature=max(M.bodytemperature-(20 * mult),0)
 				if(probmult(10))
 					boutput(M, pick("<span class='notice'><i>Brrr...</i></span>","<span class='notice'><i>Isn't it a bit chilly in here?</i></span>","<span class='notice'><i>Who left an airlock open?</i></span>"))
 				if(probmult(15))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Freeze now cools you down 20k per lifeloop instead of 10k. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This allows you to stack freeze with cryoxadone which I think is a very funny strategy to enable as its putting yourself at a decent chance of getting gibbed.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Freeze now cools you down 20 k per lifeloop
```
