### PR TITLE
Remove unnecessary Flock intangible move code

### DIFF
--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -77,12 +77,6 @@
 	else
 		return 0.75 + movement_delay_modifier
 
-/mob/living/intangible/flock/Move(NewLoc, direct)
-	src.set_dir(get_dir(src, NewLoc))
-	if (isturf(NewLoc) && istype(NewLoc, /turf/unsimulated/wall)) // no getting past these walls, fucko
-		return 0
-	..()
-
 /mob/living/intangible/flock/attack_hand(mob/user)
 	switch(user.a_intent)
 		if(INTENT_HELP)


### PR DESCRIPTION
[INTERNAL][GAME OBJECTS][BUG][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just removes unnecessary Flock intangible move code, which also allows Flock intangibles to move through unsimulated walls.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleanliness

No reason why Flock intangibles can't move through unsimulated walls

Fixes #10193