### PR TITLE
Allow client color changes to respect view tint

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -78,7 +78,7 @@
 
 /// Takes two 20-length lists, turns them into 5x4 matrices, multiplies them together, and returns a 20-length list
 /proc/mult_color_matrix(var/list/Mat1, var/list/Mat2) // always 5x4 please
-	if (!Mat1.len || !Mat2.len || Mat1.len != 20 || Mat2.len != 20)
+	if (length(Mat1) != 20 || length(Mat2) != 20)
 		return COLOR_MATRIX_IDENTITY
 
 	var/list/M1[5][5] // turn the input matrix lists into more matrix-y lists
@@ -274,8 +274,11 @@ proc/hsv_transform_color_matrix(h=0.0, s=1.0, v=1.0)
 	src.saturation_matrix = hsv_transform_color_matrix(1, s, 1)
 	src.color = mult_color_matrix(src.color_matrix, src.saturation_matrix)
 
-/client/proc/set_color(matrix=COLOR_MATRIX_IDENTITY)
-	src.color_matrix = matrix
+/client/proc/set_color(matrix=COLOR_MATRIX_IDENTITY, respect_view_tint_settings = FALSE)
+	if (!respect_view_tint_settings)
+		src.color_matrix = matrix
+	else
+		src.color_matrix = src.view_tint ? matrix : null
 	src.color = mult_color_matrix(src.color_matrix, src.saturation_matrix)
 
 /client/proc/animate_color(matrix=COLOR_MATRIX_IDENTITY, time=5, easing=SINE_EASING)

--- a/code/client.dm
+++ b/code/client.dm
@@ -1293,7 +1293,8 @@ var/global/curr_day = null
 	set name ="apply-view-tint"
 
 	view_tint = !view_tint
-
+	if (src.mob?.respect_view_tint_settings)
+		src.set_color(length(src.mob.active_color_matrix) ? src.mob.active_color_matrix : COLOR_MATRIX_IDENTITY, src.mob.respect_view_tint_settings)
 /client/verb/adjust_saturation()
 	set hidden = TRUE
 	set name = "adjust-saturation"

--- a/code/client.dm
+++ b/code/client.dm
@@ -1295,6 +1295,7 @@ var/global/curr_day = null
 	view_tint = !view_tint
 	if (src.mob?.respect_view_tint_settings)
 		src.set_color(length(src.mob.active_color_matrix) ? src.mob.active_color_matrix : COLOR_MATRIX_IDENTITY, src.mob.respect_view_tint_settings)
+
 /client/verb/adjust_saturation()
 	set hidden = TRUE
 	set name = "adjust-saturation"

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1666,11 +1666,7 @@
 				else
 					color_matrix_2_apply = mult_color_matrix(color_matrix_2_apply, src.color_matrices[cmatrix])
 			src.active_color_matrix = color_matrix_2_apply
-	if (src.client)
-		if (!src.respect_view_tint_settings)
-			src.client.set_color(src.active_color_matrix)
-		else
-			src.client.set_color(src.client.view_tint ? src.active_color_matrix : null)
+	src.client?.set_color(src.active_color_matrix, src.mob.respect_view_tint_settings || respect_view_tint_settings)
 
 /mob/proc/adjustBodyTemp(actual, desired, incrementboost, divisor)
 	var/temperature = actual

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1624,7 +1624,7 @@
 
 /// Adds a 20-length color matrix to the mob's list of color matrices
 /// cmatrix is the color matrix (must be a 16-length list!), label is the string to be used for dupe checks and removal
-/mob/proc/apply_color_matrix(var/list/cmatrix, var/label, respect_view_tint_settings = FALSE)
+/mob/proc/apply_color_matrix(var/list/cmatrix, var/label)
 	if (!cmatrix || !label)
 		return
 
@@ -1633,10 +1633,10 @@
 
 	src.color_matrices[label] = cmatrix
 
-	src.update_active_matrix(respect_view_tint_settings)
+	src.update_active_matrix()
 
 /// Removes whichever matrix is associated with the label. Must be a string!
-/mob/proc/remove_color_matrix(var/label, respect_view_tint_settings = FALSE)
+/mob/proc/remove_color_matrix(var/label)
 	if (!label || !length(src.color_matrices))
 		return
 
@@ -1647,11 +1647,11 @@
 	else
 		src.color_matrices -= label
 
-	src.update_active_matrix(respect_view_tint_settings)
+	src.update_active_matrix()
 
 /// Multiplies all of the mob's color matrices together and puts the result into src.active_color_matrix
 /// This matrix will be applied to the mob at the end of this proc, and any time the client logs in
-/mob/proc/update_active_matrix(respect_view_tint_settings)
+/mob/proc/update_active_matrix()
 	if (!src.color_matrices.len)
 		src.active_color_matrix = null
 	else
@@ -1666,7 +1666,7 @@
 				else
 					color_matrix_2_apply = mult_color_matrix(color_matrix_2_apply, src.color_matrices[cmatrix])
 			src.active_color_matrix = color_matrix_2_apply
-	src.client?.set_color(src.active_color_matrix, src.mob.respect_view_tint_settings || respect_view_tint_settings)
+	src.client?.set_color(src.active_color_matrix, src.mob.respect_view_tint_settings)
 
 /mob/proc/adjustBodyTemp(actual, desired, incrementboost, divisor)
 	var/temperature = actual

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1666,7 +1666,7 @@
 				else
 					color_matrix_2_apply = mult_color_matrix(color_matrix_2_apply, src.color_matrices[cmatrix])
 			src.active_color_matrix = color_matrix_2_apply
-	src.client?.set_color(src.active_color_matrix, src.mob.respect_view_tint_settings)
+	src.client?.set_color(src.active_color_matrix, src.respect_view_tint_settings)
 
 /mob/proc/adjustBodyTemp(actual, desired, incrementboost, divisor)
 	var/temperature = actual

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -13,6 +13,7 @@
 	blinded = 0
 	anchored = 1
 	use_stamina = 0//no puff tomfuckery
+	respect_view_tint_settings = TRUE
 	var/compute = 0
 	var/datum/flock/flock = null
 	var/wear_id = null // to prevent runtimes from AIs tracking down radio signals
@@ -29,7 +30,7 @@
 	src.see_invisible = INVIS_FLOCK
 	src.see_in_dark = SEE_DARK_FULL
 	/// funk that color matrix up, my friend
-	src.apply_color_matrix(COLOR_MATRIX_FLOCKMIND, COLOR_MATRIX_FLOCKMIND_LABEL)
+	src.apply_color_matrix(COLOR_MATRIX_FLOCKMIND, COLOR_MATRIX_FLOCKMIND_LABEL, TRUE)
 	//src.render_special.set_centerlight_icon("flockvision", "#09a68c", BLEND_OVERLAY, PLANE_FLOCKVISION, alpha=196)
 	//src.render_special.set_widescreen_fill(color="#09a68c", plane=PLANE_FLOCKVISION, alpha=196)
 


### PR DESCRIPTION
[UI][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a flag to mobs that if set will allow any client color changes for that mob to only be set if the mob's view tint is turned on.

Allows Flock players to remove the teal tint from their screen


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Was implemented for Flock, in case Flock players don't like the teal tint. 

Figured it could extend for other mobs if wanted