### PR TITLE
Standardises The Atlas Armoury

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -3788,6 +3788,7 @@
 "jK" = (
 /obj/machinery/flasher/portable,
 /obj/item/wrench,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "jL" = (

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -201,8 +201,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/riotgear,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "av" = (
 /obj/machinery/light/runway_light,
@@ -2149,7 +2148,7 @@
 	light_type = /obj/item/light/tube/reddish;
 	pixel_y = 21
 	},
-/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/caution/south,
 /area/station/ai_monitored/armory)
 "fy" = (
@@ -2157,15 +2156,13 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "fz" = (
-/obj/table/auto,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/chem_grenade/flashbang,
-/obj/item/storage/box/revimp_kit,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
 /turf/simulated/floor/caution/south,
 /area/station/ai_monitored/armory)
 "fA" = (
@@ -2416,16 +2413,66 @@
 /area/station/security/main)
 "gq" = (
 /obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/mask/gas{
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -12;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -12;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = -5
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 11;
+	pixel_y = -6
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 10;
+	pixel_y = 7
+	},
 /turf/simulated/floor/caution/east,
 /area/station/ai_monitored/armory)
 "gr" = (
@@ -2582,12 +2629,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
 "gW" = (
-/obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
-	name = "Armory";
-	req_access_txt = "37"
-	},
-/turf/simulated/floor/black,
+/obj/machinery/weapon_stand/shotgun_rack,
+/turf/simulated/floor/caution/west,
 /area/station/ai_monitored/armory)
 "gX" = (
 /turf/simulated/floor/yellow/side{
@@ -2913,8 +2956,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "hO" = (
-/turf/simulated/floor/stairs/wide/other,
-/area/station/security/main)
+/obj/machinery/computer/riotgear,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
 "hP" = (
 /obj/machinery/firealarm{
 	pixel_y = 25
@@ -3087,7 +3131,7 @@
 	persistent_id = "security"
 	},
 /turf/simulated/floor/red/side{
-	dir = 1
+	dir = 5
 	},
 /area/station/security/main)
 "ig" = (
@@ -7472,8 +7516,8 @@
 	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8;
-	autoclose = 0
+	autoclose = 0;
+	dir = 8
 	},
 /obj/access_spawn/heads,
 /turf/simulated/floor/carpet{
@@ -8128,8 +8172,8 @@
 /obj/machinery/cashreg,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8;
-	autoclose = 0
+	autoclose = 0;
+	dir = 8
 	},
 /obj/access_spawn/heads,
 /turf/simulated/floor/carpet{
@@ -8452,8 +8496,8 @@
 	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8;
-	autoclose = 0
+	autoclose = 0;
+	dir = 8
 	},
 /obj/access_spawn/heads,
 /turf/simulated/floor/carpet{
@@ -11518,9 +11562,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/red/side{
-	dir = 5
-	},
+/turf/simulated/floor/stairs/wide,
 /area/station/security/main)
 "BP" = (
 /obj/reagent_dispensers/foamtank,
@@ -12019,8 +12061,8 @@
 "Dh" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8;
-	autoclose = 0
+	autoclose = 0;
+	dir = 8
 	},
 /obj/machinery/cashreg,
 /obj/machinery/light{
@@ -13483,19 +13525,18 @@
 	},
 /area/station/science/artifact)
 "GQ" = (
+/obj/machinery/door/airlock/pyro/security{
+	aiControlDisabled = 1;
+	name = "Armory"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/stairs/wide,
-/area/station/security/main)
+/obj/access_spawn/hos,
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "GR" = (
 /obj/cable{
 	d1 = 1;
@@ -17648,7 +17689,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/red/corner{
+	dir = 4
+	},
 /area/station/security/main)
 "Ra" = (
 /obj/wingrille_spawn/auto,
@@ -17913,13 +17956,8 @@
 /turf/simulated/floor/purple,
 /area/station/janitor/office)
 "RO" = (
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
+/obj/storage/secure/crate/weapon/armory/phaser,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/caution/south,
 /area/station/ai_monitored/armory)
 "RP" = (
@@ -18267,10 +18305,14 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "SQ" = (
-/obj/machinery/recharger/wall/sticky{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/stairs/wide/other,
 /area/station/security/main)
 "SU" = (
 /obj/machinery/door/poddoor/blast/pyro{
@@ -18337,6 +18379,10 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/station/shield_zone)
+"Ta" = (
+/obj/machinery/weapon_stand/rifle_rack/recharger,
+/turf/simulated/floor/caution/west,
+/area/station/ai_monitored/armory)
 "Tb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -18978,11 +19024,13 @@
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "UL" = (
-/obj/machinery/weapon_stand/shotgun_rack,
 /obj/decal/poster/wallsign/framed_award/hos_medal{
 	pixel_y = 26
 	},
-/turf/simulated/floor/caution/south,
+/obj/machinery/vending/security_ammo,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 10
+	},
 /area/station/ai_monitored/armory)
 "UM" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -19071,14 +19119,29 @@
 /area/station/engine/combustion_chamber)
 "Va" = (
 /obj/rack,
-/obj/item/breaching_charge,
-/obj/item/breaching_charge,
-/obj/item/breaching_charge,
+/obj/item/breaching_charge{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/breaching_charge{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/breaching_charge{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /obj/item/breaching_hammer{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/turf/simulated/floor/caution/east,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 6
+	},
 /area/station/ai_monitored/armory)
 "Vb" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -20595,7 +20658,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/red/side{
-	dir = 4
+	dir = 5
 	},
 /area/station/security/main)
 "YX" = (
@@ -74228,7 +74291,7 @@ ez
 fz
 yj
 ez
-hl
+ez
 if
 QZ
 kz
@@ -74830,7 +74893,7 @@ fa
 cD
 ez
 UL
-gr
+Ta
 gW
 hO
 SQ
@@ -75134,7 +75197,7 @@ ez
 ez
 ez
 ez
-hl
+ez
 hl
 hl
 hl


### PR DESCRIPTION
[Mapping] [Balance] [QoL] [Add To Wiki]


## About the PR:
See initial PR: #10917
Slightly expands the Atlas Armoury, adding two blast suits, one airlock breaching sledgehammer, one phaser crate, one pulse rifle rack, and one AmmotTech while removing two crowd dispersal grenades, one flashbang, one counter-revolutionary implant kit, two remote signalling devices, and two electropacks.

![image](https://user-images.githubusercontent.com/88833499/196233014-e68bc59b-59ad-4f24-8dd6-7bd52375dda8.png)

When being compared to the [standardised equipment list](https://hackmd.io/@Mister-Moriarty/BkmMgDLZs), the Atlas Armoury **lacks**, for the purpose of balance, the following:
* 1x Special Grenades Crate
	* 2x Security-Issue Grenade Boxes
		* 2x Crowd Dispersal Grenades
		* 2x Smoke Grenades
		* 1x Flashbangs
		* 1x Stinger Grenades
		* 1x Shock Grenades
	* 1x Experimental Grenade Box
		* 1x High-Range Incendiary Grenade
		* 3x Incendiary Grenades
		* 3x Cryo Grenades
	* 1x Non-Lethal Landmine Box
		* 5x NT Stun Land Mines
	* 1x Stinger Grenade Box
		* 7x Stinger Grenades
* 1x N2O Canister
* 2x Optical Thermal Scanners
* 2x Night Vision Goggles



## Why's this needed?
Armouries really should be standardised as to contain the same basic equipment as each other, while also being distinct in their unique own ways. I believe that Atlas can afford to forgo a N2O tank and special grenades crate due to balance concerns on a small map, alongside thermal goggles and NVGs due to lower populations.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Standardised the Atlas Armoury.
```
