### PR TITLE
Add maintenance access to Cogmap1 NE Maintenance Doors

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -58411,6 +58411,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/kitchen,
 /obj/access_spawn/bar,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "owN" = (
@@ -60677,6 +60678,7 @@
 "rEi" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/access_spawn/bar,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "rFl" = (
@@ -61331,6 +61333,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/kitchen,
 /obj/access_spawn/bar,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "spT" = (
@@ -63922,6 +63925,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/kitchen,
 /obj/access_spawn/bar,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "vGo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix maintenance door access in Cogmap1 North-East Maintenance near Arrivals on top of Catering.
Maintenance access added to the 4 doors with a red arrow pointed to them.
![image](https://user-images.githubusercontent.com/47158232/193433484-b3a4d5a5-5a9b-417b-b775-15f3ae871cf6.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
https://github.com/goonstation/goonstation/issues/11048

The doors are named "Maintenance Airlock" but were missing maintenance access, they only had Bar and Kitchen access.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Add maintenance access to Cogmap1 North-East maintenance doors.
```
