### PR TITLE
Fixes barcodes not splitting artefact sale profits

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -314,7 +314,7 @@
 				src.artifacts_on_the_way = FALSE
 
 		// sell
-		if (scan & account)
+		if (scan && account)
 			wagesystem.shipping_budget += price / 2
 			account["current_money"] += price / 2
 		else

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -276,6 +276,8 @@
 		var/price = 0
 		var/modifier = sell_art_datum.get_rarity_modifier()
 		var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
+		var/obj/item/card/id/scan = sell_art_datum.scan
+		var/datum/db_record/account = sell_art_datum.account
 
 		// calculate price
 		price = calculate_artifact_price(modifier, max(pap?.lastAnalysis, 1))
@@ -312,7 +314,11 @@
 				src.artifacts_on_the_way = FALSE
 
 		// sell
-		wagesystem.shipping_budget += price
+		if (scan & account)
+			wagesystem.shipping_budget += price / 2
+			account["current_money"] += price / 2
+		else
+			wagesystem.shipping_budget += price
 		qdel(sell_art)
 
 		// give PDA group messages

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -73,6 +73,11 @@ ABSTRACT_TYPE(/datum/artifact/)
 	/// An additional message displayed when examining, to hint at the artifact type (mainly used for more dangerous types)
 	var/examine_hint = null
 
+	/// ID of the cargo tech skimming a cut of the sale
+	var/obj/item/card/id/scan = null
+	/// Bank account info of the cargo tech skimming a cut of the sale
+	var/datum/db_record/account = null
+
 	/// The health of the artifact, can be damaged by stimuli, chems, etc
 	/// When it hits 0, the artifact will be destroyed (after triggering ArtifactDestroyed())
 	var/health = 100

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -483,6 +483,18 @@
 						poy = text2num(params["icon-y"]) - 16 //round(A.bound_height/2)
 						DEBUG_MESSAGE("pox [pox] poy [poy]")
 				src.stick_to(target, pox, poy, user)
+			if(isobj(target))
+				var/obj/O = target
+				if(O.artifact)
+					var/datum/artifact/art = O.artifact
+					art.scan = src.scan
+					art.account = src.account
+					boutput(user, "<span class='notice'>[target] has been marked with your account routing information.</span>")
+					if(art.examine_hint)
+						art.examine_hint += " [target] belongs to [scan.registered]."
+					else
+						art.examine_hint = "[target] belongs to [scan.registered]."
+
 		return
 
 	mouse_drop(atom/over_object, src_location, over_location, over_control, params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When selling crates via cargo, QM's can skim half the profits by scanning their ID into the barcode computer and affixing the barcode on the crate being sold.

This behaviour is currently only coded for obj/storage/crate, so artefact sales can't take advantage of it.

This PR adds the necessary code to allow cargotechs to now skim profits from artefacts by attaching a registered barcode to it in the same way as crate sales. Note that barcodes are otherwise unnecessary when selling identified artefacts. Artefacts still need to be identified with forms or they are worthless.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10961
