### PR TITLE
Adds Fomalhaut MRL to nuke ops commander uplink

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1172,6 +1172,13 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	desc = "Did you lose the nuke? Have no fear, with this handy one-use remote, you can immediately call it back to you!"
 	category = "Main"
 
+/datum/syndicate_buylist/commander/mrl
+	name = "Fomelhaut MRL"
+	item = /obj/item/gun/kinetic/mrl/loaded
+	cost = 3
+	desc = "A  6-barrel multiple rocket launcher armed with guided micro-missiles. Warning: Can and will target other Operatives."
+	category = "Main"
+
 /////////////////////////////////////////// Telecrystals //////////////////////////////////////////////////
 
 /datum/syndicate_buylist/generic/telecrystal

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1173,7 +1173,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	category = "Main"
 
 /datum/syndicate_buylist/commander/mrl
-	name = "Fomelhaut MRL"
+	name = "Fomalhaut MRL"
 	item = /obj/item/gun/kinetic/mrl/loaded
 	cost = 3
 	desc = "A  6-barrel multiple rocket launcher armed with guided micro-missiles. Warning: Can and will target other Operatives."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Fomalhaut MRL to the nuke ops commander uplink for a cost of 3 points.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Surely this is a good idea.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Added Fomalhaut MRL to the nuke ops commander uplink for a cost of 3 points. 
```
