### PR TITLE
Fixes mattereater breaking when failing to eat something that's moved

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -162,6 +162,7 @@
 
 		if (!(the_object in get_filtered_atoms_in_touch_range(owner, mattereater.target_path)) && !istype(the_object, /obj/the_server_ingame_whoa))
 			owner.show_text("<span class='alert'>Man, that thing is long gone, far away, just let it go.</span>")
+			using = FALSE
 			return TRUE
 
 		var/area/cur_area = get_area(owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The matter eater bioeffect locks up when attempting to eat something that gets moved out of range.

This is because that particular check case doesn't reset the "using" variable that exists to prevent a player from opening multiple menus. As the using variable never gets reset, the player can never use matter eater again.

This PR makes the variable reset correctly for that particular check case.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11327