### PR TITLE
changes to fake death (eg. capulletium) and bug fixes

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1648,12 +1648,12 @@ var/datum/action_controller/actions
 
 	onUpdate()
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || target.health > 0 || !src.can_cpr())
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || !src.can_cpr())
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 	onStart()
-		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || target.health > 0 || !src.can_cpr())
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || !src.can_cpr())
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
@@ -1678,6 +1678,8 @@ var/datum/action_controller/actions
 		src.onRestart()
 
 	proc/can_cpr()
+		if(src.target.health > 0 && !(src.target.is_faking_death() || src.target.find_ailment_by_type(/datum/ailment/malady/flatline)))
+			return FALSE
 		if (ishuman(owner))
 			var/mob/living/carbon/human/human_owner = owner
 			if (human_owner.head && (human_owner.head.c_flags & COVERSMOUTH))
@@ -1698,7 +1700,7 @@ var/datum/action_controller/actions
 				boutput(owner, "<span class='alert'>You need to take off [human_target]'s facemask before you can give CPR!</span>")
 				return FALSE
 
-		if (isdead(target))
+		if (isdead(target) || (target.is_faking_death() && target.health > 0))
 			owner.visible_message("<span class='alert'><B>[owner] tries to perform CPR, but it's too late for [target]!</B></span>")
 			return FALSE
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2492,6 +2492,9 @@
 /mob/proc/flash(duration)
 	return 0
 
+/mob/proc/is_faking_death(includes_non_empowered_pseudonecrosis)
+	return FALSE
+
 /mob/proc/take_brain_damage(var/amount)
 	if (!isnum(amount) || amount == 0)
 		return 1

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -150,6 +150,14 @@
 /mob/living/flash(duration)
 	vision.flash(duration)
 
+/mob/living/is_faking_death(includes_non_empowered_pseudonecrosis)
+	var/datum/abilityHolder/changeling/ling_abilityholder = get_ability_holder(/datum/abilityHolder/changeling)
+	return (ling_abilityholder?.in_fakedeath ||\
+	src.bioHolder?.HasEffect("dead_scan") == 2 ||\
+	(src.bioHolder?.HasEffect("dead_scan") && includes_non_empowered_pseudonecrosis) ||\
+	(src?.reagents.has_reagent("capulettium") && src.getStatusDuration("weakened")) ||\
+	(src?.reagents.has_reagent("capulettium_plus") && src.hasStatus("resting"))) ? TRUE : FALSE
+
 /mob/living/disposing()
 	ai_target = null
 	ai_target_old.len = 0
@@ -600,10 +608,6 @@
 		return
 
 	if (isghostcritter(src))
-		return
-
-	if (src.reagents && src.reagents.has_reagent("capulettium_plus"))
-		src.show_text("You are completely paralysed and can't point!", "red")
 		return
 
 	if (istype(target, /obj/decal/point))

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -315,12 +315,7 @@
 			if (1500 to INFINITY) // critically high (180/110)
 				. += "<br><span class='alert'><B>[src.name] is sweating like a pig and red as a tomato!</B></span>"
 
-	var/changeling_fakedeath = 0
-	var/datum/abilityHolder/changeling/C = get_ability_holder(/datum/abilityHolder/changeling)
-	if (C?.in_fakedeath)
-		changeling_fakedeath = 1
-
-	if ((isdead(src)) || changeling_fakedeath || src.bioHolder?.HasEffect("dead_scan") == 2 || (src.reagents.has_reagent("capulettium") && src.getStatusDuration("weakened")) || (src.reagents.has_reagent("capulettium_plus") && src.hasStatus("resting")))
+	if ((isdead(src)) || src.is_faking_death())
 		if (!src.decomp_stage)
 			. += "<br><span class='alert'>[src] is limp and unresponsive, a dull lifeless look in [t_his] eyes.</span>"
 	else

--- a/code/mob/living/life/health_mon.dm
+++ b/code/mob/living/life/health_mon.dm
@@ -10,7 +10,7 @@
 			// Originally the isdead() check was only done in the other check if <0, which meant
 			// if you were dead but had > 0 HP (e.g. eaten by blob) you would still show
 			// a not-dead heart. So, now you don't.
-			if ((owner.bioHolder && owner.bioHolder.HasEffect("dead_scan")) || isdead(owner))
+			if (owner.is_faking_death(TRUE) || isdead(owner))
 				H.health_mon.icon_state = "-1"
 			else
 				// Handle possible division by zero

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -18,17 +18,21 @@
 	src.lastattacked = M
 	if (src != M && M.getStatusDuration("burning")) //help others put out fires!!
 		src.help_put_out_fire(M)
-	else if (src == M && src.getStatusDuration("burning"))
+		return
+	if (M.getStatusDuration("burning")) //put yourself out too
 		M.resist()
-	else if ((M.health <= 0 || M.find_ailment_by_type(/datum/ailment/malady/flatline)) && src.health >= -75.0)
-		if (src == M && src.is_bleeding())
-			src.staunch_bleeding(M) // if they've got SOMETHING to do let's not just harass them for trying to do CPR on themselves
-		else
-			src.administer_CPR(M)
-	else if (M.is_bleeding())
+		return
+	if (src == M && src.is_bleeding())
 		src.staunch_bleeding(M)
-	else if (src.health > 0)
+	if ((M.health <= 0 || M.is_faking_death() || M.find_ailment_by_type(/datum/ailment/malady/flatline)) && src.health >= -75.0)
+		src.administer_CPR(M)
+		return
+	if (M.is_bleeding())
+		src.staunch_bleeding(M)
+		return
+	if (M.health > 0 && !M.is_faking_death())
 		src.shake_awake(M)
+		return
 
 /mob/proc/help_put_out_fire(var/mob/living/M)
 	playsound(M.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0 , 0.7)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -199,7 +199,7 @@
 		if (occupant)
 			. += list(
 				"hasOccupant" = TRUE,
-				"occupantStat" = occupant.stat,
+				"occupantStat" = occupant.is_faking_death(TRUE) * 2 || occupant.stat,
 				"health" = occupant.health / occupant.max_health,
 				"oxyDamage" = occupant.get_oxygen_deprivation(),
 				"toxDamage" = occupant.get_toxin_damage(),

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -11,7 +11,7 @@
 		animate_scanning(M, "#0AEFEF")
 
 	var/death_state = M.stat
-	if (M.bioHolder && M.bioHolder.HasEffect("dead_scan"))
+	if (M.is_faking_death(TRUE))
 		death_state = 2
 
 	var/health_percent = round(100 * M.health / M.max_health)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [BUG][BALANCE][CHEMISTRY][MEDICAL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(pay extra attention in the parts of code related to CPR and help intent those are likely the most fucked up parts of my change)

faking death = under the effects of capu,capu+, empowered pseudonecrosis or changeling stasis
(in the case of fooling machines rather than humans non empowered pseudonecrosis works too)

**this only fools scanners not death detectors of stuff like gibber
also sleepers cant be used on people who are faking death as they cant inject into things they deem dead**

trying to help intent people who are faking death will give a fake fail CPR message rather than giving a blatant trying to wake up one (CPR will still work as normal if they are in crit

fixes trying being able to wake up people who are in crit via help intent click (checked if the user is in crit rather than the target until now)

removes being unable to point with capu+ in your bloodstream

fixes being unable to give CPR to people who have cardiac arrest but arent in crit (was always intented but the 2nd check broke it)

**known issues this doesnt fix:**

**people under the effects of capu still have blatant typing indicators**

**people can fully emote under the effects of capu and whisper (not touched because that fucks with its RP ling use and would be its own PR but on classic it makes the poison useless as a fake death poison)**

**similar case is for people spam rotating to signify distress while this is also true for normally KOd players and dead people a person dragging a rapidly spinning corpse down the halls is always suspicious and also contributes towards the uselessness of the fake death part of capu on the LRP server**

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
currently capu and other fake death things are painfully obvious to the point where even a naked staffie can check for capu with 1 help intent click

even the passive scan of prodocs bypasses it making the poison **painfully** obvious this is meant to fix that (partially)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*) Capulettium and other sources of fake death now fool players and machines slightly more.
(*) You can no longer try to wake up people who are in crit using help intent.
(+) Capulettium plus no longer prevents pointing.
```
