### PR TITLE
Status Display address_tag and HTML fix

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1335,6 +1335,7 @@
 		var/datum/signal/status_signal = get_free_signal()
 		status_signal.source = src
 		status_signal.transmission_method = 1
+		status_signal.data["address_tag"] = "STATDISPLAY"
 		if(timeleft < 0)
 			status_signal.data["command"] = "blank"
 		else

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -141,6 +141,7 @@
 		status_signal.source = src.master
 		status_signal.transmission_method = 1
 		status_signal.data["command"] = command
+		status_signal.data["address_tag"] = "STATDISPLAY"
 
 		switch(command)
 			if("message")

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1274,5 +1274,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	status_signal.source = src
 	status_signal.transmission_method = 1
 	status_signal.data["command"] = command
+	status_signal.data["address_tag"] = "STATDISPLAY"
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, status_signal, null, FREQ_STATUS_DISPLAY)

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -405,6 +405,7 @@
 	status_signal.source = src
 	status_signal.transmission_method = 1
 	status_signal.data["command"] = command
+	status_signal.data["address_tag"] = "STATDISPLAY"
 
 	switch(command)
 		if("message")

--- a/code/obj/machinery/status_display.dm
+++ b/code/obj/machinery/status_display.dm
@@ -39,7 +39,8 @@
 	var/lastdisplayline1 = ""		// the cached last displays
 	var/lastdisplayline2 = ""
 
-	var/frequency = 1435		// radio frequency
+	var/net_id = null
+	var/frequency = FREQ_STATUS_DISPLAY		// radio frequency
 
 	var/display_type = 0		// bitmask of messages types to display: 0=normal  1=supply shuttle  2=reseach stn destruct
 
@@ -60,7 +61,16 @@
 		crt_image.mouse_opacity = 0
 		UpdateOverlays(crt_image, "crt")
 
-		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(null, frequency)
+		src.AddComponent( \
+			/datum/component/packet_connected/radio, \
+			null, \
+			src.frequency, \
+			src.net_id, \
+			"receive_signal", \
+			FALSE, \
+			"STATDISPLAY", \
+			FALSE \
+		)
 
 		if(glow_in_dark_screen)
 			src.screen_image = image('icons/obj/status_display.dmi', src.icon_state, -1)
@@ -70,6 +80,8 @@
 			screen_image.color = list(0.66,0.66,0.66, 0.66,0.66,0.66, 0.66,0.66,0.66)
 			src.UpdateOverlays(screen_image, "screen_image")
 
+		if(!src.net_id)
+			src.net_id = generate_net_id(src)
 
 	// timed process
 	process()
@@ -178,7 +190,7 @@
 			message2 = null
 			index2 = 0
 		repeat_update = TRUE
-		desc = "[message1] [message2]"
+		desc = "[message1]<br>[message2]" // multiline messages
 		lastdisplayline1 = null
 		lastdisplayline2 = null
 
@@ -234,6 +246,12 @@
 		return ""
 
 	receive_signal(datum/signal/signal)
+		boutput(world, "Packet Received")
+		if (!signal || (!signal.data["address_tag"] && !signal.data["address_1"]))
+			return
+
+		if (signal.data["address_tag"] != "STATDISPLAY" && signal.data["address_1"] != src.net_id)
+			return
 
 		switch(signal.data["command"])
 			if("blank")
@@ -245,7 +263,7 @@
 
 			if("message")
 				mode = 2
-				set_message(signal.data["msg1"], signal.data["msg2"])
+				set_message(strip_html(signal.data["msg1"]), strip_html(signal.data["msg2"]))
 
 			if("alert")
 				mode = 3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CRITICAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds address_tag to status displays, allows singular displays to be set via address_1 and strips html from message.

Also displays msg1 and msg2 on different lines when examining.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was a bit wierd that the displays used all packets on the frequency.

Also exploit bad.


