### PR TITLE
Adds AI Metal Foam Launcher to CE Prefab

### DIFF
--- a/assets/maps/prefabs/prefab_sequestered_cloner.dmm
+++ b/assets/maps/prefabs/prefab_sequestered_cloner.dmm
@@ -487,6 +487,7 @@
 	pixel_x = -7;
 	pixel_y = 6
 	},
+/obj/item/aiModule/ability_expansion/mfoam_launcher,
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the metal foam launcher to the CE prefab.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This can be used for both good and bad things, so I decided to place it behind a puzzle in a fitting prefab. This is to prevent it from being used every round, but still be accessible for both traitors and loyal crew. Implements an item that's just been hanging out in the code for a while now.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)A traitorous former CE has left behind an experimental AI module in his hideout.
```
