### PR TITLE
Lets cyborgs rename themselves

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -608,9 +608,6 @@
 		if("occupant-rename")
 			if (!isrobot(src.occupant))
 				return
-			if (user == src.occupant)
-				boutput(user, "<span class='alert'>You may not rename yourself!</span>")
-				return
 			var/mob/living/silicon/robot/R = src.occupant
 			var/newname = copytext(strip_html(sanitize(tgui_input_text(user, "What do you want to rename [R]?", "Cyborg Maintenance", R.name))), 1, 64)
 			if ((!issilicon(user) && (BOUNDS_DIST(user, src) > 0)) || user.stat || !newname)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [SILICONS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just removes the check in docking stations preventing borgs from renaming themselves.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's strange that this is almost the only thing borgs can't do for themselves (and AIs can), and I find myself pestering roboticists a lot simply to get my named changed from "Cyborg Xhi-72" or "Pizzabot_the_destroyer".
Technically has balance concerns for tracking emagged borgs, but it requires you to access a docking station and "heavy borg with treads and a murderous look" is still a decent enough description to go off of.

Apologies if this has been suggested and closed before, but I can't see the PR if it has.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Cyborgs can now rename themselves in docking stations.
```
