### PR TITLE
Removes rule 4 no-no word

### DIFF
--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -1185,7 +1185,7 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 
 			if (C.amount >= 3000) // coffins
 				FP = /obj/storage/closet/coffin
-				FP_name = "Slutstation"
+				FP_name = "Likkista"
 				C.amount -= 3000
 
 			else if (C.amount >= 1700) // segways
@@ -1568,7 +1568,7 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 	sealed = 1
 	info = {"<small<i>This looks quite tattered and ripped up. You can't read everything around the edges because of all the holes and tears in the paper.</i></small<br><br>
 <b><i>Produkt</i></b> - <i>Pris</i><br>
-<b>Slutstation</b> - 3000<small>SSEK</small><br>
+<b>Likkista</b> - 3000<small>SSEK</small><br>
 <b>Fart</b> - 1700<small>SSEK</small><br>
 <b>Arbetsplatsolycka</b> - 330<small>SSEK</small><br>
 <b>Fyllehund</b> - 320<small>SSEK</small><br>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes an extremely obscure instance of a word that could be interpreted as not very nice by non-Swedish speakers (which is probably just about every player). There is a subtype of parrot that is an ikea vendor, that only spawns on Clarion in the HoP's office. Giving it credits will make it give you furniture with funny Swedish names. Giving 3000 or more credits will give you a coffin with a name that roughly translates to "end point," but the Swedish text is "Slutstation." Read in English, the spelling is.... unfortunate. Changed to "likkista," which is just Swedish for coffin. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bad word bad. Sorry, Swedes.
