### PR TITLE
Fixed Donut2 and Oshan armory doors

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17802,6 +17802,7 @@
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security/alt{
+	aiControlDisabled = 1;
 	dir = 4
 	},
 /turf/simulated/floor/black,
@@ -26773,7 +26774,7 @@
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security/alt{
-	aiHacking = 1
+	aiControlDisabled = 1
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -39046,6 +39046,7 @@
 /area/station/ai_monitored/armory)
 "bWG" = (
 /obj/machinery/door/airlock/pyro/security/alt{
+	aiControlDisabled = 1;
 	name = "Armory";
 	req_access_txt = "37"
 	},
@@ -44024,6 +44025,7 @@
 /area/station/engine/storage)
 "clX" = (
 /obj/machinery/door/airlock/pyro/security/alt{
+	aiControlDisabled = 1;
 	dir = 4;
 	name = "Armory";
 	req_access_txt = "37"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

<!-- Fixed Donut2 and Oshan armory doors -->

[MAPPING][FIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `aiControlDisabled = 1` to Donut2 and Oshan armory doors so they are in line with armory doors in other maps.
Removed the `aiHacking = 1` that one of the Donut2 armory doors spawns with. No idea why it was there.

These two doors in Donut2 ( bottom one had `aiHacking` )
![image](https://user-images.githubusercontent.com/47158232/194407608-7479a786-0ee4-4372-bb98-6b5c29a7adfa.png)

These two doors in Oshan
![image](https://user-images.githubusercontent.com/47158232/194410255-09a8e6ed-7ffb-4018-9a5c-86909b6b6032.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Disable AI Control roundstart on Donut2 and Oshan armory doors.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Disable roundstart AI Control in Donut2 and Oshan armory doors.
```