### PR TITLE
Fix layer issue with machines that have pixel_x,y,z offset

### DIFF
--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -13,6 +13,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	flags = FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	object_flags = NO_GHOSTCRITTER
+	layer = STORAGE_LAYER
 	var/status = 0
 	var/power_usage = 0
 	var/power_channel = EQUIP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QoL]

Fixes: #11462

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the layer of machines slightly lower so that objects spawning on them don't get hidden behind them if the machine has a pixel_x,y,z offset.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oshan's chemlab's left chemmaster produces chemicals behind it because it's pixel_x is -4
