### PR TITLE
gives extinguishers to all cyborg modules and fixes a comment

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -49,13 +49,11 @@
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/large,
-		/obj/item/extinguisher/large/cyborg,
 	)
 
 // botanist. chef. janitor.
 /datum/robot/module_tool_creator/recursive/module/civilian
 	definitions = list(
-		/obj/item/extinguisher/large/cyborg,
 		/obj/item/pen, // TODO: make more versatile version
 		/obj/item/seedplanter,
 		/obj/item/plantanalyzer,
@@ -87,6 +85,7 @@
 		/obj/item/device/reagentscanner,
 		/obj/item/device/analyzer/atmospheric/upgraded,
 		/obj/item/robojumper,
+		/obj/item/extinguisher/large,
 		/obj/item/portable_typewriter/borg,
 	)
 
@@ -107,7 +106,6 @@
 		/obj/item/electronics/soldering,
 		/obj/item/room_planner,
 		/obj/item/room_marker,
-		/obj/item/extinguisher/large/cyborg,
 		/obj/item/rcd,
 		/obj/item/deconstructor/borg,
 		/datum/robot/module_tool_creator/item_type/amount/steel_tile,
@@ -117,11 +115,10 @@
 		/datum/robot/module_tool_creator/item_type/amount/cable_coil,
 	)
 
-// engineer. mechanic.
+// engineer
 /datum/robot/module_tool_creator/recursive/module/engineering
 	definitions = list(
 		/obj/item/atmosporter,
-		/obj/item/extinguisher/large/cyborg,
 		/obj/item/weldingtool,
 		/obj/item/device/t_scanner,
 		/obj/item/electronics/scanner,
@@ -173,7 +170,6 @@
 		/obj/item/oreprospector,
 		/obj/item/satchel/mining/large,
 		/obj/item/satchel/mining/large,
-		/obj/item/extinguisher/large/cyborg,
 		/obj/item/device/gps,
 		/obj/item/device/appraisal,
 		/obj/item/device/matanalyzer,

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -85,7 +85,7 @@
 		/obj/item/device/reagentscanner,
 		/obj/item/device/analyzer/atmospheric/upgraded,
 		/obj/item/robojumper,
-		/obj/item/extinguisher/large,
+		/obj/item/extinguisher/large/cyborg,
 		/obj/item/portable_typewriter/borg,
 	)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [BALANCE][SILICONS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes the mechanic job comment from the engineer borg as the job has been merged with engineer

gives all cyborgs the cyborg xl extinguisher (only brobocop and medical didnt have it)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
**for brobocop:** mainly so you can use it as a knockoff jetpack in case you get stuck in space

space push is known to strand cyborgs in a way they cant move at all, this requires you to either:
get the jetpack upgrade, have an extinguisher, or straight up get saved by someone else (or extreme nerding like using telesci on yourself).

this doesnt fuck over the balance of the jetpack upgrade as it provides proper space movement rather than being a last ditch effort tool to save yourself when space push strands you in a spot you cant move at all in

**for medical:** same as brobocop and so you can actually put out patients rather than awkwardly automending them until the fire goes out in its own

possibly bad balance implications:
further makes the chemistry module just a worse version of the medical one in most ways
the wonders of chemnerds with access to a 300u chemistry container (NOTE: you cant take chems back out of it in other ways than just spraying it so using it as a storage is near impossible however you can use it for smoke powder bombs)
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*)Brobocop and medical cyborg modules now have a fire extinguisher.
```