### PR TITLE
Fixes being able to resist out of garrote grabs

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -1043,7 +1043,7 @@ proc/Create_Tommyname()
 // Special grab obj that doesn't care if it's in someone's hands
 /obj/item/grab/garrote_grab
 	// No breaking out under own power
-	prob_mod = 0
+	irresistible = 1
 	var/extra_deadly = 0
 	check()
 		if(!assailant || !affecting)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -17,6 +17,7 @@
 	var/item_grab_overlay_state = "grab_small"
 	var/can_pin = 1
 	var/dropped = 0
+	var/irresistible = 0
 
 	New(atom/loc, mob/assailant = null, mob/affecting = null)
 		..()
@@ -354,7 +355,9 @@
 		src.affecting.set_dir(pick(alldirs))
 		resist_count += 1
 
-		if (is_incapacitated(src.affecting))
+		if (irresistible)
+			prob_mod = 0
+		else if (is_incapacitated(src.affecting))
 			prob_mod = 0.7
 		else
 			prob_mod = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Garrote (fibre-wire) grabs are supposed to be irresistible grabs that can't be escaped without outside aid. The behaviour is currently bugged, and people can resist out of them like any normal grab.

This is because while the grab subtype /obj/item/grab/garrote_grab manually sets the probability modifier for resisting out to 0, the value gets overrode in parent procs (with 0.7 if incapacitated or 1.0 otherwise).

This PR ensures the probability modifier for resisting out of the grab remains 0 for garrote grabs, preventing people from resisting out of them once again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9935