### PR TITLE
Fixes critter hud slots not stacking correctly

### DIFF
--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -107,9 +107,9 @@
 	var/y_offset = 0
 
 	if (next_left_offset < 0)
-		x_offset = next_left_offset
+		x_offset = next_left_offset + src.wraparound_offset_left
 	else if (next_left_offset > 0)
-		x_offset = "+[next_left_offset]"
+		x_offset = "+[next_left_offset + src.wraparound_offset_left]"
 	else
 		x_offset = ""
 
@@ -134,9 +134,9 @@
 	var/y_offset = 0
 
 	if (next_right_offset < 0)
-		x_offset = next_right_offset
+		x_offset = next_right_offset - src.wraparound_offset_right
 	else if (next_right_offset > 0)
-		x_offset = "+[next_right_offset]"
+		x_offset = "+[next_right_offset - src.wraparound_offset_right]"
 	else
 		x_offset = ""
 

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -95,7 +95,7 @@
 
 /// gets the leftmost screen loc
 /datum/hud/critter/proc/loc_left()
-	if (src.left_offset < -6) // wraps vertically if the magnitude of left offset is greater than 6
+	if (src.left_offset < -9) // wraps vertically if the magnitude of left offset is greater than 6
 		src.wraparound_offset_left++
 
 	var/next_left_offset = src.next_left()
@@ -118,7 +118,7 @@
 
 /// gets the rightmost screen loc
 /datum/hud/critter/proc/loc_right()
-	if (src.right_offset > 6) // wraps vertically if the magnitude of right offset is greater than 6
+	if (src.right_offset > 9) // wraps vertically if the magnitude of right offset is greater than 6
 		src.wraparound_offset_right++
 
 	var/next_right_offset = src.next_right()

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -97,10 +97,6 @@
 /datum/hud/critter/proc/loc_left()
 	if (src.left_offset < -6) // wraps vertically if the magnitude of left offset is greater than 6
 		src.wraparound_offset_left++
-		if (src.wraparound_offset_right < src.wraparound_offset_left)
-			src.right_offset = 0
-		else
-			src.right_offset = -1
 
 	var/next_left_offset = src.next_left()
 	var/x_offset = 0
@@ -124,10 +120,6 @@
 /datum/hud/critter/proc/loc_right()
 	if (src.right_offset > 6) // wraps vertically if the magnitude of right offset is greater than 6
 		src.wraparound_offset_right++
-		if (src.wraparound_offset_left < src.wraparound_offset_right)
-			src.right_offset = 0
-		else
-			src.right_offset = 1
 
 	var/next_right_offset = src.next_right()
 	var/x_offset = 0

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -118,7 +118,7 @@
 
 /// gets the rightmost screen loc
 /datum/hud/critter/proc/loc_right()
-	if (src.right_offset > 9) // Wraps vertically if the magnitude of right offset is greater than 8. Leave a 2 space column for the leave pod button.
+	if (src.right_offset > 9) // Wraps vertically if the magnitude of right offset is greater than 8. Leave a 1 space column for the leave pod button.
 		src.wraparound_offset_right++
 
 	var/next_right_offset = src.next_right()

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -118,7 +118,7 @@
 
 /// gets the rightmost screen loc
 /datum/hud/critter/proc/loc_right()
-	if (src.right_offset > 8) // Wraps vertically if the magnitude of right offset is greater than 8. Leave a 2 space column for the leave pod button.
+	if (src.right_offset > 9) // Wraps vertically if the magnitude of right offset is greater than 8. Leave a 2 space column for the leave pod button.
 		src.wraparound_offset_right++
 
 	var/next_right_offset = src.next_right()

--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -95,7 +95,7 @@
 
 /// gets the leftmost screen loc
 /datum/hud/critter/proc/loc_left()
-	if (src.left_offset < -9) // wraps vertically if the magnitude of left offset is greater than 6
+	if (src.left_offset < -9) // Wraps vertically if the magnitude of left offset is greater than 9. Leave a 1 space column for storage containers.
 		src.wraparound_offset_left++
 
 	var/next_left_offset = src.next_left()
@@ -118,7 +118,7 @@
 
 /// gets the rightmost screen loc
 /datum/hud/critter/proc/loc_right()
-	if (src.right_offset > 9) // wraps vertically if the magnitude of right offset is greater than 6
+	if (src.right_offset > 8) // Wraps vertically if the magnitude of right offset is greater than 8. Leave a 2 space column for the leave pod button.
 		src.wraparound_offset_right++
 
 	var/next_right_offset = src.next_right()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When critters are given many HUD slots (like skeletons with their many head equipment slots) the slots are supposed to stack vertically when 6 or more are added from the left or the right.

Currently, this doesn't quite happen correctly due to some issues with the additive logic, the coords go:
-5,0
-6,0
-7,1
-8,2

This PR fixes the logic, making the coords go:
-5,0
-6,0
-6,1
-6,2

In addition, this PR also increases the number of horizontal slots before we start stacking vertically - from 6 either side to 9 either side. A gap of 1 space is left either side to account for storage containers (left side) and the leave pod button (right side).

See comments for pictures.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11490
