### PR TITLE
Allows items in pockets/hands/belts to hear chat

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3457,5 +3457,5 @@
 		src.belt?.hear_talk(M, text, real_name, lang_id)
 		src.r_hand?.hear_talk(M, text, real_name, lang_id)
 		src.l_hand?.hear_talk(M, text, real_name, lang_id)
-	..()
+	. = ..()
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3448,3 +3448,14 @@
 		. = id?.pronouns
 	if(isnull(.))
 		return ..()
+
+/mob/living/carbon/human/hear_talk(mob/M, text, real_name, lang_id) //Allows stuff in your hands/pockets/belt to pickup voice from other people
+	var/mob/self = src
+	if(M != self)	//So we dont hear ourselves twice
+		src.l_store?.hear_talk(M, text, real_name, lang_id)
+		src.r_store?.hear_talk(M, text, real_name, lang_id)
+		src.belt?.hear_talk(M, text, real_name, lang_id)
+		src.r_hand?.hear_talk(M, text, real_name, lang_id)
+		src.l_hand?.hear_talk(M, text, real_name, lang_id)
+	..()
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes hear_talk on humans to allow items located in that human's hand/pocket/belt to pick up sentences said by other mobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows players to sneakily use audio logs to record sentences without having to shamefully drop it on the ground.
Allows players to talk into another player's held microphone if they are within one tile of them.
Allows players to talk into another player's headset if the speaker is on. (If this causes too much spam as there is no range limit i could put one in place)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)You can now record sentences in audiologs if it is in your hand/pocket and talk into a microphone is someone is holding it close to you.
```
