### PR TITLE
clean up mechcomp housing hear_talk

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -31,6 +31,8 @@
 	var/can_be_welded=false
 	var/can_be_anchored=false
 	custom_suicide=true
+	open_to_sound = TRUE
+
 	New()
 		src.light = new /datum/light/point
 		src.light.attach(src)
@@ -38,10 +40,6 @@
 		processing_items |= src
 		..()
 
-	hear_talk(mob/M as mob, msg, real_name, lang_id) // hack to make microphones work
-		for(var/obj/item/mechanics/miccomp/mic in src.contents)
-			mic.hear_talk(M,msg,real_name,lang_id)
-		return
 	process()
 		if (src.light_time>0)
 			src.light_time--

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1141,10 +1141,10 @@ proc/get_adjacent_floor(atom/W, mob/user, px, py)
 // Marquesas: added an extra parameter to fix issue with changeling.
 // Unfortunately, it has to be this extra parameter, otherwise the spawn(0) in the mob say will
 // cause the mob's name to revert from the one it acquired for mimic voice.
-/atom/proc/hear_talk(mob/M as mob, text, real_name)
+/atom/proc/hear_talk(mob/M as mob, text, real_name, lang_id)
 	if (src.open_to_sound)
 		for(var/obj/O in src)
-			O.hear_talk(M,text,real_name)
+			O.hear_talk(M,text,real_name, lang_id)
 
 /**
   * Returns true if given value is a hex value


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][code-quality][minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the miccomp specific override on mechcomp housing with open_to_sound, which passes hear_talk on to all of its contents.

Also makes the atom code responsible for the above pass lang_id, which is probably good anyway but miccomps need it to pass messages right.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Workarounds reinventing shit that the game can already account for piss me off.