### PR TITLE
Fixes #11060 & Others - Special Spawn Location Fixes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -104,7 +104,7 @@
 				var/location = special_spawn_location
 				if (!istype(special_spawn_location, /turf))
 					location = pick_landmark(special_spawn_location)
-				if (location != null)
+				if (!isnull(location))
 					M.set_loc(location)
 
 			if (ishuman(M) && src.bio_effects)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -101,10 +101,11 @@
 				I.implanted(M)
 
 			if (src.special_spawn_location && !no_special_spawn)
+				var/location = special_spawn_location
 				if (!istype(special_spawn_location, /turf))
-					special_spawn_location = pick_landmark(special_spawn_location)
-				if (special_spawn_location != null)
-					M.set_loc(special_spawn_location)
+					location = pick_landmark(special_spawn_location)
+				if (location != null)
+					M.set_loc(location)
 
 			if (ishuman(M) && src.bio_effects)
 				var/list/picklist = params2list(src.bio_effects)
@@ -2348,16 +2349,11 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 							/obj/item/old_grenade/stinger/frag,
 							/obj/item/breaching_charge)
 	add_to_manifest = FALSE
+	special_spawn_location = LANDMARK_SYNDICATE
 
 	New()
 		..()
 		src.access = syndicate_spec_ops_access()
-
-#ifdef MAP_OVERRIDE_OSHAN
-	special_spawn_location = null
-#else
-	special_spawn_location = LANDMARK_SYNDICATE
-#endif
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -307,7 +307,7 @@ mob/new_player
 				var/location = JOB.special_spawn_location
 				if (!istype(JOB.special_spawn_location, /turf))
 					location = pick_landmark(JOB.special_spawn_location)
-				if (location != null)
+				if (!isnull(location))
 					character.set_loc(location)
 			else if (character.traitHolder && character.traitHolder.hasTrait("immigrant"))
 				boutput(character.mind.current,"<h3 class='notice'>You've arrived in a nondescript container! Good luck!</h3>")

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -303,13 +303,12 @@ mob/new_player
 				battlemode.living_battlers.Add(character.mind)
 				DEBUG_MESSAGE("Adding a new battler")
 				battlemode.battle_shuttle_spawn(character.mind)
-			else if (istype(JOB, /datum/job))
-				var/datum/job/job = JOB
-				if (job.special_spawn_location)
-					if (!istype(job.special_spawn_location, /turf))
-						job.special_spawn_location = pick_landmark(job.special_spawn_location)
-					if (job.special_spawn_location != null)
-						character.set_loc(job.special_spawn_location)
+			else if (JOB.special_spawn_location)
+				var/location = JOB.special_spawn_location
+				if (!istype(JOB.special_spawn_location, /turf))
+					location = pick_landmark(JOB.special_spawn_location)
+				if (location != null)
+					character.set_loc(location)
 			else if (character.traitHolder && character.traitHolder.hasTrait("immigrant"))
 				boutput(character.mind.current,"<h3 class='notice'>You've arrived in a nondescript container! Good luck!</h3>")
 				//So the location setting is handled in EquipRank in jobprocs.dm. I assume cause that is run all the time as opposed to this.


### PR DESCRIPTION
[Internal] [Bug]


## About the PR:
Fixes #11060, and some other bugs (that don't have a GitHub issue report) created by a few oversights I made in #11030. Mainly using an `if` statement that would always be true in the middle of a group of `if else` statements, and `special_spawn_location` always spawning a job type on the same spawn landmark, even if alternatives existed.