### PR TITLE
Fixes fishing abstract records from spatial tears

### DIFF
--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -89,24 +89,13 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/spatial_tear
 	fishing_atom_type = /obj/forcefield/event
 	fish_available = list(/obj/item/fish/carp = 1,\
-	/obj/item/fish/bass = 1,\
-	/obj/item/fish/salmon = 1,\
-	/obj/item/fish/herring = 1,\
-	/obj/item/fish/red_herring = 1,\
-	/obj/item/space_thing = 5,\
-	/obj/item/gnomechompski = 5,\
-	/obj/item/material_piece/cerenkite = 10,\
-	/obj/item/material_piece/erebite = 10,\
-	/obj/item/clothing/shoes/clown_shoes = 5,\
-	/obj/item/coin = 5,\
-	/mob/living/carbon/human/future = 1,\
 #ifdef SECRETS_ENABLED
 	/mob/living/carbon/human/npc/monkey/extremely_fast = 1,\
 #endif
 	/obj/critter/aberration = 1,\
 	/obj/critter/cat = 2,\
 	/obj/item/clothing/head/void_crown = 1,\
-	/obj/item/record/random = 4,\
+	/obj/item/record/spacebux = 4,\
 	/obj/critter/domestic_bee/trauma = 20)
 
 /datum/fishing_spot/fryer

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -89,6 +89,17 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/spatial_tear
 	fishing_atom_type = /obj/forcefield/event
 	fish_available = list(/obj/item/fish/carp = 1,\
+	/obj/item/fish/bass = 1,\
+	/obj/item/fish/salmon = 1,\
+	/obj/item/fish/herring = 1,\
+	/obj/item/fish/red_herring = 1,\
+	/obj/item/space_thing = 5,\
+	/obj/item/gnomechompski = 5,\
+	/obj/item/material_piece/cerenkite = 10,\
+	/obj/item/material_piece/erebite = 10,\
+	/obj/item/clothing/shoes/clown_shoes = 5,\
+	/obj/item/coin = 5,\
+	/mob/living/carbon/human/future = 1,\
 #ifdef SECRETS_ENABLED
 	/mob/living/carbon/human/npc/monkey/extremely_fast = 1,\
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fishing out of spatial tears has a chance to yield records.

However the record currently available from the tears is of path obj/item/record/random. This is an abstract class and has no song associated with it, causing issues if you try and play it.

This PR replaces that record with obj/item/record/random/spacebux, a record that randomly picks an assigned song on new().

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10415