### PR TITLE
Fixes cows insta-reacting with their own milk

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -71,6 +71,7 @@ datum
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
 				. = ..()
 				if(M.mob_flags & IS_BONEY)
+					. = FALSE
 					M.HealDamage("All", clamp(1 * volume, 0, 20), clamp(1 * volume, 0, 20)) //put a cap on instant healing
 					if(prob(15))
 						boutput(M, "<span class='notice'>The milk comforts your [pick("boanes","bones","bonez","boens","bowns","beaunes","brones","bonse")]!</span>")

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -69,7 +69,7 @@ datum
 				return
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
-				..()
+				. = ..()
 				if(M.mob_flags & IS_BONEY)
 					M.HealDamage("All", clamp(1 * volume, 0, 20), clamp(1 * volume, 0, 20)) //put a cap on instant healing
 					if(prob(15))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When cows *milk themselves they should leave a puddle of milk on the floor at their feet as it falls directly out of their bloodstream. However, current behaviour is bugged due to the milk instantly and completely reacting with the cow as a touch reaction with a volume fraction of 1 thereby seemingly preventing the milk from ever actually reaching the floor. 

This occurs because reaction_mob() is calling it's parent instead of returning it like all other touch chems.

This PR fixes the bugged behaviour by making reaction_mob() return its parent instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11035


