### PR TITLE
Standardises The Destiny Armoury

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -16428,14 +16428,6 @@
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
 	})
-"bFn" = (
-/obj/decal/tile_edge/line/red{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/deployable_turret/riot,
-/turf/simulated/floor/black,
-/area/station/ai_monitored/armory)
 "bFE" = (
 /obj/table/wood/auto,
 /obj/cable{
@@ -18360,11 +18352,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "cAA" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
 /obj/decal/tile_edge/line/red{
 	dir = 8;
 	icon_state = "line1"
 	},
+/obj/storage/secure/crate/weapon/armory/phaser,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "cAB" = (
@@ -25316,6 +25309,42 @@
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
+"fCU" = (
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -13;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "fDo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25448,6 +25477,7 @@
 	icon_state = "line1"
 	},
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "fGi" = (
@@ -25566,6 +25596,7 @@
 	icon_state = "1-2"
 	},
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "fJM" = (
@@ -25613,6 +25644,26 @@
 /obj/machinery/light,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"fKG" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/drink_rack/mug{
+	pixel_x = 3;
+	pixel_y = 29
+	},
+/obj/machinery/chem_dispenser/alcohol{
+	desc = "What? Security has moments of weakness too!";
+	name = "emergency alcohol dispenser"
+	},
+/obj/machinery/recharger/wall{
+	dir = 4;
+	pixel_x = 23;
+	pixel_y = 8
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "fKV" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -26310,20 +26361,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
-"gat" = (
-/obj/machinery/computer/security/wooden_tv{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13";
-	pixel_x = 11
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/security/beepsky)
 "gaP" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black/bright,
@@ -27877,11 +27914,12 @@
 /area/station/science/storage)
 "gQM" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/obj/decal/poster/wallsign/cdnp{
-	pixel_y = 32
+/obj/cable{
+	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -32842,16 +32880,6 @@
 /obj/item/sheet/glass/reinforced/fullstack,
 /turf/simulated/floor,
 /area/station/storage/tools)
-"jAa" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating/random,
-/area/station/security/beepsky)
 "jAb" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -33364,10 +33392,15 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/office)
 "jNQ" = (
-/obj/machinery/vending/security_ammo,
 /obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line2"
+	icon_state = "line1"
+	},
+/obj/storage/secure/crate/gear/armory/grenades,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -33406,16 +33439,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
-"jPb" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/stool/bench/red,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/security/beepsky)
 "jPk" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light_switch/north{
@@ -34379,19 +34402,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "kqr" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/tank/air,
-/obj/item/tank/air,
-/obj/item/storage/box/revimp_kit,
-/obj/item/breaching_hammer,
 /obj/decal/tile_edge/line/red{
 	dir = 10;
 	icon_state = "line2"
 	},
+/obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "kqD" = (
@@ -36664,6 +36679,34 @@
 "lzT" = (
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
+"lzV" = (
+/obj/rack,
+/obj/item/breaching_charge{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/breaching_charge{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/breaching_charge{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/decal/tile_edge/line/red{
+	dir = 6;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "lAi" = (
 /obj/machinery/vending/pda,
 /turf/simulated/floor,
@@ -37299,38 +37342,11 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "lSZ" = (
-/obj/rack,
-/obj/item/chem_grenade/flashbang,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1"
 	},
-/obj/item/clothing/suit/armor/EOD{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/clothing/suit/armor/EOD{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/helmet/EOD{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/EOD{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/ammo/bullets/smoke,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "lTX" = (
@@ -37671,20 +37687,48 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "mdv" = (
+/obj/rack,
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/decal/tile_edge/line/red{
+	dir = 4;
+	icon_state = "line1"
+	},
 /obj/machinery/light/incandescent/warm/very{
 	dir = 4;
 	nostick = 1;
 	pixel_x = 11
 	},
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line2"
-	},
-/obj/drink_rack/mug{
-	pixel_x = 6;
-	pixel_y = 29
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "mdE" = (
@@ -37850,9 +37894,9 @@
 "mhC" = (
 /obj/machinery/disposal/mail/small{
 	dir = 8;
+	mail_tag = "bar";
 	name = "mail chute-'Bar'";
-	pixel_x = 5;
-	mail_tag = "bar"
+	pixel_x = 5
 	},
 /obj/disposalpipe/trunk/mail{
 	dir = 4
@@ -39281,6 +39325,13 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
+"mSI" = (
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "mTb" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/line/yellow{
@@ -40729,13 +40780,10 @@
 	pixel_x = 20
 	},
 /obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line2"
+	dir = 4;
+	icon_state = "line1"
 	},
-/obj/machinery/chem_dispenser/alcohol{
-	desc = "What? Security has moments of weakness too!";
-	name = "emergency alcohol dispenser"
-	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "nDa" = (
@@ -42142,6 +42190,55 @@
 "oqy" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
+"orl" = (
+/obj/decal/tile_edge/line/red{
+	dir = 4;
+	icon_state = "line1"
+	},
+/obj/table/reinforced/industrial/auto,
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -7;
+	pixel_y = 19
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/storage/box/revimp_kit{
+	pixel_x = 8;
+	pixel_y = 17
+	},
+/obj/item/storage/box/flashbang_kit{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/machinery/light/incandescent/warm/very{
+	dir = 4;
+	nostick = 1;
+	pixel_x = 11
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "orm" = (
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -42965,13 +43062,8 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/recharger/wall/sticky{
-	dir = 4;
-	pixel_x = 23;
-	pixel_y = 10
-	},
 /obj/decal/tile_edge/line/red{
-	dir = 4;
+	dir = 5;
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
@@ -47363,13 +47455,6 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/sauna)
-"rdF" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/ai_monitored/armory)
 "rdR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48648,6 +48733,30 @@
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P04"
 	})
+"rQd" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/table/reinforced/industrial/auto,
+/obj/item/ammo/bullets/smoke{
+	pixel_x = 2;
+	pixel_y = 13
+	},
+/obj/item/ammo/bullets/smoke{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/obj/item/gun/kinetic/riot40mm{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/gun/kinetic/riot40mm{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "rQk" = (
 /obj/decal/stage_edge,
 /obj/machinery/computer/stockexchange,
@@ -51672,19 +51781,11 @@
 /area/station/engine/combustion_chamber)
 "tyD" = (
 /obj/storage/secure/closet/security/armory,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/recharger/wall/sticky{
+/obj/machinery/recharger/wall{
 	dir = 4;
 	pixel_x = 23;
 	pixel_y = 8
@@ -53666,14 +53767,6 @@
 /obj/machinery/bot/guardbot/mail,
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
-"uAd" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/traffic_light/trader_right,
-/turf/space,
-/area/space)
 "uAP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
@@ -54407,14 +54500,6 @@
 	dir = 9
 	},
 /area/station/science/lobby)
-"uOv" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/traffic_light/trader_left,
-/turf/space,
-/area/space)
 "uOB" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -57019,13 +57104,6 @@
 /obj/access_spawn/crematorium,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
-"wfk" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating/random,
-/area/station/security/beepsky)
 "wft" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -57313,13 +57391,6 @@
 	},
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbay)
-"wne" = (
-/obj/machinery/shuttle/engine/heater{
-	icon_state = "alt_heater-R"
-	},
-/obj/window/reinforced/north,
-/turf/simulated/floor/plating/airless,
-/area/station/security/beepsky)
 "wnu" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -57750,13 +57821,13 @@
 /area/station/storage/tools)
 "wwO" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
 	icon_state = "1-4"
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/decal/poster/wallsign/cdnp{
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -60881,17 +60952,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"ych" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/plasticflaps{
-	layer = 3
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/security/beepsky)
 "ycr" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -98906,9 +98966,9 @@ ntC
 uJT
 tyD
 oOu
-ubE
-rdF
-bFn
+vsI
+vsI
+vsI
 jNQ
 wNe
 wNe
@@ -99207,12 +99267,12 @@ juJ
 nXe
 uJT
 wNe
-wNe
+fKG
 mdv
 nCZ
-wNe
-wNe
-wNe
+ubE
+mSI
+fCU
 kEq
 pyB
 ubx
@@ -99512,9 +99572,9 @@ wNe
 wNe
 wNe
 wNe
-wNe
-wNe
-wNe
+rQd
+orl
+lzV
 xCV
 rod
 ubx
@@ -99815,11 +99875,11 @@ wNe
 wNe
 wNe
 wNe
-jPb
-gat
-bKE
-wne
-laR
+wNe
+wNe
+xCV
+vwO
+ubx
 eer
 rMN
 eer
@@ -100116,12 +100176,12 @@ ldD
 pPI
 sEl
 lME
-dYq
-ych
-wfk
-jAa
-lYO
-laR
+wNe
+wNe
+wNe
+cRY
+pyB
+ubx
 iHl
 nzx
 iHl
@@ -103944,7 +104004,7 @@ aaa
 aaa
 ojO
 oTy
-uOv
+ojO
 aaa
 gEl
 rKX
@@ -109982,7 +110042,7 @@ aaa
 cCx
 aaa
 aaa
-uAd
+iPT
 cAY
 iPT
 aaa


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
Expands the Destiny Armoury, removing a part of Beepsky's House to do so, adding: a phaser crate, a special grenades crate, one airlock breaching sledgehammer, three breaching charges, one pair of optical thermal scanners, one pair of night vision goggles, one riot launcher, one box of 40mm smoke shells, one box of flashbangs, and one crowd dispersal grenade. Removes one flashbang and two gas tanks (air mix) from the Armoury.

![image](https://user-images.githubusercontent.com/88833499/194914238-216247a9-32ee-4bf4-b466-8fff45d47f76.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Destiny Armoury is also in possession of:
* 2x Riot Launchers
* 2x 40mm Smoke Shells
* 3x Crowd Dispersal Grenades
* 1x Flashbang Box
	* 7x Flashbangs
* 1x Counter-Revolutionary Implant Kit
	* 6x Counter-Revolutionary Implants
	* 1x Implanter
* 1x Emergency Alcohol Dispenser



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. Destiny especially was lacking an assortment of essential content, alongside riot helmets, optical thermal scanners, and NVGs all being locked behind the HoS-only special equipment locker.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Expanded and standardised the Destiny Armoury.
```
