### PR TITLE
Add medals for Arcfiend and Spy Thief

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -181,6 +181,8 @@
 						rewarded_detail = copytext(rewarded_detail, 1, -2)
 						stuff_to_output += stolen_detail
 						stuff_to_output += rewarded_detail
+						if (stolen >= 7)
+							traitor.current?.unlock_medal("Professional thief", TRUE)
 
 				if (traitor.special_role == ROLE_FLOCKMIND)
 					for (var/flockname in flocks)

--- a/code/modules/antagonists/arcfiend/abilities/_arcfiend_ability_holder.dm
+++ b/code/modules/antagonists/arcfiend/abilities/_arcfiend_ability_holder.dm
@@ -8,6 +8,8 @@
 
 	/// The total number of points we've accumulated over our lifetime
 	var/lifetime_energy = 0
+	/// Number of hearts stopped with Jolt
+	var/hearts_stopped = 0
 
 	onAbilityStat()
 		..()

--- a/code/modules/antagonists/arcfiend/abilities/jolt.dm
+++ b/code/modules/antagonists/arcfiend/abilities/jolt.dm
@@ -104,6 +104,8 @@
 		if (!src.target.bioHolder?.HasEffect("resist_electric"))
 			boutput(src.target, "<span class='alert'><b>Your heart spasms painfully and stops beating!</b></span>")
 			src.target.contract_disease(/datum/ailment/malady/flatline, null, null, TRUE)
+			var/datum/abilityHolder/arcfiend/AH = src.holder
+			AH.hearts_stopped++
 		else
 			cure_arrest()
 		..()

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -50,5 +50,5 @@
 			dat.Insert(2, {"They consumed a total of [ability_holder.lifetime_energy] units of energy during this shift.
 							<br>Hearts stopped: [ability_holder.hearts_stopped]"})
 		if (src.ability_holder.hearts_stopped >= 6)
-			src.owner.current.unlock_medal("A shocking surprise", TRUE)
+			src.owner.current.unlock_medal("A shocking demise", TRUE)
 		return dat

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -47,5 +47,8 @@
 	handle_round_end(log_data)
 		var/list/dat = ..()
 		if (length(dat) && src.ability_holder)
-			dat.Insert(2, "They consumed a total of [ability_holder.lifetime_energy] units of energy during this shift.")
+			dat.Insert(2, {"They consumed a total of [ability_holder.lifetime_energy] units of energy during this shift.
+							<br>Hearts stopped: [ability_holder.hearts_stopped]"})
+		if (src.ability_holder.hearts_stopped >= 6)
+			src.owner.current.unlock_medal("A shocking surprise", TRUE)
 		return dat


### PR DESCRIPTION
[GAME MODES][MEDAL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds medals for Arcfiend and Spy Thief antagonists.

Arcfiend:
"A shocking demise"
As an Arcfiend, stop six hearts in a single shift.
![arcfiend](https://user-images.githubusercontent.com/53062374/197309473-018c97a1-a77e-4880-bd04-4bff91a645f0.png)

Spy Thief:
"Professional Thief"
As a Spy Thief, steal seven or more items in a single shift.
![thief](https://user-images.githubusercontent.com/53062374/197309480-7984ada7-8cca-468d-bd18-6af2dcd9955e.png)

The medals can be visible on the medals page before you earn them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They don't have medals associated with them currently, and I thought it would be fun

## Changelog
```changelog
(u)FlameArrow57
(+)Added medals for Arcfiend and Spy Thief!
```
