### PR TITLE
Constructable solar panels and solar trackers

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -52,13 +52,14 @@
 		..()
 		SPAWN(1 SECOND)
 			powernet = src.get_direct_powernet()
-			for(var/obj/machinery/power/data_terminal/test_link in powernet?.data_nodes) // plug and play
-				if(!istype(test_link?.master,/obj/machinery/computer/solar_control)) continue
-				var/obj/machinery/computer/solar_control/controller = test_link?.master
-				if(controller?.tracker) break // if there's already a tracker, dont connect
-				control = controller
-				control.tracker = src // otherwise, we are now the tracker
-				break
+			if (powernet)
+				for(var/obj/machinery/power/data_terminal/test_link in powernet.data_nodes) // plug and play
+					if(!istype(test_link?.master,/obj/machinery/computer/solar_control)) continue
+					var/obj/machinery/computer/solar_control/controller = test_link?.master
+					if(controller?.tracker) break // if there's already a tracker, dont connect
+					control = controller
+					control.tracker = src // otherwise, we are now the tracker
+					break
 	// called by datum/sun/calc_position() as sun's angle changes
 	proc/set_angle(var/angle)
 		sun_angle = angle
@@ -134,12 +135,13 @@
 	SPAWN(1 SECOND)
 		if (current_state == GAME_STATE_PLAYING)
 			powernet = src.get_direct_powernet()
-			for(var/obj/machinery/power/data_terminal/test_link in powernet?.data_nodes) // plug and play
-				if(!istype(test_link?.master,/obj/machinery/computer/solar_control)) continue
-				control = test_link?.master // we need to be able to find a control console
-				break
-			if(control?.cdir)
-				ndir = control.cdir
+			if(powernet)
+				for(var/obj/machinery/power/data_terminal/test_link in powernet.data_nodes) // plug and play
+					if(!istype(test_link?.master,/obj/machinery/computer/solar_control)) continue
+					control = test_link?.master // we need to be able to find a control console
+					break
+				if(control?.cdir)
+					ndir = control.cdir
 		UpdateIcon()
 		update_solar_exposure()
 
@@ -300,11 +302,12 @@
 
 /obj/machinery/computer/solar_control/disposing() // it would probably be best if we unlink all our panels
 	var/datum/powernet/powernet = src.get_direct_powernet()
-	for(var/obj/machinery/power/solar/Solar in powernet?.nodes)
-		if(Solar.control == src)
-			Solar.control = null
-	if (tracker) // we track the solar tracker now
-		tracker.control = null
+	if (powernet)
+		for(var/obj/machinery/power/solar/Solar in powernet.nodes)
+			if(Solar.control == src)
+				Solar.control = null
+		if (tracker) // we track the solar tracker now
+			tracker.control = null
 	..()
 
 /obj/machinery/computer/solar_control/process()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -20,7 +20,7 @@
 	var/id = 1 // nolonger used, kept for map compatibility
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/computer/solar_control/control
-	mats = list("MET-2"=15, "CON-1"=15)
+	mats = list("CRY-1"=15, "CON-1"=20)
 
 	north
 		id = "north"
@@ -446,6 +446,7 @@
 
 /obj/machinery/power/solar/owl_cheat
 	id = "owl"
+	mats = 0
 
 	update_solar_exposure()
 		if(isnull(sun))	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes up solar panel code enough so solar panels are plug and play

Solar panels now use the actual console they are connected to instead of an id tag
only one solar tracker can be connected at a time

the solar panels auto-connect on creation, and deconstructing the console will un-link all the panels
building the console will also link together all solar panels it can find

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
 it didn't feel right that you couldn't atleast try to build solar panels
also
constructable stuff good


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Skeletonman0
(*)Solar panels and solar trackers are now mechscannable and buildable.
