### PR TITLE
Fixes multi-turf objects taking multiplied explosion damage

### DIFF
--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -156,6 +156,10 @@ var/datum/explosion_controller/explosions
 /obj
 	var/datum/explosion/last_explosion = null
 
+/obj/disposing()
+	src.last_explosion = null
+	..()
+
 /datum/explosion
 	var/atom/source
 	var/turf/epicenter

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -77,31 +77,24 @@ var/datum/explosion_controller/explosions
 		LAGCHECK(LAG_HIGH)
 
 		for (var/turf/T as anything in queued_turfs)
-			p = queued_turfs[T]
 			explosion = queued_turfs_blame[T]
-			//boutput(world, "P1 [p]")
-			if (p >= 6)
-				for (var/obj/O in T)
-					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
-						continue
-					O.ex_act(1, explosion.last_touched, highest_explosion_power(O))
-					O.last_explosion = explosion
+			for (var/obj/O in T)
+				if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
+					continue
+				var/power = highest_explosion_power(O)
+				var/severity
+				if (power >= 6)
+					severity = 1
 					if (istype(O, /obj/cable)) // these two are hacky, newcables should relieve the need for this
 						needrebuild = 1
-			else if (p > 3)
-				for (var/obj/O in T)
-					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
-						continue
-					O.ex_act(2, explosion.last_touched, highest_explosion_power(O))
-					O.last_explosion = explosion
+				else if (power > 3)
+					severity = 2
 					if (istype(O, /obj/cable))
 						needrebuild = 1
-			else
-				for (var/obj/O in T)
-					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
-						continue
-					O.ex_act(3, explosion.last_touched, highest_explosion_power(O))
-					O.last_explosion = explosion
+				else
+					severity = 3
+				O.ex_act(severity, explosion.last_touched, power)
+				O.last_explosion = explosion
 
 		LAGCHECK(LAG_HIGH)
 

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -153,12 +153,11 @@ var/datum/explosion_controller/explosions
 				next_turf_safe |= E.turf_safe
 
 
-/obj
-	var/datum/explosion/last_explosion = null
+/obj/var/datum/explosion/last_explosion = null
 
 /obj/disposing()
 	src.last_explosion = null
-	..()
+	. = ..()
 
 /datum/explosion
 	var/atom/source

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -45,6 +45,10 @@ var/datum/explosion_controller/explosions
 			if(c++ % 100 == 0)
 				LAGCHECK(LAG_HIGH)
 
+	proc/highest_explosion_power(obj/object)
+		for (var/turf/T in object.locs)
+			. = max(., queued_turfs[T])
+
 	proc/kaboom()
 		defer_powernet_rebuild = 1
 		defer_camnet_rebuild = 1
@@ -80,7 +84,7 @@ var/datum/explosion_controller/explosions
 				for (var/obj/O in T)
 					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
 						continue
-					O.ex_act(1, explosion.last_touched, p)
+					O.ex_act(1, explosion.last_touched, highest_explosion_power(O))
 					O.last_explosion = explosion
 					if (istype(O, /obj/cable)) // these two are hacky, newcables should relieve the need for this
 						needrebuild = 1
@@ -88,7 +92,7 @@ var/datum/explosion_controller/explosions
 				for (var/obj/O in T)
 					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
 						continue
-					O.ex_act(2, explosion.last_touched, p)
+					O.ex_act(2, explosion.last_touched, highest_explosion_power(O))
 					O.last_explosion = explosion
 					if (istype(O, /obj/cable))
 						needrebuild = 1
@@ -96,7 +100,7 @@ var/datum/explosion_controller/explosions
 				for (var/obj/O in T)
 					if(istype(O, /obj/overlay) || next_turf_safe && istype(O, /obj/window) || O.last_explosion == explosion)
 						continue
-					O.ex_act(3, explosion.last_touched, p)
+					O.ex_act(3, explosion.last_touched, highest_explosion_power(O))
 					O.last_explosion = explosion
 
 		LAGCHECK(LAG_HIGH)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -101,7 +101,6 @@ Contains:
 	pixel_x = -64
 	pixel_y = -64
 
-	var/maxboom = 0
 	var/has_moved
 	var/active = 0 //determines if the singularity is contained
 	var/energy = 10
@@ -248,12 +247,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 
 /obj/machinery/the_singularity/ex_act(severity, last_touched, power)
-	if(!maxboom)
-		SPAWN(0.1 SECONDS)
-			if(severity == 1 && (maxboom ? prob(maxboom*5) : prob(30))) //need a big bomb (TTV+ sized), but a big enough bomb will always clear it
-				qdel(src)
-			maxboom = 0
-	maxboom = max(power, maxboom)
+	if (severity == 1 && prob(power * 5)) //need a big bomb (TTV+ sized), but a big enough bomb will always clear it
+		qdel(src)
 
 /obj/machinery/the_singularity/Bumped(atom/A)
 	var/gain = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes multi-turf objects taking explosive damage from every turf they cover. 
Profiler seems to say this doesn't break performance, assuming I'm using it right:
![image](https://user-images.githubusercontent.com/20713227/192888113-95015f0b-1ee6-405f-8c83-c756cff24bd5.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This lead to the flock relay taking around 12 times the explosion damage it should and being one shot by a torpedo.
💀 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)The flock relay now takes the correct amount of explosion damage.
```
