### PR TITLE
refactor calculate_melee_attack and related procs

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -388,7 +388,7 @@
 
 		if (prob(src.miss_prob) || is_incapacitated(target)|| target.restrained())
 			var/obj/item/affecting = target.get_affecting(user)
-			var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, dam_low, dam_high, 0, stam_damage_mult, !isghostcritter(user))
+			var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, dam_low, dam_high, 0, stam_damage_mult, !isghostcritter(user), can_punch = 0, can_kick = 0)
 			user.attack_effects(target, affecting)
 			msgs.base_attack_message = src.custom_msg ? src.custom_msg : "<b><span class='combat'>[user] bites [target]!</span></b>"
 			msgs.played_sound = src.sound_attack
@@ -471,7 +471,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "mauls [constructTarget(target,"combat")] with bear limbs at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 0)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 0, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("maim", "maul", "mangle", "rip", "claw", "lacerate", "mutilate")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their [src.holder]!</span></b>"
@@ -586,7 +586,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "mauls [constructTarget(target,"combat")] with bear limbs at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 1)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 1, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("maim", "maul", "mangle", "rip", "scratch", "mutilate")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their [src.holder]!</span></b>"
@@ -657,7 +657,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "slashes [constructTarget(target,"combat")] with dual saw at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 0)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, 0, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("lacerate", "carve", "mangle", "sever", "hack", "slice", "mutilate")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their [src.holder]!</span></b>"
@@ -738,7 +738,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "mauls [constructTarget(target,"combat")] with [src] at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, rand(5,9) * quality)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 10, rand(5,9) * quality, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("maim", "maul", "mangle", "rip", "claw", "lacerate", "mutilate")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their [src.holder]!</span></b>"
@@ -817,7 +817,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "melts [constructTarget(target,"combat")] with hot hands at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 3, 1, 0, 0)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 3, 1, 0, 0, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 
 		msgs.base_attack_message = "<b><span class='alert'>[user] melts [target] with their clutch!</span></b>"
@@ -1068,7 +1068,7 @@
 
 		var/send_flying = 0 // 1: a little bit | 2: across the room
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, can_punch = 0, can_kick = 0)
 
 		if (!msgs || !istype(msgs))
 			return
@@ -1260,7 +1260,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "claws [constructTarget(target,"combat")] with claw arms at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 10, 10, rand(1,3) * quality)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 10, 10, rand(1,3) * quality, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("maim", "stab", "rip", "claw", "slashe")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their [src.holder]!</span></b>"
@@ -1279,7 +1279,7 @@
 			return
 
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, can_punch = 0)
 
 		if (!msgs)
 			return
@@ -1336,7 +1336,7 @@
 		if (no_logs != 1)
 			logTheThing(LOG_COMBAT, user, "kicks [constructTarget(target,"combat")] at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 4, rand(1,3) * quality)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 4, rand(1,3) * quality, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("kick", "stomp", "boot")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target]!</span></b>"
@@ -1502,7 +1502,7 @@
 		//	L.do_disorient(24, 1 SECOND, 0, 0, 0.5 SECONDS)
 
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 5, rand(0,2) * quality)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 1, 5, rand(0,2) * quality, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("cut", "rip", "claw", "slashe")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target]!</span></b>"

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -633,7 +633,7 @@ ABSTRACT_TYPE(/mob/living/critter/aquatic)
 	if (no_logs != 1)
 		logTheThing(LOG_COMBAT, user, "slashes [constructTarget(target,"combat")] with pincers at [log_loc(user)].")
 	var/obj/item/affecting = target.get_affecting(user)
-	var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 10, 20, 0, 2)
+	var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 10, 20, 0, 2, can_punch = 0, can_kick = 0)
 	user.attack_effects(target, affecting)
 	var/action = pick("slashes", "tears into", "gouges", "rips into", "lacerates", "mutilates")
 	msgs.base_attack_message = "<b><span class='alert'>[user] [action] [target] with their [src.holder]!</span></b>"

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -957,7 +957,7 @@
 			return
 		if (prob(src.attack_hit_prob) || is_incapacitated(target)|| target.restrained())
 			var/obj/item/affecting = target.get_affecting(user)
-			var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, dam_low, dam_high, 0)
+			var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, dam_low, dam_high, 0, can_punch = 0, can_kick = 0)
 			user.attack_effects(target, affecting)
 			var/list/specific_attack_messages = pick(attack_messages)
 			msgs.base_attack_message = "<span class='combat bold'>[user] [specific_attack_messages[1]] [target] [specific_attack_messages[2]]!</span>"

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -680,7 +680,7 @@
 	//we end here. We do not deal stamina damage
 	//we do not check armor
 	//we are not affected by wrestler stuff
-
+	return
 
 
 /mob/proc/do_punch(datum/attackResults/msgs, mob/target, damage, stamina_damage_mult, can_crit, def_zone)
@@ -745,7 +745,7 @@
 
 	if (!(src.traitHolder && src.traitHolder.hasTrait("glasscannon")))
 		msgs.stamina_self -= STAMINA_HTH_COST
-
+	return
 
 
 /mob/proc/do_stam(datum/attackResults/msgs, damage, pre_armor_damage, stam_power, crit_chance, stamina_damage_mult)
@@ -765,7 +765,7 @@
 	if (can_crit && prob(crit_chance) && !target.check_block()?.can_block(DAMAGE_BLUNT, 0))
 		msgs.stamina_crit = 1
 		msgs.played_sound = pick(sounds_punch)
-
+	return
 
 
 ////////////////////////////////////////////////////// Calculate damage //////////////////////////////////////////

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1147,7 +1147,7 @@
 /mob/living/carbon/human/get_base_damage_multiplier(var/def_zone)
 	var/punchmult = 1
 
-	if (sims)
+	if (sims) //this is still a thing. huh.
 		punchmult *= sims.getMoodActionMultiplier()
 
 	return punchmult
@@ -1160,7 +1160,7 @@
 
 /mob/living/calculate_bonus_damage(var/datum/attackResults/msgs)
 	.= ..()
-
+	//i hate this
 	if (src.traitHolder.hasTrait("bigbruiser"))
 		msgs.stamina_self -= STAMINA_HTH_COST //Double the cost since this is stacked on top of default
 		msgs.stamina_target -= STAMINA_HTH_DMG * 0.25
@@ -1170,6 +1170,9 @@
 	. = ..()
 
 	if (src.is_hulk())
+		//increase damage by, typically, 5-10, scaled from 0% health to 100% health - raw values don't matter
+		//can exceed 10 damage in edge case of being under -300% health.
+		//maybe should be a bigger bonus when hurt? hulk angry etc?
 		. += max((abs(health+max_health)/max_health)*5, 5)
 
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1148,7 +1148,7 @@
 	var/punchmult = 1
 
 	if (sims) //this is still a thing. huh.
-		punchmult *= sims.getMoodActionMultiplier()
+		punchmult *= sims.getMoodActionMultiplier() //also this is a 0-1.35 scale. HUH.
 
 	return punchmult
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -581,6 +581,18 @@
 	attack_effects(target, affecting)
 	msgs.flush(suppress_flags)
 
+
+
+
+
+
+
+
+
+
+
+
+
 /mob/proc/calculate_melee_attack(var/mob/target, var/obj/item/affecting, var/base_damage_low = 2, var/base_damage_high = 9, var/extra_damage = 0, var/stamina_damage_mult = 1, var/can_crit = 1)
 	var/datum/attackResults/msgs = new(src)
 	msgs.clear(target)
@@ -643,6 +655,8 @@
 
 	return msgs
 
+
+
 /mob/proc/do_kick(datum/attackResults/msgs, mob/target, damage)
 	//setup kick effects
 	msgs.played_sound = 'sound/impact_sounds/Generic_Hit_1.ogg'
@@ -666,6 +680,8 @@
 	//we end here. We do not deal stamina damage
 	//we do not check armor
 	//we are not affected by wrestler stuff
+
+
 
 /mob/proc/do_punch(datum/attackResults/msgs, mob/target, damage, stamina_damage_mult, can_crit, def_zone)
 	msgs.played_sound = "punch"
@@ -730,6 +746,8 @@
 	if (!(src.traitHolder && src.traitHolder.hasTrait("glasscannon")))
 		msgs.stamina_self -= STAMINA_HTH_COST
 
+
+
 /mob/proc/do_stam(datum/attackResults/msgs, damage, pre_armor_damage, stam_power, crit_chance, stamina_damage_mult)
 	//calculate stamina damage to deal
 	var/stam_power = STAMINA_HTH_DMG * stamina_damage_mult
@@ -747,6 +765,57 @@
 	if (can_crit && prob(crit_chance) && !target.check_block()?.can_block(DAMAGE_BLUNT, 0))
 		msgs.stamina_crit = 1
 		msgs.played_sound = pick(sounds_punch)
+
+
+
+////////////////////////////////////////////////////// Calculate damage //////////////////////////////////////////
+
+/mob/proc/get_base_damage_multiplier()
+	return 1
+
+/mob/living/carbon/human/get_base_damage_multiplier(var/def_zone)
+	var/punchmult = 1
+
+	if (sims) //this is still a thing. huh.
+		punchmult *= sims.getMoodActionMultiplier() //also this is a 0-1.35 scale. HUH.
+
+	return punchmult
+
+/mob/proc/get_taken_base_damage_multiplier()
+	return 1
+
+/mob/proc/calculate_bonus_damage(var/datum/attackResults/msgs)
+	return 0
+
+/mob/living/calculate_bonus_damage(var/datum/attackResults/msgs)
+	.= ..()
+	//i hate this
+	if (src.traitHolder.hasTrait("bigbruiser"))
+		msgs.stamina_self -= STAMINA_HTH_COST //Double the cost since this is stacked on top of default
+		msgs.stamina_target -= STAMINA_HTH_DMG * 0.25
+
+
+/mob/living/carbon/human/calculate_bonus_damage(var/datum/attackResults/msgs)
+	. = ..()
+
+	if (src.is_hulk())
+		//increase damage by, typically, 5-10, scaled from 0% health to 100% health - raw values don't matter
+		//can exceed 10 damage in edge case of being under -300% health.
+		//maybe should be a bigger bonus when hurt? hulk angry etc?
+		. += max((abs(health+max_health)/max_health)*5, 5)
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 // This is used by certain limb datums (werewolf, shambling abomination) (Convair880).
 /proc/special_attack_silicon(var/mob/target, var/mob/living/user)
@@ -1139,43 +1208,6 @@
 	if (limbs && !limbs.r_arm && def_zone == "r_arm")
 		return "chest"
 	return def_zone
-
-////////////////////////////////////////////////////// Calculate damage //////////////////////////////////////////
-
-/mob/proc/get_base_damage_multiplier()
-	return 1
-
-/mob/living/carbon/human/get_base_damage_multiplier(var/def_zone)
-	var/punchmult = 1
-
-	if (sims) //this is still a thing. huh.
-		punchmult *= sims.getMoodActionMultiplier() //also this is a 0-1.35 scale. HUH.
-
-	return punchmult
-
-/mob/proc/get_taken_base_damage_multiplier()
-	return 1
-
-/mob/proc/calculate_bonus_damage(var/datum/attackResults/msgs)
-	return 0
-
-/mob/living/calculate_bonus_damage(var/datum/attackResults/msgs)
-	.= ..()
-	//i hate this
-	if (src.traitHolder.hasTrait("bigbruiser"))
-		msgs.stamina_self -= STAMINA_HTH_COST //Double the cost since this is stacked on top of default
-		msgs.stamina_target -= STAMINA_HTH_DMG * 0.25
-
-
-/mob/living/carbon/human/calculate_bonus_damage(var/datum/attackResults/msgs)
-	. = ..()
-
-	if (src.is_hulk())
-		//increase damage by, typically, 5-10, scaled from 0% health to 100% health - raw values don't matter
-		//can exceed 10 damage in edge case of being under -300% health.
-		//maybe should be a bigger bonus when hurt? hulk angry etc?
-		. += max((abs(health+max_health)/max_health)*5, 5)
-
 
 /////////////////////////////////////////////////////// Target damage modifiers //////////////////////////////////
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -812,6 +812,12 @@
 		msgs.stamina_self -= STAMINA_HTH_COST //Double the cost since this is stacked on top of default
 		. += STAMINA_HTH_DMG * 0.25
 
+
+
+
+
+
+
 // This is used by certain limb datums (werewolf, shambling abomination) (Convair880).
 /proc/special_attack_silicon(var/mob/target, var/mob/living/user)
 	if (!target || !issilicon(target) || !user || !isliving(user))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -726,7 +726,7 @@
 	var/pre_armor_damage = damage
 	damage -= armor_mod
 
-	do_stam(msgs, damage, pre_armor_damage, crit_chance, stamina_damage_mult)
+	do_stam(msgs, target, damage, pre_armor_damage, can_crit ? crit_chance : 0, stamina_damage_mult)
 
 	//effects for armor reducing most/all of damage
 	var/armor_blocked = 0
@@ -748,12 +748,12 @@
 	return
 
 
-/mob/proc/do_stam(datum/attackResults/msgs, damage, pre_armor_damage, stam_power, crit_chance, stamina_damage_mult)
+/mob/proc/do_stam(datum/attackResults/msgs, mob/target, damage, pre_armor_damage, stam_power, crit_chance, stamina_damage_mult)
 	//calculate stamina damage to deal
 	var/stam_power = STAMINA_HTH_DMG * stamina_damage_mult
 	//reduce stamina damage by the same proportion that base damage was reduced
 	//min cap is stam_power/3 so we still cant ignore it entirely
-	if ((damage + armor_mod) <= 0) //mbc lazy runtime fix
+	if (pre_armor_damage == 0) //mbc lazy runtime fix
 		stam_power *= (1/3) //do the least
 	else
 		stam_power *= clamp(damage/pre_armor_damage, 1, 1/3)
@@ -762,7 +762,7 @@
 	msgs.stamina_target -= max(stam_power, 0)
 
 	//if we can crit, roll for a crit. Crits are blocked by blocks.
-	if (can_crit && prob(crit_chance) && !target.check_block()?.can_block(DAMAGE_BLUNT, 0))
+	if (prob(crit_chance) && !target.check_block()?.can_block(DAMAGE_BLUNT, 0))
 		msgs.stamina_crit = 1
 		msgs.played_sound = pick(sounds_punch)
 	return

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -702,10 +702,9 @@
 			msgs.stamina_crit = 1
 			msgs.played_sound = pick(sounds_punch)
 
-		//do stamina cost
-		if (!(src.traitHolder && src.traitHolder.hasTrait("glasscannon")))
-			msgs.stamina_self -= STAMINA_HTH_COST
-
+	//do stamina cost
+	if (!(src.traitHolder && src.traitHolder.hasTrait("glasscannon")))
+		msgs.stamina_self -= STAMINA_HTH_COST
 
 	//set attack message
 	if(pre_armor_damage > 0 && damage <= 0 )
@@ -736,7 +735,6 @@
 
 	if (sims) //this is still a thing. huh.
 		. *= sims.getMoodActionMultiplier() //also this is a 0-1.35 scale. HUH.
-
 
 ///multipler to unarmed damage recieved
 /mob/proc/get_taken_base_damage_multiplier(mob/attacker, def_zone)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -279,11 +279,6 @@
 				target.remove_stamina(STAMINA_DEFAULT_BLOCK_COST)
 				return
 
-	if (istype(H))
-		for (var/uid in H.pathogens)
-			var/datum/pathogen/P = H.pathogens[uid]
-			P.ongrab(target)
-
 	if (!grab_item)
 		var/obj/item/grab/G = new /obj/item/grab(src, src, target)
 		src.put_in_hand(G, src.hand)
@@ -403,14 +398,6 @@
 			msgs.disarm_RNG_result |= "shoved"
 
 	if (prob((stampart + 5) * mult))
-		if (ishuman(src))
-			var/mob/living/carbon/human/H = src
-			for (var/uid in H.pathogens)
-				var/datum/pathogen/P = H.pathogens[uid]
-				var/ret = P.ondisarm(target, 1)
-				if (!ret)
-					msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target][DISARM_WITH_ITEM_TEXT]!</B></span>"
-					return msgs
 		msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target] to the ground[DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		msgs.disarm_RNG_result |= "shoved_down"
@@ -427,14 +414,6 @@
 	var/list/obj/item/limbs = list()
 	var/list/obj/item/loose = list()
 	var/list/obj/item/fixed_in_place = list()
-	if (ishuman(src))
-		var/mob/living/carbon/human/H2 = src
-		for (var/uid in H2.pathogens)
-			var/datum/pathogen/P = H2.pathogens[uid]
-			var/ret = P.ondisarm(target, 1)
-			if (!ret)
-				disarm_success = 0
-				break
 	if(length(items))
 		var/multi = length(items) > 1
 		for(var/obj/item/I in items)
@@ -625,11 +604,6 @@
 		msgs.affecting = def_zone
 
 	var/punchmult = get_base_damage_multiplier(def_zone)
-	if(ishuman(src))
-		var/mob/living/carbon/human/LM = src
-		for (var/uid in LM.pathogens)
-			var/datum/pathogen/P = LM.pathogens[uid]
-			punchmult *= P.onpunch(target, def_zone)
 
 	var/punchedmult = target.get_taken_base_damage_multiplier(src, def_zone)
 
@@ -1157,15 +1131,6 @@
 
 /mob/proc/get_taken_base_damage_multiplier()
 	return 1
-
-/mob/living/carbon/human/get_taken_base_damage_multiplier(var/mob/attacker, var/def_zone)
-	var/punchedmult = 1
-
-	for (var/uid in src.pathogens)
-		var/datum/pathogen/P = src.pathogens[uid]
-		punchedmult *= P.onpunched(attacker, def_zone)
-
-	return punchedmult
 
 /mob/proc/calculate_bonus_damage(var/datum/attackResults/msgs)
 	return 0

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -737,7 +737,7 @@
 	return
 
 
-/mob/proc/do_stam(datum/attackResults/msgs, damage, pre_armor_damage, stam_power, crit_chance, stamina_damage_mult)
+/mob/proc/do_stam(datum/attackResults/msgs, damage, pre_armor_damage, crit_chance, stamina_damage_mult)
 	//calculate stamina damage to deal
 	var/stam_power = STAMINA_HTH_DMG * stamina_damage_mult
 	//reduce stamina damage by the same proportion that base damage was reduced

--- a/code/modules/antagonists/wraith/critters/skeleton_commander.dm
+++ b/code/modules/antagonists/wraith/critters/skeleton_commander.dm
@@ -157,7 +157,7 @@
 			return 0
 		logTheThing("combat", user, target, "stabs [constructTarget(target,"combat")] with [src] at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 9, rand(5,7))
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 6, 9, rand(5,7), can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("slashes", "stabs", "pierces")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action] [target] with their [src.holder]!</span></b>"

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -495,7 +495,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 			return 0
 		logTheThing(LOG_COMBAT, user, "slashes [constructTarget(target,"combat")] with hand blades at [log_loc(user)].")
 		var/obj/item/affecting = target.get_affecting(user)
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 16, 16, 0, 0.8, 0)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, affecting, 16, 16, 0, 0.8, 0, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, affecting)
 		var/action = pick("stab", "slashe")
 		msgs.base_attack_message = "<b><span class='alert'>[user] [action]s [target] with their hand blades!</span></b>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors and comments the `calculate_melee_attack()` proc (and related procs)
Makes a number of unarmed attack bonuses (e.g.: hulk, wrestler) not stack with 'non-standard' unarmed attacks (e.g.: critter limbs, bladed gloves)
 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Old code was pretty messy and hard to parse
Hulk/wrestler stacking with bladed gloves and bear arms was a significant and unintended power spike


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)tarmunora
(+)Hulk/etc no longer stack with bear/etc arms, bladed gloves, etc
(+)Can no longer kick with a bear/etc arm, bladed gloves, etc
```
