### PR TITLE
Chef Objective Fix

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -457,7 +457,23 @@ ABSTRACT_TYPE(/datum/objective/crew/chef)
 		/obj/item/reagent_containers/food/snacks/pizza/xmas,
 		/obj/item/reagent_containers/food/snacks/plant/glowfruit/spawnable,
 		/obj/item/reagent_containers/food/snacks/soup/custom,
-		/obj/item/reagent_containers/food/snacks/condiment/syndisauce
+		/obj/item/reagent_containers/food/snacks/condiment/syndisauce,
+		/obj/item/reagent_containers/food/snacks/donkpocket_w,
+		/obj/item/reagent_containers/food/snacks/surstromming,
+		/obj/item/reagent_containers/food/snacks/hotdog/syndicate,
+		/obj/item/reagent_containers/food/snacks/tortilla_chip_spawner,
+		/obj/item/reagent_containers/food/snacks/pancake/classic,
+		/obj/item/reagent_containers/food/snacks/wonton_spawner,
+		/obj/item/reagent_containers/food/snacks/agar_block,
+		/obj/item/reagent_containers/food/snacks/sushi_roll/custom,
+		/obj/item/reagent_containers/food/snacks/healgoo, // might be fun to have the trench mob drops available when it's oshan
+		/obj/item/reagent_containers/food/snacks/greengoo,
+		/obj/item/reagent_containers/food/snacks/snowball,
+		/obj/item/reagent_containers/food/snacks/burger/vr,
+		/obj/item/reagent_containers/food/snacks/slimjim,
+		/obj/item/reagent_containers/food/snacks/bite,
+		/obj/item/reagent_containers/food/snacks/pickle_holder,
+		/obj/item/reagent_containers/food/snacks/snack_cake
 	)
 	var/static/list/ingredients = concrete_typesof(/obj/item/reagent_containers/food/snacks) - blacklist - concrete_typesof(/obj/item/reagent_containers/food/snacks/ingredient/egg/critter)
 /datum/objective/crew/chef/cake

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -466,8 +466,10 @@ ABSTRACT_TYPE(/datum/objective/crew/chef)
 		/obj/item/reagent_containers/food/snacks/wonton_spawner,
 		/obj/item/reagent_containers/food/snacks/agar_block,
 		/obj/item/reagent_containers/food/snacks/sushi_roll/custom,
-		/obj/item/reagent_containers/food/snacks/healgoo, // might be fun to have the trench mob drops available when it's oshan
+#ifndef UNDERWATER_MAP
+		/obj/item/reagent_containers/food/snacks/healgoo,
 		/obj/item/reagent_containers/food/snacks/greengoo,
+#endif
 		/obj/item/reagent_containers/food/snacks/snowball,
 		/obj/item/reagent_containers/food/snacks/burger/vr,
 		/obj/item/reagent_containers/food/snacks/slimjim,

--- a/code/modules/food_and_drink/condiments.dm
+++ b/code/modules/food_and_drink/condiments.dm
@@ -1,5 +1,6 @@
 // Condiments
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/condiment)
 /obj/item/reagent_containers/food/snacks/condiment
 	name = "condiment"
 	desc = "you shouldnt be able to see this"

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -1,5 +1,6 @@
 // Ingredients
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/ingredient)
 /obj/item/reagent_containers/food/snacks/ingredient
 	name = "ingredient"
 	desc = "you shouldnt be able to see this"

--- a/code/modules/food_and_drink/pies.dm
+++ b/code/modules/food_and_drink/pies.dm
@@ -1,4 +1,4 @@
-
+ABSTRACT_TYPE(/obj/item/reagent_containers/snacks/pie)
 /obj/item/reagent_containers/food/snacks/pie
 	name = "pie"
 	icon = 'icons/obj/foodNdrink/food_dessert.dmi'


### PR DESCRIPTION
[A-INTERNAL] [C-BUG]

## About the PR 
expands the blacklist for the chef crew objective to add stuff like spawners, inaccessible parent types, map- or traitor-specific items, and other various options that weren't excluded from the objective's pool before. also makes the condiment, ingredient, and pie parents abstract types

my computer won't let me test this right now so if possible someone should give this a quick pass to make sure it doesn't Break Something Horribly

## Why's this needed? 
being able to do crew objectives good