### PR TITLE
silicons (other than AI) can now use help intent location swap

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -100,7 +100,7 @@
 	var/losebreath = 0
 	var/intent = null
 	var/shakecamera = 0
-	var/a_intent = "help"
+	var/a_intent = INTENT_HELP
 	var/m_intent = "run"
 	var/lastKnownIP = null
 	var/obj/stool/buckled = null
@@ -662,8 +662,8 @@
 						if (tmob) //Wire: Fix for: Cannot modify null.now_pushing
 							tmob.now_pushing = 0
 
-		if (!issilicon(AM))
-			if (tmob.a_intent == "help" && src.a_intent == "help" && tmob.canmove && src.canmove && !tmob.buckled && !src.buckled &&!src.throwing && !tmob.throwing) // mutual brohugs all around!
+		if (!isAI(AM))
+			if (tmob.a_intent == INTENT_HELP && src.a_intent == INTENT_HELP && tmob.canmove && src.canmove && !tmob.buckled && !src.buckled && !src.throwing && !tmob.throwing) // mutual brohugs all around!
 				var/turf/oldloc = src.loc
 				var/turf/newloc = tmob.loc
 				if(!oldloc.Enter(tmob) || !newloc.Enter(src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [QOL][SILICONS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
enables help intent swap for silicons (except AI)

NOTE: i have not refactored the proc other than making 3 things use defines, only made it not block all silicons from help intent location swap
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QOL, being pushed half a room away while healing someone in deep crit is very often a death sentence for them


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Cyborgs now have help intent location swap enabled.
```
