### PR TITLE
Standardises The Donut3 Armoury

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4594,7 +4594,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bgh" = (
@@ -11891,7 +11891,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "dlb" = (
@@ -12077,9 +12077,7 @@
 /area/station/maintenance/outer/ne)
 "dmU" = (
 /obj/storage/secure/closet/security/armory,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/southeast,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/southeast,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "dmY" = (
@@ -23679,7 +23677,7 @@
 	},
 /area/station/medical/medbay)
 "gGr" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "gGE" = (
@@ -23889,7 +23887,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "gLB" = (
@@ -55037,6 +55035,9 @@
 	desc = "What? Security has moments of weakness too!";
 	name = "emergency alcohol dispenser"
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "pRW" = (
@@ -57648,23 +57649,38 @@
 /area/station/hallway/primary/west)
 "qyp" = (
 /obj/rack,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/item/clothing/glasses/thermal{
-	pixel_x = -3;
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
 	pixel_y = 3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -2
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -4;
+	pixel_y = 5
 	},
 /obj/item/clothing/glasses/thermal{
 	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = 2
 	},
 /obj/item/clothing/glasses/thermal{
-	pixel_x = 1;
+	pixel_x = 2;
 	pixel_y = -1
 	},
 /obj/item/clothing/glasses/thermal{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 5;
+	pixel_y = -4
 	},
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "qyH" = (
@@ -76610,7 +76626,7 @@
 	},
 /obj/item/clothing/mask/gas{
 	pixel_x = 7;
-	pixel_y = 9
+	pixel_y = 10
 	},
 /obj/item/clothing/head/helmet/EOD{
 	pixel_x = -7;
@@ -76618,7 +76634,7 @@
 	},
 /obj/item/clothing/head/helmet/EOD{
 	pixel_x = 7;
-	pixel_y = 8
+	pixel_y = 9
 	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/engine,
@@ -84560,7 +84576,8 @@
 	},
 /obj/access_spawn/security,
 /obj/machinery/turret{
-	dir = 8
+	dir = 8;
+	name = "armory turret"
 	},
 /obj/machinery/light/incandescent/warm/very{
 	dir = 4


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See previous PR: #10917
Removes the two night vision goggles from the eastern special equipment locker, adds four night vision goggles to the optical thermal scanner rack, and changes the riot gas pipe to be overfloor inside of the Armoury.

![image](https://user-images.githubusercontent.com/88833499/192161972-97ac54b3-52f5-4e21-9c4e-9043f019ddb5.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Donut3 Armoury is also equipped with:
* 1x (additional) Special Equipment Locker
* 3x (additional) .308 Mutadone Darts
* 2x (additional) .308 Tranquiliser Darts
* 4x (additional) Gas Masks
* 1x Pressure Tank (N2O) *(hooked up to the Security repressurisation system)*
* 1x Nuclear Charge *(with unwired data terminal)*
* 4x Crowd Dispersal Grenades
* 4x Syringes (Anti-Psychotic)
* 3x Straight Jackets
* 3x Muzzles
* 1x Emergency Alcohol Dispenser
* 3x Wine Glasses
* 3x Shot Glasses



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. As for Donut3 specifically, rebalancing the number of NVGs to a reasonable amount for a high population map is required after #10462's removal of the ones inside of the special equipment lockers. The overfloor riot gas pipes also help to clarify how the gas valves inside of the Armoury link together.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Added two additional night vision goggles to the Donut3 Armoury, alongside making the riot gas pipe visible overfloor.
```