### PR TITLE
Add DWAINE SuperUser Access to Chief Engineer

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -247,7 +247,7 @@
 						#endif
 						)
 		if("Chief Engineer")
-			return list(access_engineering, access_maint_tunnels, access_external_airlocks,
+			return list(access_engineering, access_maint_tunnels, access_external_airlocks, access_dwaine_superuser,
 						access_tech_storage, access_engineering_storage, access_engineering_eva, access_engineering_atmos,
 						access_engineering_power, access_engineering_engine, access_mining_shuttle,
 						access_engineering_control, access_engineering_mechanic, access_engineering_chief, access_mining, access_mining_outpost,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `DWAINE SuperUser` access to `Chief Engineer`. This should not make much changes gameplay wise since the `SU` login is pathetically easy to spoof to anyone who read the [Goonstation Packets wiki page](https://wiki.ss13.co/Packets#Spoofing_the_login_packet).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There are two jobs which use DWAINE. Scientists and Mechanics.

The chief of scientists Research Director has `SU` access to use `prman`
So Chief Engineer should also have `SU` access to access tools like `teleman`

Additionally, when the mainframe dies, engineering is usually called to get it back online, by checking wiring and rebooting the computer core APCs.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Add DWAINE SuperUser Access to Chief Engineer
```
