### PR TITLE
Makes flockdrones slowed instead of stunned and EMP items they pick up

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -111,6 +111,12 @@
 		var/datum/limb/L = src.equipped_limb()
 		L.grab(target, src)
 	. = ..()
+	if (istype(target, /obj/item) && target.loc == src) //no batong for radio birds
+		target.emp_act()
+
+//trying out a world where you can't stun flockdrones
+/mob/living/critter/flock/do_disorient(stamina_damage, weakened, stunned, paralysis, disorient, remove_stamina_below_zero, target_type, stack_stuns)
+	src.changeStatus("slowed", max(weakened, stunned, paralysis, disorient))
 
 /mob/living/critter/flock/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES] [INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes flockdrone stuns work like silicon stuns, except they get slowed instead of stunned for the duration. This means all stun sources (flash, baton, taser) will apply a slow for the duration they would have stunned a borg for.
Because yass threatened to remove their hands otherwise, flockdrones now EMP any item they pick up. This means any stun baton or taser they pick up will have all its charge drained instantly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently flockdrones get instantly full stunned by flash area attacks and demolished by tasers and batons. These changes are intended to make stuns still useful as a way to isolate and pick off drones without one flash being able to shut down an entire room of drones.
It might also be good to make stuns drain flock incapacitor charge, but that would require #10843 being merged first.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Flockdrones are now slowed whenever they would have been stunned.
(*)Flockdrones now EMP any item they pick up.
```
