### PR TITLE
You can't swirlie headless people anymore

### DIFF
--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -35,8 +35,18 @@ TOILET
 		return
 	if (istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
+
+		if (ishuman(G.affecting))
+			var/mob/living/carbon/human/H = G.affecting
+			if (H.head == null)
+				user.visible_message("<span class='notice'>[user] fruitlessly tries to dunk [G.affecting]'s headless body into the toilet.</span>", "<span class='notice'>You struggle trying to swirlie [G.affecting] but they dont have a head! You feel silly for even attempting it.</span>")
+				return
+			else
+				user.visible_message("<span class='notice'>[user] gives [G.affecting] a swirlie!</span>", "<span class='notice'>You give [G.affecting] a swirlie. It's like Middle School all over again!</span>")
+		else
+			user.visible_message("<span class='notice'>[user] gives [G.affecting] a swirlie!</span>", "<span class='notice'>You give [G.affecting] a swirlie. It's like Middle School all over again!</span>")
+
 		playsound(src, 'sound/effects/toilet_flush.ogg', 50, 1)
-		user.visible_message("<span class='notice'>[user] gives [G.affecting] a swirlie!</span>", "<span class='notice'>You give [G.affecting] a swirlie. It's like Middle School all over again!</span>")
 		if (G.affecting.hasStatus("burning"))
 			G.affecting.changeStatus("burning", -2 SECONDS)
 			playsound(src, 'sound/impact_sounds/burn_sizzle.ogg', 70, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-bug C-feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attempting to swirlie a decapitated corpse will bring you shame instead.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10648 and it's also slightly funny


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

