### PR TITLE
Fixes a runtime when flipping a welding mask as a non-human

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -683,30 +683,28 @@
 		up = FALSE
 		see_face = FALSE
 		icon_state = "welding"
-		boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
-		if (user.head == src)
-			src.obscure(user)
-			user.update_clothing()
+		boutput(user, "You flip the mask down. The mask now provides protection from eye damage.")
+		src.c_flags |= (COVERSEYES | BLOCKCHOKE)
+		setProperty("meleeprot_head", 1)
+		setProperty("disorient_resist_eye", 100)
+		if (ishuman(user))
+			if (user.head == src)
+				src.obscure(user)
+				user.update_clothing()
 
-			src.c_flags |= (COVERSEYES | BLOCKCHOKE)
-			setProperty("meleeprot_head", 1)
-			setProperty("disorient_resist_eye", 100)
-		else
-			boutput(user, "You try to flip the mask down, but it just doesn't fit on you.")
 
 	proc/flip_up(var/mob/living/carbon/human/user)
 		up = TRUE
 		see_face = TRUE
 		icon_state = "welding-up"
-		boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
-		if (user.head == src)
-			src.reveal(user)
-			user.update_clothing()
-		else
-			boutput(user, "You try to flip the mask up, but it just doesn't fit on you.")
+		boutput(user, "You flip the mask up. The mask now provides higher armor to the head.")
 		src.c_flags &= ~(COVERSEYES | BLOCKCHOKE)
 		setProperty("meleeprot_head", 4)
 		setProperty("disorient_resist_eye", 0)
+		if (ishuman(user))
+			if (user.head == src)
+				src.reveal(user)
+				user.update_clothing()
 
 	equipped(mob/user, slot)
 		. = ..()
@@ -725,9 +723,8 @@
 				src.reveal(owner)
 
 	attack_self(mob/user) //let people toggle these inhand too
-		if (ishuman(user))
-			for(var/obj/ability_button/mask_toggle/toggle in ability_buttons)
-				toggle.execute_ability() //This is a weird way of doing it but we'd have to get the ability button to update the icon anyhow
+		for(var/obj/ability_button/mask_toggle/toggle in ability_buttons)
+			toggle.execute_ability() //This is a weird way of doing it but we'd have to get the ability button to update the icon anyhow
 		..()
 
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -680,27 +680,30 @@
 		user.updateOverlaysClient(user.client)
 
 	proc/flip_down(var/mob/living/carbon/human/user)
-		up = FALSE
-		see_face = FALSE
-		icon_state = "welding"
-		boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
 		if (ishuman(user) && (user.head == src))
+			up = FALSE
+			see_face = FALSE
+			icon_state = "welding"
+			boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
 			src.obscure(user)
 			user.update_clothing()
 
-		src.c_flags |= (COVERSEYES | BLOCKCHOKE)
-		setProperty("meleeprot_head", 1)
-		setProperty("disorient_resist_eye", 100)
+			src.c_flags |= (COVERSEYES | BLOCKCHOKE)
+			setProperty("meleeprot_head", 1)
+			setProperty("disorient_resist_eye", 100)
+		else
+			boutput(user, "You try to flip the mask down, but it just doesn't fit on you.")
 
 	proc/flip_up(var/mob/living/carbon/human/user)
-		up = TRUE
-		see_face = TRUE
-		icon_state = "welding-up"
-		boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
 		if (ishuman(user) && (user.head == src))
+			up = TRUE
+			see_face = TRUE
+			icon_state = "welding-up"
+			boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
 			src.reveal(user)
 			user.update_clothing()
-
+		else
+			boutput(user, "You try to flip the mask up, but it just doesn't fit on you.")
 		src.c_flags &= ~(COVERSEYES | BLOCKCHOKE)
 		setProperty("meleeprot_head", 4)
 		setProperty("disorient_resist_eye", 0)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -684,7 +684,7 @@
 		see_face = FALSE
 		icon_state = "welding"
 		boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
-		if (user.head == src)
+		if (ishuman(user) && (user.head == src))
 			src.obscure(user)
 			user.update_clothing()
 
@@ -697,7 +697,7 @@
 		see_face = TRUE
 		icon_state = "welding-up"
 		boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
-		if (user.head == src)
+		if (ishuman(user) && (user.head == src))
 			src.reveal(user)
 			user.update_clothing()
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -680,11 +680,11 @@
 		user.updateOverlaysClient(user.client)
 
 	proc/flip_down(var/mob/living/carbon/human/user)
-		if (ishuman(user) && (user.head == src))
-			up = FALSE
-			see_face = FALSE
-			icon_state = "welding"
-			boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
+		up = FALSE
+		see_face = FALSE
+		icon_state = "welding"
+		boutput(user, "You flip the mask down. The mask is now protecting you from eye damage.")
+		if (user.head == src)
 			src.obscure(user)
 			user.update_clothing()
 
@@ -695,11 +695,11 @@
 			boutput(user, "You try to flip the mask down, but it just doesn't fit on you.")
 
 	proc/flip_up(var/mob/living/carbon/human/user)
-		if (ishuman(user) && (user.head == src))
-			up = TRUE
-			see_face = TRUE
-			icon_state = "welding-up"
-			boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
+		up = TRUE
+		see_face = TRUE
+		icon_state = "welding-up"
+		boutput(user, "You flip the mask up. The mask is now providing greater armor to your head.")
+		if (user.head == src)
 			src.reveal(user)
 			user.update_clothing()
 		else
@@ -725,8 +725,9 @@
 				src.reveal(owner)
 
 	attack_self(mob/user) //let people toggle these inhand too
-		for(var/obj/ability_button/mask_toggle/toggle in ability_buttons)
-			toggle.execute_ability() //This is a weird way of doing it but we'd have to get the ability button to update the icon anyhow
+		if (ishuman(user))
+			for(var/obj/ability_button/mask_toggle/toggle in ability_buttons)
+				toggle.execute_ability() //This is a weird way of doing it but we'd have to get the ability button to update the icon anyhow
 		..()
 
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -671,6 +671,10 @@
 		setProperty("meleeprot_head", 1)
 		setProperty("disorient_resist_eye", 100)
 
+	show_buttons()	//Hide the button from non-human mobs
+		if (ishuman(the_mob))
+			..()
+
 	proc/obscure(mob/user)
 		user.addOverlayComposition(/datum/overlayComposition/weldingmask)
 		user.updateOverlaysClient(user.client)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "ishuman()" check before checking for a head to fix a runtime happening when you flip a mask as someone without a head (like a ghostdrone)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad, i fix
Fixes #10671 
