### PR TITLE
Remove range limit on fabricators for cyborgs.

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -563,7 +563,7 @@
 				if (src.shock(usr, 10))
 					return
 
-		if (((BOUNDS_DIST(src, usr) == 0 || isAI(usr)) && istype(src.loc, /turf)))
+		if (((BOUNDS_DIST(src, usr) == 0 || (isAI(usr) || isrobot(usr))) && istype(src.loc, /turf)))
 			src.add_dialog(usr)
 
 			if (src.malfunction && prob(10))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL][BORGS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Remove range limit on fabricators for Borgs, so they can print it as long as they have the screen for the manufacturer open.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Borgs have no range limit on the majority of machines, this makes them be able to produce something at the manufacturer from range like the AI.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Remove fabricator range limit for cyborgs.
```
