### PR TITLE
Fixes anesthetic tank default release pressure

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -297,7 +297,7 @@ Contains:
 	name = "gas tank (sleeping agent)"
 	icon_state = "anesthetic"
 	extra_desc = "It's labeled as containing an anesthetic capable of keeping somebody unconscious while they breathe it."
-	distribute_pressure = 81
+	distribute_pressure = 110
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [QOL] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11042 by changing the default release pressure of anesthetic tanks from 81 -> 110, a value arrived at by trial and error due to me not wanting to understand breath code.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Anesthetizing someone is complicated and janky enough without the tank being set up wrong to start with. Pretty sure this value used to be fine, but something changed at some point and now it isn't.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Sleeping gas tanks now start with the correct release pressure required to anesthetize someone.
```
