### PR TITLE
Lets silicons use GPSs

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -137,8 +137,12 @@
 		user.Browse(HTML.Join(), "window=gps_[src];title=GPS;size=400x540;override_setting=1")
 		onclose(user, "gps")
 
+	attack_ai(mob/user)
+		. = ..()
+		src.show_HTML(user)
+
 	attack_self(mob/user as mob)
-		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0))
+		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0) || issilicon(usr) || isAIeye(usr))
 			src.show_HTML(user)
 		else
 			user.Browse(null, "window=gps_[src]")
@@ -149,7 +153,7 @@
 		..()
 		if (usr.stat || usr.restrained() || usr.lying)
 			return
-		if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_interact_range(src, usr)))
+		if (usr.contents.Find(src) || usr.contents.Find(src.master) || in_interact_range(src, usr) || issilicon(usr) || isAIeye(usr))
 			src.add_dialog(usr)
 			var/turf/T = get_turf(usr)
 			if(href_list["getcords"])
@@ -193,12 +197,13 @@
 				active = null
 				icon_state = "gps-off"
 
-
-			if (!src.master)
-				src.updateSelfDialog()
-			else
-				src.master.updateSelfDialog()
-
+			var/obj/item/target = src.master || src
+			target.updateSelfDialog()
+			//we want this to do self dialog updates UNLESS the user is a silicon in which case we do regular updates
+			for (var/client/client in src.clients_operating)
+				var/mob/user = client.mob
+				if (issilicon(user) || isAIeye(user))
+					target.attack_ai(user)
 			src.add_fingerprint(usr)
 		else
 			usr.Browse(null, "window=gps_[src]")

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -142,7 +142,7 @@
 		src.show_HTML(user)
 
 	attack_self(mob/user as mob)
-		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0) || issilicon(usr) || isAIeye(usr))
+		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0))
 			src.show_HTML(user)
 		else
 			user.Browse(null, "window=gps_[src]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [SILICONS] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets silicons click on space GPSs to open the interface.
The interface update code is a little hacky, because it needs to do self dialog updates for normal users and then attack dialog updates for silicons, and none of the current UI update procs support this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I can't think of a reason why they shouldn't be able to, and it's nice for the AI to be able to track someone by their space GPS (which I don't think they can do currently?)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Silicons can now use space GPSs
```
