### PR TITLE
Recategorizes bean, corn, cucumber, peas and soybean in the Seed Fabricator 

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -125,7 +125,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	crop_suffix = " cob"
 	desc = "The assistants call it maize."
 	icon_state = "corn"
-	planttype = /datum/plant/crop/corn
+	planttype = /datum/plant/veg/corn
 	bites_left = 3
 	heal_amt = 1
 	throwforce = 0
@@ -155,7 +155,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "clear corn cob"
 	desc = "Pure grain ethanol in a vague corn shape."
 	icon_state = "clearcorn"
-	planttype = /datum/plant/crop/corn
+	planttype = /datum/plant/veg/corn
 	bites_left = 3
 	heal_amt = 3
 	food_color = "#FFFFFF"
@@ -165,7 +165,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "Pepper corn cob"
 	desc = "Wha? Why's this called corn? It's pepper!"
 	icon_state = "peppercorn"
-	planttype = /datum/plant/crop/corn
+	planttype = /datum/plant/veg/corn
 	bites_left = 3
 	heal_amt = 3
 	food_color = "#373232"
@@ -175,7 +175,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "soybean pod"
 	crop_suffix = " pod"
 	desc = "These soybeans are as close as two beans in a pod. Probably because they are literally beans in a pod."
-	planttype = /datum/plant/crop/soy
+	planttype = /datum/plant/veg/soy
 	icon_state = "soy"
 	bites_left = 3
 	heal_amt = 1
@@ -188,7 +188,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "bean pod"
 	crop_suffix = " pod"
 	desc = "This bean pod contains an inordinately large bites_left of beans due to genetic engineering. How convenient."
-	planttype = /datum/plant/crop/beans
+	planttype = /datum/plant/veg/beans
 	icon_state = "beanpod"
 	bites_left = 1
 	heal_amt = 1
@@ -201,7 +201,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "pea pod"
 	crop_suffix = " pod"
 	desc = "These peas are like peas in a pod. Yeah."
-	planttype = /datum/plant/crop/peas
+	planttype = /datum/plant/veg/peas
 	icon_state = "peapod"
 	bites_left = 1
 	heal_amt = 1
@@ -221,7 +221,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "soylent chartreuse"
 	crop_suffix = " chartreuse"
 	desc = "Contains high-energy plankton!"
-	planttype = /datum/plant/crop/soy
+	planttype = /datum/plant/veg/soy
 	icon_state = "soylent"
 	bites_left = 3
 	heal_amt = 2

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -675,7 +675,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	name = "cucumber"
 	desc = "A widely-cultivated gourd, often served on sandwiches or pickled.  Not actually known for saving any kingdoms."
 	icon_state = "cucumber"
-	planttype = /datum/plant/veg/cucumber
+	planttype = /datum/plant/fruit/cucumber
 	w_class = W_CLASS_TINY
 	bites_left = 2
 	heal_amt = 1

--- a/code/modules/hydroponics/plants_crop.dm
+++ b/code/modules/hydroponics/plants_crop.dm
@@ -75,52 +75,6 @@ ABSTRACT_TYPE(/datum/plant/crop)
 		if (reagent == "insulin")
 			DNA.mutation = HY_get_mutation_from_path(/datum/plantmutation/rice/ricein)
 
-/datum/plant/crop/beans
-	name = "Bean"
-	seedcolor = "#AA7777"
-	crop = /obj/item/reagent_containers/food/snacks/plant/bean
-	starthealth = 40
-	growtime = 50
-	harvtime = 130
-	cropsize = 2
-	harvests = 4
-	endurance = 0
-	vending = 1
-	genome = 6
-	mutations = list(/datum/plantmutation/beans/jelly)
-	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/metabolism_slow)
-	assoc_reagents = list("nitrogen")
-
-/datum/plant/crop/peas
-	name = "Peas"
-	seedcolor = "#77AA77"
-	crop = /obj/item/reagent_containers/food/snacks/plant/peas
-	starthealth = 40
-	growtime = 50
-	harvtime = 130
-	cropsize = 2
-	harvests = 4
-	endurance = 0
-	vending = 1
-	genome = 8
-	mutations = list(/datum/plantmutation/peas/ammonia)
-	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/metabolism_slow)
-
-/datum/plant/crop/corn
-	name = "Corn"
-	seedcolor = "#FFFF00"
-	crop = /obj/item/reagent_containers/food/snacks/plant/corn
-	starthealth = 20
-	growtime = 60
-	harvtime = 110
-	cropsize = 3
-	harvests = 3
-	endurance = 2
-	genome = 10
-	mutations = list(/datum/plantmutation/corn/clear, /datum/plantmutation/corn/pepper)
-	commuts = list(/datum/plant_gene_strain/photosynthesis,/datum/plant_gene_strain/splicing/bad)
-	assoc_reagents = list("cornstarch")
-
 /datum/plant/crop/synthmeat
 	name = "Synthmeat"
 	seedcolor = "#550000"
@@ -183,21 +137,6 @@ ABSTRACT_TYPE(/datum/plant/crop)
 	genome = 8
 	commuts = list(/datum/plant_gene_strain/quality,/datum/plant_gene_strain/terminator)
 	assoc_reagents = list("sugar")
-
-/datum/plant/crop/soy
-	name = "Soybean"
-	seedcolor = "#CCCC88"
-	crop = /obj/item/reagent_containers/food/snacks/plant/soy
-	starthealth = 15
-	growtime = 60
-	harvtime = 105
-	cropsize = 4
-	harvests = 3
-	endurance = 1
-	genome = 7
-	commuts = list(/datum/plant_gene_strain/metabolism_fast,/datum/plant_gene_strain/quality/inferior)
-	assoc_reagents = list("grease")
-	mutations = list(/datum/plantmutation/soy/soylent)
 
 /datum/plant/crop/peanut
 	name = "Peanut"

--- a/code/modules/hydroponics/plants_fruit.dm
+++ b/code/modules/hydroponics/plants_fruit.dm
@@ -359,3 +359,17 @@ ABSTRACT_TYPE(/datum/plant/fruit)
 	nectarlevel = 10
 	assoc_reagents = list("juice_peach")
 	commuts = list(/datum/plant_gene_strain/quality)
+
+/datum/plant/fruit/cucumber
+	name = "Cucumber"
+	seedcolor = "#005622"
+	crop = /obj/item/reagent_containers/food/snacks/plant/cucumber
+	starthealth = 25
+	growtime = 50
+	harvtime = 100
+	cropsize = 8
+	harvests = 1
+	isgrass = 1
+	endurance = 6
+	genome = 19
+	commuts = list(/datum/plant_gene_strain/damage_res,/datum/plant_gene_strain/stabilizer)

--- a/code/modules/hydroponics/plants_veg.dm
+++ b/code/modules/hydroponics/plants_veg.dm
@@ -102,3 +102,64 @@ ABSTRACT_TYPE(/datum/plant/veg)
 	genome = 13
 	commuts = list(/datum/plant_gene_strain/metabolism_slow,/datum/plant_gene_strain/immunity_toxin)
 	assoc_reagents = list("currypowder")
+
+/datum/plant/veg/beans
+	name = "Bean"
+	seedcolor = "#AA7777"
+	crop = /obj/item/reagent_containers/food/snacks/plant/bean
+	starthealth = 40
+	growtime = 50
+	harvtime = 130
+	cropsize = 2
+	harvests = 4
+	endurance = 0
+	vending = 1
+	genome = 6
+	mutations = list(/datum/plantmutation/beans/jelly)
+	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/metabolism_slow)
+	assoc_reagents = list("nitrogen")
+
+/datum/plant/veg/peas
+	name = "Peas"
+	seedcolor = "#77AA77"
+	crop = /obj/item/reagent_containers/food/snacks/plant/peas
+	starthealth = 40
+	growtime = 50
+	harvtime = 130
+	cropsize = 2
+	harvests = 4
+	endurance = 0
+	vending = 1
+	genome = 8
+	mutations = list(/datum/plantmutation/peas/ammonia)
+	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/metabolism_slow)
+
+/datum/plant/veg/corn
+	name = "Corn"
+	seedcolor = "#FFFF00"
+	crop = /obj/item/reagent_containers/food/snacks/plant/corn
+	starthealth = 20
+	growtime = 60
+	harvtime = 110
+	cropsize = 3
+	harvests = 3
+	endurance = 2
+	genome = 10
+	mutations = list(/datum/plantmutation/corn/clear, /datum/plantmutation/corn/pepper)
+	commuts = list(/datum/plant_gene_strain/photosynthesis,/datum/plant_gene_strain/splicing/bad)
+	assoc_reagents = list("cornstarch")
+
+/datum/plant/veg/soy
+	name = "Soybean"
+	seedcolor = "#CCCC88"
+	crop = /obj/item/reagent_containers/food/snacks/plant/soy
+	starthealth = 15
+	growtime = 60
+	harvtime = 105
+	cropsize = 4
+	harvests = 3
+	endurance = 1
+	genome = 7
+	commuts = list(/datum/plant_gene_strain/metabolism_fast,/datum/plant_gene_strain/quality/inferior)
+	assoc_reagents = list("grease")
+	mutations = list(/datum/plantmutation/soy/soylent)

--- a/code/modules/hydroponics/plants_veg.dm
+++ b/code/modules/hydroponics/plants_veg.dm
@@ -17,20 +17,6 @@ ABSTRACT_TYPE(/datum/plant/veg)
 	genome = 12
 	commuts = list(/datum/plant_gene_strain/reagent_adder,/datum/plant_gene_strain/damage_res/bad)
 
-/datum/plant/veg/cucumber
-	name = "Cucumber"
-	seedcolor = "#005622"
-	crop = /obj/item/reagent_containers/food/snacks/plant/cucumber
-	starthealth = 25
-	growtime = 50
-	harvtime = 100
-	cropsize = 8
-	harvests = 1
-	isgrass = 1
-	endurance = 6
-	genome = 19
-	commuts = list(/datum/plant_gene_strain/damage_res,/datum/plant_gene_strain/stabilizer)
-
 /datum/plant/veg/carrot
 	name = "Carrot"
 	seedcolor = "#774400"

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -184,7 +184,7 @@
 
 	crop
 		New()
-			spawn_plant = pick(/datum/plant/crop/cotton, /datum/plant/crop/oat, /datum/plant/crop/peanut, /datum/plant/crop/soy)
+			spawn_plant = pick(/datum/plant/crop/cotton, /datum/plant/crop/oat, /datum/plant/crop/peanut, /datum/plant/veg/soy)
 			..()
 
 	tree


### PR DESCRIPTION
## About the PR

Moves bean, corn, peas and soybean to vegetable from misc and moves cucumber from vegetable to fruit.

## Why's this needed?

That's what they are!


## Changelog
```changelog
(u)Shiiba
(+)Moves bean, corn, peas and soybean to the vegetable category and cucumber to the fruit category in the seed fabricator.
```
