### PR TITLE
Make Flockdrone attack reports use actual name of what was attacked

### DIFF
--- a/code/datums/components/flock/flockprotection.dm
+++ b/code/datums/components/flock/flockprotection.dm
@@ -14,7 +14,7 @@
 	RegisterSignal(parent, COMSIG_FLOCK_ATTACK, .proc/handle_flock_attack)
 
 /// If flockdrone is in our flock, deny the attack, otherwise scream and cry
-/datum/component/flock_interest/proc/handle_flock_attack(source, atom/attacker, var/intentional)
+/datum/component/flock_interest/proc/handle_flock_attack(atom/source, atom/attacker, var/intentional)
 	if(!istype(attacker))
 		return
 
@@ -36,8 +36,18 @@
 	if(!snitch)
 		return
 
+	var/report_name = source
+	if (istype(source, /mob/living/critter/flock/bit))
+		var/mob/M = source
+		report_name = M.real_name
+	else if (istype(source, /obj/flock_structure))
+		var/obj/flock_structure/structure = source
+		report_name = "the " + structure.flock_id
+	else if (hasvar(source, "flock_id"))
+		report_name = "the " + source.vars["flock_id"]
+
 	if (!snitch.flock.isEnemy(attacker))
-		flock_speak(snitch, "Damage sighted on [source], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", snitch.flock)
+		flock_speak(snitch, "Damage sighted on [report_name], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", snitch.flock)
 	snitch.flock.updateEnemy(attacker)
 
 

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -142,6 +142,7 @@ TYPEINFO_NEW(/obj/table/flock)
 /obj/storage/closet/flock
 	name = "flashy capsule"
 	desc = "It looks kinda like a closet. There's no handle, though. Also, it looks like a giant bar of soap."
+	var/flock_id = "Containment capsule"
 	icon_state = "flock"
 	icon_closed = "flock"
 	icon_opened = "flock-open"
@@ -229,7 +230,7 @@ TYPEINFO_NEW(/obj/table/flock)
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Containment Capsule
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health_attack/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 
@@ -253,6 +254,7 @@ TYPEINFO_NEW(/obj/table/flock)
 /obj/machinery/light/flock
 	name = "shining cabochon"
 	desc = "It pulses and flares to a strange rhythm."
+	var/flock_id = "Light emitter"
 	icon_state = "flock1"
 	base_state = "flock"
 	brightness = 1.2
@@ -287,7 +289,7 @@ TYPEINFO_NEW(/obj/table/flock)
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Light Emitter
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>###=-</span></span>"}
 
 /obj/machinery/light/flock/floor
@@ -300,6 +302,7 @@ TYPEINFO_NEW(/obj/table/flock)
 /obj/lattice/flock
 	desc = "Some sort of floating mesh in space, like a bendy lattice. Those wacky flock things."
 	name = "fibrenet"
+	var/flock_id = "Structural foundation"
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "fibrenet"
 	mat_appearances_to_ignore = list("steel","gnesis")
@@ -339,6 +342,7 @@ TYPEINFO_NEW(/obj/table/flock)
 /obj/grille/flock
 	desc = "A glowing mesh of metallic fibres."
 	name = "barricade"
+	var/flock_id = "Reinforced barricade"
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "barricade"
 	health = 50
@@ -396,7 +400,7 @@ TYPEINFO_NEW(/obj/table/flock)
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Reinforced Barricade
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -285,7 +285,7 @@ TYPEINFO_NEW(/obj/table/flock)
 	playsound(T, 'sound/impact_sounds/Glass_Shatter_3.ogg', 25, 1)
 	qdel(src)
 
-/obj/item/furniture_parts/flock_chair/special_desc(dist, mob/user)
+/obj/machinery/light/flock/special_desc(dist, mob/user)
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -4,6 +4,7 @@
 	icon_state = "door1"
 	name = "weird imposing wall"
 	desc = "It sounds like it's hollow."
+	var/flock_id = "Solid seal aperture"
 	mat_appearances_to_ignore = list("steel","gnesis")
 	mat_changename = FALSE
 	mat_changedesc = FALSE
@@ -28,7 +29,7 @@
 	if (!isflockmob(user))
 		return
 	var/special_desc = {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Solid Seal Aperture
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%"}
 	if(broken)
 		special_desc += {"<br><span class='bold'>FUNCTION CRITICALLY IMPAIRED, REPAIRS REQUIRED</span>

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1099,6 +1099,7 @@
 // flock windows
 
 /obj/window/auto/feather
+	var/flock_id = "Fibrewoven window"
 	var/repair_per_resource = 1
 
 /obj/window/auto/feather/New()
@@ -1111,7 +1112,7 @@
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Fibrewoven Window
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 
@@ -1135,6 +1136,7 @@
 		return isfeathertile(src.loc) && (F.floorrunning || (F.can_floorrun && F.resources >= 1)) && (F.is_npc || (F.client && F.client.check_key(KEY_RUN)))
 
 /obj/window/feather
+	var/flock_id = "Fibrewoven window"
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "window"
 	default_material = "gnesisglass"
@@ -1157,7 +1159,7 @@
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Fibrewoven Window
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -4,6 +4,7 @@
 /turf/simulated/floor/feather
 	name = "weird floor"
 	desc = "I don't like the looks of that whatever-it-is."
+	var/flock_id = "Conduit"
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "floor"
 	flags = USEDELAY
@@ -38,7 +39,7 @@
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Conduit
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/50)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 
@@ -172,6 +173,7 @@ TYPEINFO_NEW(/turf/simulated/wall/auto/feather)
 /turf/simulated/wall/auto/feather
 	name = "weird glowing wall"
 	desc = "You can feel it thrumming and pulsing."
+	var/flock_id = "Nanite block"
 	icon = 'icons/turf/walls_flock.dmi'
 	icon_state = "flock0"
 	mod = "flock"
@@ -204,7 +206,7 @@ TYPEINFO_NEW(/turf/simulated/wall/auto/feather)
 	if (!isflockmob(user))
 		return
 	return {"<span class='flocksay'><span class='bold'>###=-</span> Ident confirmed, data packet received.
-		<br><span class='bold'>ID:</span> Nanite Block
+		<br><span class='bold'>ID:</span> [src.flock_id]
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.max_health)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 


### PR DESCRIPTION
[GAME MODES][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that Flockdrones when reporting attacks on Flock things will use their Flock name in the report. Ex. "Damage sighted on the titanic polyhedron" would appear as "Damage sighted on the Signal Relay Broadcast Amplifier"


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Small Flock clarification