### PR TITLE
Add a time before Flocktraces die

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -18,6 +18,7 @@ var/flock_signal_unleashed = FALSE
 	var/list/priority_tiles = list()
 	var/list/deconstruct_targets = list()
 	var/list/traces = list()
+	var/queued_trace_deaths = 0
 	/// Store a list of all minds who have been flocktraces of this flock at some point, indexed by name
 	var/list/trace_minds = list()
 	/// Store the mind of the current flockmind

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -175,6 +175,10 @@
 		flock.addAnnotation(src, FLOCK_ANNOTATION_FLOCKMIND_CONTROL)
 	else
 		flock.addAnnotation(src, FLOCK_ANNOTATION_FLOCKTRACE_CONTROL)
+		var/mob/living/intangible/flock/trace/flocktrace = pilot
+		if (flocktrace.dying)
+			src.addOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+			src.updateOverlaysClient(src.client)
 	if (give_alert)
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] established.\]</b></span>")
 
@@ -217,6 +221,10 @@
 			flock?.removeAnnotation(src, FLOCK_ANNOTATION_FLOCKMIND_CONTROL)
 		else
 			flock?.removeAnnotation(src, FLOCK_ANNOTATION_FLOCKTRACE_CONTROL)
+			var/mob/living/intangible/flock/trace/flocktrace = src.controller
+			if (flocktrace.dying)
+				src.removeOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+				src.updateOverlaysClient(src.client)
 		if (give_alerts && src.z == Z_LEVEL_STATION)
 			flock_speak(null, "Control of drone [src.real_name] surrended.", src.flock)
 
@@ -260,6 +268,10 @@
 		flock?.removeAnnotation(src, FLOCK_ANNOTATION_FLOCKMIND_CONTROL)
 	else
 		flock?.removeAnnotation(src, FLOCK_ANNOTATION_FLOCKTRACE_CONTROL)
+		var/mob/living/intangible/flock/trace/flocktrace = src.controller
+		if (flocktrace.dying)
+			src.removeOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+			src.updateOverlaysClient(src.client)
 	controller = null
 	src.update_health_icon()
 	src.flock_name_tag.set_info_tag(capitalize(src.ai.current_task.name))

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -10,6 +10,8 @@
 
 	compute = -FLOCKTRACE_COMPUTE_COST //it is expensive to run more threads
 
+	var/dying = FALSE
+
 /mob/living/intangible/flock/trace/New(atom/loc, datum/flock/F, free = FALSE)
 	if (free)
 		src.compute = 0
@@ -88,9 +90,24 @@
 /mob/living/intangible/flock/trace/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
-	if (src.flock && src.compute != 0 && src.flock.total_compute() < src.flock.used_compute)
-		boutput(src, "<span class='alert'>The Flock has insufficient compute to sustain your consciousness!</span>")
-		src.death()
+	if (src.flock && src.compute != 0 && src.flock.total_compute() < src.flock.used_compute && !src.dying)
+		src.dying = TRUE
+		boutput(src, "<span class='alert'>The Flock has insufficient compute to sustain your consciousness! You will die soon!</span>")
+		src.addOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+		src.updateOverlaysClient(src.client)
+		if (istype(src.loc, /mob/living/critter/flock/drone))
+			var/mob/living/critter/flock/drone/flockdrone = src.loc
+			flockdrone.addOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+			flockdrone.updateOverlaysClient(src.client)
+		SPAWN(5 SECONDS)
+			if (src?.flock)
+				if (src.flock.total_compute() < src.flock.used_compute)
+					src.death()
+				else
+					src.dying = FALSE
+					boutput(src, "<span class='alert'>The Flock has gained enough compute to keep you alive!</span>")
+					src.removeOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
+					src.updateOverlaysClient(src.client)
 
 /mob/living/intangible/flock/trace/death(gibbed, suicide = FALSE)
 	. = ..()

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -106,10 +106,10 @@
 					src.death()
 				else
 					src.dying = FALSE
-					src.flock.queued_trace_deaths--
 					boutput(src, "<span class='alert'>The Flock has gained enough compute to keep you alive!</span>")
 					src.removeOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
 					src.updateOverlaysClient(src.client)
+				src.flock.queued_trace_deaths--
 
 /mob/living/intangible/flock/trace/death(gibbed, suicide = FALSE)
 	. = ..()

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -90,8 +90,9 @@
 /mob/living/intangible/flock/trace/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
-	if (src.flock && src.compute != 0 && src.flock.total_compute() < src.flock.used_compute && !src.dying)
+	if (src.flock && src.compute != 0 && src.flock.total_compute() - src.flock.used_compute < -FLOCKTRACE_COMPUTE_COST * src.flock.queued_trace_deaths && !src.dying)
 		src.dying = TRUE
+		src.flock.queued_trace_deaths++
 		boutput(src, "<span class='alert'>The Flock has insufficient compute to sustain your consciousness! You will die soon!</span>")
 		src.addOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
 		src.updateOverlaysClient(src.client)
@@ -105,6 +106,7 @@
 					src.death()
 				else
 					src.dying = FALSE
+					src.flock.queued_trace_deaths--
 					boutput(src, "<span class='alert'>The Flock has gained enough compute to keep you alive!</span>")
 					src.removeOverlayComposition(/datum/overlayComposition/flockmindcircuit/flocktrace_death)
 					src.updateOverlaysClient(src.client)

--- a/code/modules/overlays/OverlayManager.dm
+++ b/code/modules/overlays/OverlayManager.dm
@@ -447,15 +447,20 @@
 	warp_dir = "warp_ew"
 
 /datum/overlayComposition/flockmindcircuit
+	var/alpha = 140
+
 	New()
 		var/datum/overlayDefinition/flockmindcircuit = new()
 		flockmindcircuit.d_icon = 'icons/effects/overlays/flockmindcircuit.dmi'
 		flockmindcircuit.d_icon_state = "flockmindcircuit"
 		flockmindcircuit.d_blend_mode = BLEND_DEFAULT
-		flockmindcircuit.d_alpha = 140
+		flockmindcircuit.d_alpha = src.alpha
 		definitions.Add(flockmindcircuit)
 
 		return ..()
+
+	flocktrace_death
+		alpha = 40
 
 /datum/overlayComposition/sniper_scope
 	New()


### PR DESCRIPTION
[GAME MODES][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a small pause when Flocktraces can't live before they actually die.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flocktrace deaths are pretty sudden, it would be nice to know that you are dying. Also gives a chance for Flocktraces to stay alive if compute dropped by just a small amount.