### PR TITLE
Standardises The Cogmap2 Armoury

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -35822,6 +35822,40 @@
 /turf/space,
 /area/space)
 "bEK" = (
+/obj/rack,
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -2
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/rack,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/northeast,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -35831,26 +35865,6 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
-	},
-/obj/rack,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/northeast,
-/obj/item/clothing/suit/armor/EOD,
-/obj/item/clothing/suit/armor/EOD,
-/obj/item/clothing/head/helmet/EOD,
-/obj/item/clothing/head/helmet/EOD,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/breaching_charge{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/breaching_charge{
-	pixel_x = -6;
-	pixel_y = -6
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
@@ -36020,27 +36034,34 @@
 	},
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /obj/disposalpipe/segment/transport,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_corners"
+	},
 /area/station/ai_monitored/armory)
 "bFc" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/storage/secure/crate/weapon/armory/shotgun,
-/turf/simulated/floor/engine,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_south"
+	},
 /area/station/ai_monitored/armory)
 "bFd" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
 /obj/storage/secure/crate/weapon/armory/phaser,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine{
+	dir = 1;
+	icon_state = "engine_caution_corners"
+	},
 /area/station/ai_monitored/armory)
 "bFe" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bFf" = (
@@ -36063,6 +36084,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/valve/purge/vertical,
+/obj/machinery/recharger/wall{
+	dir = 8;
+	pixel_x = -19
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bFh" = (
@@ -38128,14 +38153,33 @@
 	icon_state = "pipe-c"
 	},
 /obj/table/reinforced/auto,
-/obj/item/chem_grenade/flashbang,
-/obj/item/chem_grenade/flashbang,
-/obj/item/storage/box/revimp_kit{
-	pixel_x = 5
+/obj/item/storage/box/flashbang_kit{
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/obj/item/reagent_containers/emergency_injector/atropine,
-/obj/item/reagent_containers/emergency_injector/atropine,
-/obj/item/reagent_containers/emergency_injector/atropine,
+/obj/item/storage/box/revimp_kit{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/emergency_injector/atropine{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/emergency_injector/atropine{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/emergency_injector/atropine{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/chem_grenade/flashbang{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/chem_grenade/flashbang{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bIW" = (
@@ -40260,21 +40304,29 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine{
+	dir = 8;
+	icon_state = "engine_caution_corners"
+	},
 /area/station/ai_monitored/armory)
 "bMr" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /obj/storage/secure/crate/plasma/armory/anti_biological,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_north"
+	},
 /area/station/ai_monitored/armory)
 "bMs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /obj/storage/secure/crate/gear/armory/grenades,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine{
+	dir = 4;
+	icon_state = "engine_caution_corners"
+	},
 /area/station/ai_monitored/armory)
 "bMt" = (
 /obj/disposalpipe/segment/transport{
@@ -40303,6 +40355,10 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/ejection,
+/obj/machinery/recharger/wall{
+	dir = 8;
+	pixel_x = -19
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bMw" = (
@@ -40419,10 +40475,54 @@
 	},
 /area/station/security/checkpoint/sec_foyer)
 "bMH" = (
+/obj/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -15;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -13;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
+	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bMI" = (
@@ -76494,27 +76594,27 @@
 /area/station/bridge)
 "hGX" = (
 /obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/horizontal,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
+/obj/item/breaching_charge{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/breaching_charge{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/breaching_charge{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /obj/item/breaching_hammer{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/breaching_charge{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/breaching_charge{
-	pixel_x = -6;
-	pixel_y = -6
-	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/horizontal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "hJl" = (


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
In effect, removes the shotgun crate and one breaching charge from the Cogmap2 Armoury, and adds one additional airlock breaching sledgehammer, one flashbang box, two rechargers, and two additional night vision goggles.

![image](https://user-images.githubusercontent.com/88833499/194111746-8f355f28-4379-4530-bbfa-a4acfcb78fb0.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Cogmap2 Armoury is also equipped with:
* Security Lockdown System
* 1x Pressure Tank (N2O) (hooked up to the Security repressurisation system)
* 2x Riot Launchers
* 2x 40mm Smoke Shells
* 2x Flashbangs
* 1x Flashbang Box
	* 7x Flashbangs
* 3x Emergency Auto-Injectors (Atropine)



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. For Cogmap2 specifically, possessing seven riot shotguns is entirely unnecessary. The layout of items has also been improved.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Standardised the Cogmap2 Armoury.
```
