### PR TITLE
Fixes flockdrone corpses being bullet sponges

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -136,8 +136,10 @@
 	src.flock.removeDrone(src)
 
 /mob/living/critter/flock/projCanHit(datum/projectile/P)
-	if(istype(P, /datum/projectile/energy_bolt/flockdrone))
+	if (istype(P, /datum/projectile/energy_bolt/flockdrone))
 		return FALSE
+	if (!isalive(src)) //we cant_lie but still want to have projectiles act as if we are lying when dead
+		return prob(P.hit_ground_chance)
 	return ..()
 
 /mob/living/critter/flock/bullet_act(var/obj/projectile/P)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes flockdrone corpses always being hit by projectiles as they cannot lie down even when dead.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Trying to fire projectile weapons around areas where flock suffered heavy losses is not fun, especially when the drones can shoot through them fine.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Flockdrone corpses no longer block 100% of shots
```
