### PR TITLE
Fixes cog1 floating camera

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55999,6 +55999,12 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
+"kCR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/hallway/primary/east)
 "kFg" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/cable{
@@ -121265,7 +121271,7 @@ kiI
 akf
 alk
 ubQ
-arq
+kCR
 arc
 arr
 aqZ

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5587,17 +5587,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
-"ard" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/grime,
-/area/station/hallway/primary/east)
 "are" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -62663,6 +62652,15 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
+"ubQ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/grime,
+/area/station/hallway/primary/east)
 "ucc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/lamp/green{
@@ -121266,7 +121264,7 @@ kiI
 kiI
 akf
 alk
-arq
+ubQ
 arq
 arc
 arr
@@ -121570,7 +121568,7 @@ akf
 arq
 arq
 arq
-ard
+arc
 ars
 aqZ
 aqZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL][mapping][bug] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10873. A floating camera left over from ranch remodeling. Also adds another light because the area was oddly dark compared to the rest.

Floating camera: https://i.gyazo.com/eca32620ffe56801471780f93724a0a5.png
New placement: https://i.gyazo.com/979b87fcba6b7fe4b0f944d476e4fa7a.png


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Squashin bugs' 👍 


