### PR TITLE
Fixes *some* robotics consoles being unable to be deconstructed

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17905,9 +17905,7 @@
 	},
 /area/station/engine/inner)
 "biz" = (
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/AIbasecore1{
 	name = "Upload Station"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -17578,9 +17578,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "aYA" = (
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/status_display{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remake of #11292 due to git map jank 💀 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
consistency!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Robotics consoles on Kondaru and Donut 2 have had their safety screws removed due to budget cuts.
```
