### PR TITLE
Moves some strangely placed diner APCs

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -974,7 +974,6 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/space,
@@ -1676,7 +1675,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/diner/hallway)
+/area/diner/motel)
 "afy" = (
 /obj/stool/chair/couch{
 	dir = 8;
@@ -1803,7 +1802,6 @@
 "agA" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/darkblue,
@@ -1965,7 +1963,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/diner/hallway)
+/area/diner/motel)
 "ahR" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -2228,7 +2226,6 @@
 "ajX" = (
 /obj/decal/fakeobjects/tallsmes,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -2436,7 +2433,6 @@
 "alh" = (
 /obj/decal/fakeobjects/vacuumtape,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -2514,7 +2510,6 @@
 "alH" = (
 /obj/decal/fakeobjects/vacuumtape,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -2553,7 +2548,7 @@
 /obj/decal/cleanable/dirt,
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/diner/hallway)
+/area/diner/motel)
 "alQ" = (
 /obj/decal/fakeobjects/shuttlethruster{
 	dir = 4;
@@ -2862,7 +2857,6 @@
 /area/space)
 "amT" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small{
@@ -3630,7 +3624,6 @@
 /area/space)
 "aqp" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -3766,7 +3759,6 @@
 	charge = 5e+006
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -3910,7 +3902,6 @@
 "are" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -3929,7 +3920,6 @@
 "arf" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/networked/storage/tape_drive{
@@ -4044,7 +4034,6 @@
 /area/buddyfactory)
 "ary" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -4089,7 +4078,6 @@
 /area/space)
 "arE" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -4105,7 +4093,6 @@
 /area/space)
 "arF" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -4605,7 +4592,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -4626,7 +4612,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -5861,17 +5846,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/diner/hangar)
-"aCG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/diner/hallway)
 "aCI" = (
 /turf/simulated/floor/shuttlebay/flock{
 	dir = 8
@@ -6173,7 +6147,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer3/terminal/zeta{
@@ -6210,7 +6183,6 @@
 "aFL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/computer3frame/terminal{
@@ -8365,7 +8337,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille,
@@ -8758,7 +8729,6 @@
 "aNy" = (
 /obj/machinery/computer/solar_control,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
@@ -8987,7 +8957,6 @@
 	id = "derelict_ai_sat"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless{
@@ -9321,7 +9290,6 @@
 /area/derelict_ai_sat/core)
 "aPb" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -9461,7 +9429,6 @@
 "aPp" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/networked/radio,
@@ -9477,7 +9444,6 @@
 /area/h7)
 "aPs" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
@@ -9687,7 +9653,6 @@
 "aPV" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -9726,7 +9691,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille,
@@ -10028,7 +9992,6 @@
 /area/abandonedship)
 "aQX" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -10206,7 +10169,6 @@
 /area/derelict_ai_sat)
 "aRB" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/stool,
@@ -10789,7 +10751,6 @@
 /area/h7/crew)
 "aTb" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -10930,7 +10891,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless{
@@ -10993,7 +10953,6 @@
 "aTB" = (
 /obj/machinery/power/solar,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless{
@@ -11083,7 +11042,6 @@
 /area/h7/crew)
 "aTL" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -12195,7 +12153,6 @@
 /area/h7)
 "aWF" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/cable_coil/cut,
@@ -13143,7 +13100,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -13641,7 +13597,6 @@
 "bbn" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -13756,7 +13711,6 @@
 "bbG" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -13771,7 +13725,6 @@
 /area/space)
 "bbH" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -13783,7 +13736,6 @@
 "bbI" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -13806,7 +13758,6 @@
 /area/h7/lab)
 "bbK" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -14098,7 +14049,6 @@
 /area/h7/lab)
 "bcG" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -14220,7 +14170,6 @@
 /area/h7/lab)
 "bcV" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -14592,7 +14541,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -15129,7 +15077,6 @@
 /area/derelict_ai_sat)
 "bgS" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -15298,7 +15245,6 @@
 "bhm" = (
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille,
@@ -15378,7 +15324,6 @@
 	dir = 10
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -15415,7 +15360,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -15640,7 +15584,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -15664,7 +15607,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille/catwalk{
@@ -15682,7 +15624,6 @@
 /area/derelict_ai_sat/solar)
 "bic" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/east{
@@ -15785,7 +15726,6 @@
 /area/derelict_ai_sat/core)
 "biq" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -15927,7 +15867,6 @@
 "biG" = (
 /obj/machinery/power/furnace,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/grime,
@@ -15942,7 +15881,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
@@ -15972,7 +15910,6 @@
 "biL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -17749,7 +17686,6 @@
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east/nopoweralert,
@@ -18341,13 +18277,6 @@
 	dir = 4
 	},
 /area/h7/crew)
-"fav" = (
-/obj/decal/cleanable/dirt,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/diner/motel)
 "fbg" = (
 /obj/stool/chair/couch/green{
 	dir = 4;
@@ -18743,7 +18672,6 @@
 /area/diner/motel/observatory)
 "gmE" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -18888,9 +18816,6 @@
 	icon_state = "chair_couch-yellow"
 	},
 /obj/machinery/power/apc/autoname_north/nopoweralert,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/carpet/grime,
 /area/diner/motel)
 "gyi" = (
@@ -18937,7 +18862,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -19170,6 +19094,17 @@
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
+"htc" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/diner/motel)
 "hto" = (
 /obj/grille/catwalk/dubious{
 	icon_state = "catwalk_cross-3"
@@ -19709,7 +19644,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/diner/hallway)
+/area/diner/motel)
 "iZr" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet{
@@ -20164,7 +20099,7 @@
 "knj" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/diner/hallway)
+/area/diner/motel)
 "kov" = (
 /obj/decal/timeplug{
 	dir = 5
@@ -20439,7 +20374,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/table/auto,
@@ -20501,7 +20435,6 @@
 /area/helldrone/core)
 "lsF" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/grille,
@@ -20788,7 +20721,6 @@
 /obj/decal/cleanable/dirt,
 /obj/machinery/power/apc/autoname_east/nopoweralert,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -20874,16 +20806,6 @@
 "miz" = (
 /turf/unsimulated/wall/auto/lead/blue,
 /area/timewarp/ship)
-"miC" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/diner/motel)
 "mnS" = (
 /obj/decal/fakeobjects/shuttleengine{
 	dir = 4
@@ -21827,12 +21749,6 @@
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/diner/tug)
-"pjx" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/diner/motel)
 "pjN" = (
 /obj/lattice{
 	dir = 2;
@@ -22503,7 +22419,6 @@
 	},
 /obj/machinery/power/apc/autoname_east/nopoweralert,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/grime,
@@ -23184,6 +23099,13 @@
 	icon_state = "red2"
 	},
 /area/diner/dining)
+"tbl" = (
+/obj/machinery/power/apc/autoname_east/nopoweralert,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/diner/motel)
 "tbR" = (
 /obj/table/wood/auto,
 /obj/indestructible/shuttle_corner{
@@ -23860,13 +23782,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/diner/arcade)
-"uUk" = (
-/obj/decal/cleanable/dirt,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/diner/motel)
 "uUU" = (
 /obj/grille/catwalk{
 	icon_state = "catwalk_cross"
@@ -24017,7 +23932,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/diner/hallway)
+/area/diner/motel)
 "vly" = (
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/plating,
@@ -24494,7 +24409,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/diner/hallway)
+/area/diner/motel)
 "wIr" = (
 /obj/item/screwdriver,
 /obj/decal/fakeobjects/skeleton,
@@ -24781,7 +24696,6 @@
 /area/diner/motel/chemstorage)
 "xPl" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/landmark/spawner/loot,
@@ -24897,7 +24811,7 @@
 /area/diner/tug)
 "yiv" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/diner/hallway)
+/area/diner/motel)
 
 (1,1,1) = {"
 aaa
@@ -79924,7 +79838,7 @@ sdM
 amP
 aod
 gxH
-uUk
+sdM
 esi
 aod
 lUg
@@ -80226,7 +80140,7 @@ sdM
 usy
 aod
 lcR
-fav
+sdM
 sdM
 aod
 lvW
@@ -80528,7 +80442,7 @@ usy
 ajM
 aod
 aod
-pjx
+usy
 rRi
 aob
 wqS
@@ -80830,7 +80744,7 @@ fkr
 aih
 aod
 soj
-pjx
+usy
 tBH
 aod
 wsg
@@ -81132,7 +81046,7 @@ izy
 cRb
 aod
 aod
-miC
+vem
 eFq
 aod
 xZo
@@ -81429,12 +81343,12 @@ wIp
 wIp
 wIp
 iZq
-wIp
+htc
 iZq
 iZq
 wIp
 wIp
-aCG
+wIp
 wIp
 wIp
 hkX
@@ -81731,7 +81645,7 @@ knj
 knj
 yiv
 afw
-yiv
+tbl
 yiv
 yiv
 vlf

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1959,6 +1959,11 @@
 "ahN" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/diner/hallway)
 "ahR" = (
@@ -3119,13 +3124,6 @@
 /area/diner/motel)
 "aod" = (
 /turf/simulated/wall/auto/reinforced/old,
-/area/diner/motel)
-"aok" = (
-/obj/machinery/power/apc/autoname_north/nopoweralert,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
 /area/diner/motel)
 "aon" = (
 /obj/stool/chair{
@@ -5863,6 +5861,17 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/diner/hangar)
+"aCG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/diner/hallway)
 "aCI" = (
 /turf/simulated/floor/shuttlebay/flock{
 	dir = 8
@@ -17469,6 +17478,11 @@
 /area/radiostation/studio)
 "bYA" = (
 /obj/decal/cleanable/dirt,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/diner/motel/observatory)
 "bYC" = (
@@ -17783,6 +17797,10 @@
 	},
 /area/bee_trader)
 "cWa" = (
+/obj/machinery/power/apc/autoname_north/nopoweralert,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/diner/motel/observatory)
 "cWB" = (
@@ -18323,6 +18341,13 @@
 	dir = 4
 	},
 /area/h7/crew)
+"fav" = (
+/obj/decal/cleanable/dirt,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/diner/motel)
 "fbg" = (
 /obj/stool/chair/couch/green{
 	dir = 4;
@@ -18862,6 +18887,10 @@
 	dir = 8;
 	icon_state = "chair_couch-yellow"
 	},
+/obj/machinery/power/apc/autoname_north/nopoweralert,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/diner/motel)
 "gyi" = (
@@ -19058,6 +19087,11 @@
 /turf/simulated/floor/plating,
 /area/diner/dining)
 "hkX" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/diner/hallway)
 "hlO" = (
@@ -19268,19 +19302,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/diner/arcade)
-"hQP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grime,
-/area/diner/hallway)
 "hSH" = (
 /turf/simulated/floor/green/checker,
 /area/diner/arcade)
@@ -19682,6 +19703,11 @@
 /area/diner/motel/chemstorage)
 "iZq" = (
 /obj/decal/cleanable/dirt,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/diner/hallway)
 "iZr" = (
@@ -20139,14 +20165,6 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/diner/hallway)
-"kos" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/old,
-/area/diner/hallway)
 "kov" = (
 /obj/decal/timeplug{
 	dir = 5
@@ -20465,15 +20483,6 @@
 	},
 /turf/space,
 /area/timewarp)
-"lnt" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grime,
-/area/diner/hallway)
 "lpI" = (
 /obj/machinery/door/unpowered/shuttle{
 	autoclose = 1;
@@ -20658,6 +20667,12 @@
 	icon_state = "fred2"
 	},
 /area/timewarp/ship)
+"lMB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/fancy,
+/area/diner/motel/observatory)
 "lNV" = (
 /obj/stool,
 /obj/machinery/light/incandescent/netural{
@@ -20859,6 +20874,16 @@
 "miz" = (
 /turf/unsimulated/wall/auto/lead/blue,
 /area/timewarp/ship)
+"miC" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/diner/motel)
 "mnS" = (
 /obj/decal/fakeobjects/shuttleengine{
 	dir = 4
@@ -21802,6 +21827,12 @@
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/diner/tug)
+"pjx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/diner/motel)
 "pjN" = (
 /obj/lattice{
 	dir = 2;
@@ -22498,11 +22529,6 @@
 	},
 /area/bee_trader)
 "rdx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/decal/cleanable/ripped_poster,
 /turf/simulated/wall/auto/reinforced/old,
 /area/diner/hallway)
@@ -22620,18 +22646,6 @@
 	stone_color = "#575A5E"
 	},
 /area/space)
-"rAh" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grime,
-/area/diner/hallway)
 "rBu" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Crew Quarters"
@@ -23273,6 +23287,12 @@
 "tkr" = (
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
+"tli" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/green/fancy,
+/area/diner/motel/observatory)
 "tlX" = (
 /obj/storage/cart,
 /turf/simulated/floor/white/grime,
@@ -23674,6 +23694,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/grime,
 /area/diner/hallway)
 "uzw" = (
@@ -23835,6 +23860,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/diner/arcade)
+"uUk" = (
+/obj/decal/cleanable/dirt,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/diner/motel)
 "uUU" = (
 /obj/grille/catwalk{
 	icon_state = "catwalk_cross"
@@ -24233,13 +24265,6 @@
 	icon_state = "fred2"
 	},
 /area/radiostation/bedroom)
-"wgE" = (
-/obj/machinery/power/apc/autoname_north/nopoweralert,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/diner/motel/observatory)
 "wjS" = (
 /obj/machinery/vending/cola/red,
 /obj/decal/cleanable/dirt,
@@ -24463,6 +24488,11 @@
 	},
 /area/diner/dining)
 "wIp" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/diner/hallway)
 "wIr" = (
@@ -24514,6 +24544,12 @@
 "wSz" = (
 /turf/simulated/floor/scorched,
 /area/diner/hangar)
+"xdk" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/green/fancy,
+/area/diner/motel/observatory)
 "xfi" = (
 /obj/decal/poster/wallsign/stencil/right/t,
 /obj/decal/poster/wallsign/stencil/left/u,
@@ -78680,8 +78716,8 @@ pjN
 pjN
 pjN
 pjN
-boO
-boO
+pjN
+pjN
 boO
 apU
 akd
@@ -78982,9 +79018,9 @@ pjN
 pjN
 pjN
 pjN
+pjN
+pjN
 boP
-aod
-aod
 skq
 ake
 aoT
@@ -79285,11 +79321,11 @@ aaa
 aaa
 aaa
 aaa
-aod
-aok
+aaa
+aaa
 rdx
-rAh
-lnt
+jyD
+aoU
 crC
 aaa
 aaa
@@ -79888,7 +79924,7 @@ sdM
 amP
 aod
 gxH
-sdM
+uUk
 esi
 aod
 lUg
@@ -80190,7 +80226,7 @@ sdM
 usy
 aod
 lcR
-sdM
+fav
 sdM
 aod
 lvW
@@ -80492,7 +80528,7 @@ usy
 ajM
 aod
 aod
-usy
+pjx
 rRi
 aob
 wqS
@@ -80780,7 +80816,7 @@ aaa
 aaa
 aaa
 ahT
-ahT
+lRy
 grK
 ahW
 iob
@@ -80794,7 +80830,7 @@ fkr
 aih
 aod
 soj
-usy
+pjx
 tBH
 aod
 wsg
@@ -81096,7 +81132,7 @@ izy
 cRb
 aod
 aod
-vem
+miC
 eFq
 aod
 xZo
@@ -81386,7 +81422,7 @@ aaa
 ahT
 dVm
 hKm
-ahW
+tli
 bYA
 ahN
 wIp
@@ -81398,7 +81434,7 @@ iZq
 iZq
 wIp
 wIp
-wIp
+aCG
 wIp
 wIp
 hkX
@@ -81688,7 +81724,7 @@ aaa
 ahT
 enz
 aEE
-ahW
+lMB
 rEz
 alO
 knj
@@ -81990,7 +82026,7 @@ aaa
 ahT
 lBY
 xfN
-ahW
+lMB
 vFH
 aod
 aod
@@ -82290,9 +82326,9 @@ aaa
 aaa
 aaa
 ahT
-ahT
+lRy
 cWa
-ahW
+xdk
 gmp
 aod
 ajh
@@ -83815,11 +83851,11 @@ aaa
 aaa
 aaa
 aaa
-lRy
-wgE
-kos
-bFR
-hQP
+aaa
+aaa
+apU
+wqS
+ste
 huF
 lHd
 xsh
@@ -84116,9 +84152,9 @@ pjN
 pjN
 pjN
 pjN
+pjN
+pjN
 boO
-lRy
-lRy
 apU
 wqS
 ste
@@ -84418,8 +84454,8 @@ pjN
 pjN
 pjN
 pjN
-boP
-boP
+pjN
+gzA
 boP
 crC
 bxI

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -18815,7 +18815,6 @@
 	dir = 8;
 	icon_state = "chair_couch-yellow"
 	},
-/obj/machinery/power/apc/autoname_north/nopoweralert,
 /turf/simulated/floor/carpet/grime,
 /area/diner/motel)
 "gyi" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There were some APCs in the space diner hidden in walls for reasons unknown to science. They are now much more easily accessible.
Fixes #11056


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nidalee's brain-collecting cyborg army was nearly halted earlier when the APC ran out and we couldn't find it, thank you to the admin who spawned us in a new one!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Moved some strangely placed space diner APCs from inside the walls to more normal locations.
```
