### PR TITLE
Refactors 'special_spawn_location' To Use Map Landmarks

### DIFF
--- a/_std/defines/landmarks.dm
+++ b/_std/defines/landmarks.dm
@@ -17,6 +17,7 @@
 #define LANDMARK_GPS_WAYPOINT "GPS Waypoint"
 #define LANDMARK_ARTIFACT_SPAWN "artifact spawner"
 #define LANDMARK_RANDOM_ROOM_ARTIFACT_SPAWN "artifact spawner random room"
+#define LANDMARK_RADIO_SHOW_HOST "Radio-Show-Host-Spawn"
 
 // shuttle landmarks
 #define LANDMARK_SHUTTLE_CENTCOM "shuttle-centcom"

--- a/code/datums/controllers/custom_job_savefile.dm
+++ b/code/datums/controllers/custom_job_savefile.dm
@@ -56,9 +56,6 @@ datum/job_controller/proc/savefile_save(client/user, profileNum=1)
 	F["[profileNum]_access"] << src.job_creator.access
 	F["[profileNum]_change_name_on_spawn"] << src.job_creator.change_name_on_spawn
 	F["[profileNum]_special_spawn_location"] << src.job_creator.special_spawn_location
-	F["[profileNum]_spawn_x"] << src.job_creator.spawn_x
-	F["[profileNum]_spawn_y"] << src.job_creator.spawn_y
-	F["[profileNum]_spawn_z"] << src.job_creator.spawn_z
 	F["[profileNum]_bio_effects"] << src.job_creator.bio_effects
 	F["[profileNum]_objective"] << src.job_creator.objective
 	F["[profileNum]_receives_implant"] << src.job_creator.receives_implant
@@ -118,9 +115,6 @@ datum/job_controller/proc/savefile_load(client/user, var/profileNum = 1)
 	F["[profileNum]_access"] >> src.job_creator.access
 	F["[profileNum]_change_name_on_spawn"] >> src.job_creator.change_name_on_spawn
 	F["[profileNum]_special_spawn_location"] >> src.job_creator.special_spawn_location
-	F["[profileNum]_spawn_x"] >> src.job_creator.spawn_x
-	F["[profileNum]_spawn_y"] >> src.job_creator.spawn_y
-	F["[profileNum]_spawn_z"] >> src.job_creator.spawn_z
 	F["[profileNum]_bio_effects"] >> src.job_creator.bio_effects
 	F["[profileNum]_objective"] >> src.job_creator.objective
 	F["[profileNum]_receives_implant"] >> src.job_creator.receives_implant

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -108,7 +108,7 @@ var/datum/job_controller/job_controls
 		dat += "<A href='?src=\ref[src];EditWages=1'>Wages Per Payday:</A> [src.job_creator.wages]<br>"
 		dat += "<A href='?src=\ref[src];EditLimit=1'>Job Limit:</A> [src.job_creator.limit]<br>"
 		dat += "<A href='?src=\ref[src];ChangeName=1'>Can Change Name on Spawn:</A> [src.job_creator.change_name_on_spawn ? "Yes":"No"]<br>"
-		dat += "<A href='?src=\ref[src];SetSpawnLoc=1'>Spawn Location:</A> [src.job_creator.special_spawn_location ? locate(src.job_creator.spawn_x,src.job_creator.spawn_y,src.job_creator.spawn_z) : "Default"]<br>"
+		dat += "<A href='?src=\ref[src];SetSpawnLoc=1'>Spawn Location:</A> [src.job_creator.special_spawn_location]<br>"
 		dat += "<A href='?src=\ref[src];SpawnId=1'>Spawns with ID:</A> [src.job_creator.spawn_id ? "Yes" : "No"]<br>"
 		dat += "<A href='?src=\ref[src];EditObjective=1'>Custom Objective:</A> [src.job_creator.objective][src.job_creator.objective ? (" (Crew Objective)") : ""]<br>"
 		dat += "<A href='?src=\ref[src];ToggleAnnounce=1'>Head of Staff-style Announcement:</A> [src.job_creator.announce_on_join?"Yes":"No"]<br>"
@@ -893,10 +893,7 @@ var/datum/job_controller/job_controls
 					alert("Please move to the target location and then press OK.")
 					var/atom/trg = get_turf(usr)
 					if(trg)
-						src.job_creator.special_spawn_location = 1
-						src.job_creator.spawn_x = trg.x
-						src.job_creator.spawn_y = trg.y
-						src.job_creator.spawn_z = trg.z
+						src.job_creator.special_spawn_location = trg
 			src.job_creator()
 
 		if(href_list["CreateJob"])
@@ -934,9 +931,6 @@ var/datum/job_controller/job_controls
 				JOB.access = JOB.access | src.job_creator.access
 				JOB.change_name_on_spawn = src.job_creator.change_name_on_spawn
 				JOB.special_spawn_location = src.job_creator.special_spawn_location
-				JOB.spawn_x = src.job_creator.spawn_x
-				JOB.spawn_y = src.job_creator.spawn_y
-				JOB.spawn_z = src.job_creator.spawn_z
 				JOB.bio_effects = src.job_creator.bio_effects
 				JOB.objective = src.job_creator.objective
 				JOB.announce_on_join = src.job_creator.announce_on_join

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -50,10 +50,7 @@
 	var/mob/living/mob_type = /mob/living/carbon/human
 	var/datum/mutantrace/starting_mutantrace = null
 	var/change_name_on_spawn = 0
-	var/special_spawn_location = 0
-	var/spawn_x = 0
-	var/spawn_y = 0
-	var/spawn_z = 0
+	var/special_spawn_location = null
 	var/bio_effects = null
 	var/objective = null
 	var/rounds_needed_to_play = 0 //0 by default, set to the amount of rounds they should have in order to play this
@@ -103,7 +100,11 @@
 				I.implanted(M)
 
 			if (src.special_spawn_location && !no_special_spawn)
-				M.set_loc(locate(spawn_x,spawn_y,spawn_z))
+				// Deals with landmark special spawn locations.
+				if (!istype(special_spawn_location, /turf))
+					special_spawn_location = pick_landmark(special_spawn_location)
+				if (special_spawn_location != null)
+					M.set_loc(special_spawn_location)
 
 			if (ishuman(M) && src.bio_effects)
 				var/list/picklist = params2list(src.bio_effects)
@@ -1724,22 +1725,13 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	wages = PAY_TRADESMAN
 #ifdef MAP_OVERRIDE_MANTA
 	limit = 0
-	special_spawn_location = 0
+	special_spawn_location = null
 #elif defined(MAP_OVERRIDE_OSHAN)
 	limit = 1
-	special_spawn_location = 0
-#elif defined(UPSCALED_MAP)
-	limit = 1
-	special_spawn_location = 1
-	spawn_x = 276 * 2
-	spawn_y = 257 * 2
-	spawn_z = 3
+	special_spawn_location = null
 #else
 	limit = 1
-	special_spawn_location = 1
-	spawn_x = 276
-	spawn_y = 257
-	spawn_z = 3
+	special_spawn_location = LANDMARK_RADIO_SHOW_HOST
 #endif
 	slot_ears = list(/obj/item/device/radio/headset/command/radio_show_host)
 	slot_eyes = list(/obj/item/clothing/glasses/regular)
@@ -2272,6 +2264,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	slot_belt = list()
 	spawn_id = 0
 	radio_announcement = FALSE
+	special_spawn_location = LANDMARK_SYNDICATE
 	var/leader = FALSE
 
 	special_setup(var/mob/living/carbon/human/M)
@@ -2290,6 +2283,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 
 /datum/job/special/syndicate_operative/leader
 	name = "Syndicate Operative Commander"
+	special_spawn_location = LANDMARK_SYNDICATE_BOSS
 	leader = TRUE
 
 /datum/job/special/syndicate_weak
@@ -2353,12 +2347,9 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		src.access = syndicate_spec_ops_access()
 
 #ifdef MAP_OVERRIDE_OSHAN
-	special_spawn_location = 0
+	special_spawn_location = null
 #else
-	special_spawn_location = 1
-	spawn_x = 96
-	spawn_y = 272
-	spawn_z = 2
+	special_spawn_location = LANDMARK_SYNDICATE
 #endif
 
 	special_setup(var/mob/living/carbon/human/M)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -100,7 +100,6 @@
 				I.implanted(M)
 
 			if (src.special_spawn_location && !no_special_spawn)
-				// Deals with landmark special spawn locations.
 				if (!istype(special_spawn_location, /turf))
 					special_spawn_location = pick_landmark(special_spawn_location)
 				if (special_spawn_location != null)

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -283,8 +283,13 @@ mob/new_player
 			else if(istype(ticker.mode, /datum/game_mode/pod_wars))
 				var/datum/game_mode/pod_wars/mode = ticker.mode
 				mode.add_latejoin_to_team(character.mind, JOB)
-			else if (istype(JOB, /datum/job/special/syndicate_operative))
-				character.set_loc(pick_landmark(LANDMARK_SYNDICATE))
+			else if (istype(JOB, /datum/job))
+				var/datum/job/job = JOB
+				if (job.special_spawn_location)
+					if (!istype(job.special_spawn_location, /turf))
+						job.special_spawn_location = pick_landmark(job.special_spawn_location)
+					if (job.special_spawn_location != null)
+						character.set_loc(job.special_spawn_location)
 			else if(istype(ticker.mode, /datum/game_mode/battle_royale))
 				var/datum/game_mode/battle_royale/battlemode = ticker.mode
 				if (current_state < GAME_STATE_FINISHED)

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1457,6 +1457,9 @@
 /obj/machinery/light_switch/south{
 	pixel_x = 5
 	},
+/obj/landmark{
+	name = "Radio-Show-Host-Spawn"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/radiostation/studio)
 "aeF" = (


### PR DESCRIPTION
[Internal] [Code Quality]


## About the PR:
Refactors the `special_spawn_location` variable on `/datum/job` to use map landmarks and turfs rather than (x, y, z) coordinates to spawn players in specific places, such as on the Cairngorm or Radio Ship.



## Why's this needed? 
Using (x, y, z) coordinates to spawn the Radio Host on their ship is downright cursed. This should also allow for a far simpler way to allocate special spawn positions when coding new jobs.