### PR TITLE
Changes to LOOC to allow hearing people inside of containers (i.e. lockers, etc)

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -691,21 +691,17 @@
 
 	var/list/recipients = list()
 
-	for (var/mob/M in range(LOOC_RANGE))
-		if (!M.client)
-			continue
-		if (M.client.preferences && !M.client.preferences.listen_looc)
-			continue
-		recipients += M.client
+	var/our_location = get_turf(src)
 
 	for (var/client/C)
-		if (!C.mob) continue
-		var/mob/M = C.mob
-
-		if (M.client in recipients)
+		if (!C.mob)
 			continue
-		if (M.client.holder && !M.client.only_local_looc && !M.client.player_mode)
-			recipients += M.client
+		if (C.preferences && !C.preferences.listen_looc)
+			continue
+		if (C.holder && !C.only_local_looc && !C.player_mode) // is admin with global looc enabled and not in player mode
+			recipients += C
+		else if (IN_RANGE(C.mob, our_location, LOOC_RANGE)) // is in range to hear looc
+			recipients += C
 
 	var looc_style = ""
 	if (src.client.holder && !src.client.stealth)
@@ -717,7 +713,7 @@
 		looc_style = "color: #a24cff;"
 
 	var/image/chat_maptext/looc_text = null
-	looc_text = make_chat_maptext(src, "\[LOOC: [msg]]", looc_style)
+	looc_text = make_chat_maptext(our_location, "\[LOOC: [msg]]", looc_style)
 	if(looc_text)
 		looc_text.measure(src.client)
 		for(var/image/chat_maptext/I in src.chat_text.lines)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes how LOOC acquires its recipients:

Previously: 
loops through everything around you, adds mobs found (alongside checks for admins, playermode and whatnot).
Issues: doesn't check inside containers, adding recursive looping through containers could be potentially a lot atoms to traverse.


PR: 
loops through all clients, checks if their mob is within range of the LOOC message (alongside checks for admins, playermode and whatnot).
This fixes the container issue, only downside is having to check whether each client is in range, I haven't run the numbers (difficult to test this locally), but the cost should be fairly predictable and linear compared to recursively looking through containers, which may or may not contain tons of objects.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being inside a container no longer obstructs the player's LOOC messages.
Closes #11248
