### PR TITLE
Nadir-friendly Trench Prefab Set: Miraclium Survey and Martian Glomp

### DIFF
--- a/assets/maps/prefabs/prefab_water_martian_glomp.dmm
+++ b/assets/maps/prefabs/prefab_water_martian_glomp.dmm
@@ -5,22 +5,6 @@
 "c" = (
 /turf/simulated/martian/floor,
 /area/prefab/martian_glomp)
-"e" = (
-/obj/indestructible/shuttle_corner{
-	dir = 10;
-	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
-	},
-/turf/simulated/martian/floor,
-/area/prefab/martian_glomp)
-"f" = (
-/obj/indestructible/shuttle_corner{
-	dir = 5;
-	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
-	},
-/turf/simulated/martian/floor,
-/area/prefab/martian_glomp)
 "g" = (
 /obj/map/light/white,
 /turf/unsimulated/wall/auto/adventure/martian,
@@ -62,20 +46,14 @@
 /area/prefab/martian_glomp)
 "t" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 10;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/floor,
 /area/noGenerate)
-"v" = (
-/obj/indestructible/shuttle_corner{
-	dir = 6;
-	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
-	},
-/turf/simulated/martian/floor,
-/area/prefab/martian_glomp)
 "w" = (
 /obj/decal/cleanable/slime,
 /obj/machinery/door/unpowered/martian,
@@ -83,17 +61,21 @@
 /area/prefab/martian_glomp)
 "x" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 9;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/floor,
 /area/noGenerate)
 "y" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 5;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/clear,
 /area/noGenerate)
@@ -108,9 +90,11 @@
 /area/prefab/martian_glomp)
 "D" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 10;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/clear,
 /area/noGenerate)
@@ -137,9 +121,11 @@
 /area/space)
 "K" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 9;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/clear,
 /area/noGenerate)
@@ -168,20 +154,14 @@
 /area/prefab/martian_glomp)
 "P" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 6;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/floor,
 /area/noGenerate)
-"Q" = (
-/obj/indestructible/shuttle_corner{
-	dir = 9;
-	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
-	},
-/turf/simulated/martian/floor,
-/area/prefab/martian_glomp)
 "R" = (
 /obj/decal/aliencomputer{
 	pixel_y = 32
@@ -202,9 +182,11 @@
 /area/prefab/martian_glomp)
 "T" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 5;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/floor,
 /area/noGenerate)
@@ -217,9 +199,11 @@
 /area/prefab/martian_glomp)
 "W" = (
 /obj/indestructible/shuttle_corner{
+	desc = "Grody. How long has this been here?";
 	dir = 6;
 	icon = 'icons/turf/walls_martian.dmi';
-	icon_state = "diagonal"
+	icon_state = "diagonal";
+	name = "withered wall"
 	},
 /turf/variableTurf/clear,
 /area/noGenerate)
@@ -269,10 +253,10 @@ a
 W
 O
 o
-Q
+o
 c
 Y
-e
+o
 o
 o
 a
@@ -285,7 +269,7 @@ c
 c
 c
 n
-e
+o
 o
 y
 "}
@@ -304,9 +288,9 @@ o
 (6,1,1) = {"
 a
 o
-f
+o
 S
-v
+o
 o
 w
 o
@@ -319,7 +303,7 @@ o
 o
 o
 o
-Q
+o
 r
 V
 j
@@ -341,12 +325,12 @@ o
 a
 a
 o
-f
+o
 M
 L
 C
 Z
-v
+o
 o
 "}
 (10,1,1) = {"
@@ -357,7 +341,7 @@ g
 N
 c
 c
-v
+o
 o
 o
 "}
@@ -366,9 +350,9 @@ a
 a
 o
 o
-f
+o
 c
-v
+o
 o
 o
 K

--- a/assets/maps/prefabs/prefab_water_martian_glomp.dmm
+++ b/assets/maps/prefabs/prefab_water_martian_glomp.dmm
@@ -1,0 +1,396 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/variableTurf/clear,
+/area/space)
+"c" = (
+/turf/simulated/martian/floor,
+/area/space)
+"e" = (
+/obj/indestructible/shuttle_corner{
+	dir = 10;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"f" = (
+/obj/indestructible/shuttle_corner{
+	dir = 5;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"g" = (
+/obj/map/light/white,
+/turf/unsimulated/wall/auto/adventure/martian,
+/area/space)
+"i" = (
+/turf/variableTurf/floor,
+/area/noGenerate)
+"j" = (
+/obj/decal/aliencomputer{
+	pixel_x = -32
+	},
+/obj/overlay{
+	desc = "The corpse of a long dead space thing.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "marscorpse";
+	name = "dead martian"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"n" = (
+/obj/item/reagent_containers/food/snacks/yuck{
+	desc = "It's a bad day if you have to eat this for dinner.";
+	doants = 0
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"r" = (
+/obj/decal/cleanable/slime,
+/turf/simulated/martian/floor,
+/area/space)
+"s" = (
+/obj/crevice{
+	pixel_y = 30
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"t" = (
+/obj/indestructible/shuttle_corner{
+	dir = 10;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/floor,
+/area/noGenerate)
+"v" = (
+/obj/indestructible/shuttle_corner{
+	dir = 6;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"w" = (
+/obj/decal/cleanable/slime,
+/obj/machinery/door/unpowered/martian,
+/turf/simulated/martian/floor,
+/area/space)
+"x" = (
+/obj/indestructible/shuttle_corner{
+	dir = 9;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/floor,
+/area/noGenerate)
+"y" = (
+/obj/indestructible/shuttle_corner{
+	dir = 5;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"z" = (
+/obj/machinery/door/unpowered/martian,
+/turf/simulated/martian/floor,
+/area/space)
+"C" = (
+/obj/critter/martian/warrior/dead,
+/obj/decal/cleanable/slime,
+/turf/simulated/martian/floor,
+/area/space)
+"D" = (
+/obj/indestructible/shuttle_corner{
+	dir = 10;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"E" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "Some type of martian gewgaw, perhaps a gimcrack or bauble.";
+	icon = 'icons/obj/artifacts/artifacts.dmi';
+	icon_state = "martian-3";
+	name = "martian machine"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"G" = (
+/obj/crevice{
+	pixel_y = 30
+	},
+/obj/item/material_piece/bone,
+/turf/simulated/martian/floor,
+/area/space)
+"J" = (
+/turf/unsimulated/wall/auto/adventure/martian,
+/area/space)
+"K" = (
+/obj/indestructible/shuttle_corner{
+	dir = 9;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"L" = (
+/obj/decal/cleanable/generic{
+	desc = "Tiny bits of bone strewn about.";
+	name = "bone fragments"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"M" = (
+/obj/item/material_piece/bone{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"N" = (
+/obj/decal/aliencomputer{
+	pixel_y = 32
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"O" = (
+/turf/unsimulated/wall/auto/adventure/martian/exterior,
+/area/space)
+"P" = (
+/obj/indestructible/shuttle_corner{
+	dir = 6;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/floor,
+/area/noGenerate)
+"Q" = (
+/obj/indestructible/shuttle_corner{
+	dir = 9;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"R" = (
+/obj/decal/aliencomputer{
+	pixel_y = 32
+	},
+/obj/landmark/artifact,
+/turf/simulated/martian/floor,
+/area/space)
+"S" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "Okay, you're pretty sure that even the martians didn't know what this thing is.";
+	icon = 'icons/obj/artifacts/artifacts.dmi';
+	icon_state = "martian-4";
+	name = "martian machine"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+"T" = (
+/obj/indestructible/shuttle_corner{
+	dir = 5;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/floor,
+/area/noGenerate)
+"V" = (
+/obj/crevice{
+	pixel_x = -30
+	},
+/obj/critter/martian/soldier/dead,
+/turf/simulated/martian/floor,
+/area/space)
+"W" = (
+/obj/indestructible/shuttle_corner{
+	dir = 6;
+	icon = 'icons/turf/walls_martian.dmi';
+	icon_state = "diagonal"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"X" = (
+/obj/critter/martian/soldier/dead,
+/turf/simulated/martian/floor,
+/area/space)
+"Y" = (
+/obj/landmark/artifact,
+/turf/simulated/martian/floor,
+/area/space)
+"Z" = (
+/obj/overlay{
+	desc = "The corpse of a long dead space thing.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "marscorpse";
+	name = "dead martian"
+	},
+/turf/simulated/martian/floor,
+/area/space)
+
+(1,1,1) = {"
+a
+a
+W
+T
+i
+P
+J
+y
+a
+a
+"}
+(2,1,1) = {"
+a
+W
+O
+J
+z
+J
+J
+J
+y
+a
+"}
+(3,1,1) = {"
+W
+O
+J
+Q
+c
+Y
+e
+J
+J
+a
+"}
+(4,1,1) = {"
+O
+g
+R
+c
+c
+c
+n
+e
+J
+y
+"}
+(5,1,1) = {"
+D
+O
+s
+c
+c
+c
+r
+E
+J
+J
+"}
+(6,1,1) = {"
+a
+J
+f
+S
+v
+J
+w
+J
+g
+J
+"}
+(7,1,1) = {"
+a
+J
+J
+J
+J
+Q
+r
+V
+j
+J
+"}
+(8,1,1) = {"
+a
+D
+J
+G
+L
+c
+r
+n
+X
+J
+"}
+(9,1,1) = {"
+a
+a
+J
+f
+M
+L
+C
+Z
+v
+J
+"}
+(10,1,1) = {"
+a
+a
+J
+g
+N
+c
+c
+v
+J
+J
+"}
+(11,1,1) = {"
+a
+a
+J
+J
+f
+c
+v
+J
+J
+K
+"}
+(12,1,1) = {"
+a
+a
+D
+J
+J
+z
+J
+J
+K
+a
+"}
+(13,1,1) = {"
+a
+a
+a
+D
+x
+i
+t
+K
+a
+a
+"}

--- a/assets/maps/prefabs/prefab_water_martian_glomp.dmm
+++ b/assets/maps/prefabs/prefab_water_martian_glomp.dmm
@@ -4,7 +4,7 @@
 /area/space)
 "c" = (
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "e" = (
 /obj/indestructible/shuttle_corner{
 	dir = 10;
@@ -12,7 +12,7 @@
 	icon_state = "diagonal"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "f" = (
 /obj/indestructible/shuttle_corner{
 	dir = 5;
@@ -20,11 +20,11 @@
 	icon_state = "diagonal"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "g" = (
 /obj/map/light/white,
 /turf/unsimulated/wall/auto/adventure/martian,
-/area/space)
+/area/prefab/martian_glomp)
 "i" = (
 /turf/variableTurf/floor,
 /area/noGenerate)
@@ -39,24 +39,27 @@
 	name = "dead martian"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "n" = (
 /obj/item/reagent_containers/food/snacks/yuck{
 	desc = "It's a bad day if you have to eat this for dinner.";
 	doants = 0
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
+"o" = (
+/turf/unsimulated/wall/auto/adventure/martian,
+/area/prefab/martian_glomp)
 "r" = (
 /obj/decal/cleanable/slime,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "s" = (
 /obj/crevice{
 	pixel_y = 30
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "t" = (
 /obj/indestructible/shuttle_corner{
 	dir = 10;
@@ -72,12 +75,12 @@
 	icon_state = "diagonal"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "w" = (
 /obj/decal/cleanable/slime,
 /obj/machinery/door/unpowered/martian,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "x" = (
 /obj/indestructible/shuttle_corner{
 	dir = 9;
@@ -97,12 +100,12 @@
 "z" = (
 /obj/machinery/door/unpowered/martian,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "C" = (
 /obj/critter/martian/warrior/dead,
 /obj/decal/cleanable/slime,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "D" = (
 /obj/indestructible/shuttle_corner{
 	dir = 10;
@@ -121,14 +124,14 @@
 	name = "martian machine"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "G" = (
 /obj/crevice{
 	pixel_y = 30
 	},
 /obj/item/material_piece/bone,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "J" = (
 /turf/unsimulated/wall/auto/adventure/martian,
 /area/space)
@@ -146,23 +149,23 @@
 	name = "bone fragments"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "M" = (
 /obj/item/material_piece/bone{
 	pixel_x = -9;
 	pixel_y = 6
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "N" = (
 /obj/decal/aliencomputer{
 	pixel_y = 32
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "O" = (
 /turf/unsimulated/wall/auto/adventure/martian/exterior,
-/area/space)
+/area/prefab/martian_glomp)
 "P" = (
 /obj/indestructible/shuttle_corner{
 	dir = 6;
@@ -178,14 +181,14 @@
 	icon_state = "diagonal"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "R" = (
 /obj/decal/aliencomputer{
 	pixel_y = 32
 	},
 /obj/landmark/artifact,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "S" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -196,7 +199,7 @@
 	name = "martian machine"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "T" = (
 /obj/indestructible/shuttle_corner{
 	dir = 5;
@@ -211,7 +214,7 @@
 	},
 /obj/critter/martian/soldier/dead,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "W" = (
 /obj/indestructible/shuttle_corner{
 	dir = 6;
@@ -223,11 +226,11 @@
 "X" = (
 /obj/critter/martian/soldier/dead,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "Y" = (
 /obj/landmark/artifact,
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 "Z" = (
 /obj/overlay{
 	desc = "The corpse of a long dead space thing.";
@@ -236,7 +239,7 @@
 	name = "dead martian"
 	},
 /turf/simulated/martian/floor,
-/area/space)
+/area/prefab/martian_glomp)
 
 (1,1,1) = {"
 a
@@ -254,24 +257,24 @@ a
 a
 W
 O
-J
+o
 z
-J
-J
-J
+o
+o
+o
 y
 a
 "}
 (3,1,1) = {"
 W
 O
-J
+o
 Q
 c
 Y
 e
-J
-J
+o
+o
 a
 "}
 (4,1,1) = {"
@@ -283,7 +286,7 @@ c
 c
 n
 e
-J
+o
 y
 "}
 (5,1,1) = {"
@@ -295,90 +298,90 @@ c
 c
 r
 E
-J
-J
+o
+o
 "}
 (6,1,1) = {"
 a
-J
+o
 f
 S
 v
-J
+o
 w
-J
+o
 g
-J
+o
 "}
 (7,1,1) = {"
 a
-J
-J
-J
-J
+o
+o
+o
+o
 Q
 r
 V
 j
-J
+o
 "}
 (8,1,1) = {"
 a
 D
-J
+o
 G
 L
 c
 r
 n
 X
-J
+o
 "}
 (9,1,1) = {"
 a
 a
-J
+o
 f
 M
 L
 C
 Z
 v
-J
+o
 "}
 (10,1,1) = {"
 a
 a
-J
+o
 g
 N
 c
 c
 v
-J
-J
+o
+o
 "}
 (11,1,1) = {"
 a
 a
-J
-J
+o
+o
 f
 c
 v
-J
-J
+o
+o
 K
 "}
 (12,1,1) = {"
 a
 a
 D
-J
-J
+o
+o
 z
-J
-J
+o
+o
 K
 a
 "}

--- a/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
+++ b/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
@@ -9,52 +9,76 @@
 	name = "surveyors' stripe"
 	},
 /obj/machinery/tripod,
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
+"i" = (
+/obj/item/device/audio_log/miraclium_survey,
+/turf/space/fluid/trench,
+/area/noGenerate)
 "o" = (
-/turf/variableTurf/floor,
-/area/space)
+/obj/random_item_spawner/tools/one,
+/turf/space/fluid/trench,
+/area/noGenerate)
 "s" = (
 /obj/decal/cleanable/machine_debris{
 	desc = "A pile that was probably a machine at some point."
 	},
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
+"A" = (
+/obj/item/mining_tool/drill,
+/turf/space/fluid/trench,
+/area/noGenerate)
+"C" = (
+/turf/space/fluid/trench,
+/area/noGenerate)
+"D" = (
+/obj/item/breaching_charge/mining,
+/turf/space/fluid/trench,
+/area/noGenerate)
 "E" = (
 /obj/decal/cleanable/dirt/dirt2,
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "F" = (
 /obj/decal/fakeobjects/beacon{
 	desc = "A small tracking beacon in fairly poor condition. Nothing in the surroundings should have disturbed it - what broke it?"
 	},
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "K" = (
 /obj/item/tripod,
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "O" = (
 /obj/item/raw_material/miracle,
-/turf/variableTurf/floor,
-/area/space)
+/turf/space/fluid/trench,
+/area/noGenerate)
+"Q" = (
+/obj/item/device/t_scanner,
+/turf/space/fluid/trench,
+/area/noGenerate)
+"R" = (
+/obj/item/device/gps,
+/turf/space/fluid/trench,
+/area/noGenerate)
 
 (1,1,1) = {"
 a
-o
+C
 a
 a
 a
 "}
 (2,1,1) = {"
-o
+C
 F
-o
+A
 a
 a
 "}
 (3,1,1) = {"
-o
+i
 E
 O
 o
@@ -62,15 +86,15 @@ K
 "}
 (4,1,1) = {"
 a
-o
+Q
 c
-o
+C
 E
 "}
 (5,1,1) = {"
 a
-o
-o
+C
+D
 O
 a
 "}
@@ -84,7 +108,7 @@ a
 (7,1,1) = {"
 a
 a
-o
+R
 a
 a
 "}

--- a/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
+++ b/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
@@ -1,0 +1,90 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/variableTurf/clear,
+/area/space)
+"c" = (
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "bot2";
+	name = "surveyors' stripe"
+	},
+/obj/machinery/tripod,
+/turf/variableTurf/floor,
+/area/space)
+"o" = (
+/turf/variableTurf/floor,
+/area/space)
+"s" = (
+/obj/decal/cleanable/machine_debris{
+	desc = "A pile that was probably a machine at some point."
+	},
+/turf/variableTurf/floor,
+/area/space)
+"E" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/variableTurf/floor,
+/area/space)
+"F" = (
+/obj/decal/fakeobjects/beacon{
+	desc = "A small tracking beacon in fairly poor condition. Nothing in the surroundings should have disturbed it - what broke it?"
+	},
+/turf/variableTurf/floor,
+/area/space)
+"K" = (
+/obj/item/tripod,
+/turf/variableTurf/floor,
+/area/space)
+"O" = (
+/obj/item/raw_material/miracle,
+/turf/variableTurf/floor,
+/area/space)
+
+(1,1,1) = {"
+a
+o
+a
+a
+a
+"}
+(2,1,1) = {"
+o
+F
+o
+a
+a
+"}
+(3,1,1) = {"
+o
+E
+O
+o
+K
+"}
+(4,1,1) = {"
+a
+o
+c
+o
+E
+"}
+(5,1,1) = {"
+a
+o
+o
+O
+a
+"}
+(6,1,1) = {"
+a
+a
+E
+s
+a
+"}
+(7,1,1) = {"
+a
+a
+o
+a
+a
+"}

--- a/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
+++ b/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
@@ -9,58 +9,84 @@
 	name = "surveyors' stripe"
 	},
 /obj/machinery/tripod,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "i" = (
 /obj/item/device/audio_log/miraclium_survey,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "o" = (
 /obj/random_item_spawner/tools/one,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "s" = (
 /obj/decal/cleanable/machine_debris{
 	desc = "A pile that was probably a machine at some point."
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "A" = (
 /obj/item/mining_tool/drill,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "C" = (
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "D" = (
 /obj/item/breaching_charge/mining,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "E" = (
 /obj/decal/cleanable/dirt/dirt2,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "F" = (
 /obj/decal/fakeobjects/beacon{
 	desc = "A small tracking beacon in fairly poor condition. Nothing in the surroundings should have disturbed it - what broke it?"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "K" = (
 /obj/item/tripod,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "O" = (
 /obj/item/raw_material/miracle,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "Q" = (
 /obj/item/device/t_scanner,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 "R" = (
 /obj/item/device/gps,
-/turf/space/fluid/trench,
+/turf/space/fluid/trench{
+	spawningFlags = null
+	},
 /area/noGenerate)
 
 (1,1,1) = {"

--- a/code/area.dm
+++ b/code/area.dm
@@ -1427,6 +1427,10 @@ ABSTRACT_TYPE(/area/prefab)
 	icon_state = "red"
 	sound_environment = 2
 
+/area/prefab/martian_glomp
+	name = "Martian Mass"
+	icon_state = "red"
+
 /area/prefab/mobius
 	name = "Mobius Strip Mall"
 	icon_state = "purple"

--- a/code/modules/worldgen/prefab/mining.dm
+++ b/code/modules/worldgen/prefab/mining.dm
@@ -531,7 +531,7 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 	martian_glomp // Martian glomp (boarding pod? escape pod? you decide) that ended up very stranded
 		underwater = 1
 		maxNum = 1
-		probability = 100 //DEBUG DEBUG DEBUG
+		probability = 30
 		prefabPath = "assets/maps/prefabs/prefab_water_martian_glomp.dmm"
 		prefabSizeX = 13
 		prefabSizeY = 10

--- a/code/modules/worldgen/prefab/mining.dm
+++ b/code/modules/worldgen/prefab/mining.dm
@@ -300,6 +300,14 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 		prefabPath = "assets/maps/prefabs/prefab_water_nadirelevator.dmm" //also sneakily contains diner and siphon shaft cover
 		prefabSizeX = 46
 		prefabSizeY = 41
+
+	miracliumsurvey
+		underwater = 1
+		maxNum = 1
+		probability = 100
+		prefabPath = "assets/maps/prefabs/prefab_water_miraclium_survey.dmm"
+		prefabSizeX = 6
+		prefabSizeY = 3
 #endif
 
 //nadir shouldn't have most general prefabs due to circumstances of trench
@@ -519,6 +527,14 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 		prefabPath = "assets/maps/prefabs/prefab_water_ydrone.dmm"
 		prefabSizeX = 15
 		prefabSizeY = 15
+
+	martian_glomp // Martian glomp (boarding pod? escape pod? you decide) that ended up very stranded
+		underwater = 1
+		maxNum = 1
+		probability = 100 //DEBUG DEBUG DEBUG
+		prefabPath = "assets/maps/prefabs/prefab_water_martian_glomp.dmm"
+		prefabSizeX = 13
+		prefabSizeY = 10
 
 #if defined(MAP_OVERRIDE_OSHAN)
 	sea_miner

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -429,3 +429,39 @@
 								"Electronic Voice",
 								"???")
 
+// prefab_water_miraclium_survey.dmm
+// nadir: survey site where the big ol' miraclium deposit was located
+
+/obj/item/device/audio_log/miraclium_survey
+
+		name = "hardened audio log"
+		desc = "A fairly spartan recording device. It seems to be constructed of non-standard materials, with an unfamiliar connector."
+		continuous = 0
+		audiolog_messages = list("Begin log. Technician Reed, survey report, site 2a.",
+								"Deep-crust probe reported improved density over site 1e.",
+								"Anomalous mineral yields estimated-",
+								"*loud clattering noise*",
+								"HARRY! GET YOUR ASS OVER HERE!",
+								"What the hell, Steve? I'm in the middle of a report!",
+								"Dude. We found the big one. Like, the REALLY big one.",
+								"*muffled footsteps*",
+								"Holy shit, you weren't kidding. Gimme one of those.",
+								"*loud thump*",
+								"Goddamn. That's the real deal. Rainbow rocks.",
+								"Let's get the hell back home. I can already taste the burger.",
+								"Shouldn't we grab the log? The tools?",
+								"Nobody's gonna give a shit about those. We found it.")
+		audiolog_speakers = list("gruff male voice",
+								"gruff male voice",
+								"gruff male voice",
+								"???",
+								"young male voice",
+								"gruff male voice",
+								"young male voice",
+								"???",
+								"gruff male voice",
+								"???",
+								"gruff male voice",
+								"gruff male voice",
+								"young male voice",
+								"gruff male voice")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds two new trench prefabs, one for all underwater maps and one Nadir-exclusive; will likely be the first in a series of such PRs I make, depending on how many ideas I can come up with, and is the next step after my previous "permissible trench prefab adjustment" PR.

### Miraclium Survey

**Appears only on Nadir - Very small prefab (6x3) - 100% spawn chance**

![miraclium_survey](https://user-images.githubusercontent.com/12454065/197097539-95ff6770-d589-45e5-a6d1-c5d4f85e8d7a.png)

Remote surveying was able to find the right area, but pinpointing the Miraclium deposit the probes indicated took some legwork from Nanotrasen personnel. You've stumbled upon the remnants of that expedition.

### Martian Glomp

**Appears on any trench map - Small prefab (13x10) - 30% spawn chance**

![martian_glomp](https://user-images.githubusercontent.com/12454065/197097898-53d6d6d3-a292-4257-a3b6-a25f1ed40074.png)

A chunk of Martian biological structure lies dormant at the bottom of the trench, its occupants - and whatever their mission may have been - long since expired. Remnants strewn about tell a grim story.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves the variety of available trench prefabs, particularly of note on Nadir due to its reduced prefab selection.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Added two new trench prefabs to explore, a Martian remnant for all underwater maps and a Nadir-exclusive piece of history.
```
