### PR TITLE
Multi mining-magnet drifting

### DIFF
--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -171,21 +171,6 @@ var/list/asteroid_blocked_turfs = list()
 	luminosity = 1
 	expandable = 0
 
-	proc/check_for_unacceptable_content()
-		for (var/mob/living/L in src.contents)
-			if(!isintangible(L)) //neither blob overmind or AI eye should block this
-				return 1
-		for (var/obj/machinery/vehicle/V in src.contents)
-			return 1
-		for (var/obj/artifact/A in src.contents) // check if an artifact has someone inside
-			if (istype(A, /obj/artifact/prison))
-				var/datum/artifact/prison/P = A.artifact
-				if(istype(P.prisoner)) return 1
-			else if (istype(A, /obj/artifact/cloner))
-				var/datum/artifact/cloner/C = A.artifact
-				if(istype(C.clone)) return 1
-		return 0
-
 /obj/forcefield/mining
 	name = "magnetic forcefield"
 	desc = "A powerful field used by the mining magnet to attract minerals."

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -111,6 +111,16 @@ var/global/list/job_start_locations = list()
 /obj/landmark/magnet_center
 	name = LANDMARK_MAGNET_CENTER
 	icon_state = "magnet-center"
+	var/width = 15
+	var/height = 15
+	var/obj/machinery/mining_magnet/magnet
+
+	New()
+		var/turf/T = locate(src.x-round(width/2), src.y-round(height/2), src.z)
+		var/obj/magnet_target_marker/M = new /obj/magnet_target_marker(T)
+		M.width = src.width
+		M.height = src.height
+		..()
 
 /obj/landmark/magnet_shield
 	name = LANDMARK_MAGNET_SHIELD

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -181,9 +181,32 @@
 		return walls
 
 	proc/check_for_unacceptable_content()
-		if(mining_controls.magnet_area)
-			return mining_controls.magnet_area.check_for_unacceptable_content()
-		return 1
+		// this used to use an area, which meant it only checked
+		var/turf/origin = get_turf(src)
+		var/unacceptable = FALSE
+		for (var/turf/T in block(origin, locate(origin.x + width - 1, origin.y + height - 1, origin.z)))
+
+			for (var/mob/living/L in T)
+				if(!isintangible(L)) //neither blob overmind or AI eye should block this
+					unacceptable = TRUE
+					break
+			for (var/obj/machinery/vehicle/V in T)
+				unacceptable = TRUE
+				break
+
+			for (var/obj/artifact/A in T) // check if an artifact has someone inside
+				if (istype(A, /obj/artifact/prison))
+					var/datum/artifact/prison/P = A.artifact
+					if(istype(P.prisoner))
+						unacceptable = TRUE
+						break
+				else if (istype(A, /obj/artifact/cloner))
+					var/datum/artifact/cloner/C = A.artifact
+					if(istype(C.clone))
+						unacceptable = TRUE
+						break
+
+		return unacceptable
 
 	proc/UL()
 		var/turf/origin = get_turf(src)
@@ -202,6 +225,14 @@
 		var/turf/origin = get_turf(src)
 		var/turf/dr = locate(origin.x + width - 1, origin.y, origin.z)
 		return dr
+
+	New()
+		..()
+		START_TRACKING
+
+	disposing()
+		STOP_TRACKING
+		..()
 
 	proc/construct()
 		var/turf/origin = get_turf(src)
@@ -332,7 +363,7 @@
 	var/malfunctioning = 0
 	var/rarity_mod = 0
 
-	var/uses_global_controls = TRUE
+	var/autosetup = TRUE
 
 	var/image/active_overlay = null
 	var/list/damage_overlays = list()
@@ -340,126 +371,29 @@
 	var/sound_destroyed = 'sound/impact_sounds/Machinery_Break_1.ogg'
 	var/obj/machinery/power/apc/mining_apc = null
 
-	proc/get_magnetic_center()
-		return mining_controls.magnetic_center
+	var/marker_type = /obj/magnet_target_marker
+	var/obj/magnet_target_marker/target = null
+	var/list/wall_bits = list()
 
-	proc/get_scan_range()
-		return 6
+	// reworked to nolonger use areas
+	proc/get_magnetic_center()
+		return target?.magnetic_center // the target marker has the center
+
+	proc/get_scan_range() // reworked
+		if (target)
+			return target.scan_range
+		return 6 // 6 if there's no center marker
 
 	proc/check_for_unacceptable_content()
-		if(mining_controls.magnet_area)
-			return mining_controls.magnet_area.check_for_unacceptable_content()
-		return 1
+		if (target)
+			return target.check_for_unacceptable_content()
+		return 1 // fail if there's no center marker
 
-	construction
-		var/marker_type = /obj/magnet_target_marker
-		var/obj/magnet_target_marker/target = null
-		var/list/wall_bits = list()
-		uses_global_controls = FALSE
+	proc/get_encounter(var/rarity_mod)
+		return mining_controls.select_encounter(rarity_mod)
 
-		get_magnetic_center()
-			if (target)
-				return target.magnetic_center
-			return null
-
-		get_scan_range()
-			if (target)
-				return target.scan_range
-			return 0
-
-		check_for_unacceptable_content()
-			if (target)
-				return target.check_for_unacceptable_content()
-			return 1
-
-		New()
-			..()
-			if (mining_apc)
-				mining_apc = null // Don't want random apcs across the map going haywire.
-
-		process()
-			if (!target)
-				return
-			if (automatic_mode && last_used < TIME && last_delay < TIME)
-				if (target.check_for_unacceptable_content())
-					last_delay = TIME + auto_delay
-					return
-				else
-					SPAWN(0)
-						pull_new_source()
-
-		proc/get_encounter(var/rarity_mod)
-			return mining_controls.select_encounter(rarity_mod)
-
-		pull_new_source(var/selectable_encounter_id = null)
-			if (!target)
-				return
-
-			if (!wall_bits.len)
-				wall_bits = target.generate_walls()
-
-			for (var/obj/forcefield/mining/M in wall_bits)
-				M.set_opacity(1)
-				M.set_density(1)
-				M.invisibility = INVIS_NONE
-
-			active = 1
-
-			if (last_used > TIME)
-				damage(rand(2,6))
-
-			last_used = TIME + cooldown_time
-			playsound(src.loc, sound_activate, 100, 0, 3, 0.25)
-			build_icon()
-
-			target.erase_area()
-
-			var/sleep_time = attract_time
-			if (sleep_time < 1)
-				sleep_time = 20
-			sleep_time /= 2
-
-			if (malfunctioning && prob(20))
-				do_malfunction()
-			sleep(sleep_time)
-
-			var/datum/mining_encounter/MC
-
-			if(selectable_encounter_id != null)
-				if(selectable_encounter_id in mining_controls.mining_encounters_selectable)
-					MC = mining_controls.mining_encounters_selectable[selectable_encounter_id]
-					mining_controls.remove_selectable_encounter(selectable_encounter_id)
-				else
-					boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: INVALID ENCOUNTER)")
-					MC = get_encounter(rarity_mod)
-			else
-				MC = get_encounter(rarity_mod)
-
-			if(MC)
-				MC.generate(target)
-			else
-				for (var/obj/forcefield/mining/M in mining_controls.magnet_shields)
-					M.set_opacity(0)
-					M.set_density(0)
-					M.invisibility = INVIS_INFRA
-				active = 0
-				boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: NO ENCOUNTER)")
-				return
-
-			sleep(sleep_time)
-			if (malfunctioning && prob(20))
-				do_malfunction()
-
-			active = 0
-			build_icon()
-
-			for (var/obj/forcefield/mining/M in wall_bits)
-				M.set_opacity(0)
-				M.set_density(0)
-				M.invisibility = INVIS_ALWAYS
-
-			src.updateUsrDialog()
-			return
+	construction // here so old maps dont get broken
+		autosetup = FALSE
 
 		small
 			marker_type = /obj/magnet_target_marker/small
@@ -478,17 +412,30 @@
 				linked_chassis = MC
 				MC.linked_magnet = src
 				break
+			// mining magnets can automatically set up immediately at roundstart as a treat
+			if (!target && autosetup)
+				var/obj/closest
+				var/closestDistance = 300
 
-			for (var/obj/machinery/power/apc/APC in range(20,src))
-				var/area/the_area = get_area(APC)
-				if (the_area.type == /area/station/quartermaster/magnet)
-					mining_apc = APC
-					break
+				// find the closest marker. there should be one per magnet
+
+				// Magnet center is used first
+				for_by_tcl(marker, /obj/magnet_target_marker)
+					if (istype(marker,marker_type))
+						if (GET_DIST(marker,src) < closestDistance) // same as the magnetizer limit i think
+							closest = marker
+				src.target = closest
+				if (istype(target))
+					target.construct()
+			if (!mining_apc) // no checking 400 tiles for an apc holy shit
+				mining_apc = get_local_apc()
 
 	process()
-		..()
+
+		if (!target)
+			return
 		if (automatic_mode && last_used < TIME && last_delay < TIME)
-			if (mining_controls.magnet_area.check_for_unacceptable_content())
+			if (target.check_for_unacceptable_content())
 				last_delay = TIME + auto_delay
 				return
 			else
@@ -626,7 +573,13 @@
 					mining_apc.zapStuff()
 
 	proc/pull_new_source(var/selectable_encounter_id = null)
-		for (var/obj/forcefield/mining/M in mining_controls.magnet_shields)
+		if (!target)
+			return
+
+		if (!length(wall_bits))
+			wall_bits = target.generate_walls()
+
+		for (var/obj/forcefield/mining/M in wall_bits)
 			M.set_opacity(1)
 			M.set_density(1)
 			M.invisibility = INVIS_NONE
@@ -640,21 +593,7 @@
 		playsound(src.loc, sound_activate, 100, 0, 3, 0.25)
 		build_icon()
 
-		for (var/obj/O in mining_controls.magnet_area.contents)
-			if (!(O.type in mining_controls.magnet_do_not_erase))
-				qdel(O)
-		for (var/turf/simulated/T in mining_controls.magnet_area.contents)
-			var/datum/client_image_group/cig = get_image_group(T) //clear out scan results
-			for(var/image/i in cig.images)
-				cig.remove_image(i)
-			if (!istype(T,/turf/simulated/floor/airless/plating/catwalk/))
-				T.ReplaceWith(/turf/space)
-				//qdel(T)
-		if(station_repair.station_generator)
-			for (var/turf/unsimulated/UT in mining_controls.magnet_area.contents)
-				UT.ReplaceWith(/turf/space, force=TRUE)
-		for (var/turf/space/S in mining_controls.magnet_area.contents)
-			S.ClearAllOverlays()
+		target.erase_area()
 
 		var/sleep_time = attract_time
 		if (sleep_time < 1)
@@ -673,14 +612,14 @@
 				mining_controls.remove_selectable_encounter(selectable_encounter_id)
 			else
 				boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: INVALID ENCOUNTER)")
-				MC = mining_controls.select_encounter(rarity_mod)
+				MC = get_encounter(rarity_mod)
 		else
-			MC = mining_controls.select_encounter(rarity_mod)
+			MC = get_encounter(rarity_mod)
 
 		if(MC)
-			MC.generate(null)
+			MC.generate(target)
 		else
-			for (var/obj/forcefield/mining/M in mining_controls.magnet_shields)
+			for (var/obj/forcefield/mining/M in wall_bits)
 				M.set_opacity(0)
 				M.set_density(0)
 				M.invisibility = INVIS_INFRA
@@ -690,7 +629,8 @@
 
 		if(station_repair.station_generator)
 			var/list/turf/space/repair_turfs = list()
-			for(var/turf/space/T in mining_controls.magnet_area.contents)
+			var/turf/origin = get_turf(target)
+			for (var/turf/space/T in block(origin, locate(origin.x + target.width - 1, origin.y + target.height - 1, origin.z)))
 				repair_turfs += T
 			station_repair.repair_turfs(repair_turfs)
 
@@ -701,7 +641,7 @@
 		active = 0
 		build_icon()
 
-		for (var/obj/forcefield/mining/M in mining_controls.magnet_shields)
+		for (var/obj/forcefield/mining/M in wall_bits)
 			M.set_opacity(0)
 			M.set_density(0)
 			M.invisibility = INVIS_ALWAYS
@@ -741,11 +681,11 @@
 			if ("activateselectable")
 				if (magnetNotReady)
 					return
-				if (src.uses_global_controls && !istype(mining_controls.magnet_area))
+				if (!target || !src.get_magnetic_center())
 					boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder!")
 					return
 
-				if (src.check_for_unacceptable_content())
+				if (target.check_for_unacceptable_content())
 					src.visible_message("<b>[src.name]</b> states, \"Safety lock engaged. Please remove all personnel and vehicles from the magnet area.\"")
 				else
 					src.last_use_attempt = TIME + 10
@@ -754,11 +694,11 @@
 			if ("activatemagnet")
 				if (magnetNotReady)
 					return
-				if (src.uses_global_controls && !istype(mining_controls.magnet_area))
+				if (!target || !src.get_magnetic_center())
 					boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder!")
 					return
 
-				if (src.check_for_unacceptable_content())
+				if (target.check_for_unacceptable_content())
 					src.visible_message("<b>[src.name]</b> states, \"Safety lock engaged. Please remove all personnel and vehicles from the magnet area.\"")
 				else
 					src.last_use_attempt = TIME + 10 // This is to prevent href exploits or autoclickers from pulling multiple times simultaneously

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -40858,7 +40858,10 @@
 	},
 /area/station/engine/ptl)
 "bJI" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "bJJ" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -42232,7 +42232,10 @@
 	},
 /area/station/quartermaster/refinery)
 "chK" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "chL" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -70698,7 +70698,10 @@
 /turf/simulated/floor/engine/vacuum,
 /area/supply/delivery_point)
 "def" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "deg" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -31617,7 +31617,10 @@
 /turf/simulated/floor/blue/side,
 /area/station/hydroponics/bay)
 "iRf" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "iRw" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -57257,7 +57257,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/ai_monitored/storage/eva)
 "qtm" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 11;
+	width = 11
+	},
 /turf/space,
 /area/mining/magnet)
 "qts" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -24717,7 +24717,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "byB" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "byC" = (

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -10339,7 +10339,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "cWF" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "cWH" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -6718,7 +6718,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L16";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "akQ" = (
@@ -7871,7 +7871,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L2";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "amP" = (
@@ -8191,7 +8191,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L15";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "anj" = (
@@ -9545,7 +9545,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L1";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "apw" = (
@@ -9814,7 +9814,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L3";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "apM" = (
@@ -10219,7 +10219,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L4";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "aql" = (
@@ -14886,7 +14886,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L10";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axI" = (
@@ -14897,7 +14897,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L11";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axJ" = (
@@ -14908,7 +14908,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L12";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axK" = (
@@ -14919,7 +14919,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L13";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axL" = (
@@ -14930,7 +14930,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L14";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axM" = (
@@ -14941,7 +14941,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L5";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axN" = (
@@ -14952,7 +14952,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L6";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axO" = (
@@ -14963,7 +14963,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L7";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axP" = (
@@ -14974,7 +14974,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L8";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axQ" = (
@@ -14985,7 +14985,7 @@
 	},
 /turf/simulated/floor{
 	icon_state = "L9";
-	transform = list(-1, 0, -1, 0, 1, 0)
+	transform = list(-1,0,-1,0,1,0)
 	},
 /area/station/crew_quarters/market)
 "axR" = (
@@ -15905,48 +15905,48 @@
 "aAG" = (
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aAH" = (
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAI" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/i{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aAJ" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -15955,26 +15955,26 @@
 "aAK" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAL" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 6;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -15985,15 +15985,15 @@
 "aAM" = (
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 6;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -16004,11 +16004,11 @@
 "aAN" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 8
@@ -16018,18 +16018,18 @@
 "aAO" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
 "aAP" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -16040,18 +16040,18 @@
 "aAQ" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
 "aAR" = (
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16060,19 +16060,19 @@
 "aAS" = (
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/n{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -19;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16081,74 +16081,74 @@
 "aAT" = (
 /obj/decal/poster/wallsign/stencil/right/k{
 	pixel_x = 10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aAU" = (
 /obj/decal/poster/wallsign/stencil/right/m{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/m{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "aAV" = (
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/c{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aAW" = (
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/u{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/t{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aAX" = (
 /obj/decal/poster/wallsign/stencil/right/r{
 	pixel_x = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/v{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -18;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aAY" = (
 /obj/decal/poster/wallsign/stencil/right/s{
 	pixel_x = -1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16157,44 +16157,44 @@
 "aAZ" = (
 /obj/decal/poster/wallsign/stencil/left/b{
 	pixel_x = -20;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBa" = (
 /obj/decal/poster/wallsign/stencil/left/c{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBb" = (
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "aBc" = (
 /obj/decal/poster/wallsign/stencil/left/g{
 	pixel_x = -11;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/n{
 	pixel_x = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -16203,29 +16203,29 @@
 "aBd" = (
 /obj/decal/poster/wallsign/stencil/left/l{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBe" = (
 /obj/decal/poster/wallsign/stencil/left/m{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aBf" = (
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/cable{
 	d1 = 4;
@@ -16239,44 +16239,44 @@
 "aBg" = (
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -15;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBh" = (
 /obj/decal/poster/wallsign/stencil/left/p{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/h{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aBi" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -13;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aBj" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -14;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/t{
 	pixel_x = 9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/catering{
@@ -16285,15 +16285,15 @@
 "aBk" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -16;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/u{
 	pixel_x = -4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -16302,15 +16302,15 @@
 "aBl" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/cable{
 	d1 = 4;
@@ -16324,63 +16324,63 @@
 "aBm" = (
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/depot)
 "aBn" = (
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -10;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/l{
 	pixel_x = 2;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aBo" = (
 /obj/decal/poster/wallsign/stencil/left/s{
 	pixel_x = -21;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/d{
 	pixel_x = -8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/e{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/airbridge)
 "aBp" = (
 /obj/decal/poster/wallsign/stencil/left/y{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/a{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aBq" = (
 /obj/decal/poster/wallsign/stencil/left/y{
 	pixel_x = -12;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/t{
 	pixel_x = 0;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
 	icon_state = "R12"
@@ -17529,7 +17529,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 8, "QM" = 2, "Engine" = 2, "Catering" = 2, "MedSci" = 2, "Security" = 2)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=8,"QM"=2,"Engine"=2,"Catering"=2,"MedSci"=2,"Security"=2)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -24887,15 +24887,15 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/right/c{
 	pixel_x = 7;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/r{
 	pixel_x = -17;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -26279,11 +26279,11 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/stencil/right/g{
 	pixel_x = 3;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /obj/decal/poster/wallsign/stencil/left/o{
 	pixel_x = -9;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -30031,7 +30031,10 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bee" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "bef" = (
@@ -34667,7 +34670,7 @@
 	pixel_y = -7
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "boK" = (
@@ -36243,91 +36246,91 @@
 "brz" = (
 /obj/machinery/cargo_router{
 	default_direction = 1;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 1, "EVA" = 4, "Disposals" = 1, "QM" = 1, "Engine" = 1, "Catering" = 1, "MedSci" = 1, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=1,"EVA"=4,"Disposals"=1,"QM"=1,"Engine"=1,"Catering"=1,"MedSci"=1,"Security"=1)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brA" = (
 /obj/machinery/cargo_router{
 	default_direction = 1;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 1, "QM" = 1, "Engine" = 4, "Catering" = 1, "MedSci" = 1, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=1,"QM"=1,"Engine"=4,"Catering"=1,"MedSci"=1,"Security"=1)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brB" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 1, "MedSci" = 2, "Security" = 1)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=1,"MedSci"=2,"Security"=1)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brC" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 2, "MedSci" = 2, "Security" = 4)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=2,"MedSci"=2,"Security"=4)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brD" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 2, "QM" = 2, "Engine" = 2, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=2,"QM"=2,"Engine"=2,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brE" = (
 /obj/machinery/cargo_router{
 	default_direction = 2;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 2, "Engine" = 4, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=2,"Engine"=4,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "brF" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 2, "Disposals" = 4, "QM" = 4, "Engine" = 4, "Catering" = 1, "MedSci" = 2, "Security" = 1)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=2,"Disposals"=4,"QM"=4,"Engine"=4,"Catering"=1,"MedSci"=2,"Security"=1)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brG" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 4, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 4, "Engine" = 2, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=4,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=4,"Engine"=2,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brH" = (
 /obj/machinery/cargo_router{
 	default_direction = 4;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 4, "EVA" = 4, "Disposals" = 4, "QM" = 4, "Engine" = 4, "Catering" = 4, "MedSci" = 4, "Security" = 4)
+	destinations = list("Airbridge"=2,"Cafeteria"=4,"EVA"=4,"Disposals"=4,"QM"=4,"Engine"=4,"Catering"=4,"MedSci"=4,"Security"=4)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brI" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 1, "EVA" = 8, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=1,"EVA"=8,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brJ" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 2, "Cafeteria" = 2, "EVA" = 2, "Disposals" = 8, "QM" = 8, "Engine" = 2, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=2,"Cafeteria"=2,"EVA"=2,"Disposals"=8,"QM"=8,"Engine"=2,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "brK" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 8, "EVA" = 8, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 2, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=8,"EVA"=8,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=2,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
 "brL" = (
 /obj/machinery/cargo_router{
 	default_direction = 8;
-	destinations = list("Airbridge" = 8, "Cafeteria" = 8, "EVA" = 1, "Disposals" = 8, "QM" = 8, "Engine" = 8, "Catering" = 8, "MedSci" = 8, "Security" = 8)
+	destinations = list("Airbridge"=8,"Cafeteria"=8,"EVA"=1,"Disposals"=8,"QM"=8,"Engine"=8,"Catering"=8,"MedSci"=8,"Security"=8)
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
@@ -46757,7 +46760,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "bLu" = (
@@ -62480,7 +62483,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 8;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cmX" = (
@@ -62499,7 +62502,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cmZ" = (
@@ -62521,7 +62524,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 5;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cnb" = (
@@ -62529,7 +62532,7 @@
 /obj/machinery/phone,
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 4;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "cnc" = (
@@ -67682,7 +67685,7 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 1;
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "fno" = (
@@ -69879,7 +69882,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/specialroom/bar/edge{
-	transform = list(-1, 0, 0, 0, 1, 0)
+	transform = list(-1,0,0,0,1,0)
 	},
 /area/station/crew_quarters/cafeteria)
 "tpK" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -23551,7 +23551,10 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "jMP" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "jMT" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes mining magnets to not use areas to find the magnet / run the safety checks.
as a result, this fixes #11032

instead, the magnet uses either the magnet center landmark, or the object generated from the magnetizer directly.
width / height vars on either of these control the dimensions of the empty space inside the magnet catwalks.

this allows multiple magnets to work at the same time, with each magnet grabbing what is closest to it
![image](https://user-images.githubusercontent.com/64938519/192444238-db7bbe73-a1f6-4eb0-a581-0d667c624207.png)

i did some testing, and it seemed like it was working normally, but there may be bugs.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
currently, the magnets interfere with eachother.
the safety check for if a pod/human is in the magnet area specifically checks the station magnet area.

also it might be nice if pod wars takes advantage of this to have both magnets set up on roundstart


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Skeletonman0
(*)New breakthroughs allow multiple mining magnets to operate at the same time. Please report any bugs you find
```
