### PR TITLE
removes organ damage from the BR gamemode

### DIFF
--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -297,7 +297,7 @@
 
 	//damage/heal obj. Provide negative values for healing.	//maybe I'll change cause I don't like this. But this functionality is found in some other damage procs for other things, might as well keep it consistent.
 	take_damage(brute, burn, tox, damage_type)
-		if(isvampire(donor) || istype(ticker?.mode, /datum/game_mode/battle_royale) && !(istype(src, /obj/item/organ/chest) || istype(src, /obj/item/organ/head)))
+		if((isvampire(donor) || istype(ticker?.mode, /datum/game_mode/battle_royale)) && !(istype(src, /obj/item/organ/chest) || istype(src, /obj/item/organ/head)))
 			return //vampires are already dead inside
 
 		src.brute_dam += brute

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -297,7 +297,7 @@
 
 	//damage/heal obj. Provide negative values for healing.	//maybe I'll change cause I don't like this. But this functionality is found in some other damage procs for other things, might as well keep it consistent.
 	take_damage(brute, burn, tox, damage_type)
-		if(isvampire(donor) && !(istype(src, /obj/item/organ/chest) || istype(src, /obj/item/organ/head) || istype(src, /obj/item/skull) || istype(src, /obj/item/clothing/head/butt)))
+		if(isvampire(donor) || istype(ticker?.mode, /datum/game_mode/battle_royale) && !(istype(src, /obj/item/organ/chest) || istype(src, /obj/item/organ/head)))
 			return //vampires are already dead inside
 
 		src.brute_dam += brute


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [GAMEMODES][BALANCE] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
disables organ damage in BR


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
unlike a normal round BR is very fast paced, organ damage dooms you in fights and is barely even fixable especially after the removal of most medbay heals making the already hard self surgery in time near impossible.

**this has one drawback however:**
it makes the current meta of guns being worse than melee even bigger however a bigger part of that is the extreme scarcity of ammo
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Removed organ damage from the battle royale gamemode.
```
