### PR TITLE
Adds sanitization to Siphon Controls

### DIFF
--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -287,7 +287,7 @@
 			if(field == "Intensity")
 				var/maxintens = manifest["Maximum Intensity"]
 				intensity_sum += manifest[field]
-				minitext += "<strong>[field]</strong> &middot; [manifest[field]][maxintens ? " / [maxintens]" : ""] "
+				minitext += "<strong>[field]</strong> &middot; [strip_html(manifest[field])][maxintens ? " / [maxintens]" : ""] "
 				minitext += "<A href='[topicLink("calibrate","\ref[device_index]")]'>(Calibrate)</A><br>"
 			else if(field != "INT_TARGETID" && field != "Maximum Intensity")
 				if(field == "Identifier" && manifest[field] == "SIPHON") saveforsiphon = TRUE

--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -291,7 +291,7 @@
 				minitext += "<A href='[topicLink("calibrate","\ref[device_index]")]'>(Calibrate)</A><br>"
 			else if(field != "INT_TARGETID" && field != "Maximum Intensity")
 				if(field == "Identifier" && manifest[field] == "SIPHON") saveforsiphon = TRUE
-				minitext += "<strong>[field]</strong> &middot; [manifest[field]]<br>"
+				minitext += "<strong>[field]</strong> &middot; [strip_html(manifest[field])]<br>"
 		if(saveforsiphon)
 			mainlist += minitext
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Uses strip_html() on fields when they are displayed to the UI.

Wasn't sure whether intensity needed sanitization but I think its needed?