### PR TITLE
Fixes a runtime on cyborg death

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -254,6 +254,7 @@
 		hud.update_pulling()
 
 	death(gibbed)
+		src.stat = 2
 		logTheThing(LOG_COMBAT, src, "was destroyed at [log_loc(src)].")
 		src.mind?.register_death()
 		if (src.syndicate)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Caused by `death` not setting stat properly, causing it to be called multiple times on the same borg.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes bad