### PR TITLE
Traders Arriving Use Signals to Extend Airbridges / Trigger Lights

### DIFF
--- a/_std/defines/component_defines/component_defines_global.dm
+++ b/_std/defines/component_defines/component_defines_global.dm
@@ -37,20 +37,27 @@
 #define COMSIG_GLOBAL_SUSSY_PHRASE "sussy"
 #define COMSIG_GLOBAL_UNCOOL_PHRASE "uncool_word"
 
-// ---- Trader Shuttle Movement ----
+// ---- Generic Dock Events ----
+
+	/// Shuttle is about to arrive at a dock
+	#define COMSIG_DOCK_EVENT_INCOMING "dock_incoming"
+
+	/// Shuttle has arrived
+	#define COMSIG_DOCK_EVENT_ARRIVED "dock_arrived"
+
+	/// Shuttle is about to depart
+	#define COMSIG_DOCK_EVENT_OUTGOING "dock_outgoing"
+
+	/// Shuttle has departed from the dock
+	#define COMSIG_DOCK_EVENT_DEPARTED "dock_departed"
+
+// ---- Trader Docks ----
 
 	/// When a trader is arriving/departing at the 'left' trading area on-station
-	#define COMSIG_TRADER_LEFT "trader_left"
+	#define COMSIG_DOCK_TRADER_WEST "trader_left"
 
 	/// When a trader is arriving/departing at the 'right' trading area on-station
-	#define COMSIG_TRADER_RIGHT "trader_right"
+	#define COMSIG_DOCK_TRADER_EAST "trader_right"
 
 	/// When a trader is arriving/departing at the diner trading area
-	#define COMSIG_TRADER_DINER "trader_diner"
-
-	/// When a trader has arrived at centcom
-	#define COMSIG_TRADER_RETURNED "trader_returned"
-
-	/// When a trader has stopped moving
-	#define COMSIG_TRADER_STOPPED "trader_stopped"
-
+	#define COMSIG_DOCK_TRADER_DINER "trader_diner"

--- a/_std/defines/component_defines/component_defines_global.dm
+++ b/_std/defines/component_defines/component_defines_global.dm
@@ -36,28 +36,3 @@
 /// ⠀⠀⠀⠀⠀⠀⠀⠈⠛⠻⠿⠿⠿⠿⠋⠁⠀⠀⠀⠀
 #define COMSIG_GLOBAL_SUSSY_PHRASE "sussy"
 #define COMSIG_GLOBAL_UNCOOL_PHRASE "uncool_word"
-
-// ---- Generic Dock Events ----
-
-	/// Shuttle is about to arrive at a dock
-	#define COMSIG_DOCK_EVENT_INCOMING "dock_incoming"
-
-	/// Shuttle has arrived
-	#define COMSIG_DOCK_EVENT_ARRIVED "dock_arrived"
-
-	/// Shuttle is about to depart
-	#define COMSIG_DOCK_EVENT_OUTGOING "dock_outgoing"
-
-	/// Shuttle has departed from the dock
-	#define COMSIG_DOCK_EVENT_DEPARTED "dock_departed"
-
-// ---- Trader Docks ----
-
-	/// When a trader is arriving/departing at the 'left' trading area on-station
-	#define COMSIG_DOCK_TRADER_WEST "trader_left"
-
-	/// When a trader is arriving/departing at the 'right' trading area on-station
-	#define COMSIG_DOCK_TRADER_EAST "trader_right"
-
-	/// When a trader is arriving/departing at the diner trading area
-	#define COMSIG_DOCK_TRADER_DINER "trader_diner"

--- a/_std/defines/component_defines/component_defines_global.dm
+++ b/_std/defines/component_defines/component_defines_global.dm
@@ -36,3 +36,21 @@
 /// ⠀⠀⠀⠀⠀⠀⠀⠈⠛⠻⠿⠿⠿⠿⠋⠁⠀⠀⠀⠀
 #define COMSIG_GLOBAL_SUSSY_PHRASE "sussy"
 #define COMSIG_GLOBAL_UNCOOL_PHRASE "uncool_word"
+
+// ---- Trader Shuttle Movement ----
+
+	/// When a trader is arriving/departing at the 'left' trading area on-station
+	#define COMSIG_TRADER_LEFT "trader_left"
+
+	/// When a trader is arriving/departing at the 'right' trading area on-station
+	#define COMSIG_TRADER_RIGHT "trader_right"
+
+	/// When a trader is arriving/departing at the diner trading area
+	#define COMSIG_TRADER_DINER "trader_diner"
+
+	/// When a trader has arrived at centcom
+	#define COMSIG_TRADER_RETURNED "trader_returned"
+
+	/// When a trader has stopped moving
+	#define COMSIG_TRADER_STOPPED "trader_stopped"
+

--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -93,3 +93,31 @@
 
 	/// Return whether an action by a thing (/atom) that can optionally be intentional (boolean) is denied because it would harm a flock.
 	#define COMSIG_FLOCK_ATTACK "flock_attack"
+
+// ---- Dock Signals and Events ----
+// Docks are categorized by the shuttle that uses them. Docks are not interchangable.
+// Registered listeners recieve a signal for each shuttle state change.
+// When handling the signal, the provided argument will match a dock event define.
+
+	// ---- Dock Events ----
+		/// Shuttle is about to arrive at a dock
+		#define DOCK_EVENT_INCOMING "dock_incoming"
+
+		/// Shuttle has arrived
+		#define DOCK_EVENT_ARRIVED "dock_arrived"
+
+		/// Shuttle is about to depart
+		#define DOCK_EVENT_OUTGOING "dock_outgoing"
+
+		/// Shuttle has departed
+		#define DOCK_EVENT_DEPARTED "dock_departed"
+
+	// ---- "Travelling Trader" random event docks ----
+		/// The 'left' trading area on-station
+		#define COMSIG_DOCK_TRADER_WEST "trader_left"
+
+		/// The 'right' trading area on-station
+		#define COMSIG_DOCK_TRADER_EAST "trader_right"
+
+		/// The diner trading area
+		#define COMSIG_DOCK_TRADER_DINER "trader_diner"

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -25,7 +25,7 @@
 #endif
 		var/docked_where = shuttle == "diner" ? "space diner" : "station";
 		command_alert("A merchant shuttle will dock with the [docked_where] shortly.", "Commerce and Customs Alert")
-		signal_dock(shuttle, COMSIG_DOCK_EVENT_INCOMING)
+		signal_dock(shuttle, DOCK_EVENT_INCOMING)
 		for(var/client/C in clients)
 			if(C.mob && (C.mob.z == Z_LEVEL_STATION))
 				C.mob.playsound_local(C.mob, 'sound/misc/announcement_chime.ogg', 30, 0)
@@ -42,16 +42,16 @@
 					end_location = locate(map_settings ? map_settings.merchant_right_station : /area/shuttle/merchant_shuttle/right_station)
 
 			var/list/dest_turfs = src.arrive()
-			signal_dock(shuttle, COMSIG_DOCK_EVENT_ARRIVED)
+			signal_dock(shuttle, DOCK_EVENT_ARRIVED)
 
 			SPAWN(rand(5 MINUTES, 10 MINUTES))
 				command_alert("The merchant shuttle is preparing to undock, please stand clear.", "Merchant Departure Alert")
 
-				signal_dock(shuttle, COMSIG_DOCK_EVENT_OUTGOING)
+				signal_dock(shuttle, DOCK_EVENT_OUTGOING)
 				sleep(30 SECONDS)
 
 				src.depart(dest_turfs)
-				signal_dock(shuttle, COMSIG_DOCK_EVENT_DEPARTED)
+				signal_dock(shuttle, DOCK_EVENT_DEPARTED)
 				active = FALSE
 
 	proc/signal_dock(var/dock, var/event)

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -25,13 +25,7 @@
 #endif
 		var/docked_where = shuttle == "diner" ? "space diner" : "station";
 		command_alert("A merchant shuttle will dock with the [docked_where] shortly.", "Commerce and Customs Alert")
-		if(shuttle == "diner")
-			SEND_GLOBAL_SIGNAL(COMSIG_TRADER_DINER)
-		else
-			if(shuttle == "left")
-				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_LEFT)
-			else
-				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RIGHT)
+		signal_dock(shuttle, COMSIG_DOCK_EVENT_INCOMING)
 		for(var/client/C in clients)
 			if(C.mob && (C.mob.z == Z_LEVEL_STATION))
 				C.mob.playsound_local(C.mob, 'sound/misc/announcement_chime.ogg', 30, 0)
@@ -48,23 +42,26 @@
 					end_location = locate(map_settings ? map_settings.merchant_right_station : /area/shuttle/merchant_shuttle/right_station)
 
 			var/list/dest_turfs = src.arrive()
-			SEND_GLOBAL_SIGNAL(COMSIG_TRADER_STOPPED)
+			signal_dock(shuttle, COMSIG_DOCK_EVENT_ARRIVED)
 
 			SPAWN(rand(5 MINUTES, 10 MINUTES))
 				command_alert("The merchant shuttle is preparing to undock, please stand clear.", "Merchant Departure Alert")
 
-				if(shuttle == "diner")
-					SEND_GLOBAL_SIGNAL(COMSIG_TRADER_DINER)
-				else
-					if(shuttle == "left")
-						SEND_GLOBAL_SIGNAL(COMSIG_TRADER_LEFT)
-					else
-						SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RIGHT)
+				signal_dock(shuttle, COMSIG_DOCK_EVENT_OUTGOING)
 				sleep(30 SECONDS)
 
 				src.depart(dest_turfs)
-				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RETURNED)
+				signal_dock(shuttle, COMSIG_DOCK_EVENT_DEPARTED)
 				active = FALSE
+
+	proc/signal_dock(var/dock, var/event)
+		switch(dock)
+			if("diner")
+				SEND_GLOBAL_SIGNAL(COMSIG_DOCK_TRADER_DINER, event)
+			if("left")
+				SEND_GLOBAL_SIGNAL(COMSIG_DOCK_TRADER_WEST, event)
+			if("right")
+				SEND_GLOBAL_SIGNAL(COMSIG_DOCK_TRADER_EAST, event)
 
 	/// Get shuttle from centcom
 	proc/arrive()

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -25,6 +25,13 @@
 #endif
 		var/docked_where = shuttle == "diner" ? "space diner" : "station";
 		command_alert("A merchant shuttle will dock with the [docked_where] shortly.", "Commerce and Customs Alert")
+		if(shuttle == "diner")
+			SEND_GLOBAL_SIGNAL(COMSIG_TRADER_DINER)
+		else
+			if(shuttle == "left")
+				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_LEFT)
+			else
+				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RIGHT)
 		for(var/client/C in clients)
 			if(C.mob && (C.mob.z == Z_LEVEL_STATION))
 				C.mob.playsound_local(C.mob, 'sound/misc/announcement_chime.ogg', 30, 0)
@@ -41,14 +48,23 @@
 					end_location = locate(map_settings ? map_settings.merchant_right_station : /area/shuttle/merchant_shuttle/right_station)
 
 			var/list/dest_turfs = src.arrive()
+			SEND_GLOBAL_SIGNAL(COMSIG_TRADER_STOPPED)
 
-			SPAWN(rand(5 MINUTES, 10 MINUTES))
+			// SPAWN(rand(5 MINUTES, 10 MINUTES))
+			SPAWN(1 MINUTE) // TODO: This is for testing only don't leave it
 				command_alert("The merchant shuttle is preparing to undock, please stand clear.", "Merchant Departure Alert")
 
+				if(shuttle == "diner")
+					SEND_GLOBAL_SIGNAL(COMSIG_TRADER_DINER)
+				else
+					if(shuttle == "left")
+						SEND_GLOBAL_SIGNAL(COMSIG_TRADER_LEFT)
+					else
+						SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RIGHT)
 				sleep(30 SECONDS)
 
 				src.depart(dest_turfs)
-
+				SEND_GLOBAL_SIGNAL(COMSIG_TRADER_RETURNED)
 				active = FALSE
 
 	/// Get shuttle from centcom

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -50,8 +50,7 @@
 			var/list/dest_turfs = src.arrive()
 			SEND_GLOBAL_SIGNAL(COMSIG_TRADER_STOPPED)
 
-			// SPAWN(rand(5 MINUTES, 10 MINUTES))
-			SPAWN(1 MINUTE) // TODO: This is for testing only don't leave it
+			SPAWN(rand(5 MINUTES, 10 MINUTES))
 				command_alert("The merchant shuttle is preparing to undock, please stand clear.", "Merchant Departure Alert")
 
 				if(shuttle == "diner")

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -398,21 +398,30 @@
 	on = 0
 	wallmounted = 0
 	removable_bulb = 0
-	var/connected_signal = null
+	var/connected_dock = null
 
 	New()
 		..()
-		if(src.connected_signal)
-			RegisterSignal(GLOBAL_SIGNAL, src.connected_signal, .proc/incoming)
-			RegisterSignal(GLOBAL_SIGNAL, COMSIG_TRADER_STOPPED, .proc/stop )
-			RegisterSignal(GLOBAL_SIGNAL, COMSIG_TRADER_RETURNED, .proc/stop )
+		if(src.connected_dock)
+			RegisterSignal(GLOBAL_SIGNAL, src.connected_dock, .proc/dock_signal_handler)
 
-	proc/incoming()
-		color = "#eb6b15"
+	proc/dock_signal_handler(datum/holder, var/signal)
+		switch(signal)
+			if(COMSIG_DOCK_EVENT_INCOMING)
+				src.activate()
+			if(COMSIG_DOCK_EVENT_ARRIVED)
+				src.deactivate()
+			if(COMSIG_DOCK_EVENT_OUTGOING)
+				src.activate()
+			if(COMSIG_DOCK_EVENT_DEPARTED)
+				src.deactivate()
+
+	proc/activate()
+		color = "#da9b49"
 		on = 1
 		update()
 
-	proc/stop()
+	proc/deactivate()
 		color = null
 		on = 0
 		update()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -398,6 +398,7 @@
 	on = 0
 	wallmounted = 0
 	removable_bulb = 0
+	var/static/warning_color = "#da9b49"
 	var/connected_dock = null
 
 	New()
@@ -407,17 +408,17 @@
 
 	proc/dock_signal_handler(datum/holder, var/signal)
 		switch(signal)
-			if(COMSIG_DOCK_EVENT_INCOMING)
+			if(DOCK_EVENT_INCOMING)
 				src.activate()
-			if(COMSIG_DOCK_EVENT_ARRIVED)
+			if(DOCK_EVENT_ARRIVED)
 				src.deactivate()
-			if(COMSIG_DOCK_EVENT_OUTGOING)
+			if(DOCK_EVENT_OUTGOING)
 				src.activate()
-			if(COMSIG_DOCK_EVENT_DEPARTED)
+			if(DOCK_EVENT_DEPARTED)
 				src.deactivate()
 
 	proc/activate()
-		color = "#da9b49"
+		color = warning_color
 		on = 1
 		update()
 
@@ -426,18 +427,36 @@
 		on = 0
 		update()
 
-	delay2
-		icon_state = "runway20"
-		base_state = "runway2"
-	delay3
-		icon_state = "runway30"
-		base_state = "runway3"
-	delay4
-		icon_state = "runway40"
-		base_state = "runway4"
-	delay5
-		icon_state = "runway50"
-		base_state = "runway5"
+	trader_left // matching mapping area convensions
+		connected_dock = COMSIG_DOCK_TRADER_WEST
+
+		delay2
+			icon_state = "runway20"
+			base_state = "runway2"
+		delay3
+			icon_state = "runway30"
+			base_state = "runway3"
+		delay4
+			icon_state = "runway40"
+			base_state = "runway4"
+		delay5
+			icon_state = "runway50"
+			base_state = "runway5"
+
+	trader_right
+		connected_dock = COMSIG_DOCK_TRADER_EAST
+		delay2
+			icon_state = "runway20"
+			base_state = "runway2"
+		delay3
+			icon_state = "runway30"
+			base_state = "runway3"
+		delay4
+			icon_state = "runway40"
+			base_state = "runway4"
+		delay5
+			icon_state = "runway50"
+			base_state = "runway5"
 
 // Traffic lights on/off is signal controlled; light switches should not affect us.
 /obj/machinery/light/traffic_light/power_change()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -385,6 +385,58 @@
 		icon_state = "runway50"
 		base_state = "runway5"
 
+/obj/machinery/light/traffic_light
+	name = "warning light"
+	desc = "A small light used to warn when shuttle traffic is expected."
+	icon_state = "runway10"
+	base_state = "runway1"
+	fitting = "bulb"
+	brightness = 0.5
+	light_type = /obj/item/light/bulb
+	allowed_type = /obj/item/light/bulb
+	plane = PLANE_NOSHADOW_BELOW
+	on = 0
+	wallmounted = 0
+	removable_bulb = 0
+	var/connected_signal = null
+
+	New()
+		..()
+		if(src.connected_signal)
+			RegisterSignal(GLOBAL_SIGNAL, src.connected_signal, .proc/incoming)
+			RegisterSignal(GLOBAL_SIGNAL, COMSIG_TRADER_STOPPED, .proc/stop )
+			RegisterSignal(GLOBAL_SIGNAL, COMSIG_TRADER_RETURNED, .proc/stop )
+
+	proc/incoming()
+		color = "#eb6b15"
+		on = 1
+		update()
+
+	proc/stop()
+		color = null
+		on = 0
+		update()
+
+	delay2
+		icon_state = "runway20"
+		base_state = "runway2"
+	delay3
+		icon_state = "runway30"
+		base_state = "runway3"
+	delay4
+		icon_state = "runway40"
+		base_state = "runway4"
+	delay5
+		icon_state = "runway50"
+		base_state = "runway5"
+
+// Traffic lights on/off is signal controlled; light switches should not affect us.
+/obj/machinery/light/traffic_light/power_change()
+	if(src.loc)
+		var/area/A = get_area(src)
+		var/state = src.on && A.power_light
+		seton(state)
+
 /obj/machinery/light/beacon
 	name = "tripod light"
 	desc = "A large portable light tripod."

--- a/code/obj/airbridge.dm
+++ b/code/obj/airbridge.dm
@@ -257,6 +257,7 @@
 	name = "Airbridge Computer"
 	desc = "Used to control the airbridge."
 	id = "noodles"
+	icon = 'icons/obj/airtunnel.dmi'
 	icon_state = "airbr0"
 
 	// set this var to 1 in the map editor if you want the airbridge to establish and pressurize when the round starts
@@ -296,11 +297,11 @@
 
 	proc/dock_signal_handler(datum/holder, var/signal)
 		switch(signal)
-			if(COMSIG_DOCK_EVENT_INCOMING)
+			if(DOCK_EVENT_INCOMING)
 				src.establish_bridge()
-			if(COMSIG_DOCK_EVENT_ARRIVED)
+			if(DOCK_EVENT_ARRIVED)
 				src.pressurize()
-			if(COMSIG_DOCK_EVENT_DEPARTED)
+			if(DOCK_EVENT_DEPARTED)
 				src.remove_bridge()
 
 	proc/get_links()
@@ -479,11 +480,15 @@
 		status |= BROKEN
 
 /obj/machinery/computer/airbr/emergency_shuttle
-	icon = 'icons/obj/airtunnel.dmi'
 	emergency = 1
 
-/* -------------------- Button -------------------- */
+/obj/machinery/computer/airbr/trader_left // matching mapping area conventions
+	connected_dock = COMSIG_DOCK_TRADER_WEST
 
+/obj/machinery/computer/airbr/trader_right
+	connected_dock = COMSIG_DOCK_TRADER_EAST
+
+/* -------------------- Button -------------------- */
 /obj/machinery/airbr_test_button
 	name = "Airbridge Button"
 	icon = 'icons/obj/objects.dmi'

--- a/code/obj/airbridge.dm
+++ b/code/obj/airbridge.dm
@@ -469,6 +469,14 @@
 /obj/machinery/computer/airbr/emergency_shuttle
 	icon = 'icons/obj/airtunnel.dmi'
 	emergency = 1
+	var/connected_signal = null
+
+	New()
+		..()
+		if (src.connected_signal)
+			RegisterSignal(GLOBAL_SIGNAL, src.connected_signal, .proc/establish_bridge)
+			RegisterSignal(GLOBAL_SIGNAL, COMSIG_TRADER_RETURNED, .proc/remove_bridge)
+
 
 /* -------------------- Button -------------------- */
 

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2474,13 +2474,11 @@
 	},
 /area/station/crewquarters/cryotron)
 "afl" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
+/obj/machinery/computer/airbr/trader_left{
 	density = 0;
-	emergency = 0;
 	id = "merchant_N";
 	pixel_y = 32;
-	req_access_txt = "";
-	connected_dock = "trader_left"
+	req_access_txt = ""
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -4198,13 +4196,11 @@
 	},
 /area/station/crewquarters/cryotron)
 "aiq" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
+/obj/machinery/computer/airbr/trader_right{
 	density = 0;
-	emergency = 0;
 	id = "merchant_S";
 	pixel_y = 32;
-	req_access_txt = "";
-	connected_dock = "trader_right"
+	req_access_txt = ""
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -43731,9 +43727,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left,
 /turf/space,
 /area/station/shield_zone)
 "ele" = (
@@ -44201,9 +44195,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right,
 /turf/space,
 /area/station/shield_zone)
 "flb" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2480,7 +2480,7 @@
 	id = "merchant_N";
 	pixel_y = 32;
 	req_access_txt = "";
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -4204,7 +4204,7 @@
 	id = "merchant_S";
 	pixel_y = 32;
 	req_access_txt = "";
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -43732,7 +43732,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/station/shield_zone)
@@ -44202,7 +44202,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/station/shield_zone)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2479,7 +2479,8 @@
 	emergency = 0;
 	id = "merchant_N";
 	pixel_y = 32;
-	req_access_txt = ""
+	req_access_txt = "";
+	connected_signal = "trader_left"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -4202,7 +4203,8 @@
 	emergency = 0;
 	id = "merchant_S";
 	pixel_y = 32;
-	req_access_txt = ""
+	req_access_txt = "";
+	connected_signal = "trader_right"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -43725,6 +43727,15 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"ekn" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light{
+	connected_signal = "trader_left"
+	},
+/turf/space,
+/area/station/shield_zone)
 "ele" = (
 /obj/cable{
 	d1 = 1;
@@ -44186,6 +44197,15 @@
 	},
 /turf/simulated/floor/damaged2,
 /area/station/quartermaster/storage)
+"fjt" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light{
+	connected_signal = "trader_right"
+	},
+/turf/space,
+/area/station/shield_zone)
 "flb" = (
 /obj/cable,
 /obj/cable{
@@ -90006,10 +90026,10 @@ aay
 rlE
 afl
 ajr
-agq
+ekn
 agJ
 agJ
-agq
+fjt
 rlE
 aiq
 ajr

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -2850,7 +2850,9 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay5,
+/obj/machinery/light/traffic_light/delay5{
+	connected_signal = "trader_right"
+	},
 /turf/space,
 /area/space)
 "agE" = (
@@ -2858,7 +2860,9 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay4,
+/obj/machinery/light/traffic_light/delay4{
+	connected_signal = "trader_left"
+	},
 /turf/space,
 /area/space)
 "agF" = (
@@ -5641,7 +5645,9 @@
 	dir = 8;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay3,
+/obj/machinery/light/traffic_light/delay3{
+	connected_signal = "trader_left"
+	},
 /turf/space,
 /area/space)
 "anm" = (
@@ -68614,7 +68620,6 @@
 	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/space)
 "cZv" = (
@@ -76773,6 +76778,16 @@
 /obj/item/tank/jetpack/micro,
 /turf/simulated/floor/bot,
 /area/station/ai_monitored/storage/eva)
+"iwD" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay3{
+	connected_signal = "trader_right"
+	},
+/turf/space,
+/area/space)
 "izF" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
@@ -77173,6 +77188,16 @@
 /obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/hangar/science)
+"kiP" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay4{
+	connected_signal = "trader_right"
+	},
+/turf/space,
+/area/space)
 "kiZ" = (
 /obj/cable,
 /obj/cable{
@@ -77402,6 +77427,16 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
+"lqm" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay3{
+	connected_signal = "trader_left"
+	},
+/turf/space,
+/area/space)
 "lsb" = (
 /obj/cable{
 	d1 = 4;
@@ -78981,6 +79016,16 @@
 	dir = 4
 	},
 /area/shuttle/arrival/station)
+"svA" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay5{
+	connected_signal = "trader_left"
+	},
+/turf/space,
+/area/space)
 "sEu" = (
 /obj/cable{
 	d1 = 4;
@@ -102360,14 +102405,14 @@ aaa
 aaa
 aaa
 aaa
-agD
+svA
 aaa
 ahg
 ahg
 ahg
 ahg
 aaa
-agD
+svA
 aaa
 aaa
 aaa
@@ -103081,14 +103126,14 @@ aaa
 aaa
 aaa
 aaa
-aao
+kiP
 dax
 dax
 dax
 dax
 dax
 dax
-aao
+kiP
 aaa
 aaa
 aaa
@@ -103383,14 +103428,14 @@ aaa
 aaa
 aaa
 aaa
-agE
+aao
 dax
 dax
 dax
 dax
 dax
 dax
-agE
+aao
 aaa
 aaa
 aaa
@@ -103685,14 +103730,14 @@ aaa
 aaa
 aaa
 aaa
-aao
+iwD
 dax
 dax
 dax
 dax
 dax
 dax
-aao
+iwD
 aaa
 aaa
 aaa
@@ -104172,7 +104217,7 @@ aaa
 aaa
 aaa
 aaa
-afA
+lqm
 aaa
 afI
 aiE
@@ -104296,7 +104341,7 @@ dcj
 dcj
 dbu
 aaa
-afA
+aao
 aaa
 aaa
 aaa

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -2851,7 +2851,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay5{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/space)
@@ -2861,7 +2861,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay4{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)
@@ -5646,7 +5646,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay3{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)
@@ -76784,7 +76784,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay3{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/space)
@@ -77194,7 +77194,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay4{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/space)
@@ -77433,7 +77433,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay3{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)
@@ -79022,7 +79022,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay5{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -2850,9 +2850,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay5{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right/delay5,
 /turf/space,
 /area/space)
 "agE" = (
@@ -2860,9 +2858,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay4{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left/delay4,
 /turf/space,
 /area/space)
 "agF" = (
@@ -5645,9 +5641,7 @@
 	dir = 8;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay3{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left/delay3,
 /turf/space,
 /area/space)
 "anm" = (
@@ -76783,9 +76777,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay3{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right/delay3,
 /turf/space,
 /area/space)
 "izF" = (
@@ -77193,9 +77185,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay4{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right/delay4,
 /turf/space,
 /area/space)
 "kiZ" = (
@@ -77432,9 +77422,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay3{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left/delay3,
 /turf/space,
 /area/space)
 "lsb" = (
@@ -79021,9 +79009,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay5{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left/delay5,
 /turf/space,
 /area/space)
 "sEu" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -31573,6 +31573,16 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"iPT" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay3{
+	connected_signal = "trader_right"
+	},
+/turf/space,
+/area/space)
 "iQk" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41928,6 +41938,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
+"ojO" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light/delay3{
+	connected_signal = "trader_left"
+	},
+/turf/space,
+/area/space)
 "ojU" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -44409,7 +44429,8 @@
 	emergency = 0;
 	id = "merchant_R";
 	pixel_y = 32;
-	req_access_txt = ""
+	req_access_txt = "";
+	connected_signal = "trader_right"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
@@ -49098,7 +49119,8 @@
 	emergency = 0;
 	id = "merchant_L";
 	pixel_y = 32;
-	req_access_txt = ""
+	req_access_txt = "";
+	connected_signal = "trader_left"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
@@ -53656,6 +53678,16 @@
 /obj/machinery/bot/guardbot/mail,
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
+"uAd" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light{
+	connected_signal = "trader_right"
+	},
+/turf/space,
+/area/space)
 "uAP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
@@ -54390,6 +54422,16 @@
 	dir = 9
 	},
 /area/station/science/lobby)
+"uOv" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/traffic_light{
+	connected_signal = "trader_left"
+	},
+/turf/space,
+/area/space)
 "uOB" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -103920,9 +103962,9 @@ aaa
 crG
 aaa
 aaa
-aaa
+ojO
 oTy
-aaa
+uOv
 aaa
 gEl
 rKX
@@ -109960,9 +110002,9 @@ aaa
 cCx
 aaa
 aaa
-aaa
+uAd
 cAY
-aaa
+iPT
 aaa
 aaa
 apR

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -31578,9 +31578,7 @@
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay3{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right,
 /turf/space,
 /area/space)
 "iQk" = (
@@ -41943,9 +41941,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light/delay3{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left,
 /turf/space,
 /area/space)
 "ojU" = (
@@ -44424,13 +44420,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "pCL" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
+/obj/machinery/computer/airbr/trader_right{
 	density = 0;
-	emergency = 0;
 	id = "merchant_R";
 	pixel_y = 32;
-	req_access_txt = "";
-	connected_dock = "trader_right"
+	req_access_txt = ""
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
@@ -49114,13 +49108,11 @@
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/pool)
 "sbJ" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
+/obj/machinery/computer/airbr/trader_left{
 	density = 0;
-	emergency = 0;
 	id = "merchant_L";
 	pixel_y = 32;
-	req_access_txt = "";
-	connected_dock = "trader_left"
+	req_access_txt = ""
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
@@ -53683,9 +53675,7 @@
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light{
-	connected_dock = "trader_right"
-	},
+/obj/machinery/light/traffic_light/trader_right,
 /turf/space,
 /area/space)
 "uAP" = (
@@ -54427,9 +54417,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/traffic_light{
-	connected_dock = "trader_left"
-	},
+/obj/machinery/light/traffic_light/trader_left,
 /turf/space,
 /area/space)
 "uOB" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -31579,7 +31579,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay3{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/space)
@@ -41944,7 +41944,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light/delay3{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)
@@ -44430,7 +44430,7 @@
 	id = "merchant_R";
 	pixel_y = 32;
 	req_access_txt = "";
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
@@ -49120,7 +49120,7 @@
 	id = "merchant_L";
 	pixel_y = 32;
 	req_access_txt = "";
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
@@ -53684,7 +53684,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light{
-	connected_signal = "trader_right"
+	connected_dock = "trader_right"
 	},
 /turf/space,
 /area/space)
@@ -54428,7 +54428,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/traffic_light{
-	connected_signal = "trader_left"
+	connected_dock = "trader_left"
 	},
 /turf/space,
 /area/space)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE][MAPPING][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Feature: signals for trading docks: `COMSIG_DOCK_TRADER_*`
* Feature: events for shuttle docking `DOCK_EVENT_*`
* Feature: new light subtypes: `/obj/machinery/light/traffic_light`
  * Implements for cogmap2; valuable info given the distance between trader ports
* Feature: New Airbridge subtypes (`/obj/machinery/computer/airbr`)
  * Implements for Clarion and Destiny, where extending them is a manual chore

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make in-game events more immersive. Clear visual feedback/indication for players (before they get squished/ditched by the trader shuttle).

I can put together a follow-up PR adding these lights to more maps. 

Getting the implementation/pattern right here is important to me as I want to extend this to transit shuttles.

## Examples

https://user-images.githubusercontent.com/91498627/191144561-e15ca046-0e92-4dec-96f2-89f2b999cfac.mp4

https://user-images.githubusercontent.com/91498627/191144599-44da8374-a350-42cb-a642-9d4c4f06c83f.mp4

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(*)Destiny and Clarion's airbridges now extend, pressurize, and retract automatically for traders
(+)Cogmap2's trader docks now light up when traders are set to arrive and depart
```
