### PR TITLE
fixes swapped nukie plant names on wrestlemap

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -943,8 +943,8 @@ var/global/list/mapNames = list(
 		"outside the Ringularity" = list(/area/station/engine/inner),
 		"the courtroom" = list(/area/station/storage/warehouse),
 		"the medbay" = list(/area/station/medical/medbay, /area/station/medical/medbay),
-		"the security lobby" = list(/area/station/chapel/sanctuary),
-		"the chapel" = list(/area/station/security/secwing),
+		"the security lobby" = list(/area/station/security/secwing),
+		"the chapel" = list(/area/station/chapel/sanctuary),
 		"the south crew quarters" = list(/area/station/crew_quarters/quarters_south))
 
 /datum/map_settings/pod_wars


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [BUG][MAPPING] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes wrestlemap chapel and sec lobby plants having swapped names


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad