### PR TITLE
Fix head transplants breaking head appearance updates.

### DIFF
--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -177,43 +177,8 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		body_icon = toCopy.body_icon
 		body_icon_state = toCopy.body_icon_state
-		head_icon = toCopy.head_icon
-		head_icon_state = toCopy.head_icon_state
 
-		customization_icon = toCopy.customization_icon
-
-		customization_first_color_original = toCopy.customization_first_color_original
-		customization_first_color = toCopy.customization_first_color
-		customization_first = toCopy.customization_first
-		customization_first_offset_y = toCopy.customization_first_offset_y
-		customization_first_original = toCopy.customization_first_original
-
-		customization_second_color_original = toCopy.customization_second_color_original
-		customization_second_color = toCopy.customization_second_color
-		customization_second = toCopy.customization_second
-		customization_second_offset_y = toCopy.customization_second_offset_y
-		customization_second_original = toCopy.customization_second_original
-
-		customization_third_color_original = toCopy.customization_third_color_original
-		customization_third_color = toCopy.customization_third_color
-		customization_third = toCopy.customization_third
-		customization_third_offset_y = toCopy.customization_third_offset_y
-		customization_third_original = toCopy.customization_third_original
-
-		special_hair_1_icon = toCopy.special_hair_1_icon
-		special_hair_1_state = toCopy.special_hair_1_state
-		special_hair_1_color_ref = toCopy.special_hair_1_color_ref
-		special_hair_1_offset_y = toCopy.special_hair_1_offset_y
-
-		special_hair_2_icon = toCopy.special_hair_2_icon
-		special_hair_2_state = toCopy.special_hair_2_state
-		special_hair_2_color_ref = toCopy.special_hair_2_color_ref
-		special_hair_2_offset_y = toCopy.special_hair_2_offset_y
-
-		special_hair_3_icon = toCopy.special_hair_3_icon
-		special_hair_3_state = toCopy.special_hair_3_state
-		special_hair_3_color_ref = toCopy.special_hair_3_color_ref
-		special_hair_3_offset_y = toCopy.special_hair_3_offset_y
+		CopyOtherHeadAppearance(toCopy)
 
 		mob_detail_1_icon = toCopy.mob_detail_1_icon
 		mob_detail_1_state = toCopy.mob_detail_1_state
@@ -259,6 +224,45 @@ var/list/datum/bioEffect/mutini_effects = list()
 			var/mob/living/carbon/human/H = owner
 			H.update_colorful_parts()
 		return src
+
+	proc/CopyOtherHeadAppearance(var/datum/appearanceHolder/toCopy)
+		head_icon = toCopy.head_icon
+		head_icon_state = toCopy.head_icon_state
+
+		customization_icon = toCopy.customization_icon
+
+		customization_first_color_original = toCopy.customization_first_color_original
+		customization_first_color = toCopy.customization_first_color
+		customization_first = toCopy.customization_first
+		customization_first_offset_y = toCopy.customization_first_offset_y
+		customization_first_original = toCopy.customization_first_original
+
+		customization_second_color_original = toCopy.customization_second_color_original
+		customization_second_color = toCopy.customization_second_color
+		customization_second = toCopy.customization_second
+		customization_second_offset_y = toCopy.customization_second_offset_y
+		customization_second_original = toCopy.customization_second_original
+
+		customization_third_color_original = toCopy.customization_third_color_original
+		customization_third_color = toCopy.customization_third_color
+		customization_third = toCopy.customization_third
+		customization_third_offset_y = toCopy.customization_third_offset_y
+		customization_third_original = toCopy.customization_third_original
+
+		special_hair_1_icon = toCopy.special_hair_1_icon
+		special_hair_1_state = toCopy.special_hair_1_state
+		special_hair_1_color_ref = toCopy.special_hair_1_color_ref
+		special_hair_1_offset_y = toCopy.special_hair_1_offset_y
+
+		special_hair_2_icon = toCopy.special_hair_2_icon
+		special_hair_2_state = toCopy.special_hair_2_state
+		special_hair_2_color_ref = toCopy.special_hair_2_color_ref
+		special_hair_2_offset_y = toCopy.special_hair_2_offset_y
+
+		special_hair_3_icon = toCopy.special_hair_3_icon
+		special_hair_3_state = toCopy.special_hair_3_state
+		special_hair_3_color_ref = toCopy.special_hair_3_color_ref
+		special_hair_3_offset_y = toCopy.special_hair_3_offset_y
 
 	disposing()
 		owner = null

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -289,6 +289,18 @@
 		src.pixel_y = rand(-20,-8)
 		src.pixel_x = rand(-8,8)
 
+	on_transplant(mob/M)
+		. = ..()
+		// at this point in time, the head's "donor" is M, but the head's donor_appearance is the last person it was attached to's bioholder's mobappearance
+		if(!src.donor?.bioHolder?.mobAppearance)
+			return
+
+		var/datum/appearanceHolder/currentHeadAppearanceOwner = src.donor_appearance
+
+		// we will move the head's appearance onto its new owner's mobappearance and then update its appearance reference to that
+		src.donor.bioHolder.mobAppearance.CopyOtherHeadAppearance(currentHeadAppearanceOwner)
+		src.donor_appearance = src.donor.bioHolder.mobAppearance
+
 	on_removal()
 		src.transplanted = 1
 		if (src.linked_human)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Heads carry a reference to their owner's appearanceholder and they grab their hair, hair color etc from that reference.

This reference isn't updated on transplants, which at first doesn't cause any issues, since the head will still retain its appearance.
However, if you then try to change the new owner's appearance (for example via genetics), the head won't update as it still carries the reference to its original owner's old appearanceholder.

At the moment of transplantation, the head's `donor` is updated to the new owner of the head, while its appearanceholder reference still references the old owner's. This PR moves the old appearanceholder's head appearance onto the new owner's appearanceholder and then updates the reference.

The PR also refactors appearanceholder's `CopyOther`'s proc's head-related updates into a separate proc for purposes of these updates.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Head transplants break head-related visual updates, this PR fixes that.

