### PR TITLE
Remove cyborg module automatically when installing new one

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -827,11 +827,13 @@
 			if(moduleRef)
 				var/obj/item/robot_module/module = locate(moduleRef) in src.modules
 				if (module)
-					if (R.module)
-						boutput(user, "<span class='alert'>[R] already has a module installed!</span>")
-					else
-						R.set_module(module)
-						src.modules.Remove(module)
+					if (R.module) // Remove installed module to make room for new module
+						var/obj/item/robot_module/removed_module = R.remove_module()
+						src.modules.Add(removed_module)
+						removed_module.set_loc(src)
+
+					R.set_module(module)
+					src.modules.Remove(module)
 					R.update_appearance()
 			. = TRUE
 		if("module-remove")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When installing a cyborg module, make the previous module automatically uninstall.

Tested with a cyborg changing their own module and a human changing a cyborg module.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL for cyborgs so they won't need to remove their module first, switch to a different page of the cyborg docking station, then install the module they want.


## Changelog

```changelog
(u)DrWolfy
(+)Equipping a cyborg module in the cyborg docking station while already having one installed will swap the two.
```
