### PR TITLE
Adds unreferenced slipperiness trap to trickster

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -1556,6 +1556,8 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 				trap_choice = /obj/machinery/wraith/runetrap/stunning
 			if("Sleepyness")
 				trap_choice = /obj/machinery/wraith/runetrap/sleepyness
+			if("Slipperiness")
+				trap_choice = /obj/machinery/wraith/runetrap/slipping
 
 		if(P != null)
 			new trap_choice(T, P.master)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I had made this gimmicky trap for trickster wraith located in runetrap.dm but forgot to add it to the list of spawnable traps. This fixes that. The trap behaves similarly to a banana peel with the upside of being a spawnable trap, which means its invisible if it is dark enough, and is reusable.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Restores unused code. Also a generally funny trap to have as trickster.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus
(+)Adds a slipping trap to trickster wraith.
```
