### PR TITLE
Fixes abilitystat line length again

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -1196,7 +1196,7 @@
 			if (H.topBarRendered && H.rendered)
 				var/list/stats = H.onAbilityStat()
 				for (var/x in stats)
-					var/line_length = length(x) + 1 + length(stats[x])
+					var/line_length = length(x) + 1 + length(num2text(stats[x]))
 					longest_line = max(longest_line, line_length)
 					msg += "[x] [stats[x]]<br>"
 					i++


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a missing type conversion causing abilitystats to be slightly too short and cull the text

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hey you remember when thralls could see their max health in an abilitystat display? Now that works again!