### PR TITLE
buff fire bots, probably too much

### DIFF
--- a/code/mob/living/critter/mob_bots.dm
+++ b/code/mob/living/critter/mob_bots.dm
@@ -268,10 +268,10 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 		. = ..()
 		color = pick(list(
 			null,\
-			list(0,1,0,0,0,1,1,0,0),\
-			list(0,0,1,1,0,0,0,1,0),\
-			list(0.5,0.5,0,0,0.5,0.5,0.5,0,0.5),\
-			list(0.5,0,0.5,0.5,0.5,0,0,0.5,0.5),
+			list(0.780465,0.129599,0.76233,0,0.0941811,0.94407,0.867769,0,0.858187,0.639099,0.46042,0,0,0,0,1,0,0,0,0),\
+			list(0.309832,0.486208,0.704786,0,0.57733,0.407169,0.343657,0,0.440741,0.307279,0.0361456,0,0,0,0,1,0,0,0,0),\
+			list(0.923407,0.489071,0.0133575,0,0.416634,0.00596684,0.0659536,0,0.151125,0.954365,0.946033,0,0,0,0,1,0,0,0,0),\
+			list(0.34802,0.586676,0.382593,0,0.265555,0.208964,0.409951,0,0.395675,0.227339,0.498367,0,0,0,0,1,0,0,0,0),
 		))
 
 		src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_foam)
@@ -283,6 +283,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 			playsound(src, 'sound/effects/sparks4.ogg', 50)
 			src.audible_message("<span class='alert'><B>[src] buzzes oddly!</B></span>")
 			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_fire)
+			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_foam/fuel)
 			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_foam/throw_humans)
 			src.emagged = TRUE
 			return TRUE
@@ -294,6 +295,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 		New()
 			. = ..()
 			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_fire)
+			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_foam/fuel)
 			src.abilityHolder.addAbility(/datum/targetable/critter/bot/spray_foam/throw_humans)
 
 
@@ -306,6 +308,12 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 	icon = 'icons/mob/critter_ui.dmi'
 	icon_state = "firebot_foam"
 	var/const/num_water_effects = 5
+	/// list of reagents to spray and their quantities
+	var/list/spray_reagents = list("water"=2, "ff-foam"=8)
+	/// reagent container size, passed to the spray proc
+	var/max_spray = 15
+	/// temp of the sprayed reagents
+	var/spray_temperature=T20C
 
 	cast(atom/target)
 		if(!holder?.owner)
@@ -326,10 +334,18 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 			if(!W) return
 			W.set_loc(get_turf(holder.owner))
 			var/turf/my_target = pick(the_targets)
-			var/datum/reagents/R = new/datum/reagents(15)
-			R.add_reagent("water", 2)
-			R.add_reagent("ff-foam", 8)
+			var/datum/reagents/R = new/datum/reagents(max_spray)
+			for(var/reagent_key in spray_reagents)
+				R.add_reagent(reagent_key, spray_reagents[reagent_key], temp_new = spray_temperature)
 			W.spray_at(my_target, R, 1)
+
+	fuel
+		name = "Spray Burning Fuel"
+		desc = "Spray burning fuel all over the place. Highly flammable but near useless in flooded areas."
+		icon_state = "firebot_fire"
+		spray_reagents = list("fuel"=5)
+		spray_temperature = T0C + 200
+		cooldown = 15 SECONDS
 
 	throw_humans
 		name = "High Pressure Foam"
@@ -348,7 +364,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 
 /datum/targetable/critter/bot/spray_fire
 	name = "Spray Flames"
-	desc = "Sometimes you gotta make your own fun."
+	desc = "Sometimes you gotta make your own fun. Spray a short range flammable aerosol. Works in flooded areas."
 	targeted = TRUE
 	target_anything = TRUE
 	cooldown = 10 SECONDS
@@ -356,7 +372,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 	icon_state = "firebot_fire"
 	var/max_fire_range = 3
 	cooldown = 10 SECONDS
-	var/temp = 1200
+	var/temp = 7000
 
 	cast(atom/target)
 		if (..())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Gives firebots a new skill to spray burning welding fuel. Doesn't work in flooded areas so they get to keep the old flame puff too
- Increases the temperature of the fire puff to 7000 to be more consistent with other heat sources
- New firebot colors that aren't awful
![image](https://user-images.githubusercontent.com/33204415/192022354-9f454f4a-8efe-4849-a900-b5444698cae5.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- make firebots more fun to play


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Playable emagged firebots now how have a new skill to spray burning welding fuel, and come in less ugly colors.
```
