### PR TITLE
Fixes #11098 - Bat/Fireball flip

### DIFF
--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -327,6 +327,9 @@
 
 		.= delay
 
+	mob_flip_inside(mob/user)
+		animate_spin(src, pick("L", "R"), 1, FALSE)
+
 	ex_act(severity)
 		dispel(1)
 		if(owner) owner.ex_act(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces `mob_flip_inside()` on the bat form object with a quick spin animation. This also applies to fire elemental's fireball form, since it's basically just a reskinned batform.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11098


