### PR TITLE
Gives critter skeletons calcium blood

### DIFF
--- a/code/mob/living/critter/skeleton.dm
+++ b/code/mob/living/critter/skeleton.dm
@@ -38,7 +38,7 @@
 	can_throw = 1
 	can_grab = 1
 	can_disarm = 1
-	blood_id = null
+	blood_id = "calcium"
 	burning_suffix = "humanoid"
 	metabolizes = 0
 	mob_flags = IS_BONEY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Critter skeletons currently bleed normal blood.

This PR makes them bleed calcium blood instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency with player skeletons.