### PR TITLE
Fixes #10936 - Changes Stealth Storages To No Longer Be Flammable

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -269,6 +269,7 @@
 	flags = FPRINT | TABLEPASS | NOSPLASH
 	w_class = W_CLASS_SMALL
 	max_wclass = W_CLASS_NORMAL
+	burn_possible = FALSE
 
 	New()
 		..()


### PR DESCRIPTION
[Game Objects] [Bug]


## About the PR:
Fixes #10936 by setting the `burn_possible` var to `FALSE` for the stealth storage. The stealth storage currently inherits the flammability values from `obj/item/storage`, leading to it burning in fires over 2,500°C.