### PR TITLE
Adds admin logging to chemical request console

### DIFF
--- a/code/modules/chemistry/chem_requester.dm
+++ b/code/modules/chemistry/chem_requester.dm
@@ -2,6 +2,7 @@ var/list/datum/chem_request/chem_requests = list()
 
 /datum/chem_request
 	var/requester_name = ""
+	var/reagent_id = ""
 	var/reagent_name = ""
 	var/reagent_color = null
 	var/note = ""
@@ -78,6 +79,7 @@ var/list/datum/chem_request/chem_requests = list()
 				. = TRUE
 			if ("set_reagent")
 				src.request.reagent_name = params["reagent_name"]
+				src.request.reagent_id = params["reagent_id"]
 				var/datum/reagent/reagent = reagents_cache[params["reagent_id"]]
 				if (reagent)
 					src.request.reagent_color = list(reagent.fluid_r, reagent.fluid_g, reagent.fluid_b)
@@ -93,7 +95,7 @@ var/list/datum/chem_request/chem_requests = list()
 				src.request.time = ticker.round_elapsed_ticks
 				//byond jank, lists are only associative if they aren't int indexed
 				chem_requests["[src.request.id]"] = src.request
-				logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] placed a chemical request for [src.request.volume] units of [src.request.reagent_name] using [src.request.requester_name]'s ID at [log_loc(src)], notes: \"[src.request.note]\"")
+				logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] placed a chemical request for [src.request.volume] units of [src.request.reagent_id] using [src.request.requester_name]'s ID at [log_loc(src)], notes: \"[src.request.note]\"")
 				var/datum/signal/pdaSignal = get_free_signal()
 				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="RESEARCH-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"="Notification: new chemical request received.")
 				radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
@@ -161,11 +163,11 @@ var/list/datum/chem_request/chem_requests = list()
 				var/datum/chem_request/request = chem_requests["[params["id"]]"]
 				if (request)
 					request.state = "denied"
-					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] denied [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_name] at [log_loc(src)]")
+					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] denied [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_id] at [log_loc(src)]")
 				. = TRUE
 			if ("fulfil")
 				var/datum/chem_request/request = chem_requests["[params["id"]]"]
 				if (request)
-					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] fulfilled [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_name] at [log_loc(src)]")
+					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] fulfilled [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_id] at [log_loc(src)]")
 					request.state = "fulfilled"
 				. = TRUE

--- a/code/modules/chemistry/chem_requester.dm
+++ b/code/modules/chemistry/chem_requester.dm
@@ -93,6 +93,7 @@ var/list/datum/chem_request/chem_requests = list()
 				src.request.time = ticker.round_elapsed_ticks
 				//byond jank, lists are only associative if they aren't int indexed
 				chem_requests["[src.request.id]"] = src.request
+				logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] placed a chemical request for [src.request.volume] units of [src.request.reagent_name] using [src.request.requester_name]'s ID at [log_loc(src)], notes: \"[src.request.note]\"")
 				var/datum/signal/pdaSignal = get_free_signal()
 				pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="RESEARCH-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"="Notification: new chemical request received.")
 				radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
@@ -160,9 +161,11 @@ var/list/datum/chem_request/chem_requests = list()
 				var/datum/chem_request/request = chem_requests["[params["id"]]"]
 				if (request)
 					request.state = "denied"
+					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] denied [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_name] at [log_loc(src)]")
 				. = TRUE
 			if ("fulfil")
 				var/datum/chem_request/request = chem_requests["[params["id"]]"]
 				if (request)
+					logTheThing(LOG_STATION, src, "[constructTarget(ui.user)] fulfilled [request.requester_name]'s chemical request for [request.volume] units of [request.reagent_name] at [log_loc(src)]")
 					request.state = "fulfilled"
 				. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN] [INTERNAL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds logging for placing, approving and denying chemical requests.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flourish asked for it, things should be logged