### PR TITLE
Adds A Chance for Wraith On Spy-Thieves

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -161,7 +161,7 @@
 	if (traitor_scaling)
 		num_spies = clamp(round((num_players + randomizer) / pop_divisor), 2, spies_possible)
 
-	if (num_spies > 4 && prob(10))
+	if (num_spies > 2 && prob(10))
 		num_spies -= 1
 		num_wraiths = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODE] [FEATURE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds a chance (10%) for a wraith to spawn on the spy-thieves game mode if there is at least 3 round-start spies.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should increase the chance that players get to play wraiths, while also giving sec something to do while the spy-thieves setup.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CodeDude
(*)Round-start wraiths can now appear on the spy-thieves game mode if there is at least 3 spies.
```
