### PR TITLE
fix donut 2 mining magnet not setting up properly

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -24948,7 +24948,10 @@
 	},
 /area/station/solar/south)
 "bIg" = (
-/obj/landmark/magnet_center,
+/obj/landmark/magnet_center{
+	height = 13;
+	width = 13
+	},
 /turf/space,
 /area/mining/magnet)
 "bIi" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11324
makes Donut2 magnet actually set up properly at roundstart


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, fix good
