### PR TITLE
Fixes a runtime with the syndie zippo lighter

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1279,8 +1279,8 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 			if (master)
 				if(istype(master,/obj/item/device/light/zippo) && master:on)
 					var/obj/item/device/light/zippo/Z = master
-					if (Z.reagents.get_reagent_amount("fuel"))
-						Z.reagents.remove_reagent("fuel", 1)
+					if (Z.infinite_fuel || Z.reagents?.get_reagent_amount("fuel"))
+						Z.reagents?.remove_reagent("fuel", 1)
 						flame_succ = 1
 					else
 						flame_succ = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME] [GAME OBJECT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
^


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I probably caused this at some point
