### PR TITLE
Fixes cluster sawflies not having a sprite

### DIFF
--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -67,6 +67,7 @@
 	stamina_cost = 20
 	stamina_crit_chance = 35
 	sound_armed = 'sound/machines/sawflyrev.ogg'
+	icon = 'icons/obj/items/sawfly.dmi'
 	icon_state = "clusterflyA"
 	icon_state_armed = "clusterflyA1"
 	payload = /mob/living/critter/robotic/sawfly/ai_controlled


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When I touched up on sawflies, I forgot to update the .DMI file for cluster sawflies, leading to #11543


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #11543

