### PR TITLE
Fixes faustian victims showing up on antag screen

### DIFF
--- a/code/WorkInProgress/infernal_contracts.dm
+++ b/code/WorkInProgress/infernal_contracts.dm
@@ -579,7 +579,6 @@ obj/item/contract/wrestle
 		if(!..())
 			return 0
 		SPAWN(1 DECI SECOND)
-			user.mind.special_role = "Faustian Wrestler"
 			sleep(0.1 SECONDS)
 			user.make_wrestler(1)
 			user.traitHolder.addTrait("addict") //HEH
@@ -629,7 +628,6 @@ obj/item/contract/genetic
 					user.bioHolder.AddEffect("mutagenic_field_prenerf", 0, 0, 1)
 					SPAWN(0.2 SECONDS)
 						boutput(user, "<span class='success'>You have ascended beyond mere humanity!</span>")
-						user.mind.special_role = "Genetic Demigod"
 
 		return 1
 
@@ -672,7 +670,6 @@ obj/item/contract/horse
 			user.horse()
 			user.traitHolder.addTrait("soggy")
 			boutput(user, "<span class='alert'><font size=6><B>NEIGH</b></font></span>")
-			user.mind.special_role = "Faustian Horse"
 
 		return 1
 
@@ -712,7 +709,6 @@ obj/item/contract/vampire
 		if(!..())
 			return 0
 		SPAWN(1 DECI SECOND)
-			user.mind.special_role = ROLE_VAMPIRE
 			user.make_vampire(1)
 			boutput(user, "<span style=\"color:red; font-size:150%\"><b>Note that you are not an antagonist (unless you were already one), you simply have some of the powers of one.</b></span>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr makes it to where the victims of certain faustian contracts wont show up on the antag end screen by removing theyre special mind role. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix good

