### PR TITLE
Makes smart pistol smarter

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1676,7 +1676,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic/single_action)
 
 
 /datum/component/holdertargeting/smartgun/nukeop/is_valid_target(mob/user, mob/M)
-	return ..() && !istype(M.get_id(), /obj/item/card/id/syndicate)
+	return ..() && !(istype(M.get_id(), /obj/item/card/id/syndicate) || isnukeopgunbot(M) || istype(M, /mob/living/critter/robotic/sawfly))
 
 /obj/item/gun/kinetic/smg
 	name = "\improper Bellatrix submachine gun"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11046 by making the smart pistol no longer target sawflies or nukeop gunbots


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
smart gun should not be stupid


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)The Hydra smart pistol is now slightly smarter and no longer targets sawflies or nukeop gunbots.
```
