### PR TITLE
Add light switch to Kondaru HoP quarters

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -27426,6 +27426,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/bridge/hos)
 "bHk" = (
@@ -50169,7 +50170,6 @@
 	pixel_x = 5
 	},
 /obj/item/device/radio/intercom/bridge,
-/obj/blind_switch/area/west,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/bridge/hos)
 "njL" = (
@@ -55774,6 +55774,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/blind_switch/area/south,
 /turf/simulated/floor/sanitary,
 /area/station/bridge/hos)
 "sJN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add light switch to Kondaru HoP next to the desk and bed.
Move the blind switch in the HoP's room to next to the toilet.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Kondaru HoP's room has no light switch, this also makes them inline with the other heads of staff room.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Add a light switch to Kondaru HoP quarters.
```
