### PR TITLE
Renames Red Space Suits to Syndicate Space Suits

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1109,14 +1109,14 @@
 		item_state = "spacecap-red"
 
 /obj/item/clothing/suit/space/syndicate_worn
-	name = "worn red space suit"
+	name = "worn syndicate space suit"
 	icon_state = "syndicate"
 	item_state = "space_suit_syndicate"
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives. Looks like this one has seen better days."
 	contraband = 3
 
 /obj/item/clothing/suit/space/syndicate
-	name = "red space suit"
+	name = "syndicate space suit"
 	icon_state = "syndicate"
 	item_state = "space_suit_syndicate"
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives."


### PR DESCRIPTION
## About the PR
just an item rename, see the title

## Why's this needed? 
makes the sort of declaration that wearing the suit around station is much clearer to the wearer, as well as letting new security know Why it's marked as contraband 

## Changelog
```changelog
(u)Waffleloffle
(+)Renamed the red space suit to the syndicate space suit.
```
