### PR TITLE
Fixes runtime when floorbots get turned off mid-action

### DIFF
--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -594,6 +594,9 @@
 
 	onEnd()
 		..()
+		if (!master.on)
+			interrupt(INTERRUPT_ALWAYS)
+			return
 		playsound(master, 'sound/impact_sounds/Generic_Stab_1.ogg', 50, 1)
 		var/turf/simulated/floor/T = master.target
 		if(!istype(T))

--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -594,9 +594,6 @@
 
 	onEnd()
 		..()
-		if (!master.on)
-			interrupt(INTERRUPT_ALWAYS)
-			return
 		playsound(master, 'sound/impact_sounds/Generic_Stab_1.ogg', 50, 1)
 		var/turf/simulated/floor/T = master.target
 		if(!istype(T))

--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -532,6 +532,8 @@
 
 	onEnd()
 		..()
+		if (!master.on)
+			interrupt(INTERRUPT_ALWAYS)
 		playsound(master, 'sound/impact_sounds/Generic_Stab_1.ogg', 50, 1)
 		if (new_tile)
 			// Make a new tile

--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -532,8 +532,8 @@
 
 	onEnd()
 		..()
-		if (!master.on)
-			interrupt(INTERRUPT_ALWAYS)
+		if (!master.target)
+			return
 		playsound(master, 'sound/impact_sounds/Generic_Stab_1.ogg', 50, 1)
 		if (new_tile)
 			// Make a new tile


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Floorbots currently cause a runtime error when turned off right before they complete their repairing action.

This is because while there is a check to interrupt the action bar if it detects the bot has been switched off during the onUpdate() proc, if switched off in the final third of the action bar we don't call onUpdate() again and we proceed directly to calling onEnd(). As turning off the bot clears its target turf, the bot ultimately ends up trying to build() a tile on a null turf which causes a runtime.

Accordingly, this PR adds an early check+return at the start of the onEnd() action bar proc to make sure that if the floorbot was turned off just at the wrong moment we don't runtime.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11351