### PR TITLE
Fixes incorrect thrall special role popup

### DIFF
--- a/browserassets/html/traitorTips/vampiricthrallTips.html
+++ b/browserassets/html/traitorTips/vampiricthrallTips.html
@@ -2,6 +2,6 @@
 <div class="traitor-tips">
     <h1 class="center">You have been revived as a thrall!</h1>
     <p>You feel an <em>unwavering loyalty</em> to your new master! (As such, <em>do not reveal their identity</em> or otherwise act against their best interests.)</p>
-	<p>You will slowly lose blood points over time. Your max health will decrease as blood points are lost. You can regain blood points by taking an additional donation from your master.>
+	<p>You will slowly lose blood points over time. Your max health will decrease as blood points are lost. You can regain blood points by drinking the blood of humans or taking an additional donation from your master.
 	<p>For more information, consult <a href='?src={ref};wiki=Thrall'>the wiki</a></p>
 </div>

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -409,7 +409,6 @@
 				VZ.master = src
 
 			boutput(M, "<span class='alert'><b>You awaken filled with purpose - you must serve your master vampire, [owner.real_name]!</B></span>")
-			M.show_antag_popup("mindhack")
 			M.antagonist_overlay_refresh(1)
 			owner.antagonist_overlay_refresh(1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes being thralled incorrectly displaying the mindhack antag popup and also updates the thrall popup.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad.