### PR TITLE
Roundstart mime... again.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1352,7 +1352,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	name = "Mime"
 	limit = 1
 	wages = PAY_DUMBCLOWN*2 // lol okay whatever
-	linkcolor = "#FF99FF"
 	slot_belt = list(/obj/item/device/pda2)
 	slot_head = list(/obj/item/clothing/head/mime_bowler)
 	slot_mask = list(/obj/item/clothing/mask/mime)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1348,10 +1348,11 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		src.access = get_access("Space Cowboy")
 		return
 
-/datum/job/special/mime
+/datum/job/civilian/mime
 	name = "Mime"
 	limit = 1
 	wages = PAY_DUMBCLOWN*2 // lol okay whatever
+	linkcolor = "#d96969"
 	slot_belt = list(/obj/item/device/pda2)
 	slot_head = list(/obj/item/clothing/head/mime_bowler)
 	slot_mask = list(/obj/item/clothing/mask/mime)
@@ -2590,34 +2591,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		src.access = get_access("Boxer")
 		return
-
-/datum/job/daily/monday
-	name = "Mime"
-	limit = 1
-	wages = PAY_DUMBCLOWN*2
-	slot_belt = list(/obj/item/device/pda2)
-	slot_head = list(/obj/item/clothing/head/mime_bowler)
-	slot_mask = list(/obj/item/clothing/mask/mime)
-	slot_jump = list(/obj/item/clothing/under/misc/mime/alt)
-	slot_suit = list(/obj/item/clothing/suit/scarf)
-	slot_glov = list(/obj/item/clothing/gloves/latex)
-	slot_foot = list(/obj/item/clothing/shoes/black)
-	slot_poc1 = list(/obj/item/pen/crayon/white)
-	slot_poc2 = list(/obj/item/paper)
-	items_in_backpack = list(/obj/item/baguette)
-	change_name_on_spawn = 1
-
-	New()
-		..()
-		src.access = get_access("Mime")
-		return
-
-	special_setup(var/mob/living/carbon/human/M)
-		..()
-		if (!M)
-			return
-		M.bioHolder.AddEffect("mute", magical=1)
-		M.bioHolder.AddEffect("blankman", magical=1)
 
 /datum/job/daily/tuesday
 	name = "Barber"

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1352,7 +1352,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	name = "Mime"
 	limit = 1
 	wages = PAY_DUMBCLOWN*2 // lol okay whatever
-	linkcolor = "#d96969"
+	linkcolor = "#FF99FF"
 	slot_belt = list(/obj/item/device/pda2)
 	slot_head = list(/obj/item/clothing/head/mime_bowler)
 	slot_mask = list(/obj/item/clothing/mask/mime)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL][QOL][PLAYER ACTIONS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

To note, the mime job colour is default blue for simplicity of PR. The colour I thought looked the best with the current HTML preferences being a white background, which locks out using white, was this. https://i.gyazo.com/70b80ea2d452633b05801786fa5da202.png

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables the Mime role as a roundstart/preference job. With that change, antagonist mimes will become more common and we'll see some new interesting gimmicks from that. ❤️


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Community overwhelmingly wanted mime to be a roundstart job last year, but it was originally declined for not having appropriate content to be roundstart, seen with #3884. It now has its own traitor item from #9724, and more content designed for it for clothing, cargo crates, etc. Mime has become an even more frequent pick and is regularly sniped as soon as a round starts because many players adore the job quite a lot.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Momoberry, LeahTheTech 🆕⚖📦
(*)Mimes have been enabled as a round start job and job preference. Hooray!

```
