### PR TITLE
Fix appearance/heads regression breaking the tommygun/tommyize.

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -127,13 +127,17 @@ proc/Create_Tommyname()
 
 /mob/living/carbon/human/proc/tommyize_reshape()
 	//Set up the new appearance
-	var/datum/appearanceHolder/AH = new
-	AH.gender = "male"
-	AH.customization_first = new /datum/customization_style/hair/long/dreads
-	AH.gender = "male"
-	AH.s_tone = "#FAD7D0"
-	AH.owner = src
-	AH.parentHolder = src.bioHolder
+	if(src.bioHolder)
+		src.bioHolder.AddEffect("accent_tommy")
+		if(src.bioHolder.mobAppearance)
+			var/datum/appearanceHolder/AH = src.bioHolder.mobAppearance
+			AH.gender = "male"
+			AH.customization_first = new /datum/customization_style/hair/long/dreads
+			AH.customization_first_color = "#101010"
+			AH.customization_second = new /datum/customization_style/none
+			AH.customization_third = new /datum/customization_style/none
+			AH.s_tone = "#FAD7D0"
+			src.bioHolder.AddEffect("accent_tommy")
 
 	src.gender = "male"
 	src.real_name = Create_Tommyname()
@@ -161,9 +165,6 @@ proc/Create_Tommyname()
 	src.sound_scream = 'sound/voice/tommy_you-are-tearing-me-apart-lisauh.ogg'
 	src.sound_fingersnap = 'sound/voice/tommy_did-not-hit-hehr.ogg'
 
-	if(src.bioHolder)
-		src.bioHolder.mobAppearance = AH
-		src.bioHolder.AddEffect("accent_tommy")
 	src.update_colorful_parts()
 
 //------------------------//


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Issue: tommyize doesn't update the head appearance (hair, etc remain the same).
Tommyize used to work by creating a new appearanceholder and replacing the current one on a mob.

However, since some timeframe, heads appear to be updating their appearanceholder based off their own data and references.
This means that while a mob's appearanceholder would be replaced by tommyize, their head would still hold references to the old one.

This PR makes it so that to avoid various issues the appearanceholder update just works on the current appearanceholder instead of creating a whole new one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes tommygun/tommyize not changing head appearance.
Closes #11214
