### PR TITLE
Fixes #11182 Midas touch duplication for food_box subtypes

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -99,7 +99,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_CONSTRUCTION		// Construction mode
 //#define MAP_OVERRIDE_DESTINY			// Destiny/RP
 //#define MAP_OVERRIDE_CLARION			// Destiny/Alt RP
-//#define MAP_OVERRIDE_COGMAP
+#define MAP_OVERRIDE_COGMAP
 //#define MAP_OVERRIDE_COGMAP2			// Cogmap 2
 //#define MAP_OVERRIDE_DONUT2			// Updated Donut2
 //#define MAP_OVERRIDE_DONUT3			// Donut3 by Ryumi

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -99,7 +99,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_CONSTRUCTION		// Construction mode
 //#define MAP_OVERRIDE_DESTINY			// Destiny/RP
 //#define MAP_OVERRIDE_CLARION			// Destiny/Alt RP
-#define MAP_OVERRIDE_COGMAP
+//#define MAP_OVERRIDE_COGMAP
 //#define MAP_OVERRIDE_COGMAP2			// Cogmap 2
 //#define MAP_OVERRIDE_DONUT2			// Updated Donut2
 //#define MAP_OVERRIDE_DONUT3			// Donut3 by Ryumi

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -428,8 +428,8 @@ TRAYS
 	icon = 'icons/obj/foodNdrink/food_related.dmi'
 	icon_state = "donutbox"
 	uses_multiple_icon_states = 1
-	amount = 6
-	var/max_amount = 6
+	var/count = 6
+	var/max_count = 6
 	var/box_type = "donutbox"
 	var/has_closed_state = 1
 	var/contained_food = /obj/item/reagent_containers/food/snacks/donut/custom/random
@@ -445,8 +445,8 @@ TRAYS
 		name = "egg carton"
 		desc = "A carton that holds a bunch of eggs. What kind of eggs? What grade are they? Are the eggs from space? Space chicken eggs?"
 		icon_state = "eggbox"
-		amount = 12
-		max_amount = 12
+		count = 12
+		max_count = 12
 		box_type = "eggbox"
 		contained_food = /obj/item/reagent_containers/food/snacks/ingredient/egg
 		allowed_food = /obj/item/reagent_containers/food/snacks/ingredient/egg
@@ -456,8 +456,8 @@ TRAYS
 		name = "lollipop bowl"
 		desc = "A little bowl of sugar-free lollipops, totally healthy in every way! They're medicinal, after all!"
 		icon_state = "lpop8"
-		amount = 8
-		max_amount = 8
+		count = 8
+		max_count = 8
 		box_type = "lpop"
 		has_closed_state = 0
 		contained_food = /obj/item/reagent_containers/food/snacks/lollipop/random_medical
@@ -475,19 +475,19 @@ TRAYS
 
 	get_desc(dist)
 		if(dist <= 1)
-			. += "There's [(src.amount > 0) ? src.amount : "no" ] [src.contained_food_name][s_es(src.amount)] in [src]."
+			. += "There's [(src.count > 0) ? src.count : "no" ] [src.contained_food_name][s_es(src.count)] in [src]."
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/tongs))
 			return src.Attackhand(user)
-		if(src.amount >= src.max_amount)
+		if(src.count >= src.max_count)
 			boutput(user, "You can't fit anything else in [src]!")
 			return
 		else
 			if(istype(W, src.allowed_food))
 				user.drop_item()
 				W.set_loc(src)
-				src.amount ++
+				src.count ++
 				tooltip_rebuild = 1
 				boutput(user, "You place [W] into [src].")
 				src.update()
@@ -500,21 +500,21 @@ TRAYS
 				return ..()
 
 	attack_hand(mob/user)
-		if((!istype(src.loc, /turf) && !user.is_in_hands(src)) || src.amount == 0)
+		if((!istype(src.loc, /turf) && !user.is_in_hands(src)) || src.count == 0)
 			..()
 			return
 		src.add_fingerprint(user)
 		var/list/obj/item/reagent_containers/food/snacks/myFoodList = src.contents
 		if(myFoodList.len >= 1)
 			var/obj/item/reagent_containers/food/snacks/myFood = myFoodList[myFoodList.len]
-			if(src.amount >= 1)
-				src.amount--
+			if(src.count >= 1)
+				src.count--
 				tooltip_rebuild = 1
 			user.put_in_hand_or_drop(myFood)
 			boutput(user, "You take [myFood] out of [src].")
 		else
-			if(src.amount >= 1)
-				src.amount--
+			if(src.count >= 1)
+				src.count--
 				tooltip_rebuild = 1
 				var/obj/item/reagent_containers/food/snacks/newFood = new src.contained_food(src.loc)
 				user.put_in_hand_or_drop(newFood)
@@ -524,14 +524,14 @@ TRAYS
 	attack_self(mob/user as mob)
 		if(!src.has_closed_state) return
 		if(src.icon_state == "[src.box_type]")
-			src.icon_state = "[src.box_type][src.amount]"
+			src.icon_state = "[src.box_type][src.count]"
 			boutput(user, "You open [src].")
 		else
 			src.icon_state = "[src.box_type]"
 			boutput(user, "You close [src].")
 
 	proc/update()
-		src.icon_state = "[src.box_type][src.amount]"
+		src.icon_state = "[src.box_type][src.count]"
 		return
 
 //=-=-=-=-=-=-=-=-=-=-=-=-


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Internal] [C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11182 which caused Midas touch to duplicate food_box subtypes such as egg cartons and donut boxes.

The issue was that these items used the 'amount' variable to track the count of donuts, eggs, etc. This variable is more typically used for stacks of items and the Midas touch interaction assumes the variable is being used in this way. This was fixed by creating a 'count' variable to replace the 'amount' variable in the food_box type and its subtypes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Turning a donut box gold shouldn't create a second one.


