### PR TITLE
Fixes computer3 subtypes reverting to computer3 when deconstructing/reconstructing

### DIFF
--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -33,6 +33,7 @@
 		desc = "A light micro-computer frame used for terminal systems."
 		icon = 'icons/obj/terminal_frame.dmi'
 		created_icon_state = "dterm"
+		computer_type = /obj/machinery/computer3/terminal
 		material_amt = 0.3
 		max_peripherals = 2
 		metal_given = 3
@@ -42,6 +43,7 @@
 		name = "Desktop Computer-frame"
 		icon = 'icons/obj/computer_frame_desk.dmi'
 		created_icon_state = "old"
+		computer_type = /obj/machinery/computer3/personal/personel_alt
 		max_peripherals = 3
 		metal_given = 3
 		glass_needed = 1

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -24,6 +24,7 @@
 	var/max_peripherals = 3
 	var/list/peripherals = list()
 	var/created_icon_state = "computer_generic"
+	var/computer_type = /obj/machinery/computer3
 	var/glass_needed = 2 //How much glass does this need for a screen?
 	var/metal_given = 5 //How much metal does this give when destroyed?
 
@@ -181,7 +182,9 @@
 			if (isscrewingtool(P))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				boutput(user, "<span class='notice'>You connect the monitor.</span>")
-				var/obj/machinery/computer3/C= new /obj/machinery/computer3( src.loc )
+				if(!ispath(computer_type, /obj/machinery/computer3))
+					src.computer_type = /obj/machinery/computer3
+				var/obj/machinery/computer3/C= new src.computer_type( src.loc )
 				C.set_dir(src.dir)
 				if(src.material) C.setMaterial(src.material)
 				C.setup_drive_size = 0

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -691,6 +691,7 @@ function lineEnter (ev)
 	if(!ispath(setup_frame_type, /obj/computer3frame))
 		src.setup_frame_type = /obj/computer3frame
 	var/obj/computer3frame/A = new setup_frame_type( src.loc )
+	A.computer_type = src.type
 	if(src.material) A.setMaterial(src.material)
 	A.created_icon_state = src.base_icon_state
 	A.set_dir(src.dir)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[P-Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you remove the screen of a subtype of obj/machinery/computer3 with a screwdriver then screw the screen back on, the subtype computer frame (ie: a computer3/terminal, a computer3/desktop etc.) will be built as a standard console (aka computer3).

This is because frame construction code doesn't pay attention to the frame subtype when screwing a computer together - it just makes a standard computer3 console irregardless of frame.

This PR makes frames keep track of what computer they're supposed to turn into & ensures they turn into the correct one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10591
