### PR TITLE
Refactors various face-visibility checks in code to use the face_visible() proc.

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -76,7 +76,7 @@
 			. += "<br><span class='[src.wear_mask.blood_DNA ? "alert" : "notice"]'>[src.name] has [bicon(src.wear_mask)] \an [src.wear_mask.name] on [t_his] face.</span>"
 
 	if (src.glasses && !(src.wear_suit?.hides_from_examine & C_GLASSES) && !(src.head?.hides_from_examine & C_GLASSES))
-		if (((src.wear_mask && src.wear_mask.see_face) || !src.wear_mask) && ((src.head && src.head.see_face) || !src.head))
+		if (face_visible())
 			. += "<br><span class='[src.glasses.blood_DNA ? "alert" : "notice"]'>[src.name] has [bicon(src.glasses)] \an [src.glasses.name] on [t_his] face.</span>"
 
 	if (src.l_hand)
@@ -159,7 +159,7 @@
 
 	if (src.organHolder)
 		if (src.organHolder.head)
-			if (((src.wear_mask && src.wear_mask.see_face) || !src.wear_mask) && ((src.head && src.head.see_face) || !src.head))
+			if (face_visible())
 				if (!src.organHolder.skull)
 					. += "<br><span class='alert'><B>[src.name] no longer has a skull in [t_his] head, [t_his] face is just empty skin mush!</B></span>"
 

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -9,14 +9,7 @@
 
 			//TODO : move this code somewhere else that updates from an event trigger instead of constantly
 			var/arrestState = ""
-			var/see_face = 1
-			if (istype(H.wear_mask) && !H.wear_mask.see_face)
-				see_face = 0
-			else if (istype(H.head) && !H.head.see_face)
-				see_face = 0
-			else if (istype(H.wear_suit) && !H.wear_suit.see_face)
-				see_face = 0
-			var/visibleName = see_face ? H.real_name : H.name
+			var/visibleName = H.face_visible() ? H.real_name : H.name
 
 			var/datum/db_record/record = data_core.security.find_record("name", visibleName)
 			if(record)

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -981,15 +981,8 @@
 			return threatcount
 
 		if (src.check_records) // bot is set to actively compare security records
-			var/see_face = 1
-			if (istype(perp.wear_mask) && !perp.wear_mask.see_face)
-				see_face = 0
-			else if (istype(perp.head) && !perp.head.see_face)
-				see_face = 0
-			else if (istype(perp.wear_suit) && !perp.wear_suit.see_face)
-				see_face = 0
+			var/perpname = perp.face_visible() ? perp.real_name : perp.name
 
-			var/perpname = see_face ? perp.real_name : perp.name
 			for (var/datum/db_record/R as anything in data_core.security.find_records("name", perpname))
 				if(R["criminal"] == "*Arrest*")
 					threatcount = 7

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -284,15 +284,7 @@
 			return threatcount
 
 		if (src.check_records)
-			var/see_face = 1
-			if (istype(perp.wear_mask) && !perp.wear_mask.see_face)
-				see_face = 0
-			else if (istype(perp.head) && !perp.head.see_face)
-				see_face = 0
-			else if (istype(perp.wear_suit) && !perp.wear_suit.see_face)
-				see_face = 0
-
-			var/perpname = see_face ? perp.real_name : perp.name
+			var/perpname = perp.face_visible() ? perp.real_name : perp.name
 
 			for (var/datum/db_record/R as anything in data_core.security.find_records("name", perpname))
 				if(R["criminal"] == "*Arrest*")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some places in code used copy-pasted face visibility checking. The code exists as a proc on humans, the PR makes these instances just use the proc.
One particular instance remains on head.dm but it has to remain as it functions separately and isn't attached to a human.
This also indirectly fixes some bugs: some face visibility checks didn't account for suits being able to hide your face.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code cleanliness, unintentionally fixes some bugs/oversights.
