### PR TITLE
Add an AFK check for Flockminds

### DIFF
--- a/_std/macros/flock.dm
+++ b/_std/macros/flock.dm
@@ -16,6 +16,9 @@
 #define FLOCK_ANNOTATION_FLOCKTRACE_CONTROL "flocktrace_face"
 #define FLOCK_ANNOTATION_HEALTH "health"
 
+// flock intangibles
+#define FLOCK_AFK_COUNTER_THRESHOLD 180 SECONDS
+
 // costs
 #define FLOCK_CONVERT_COST 20
 #define FLOCK_BARRICADE_COST 20

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -447,11 +447,11 @@ var/flock_signal_unleashed = FALSE
 /datum/flock/proc/getActiveTraces()
 	var/list/active_traces = list()
 	for (var/mob/living/intangible/flock/trace/T as anything in src.traces)
-		if (T.client)
+		if (T.client && T.afk_counter < T.afk_counter_threshold)
 			active_traces += T
 		else if (istype(T.loc, /mob/living/critter/flock/drone))
 			var/mob/living/critter/flock/drone/flockdrone = T.loc
-			if (flockdrone.client)
+			if (flockdrone.client && T.afk_counter < T.afk_counter_threshold)
 				active_traces += T
 	return active_traces
 

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -447,11 +447,11 @@ var/flock_signal_unleashed = FALSE
 /datum/flock/proc/getActiveTraces()
 	var/list/active_traces = list()
 	for (var/mob/living/intangible/flock/trace/T as anything in src.traces)
-		if (T.client && T.afk_counter < T.afk_counter_threshold)
+		if (T.client && T.afk_counter < FLOCK_AFK_COUNTER_THRESHOLD)
 			active_traces += T
 		else if (istype(T.loc, /mob/living/critter/flock/drone))
 			var/mob/living/critter/flock/drone/flockdrone = T.loc
-			if (flockdrone.client && T.afk_counter < T.afk_counter_threshold)
+			if (flockdrone.client && T.afk_counter < FLOCK_AFK_COUNTER_THRESHOLD)
 				active_traces += T
 	return active_traces
 

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -61,13 +61,16 @@
 	if (!src.flock)
 		return
 	src.flock.peak_compute = max(src.flock.peak_compute, src.flock.total_compute())
-	if (src.afk_counter > src.afk_counter_threshold)
-		var/list/traces = src.flock.getActiveTraces()
-		if (length(traces))
-			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience detected. Self-programmed routines promoting new Flockmind.\]</b></span>")
-			var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
-			chosen_trace.promoteToFlockmind(FALSE)
-		src.afk_counter = 0
+	if (src.afk_counter > src.afk_counter_threshold * 3 / 4)
+		if (!ON_COOLDOWN(src, "afk_message", src.afk_counter_threshold))
+			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Sentience pause detected. Preparing promotion routines.\]</b></span>")
+		if (src.afk_counter > src.afk_counter_threshold)
+			var/list/traces = src.flock.getActiveTraces()
+			if (length(traces))
+				boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience confirmed. Self-programmed routines promoting new Flockmind.\]</b></span>")
+				var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
+				chosen_trace.promoteToFlockmind(FALSE)
+			src.afk_counter = 0
 	if (src.started)
 		if (src.flock.getComplexDroneCount())
 			return

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -58,8 +58,21 @@
 /mob/living/intangible/flock/flockmind/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
+	if (!src.flock)
+		return
 	src.flock.peak_compute = max(src.flock.peak_compute, src.flock.total_compute())
-	if (src.started && src.flock)
+	if (get_turf(src) == src.previous_turf)
+		src.afk_counter++
+		if (src.afk_counter > round(src.afk_counter_threshold / parent.schedule_interval))
+			var/list/traces = src.flock.getActiveTraces()
+			if (length(traces))
+				var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
+				chosen_trace.promoteToFlockmind(FALSE)
+			src.afk_counter = 0
+	else
+		src.afk_counter = 0
+		src.previous_turf = get_turf(src)
+	if (src.started)
 		if (src.flock.getComplexDroneCount())
 			return
 		for (var/obj/flock_structure/s in src.flock.structures)

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -61,17 +61,13 @@
 	if (!src.flock)
 		return
 	src.flock.peak_compute = max(src.flock.peak_compute, src.flock.total_compute())
-	if (get_turf(src) == src.previous_turf)
-		src.afk_counter++
-		if (src.afk_counter > round(src.afk_counter_threshold / parent.schedule_interval))
-			var/list/traces = src.flock.getActiveTraces()
-			if (length(traces))
-				var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
-				chosen_trace.promoteToFlockmind(FALSE)
-			src.afk_counter = 0
-	else
+	if (src.afk_counter > src.afk_counter_threshold)
+		var/list/traces = src.flock.getActiveTraces()
+		if (length(traces))
+			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience detected. Self-instructed routines promoting new Flockmind.\]</b></span>")
+			var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
+			chosen_trace.promoteToFlockmind(FALSE)
 		src.afk_counter = 0
-		src.previous_turf = get_turf(src)
 	if (src.started)
 		if (src.flock.getComplexDroneCount())
 			return

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -64,7 +64,7 @@
 	if (src.afk_counter > src.afk_counter_threshold)
 		var/list/traces = src.flock.getActiveTraces()
 		if (length(traces))
-			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience detected. Self-instructed routines promoting new Flockmind.\]</b></span>")
+			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience detected. Self-programmed routines promoting new Flockmind.\]</b></span>")
 			var/mob/living/intangible/flock/trace/chosen_trace = pick(traces)
 			chosen_trace.promoteToFlockmind(FALSE)
 		src.afk_counter = 0

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -61,10 +61,10 @@
 	if (!src.flock)
 		return
 	src.flock.peak_compute = max(src.flock.peak_compute, src.flock.total_compute())
-	if (src.afk_counter > src.afk_counter_threshold * 3 / 4)
-		if (!ON_COOLDOWN(src, "afk_message", src.afk_counter_threshold))
+	if (src.afk_counter > FLOCK_AFK_COUNTER_THRESHOLD * 3 / 4)
+		if (!ON_COOLDOWN(src, "afk_message", FLOCK_AFK_COUNTER_THRESHOLD))
 			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Sentience pause detected. Preparing promotion routines.\]</b></span>")
-		if (src.afk_counter > src.afk_counter_threshold)
+		if (src.afk_counter > FLOCK_AFK_COUNTER_THRESHOLD)
 			var/list/traces = src.flock.getActiveTraces()
 			if (length(traces))
 				boutput(src, "<span class='flocksay'><b>\[SYSTEM: Lack of sentience confirmed. Self-programmed routines promoting new Flockmind.\]</b></span>")

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -18,7 +18,7 @@
 	var/wear_id = null // to prevent runtimes from AIs tracking down radio signals
 
 	var/afk_counter = 0
-	var/afk_counter_threshold = 180 // 1 count per second
+	var/afk_counter_threshold = 180 SECONDS
 	var/turf/previous_turf = null
 
 /mob/living/intangible/flock/New()
@@ -66,11 +66,16 @@
 			plane.alpha = 0
 	..()
 
-/mob/living/intangible/flock/flockmind/Life(datum/controller/process/mobs/parent)
+/mob/living/intangible/flock/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return 1
 	if (src.client)
 		src.antagonist_overlay_refresh(0, 0)
+	if (get_turf(src) == src.previous_turf)
+		src.afk_counter += parent.schedule_interval
+	else
+		src.afk_counter = 0
+		src.previous_turf = get_turf(src)
 
 /mob/living/intangible/flock/is_spacefaring() return 1
 /mob/living/intangible/flock/say_understands() return 1

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -18,7 +18,6 @@
 	var/wear_id = null // to prevent runtimes from AIs tracking down radio signals
 
 	var/afk_counter = 0
-	var/afk_counter_threshold = 180 SECONDS
 	var/turf/previous_turf = null
 
 /mob/living/intangible/flock/New()

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -17,6 +17,10 @@
 	var/datum/flock/flock = null
 	var/wear_id = null // to prevent runtimes from AIs tracking down radio signals
 
+	var/afk_counter = 0
+	var/afk_counter_threshold = 180 // 1 count per second
+	var/turf/previous_turf = null
+
 /mob/living/intangible/flock/New()
 	..()
 	src.appearance_flags |= NO_CLIENT_COLOR
@@ -32,6 +36,7 @@
 	src.apply_color_matrix(COLOR_MATRIX_FLOCKMIND, COLOR_MATRIX_FLOCKMIND_LABEL)
 	//src.render_special.set_centerlight_icon("flockvision", "#09a68c", BLEND_OVERLAY, PLANE_FLOCKVISION, alpha=196)
 	//src.render_special.set_widescreen_fill(color="#09a68c", plane=PLANE_FLOCKVISION, alpha=196)
+	src.previous_turf = get_turf(src)
 
 /mob/living/intangible/flock/Login()
 	..()


### PR DESCRIPTION
[GAME MODES][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds an AFK check to the Flockmind. If they are AFK for long enough, a present Flocktrace will be promoted to the Flockmind.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If the Flockmind happens to be afk, it can really hurt the Flock, especially if they are AFK when they spawn.