### PR TITLE
Removes "thrall" prefix from thrall names and gives them a speech effect

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -390,8 +390,6 @@
 					owner.TakeDamage("chest", 0, 30)
 					return
 
-
-			M.real_name = "thrall [M.real_name]"
 			if (M.mind)
 				M.mind.special_role = ROLE_VAMPTHRALL
 				if(ismob(owner))

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1052,11 +1052,13 @@ TYPEINFO(/datum/mutantrace)
 		if(ishuman(src.mob))
 			src.add_ability(src.mob)
 			M.add_stam_mod_max("vampiric_thrall", 100)
+			M.bioHolder.AddEffect("accent_thrall", magical=TRUE)
 			//APPLY_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall", 15)
 
 	disposing()
 		if (ishuman(src.mob))
 			src.mob.remove_stam_mod_max("vampiric_thrall")
+			src.mob.bioHolder.RemoveEffect("accent_thrall")
 			//REMOVE_ATOM_PROPERTY(src.mob, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall")
 		..()
 

--- a/code/modules/medical/genetics/bioEffects/speech.dm
+++ b/code/modules/medical/genetics/bioEffects/speech.dm
@@ -821,7 +821,7 @@
 	can_reclaim = 0
 	can_scramble = 0
 	curable_by_mutadone = 0
-	acceptable_in_mutini = 0
+	acceptable_in_mutini = 1
 
 	OnSpeak(message)
 		if (!istext(message))

--- a/code/modules/medical/genetics/bioEffects/speech.dm
+++ b/code/modules/medical/genetics/bioEffects/speech.dm
@@ -803,3 +803,27 @@
 			return ""
 		message = scoobify(message, 1)
 		return message
+
+/datum/bioEffect/speech/thrall
+	name = "Frontal Gyrus Alteration Type-V"
+	desc = "Forces the language center of the subject's brain to emit gurgling, raspy speech."
+	id = "accent_thrall"
+	effectType = EFFECT_TYPE_DISABILITY
+	isBad = 1
+	msgGain = "Your throat gurgles with blood."
+	msgLose = "You feel your throat clear."
+	probability = 0
+	occur_in_genepools = 0
+	scanner_visibility = 0
+	can_research = 0
+	can_make_injector = 0
+	can_copy = 0
+	can_reclaim = 0
+	can_scramble = 0
+	curable_by_mutadone = 0
+	acceptable_in_mutini = 0
+
+	OnSpeak(message)
+		if (!istext(message))
+			return ""
+		return thrall_parse(message)

--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -2342,3 +2342,10 @@ var/list/zalgo_mid = list(
 		modded += pick(" rhaggy!"," rir bruddy."," rhoinks!"," rharoo!")
 
 	return modded
+
+/proc/thrall_parse(var/string)
+	var/list/end_punctuation = list("!", "?", ".")
+	var/pos = length(string)
+	while (pos > 0 && (string[pos] in end_punctuation))
+		string = copytext(string, 1, pos--)
+	return string + "..."

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -449,7 +449,7 @@
 		if (src.bioHolder.HasEffect("accent_comic"))
 			font_accent = "Comic Sans MS"
 
-		if (src.bioHolder && src.bioHolder.genetic_stability < 50)
+		if (src.bioHolder.genetic_stability < 50 || src.bioHolder.HasEffect("accent_thrall"))
 			speechverb = "gurgles"
 
 	if (src.get_brain_damage() >= 60)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES] [ADD TO WIKI] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the eternally buggy "thrall" prefix from vampiric thralls, and instead gives them a speech effect causing their speech verb to be "gurgles", removes any ending punctuation from their messages and adds "..." to the end.
So `Yes!` becomes 
![image](https://user-images.githubusercontent.com/20713227/191807902-62cf8a83-5af1-4f67-8976-ed1ae60704f7.png)
and `WHAT?!` becomes
![image](https://user-images.githubusercontent.com/20713227/191808361-173cb738-dd6b-4ee0-a51b-6a90fa4739b2.png)
Fixes #8640


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Suggested here: https://forum.ss13.co/showthread.php?tid=19764
Makes it a bit more subtle, while still obvious when you speak.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Vampiric thralls no longer have "thrall" added to their name, and instead have a gurgling speech effect.
```
