### PR TITLE
Fix chat scroll message for cutting off someone's butt

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -1124,7 +1124,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 					return 1
 
 				surgeon.tri_message(patient, "<span class='alert'><b>[surgeon]</b> severs [patient == surgeon ? "[his_or_her(patient)]" : "[patient]'s"] butt's connection to the stomach with [src]!</span>",\
-				surgeon , "<span class='alert'>You sever [surgeon == patient ? "your" : "[patient]'s"] butt's connection to the stomach with [src]!</span>",\
+					"<span class='alert'>You sever [surgeon == patient ? "your" : "[patient]'s"] butt's connection to the stomach with [src]!</span>",\
 					"<span class='alert'>[patient == surgeon ? "You sever" : "<b>[surgeon]</b> severs"] your butt's connection to the stomach with [src]!</span>")
 
 				patient.TakeDamage("chest", damage_low, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug][A-Medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the chat scroll message for cutting off someone's butt. The current one has a typo in the proc call that adds an extra argument. This typo prevents the chat scroll message from showing up.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11254

