### PR TITLE
Standardises The Cogmap1 Armoury

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1074,9 +1074,6 @@
 /area/station/crew_quarters/clown)
 "adV" = (
 /obj/rack,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
 /obj/item/breaching_charge{
 	pixel_x = 10;
 	pixel_y = 1
@@ -1090,8 +1087,15 @@
 	pixel_y = -5
 	},
 /obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/breaching_hammer{
 	pixel_x = -1;
 	pixel_y = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
@@ -1845,48 +1849,55 @@
 /area/station/crew_quarters/quartersB)
 "agc" = (
 /obj/rack,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = -8
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 9;
+	pixel_y = 5
 	},
 /obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
-	pixel_y = 4
+	pixel_x = 8
 	},
 /obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
-	pixel_y = -3
+	pixel_x = 7;
+	pixel_y = -5
 	},
 /obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
+	pixel_x = 6;
 	pixel_y = -10
 	},
-/obj/item/clothing/mask/gas/emergency{
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/nightvision{
 	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 9;
 	pixel_y = 11
 	},
 /obj/item/clothing/mask/gas/emergency{
-	pixel_x = -1;
+	pixel_x = 3;
 	pixel_y = 11
 	},
 /obj/item/clothing/mask/gas/emergency{
-	pixel_x = 7;
+	pixel_x = -3;
 	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
@@ -52096,40 +52107,36 @@
 /area/station/quartermaster/office)
 "foS" = (
 /obj/rack,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
 	},
 /obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
 	pixel_x = -13;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = 12
 	},
 /obj/item/clothing/suit/armor/EOD{
-	pixel_x = 9;
-	pixel_y = -1
+	pixel_x = 9
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -15;
-	pixel_y = 12
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 1;
-	pixel_y = 12
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
 	},
 /obj/item/clothing/head/helmet/EOD{
 	pixel_x = 12;
 	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
@@ -54427,6 +54434,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"isQ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space,
+/area/station/turret_protected/armory_outside)
 "isX" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	dir = 4;
@@ -57406,6 +57422,15 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
+"mWX" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space,
+/area/station/turret_protected/armory_outside)
 "mXu" = (
 /obj/item/device/radio/intercom/security{
 	dir = 4
@@ -60745,6 +60770,15 @@
 	icon_state = "fred5"
 	},
 /area/station/crew_quarters/hor)
+"rMo" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space,
+/area/station/turret_protected/armory_outside)
 "rMr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/pool)
@@ -94908,7 +94942,7 @@ nxc
 nxc
 nxc
 nxc
-nxc
+rMo
 nxc
 nxc
 nxc
@@ -96715,7 +96749,7 @@ adC
 adC
 nxc
 gsU
-nxc
+isQ
 act
 acV
 vOf
@@ -98230,7 +98264,7 @@ gsU
 nxc
 gsU
 nxc
-nxc
+mWX
 nxc
 nxc
 nxc


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
Adds one airlock breaching sledgehammer, one optical thermal scanner, and one gas mask to the Cogmap1 Armoury alongside replacing one set of riot armour with a bomb disposal suit. External perimeter cameras have also been added.

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Cogmap1 Armoury is also equipped with:
* 1x Doughnut, the most pertinent of Security equipment.



## Why's this needed? Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. The Cogmap1 Armoury just needed to few touchups, and lacked external cameras.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Added one airlock breaching sledgehammer and one thermal scanner to the Cogmap1 Armoury alongside replacing one set of riot armour with a bomb disposal suit. External perimeter cameras have also been added.
```