### PR TITLE
Let cyborgs use their beakers in Reagent Extractors

### DIFF
--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -852,7 +852,7 @@
 
 		if(!W.cant_drop)
 			user.drop_item()
-			if(!W.qdeled)
+			if(!QDELETED(W))
 				W.set_loc(src)
 		if(W.qdeled)
 			W = null

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -854,7 +854,7 @@
 			user.drop_item()
 			if(!QDELETED(W))
 				W.set_loc(src)
-		if(W.qdeled)
+		if(QDELETED(W))
 			W = null
 		else
 			if(!src.extract_to) src.extract_to = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL][BORGS][CHEMISTRY]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Let cyborgs use their beakers in Reagent Extractors.
Copied the approach the Chemical Dispenser uses for it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Chemistry Cyborgs can't use the reagent extractor to produce chemicals. They can use all the functions of the reagent extractor but need a human to put a container inside the reagent extractor.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Cyborgs can now use their beakers in the reagent extractor.
```
