### PR TITLE
Removes Miranda, sec gear and traitor restrictions from discount superhero.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2130,12 +2130,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	wages = PAY_UNTRAINED
 	limit = 1
 	change_name_on_spawn = 1
-	allow_traitors = 0
-	allow_spy_theft = 0
-	cant_spawn_as_rev = 1
-	receives_miranda = 1
-	slot_ears = list(/obj/item/device/radio/headset/security)
-	slot_eyes = list(/obj/item/clothing/glasses/sunglasses/sechud/superhero)
+	slot_ears = list(/obj/item/device/radio/headset)
+	slot_eyes = list(/obj/item/clothing/glasses/sunglasses)
 	slot_glov = list(/obj/item/clothing/gloves/latex/blue)
 	slot_jump = list(/obj/item/clothing/under/gimmick/superhero)
 	slot_foot = list(/obj/item/clothing/shoes/tourist)
@@ -2152,7 +2148,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 		..()
 		if (!M)
 			return
-		M.traitHolder.addTrait("training_security")
 		if(prob(60))
 			var/aggressive = pick("eyebeams","cryokinesis")
 			var/defensive = pick("fire_resist","cold_resist","rad_resist","breathless") // no thermal resist, gotta have some sort of comic book weakness


### PR DESCRIPTION
[BALANCE] [QOL]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes sec gear and Miranda from the discount superhero job, but lets them spawn as a latejoin antag.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Discount superhero is currently in a very weird state, being a gimmick job and having Staff Assistant access, but getting a security headset and sechuds, as well as Miranda and getting a restriction from being an antag.
I believe with the removal of Part-Time VOs and security access from lawyers, we are moving towards a direction where gimmick jobs are not part of the security department, which is exactly the purpose of the PR.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chatauscours
(+)The Discount Superhero can now spawn as an antag, but no longer recieves any security training or gear.
```
