### PR TITLE
Lower the Pop Divisor of Vampire Gamemode on Classic

### DIFF
--- a/code/datums/gamemodes/vampire.dm
+++ b/code/datums/gamemodes/vampire.dm
@@ -11,7 +11,11 @@
 	has_werewolves = 0
 	major_threats = list(ROLE_WRAITH)
 
+#ifdef RP_MODE
 	num_enemies_divisor = 20
+#else
+	num_enemies_divisor = 15
+#endif
 
 /datum/game_mode/mixed/vampire/announce()
 	boutput(world, "<B>The current game mode is - Vampire!</B>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[gamemodes] [balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr lowers the pop divisor of the vampire gamemode to 15 outside of rp, down from 20.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit odd for vampire's pop divisor being so high, especially considering that wizard is 12 and changeling only has 20 on rp. This brings it more in line with other gamemodes.
