### PR TITLE
Adds another define to override map to atlas in build.dm

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -32,6 +32,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+//#define MAP_OVERRIDE_ATLAS //if you're defining gotta_go_fast, you'll also want to override to atlas.
 
 //////////// CONVENIENCE OPTIONS FOR TESTING ETC
 //#define DEBUG_EVERYONE_GETS_CAPTAIN_ID // all IDs are captain rank, kept separate from below options to avoid disrupting access-related tests


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a line below GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW so you can override map to atlas without scrolling down


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not super important, but this makes it fractionally easier to configure the build for faster compiling. I don't like scrolling all the way down to the map defines every time I want to skip zlevels being built.

