### PR TITLE
Some QOL / Bug fixes for annoying things that happened on crash map

### DIFF
--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -206,8 +206,24 @@
 			if (A != TargA)
 				if (istype(A,/area/built_zone))
 					TargA.contents += T // steal the turf from the old
-			if (A.area_apc)
-				A.area_apc.area = TargA
+
+			if (A.area_apc) // steal the APCs
+				var/obj/machinery/power/apc/Aapc = A.area_apc
+				Aapc.area = TargA
+				Aapc.name = "[TargA.name] APC"
+				if (!TargA.area_apc)
+					TargA.area_apc = Aapc
+
+			for (var/obj/machinery/M in A.machines) // steal all the machines too
+				A.machines -= M
+				TargA.machines += M
+				if (istype(M,/obj/machinery/light)) // steal all the lights
+					A.remove_light(M)
+					TargA.add_light(M)
+
+			SPAWN(0.5 SECONDS) // apc code does this too
+				if (TargA.area_apc)
+					TargA.area_apc.update()
 
 	proc/identify_room(var/turf/T) // stolen from what this was using before
 		var/list/affected = list()

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -325,9 +325,12 @@
 		if (!members || !F) return
 		if (length(src.members) == 1)
 			var/turf/T
+			var/blocked
 			for( var/dir in cardinal )
 				T = get_step( F, dir )
-				if (! (istype(T, /turf/simulated/floor) || istype (T, /turf/unsimulated/floor)) ) continue
+				if (! (istype(T, /turf/simulated/floor) || istype (T, /turf/unsimulated/floor)) )
+					blocked++
+					continue
 				if (T.Enter(src))
 					if (T.active_liquid && T.active_liquid.group)
 						T.active_liquid.group.join(src)
@@ -336,6 +339,10 @@
 						F.set_loc(T)
 						T.active_liquid = F
 					break
+				else
+					blocked++
+			if(blocked = length(cardinal)) // failed
+				src.remove(F,0,2)
 		else
 			var/turf/T
 			for( var/dir in cardinal )

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -341,7 +341,7 @@
 					break
 				else
 					blocked++
-			if(blocked = length(cardinal)) // failed
+			if(blocked == length(cardinal)) // failed
 				src.remove(F,0,2)
 		else
 			var/turf/T

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -194,6 +194,17 @@ var/zapLimiter = 0
 	terminal = null
 	..()
 
+/obj/machinery/power/apc/was_deconstructed_to_frame(mob/user)
+	. = ..()
+	qdel(src.terminal)
+	if(src.area?.area_apc == src)
+		src.area.area_apc = null
+	src.area = null
+
+/obj/machinery/power/apc/was_built_from_frame(mob/user, newly_built)
+	. = ..()
+	src.New()
+
 /obj/machinery/power/apc/examine(mob/user)
 	. = ..()
 

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -570,7 +570,17 @@ Broken RCD + Effects
 			var/obj/machinery/door/airlock/T = new interim(A)
 			log_construction(user, "builds an airlock ([T])")
 
-			//if(map_setting == "COG2") T.set_dir(user.dir)
+			// makes everything around it look nice
+			T.set_dir(user.dir)
+			for (var/obj/window/auto/O in orange(1,T))
+				O.UpdateIcon()
+			for (var/obj/grille/G in orange(1,T))
+				G.UpdateIcon()
+			for (var/turf/simulated/wall/auto/W in orange(1,T))
+				W.UpdateIcon()
+			for (var/turf/simulated/wall/false_wall/F in orange(1,T))
+				F.UpdateIcon()
+
 			T.autoclose = TRUE
 
 	update_icon() //we got fancy rcds now
@@ -798,6 +808,15 @@ Broken RCD + Effects
 			else
 				T.req_access = null
 				T.req_access_txt = null
+
+			for (var/obj/window/auto/O in orange(1,T))
+				O.UpdateIcon()
+			for (var/obj/grille/G in orange(1,T))
+				G.UpdateIcon()
+			for (var/turf/simulated/wall/auto/W in orange(1,T))
+				W.UpdateIcon()
+			for (var/turf/simulated/wall/false_wall/F in orange(1,T))
+				F.UpdateIcon()
 
 /obj/item/rcd/material
 

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -38,7 +38,7 @@
 	New()
 		..()
 		src.ini_dir = src.dir
-		update_nearby_tiles(need_rebuild=1)
+		update_nearby_tiles(need_rebuild=1,selfnotify=1) // self notify to stop fluid jankness
 		if (default_material)
 			src.setMaterial(getMaterial(default_material), copy = FALSE)
 		if (default_reinforcement)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -505,6 +505,7 @@ proc/generate_space_color()
 /turf/proc/ReplaceWith(var/what, var/keep_old_material = 1, var/handle_air = 1, handle_dir = 1, force = 0)
 	var/turf/simulated/new_turf
 	var/old_dir = dir
+	var/old_liquid = active_liquid // replacing stuff wasn't clearing liquids properly
 
 	var/oldmat = src.material
 
@@ -624,6 +625,7 @@ proc/generate_space_color()
 		new_turf.set_dir(old_dir)
 
 	new_turf.levelupdate()
+	new_turf.active_liquid = old_liquid
 
 	new_turf.RL_ApplyGeneration = rlapplygen
 	new_turf.RL_UpdateGeneration = rlupdategen

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -28,9 +28,7 @@
 
 		src.AddComponent(/datum/component/bullet_holes, 15, 10)
 
-		//for fluids
-		if (src.active_liquid && src.active_liquid.group)
-			src.active_liquid.group.displace(src.active_liquid)
+		src.selftilenotify() // displace fluid
 
 		#ifdef XMAS
 		if(src.z == Z_LEVEL_STATION && current_state <= GAME_STATE_PREGAME)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -127,6 +127,7 @@
 	newlight.fitting = parts.fitting
 	newlight.status = 1 // LIGHT_EMPTY
 	if (istype(src,/turf/simulated/wall/auto))
+		newlight.nostick = 0
 		newlight.autoposition()
 	newlight.add_fingerprint(user)
 	src.add_fingerprint(user)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -126,6 +126,8 @@
 	newlight.base_state = parts.installed_base_state
 	newlight.fitting = parts.fitting
 	newlight.status = 1 // LIGHT_EMPTY
+	if (istype(src,/turf/simulated/wall/auto))
+		newlight.nostick = 0 // sticky lights are cool and good
 	newlight.add_fingerprint(user)
 	src.add_fingerprint(user)
 	user.u_equip(parts)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -127,7 +127,7 @@
 	newlight.fitting = parts.fitting
 	newlight.status = 1 // LIGHT_EMPTY
 	if (istype(src,/turf/simulated/wall/auto))
-		newlight.nostick = 0 // sticky lights are cool and good
+		newlight.autoposition()
 	newlight.add_fingerprint(user)
 	src.add_fingerprint(user)
 	user.u_equip(parts)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this PR aims to fix some annoying stuff including:

water going under windows / walls and spreading through them
apcs bugging out permanently after deconstructing
room designator bugging out machines inside the area
rcd created doors not updating walls/windows
rcd created lights not autoplacing


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, also makes crash rounds hopefully less annoying


