### PR TITLE
Fixes flock peak compute round end display

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -552,7 +552,6 @@ var/flock_signal_unleashed = FALSE
 	src.achievements = list()
 	src.total_compute = 0
 	src.used_compute = 0
-	src.peak_compute = 0
 	if (!real)
 		src.load_structures()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flock peak compute was being reset on death for some reason, meaning it would always display as zero at the end of the round if the flock died. This stops it doing that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad