### PR TITLE
Give chemistry borgs a hand labeler

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -37,6 +37,7 @@
 // scientist.
 /datum/robot/module_tool_creator/recursive/module/chemistry
 	definitions = list(
+		/obj/item/hand_labeler,
 		/obj/item/robot_chemaster,
 		// TODO: utility grenade fabricator?
 		/obj/item/reagent_containers/syringe,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BORGS][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Give Chemistry cyborgs a hand labeler.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Chemistry cyborgs just like a regular science use floor beakers to store chemicals, but unlike a scientist they can't properly label the beaker for chemistry or medbay usage.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Adds a hand labeler to chemistry cyborgs.
```
