### PR TITLE
Adds sanitization to Trasnception Interlink

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -656,7 +656,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		var/list/manifest = known_pads[device_index]
 		for(var/field in manifest)
 			if(field != "INT_TARGETID")
-				minitext += "<strong>[field]</strong> &middot; [manifest[field]]<br>"
+				minitext += "<strong>[field]</strong> &middot; [strip_html(manifest[field])]<br>"
 		rollingtext += minitext
 		rollingtext += "<A href='[topicLink("send","\ref[device_index]")]'>Send</A> | "
 		rollingtext += "<A href='[topicLink("receive","\ref[device_index]")]'>Receive</A><br><br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Uses `strip_html()` on fields when they are displayed to the UI.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'd rather have sanitization on end devices rather than on packets themselves, seeing as the only place it matters is when it is displayed.