### PR TITLE
Extends packet key max length in packet sender PDA program

### DIFF
--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -385,7 +385,7 @@
 		else if(href_list["edit"])
 			var/codekey = href_list["code"]
 
-			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender", codekey) as text|null ), 1, 16)
+			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender", codekey) as text|null ), 1, 255)
 			if(!newkey)
 				return
 
@@ -433,7 +433,7 @@
 			if(keyval && (keyval.len >= MAX_PACKET_KEYS))
 				return
 
-			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender") as text|null ), 1, 16)
+			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender") as text|null ), 1, 255)
 			if(!newkey)
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug][A-Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the packet sender key max text length from 15 to 254 to match the value max length.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10379

Some existing packet key fields such as sender_assignment were not able to be included in packet sender packets since they were longer than 15 characters. This removes that limitation.

