### PR TITLE
Fixes writing cleanables having reagents

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -196,7 +196,7 @@
 #define FIRESOURCE_IGNITER 2
 
 // for pen reagent dipping
-#define PEN_REAGENT_CAPACITY 5
+#define PEN_REAGENT_CAPACITY 4
 
 /// The default, the attack is animated, a message is given, and particles are shown (most items)
 #define ATTACK_VISIBLE 0

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -759,10 +759,6 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	var/artist = null//the key of the one who wrote it
 	real_name = "writing"
 
-	New()
-		. = ..()
-		src.create_reagents(PEN_REAGENT_CAPACITY)
-
 	get_desc(dist)
 		. = "<br><span class='notice'>It says[src.material ? src.material : src.color_name ? " in [src.color_name]" : null]:</span><br>[words]"
 		if (src.reagents.total_volume)

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -135,7 +135,8 @@
 			G.pixel_y = rand(-4,4)
 		if (src.reagents.total_volume)
 			G.color = src.reagents.get_average_rgb()
-			src.reagents.trans_to(G, PEN_REAGENT_CAPACITY)
+			G.sample_reagent = src.reagents.get_master_reagent_id()
+			G.sample_amt = PEN_REAGENT_CAPACITY
 
 		src.remove_filter("reagent_coloration")
 		src.color_name = initial(src.color_name)

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -136,7 +136,8 @@
 		if (src.reagents.total_volume)
 			G.color = src.reagents.get_average_rgb()
 			G.sample_reagent = src.reagents.get_master_reagent_id()
-			G.sample_amt = PEN_REAGENT_CAPACITY
+			var/datum/reagent/master_reagent = src.reagents.reagent_list[G.sample_reagent]
+			G.sample_amt = master_reagent.volume
 			src.reagents.clear_reagents()
 
 		src.remove_filter("reagent_coloration")

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -137,7 +137,7 @@
 			G.color = src.reagents.get_average_rgb()
 			G.sample_reagent = src.reagents.get_master_reagent_id()
 			G.sample_amt = PEN_REAGENT_CAPACITY
-			src.reagents.remove_reagent(G.sample_reagent, PEN_REAGENT_CAPACITY)
+			src.reagents.clear_reagents()
 
 		src.remove_filter("reagent_coloration")
 		src.color_name = initial(src.color_name)

--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -137,6 +137,7 @@
 			G.color = src.reagents.get_average_rgb()
 			G.sample_reagent = src.reagents.get_master_reagent_id()
 			G.sample_amt = PEN_REAGENT_CAPACITY
+			src.reagents.remove_reagent(G.sample_reagent, PEN_REAGENT_CAPACITY)
 
 		src.remove_filter("reagent_coloration")
 		src.color_name = initial(src.color_name)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes writing cleanables to use `sample_reagent` and `sample_amt` instead of adding reagents directly, also changes the pen dipping amount to prevent them immediately dissolving into a puddle.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The cleanables having reagents made them delete each other when 3 or more were on the same turf, breaking crayon art.