### PR TITLE
fixes cog1 medbay breakroom lights

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -58884,6 +58884,7 @@
 	pixel_x = 3;
 	pixel_y = 11
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
 "pdT" = (
@@ -59403,13 +59404,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"pTr" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/cdc)
 "pUw" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
@@ -64021,6 +64015,7 @@
 	pixel_x = -7;
 	pixel_y = 18
 	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
 "vOf" = (
@@ -100210,7 +100205,7 @@ kfp
 mRI
 sfM
 vMs
-pTr
+cxe
 mOn
 cyr
 cyA
@@ -101115,7 +101110,7 @@ kAM
 jwL
 xCr
 pbP
-pTr
+cxe
 cxJ
 cxV
 cxp


### PR DESCRIPTION
[bugfix]

## About the PR 
swaps for south-mounted lights


## Why's this needed? 
Fixes #11170