### PR TITLE
Brig flushers now take into account your actual name if your face is visible.

### DIFF
--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -231,7 +231,14 @@
 					M.handcuffs.drop_handcuffs(M)
 
 				//Might as well set their security record to "released"
-				var/datum/db_record/R = data_core.security.find_record("name", M.name)
+				var/nameToCheck = M.name
+				if (ishuman(M))
+					var/mob/living/carbon/human/H = M
+					// this makes it so that if your face is unobstructed and your id is wrong, i.e. you show up as John Smith (as Someone Else)
+					// it will take into account your actual name (John Smith) and still work, instead of searching for a "John Smith (as Someone Else)" in the records
+					// unless your face is obstructed, then it works normally by taking your visible name, with intended or unintended results
+					nameToCheck = H.face_visible() ? H.real_name : H.name
+				var/datum/db_record/R = data_core.security.find_record("name", nameToCheck)
 				if(!isnull(R) && ((R["criminal"] == "Incarcerated") || (R["criminal"] == "*Arrest*")))
 					R["criminal"] = "Released"
 	// timed process


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Brig flushers try to set your security record as "released" if you were set to arrest or as incarcerated.
However, the way they do this is by plainly grabbing your mob's name.
This means that if your face is obscured, you don't have an ID and your mob is seen as "Unknown", the flusher looks for "Unknown"'s security record.
Similarly, if you're wearing a non-matching ID and you show up as John Smith (as Someone Else) or John Smith (as Captain), those are the names that are searched for in the security records, interfering with your security record update.

This PR makes it so that the chute works properly in the latter of these two examples: if your face is visible, it takes your real name into account. So in the case of John Smith (as Someone Else), it'll only take into account John Smith.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes the brig flusher more reliable and less confusing for a fairly common situation.