### PR TITLE
Oshan science minor adjustments

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -8468,6 +8468,7 @@
 /area/station/science/storage)
 "auh" = (
 /obj/machinery/light/incandescent/harsh/very,
+/obj/machinery/manufacturer/science,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "aui" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -5256,6 +5256,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "ami" = (
@@ -9663,10 +9667,18 @@
 /area/station/science/artifact)
 "awR" = (
 /obj/machinery/light/incandescent/cool,
-/obj/machinery/disposal/mail/autoname{
-	mail_tag = "artlab"
+/obj/table/reinforced/auto,
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/disposalpipe/trunk/mail/south,
+/obj/item/cargotele{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/cargotele{
+	pixel_x = 6
+	},
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "awS" = (
@@ -10093,17 +10105,12 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "axR" = (
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "axS" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -10119,6 +10126,9 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -10494,7 +10504,6 @@
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "ayV" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -11542,7 +11551,6 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "aBi" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -46460,6 +46468,13 @@
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/grime,
 /area/diner/hallway)
+"njp" = (
+/obj/machinery/disposal/mail/autoname{
+	mail_tag = "artlab"
+	},
+/obj/disposalpipe/trunk/mail/south,
+/turf/simulated/floor/black,
+/area/station/science/artifact)
 "nkh" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -46611,6 +46626,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
+"ofe" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/science/artifact)
 "oiZ" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
@@ -109220,10 +109239,10 @@ ape
 aSG
 ape
 avE
-awQ
-awQ
-awQ
-awQ
+njp
+ofe
+ofe
+ofe
 amh
 awQ
 awP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[SCIENCE][MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Minor adjustments to Science in Oshan.

Add science fabricator to science storage:
Science did have a fabricator, but it was in Sciente Outpost, which requires a pod or the sometimes buggy transport pipes to reach. Meaning to blindfold a monkey, you'd need to go to the science outpost then back to your ValueChimp at science storage or ask a Geneticist.

Add a recharger and two cargo transporters to artifact lab:
There is no disposal pipe going from science to quartermaster,  meaning the only way to get an artifact quickly to QM was to go there manually, make a MechComp teleporter or ask the quartermaster for a cargo transporter.
With artlab spawning with a cargo transporter it means scientists won't need to take it from QM.

![image](https://user-images.githubusercontent.com/47158232/195484263-8f545187-9578-49f2-b215-1435b3115da0.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Increase QoL for Oshan artifact lab.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Added a science fabricator to Oshan's research and two cargo transporters and a recharger to Oshan's artifact lab.
```
