### PR TITLE
Fixes gun-based suicide requiring double ammo

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -520,7 +520,6 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	if (!src.canshoot())
 		return 0
 
-	src.process_ammo(user)
 	user.visible_message("<span class='alert'><b>[user] places [src] against [his_or_her(user)] head!</b></span>")
 	var/dmg = user.get_brute_damage() + user.get_burn_damage()
 	src.shoot_point_blank(user, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attempting to suicide with a gun currently both requires and consumes double ammo, failing if it couldn't fire twice.

This is because the gun custom suicide calls both process_ammo() and shoot_point_blank(), which also calls process_ammo(). Remaining ammo is checked and incremented each time process_ammo is called.

This PR removes the unnecessary extra process_ammo.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8804