### PR TITLE
Nadir Fixbatch 2

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -23,6 +23,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 	icon_state = "array"
 	bound_height = 64
 	bound_width = 96
+	mats = 0
 
 	///Whether array permits transception; can be disabled temporarily by anti-overload measures, or toggled manually
 	var/primed = TRUE

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -38641,6 +38641,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/landmark/start{
+	name = "Medical Director"
+	},
 /obj/stool/chair/office/blue{
 	dir = 1
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1570,6 +1570,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/floorguide/mining{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "aKU" = (
@@ -3271,10 +3274,11 @@
 "bEl" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
-/obj/item/device/analyzer/atmosanalyzer_upgrade{
+/obj/item/paper{
+	info = "if the siphon nerds kick you out use the mining fab, dive suits work just fine in acid if you loom them after EVA";
+	name = "creased note";
 	pixel_x = -15;
-	pixel_y = 3;
-	rand_pos = 0
+	pixel_y = 9
 	},
 /obj/item/device/nanoloom{
 	pixel_x = -13;
@@ -5512,6 +5516,8 @@
 "cQf" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/east,
+/obj/rack,
+/obj/item/sea_ladder,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
@@ -7901,11 +7907,6 @@
 /obj/stool/bench/red/auto,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"edv" = (
-/turf/simulated/floor/yellowblack{
-	dir = 5
-	},
-/area/station/engine/storage)
 "edJ" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -9057,6 +9058,10 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
+"eJW" = (
+/obj/item/sea_ladder,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northwest)
 "eKw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/emergencyinternals)
@@ -12768,12 +12773,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "gzE" = (
-/obj/storage/closet/wardrobe/red/security_gimmick,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/machinery/vending/jobclothing/security,
 /turf/simulated/floor/redblack/corner,
 /area/station/security/equipment)
 "gzN" = (
@@ -12868,6 +12873,8 @@
 	pixel_y = 21
 	},
 /obj/machinery/light_switch/east,
+/obj/rack,
+/obj/item/sea_ladder,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
@@ -14789,6 +14796,10 @@
 	pixel_y = 21
 	},
 /obj/blind_switch/area/north,
+/obj/item/device/analyzer/atmosanalyzer_upgrade{
+	pixel_x = -14;
+	rand_pos = 0
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -21878,6 +21889,15 @@
 	do_not_irradiate = 1;
 	name = "South Catalytic Substation"
 	})
+"kMu" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "kMG" = (
 /obj/machinery/computer3/generic/communications{
 	dir = 8
@@ -23174,11 +23194,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "ltn" = (
-/obj/storage/secure/closet/medical/uniforms,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/vending/jobclothing/medical,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -23380,6 +23400,10 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/east)
+"lyg" = (
+/obj/item/sea_ladder,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "lyz" = (
 /obj/machinery/light{
 	dir = 1;
@@ -24566,6 +24590,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"lYm" = (
+/obj/decal/tile_edge/floorguide/mining{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "lYP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -24988,6 +25018,8 @@
 	pixel_y = 21
 	},
 /obj/machinery/light_switch/west,
+/obj/rack,
+/obj/item/sea_ladder,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
@@ -30973,6 +31005,17 @@
 "ptO" = (
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/cafeteria)
+"pum" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/engine/caution/south,
+/area/station/quartermaster/cargobay{
+	name = "Cargo Primary Endpoint"
+	})
 "puq" = (
 /obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/sanitary,
@@ -35995,6 +36038,12 @@
 	},
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
+	})
+"sju" = (
+/obj/item/sea_ladder,
+/turf/simulated/floor/industrial,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
 	})
 "sjI" = (
 /obj/disposalpipe/segment/vertical,
@@ -44696,6 +44745,8 @@
 "wNN" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch/west,
+/obj/rack,
+/obj/item/sea_ladder,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
@@ -45850,6 +45901,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/item/sea_ladder,
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
@@ -46034,6 +46086,9 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/transport,
+/obj/decal/tile_edge/floorguide/arrow_e{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "xyJ" = (
@@ -77825,7 +77880,7 @@ dqY
 nQY
 bxP
 vKn
-vKn
+lyg
 umj
 umj
 ewN
@@ -83815,7 +83870,7 @@ qcT
 bUz
 qmk
 gjr
-ukW
+eJW
 lMz
 tTK
 jtq
@@ -97153,7 +97208,7 @@ pyd
 swU
 vEo
 rZb
-rZb
+kMu
 vlO
 xhg
 nes
@@ -97467,7 +97522,7 @@ mrq
 jRq
 nym
 tMp
-tAy
+pum
 ykm
 lty
 lty
@@ -104701,7 +104756,7 @@ rZb
 vWX
 mkh
 pmb
-ciw
+lYm
 ciw
 ciw
 eGD
@@ -105003,7 +105058,7 @@ rZb
 vXS
 syh
 gQh
-edv
+ciw
 ciw
 ciw
 gGE
@@ -106226,7 +106281,7 @@ ntr
 kRh
 mut
 giN
-ntr
+sju
 cBV
 lCi
 neB

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -30,6 +30,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "aaN" = (
@@ -678,6 +679,7 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aoA" = (
@@ -941,6 +943,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/emergency2)
 "auT" = (
@@ -1702,6 +1705,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aPz" = (
@@ -2545,6 +2549,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
@@ -2751,6 +2756,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "bsp" = (
@@ -4146,6 +4152,7 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/pool)
 "caj" = (
@@ -4595,6 +4602,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "cnT" = (
@@ -5072,6 +5080,7 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "cCu" = (
@@ -5224,6 +5233,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
 "cHV" = (
@@ -9113,6 +9123,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "eMc" = (
@@ -10144,6 +10155,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "fob" = (
@@ -12007,6 +12019,7 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/disposalpipe/segment/transport,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black/corner,
 /area/station/maintenance/northeast)
 "ggX" = (
@@ -15110,6 +15123,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "hAF" = (
@@ -16244,6 +16258,7 @@
 "icz" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/blueblack/corner,
 /area/station/maintenance/north)
 "icE" = (
@@ -16493,6 +16508,7 @@
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner)
 "ihU" = (
@@ -17334,6 +17350,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "iBy" = (
@@ -18932,6 +18949,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/emergencyinternals)
 "jrJ" = (
@@ -20324,6 +20342,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "kba" = (
@@ -22520,6 +22539,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/northwest)
 "lcr" = (
@@ -22684,6 +22704,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
@@ -23631,6 +23652,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner)
 "lEA" = (
@@ -25569,6 +25591,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "mwl" = (
@@ -25797,6 +25820,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "mCC" = (
@@ -26164,6 +26188,7 @@
 /area/station/medical/medbay)
 "mLZ" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "mMa" = (
@@ -26687,6 +26712,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/southwest)
 "nbE" = (
@@ -27134,6 +27160,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "nmi" = (
@@ -28011,6 +28038,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner)
 "nIv" = (
@@ -30236,6 +30264,7 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/minitiles/black,
 /area/station/engine/inner{
 	name = "Transception Array Control"
@@ -30832,6 +30861,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ppv" = (
@@ -31590,6 +31620,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/barber_shop)
 "pKY" = (
@@ -34109,6 +34140,7 @@
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/engine/inner{
 	name = "Transception Array Control"
@@ -34457,6 +34489,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "rsn" = (
@@ -35895,6 +35928,7 @@
 /area/listeningpost)
 "sgm" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "sgu" = (
@@ -35956,6 +35990,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner)
 "shh" = (
@@ -36648,6 +36683,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/transport,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "sxE" = (
@@ -37066,6 +37102,7 @@
 /area/shuttle/sea_elevator_room)
 "sJd" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "sJl" = (
@@ -40200,6 +40237,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ukt" = (
@@ -40485,6 +40523,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "usf" = (
@@ -41153,6 +41192,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/radio/lab)
 "uJE" = (
@@ -42742,6 +42782,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "vCk" = (
@@ -42913,6 +42954,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "vGW" = (
@@ -44038,6 +44080,7 @@
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
 "wup" = (
@@ -45827,6 +45870,7 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/engine/inner{
 	name = "Transception Array Control"
@@ -47444,6 +47488,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "ykm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][BUG][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small set of tweaks to Nadir map and an associated feature.

nadir.dmm:

- Swapped medical and security clothing lockers with the new clothing vendors. Fixes #11452 
- Tidied up Engineering a little, fixing a slightly errant tile choice and adding floor guides to more clearly telegraph the presence of a mining fabricator in engineering storage (backup mineral acquisition in case Siphon is damaged or busy), as well as a small info sheet on the engineers' table.
- Fixed lapses in AI camera coverage in eastern QM and the hall north of the Warehouse.
- Introduced sea ladders dispersed around the station, eight in total.
- Added previously overlooked access spawners to doors of types /obj/machinery/door/airlock/pyro/maintenance/alt and /obj/machinery/door/airlock/pyro/engineering. Fixes #11458
- Added an absent player start for the Medical Director. Fixes #11470

nadir_antenna.dm:

- Fixes an oversight where the transception array could be scanned by Mechanics due to inheriting a mats value from its parent object, by setting the mats value to 0.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves Nadir's usability and feature completeness.