### PR TITLE
Add existing syndie backpack to listening post closet

### DIFF
--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -218,7 +218,8 @@
 #endif
 	/obj/item/crowbar,
 	/obj/item/cell/supercell/charged,
-	/obj/item/device/multitool)
+	/obj/item/device/multitool,
+	/obj/item/storage/backpack/syndie)
 
 /obj/storage/closet/syndicate/nuclear
 	desc = "Nuclear preperations closet."


### PR DESCRIPTION
## About the PR
Adds an already existing syndicate backpack to the gear closet that's in the listening post. Said backpack is from pod wars. Said closet also exists on the Cairngorm, which I imagine is ok.
![image](https://user-images.githubusercontent.com/6396368/196055584-61177911-5e35-4bf1-bab6-cc775b033710.png)

## Why's this needed?
Pretty minor but nice QoL. Helps you ditch your old identity a tiny bit more for gimmicks instead of being stuck with whatever scientist/captain backpack you had before, while still screaming "I am a baddie."

## Changelog

```changelog
(u)Garash
(+)Added a syndicate backpack (regular 7-slots) to the listening post gear closet so you get to ditch your old grey backpack and look extra evil.
```

[A-Clothing][C-QoL]