### PR TITLE
Further tidying for Nadir device packet readouts

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -656,7 +656,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		var/list/manifest = known_pads[device_index]
 		for(var/field in manifest)
 			if(field != "INT_TARGETID")
-				minitext += "<strong>[field]</strong> &middot; [strip_html(manifest[field])]<br>"
+				minitext += "<strong>[field]</strong> &middot; [tidy_net_data(manifest[field])]<br>"
 		rollingtext += minitext
 		rollingtext += "<A href='[topicLink("send","\ref[device_index]")]'>Send</A> | "
 		rollingtext += "<A href='[topicLink("receive","\ref[device_index]")]'>Receive</A><br><br>"

--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -285,13 +285,14 @@
 		var/list/manifest = known_devices[device_index]
 		for(var/field in manifest)
 			if(field == "Intensity")
-				var/maxintens = manifest["Maximum Intensity"]
-				intensity_sum += manifest[field]
-				minitext += "<strong>[field]</strong> &middot; [strip_html(manifest[field])][maxintens ? " / [maxintens]" : ""] "
+				var/maxintens = tidy_net_data(manifest["Maximum Intensity"])
+				if(isnum(manifest[field]))
+					intensity_sum += manifest[field]
+				minitext += "<strong>[field]</strong> &middot; [tidy_net_data(manifest[field])][maxintens ? " / [maxintens]" : ""] "
 				minitext += "<A href='[topicLink("calibrate","\ref[device_index]")]'>(Calibrate)</A><br>"
 			else if(field != "INT_TARGETID" && field != "Maximum Intensity")
 				if(field == "Identifier" && manifest[field] == "SIPHON") saveforsiphon = TRUE
-				minitext += "<strong>[field]</strong> &middot; [isnum(manifest[field]) ? manifest[field] : strip_html(manifest[field])]<br>"
+				minitext += "<strong>[field]</strong> &middot; [tidy_net_data(manifest[field])]<br>"
 		if(saveforsiphon)
 			mainlist += minitext
 		else

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -369,6 +369,10 @@ proc/get_angle(atom/a, atom/b)
 	// 	index = findtext(t, ">")
 	. = html_encode(t)
 
+///Cleans up data passed in from network packets for display so it doesn't mess with formatting
+/proc/tidy_net_data(var/t)
+	. = isnum(t) ? t : strip_html(t)
+
 /proc/map_numbers(var/x, var/in_min, var/in_max, var/out_min, var/out_max)
 	. = ((x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CLEAN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Follows up on #11481 and #11483 by streamlining the changes with a helper proc and fixing some further omissions.

- Adds a small "tidy_net_data" proc containing Conchuckter's ternary switch, and substitutes it for the previous ternary or strip_html uses to improve readability. **Fixes bug:** the current intensity readout on resonators will once again be visible (it was still using strip_html).
- Expands usage of said checks in resonator intensity indexing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes Nadir's networked device readouts more cohesive, and hopefully harder to mess with in problematic ways (while still possible to mess with).