### PR TITLE
New Command Traitor Item: AI Laser Upgrade Modules

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -984,9 +984,10 @@ This is basically useless for anyone but miners.
 	item = /obj/item/aiModule/ability_expansion/laser
 	cost = 6
 	vr_allowed = FALSE
+	not_in_crates = TRUE
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
-	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
+	can_buy = UPLINK_TRAITOR
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -983,7 +983,7 @@ This is basically useless for anyone but miners.
 	name = "AI Camera Taser Module"
 	item = /obj/item/aiModule/ability_expansion/taser
 	cost = 6
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the tasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -992,7 +992,7 @@ This is basically useless for anyone but miners.
 	name = "AI Camera Laser Module"
 	item = /obj/item/aiModule/ability_expansion/laser
 	cost = 7
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -979,6 +979,24 @@ This is basically useless for anyone but miners.
 	not_in_crates = 1
 	can_buy = UPLINK_TRAITOR
 
+/datum/syndicate_buylist/traitor/ai_taser
+	name = "AI Camera Taser Module"
+	item = /obj/item/aiModule/ability_expansion/taser
+	cost = 6
+	vr_allowed = 0
+	desc = "An AI module that upgrades any AI connected to the installed law rack access to the tasers installed in the cameras."
+	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
+
+/datum/syndicate_buylist/traitor/ai_laser
+	name = "AI Camera Laser Module"
+	item = /obj/item/aiModule/ability_expansion/laser
+	cost = 7
+	vr_allowed = 0
+	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
+	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -979,19 +979,10 @@ This is basically useless for anyone but miners.
 	not_in_crates = 1
 	can_buy = UPLINK_TRAITOR
 
-/datum/syndicate_buylist/traitor/ai_taser
-	name = "AI Camera Taser Module"
-	item = /obj/item/aiModule/ability_expansion/taser
-	cost = 6
-	vr_allowed = FALSE
-	desc = "An AI module that upgrades any AI connected to the installed law rack access to the tasers installed in the cameras."
-	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
-	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
-
 /datum/syndicate_buylist/traitor/ai_laser
 	name = "AI Camera Laser Module"
 	item = /obj/item/aiModule/ability_expansion/laser
-	cost = 7
+	cost = 6
 	vr_allowed = FALSE
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE] [INPUT WANTED] [EXPERIMENTAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds a new item for traitorous heads of staff, an upgrade module that lets the AI use a laser ability from their cameras. The laser module shoots a 20 damage phaser shot, with a 10 second cool down, that costs 6 tc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI ability upgrade modules have been in the code for a while now, and I figured this ability wouldn't really fit as anything other than a traitor item. Plus gives traitor members of command more control of how a rogue AI can help them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Adds a new command traitor item: An AI laser upgrade module that costs 6 tc.
