### PR TITLE
"Fixes" crit stuns

### DIFF
--- a/code/mob/living/life/critical.dm
+++ b/code/mob/living/life/critical.dm
@@ -31,7 +31,8 @@
 					if (isalive(owner))
 						if (owner?.mind)
 							owner.lastgasp() // if they were ok before dropping below zero health, call lastgasp() before setting them unconscious
-					owner.setStatusMin("paralysis", 1.5 SECONDS * mult)
+					if (probmult(60))
+						owner.setStatusMin("paralysis", 1.5 SECONDS)
 				if (-99 to -80)
 					owner.take_oxygen_deprivation(1 * mult)
 					if (probmult(4))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [BALANCE] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes deep crit stuns (< -100 health) to be a `probmult(60)` chance for a set 1.5 second stun instead, matching how all other crit stuns scale the chance for them to occur rather than the duration of the stun.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
68ca91f increased the lifeloop speed, which in theory shouldn't cause crit to act strangely because everything uses mult. BUT deep crit stuns happened with a 100% chance every life loop, with only the duration being scaled by mult. This meant that since the life loop is happening faster you would be being constantly stunned for a very short duration, making it near impossible to grab an epinephrine injector or defib to save yourself.

Not sure if the numbers are right, or if it would be better to use an `ON_COOLDOWN` instead of a `probmult`.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Adjusted deep crit stun logic to hopefully cause less infinite micro stun chains.
```
