### PR TITLE
Changes tree mutations to use infusions

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2308,9 +2308,11 @@ datum
 
 			reaction_turf(var/turf/T, var/volume)
 				if (!istype(T, /turf/space))
-					if (volume >= 10)
+					if (volume >= 10 && holder.total_temperature < T0C + 180)
 						if (!locate(/obj/item/material_piece/rubber/latex) in T)
 							new /obj/item/material_piece/rubber/latex(T)
+					else
+						return TRUE
 
 		flubber
 			name = "Liquified space rubber"

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -22,6 +22,8 @@
 	var/list/PTrange = list(null,null)
 	var/list/ENrange = list(null,null)
 	var/commut = null // is a paticular common mutation required for this? (keeping it to 1 for now)
+	/// Is a particular other mutation required for this? (type not instance)
+	var/datum/plantmutation/required_mutation = null
 	var/chance = 8 // How likely out of 100% is this mutation to appear when conditions are met?
 	var/list/assoc_reagents = list() // Used for extractions, harvesting, etc
 
@@ -673,7 +675,9 @@
 	name_prefix = "Money "
 	iconmod = "TreeCash"
 	crop = /obj/item/spacecash
-	chance = 20
+	required_mutation = /datum/plantmutation/tree/paper
+	PTrange = list(30, null)
+	chance = 50
 
 /datum/plantmutation/tree/paper
 	name = "Paper Tree"
@@ -681,7 +685,6 @@
 	name_prefix = "Paper "
 	iconmod = "TreePaper"
 	crop = /obj/item/paper
-	chance = 20
 
 /datum/plantmutation/tree/dog
 	name = "Dogwood Tree"
@@ -720,7 +723,6 @@
 	name_prefix = "Rubber "
 	iconmod = "TreeRubber"
 	crop = /obj/item/material_piece/rubber/latex
-	chance = 20
 
 /datum/plantmutation/tree/sassafras
 	name = "Sassafras Tree"

--- a/code/modules/hydroponics/plants_crop.dm
+++ b/code/modules/hydroponics/plants_crop.dm
@@ -259,8 +259,16 @@ ABSTRACT_TYPE(/datum/plant/crop)
 		..()
 		var/datum/plantgenes/DNA = S.plantgenes
 		if (!DNA) return
-		if (reagent == "radium")
-			DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/tree/glowstick)
+		switch (reagent)
+			if ("radium")
+				DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/tree/glowstick)
+			if ("paper")
+				DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/tree/paper)
+			if ("wolfsbane")
+				DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/tree/dog)
+			if ("rubber")
+				DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/tree/rubber)
+
 
 /datum/plant/crop/coffee
 	name = "Coffee"

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -680,3 +680,14 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				return
 
 
+/datum/materialProc/rubber_temp
+	execute(var/atom/location, var/temp)
+		if (istype(owner.owner, /obj/cable) || istype(owner.owner, /obj/item/cable_coil)) //let's just not deal with that
+			return
+		if (temp >= T0C + 180) //wikipedia told me rubber melts at 180C
+			var/datum/reagents/temp_reagents = new(10)
+			temp_reagents.add_reagent("rubber", 10)
+			temp_reagents.set_reagent_temp(temp)
+			temp_reagents.reaction(get_turf(owner.owner))
+			qdel(temp_reagents)
+			qdel(owner.owner)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -682,7 +682,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 
 /datum/materialProc/rubber_temp
 	execute(var/atom/location, var/temp)
-		if (istype(owner.owner, /obj/cable) || istype(owner.owner, /obj/item/cable_coil)) //let's just not deal with that
+		if (istype(owner.owner, /obj/cable) || istype(owner.owner, /obj/item/cable_coil) || isturf(owner.owner)) //let's just not deal with that
 			return
 		if (temp >= T0C + 180) //wikipedia told me rubber melts at 180C
 			var/datum/reagents/temp_reagents = new(10)

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1460,6 +1460,7 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		. = ..()
 		material_flags |= MATERIAL_RUBBER
 		setProperty("electrical", 3)
+		addTrigger(triggersTemp, new /datum/materialProc/rubber_temp())
 
 /datum/material/rubber/latex
 	mat_id = "latex"

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1795,14 +1795,15 @@ proc/HYPmutationcheck_full(var/datum/plant/growing,var/datum/plantgenes/DNA,var/
 	// have to appear, and if all of them are matchedit gives the green light to go ahead and
 	// add it - though there's still a % chance involved after this check passes which is handled
 	// where this check is called, usually.
-	if(!HYPmutationcheck_sub(MUT.GTrange[1],MUT.GTrange[2],DNA.growtime)) return 0
-	if(!HYPmutationcheck_sub(MUT.HTrange[1],MUT.HTrange[2],DNA.harvtime)) return 0
-	if(!HYPmutationcheck_sub(MUT.HVrange[1],MUT.HVrange[2],DNA.harvests)) return 0
-	if(!HYPmutationcheck_sub(MUT.CZrange[1],MUT.CZrange[2],DNA.cropsize)) return 0
-	if(!HYPmutationcheck_sub(MUT.PTrange[1],MUT.PTrange[2],DNA.potency)) return 0
-	if(!HYPmutationcheck_sub(MUT.ENrange[1],MUT.ENrange[2],DNA.endurance)) return 0
-	if(MUT.commut && !HYPCheckCommut(DNA,MUT.commut)) return 0
-	return 1
+	if(!HYPmutationcheck_sub(MUT.GTrange[1],MUT.GTrange[2],DNA.growtime)) return FALSE
+	if(!HYPmutationcheck_sub(MUT.HTrange[1],MUT.HTrange[2],DNA.harvtime)) return FALSE
+	if(!HYPmutationcheck_sub(MUT.HVrange[1],MUT.HVrange[2],DNA.harvests)) return FALSE
+	if(!HYPmutationcheck_sub(MUT.CZrange[1],MUT.CZrange[2],DNA.cropsize)) return FALSE
+	if(!HYPmutationcheck_sub(MUT.PTrange[1],MUT.PTrange[2],DNA.potency)) return FALSE
+	if(!HYPmutationcheck_sub(MUT.ENrange[1],MUT.ENrange[2],DNA.endurance)) return FALSE
+	if(MUT.commut && !HYPCheckCommut(DNA,MUT.commut)) return FALSE
+	if(MUT.required_mutation && !istype(DNA.mutation, MUT.required_mutation)) return FALSE
+	return TRUE
 
 proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 	// Part of mutationcheck_full. Just a simple mathematical check to keep the prior proc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [HYDROPONICS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes tree mutations to (mostly) use infusions rather than random chance.
- Paper tree now requires infusion with paper
- Money trees now only mutate from paper trees with >= 30 potency
- Dogwood tree now requires infusion with aconitine
- Rubber tree now requires infusion with liquid rubber
- Sassafras has been left as a random mutation both because I couldn't think of a chem and because it was already base chance to occur.

Since liquid rubber was kind of hard to get previously, it can now be made by exposing any rubber item (not cables) to a temperature of 180C, causing it to melt into a puddle of 10u of rubber.
I'm reasonably sure this won't break anything horribly, but if it does I can change it to be an acetone interaction or something.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Trees have a lot of mutations, getting any specific mutation was an RNG mess, this should make it a lot more enjoyable.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Most tree mutations now require reagent infusions.
(*)Rubber items now melt into liquid rubber above 180C.
```
