### PR TITLE
Removes the soul requirement from disaster mode wraiths

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -834,7 +834,7 @@
 
 	proc/evolve(var/effect as text)
 		var/datum/abilityHolder/wraith/AH = holder
-		if (AH.corpsecount < AH.absorbs_to_evolve)
+		if (AH.corpsecount < AH.absorbs_to_evolve && !istype(ticker.mode, /datum/game_mode/disaster))
 			boutput(holder.owner, "<span class='notice'>You didn't absorb enough souls. You need to absorb at least [AH.absorbs_to_evolve - AH.corpsecount] more!</span>")
 			return 1
 		if (holder.points < pointCost)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODES] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This removes the soul requirement for wraiths during a disaster round to evolve, letting them evolve as soon as they get enough points.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Disaster rounds only last 20 minutes, making it hard for wraiths to fully utilize their abilities if they are able to evolve. This makes it so wraiths will be able to use their evolved forms more.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Disaster round wraiths can now evolve without having to absorb any corpses.
```
