### PR TITLE
Removes secret chems from bartender objective

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -425,9 +425,20 @@ ABSTRACT_TYPE(/datum/objective/crew/bartender)
 	set_up()
 		..()
 		var/list/names[DRINK_OBJ_COUNT]
-		for(var/i in 1 to DRINK_OBJ_COUNT)
+		var/i = 0
+		while(i < DRINK_OBJ_COUNT) //for loops don't let you modify the iterator :)))
+			i++
 			var/choiceType = pick(cocktails)
-			var/datum/reagent/fooddrink/instance =  new choiceType
+			var/datum/reagent/fooddrink/instance = new choiceType
+			var/hidden = 0
+			var/list/reactions = chem_reactions_by_result[instance.id]
+			for (var/datum/chemical_reaction/reaction_type in reactions)
+				if (initial(reaction_type.hidden))
+					hidden++
+			//if all reactions producing this reagent are hidden, then skip it and try again
+			if (hidden == length(reactions))
+				i--
+				continue
 			names[i] = instance.name
 			ids[i] = instance.id
 		explanation_text = "Mix a "

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -425,9 +425,7 @@ ABSTRACT_TYPE(/datum/objective/crew/bartender)
 	set_up()
 		..()
 		var/list/names[DRINK_OBJ_COUNT]
-		var/i = 0
-		while(i < DRINK_OBJ_COUNT) //for loops don't let you modify the iterator :)))
-			i++
+		for (var/i = 1; i <= DRINK_OBJ_COUNT; i++)
 			var/choiceType = pick(cocktails)
 			var/datum/reagent/fooddrink/instance = new choiceType
 			var/hidden = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [CATERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just makes the bartender objective check if cocktails only have hidden recipes before adding them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Suggested here: https://forum.ss13.co/showthread.php?tid=19944
