### PR TITLE
moves a book on oshan by one tile

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -10785,6 +10785,7 @@
 /area/station/hallway/primary/north)
 "azw" = (
 /obj/table/reinforced/chemistry/auto,
+/obj/item/paper/book/from_file/pharmacopia,
 /obj/machinery/phone{
 	pixel_y = 6
 	},
@@ -13968,7 +13969,6 @@
 	name = "Glassware Recycler"
 	},
 /obj/table/reinforced/chemistry/auto,
-/obj/item/paper/book/from_file/pharmacopia,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [QOL][MAPPING] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
moves the pharmacopia in the oshan chemistry lab by one tile


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
tiny bit of QOL (that book used to spawn on top of the glass recycler and blocked it roundstart)
