### PR TITLE
Fixes yet another way to lose the nuke

### DIFF
--- a/code/obj/submachine/syndicate_teleporter.dm
+++ b/code/obj/submachine/syndicate_teleporter.dm
@@ -5,6 +5,7 @@
 	density = 0
 	opacity = 0
 	anchored = 1
+	layer = FLOOR_EQUIP_LAYER1
 	var/recharging =0
 	var/id = "shuttle" //The main location of the teleporter
 	var/recharge = 20 //A short recharge time between teleports


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fun fact: the syndicate teleporter on the Caingorm is 0.01 layers higher than the nuke, meaning if some excited nukie runs straight down out of the briefing room they will shove the nuke directly under the teleporter and out of sight.
This fixes that by setting to the same layer as a regular telepad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less extremely stupid ahelps from me asking where nuke.