### PR TITLE
Spatial Interdictor QoL and efficiency improvement pass

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3015,7 +3015,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /************ INTERDICTOR STUFF ************/
 
-/datum/manufacture/interdictor_frame
+/datum/manufacture/interdictor_kit
 	name = "Interdictor Assembly Kit"
 	item_paths = list("MET-2","CON-1")
 	item_amounts = list(10,4)

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3016,10 +3016,10 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /************ INTERDICTOR STUFF ************/
 
 /datum/manufacture/interdictor_frame
-	name = "Interdictor Frame Kit"
-	item_paths = list("MET-2")
-	item_amounts = list(10)
-	item_outputs = list(/obj/item/interdictor_frame_kit)
+	name = "Interdictor Assembly Kit"
+	item_paths = list("MET-2","CON-1")
+	item_amounts = list(10,4)
+	item_outputs = list(/obj/item/interdictor_kit)
 	time = 15 SECONDS
 	create = 1
 	category = "Machinery"
@@ -3027,7 +3027,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_lambda
 	name = "Lambda Phase-Control Rod"
 	item_paths = list("MET-2","CON-1","CRY-1","INS-1")
-	item_amounts = list(10,20,10,5)
+	item_amounts = list(2,10,5,2)
 	item_outputs = list(/obj/item/interdictor_rod)
 	time = 20 SECONDS
 	create = 1
@@ -3036,7 +3036,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_sigma
 	name = "Sigma Phase-Control Rod"
 	item_paths = list("MET-2","CON-2","INS-1","POW-1")
-	item_amounts = list(10,25,10,5)
+	item_amounts = list(2,10,5,2)
 	item_outputs = list(/obj/item/interdictor_rod/sigma)
 	time = 20 SECONDS
 	create = 1

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -52,7 +52,7 @@
 		name = "Engineering Manudrive: Spatial Interdictor Assembly Blueprint"
 		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture spatial interdictor rods and frames."
 		icon_state = "datadisk2"
-		temp_recipe_string = list(/datum/manufacture/interdictor_frame,
+		temp_recipe_string = list(/datum/manufacture/interdictor_kit,
 		/datum/manufacture/interdictor_rod_lambda,
 		/datum/manufacture/interdictor_rod_sigma)
 

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -249,9 +249,8 @@
 //assembly zone
 
 //interdictor rod: the doohickey that lets the interdictor do its thing
-//the blueprint to create this should be in engineering along with guide, frame blueprint and mainboards
-//these are the primary factor for scarcity as they require several materials to manufacture
-//blueprint paths: /obj/item/paper/manufacturer_blueprint/interdictor_rod_lambda & /obj/item/paper/manufacturer_blueprint/interdictor_rod_sigma
+//these are a primary factor for scarcity as they require several materials to manufacture, alongside the power cells
+//can be manufactured by installing /obj/item/disk/data/floppy/manudrive/interdictor_parts
 
 /obj/item/interdictor_rod
 	name = "Lambda phase-control rod"
@@ -276,9 +275,7 @@
 		interdist = 7
 
 //interdictor board: power management circuitry and whatnot
-//engineering should start with about three of these,
-//adjacent to the rod/frame blueprint and the interdictor assembly and use guide.
-//mechanics can scan to reproduce
+//included in the assembly kit alongside frame
 
 /obj/item/interdictor_board
 	name = "spatial interdictor mainboard"
@@ -292,12 +289,11 @@
 	w_class = W_CLASS_TINY
 	flags = FPRINT | TABLEPASS | CONDUCT
 
-//interdictor frame: main framework for assembling the interdictor (lo and behold)
-//the blueprint to create this should be in engineering along with guide, rod blueprint and mainboards
-//blueprint path is /obj/item/paper/manufacturer_blueprint/interdictor_frame
+//interdictor assembly kit: supplies the core components for assembling the interdictor (lo and behold)
+//can be manufactured by installing /obj/item/disk/data/floppy/manudrive/interdictor_parts
 
-/obj/item/interdictor_frame_kit
-	name = "spatial interdictor frame kit"
+/obj/item/interdictor_kit
+	name = "spatial interdictor assembly kit"
 	desc = "You can hear an awful lot of junk rattling around in this box."
 	icon = 'icons/obj/machines/interdictor.dmi'
 	icon_state = "interdict-kit"
@@ -320,10 +316,15 @@
 
 		if (canbuild)
 			boutput(user, "<span class='notice'>You empty the box of parts onto the floor.</span>")
-			var/obj/O = new /obj/interdictor_frame( get_turf(user) )
-			O.fingerprints = src.fingerprints
-			O.fingerprints_full = src.fingerprints_full
+			var/obj/frame = new /obj/interdictor_frame( get_turf(user) )
+			frame.fingerprints = src.fingerprints
+			frame.fingerprints_full = src.fingerprints_full
+			var/obj/board = new /obj/item/interdictor_board( get_turf(user) )
+			board.fingerprints = src.fingerprints
+			board.fingerprints_full = src.fingerprints_full
 			qdel(src)
+
+//unconstructed interdictor, where the assembly procedure happens
 
 /obj/interdictor_frame
 	name = "spatial interdictor frame"
@@ -352,17 +353,17 @@
 		switch(state)
 			if(0)
 				if (iswrenchingtool(I))
-					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 4 SECONDS), user)
+					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 2 SECONDS), user)
 				else
 					..()
 			if(1)
 				if (istype(I, /obj/item/interdictor_board))
-					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 2 SECONDS), user)
+					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 1 SECOND), user)
 				else
 					..()
 			if(2)
 				if (istype(I, /obj/item/interdictor_rod))
-					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 2 SECONDS), user)
+					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 1 SECOND), user)
 				else
 					..()
 			if(3)
@@ -385,12 +386,12 @@
 					if (I.amount < 4)
 						boutput(user, "<span style=\"color:red\">You don't have enough cable to connect the components (4 required).</span>")
 					else
-						actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 4 SECONDS), user)
+						actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 1 SECOND), user)
 				else
 					..()
 			if(5)
 				if (istype(I, /obj/item/electronics/soldering))
-					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 2 SECONDS), user)
+					actions.start(new /datum/action/bar/icon/interdictor_assembly(src, I, 1 SECOND), user)
 				else
 					..()
 			if(6)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2644,11 +2644,11 @@
 	icon_state = "blueprint"
 	blueprint = /datum/manufacture/alastor
 
-/obj/item/paper/manufacturer_blueprint/interdictor_frame
-	name = "Interdictor Frame Kit"
+/obj/item/paper/manufacturer_blueprint/interdictor_kit
+	name = "Interdictor Assembly Kit"
 	icon = 'icons/obj/writing.dmi'
 	icon_state = "interdictor_blueprint"
-	blueprint = /datum/manufacture/interdictor_frame
+	blueprint = /datum/manufacture/interdictor_kit
 
 /obj/item/paper/manufacturer_blueprint/interdictor_rod_lambda
 	name = "Lambda Phase-Control Rod"

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -130,8 +130,8 @@
 		spawn_contents = list(/obj/item/pipebomb/bomb/engineering = 6)
 
 	interdictor
-		name = "interdictor assembly kit"
-		desc = "Contains mainboards, a manudrive and a usage guide for spatial interdictors."
+		name = "interdictor fabrication crate"
+		desc = "Contains a drive with spatial interdictor manufacture data, power cells, and a usage guide for spatial interdictors."
 		req_access = list(access_engineering)
 
 		make_my_stuff()
@@ -140,14 +140,14 @@
 				B1.pixel_x = 8
 				B1.pixel_y = 3
 
-				var/obj/item/interdictor_board/B2 = new(src)
+				var/obj/item/cell/supercell/B2 = new(src)
 				B2.pixel_x = -6
 				B2.pixel_y = -3
 
-				var/obj/item/interdictor_board/B3 = new(src)
+				var/obj/item/cell/supercell/B3 = new(src)
 				B3.pixel_x = -6
 
-				var/obj/item/interdictor_board/B4 = new(src)
+				var/obj/item/cell/supercell/B4 = new(src)
 				B4.pixel_x = -6
 				B4.pixel_y = 3
 

--- a/strings/books/interdictor_guide.txt
+++ b/strings/books/interdictor_guide.txt
@@ -39,7 +39,7 @@
 	<hr>
 	<h3>ASSEMBLING THE DEVICE</h3>
 	<br>
-	(I) Assemble the frame kit and phase-control rod at any manufacturer using the blueprints included with your Spatial Interdictor Starter Kit. Materials not provided.
+	(I) Fabricate the assembly kit and phase-control rod at any manufacturer using the drive included with your interdictor crate. Materials not provided.
 	<br>
 	Phase control rods may be manufactured in Lambda or Sigma configurations. Lambda rods cover a three-unit radius, while the advanced but more materially complex Sigma rods cover a seven-unit radius.
 	<br>
@@ -48,9 +48,7 @@
 	<br>
 	(II) Gather the following equipment before assembly:
 	<br>
-	- Interdictor frame kit
-	<br>
-	- Interdictor mainboard
+	- Interdictor assembly kit, containing frame and mainboard
 	<br>
 	- Interdictor phase-control rod
 	<br>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][QOL][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Substantially improves the process of creating spatial interdictors in several key facets.

- Reduces the duration of most action bars during the interdictor assembly process, cutting nine seconds off of the previous total time (pre-engineer training).
- Dramatically reduces the required materials for interdictor phase-control rods. All rods are now standardized to 0.2 MET-2 (from 1), 1 conductor based on tier (previously 2 to 2.5), 0.5 first-layer material (previously 1), and 0.2 second-layer material (previously 0.5).
- Interdictor mainboards are now included with the assembly kit, adding a requirement of 0.4 conductive metal but removing the step where these boards had to be scanned and reverse-engineered to produce more interdictors.
- As mainboards are now included, the interdictor crate now includes three uncharged power cells, as cells are a necessary step in interdictor assembly.

Some associated names, paths and bits of documentation (in-game and out) were changed to more accurately reflect the new state of the assembly process.

This is tagged Balance due to the potential ramifications for severity of random events, should these become popular; my belief is that if Engineers go to the trouble of making a bunch of these things, the protection that's afforded should match their effort (which it probably should after this, as opposed to only giving you patchwork protection unless you're dumping in a colossal amount of minerals).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Interdictors in their current state are unduly expensive and tedious to create given their role as a preventative device; improvements to this process should make them a more appealing option for Engineers to pursue.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Spatial interdictors are now quicker to assemble, require fewer secondary assembly steps and consume much fewer materials.
(+)Spatial interdictor mainboards are now part of the kit created at manufacturers, and no longer need to be separately scanned and reproduced.
```
