### PR TITLE
Lowers Pop Divisor For Arcfiend Game Mode On Classic

### DIFF
--- a/code/datums/gamemodes/arcfiend.dm
+++ b/code/datums/gamemodes/arcfiend.dm
@@ -11,7 +11,11 @@
 	has_werewolves = 0
 	major_threats = list(ROLE_WRAITH)
 
+#ifdef RP_MODE
 	num_enemies_divisor = 20
+#else
+	num_enemies_divisor = 15
+#endif
 
 /datum/game_mode/mixed/arcfiend/announce()
 	boutput(world, "<B>The current game mode is - Arcfiend!</B>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[gamemodes] [balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers the pop divisor for the arcfiend game mode down to 15 on classic, down from 20. Rp's pop divisor is unchanged.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See #11530. Split these into two prs cause atomization good.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The antag population for the Arcfiend game mode on classic now scales for every 15 players, down from every 20 players.
```
