### PR TITLE
Fixes* some explosion runtimes

### DIFF
--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -66,13 +66,13 @@ var/datum/explosion_controller/explosions
 			//boutput(world, "P1 [p]")
 			if (p >= 6)
 				for (var/mob/M in T)
-					M.ex_act(1, explosion.last_touched, p)
+					M.ex_act(1, explosion?.last_touched, p)
 			else if (p > 3)
 				for (var/mob/M in T)
-					M.ex_act(2, explosion.last_touched, p)
+					M.ex_act(2, explosion?.last_touched, p)
 			else
 				for (var/mob/M in T)
-					M.ex_act(3, explosion.last_touched, p)
+					M.ex_act(3, explosion?.last_touched, p)
 
 		LAGCHECK(LAG_HIGH)
 
@@ -93,7 +93,7 @@ var/datum/explosion_controller/explosions
 						needrebuild = 1
 				else
 					severity = 3
-				O.ex_act(severity, explosion.last_touched, power)
+				O.ex_act(severity, explosion?.last_touched, power)
 				O.last_explosion = explosion
 
 		LAGCHECK(LAG_HIGH)
@@ -122,7 +122,7 @@ var/datum/explosion_controller/explosions
 					continue // they can break even on severity 3
 				else if(istype(T, /turf/simulated))
 					severity = max(severity, 3)
-			T.ex_act(severity, explosion.last_touched)
+			T.ex_act(severity, explosion?.last_touched)
 #endif
 		LAGCHECK(LAG_HIGH)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIMES] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes some runtimes in the explosion controller by just letting it pass null for the blame fingerprints.
The actual cause of this is that somehow `queued_turfs` and `queued_turfs_blame` are becoming desynched. Possibly due to multiple versions of this proc running at the same time despite that being seemingly impossible?
Anyway this should return it to how it was before the explosion refactor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad