### PR TITLE
Gives nightvision to the harbinger's summons and to the manifested trickster

### DIFF
--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -25,7 +25,7 @@
 				M.summons = list()
 			M.summons += src
 
-
+		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
 		//Let us spawn as stuff
 		abilityHolder.addAbility(/datum/targetable/critter/nascent/become_spiker)
 		abilityHolder.addAbility(/datum/targetable/critter/nascent/become_voidhound)

--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -25,7 +25,7 @@
 				M.summons = list()
 			M.summons += src
 
-		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		//Let us spawn as stuff
 		abilityHolder.addAbility(/datum/targetable/critter/nascent/become_spiker)
 		abilityHolder.addAbility(/datum/targetable/critter/nascent/become_voidhound)

--- a/code/modules/antagonists/wraith/critters/skeleton_commander.dm
+++ b/code/modules/antagonists/wraith/critters/skeleton_commander.dm
@@ -26,6 +26,7 @@
 				M.summons = list()
 			M.summons += src
 
+		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
 		abilityHolder.addAbility(/datum/targetable/critter/skeleton_commander/rally)
 		abilityHolder.addAbility(/datum/targetable/critter/skeleton_commander/summon_lesser_skeleton)
 

--- a/code/modules/antagonists/wraith/critters/skeleton_commander.dm
+++ b/code/modules/antagonists/wraith/critters/skeleton_commander.dm
@@ -26,7 +26,7 @@
 				M.summons = list()
 			M.summons += src
 
-		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		abilityHolder.addAbility(/datum/targetable/critter/skeleton_commander/rally)
 		abilityHolder.addAbility(/datum/targetable/critter/skeleton_commander/summon_lesser_skeleton)
 

--- a/code/modules/antagonists/wraith/critters/spiker.dm
+++ b/code/modules/antagonists/wraith/critters/spiker.dm
@@ -25,6 +25,7 @@
 			if (isnull(M.summons))
 				M.summons = list()
 			M.summons += src
+		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
 		abilityHolder.addAbility(/datum/targetable/critter/spiker/hook)
 		abilityHolder.addAbility(/datum/targetable/critter/spiker/lash)
 

--- a/code/modules/antagonists/wraith/critters/spiker.dm
+++ b/code/modules/antagonists/wraith/critters/spiker.dm
@@ -25,7 +25,7 @@
 			if (isnull(M.summons))
 				M.summons = list()
 			M.summons += src
-		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		abilityHolder.addAbility(/datum/targetable/critter/spiker/hook)
 		abilityHolder.addAbility(/datum/targetable/critter/spiker/lash)
 

--- a/code/modules/antagonists/wraith/critters/trickster_puppet.dm
+++ b/code/modules/antagonists/wraith/critters/trickster_puppet.dm
@@ -25,7 +25,7 @@
 
 		last_life_update = TIME
 
-		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		src.abilityHolder = new /datum/abilityHolder/wraith(src)
 		src.abilityHolder.points = master?.abilityHolder.points
 

--- a/code/modules/antagonists/wraith/critters/trickster_puppet.dm
+++ b/code/modules/antagonists/wraith/critters/trickster_puppet.dm
@@ -25,6 +25,7 @@
 
 		last_life_update = TIME
 
+		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
 		src.abilityHolder = new /datum/abilityHolder/wraith(src)
 		src.abilityHolder.points = master?.abilityHolder.points
 

--- a/code/modules/antagonists/wraith/critters/voidhound.dm
+++ b/code/modules/antagonists/wraith/critters/voidhound.dm
@@ -29,7 +29,7 @@
 			if (isnull(M.summons))
 				M.summons = list()
 			M.summons += src
-		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		abilityHolder.addAbility(/datum/targetable/critter/voidhound/cloak)
 		abilityHolder.addAbility(/datum/targetable/critter/voidhount/rushdown)
 

--- a/code/modules/antagonists/wraith/critters/voidhound.dm
+++ b/code/modules/antagonists/wraith/critters/voidhound.dm
@@ -29,6 +29,7 @@
 			if (isnull(M.summons))
 				M.summons = list()
 			M.summons += src
+		src.bioHolder.AddEffect("nightvision", 0, 0, 0, 1)
 		abilityHolder.addAbility(/datum/targetable/critter/voidhound/cloak)
 		abilityHolder.addAbility(/datum/targetable/critter/voidhount/rushdown)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives some level of dark vision to the skeleton commander, tentacle fiend, voidhound and nascent that the harbinger spawns.
Also gives the same level of dark vision to the trickster when they haunt as a puppet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Creatures of the aether that routinely roam maintenance, cant really wear pda lights or light-giving clothing, some level of vision is needed.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus
(+)The harbinger wraith's summons now see in the dark and so does the trickster wraith.
```
