### PR TITLE
Standardises The Oshan Armoury

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -28650,7 +28650,7 @@
 /obj/machinery/turret{
 	name = "armory turret"
 	},
-/turf/simulated/floor/delivery/caution,
+/turf/simulated/floor/red/redblackchecker,
 /area/station/ai_monitored/armory)
 "bwF" = (
 /obj/disposalpipe/segment/morgue,
@@ -38449,9 +38449,7 @@
 "bVa" = (
 /obj/item/device/radio/intercom/security,
 /obj/machinery/vending/security_ammo,
-/turf/simulated/floor/redblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bVc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -39381,9 +39379,6 @@
 /obj/cable,
 /turf/simulated/floor/red,
 /area/station/security/brig)
-"bXu" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/ai_monitored/armory)
 "bXv" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/redblack{
@@ -39690,9 +39685,49 @@
 /area/station/ai_monitored/armory)
 "bYq" = (
 /obj/rack,
-/obj/item/storage/box/flashbang_kit,
-/obj/item/storage/box/flashbang_kit{
-	pixel_x = -4
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -15;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -13;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor/redblack/corner{
@@ -39709,11 +39744,27 @@
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
 "bYt" = (
-/obj/item/reagent_containers/food/snacks/donut/custom/robust{
-	pixel_y = 4;
-	rand_pos = 0
-	},
 /obj/table/reinforced/industrial/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_x = 11;
+	pixel_y = 6
+	},
+/obj/item/device/radio/electropack{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/item/device/radio/electropack{
+	pixel_x = -14;
+	pixel_y = 2
+	},
+/obj/item/device/radio/signaler{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/device/radio/signaler{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -45144,7 +45195,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "gJy" = (
-/obj/machinery/weapon_stand/rifle_rack/recharger,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/obj/item/ammo/bullets/tranq_darts,
+/obj/item/ammo/bullets/tranq_darts,
+/obj/item/ammo/bullets/tranq_darts,
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
@@ -45489,11 +45543,19 @@
 	name = "Catering Hangar"
 	})
 "iPj" = (
-/obj/item/kitchen/food_box/donut_box{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/table/reinforced/industrial/auto,
+/obj/item/storage/box/revimp_kit{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/storage/box/revimp_kit{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/food/snacks/donut/custom/robust{
+	pixel_x = -1;
+	pixel_y = 2;
+	rand_pos = 0
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -45756,6 +45818,32 @@
 	name = "not grass"
 	},
 /area/station/ranch)
+"jWq" = (
+/obj/rack,
+/obj/item/breaching_charge{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/breaching_charge{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/breaching_charge{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/station/ai_monitored/armory)
 "jZw" = (
 /obj/machinery/vending/air_vendor,
 /turf/simulated/floor,
@@ -45818,6 +45906,11 @@
 	dir = 4
 	},
 /area/station/medical/medbay/lobby)
+"krS" = (
+/turf/simulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/station/ai_monitored/armory)
 "ksg" = (
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -46221,32 +46314,37 @@
 /area/station/ai_monitored/storage/eva)
 "mLJ" = (
 /obj/rack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/breaching_charge{
-	pixel_x = -2;
-	pixel_y = -5
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 9;
+	pixel_y = 7
 	},
-/obj/item/breaching_charge{
-	pixel_x = -2;
-	pixel_y = -5
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/item/breaching_charge{
-	pixel_x = -2;
-	pixel_y = -5
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 7;
+	pixel_y = -3
 	},
-/obj/item/breaching_hammer{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 6;
+	pixel_y = -8
 	},
-/obj/item/breaching_hammer{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -8;
+	pixel_y = -6
 	},
 /turf/simulated/floor/redblack/corner{
 	dir = 1
@@ -46707,15 +46805,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/inner/central)
 "pij" = (
-/obj/rack,
-/obj/item/storage/box/revimp_kit{
-	pixel_x = 2
-	},
-/obj/item/storage/box/revimp_kit{
-	pixel_x = -3
-	},
-/obj/item/gun/energy/phaser_gun,
-/obj/item/gun/energy/phaser_gun,
+/obj/storage/secure/crate/weapon/armory/phaser,
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -47707,14 +47797,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "vex" = (
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
-/obj/item/ammo/bullets/tranq_darts,
-/obj/item/ammo/bullets/tranq_darts,
-/obj/item/ammo/bullets/tranq_darts,
-/obj/machinery/light/incandescent/harsh/very,
+/obj/machinery/weapon_stand/rifle_rack/recharger,
 /obj/decal/poster/wallsign/framed_award/hos_medal{
 	pixel_y = 28
 	},
+/obj/machinery/light/incandescent/harsh/very,
 /turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "vfw" = (
@@ -48209,17 +48296,26 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "xWR" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
+/obj/table/reinforced/industrial/auto,
+/obj/item/storage/box/flashbang_kit{
+	pixel_y = 13
+	},
+/obj/item/storage/box/flashbang_kit{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -9;
+	pixel_y = 2
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -91685,7 +91781,7 @@ bTR
 bTR
 bTR
 bTR
-bXu
+bTR
 bTR
 bTR
 vcb
@@ -92588,8 +92684,8 @@ bQF
 bRH
 bSN
 bTR
-bVX
-bVX
+jWq
+krS
 bWH
 bVX
 bVX


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
In effect, removes two phasers from the Oshan Armoury, and adds a phaser crate, two night vision goggles, two optical thermal scanners, two bomb disposal suits, and two gas masks.

![image](https://user-images.githubusercontent.com/88833499/194774792-408d685b-2507-4060-be14-8b1953a9e5a8.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Oshan Armoury also possesses:
* 3x (additional) .308 Tranquiliser Darts
* 3x Crowd Dispersal Grenades
* 2x Flashbang Boxes
	* 7x Flashbangs
* 2x Counter-Revolutionary Implant Kits
	* 6x Counter-Revolutionary Implants
	* 1x Implanter
* 2x Electropacks
* 2x Remote Signalling Devices
* 1x Doughnut Box
	* 6x Doughnuts
* 1x Robust Doughnut



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Standardised the Oshan Armoury.
```
