### PR TITLE
Adds the botany hydro-mister to maps missing it.

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -65686,6 +65686,12 @@
 /obj/storage/cart,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
+"ydh" = (
+/obj/machinery/hydro_mister,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "yeH" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -126943,7 +126949,7 @@ qUI
 avj
 xdC
 arn
-arn
+ydh
 mPp
 mPp
 adC

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -76046,6 +76046,17 @@
 /obj/item/shipcomponent/mainweapon/phaser,
 /turf/simulated/floor/shuttlebay,
 /area/station/security/checkpoint/podbay)
+"fqO" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/hydro_mister,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "fuP" = (
 /obj/cable{
 	d1 = 4;
@@ -105377,7 +105388,7 @@ arT
 aeX
 auF
 awe
-azo
+fqO
 azn
 aAH
 aFG

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -34370,6 +34370,7 @@
 	icon_state = "delivery2";
 	tag = ""
 	},
+/obj/machinery/hydro_mister,
 /turf/simulated/floor/greenblack{
 	dir = 6
 	},

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -3706,6 +3706,10 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/engine/engineering/ce)
+"beb" = (
+/obj/machinery/hydro_mister,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/hydroponics)
 "bec" = (
 /obj/table/auto,
 /obj/item/gun/russianrevolver{
@@ -159926,7 +159930,7 @@ vcW
 ryX
 vqF
 wth
-tpx
+beb
 tpx
 kRm
 ryX

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -6718,7 +6718,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L16";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "akQ" = (
@@ -7871,7 +7871,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L2";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "amP" = (
@@ -8191,7 +8191,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L15";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "anj" = (
@@ -9545,7 +9545,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L1";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "apw" = (
@@ -9814,7 +9814,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L3";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "apM" = (
@@ -10219,7 +10219,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L4";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "aql" = (
@@ -14886,7 +14886,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L10";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axI" = (
@@ -14897,7 +14897,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L11";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axJ" = (
@@ -14908,7 +14908,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L12";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axK" = (
@@ -14919,7 +14919,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L13";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axL" = (
@@ -14930,7 +14930,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L14";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axM" = (
@@ -14941,7 +14941,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L5";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axN" = (
@@ -14952,7 +14952,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L6";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axO" = (
@@ -14963,7 +14963,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L7";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axP" = (
@@ -14974,7 +14974,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L8";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axQ" = (
@@ -14985,7 +14985,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L9";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axR" = (
@@ -15905,48 +15905,48 @@
 "aAG" = (
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aAH" = (
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAI" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/i{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aAJ" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -15955,26 +15955,26 @@
 "aAK" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAL" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 6;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -15985,15 +15985,15 @@
 "aAM" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 6;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -16004,11 +16004,11 @@
 "aAN" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 8
@@ -16018,18 +16018,18 @@
 "aAO" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
 "aAP" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -16040,18 +16040,18 @@
 "aAQ" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
 "aAR" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16060,19 +16060,19 @@
 "aAS" = (
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -19;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16081,74 +16081,74 @@
 "aAT" = (
 /obj/decal/poster/wallsign/stencil/right/k{
 	pixel_x = 10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aAU" = (
 /obj/decal/poster/wallsign/stencil/right/m{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/m{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAV" = (
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/c{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aAW" = (
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/u{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/t{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aAX" = (
 /obj/decal/poster/wallsign/stencil/right/r{
 	pixel_x = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/v{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aAY" = (
 /obj/decal/poster/wallsign/stencil/right/s{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16157,44 +16157,44 @@
 "aAZ" = (
 /obj/decal/poster/wallsign/stencil/left/b{
 	pixel_x = -20;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBa" = (
 /obj/decal/poster/wallsign/stencil/left/c{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBb" = (
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aBc" = (
 /obj/decal/poster/wallsign/stencil/left/g{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/n{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -16203,29 +16203,29 @@
 "aBd" = (
 /obj/decal/poster/wallsign/stencil/left/l{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBe" = (
 /obj/decal/poster/wallsign/stencil/left/m{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aBf" = (
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/cable{
 	d1 = 4;
@@ -16239,44 +16239,44 @@
 "aBg" = (
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBh" = (
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/h{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBi" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aBj" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/t{
 	pixel_x = 9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -16285,15 +16285,15 @@
 "aBk" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/u{
 	pixel_x = -4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16302,15 +16302,15 @@
 "aBl" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/cable{
 	d1 = 4;
@@ -16324,63 +16324,63 @@
 "aBm" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aBn" = (
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/l{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aBo" = (
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -21;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aBp" = (
 /obj/decal/poster/wallsign/stencil/left/y{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBq" = (
 /obj/decal/poster/wallsign/stencil/left/y{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/t{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -17529,7 +17529,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 8, "QM" = 2, "Engine" = 2, "Catering" = 2, "MedSci" = 2, "Security" = 2)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=8,"QM"=2,"Engine"=2,"Catering"=2,"MedSci"=2,"Security"=2)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -24887,15 +24887,15 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -26279,11 +26279,11 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -34667,7 +34667,7 @@
 	pixel_y = -7
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "boK" = (
@@ -36243,91 +36243,91 @@
 "brz" = (
 /obj/machinery/cargo_router{
 	default_direction = 1;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 1, "EVA" = 4, "Disposals" = 1, "QM" = 1, "Engine" = 1, "Catering" = 1, "MedSci" = 1, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=1,"EVA"=4,"Disposals"=1,"QM"=1,"Engine"=1,"Catering"=1,"MedSci"=1,"Security"=1)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brA" = (
 /obj/machinery/cargo_router{
 	default_direction = 1;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 1, "QM" = 1, "Engine" = 4, "Catering" = 1, "MedSci" = 1, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=1,"QM"=1,"Engine"=4,"Catering"=1,"MedSci"=1,"Security"=1)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brB" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 1, "MedSci" = 2, "Security" = 1)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=1,"MedSci"=2,"Security"=1)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brC" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 2, "MedSci" = 2, "Security" = 4)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=2,"MedSci"=2,"Security"=4)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brD" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brE" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 2, "Engine" = 4, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=2,"Engine"=4,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brF" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 2, "Disposals" = 4, "QM" = 4, "Engine" = 4, "Catering" = 1, "MedSci" = 2, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=2,"Disposals"=4,"QM"=4,"Engine"=4,"Catering"=1,"MedSci"=2,"Security"=1)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brG" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 4, "Engine" = 2, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=4,"Engine"=2,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brH" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 4, "Engine" = 4, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=2,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=4,"Engine"=4,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brI" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 1, "EVA" = 8, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=1,"EVA"=8,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brJ" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 8, "QM" = 8, "Engine" = 2, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=8,"QM"=8,"Engine"=2,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brK" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 8, "EVA" = 8, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 2, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=8,"EVA"=8,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=2,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brL" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 8, "EVA" = 1, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=8,"EVA"=1,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
@@ -46757,7 +46757,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "bLu" = (
@@ -62480,7 +62480,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cmX" = (
@@ -62499,7 +62499,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cmZ" = (
@@ -62521,7 +62521,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cnb" = (
@@ -62529,7 +62529,7 @@
 /obj/machinery/phone,
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cnc" = (
@@ -65533,6 +65533,7 @@
 	},
 /area/station/hydroponics/bay)
 "cuB" = (
+/obj/machinery/hydro_mister,
 /turf/simulated/floor/green/side{
 	dir = 6
 	},
@@ -67682,7 +67683,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "fno" = (
@@ -69879,7 +69880,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "tpK" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -21365,6 +21365,7 @@
 	dir = 4;
 	pixel_x = -6
 	},
+/obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -25806,7 +25807,7 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "kNX" = (
-/obj/machinery/hydro_growlamp,
+/obj/machinery/hydro_mister,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [QoL] [Add To Wiki]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds hydro-mister to Cog1, Cog2, Horizon, pamgoC, Ozymandias, and Wrestlemap.
![FogMachine](https://user-images.githubusercontent.com/61445638/192426884-eebc3912-a530-4c70-a925-32a19bb87396.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Requested by Scaltra#6709

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Herbert
(+)The botanical mister has been added to maps previously missing it. Hooray!
```
