### PR TITLE
Adds PDA alert category to ion storm

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -163,10 +163,9 @@ ABSTRACT_TYPE(/datum/ion_category)
 	var/list/atom/targets = list()
 
 	proc/valid_instance(var/atom/found)
-		var/turf/T = null
-		if (found.z != Z_LEVEL_STATION)
+		var/turf/T = get_turf(found)
+		if (T.z != Z_LEVEL_STATION)
 			return FALSE
-		T = get_turf(found)
 		if (!istype(T.loc,/area/station/))
 			return FALSE
 		return TRUE
@@ -301,3 +300,21 @@ ABSTRACT_TYPE(/datum/ion_category)
 
 	action(var/obj/machinery/firealarm/alarm)
 		alarm.alarm()
+
+/datum/ion_category/pda_alerts
+	amount = 3
+
+	valid_instance(var/obj/item/device/pda2/pda)
+		return ..() && pda.owner
+
+	build_targets()
+		for_by_tcl(pda, /obj/item/device/pda2)
+			if (valid_instance(pda))
+				targets += pda
+
+	action(var/obj/item/device/pda2/pda)
+		for (var/datum/computer/file/pda_program/prog in pda.hd.root.contents)
+			if (istype(prog, /datum/computer/file/pda_program/emergency_alert))
+				pda.run_program(prog)
+				var/datum/computer/file/pda_program/emergency_alert/alert_prog = prog
+				alert_prog.send_alert(rand(1,4), TRUE)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -328,6 +328,7 @@
 
 /obj/item/device/pda2/New()
 	..()
+	START_TRACKING
 	// This should probably be okay before the spawn, this way the HUD ability actually immediately shows up
 	if(src.setup_default_module)
 		src.module = new src.setup_default_module(src)
@@ -394,6 +395,7 @@
 			src.set_scan_program(scan)
 
 /obj/item/device/pda2/disposing()
+	STOP_TRACKING
 	if (src.cartridge)
 		src.cartridge.dispose()
 		src.cartridge = null

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -768,7 +768,7 @@ Code:
 		src.master.updateSelfDialog()
 		return
 
-	proc/send_alert(var/mailgroupNum=0)
+	proc/send_alert(var/mailgroupNum=0, var/remote = FALSE)
 		if(!src.master || !isnum(mailgroupNum) || (last_transmission && (last_transmission + 3000 > ticker.round_elapsed_ticks)))
 			return
 
@@ -801,7 +801,7 @@ Code:
 
 		src.post_signal(signal)
 
-		if(isliving(usr))
+		if(isliving(usr) && !remote)
 			playsound(src.master, 'sound/items/security_alert.ogg', 60)
 			var/map_text = null
 			map_text = make_chat_maptext(usr, "Emergency alert sent.", "font-family: 'Helvetica'; color: #D30000; font-size: 7px;", alpha = 215)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ion storms now trigger 3 random PDA alerts.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
General confusion and bewilderment. Also the ID scrambling PR made me think of this.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Ion storms can now cause PDA alert systems to malfunction.
```
