### PR TITLE
Standardises The Clarion Armoury

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -26807,13 +26807,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bfq" = (
+/obj/machinery/light,
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -43047,6 +43048,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -43250,33 +43254,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/storage/secure/crate/gear/armory/grenades{
-	name = "special equipment crate"
-	},
-/obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/glasses/thermal{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/nightvision{
-	pixel_x = -7;
-	pixel_y = -1
-	},
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -43366,6 +43344,11 @@
 /obj/machinery/turretid{
 	pixel_x = 24;
 	req_access_txt = null
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -43625,6 +43608,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -44263,15 +44247,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
-"foz" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/ai_monitored/armory)
 "foU" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -44552,6 +44527,22 @@
 	dir = 1
 	},
 /area/station/turret_protected/ai)
+"fSg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "fTq" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/machinery/door/poddoor/blast{
@@ -44641,9 +44632,12 @@
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "fYK" = (
-/obj/machinery/vending/security_ammo,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/redblack{
-	dir = 5
+	dir = 1
 	},
 /area/station/ai_monitored/armory)
 "fZZ" = (
@@ -45073,18 +45067,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/md)
-"hid" = (
-/obj/item/device/radio/intercom/AI{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/station/bridge)
 "hkw" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -45659,8 +45641,8 @@
 /area/station/security/main)
 "iCw" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt{
-	name = "Armory Foyer";
-	dir = 4
+	dir = 4;
+	name = "Armory Foyer"
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
@@ -46220,14 +46202,9 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/flamethrower/assembled/loaded,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_north,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/redblack{
-	dir = 5
+	dir = 4
 	},
 /area/station/ai_monitored/armory)
 "kcx" = (
@@ -46285,7 +46262,39 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "kgl" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/rack,
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -2
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/rack,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -19
@@ -46452,15 +46461,15 @@
 /area/station/crewquarters/cryotron)
 "kAg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -48063,6 +48072,14 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/item/device/radio/intercom/AI{
+	dir = 1
+	},
+/obj/cable{
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "oxM" = (
@@ -48838,7 +48855,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/obj/storage/secure/crate/weapon/armory/phaser,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -48856,6 +48873,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/fitness)
+"qBx" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/vending/security_ammo,
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/ai_monitored/armory)
 "qDe" = (
 /obj/disposalpipe/segment,
 /obj/table/reinforced/auto,
@@ -49048,42 +49075,54 @@
 /area/station/security/brig)
 "rex" = (
 /obj/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -15;
+	pixel_y = 8
+	},
 /obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
 	pixel_x = -13;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = 12
 	},
 /obj/item/clothing/suit/armor/EOD{
-	pixel_x = 9;
-	pixel_y = -1
+	pixel_x = 9
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -15;
-	pixel_y = 12
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
 	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 1;
-	pixel_y = 12
+/obj/item/clothing/mask/gas{
+	pixel_x = 11;
+	pixel_y = 8
 	},
 /obj/item/clothing/head/helmet/EOD{
 	pixel_x = 12;
 	pixel_y = 8
 	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/disposalpipe/segment/food,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/food,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -49323,12 +49362,7 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "rTC" = (
-/obj/machinery/light_switch/south{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -49996,6 +50030,10 @@
 /obj/item/breaching_charge{
 	pixel_x = -2;
 	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
 	},
 /obj/item/breaching_hammer{
 	pixel_x = -1;
@@ -51175,14 +51213,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"wkk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/station/ai_monitored/armory)
 "wkm" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -83895,7 +83925,7 @@ iwK
 gtp
 jgI
 cvm
-foz
+biM
 biM
 bll
 leh
@@ -84152,7 +84182,7 @@ aQR
 jVU
 bgz
 fYK
-wkk
+glL
 glL
 glL
 kgl
@@ -84408,7 +84438,7 @@ bda
 qkV
 ovR
 bgz
-bgz
+qBx
 kcn
 qxa
 cUY
@@ -84662,9 +84692,9 @@ oQm
 bay
 bbM
 bdb
+fSg
 bfq
-bfq
-hid
+aQY
 bgz
 bgz
 bgz


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
Expands the Clarion Armoury slightly, and adds one pair of night vision goggles, one optical thermal scanner, four gas masks, one airlock breaching sledgehammer, and one phaser crate to it, alongside replacing one set of riot armour with a bomb disposal suit. The anti-biological crate has also been moved outside of the Armoury to accommodate these changes.

![image](https://user-images.githubusercontent.com/88833499/193321764-7ad058ea-9093-4845-9247-57efb0d92de5.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Clarion Armoury is equipped with everything under the essential contents section, and nothing additional.



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. The Clarion Armoury just needed to few touchups, and was quite simple to standardise.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Standardised the Clarion Armoury's equipment.
```