### PR TITLE
Refactors Audio Logs And Adds Maptext (Alongside Other QoL Features)

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -4,9 +4,13 @@
 
 #define hex2num(X) text2num(X, 16)
 
+#define hsl2rgb(hue, sat, lum) rgb(h=hue,s=sat,l=lum)
+
 #define hsv2rgb(hue, sat, val) rgb(h=hue,s=sat,v=val)
 
 #define hsv2rgblist(hue, sat, val) rgb2num(hsv2rgb(hue, sat, val))
+
+#define rgb2hsl(r, g, b) rgb2num(rgb(r, g, b), COLORSPACE_HSL)
 
 #define rgb2hsv(r, g, b) rgb2num(rgb(r, g, b), COLORSPACE_HSV)
 

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -119,7 +119,7 @@
 		..()
 		if (usr.stat || usr.restrained() || usr.lying)
 			return
-		if ((usr.contents.Find(src) || usr.contents.Find(src.master) || in_interact_range(src, usr) && istype(src.loc, /turf)))
+		if (((src in usr.contents) || (src.master in usr.contents) || in_interact_range(src, usr) && istype(src.loc, /turf)))
 			src.add_dialog(usr)
 			switch(href_list["command"])
 				if ("rec")
@@ -311,28 +311,27 @@
 		return
 
 	proc/create_name_colours(var/list/names)
-		if (!names.len)
+		if (!length(names))
 			return
 
 		var/list/unique_names = list()
-		for (var/i in 1 to names.len)
+		for (var/i in 1 to length(names))
 			if (!(names[i] in unique_names))
 				unique_names.Add(names[i])
 
 		name_colours = list()
-		if (unique_names.len == 1)
+		if (length(unique_names) == 1)
 			name_colours[unique_names[1]] = text_colour
 			return
 
 		var/list/text_rgb = hex_to_rgb_list(text_colour)
 		var/list/text_hsl = rgb2hsl(text_rgb[1], text_rgb[2], text_rgb[3])
-		var/lightness_part = 60 / (unique_names.len + 1)
+		var/lightness_part = 60 / (length(unique_names) + 1)
 
-		for (var/i in 1 to unique_names.len)
+		for (var/i in 1 to length(unique_names))
 			var/lightness = 20 + (lightness_part * i)
 			var/colour = hsl2rgb(text_hsl[1], text_hsl[2], lightness)
 			name_colours[unique_names[i]] = colour
-			message_admins("[lightness]")
 
 #undef MODE_OFF
 #undef MODE_RECORDING

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -100,58 +100,6 @@
 		updateSelfDialog()
 			return updateUsrDialog()
 
-	attack_self(mob/user as mob)
-		..()
-		if (user.stat || user.restrained() || user.lying)
-			return
-		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0 && istype(src.loc, /turf)))
-			src.add_dialog(user)
-
-			var/dat = "<TT><b>Audio Logger</b><br>"
-			if (src.tape)
-				dat += "Memory [src.tape.use_percentage()]% Full -- <a href='byond://?src=\ref[src];command=eject'>Eject</a><br>"
-			else
-				dat += "No Tape Loaded<br>"
-
-			dat += "<table cellspacing=5><tr>"
-			dat += "<td><a href='byond://?src=\ref[src];command=rec'>[src.mode == MODE_RECORDING ? "Recording" : "Not Recording"]</a></td>"
-			dat += "<td><a href='byond://?src=\ref[src];command=play'>[src.mode == MODE_PLAYING ? "Playing" : "Not Playing"]</a></td>"
-			dat += "<td><a href='byond://?src=\ref[src];command=stop'>Stop</a></td>"
-			dat += "<td><a href='byond://?src=\ref[src];command=clear'>Clear Log</a></td>"
-			dat += "<td><a href='byond://?src=\ref[src];command=continuous_mode'>[continuous ? "Looping" : "No Loop"]</a></td></table></tt>"
-
-			user.Browse(dat, "window=audiolog;size=400x140")
-			onclose(user, "audiolog")
-		else
-			user.Browse(null, "window=audiolog")
-			src.remove_dialog(user)
-
-		return
-
-	attackby(obj/item/I, mob/user)
-		if (istype(I, /obj/item/audio_tape))
-			if (src.tape)
-				boutput(user, "There is already a tape loaded.")
-				return
-
-			user.drop_item(I)
-			I.set_loc(src)
-			src.tape = I
-			src.tape.log_line = 1
-			src.icon_state = initial(src.icon_state)
-			src.updateSelfDialog()
-
-			playsound(src.loc, 'sound/machines/law_insert.ogg', 40, 0.5)
-			user.visible_message("[user] loads a tape into [src].", "You load a tape into [src].")
-
-		else
-			..()
-
-	MouseDrop_T(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/audio_tape) && in_interact_range(src, user) && in_interact_range(W, user))
-			return src.Attackby(W, user)
-		return ..()
-
 	New()
 		..()
 		if (!src.chat_text)
@@ -214,6 +162,58 @@
 			usr.Browse(null, "window=audiolog")
 			return
 		return
+
+	attack_self(mob/user as mob)
+		..()
+		if (user.stat || user.restrained() || user.lying)
+			return
+		if ((user.contents.Find(src) || user.contents.Find(src.master) || BOUNDS_DIST(src, user) == 0 && istype(src.loc, /turf)))
+			src.add_dialog(user)
+
+			var/dat = "<TT><b>Audio Logger</b><br>"
+			if (src.tape)
+				dat += "Memory [src.tape.use_percentage()]% Full -- <a href='byond://?src=\ref[src];command=eject'>Eject</a><br>"
+			else
+				dat += "No Tape Loaded<br>"
+
+			dat += "<table cellspacing=5><tr>"
+			dat += "<td><a href='byond://?src=\ref[src];command=rec'>[src.mode == MODE_RECORDING ? "Recording" : "Not Recording"]</a></td>"
+			dat += "<td><a href='byond://?src=\ref[src];command=play'>[src.mode == MODE_PLAYING ? "Playing" : "Not Playing"]</a></td>"
+			dat += "<td><a href='byond://?src=\ref[src];command=stop'>Stop</a></td>"
+			dat += "<td><a href='byond://?src=\ref[src];command=clear'>Clear Log</a></td>"
+			dat += "<td><a href='byond://?src=\ref[src];command=continuous_mode'>[continuous ? "Looping" : "No Loop"]</a></td></table></tt>"
+
+			user.Browse(dat, "window=audiolog;size=400x140")
+			onclose(user, "audiolog")
+		else
+			user.Browse(null, "window=audiolog")
+			src.remove_dialog(user)
+
+		return
+
+	attackby(obj/item/I, mob/user)
+		if (istype(I, /obj/item/audio_tape))
+			if (src.tape)
+				boutput(user, "There is already a tape loaded.")
+				return
+
+			user.drop_item(I)
+			I.set_loc(src)
+			src.tape = I
+			src.tape.log_line = 1
+			src.icon_state = initial(src.icon_state)
+			src.updateSelfDialog()
+
+			playsound(src.loc, 'sound/machines/law_insert.ogg', 40, 0.5)
+			user.visible_message("[user] loads a tape into [src].", "You load a tape into [src].")
+
+		else
+			..()
+
+	MouseDrop_T(obj/item/W as obj, mob/user as mob)
+		if (istype(W, /obj/item/audio_tape) && in_interact_range(src, user) && in_interact_range(W, user))
+			return src.Attackby(W, user)
+		return ..()
 
 	hear_talk(var/mob/living/carbon/speaker, messages, real_name, lang_id)
 		if (src.mode != MODE_RECORDING || !src.tape)


### PR DESCRIPTION
[Game Objects] [Code Quality] [Feature] [QoL]


## About the PR:
Refactores audio logs; changes listed below.
* Refactored how audio logs play messages to use a while loop; they previously relied upon `process` updates. A while loop allows for finer control over how long each message is displayed, currently set to five seconds per message (for maptext).
* Audio logs now display green-coloured maptext, the lightness of which is varied for each speaker should there be more than one speaker. To facilitate this, new `hsl2rgb` and `rgb2hsl` defines have been created.
* Self destructing audio logs now give a five second warning, with accompanying bright red maptext.
* Sounds have been added for inserting and removing tapes, alongside toggling buttons.
* Audio logs now correctly reset to line one upon finishing their tape.

![image](https://user-images.githubusercontent.com/88833499/196769400-69e11454-d21d-45d4-932a-7b97a67a1e98.png)



## Why's this needed?
Audio logs are sadly underused, and a large factor in this is that they are cumbersome to use and to read/listen to. The above should help alleviate that.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Audio logs now display maptext. This is accompanied by some internal code changes; please report any bugs that you may encounter.
```
