### PR TITLE
fix the solars set_panels proc so it actually rotates the panels properly

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -410,13 +410,13 @@
 	var/datum/powernet/powernet = src.get_direct_powernet()
 	if (!powernet) return
 	for(var/obj/machinery/power/solar/Solar in powernet.nodes)
-		if(Solar.control) continue
+		if(Solar.control != src) continue
 		if(current_state != GAME_STATE_PLAYING && Solar.id != src.solar_id)
 			continue // some solars are weird
 		Solar.control = src
-		src.cdir = Solar.adir
+		Solar.ndir = src.cdir
 	for(var/obj/machinery/power/tracker/Tracker in powernet.nodes)
-		if(Tracker.control) continue
+		if(Tracker.control != src) continue
 		if(current_state != GAME_STATE_PLAYING && Tracker.id != src.solar_id)
 			continue // some solars are weird
 		Tracker.control = src

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -410,7 +410,7 @@
 	var/datum/powernet/powernet = src.get_direct_powernet()
 	if (!powernet) return
 	for(var/obj/machinery/power/solar/Solar in powernet.nodes)
-		if(Solar.control != src) continue
+		if(Solar.control != src && Solar.control) continue
 		if(current_state != GAME_STATE_PLAYING && Solar.id != src.solar_id)
 			continue // some solars are weird
 		Solar.control = src
@@ -418,7 +418,7 @@
 
 	if (!src.tracker)
 		for(var/obj/machinery/power/tracker/Tracker in powernet.nodes)
-			if(Tracker.control != src) continue
+			if(Tracker.control != src && Solar.control) continue
 			if(current_state != GAME_STATE_PLAYING && Tracker.id != src.solar_id)
 				continue // some solars are weird
 			Tracker.control = src

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -415,13 +415,15 @@
 			continue // some solars are weird
 		Solar.control = src
 		Solar.ndir = src.cdir
-	for(var/obj/machinery/power/tracker/Tracker in powernet.nodes)
-		if(Tracker.control != src) continue
-		if(current_state != GAME_STATE_PLAYING && Tracker.id != src.solar_id)
-			continue // some solars are weird
-		Tracker.control = src
-		src.tracker = Tracker
-		break
+
+	if (!src.tracker)
+		for(var/obj/machinery/power/tracker/Tracker in powernet.nodes)
+			if(Tracker.control != src) continue
+			if(current_state != GAME_STATE_PLAYING && Tracker.id != src.solar_id)
+				continue // some solars are weird
+			Tracker.control = src
+			src.tracker = Tracker
+			break
 
 // hotfix until someone edits all maps to add proper wires underneath the computers
 /obj/machinery/computer/solar_control/get_power_wire()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -418,7 +418,7 @@
 
 	if (!src.tracker)
 		for(var/obj/machinery/power/tracker/Tracker in powernet.nodes)
-			if(Tracker.control != src && Solar.control) continue
+			if(Tracker.control != src && Tracker.control) continue
 			if(current_state != GAME_STATE_PLAYING && Tracker.id != src.solar_id)
 				continue // some solars are weird
 			Tracker.control = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes a dumb mistake i made in constructable solars where it would never actually set a var properly
also makes it so the control console will only look for a tracker if it doesn't have one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, fix good

