### PR TITLE
Remove evolve ability button on poltergeist

### DIFF
--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -99,7 +99,7 @@
 		src.see_in_dark = SEE_DARK_FULL
 		src.abilityHolder = new /datum/abilityHolder/wraith(src)
 		src.abilityHolder.points = 50
-		if (!istype(src, /mob/wraith/wraith_trickster) && !istype(src, /mob/wraith/wraith_decay) && !istype(src, /mob/wraith/wraith_harbinger))
+		if (!istype(src, /mob/wraith/wraith_trickster) && !istype(src, /mob/wraith/wraith_decay) && !istype(src, /mob/wraith/wraith_harbinger) && !istype(src, /mob/wraith/poltergeist))
 			src.addAbility(/datum/targetable/wraithAbility/specialize)
 		src.addAllBasicAbilities()
 		last_life_update = TIME


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Poltergeist inherited the evolve ability button from wraith, this fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Poltergeists cant turn into any of the wraith paths, no matter how hard they try to.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
