### PR TITLE
Add new category "Ancient" to clothing booth

### DIFF
--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1223,3 +1223,41 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/western/westboot)
 		path = /obj/item/clothing/shoes/westboot/brown
 
 
+// Ancient
+
+ABSTRACT_TYPE(/datum/clothingbooth_item/ancient)
+/datum/clothingbooth_item/ancient
+	name = "ancient"
+	category = "Ancient"
+	cost = PAY_UNTRAINED/1
+
+/datum/clothingbooth_item/ancient/greekhat
+	name = "Greek Helmet"
+	path = /obj/item/clothing/head/helmet/greek
+	slot = SLOT_HEAD
+	cost = PAY_UNTRAINED/2
+
+/datum/clothingbooth_item/ancient/greek
+	name = "Greek Armor"
+	path = /obj/item/clothing/suit/greek
+	slot = SLOT_WEAR_SUIT
+	cost = PAY_UNTRAINED/1
+
+/datum/clothingbooth_item/ancient/toga
+	name = "Toga"
+	path = /obj/item/clothing/under/gimmick/toga
+	slot = SLOT_W_UNIFORM
+	cost = PAY_UNTRAINED/1
+
+/datum/clothingbooth_item/ancient/vikinghat
+	name = "Viking Helmet"
+	path = /obj/item/clothing/head/helmet/viking
+	slot = SLOT_HEAD
+	cost = PAY_UNTRAINED/2
+
+/datum/clothingbooth_item/ancient/viking
+	name = "Viking Armor"
+	path = /obj/item/clothing/under/gimmick/viking
+	slot = SLOT_W_UNIFORM
+	cost = PAY_UNTRAINED/1
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CLOTHING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new category to the clothing booth named "Ancient". It includes a variety of classical costumes, namely viking and greek armor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Once more, I think fashion is a fun aspect of the game and enhances roleplay. These costumes were previously only available through RNG, or by playing on specific maps (Destiny, etc.). Making them more widely available seems more appealing.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ryou
(+)Added a new "Ancient" category to the clothing booth.
```
