### PR TITLE
Adds unstocked general manufacturer to Oshan refinery

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -35275,11 +35275,13 @@
 	},
 /area/station/quartermaster/refinery)
 "bNj" = (
-/obj/storage/cart,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/item/rods/steel/fullstack,
+/obj/machinery/manufacturer/general{
+	free_resource_amt = 0;
+	free_resources = null
+	},
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -47717,6 +47719,14 @@
 /obj/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating,
 /area/diner/backroom)
+"uEF" = (
+/obj/item/rods/steel/fullstack{
+	pixel_x = 11
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/quartermaster/refinery)
 "uEG" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -87546,7 +87556,7 @@ bHU
 bII
 cgr
 bKD
-bLY
+uEF
 bNj
 aOL
 bPs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][MAPPING][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a general manufacturer on the east wall of the Oshan refinery, with free resources set to zero. The stack of rods previously occupying the spot was moved a bit north, piled against the wall.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Oshan's lack of any public general manufacturer can make procurement of basic equipment unduly difficult, even with miners on staff.

Introducing a public general manufacturer that lacks any materials at round start serves as a compromise, preserving the general scarcity of supplies available without departmental access while adding a spot for people to use materials they've gotten their hands on (i.e. Rockbox sales, QM-provided resources, reclaimed products) for equipment fabrication.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Oshan's refinery now includes an unstocked general manufacturer.
```
