### PR TITLE
nanite diseases only work on humans

### DIFF
--- a/code/modules/medical/diseases/corrupt_robotic_transformation.dm
+++ b/code/modules/medical/diseases/corrupt_robotic_transformation.dm
@@ -12,6 +12,11 @@
 /datum/ailment/disease/corrupt_robotic_transformation/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
 		return
+
+	if (!ishuman(affected_mob))
+		affected_mob.cure_disease(D)
+		return
+
 	switch(D.stage)
 		if(2)
 			if (probmult(8))

--- a/code/modules/medical/diseases/robotic_transformation.dm
+++ b/code/modules/medical/diseases/robotic_transformation.dm
@@ -12,6 +12,11 @@
 /datum/ailment/disease/robotic_transformation/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
 		return
+
+	if (!ishuman(affected_mob))
+		affected_mob.cure_disease(D)
+		return
+
 	switch(D.stage)
 		if(2)
 			if (probmult(8))
@@ -81,6 +86,11 @@
 /datum/ailment/disease/good_robotic_transformation/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
 		return
+
+	if (!ishuman(affected_mob))
+		affected_mob.cure_disease(D)
+		return
+
 	switch(D.stage)
 		if(2)
 			if (probmult(8))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes all types of nanite disease (borg, organ-replace, mechmonstrosity) only work on `mob/.../human`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #11313
most of the effects would fail on critters/etc anyways