### PR TITLE
Correctly reset requisition roll counts after failed sale

### DIFF
--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -360,6 +360,9 @@ ABSTRACT_TYPE(/datum/req_contract)
 				if(X) qdel(X)
 			if(!length(sell_crate.contents)) //total clean sale, tell shipping manager to del the crate
 				. = REQ_RETURN_FULLSALE
+		else //sale unsuccessful; reset rolling counts of all contract entries in preparation for subsequent fulfillment attempts
+			for(var/datum/rc_entry/shopped in rc_entries)
+				shopped.rollcount = 0
 		return
 
 #undef RC_ITEM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a small bit of functionality to the tail end of the main "requisify" requisitions evaluation proc to properly reset each contract entry's rolling count to zero. This prevents partial evaluation successes from "rolling over" between fulfillment attempts, which caused unintended behaviors primarily including goods being returned when they were supposed to comprise part of the sale.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #11320
