### PR TITLE
Cyborgs can no longer remove APC batteries

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -570,7 +570,7 @@ var/zapLimiter = 0
 
 	interact_particle(user,src)
 
-	if(opened && !isAI(user))
+	if(opened && !isAIeye(user) && !issilicon(user))
 		if(cell)
 			user.put_in_hand_or_drop(cell)
 			cell.UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug][A-Silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disables silicons from removing APC batteries.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11013

Silicons were able to remove APC batteries no matter how far away they were. Silicons cannot install batteries, so there is little reason for them to remove them. This also aligns more with the cyborg's inability to physically interact with things without their tools.

