### PR TITLE
Better disarm logging

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -962,14 +962,14 @@
 			if (length(src.disarm_RNG_result))
 				if ("drop_item" in src.disarm_RNG_result)
 					target.deliver_move_trigger("bump")
-					var/dropped_items = null
+					var/list/dropped_items = list()
 					for(var/obj/item/I in target.equipped_list())
 						if(!(I.temp_flags & IS_LIMB_ITEM))
-							dropped_items += " [I],"
+							dropped_items += "[I]"
 							target.drop_item_throw(I)
-					if(!isnull(dropped_items))
-						var/final_items_log = copytext(dropped_items, 1, -1)
-						disarm_log += " making them drop item(s):([final_items_log] ),"
+					if(length(dropped_items))
+						var/final_items_log = jointext(dropped_items, ", ")
+						disarm_log += " making them drop item(s): ([final_items_log] )."
 
 				if ("handle_item_arm" in src.disarm_RNG_result)
 					for(var/obj/item/I in target.equipped_list())

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -895,7 +895,7 @@
 			logTheThing(LOG_DEBUG, owner, "<b>Marquesas/Melee Attack Refactor:</b> NO AFFECTING FLUSH! WARNING!")
 			return
 
-		var/disarm_log = null
+		var/list/disarm_log = list()
 
 		if (!msg_group)
 			msg_group = "[affecting]_attacks_[target]_with_[disarm ? "disarm" : "harm"]"
@@ -969,7 +969,7 @@
 							target.drop_item_throw(I)
 					if(length(dropped_items))
 						var/final_items_log = jointext(dropped_items, ", ")
-						disarm_log += " making them drop item(s): ([final_items_log] )."
+						disarm_log += " making them drop item(s): ([final_items_log])"
 
 				if ("handle_item_arm" in src.disarm_RNG_result)
 					for(var/obj/item/I in target.equipped_list())
@@ -984,7 +984,7 @@
 						var/prev_intent = target.a_intent
 						target.set_a_intent(INTENT_HARM)
 
-						disarm_log += " attempting to make them self-attack with the item arm: [I],"
+						disarm_log += " attempting to make them self-attack with the item arm: [I]"
 						target.Attackby(I, target)
 
 						target.set_a_intent(prev_intent)
@@ -1006,9 +1006,7 @@
 					disarm_log += " shoving them away "
 			else
 				target.deliver_move_trigger("bump")
-				disarm_log = " "
-			var/final_disarm_log = copytext(disarm_log, 1, -1)
-			logTheThing(LOG_COMBAT, owner, "disarms [constructTarget(target,"combat")][final_disarm_log] at [log_loc(owner)].")
+			logTheThing(LOG_COMBAT, owner, "disarms [constructTarget(target,"combat")][jointext(disarm_log, ", ")] at [log_loc(owner)].")
 		else
 #ifdef DATALOGGER
 			game_stats.Increment("violence")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increased detail in disarm logging.
PRing to check I have not missed something/done this in a stupid way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If someone claims that X disarmed their baton/egun/cheeseburger we don't actually know it happened beyond the disarm attack.