### PR TITLE
Syndicate pizza slices can no longer be caught

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -183,21 +183,20 @@
 				take_bleeding_damage(user, user, 50, DAMAGE_CUT)
 			..()
 
-	throw_impact(M)
-		..()
-		if (!sharpened || isnull(M))
-			return
-		if (sliced)
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
+	throw_impact(atom/A)
+		if (!sharpened || isnull(A) || !sliced)
+			..()
+		else
+			if (iscarbon(A))
+				var/mob/living/carbon/human/H = A
 				H.implant.Add(src)
-				src.visible_message("<span class='alert'>[src] gets embedded in [M]!</span>")
+				src.visible_message("<span class='alert'>[src] gets embedded in [H]!</span>")
 				playsound(src.loc, 'sound/impact_sounds/Flesh_Cut_1.ogg', 100, 1)
 				H.changeStatus("weakened", 2 SECONDS)
-				src.set_loc(M)
-				src.transfer_all_reagents(M)
-			random_brute_damage(M, 11)
-			take_bleeding_damage(M, null, 25, DAMAGE_STAB)
+				src.set_loc(H)
+				src.transfer_all_reagents(H)
+			random_brute_damage(A, 11)
+			take_bleeding_damage(A, null, 25, DAMAGE_STAB)
 
 	proc/add_topping(var/num)
 		var/icon/I


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sharpened pizza slices (produced with the syndie pizza cutter) can be caught and returned to sender by holding space.

This is because unlike other throwable traitor items, such as the butcher knife, pizza slices always call the throw_impact() parent.

This PR changes the behaviour such so that the sharp pizza slices don't call the parent, and therefore can't be caught mid-flight.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8448
Usage of a traitor item shouldn't be completely negatable by holding space, doubly so given it's not a particularly powerful one.

```changelog
(u)MetricDuck
(+)Pizza slices sharpened with the syndicate pizza cutter can no longer be caught mid-throw.
```