### PR TITLE
Makes buttcrabs immune to tox damage

### DIFF
--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -257,7 +257,6 @@
 	setup_healths()
 		add_hh_flesh(5, 1)
 		add_hh_flesh_burn(4, 1.25)
-		add_health_holder(/datum/healthHolder/toxin)
 
 
 	//Give master the DNA we collected, the DNA points it cost to create us, and their arm back!
@@ -562,7 +561,8 @@
 	setup_healths()
 		add_hh_flesh(16, 1)
 		add_hh_flesh_burn(5, 1.25)
-		add_health_holder(/datum/healthHolder/toxin)
+
+
 
 	return_to_master()
 		if (ishuman(hivemind_owner.owner))

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -257,6 +257,7 @@
 	setup_healths()
 		add_hh_flesh(5, 1)
 		add_hh_flesh_burn(4, 1.25)
+		add_health_holder(/datum/healthHolder/toxin)
 
 
 	//Give master the DNA we collected, the DNA points it cost to create us, and their arm back!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It makes buttcrabs immune to tox damage.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes no sense for buttcrabs to be able to take tox damage as they are a sentient ass with legs. It also fixes #10910 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)golferjoe
(+)Buttcrabs are now immune to tox damage.
```
