### PR TITLE
Pods now require some plasma in the fuel tank to run

### DIFF
--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -18,6 +18,10 @@
 
 	activate()
 		..()
+		if(ship.fueltank.air_contents.toxins <= 0)
+			boutput(usr, "[ship.ship_message("No plasma located inside of the fuel tank!")]")
+			src.deactivate()
+			return
 		ship.powercapacity = src.powergenerated
 		return
 	////Warp requires recharge time

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -398,6 +398,7 @@
 					W.set_loc(src)
 					src.fueltank = W
 					src.updateDialog()
+					src.engine.activate()
 				else
 					boutput(usr, "<span class='alert'>That doesn't fit there.</span>")
 					return
@@ -408,6 +409,7 @@
 					fueltank.set_loc(src.loc)
 					fueltank = null
 					src.updateDialog()
+					src.engine.deactivate()
 				else
 					boutput(usr, "<span class='alert'>There's no tank in the slot.</span>")
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If pods and subs dont have a fuel tank/the fuel tank doesnt contain any plasma, the engine wont be able to run. This pr does not introduce any fuel drain mechanics to pods


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its just kinda weird that pods dont do this currently, I think its a neat little touch that makes sense.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Pods now require some plasma in the fuel tank in order for the engine to run. 
```
