### PR TITLE
Revamps Cyanide

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -277,10 +277,10 @@ datum
 				if (!counter) counter = 1
 				M.take_toxin_damage(0.5 * mult)  // a bit of tox to show you that something is indeed, not alright
 
-				if (holder.get_reagent_amount("space_drugs") < 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
-					counter = max(0.5, counter + ( holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult) //speed of poisoning scales nonlinearly
-				else                                                                                        //with dosage
+				if (holder.get_reagent_amount("space_drugs") > 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
 					counter += 0.25 * mult
+				else
+					counter += max(0.5, (holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult)//speed of poisoning scales nonlinearly with dosage
 
 				switch(counter)
 					if (1 to 25)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -278,7 +278,7 @@ datum
 				M.take_toxin_damage(0.5 * mult)  // a bit of tox to show you that something is indeed, not alright
 				M.change_misstep_chance(2 * mult) //stumbling a tad bit
 
-				if(!M.reagents.has_reagent("space_drugs")) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
+				if (holder.get_reagent_amount("space_drugs") > 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
 					counter = max(0.5, counter + ( holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult) //speed of poisoning scales nonlinearly
 				else                                                                                        //with dosage
 					counter += 0.25 * mult

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -263,7 +263,7 @@ datum
 			blob_damage = 5
 			value = 7 // 3 2 1 heat
 			target_organs = list("left_lung","right_lung","heart")
-			flushing_multiplier = 0.5
+			flushing_multiplier = 0.8
 			var/counter = 1
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -278,7 +278,7 @@ datum
 				M.take_toxin_damage(0.5 * mult)  // a bit of tox to show you that something is indeed, not alright
 				M.change_misstep_chance(2 * mult) //stumbling a tad bit
 
-				if (holder.get_reagent_amount("space_drugs") > 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
+				if (holder.get_reagent_amount("space_drugs") < 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
 					counter = max(0.5, counter + ( holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult) //speed of poisoning scales nonlinearly
 				else                                                                                        //with dosage
 					counter += 0.25 * mult

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -280,7 +280,7 @@ datum
 				if (holder.get_reagent_amount("space_drugs") > 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
 					counter += 0.25 * mult
 				else
-					counter += max(0.5, (holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult)//speed of poisoning scales nonlinearly with dosage
+					counter += max(0.5, (holder.get_reagent_amount(src.id) ** 0.36 / 1.75) * mult)//speed of poisoning scales nonlinearly with dosage
 
 				switch(counter)
 					if (1 to 25)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -272,11 +272,10 @@ datum
 					counter = max(counter, 12)
 				return
 
-			on_mob_life(var/mob/M, var/mult = 1) // -cogwerks. previous version
+			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom
 				if (!counter) counter = 1
 				M.take_toxin_damage(0.5 * mult)  // a bit of tox to show you that something is indeed, not alright
-				M.change_misstep_chance(2 * mult) //stumbling a tad bit
 
 				if (holder.get_reagent_amount("space_drugs") < 5) //amyl nitrate inhibits cyanide's effects IRL, space drugs is pretty close
 					counter = max(0.5, counter + ( holder.get_reagent_amount(src.id) ** 0.36 / 2) * mult) //speed of poisoning scales nonlinearly
@@ -306,8 +305,13 @@ datum
 						if (ishuman(M))
 							var/mob/living/carbon/human/H = M
 							if (H.organHolder)                    //chance of damage starts at 15 and rises
-								H.organHolder.damage_organs(0, 0, 3*mult, target_organs, min((counter * 0.6), 60))
-
+								H.organHolder.damage_organs(0, 0, 2 * mult, target_organs, min((counter * 0.6), 60))
+								if(H.organHolder.heart.get_damage() > 30) //bad things will happen if you don't treat this stuff
+									H.contract_disease(/datum/ailment/malady/heartfailure, null, null, 1)
+								if(H.organHolder.left_lung.get_damage() > 30)
+									H.contract_disease(/datum/ailment/disease/respiratory_failure/left, null, null, 1)
+								if(H.organHolder.right_lung.get_damage() > 30)
+									H.contract_disease(/datum/ailment/disease/respiratory_failure/right, null, null, 1)
 
 				..()
 				return


### PR DESCRIPTION
[LABEL][feature][balance][chemistry]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR remakes cyanide, changing it from dealing 1.5 tox damage per second with some random stuns, to acting in two stages.

Stage 1: this stage comes with barely any tox damage, but emotes and messages. Lasts 25 cycles if the method of application was through the skin, or 13 if it was any other method.

Stage 2: cyanide starts dealing increasing oxygen damage over time, as well as a small amount of heart and lung damage, that whilst not enough to completely kill your heart and lungs, may trigger heart failure or respiratory failure.

It is overall much less stackable, as most of it's danger potential comes after one or two minutes of exposure, but poses a ever increasing threat as long as it is in you. It's progression can be significantly slowed down, however via having space drugs in your system, as it simulates it's interaction with Amyl Nitrate. The speed at which it progresses is also dependant on dose, so 100 units will be roughly twice as fast as 20 units.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As of now, a lot of poisons are simple tox per second chems, and this poses a problem where stacking can be very effective and kill you much faster than they should. This makes it so small amounts of cyanide wont be anywhere near as strong or stackable, whilst also giving cyanide some extra flavor and separating it a bit from all the other "+2 TOX" chems out there.

![cyanide](https://user-images.githubusercontent.com/52242687/194439506-744c697a-87eb-4d18-8c86-00c544877713.png)

example of cyanide at work: https://youtu.be/plDGK4McHLY

```changelog
(u)Hans
(*)Revamped Cyanide's behavior.(minor notes for more)
(+)Cyanide now primarily deals oxygen damage, and has a ramp up period before it starts being dangerous, but will become more dangerous with time and cause heart and respiratory failure.
(+)Cyanide's progression can now be significantly slowed down with Space Drugs.
(+)The speed at which cyanide poisoning occurs is now dependant on the dose you are given, for instance 100 units of cyanide will be roughly twice as fast as 20 units.
```
