### PR TITLE
Prevents A Non-Admin Respawn Antag Wraith from Spawning If A Wraith is Already Alive

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -44,6 +44,13 @@
 				return
 
 			src.antagonist_type = pick(list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Flockmind"))
+			for(var/mob/wraith/W in ROLE_WRAITH)
+				if(W.deaths < 2)
+					src.antagonist_type -= list("Wraith")
+					src.antagonist_type = pick(list())
+				if(isnull(W.deaths))
+					return
+
 
 		switch (src.antagonist_type)
 			if ("Blob", "Blob (AI)")

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -51,7 +51,6 @@
 				if(isnull(W.deaths))
 					return
 
-
 		switch (src.antagonist_type)
 			if ("Blob", "Blob (AI)")
 				src.centcom_headline = initial(src.centcom_headline) // Gotta reset this.

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -49,7 +49,7 @@
 					src.antagonist_type -= list("Wraith")
 					src.antagonist_type = pick(list())
 				if(isnull(W.deaths))
-					return
+					continue
 
 		switch (src.antagonist_type)
 			if ("Blob", "Blob (AI)")

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -44,7 +44,7 @@
 				return
 
 			src.antagonist_type = pick(list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Flockmind"))
-			for(var/mob/wraith/W in ROLE_WRAITH)
+			for(var/mob/wraith/W in ticker.mode.traitors)
 				if(W.deaths < 2)
 					src.antagonist_type -= list("Wraith")
 					src.antagonist_type = pick(list())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This prevents another wraith from being chosen as the random event antag if a wraith is still alive. This does not affect the admin event.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Multiple wraiths cause issues, both for the crew having to deal with multiple wraiths, and for other wraiths trying to absorb bodies.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->


