### PR TITLE
Change v_space type from datum to obj

### DIFF
--- a/code/datums/Vspace.dm
+++ b/code/datums/Vspace.dm
@@ -12,7 +12,7 @@
 
 	var/mob/living/user = usr
 	if (user.network_device)
-		var/datum/v_space/V
+		var/obj/v_space/V
 		V.Enter_Vspace(user, user.network_device)
 	return
 
@@ -24,7 +24,7 @@
 	if (!usr.client) return
 	if (!istype(usr, /mob/living/carbon/human/virtual/)) return
 
-	var/datum/v_space/V
+	var/obj/v_space/V
 	V.Leave_Vspace(usr)
 	return*/
 
@@ -47,9 +47,9 @@
 		Station_VNet.Leave_Vspace(user)
 		return
 
-var/global/datum/v_space/v_space_network/Station_VNet
+var/global/obj/v_space/v_space_network/Station_VNet
 
-datum/v_space
+obj/v_space
 	var
 		active = 0
 		list/users = list()			  //Who is in V-space

--- a/code/datums/controllers/process/machines.dm
+++ b/code/datums/controllers/process/machines.dm
@@ -12,7 +12,7 @@
 		name = "Machine"
 		schedule_interval = MACHINE_PROC_INTERVAL
 
-		Station_VNet = new /datum/v_space/v_space_network()
+		Station_VNet = new /obj/v_space/v_space_network()
 
 	copyStateFrom(datum/controller/process/target)
 		var/datum/controller/process/machines/old_machines = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters the type of v_space from datum to obj to fix an issue with the VR login process.

During login, there is a brief window where your character is generated but not placed within the virtual world; v_space creates this character inside src.

Because v_space was a datum and not an object, it could not physically contain this avatar during the transitional period, and dumped the avatar into the station Z-level at (182,57,1) regardless of its eventual destination.

Changing it to an object allows it to reside in nullspace, and in turn allows the avatar to be contained within nullspace for that transitive period, fixing this flaky and possibly exploitable behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cleans up a bit of fascinating jank that Nadir made more relevant.

Fixes #11467 