### PR TITLE
Analyzers show temperature in Kelvin

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -496,7 +496,7 @@
 				data += "[reagent_data]"
 
 			if (show_temp)
-				data += "<br><span class='notice'>Overall temperature: [reagents.total_temperature - T0C]&deg;C ([reagents.total_temperature * 1.8 - T0F]&deg;F)</span>"
+				data += "<br><span class='notice'>Overall temperature: [reagents.total_temperature] K</span>"
 		else
 			data = "<span class='notice'>No active chemical agents found in [A].</span>"
 	else
@@ -755,14 +755,14 @@
 		if (pda_readout == 1) // Output goes into PDA interface, not the user's chatbox.
 			data = "Air Pressure: [round(pressure, 0.1)] kPa<br>\
 			[CONCENTRATION_REPORT(check_me, "<br>")]\
-			Temperature: [round(check_me.temperature - T0C)]&deg;C<br>"
+			Temperature: [round(check_me.temperature)] K<br>"
 
 		else if (simple_output) // For the log_atmos() proc.
-			data = "(<b>Pressure:</b> <i>[round(pressure, 0.1)] kPa</i>, <b>Temp:</b> <i>[round(check_me.temperature - T0C)]&deg;C</i>\
+			data = "(<b>Pressure:</b> <i>[round(pressure, 0.1)] kPa</i>, <b>Temp:</b> <i>[round(check_me.temperature)] K</i>\
 			, <b>Contents:</b> <i>[CONCENTRATION_REPORT(check_me, ", ")]</i>"
 
 		else if (alert_output) // For the alert_atmos() proc.
-			data = "(<b>Pressure:</b> <i>[round(pressure, 0.1)] kPa</i>, <b>Temp:</b> <i>[round(check_me.temperature - T0C)]&deg;C</i>\
+			data = "(<b>Pressure:</b> <i>[round(pressure, 0.1)] kPa</i>, <b>Temp:</b> <i>[round(check_me.temperature)] K</i>\
 			, <b>Contents:</b> <i>[SIMPLE_CONCENTRATION_REPORT(check_me, ", ")]</i>"
 
 		else
@@ -771,7 +771,7 @@
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
 			[CONCENTRATION_REPORT(check_me, "<br>")]\
-			Temperature: [round(check_me.temperature - T0C)]&deg;C<br>"
+			Temperature: [round(check_me.temperature)] K<br>"
 
 	else
 		// Only used for "Atmospheric Scan" accessible through the PDA interface, which targets the turf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces other temperature scales in the reagent analyzer and atmospheric analyzer ( handheld, PDA and Atmos Alert ) with Kelvin.

![image](https://user-images.githubusercontent.com/47158232/197640800-716ff6fc-4d3d-43e0-b8a1-a1146a2e2799.png)
![image](https://user-images.githubusercontent.com/47158232/197640861-acab1bfb-414b-4214-82dc-870f3edd1882.png)
![image](https://user-images.githubusercontent.com/47158232/197641577-a75eadf7-3677-40f3-89f2-d7cdfd4a2ee5.png)
![image](https://user-images.githubusercontent.com/47158232/197641829-d27ecc71-95fa-413f-baaa-ab429aeded57.png)
![image](https://user-images.githubusercontent.com/47158232/197641798-91f79e5f-c44c-463a-8a91-4fb8061b44b8.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Temperature reactions in the wiki are all in Kelvin. Also temperature formulas in science and code like ideal gas law use Kelvin.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Reagent and atmospheric analyzers report temperature in Kelvin.
```
