### PR TITLE
Doubles mixed major threat spawn chance and lowers antag cost

### DIFF
--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -58,17 +58,17 @@
 	src.latejoin_antag_roles[ROLE_GRINCH] = 1;
 #endif
 
-	var/major_threat_chance = length(src.major_threats) * 10
+	var/major_threat_chance = length(src.major_threats) * 20
 	if ((num_enemies >= 4 && prob(major_threat_chance)) || debug_mixed_forced_wraith || debug_mixed_forced_blob || debug_mixed_forced_flock)
 		var/chosen = weighted_pick(src.major_threats)
 		if (chosen == ROLE_WRAITH || debug_mixed_forced_wraith)
 			num_enemies = max(num_enemies - 2, 1)
 			num_wraiths = 1
 		else if (chosen == ROLE_BLOB || debug_mixed_forced_blob)
-			num_enemies = max(num_enemies - 4, 1)
+			num_enemies = max(num_enemies - 3, 1)
 			num_blobs = 1
 		else if (chosen == ROLE_FLOCKMIND || debug_mixed_forced_flock)
-			num_enemies = max(num_enemies - 3, 1)
+			num_enemies = max(num_enemies - 2, 1)
 			num_flockminds = 1
 	for(var/j = 0, j < num_enemies, j++)
 		if(has_wizards && prob(10)) // powerful combat roles


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES] [INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes major threat spawn chance from `10 * number of major threats`% to `20 * number of major threats`%, meaning a 60% chance for either a blob, flock or wraith in mixed, and a 20% chance for wraith in arcfiend, vampire and mixed (rp) modes.
Also reduces the amount of other antag slots taken up by flock and blob by one each, blob goes from `4 -> 3` and flock goes from `3 -> 2`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There was a forum thread about wanting to see more wraiths, flock is now at a point of being (somewhat) balanced enough to turn up in more rounds and everyone likes mixed blob.
Also a common complaint when seeing these antags in mixed is that the round is very slow after they are killed due to the large number of slots they take up.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Mixed "major threat" antagonists (Blob, Flock and Wraith) are now twice as common and replace fewer normal antagonists.
```
