### PR TITLE
Adds ability to slot vocal translators into masks (excluding internals)

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1408,6 +1408,10 @@
 		var/obj/item/clothing/mask/monkey_translator/mask = src.wear_mask
 		say_language = mask.new_language
 
+	if (src.wear_mask && src.wear_mask.vtranslate)
+		var/obj/item/clothing/mask/monkey_translator/mask = src.wear_mask
+		say_language = mask.vtranslate.new_language
+
 	message = copytext(message, 1, MAX_MESSAGE_LEN)
 
 	if (src.fakedead)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability to slot vocal translators into masks, similar to how voice changers work. A mask already containing a voice changer or internals is unable to have a vocal translator be slotted into. Similarly, voice changers cannot be inserted into a mask containing a vocal translator (though voice changers continue to work with internals, as before)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wearing masks is a cool roleplaying feature that enhances individuality. Monkeys are unable to wear masks and vocal translators at the same time to prevent the usage of internals, from my understanding. With this change, they STILL won't be able to use internals, however they are able to run around with a cute masquerade mask while maintaining the ability to speak.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Glamurio (Ryou)
(*)Added the ability to slot vocal translators into masks (excluding internals).
```
