### PR TITLE
Dive suit manufacture capability for mining fabricators

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1997,6 +1997,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/engdivesuit
+	name = "Engineering Diving Suit Set"
+	item_paths = list("FAB-1","MET-1","CRY-1")
+	item_amounts = list(3,3,2)
+	item_outputs = list(/obj/item/clothing/suit/space/diving/engineering,/obj/item/clothing/head/helmet/space/engineer/diving/engineering)
+	time = 15 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/oresatchel
 	name = "Ore Satchel"
 	item_paths = list("FAB-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2273,6 +2273,9 @@
 		/datum/manufacture/shoes,
 		/datum/manufacture/breathmask,
 		/datum/manufacture/engspacesuit,
+#ifdef UNDERWATER_MAP
+		/datum/manufacture/engdivesuit,
+#endif
 		/datum/manufacture/industrialarmor,
 		/datum/manufacture/industrialboots,
 		/datum/manufacture/powercell,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][BALANCE][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Creates /datum/manufacture/engdivesuit, "Engineering Diving Suit Set", which manufactures precisely that at the same cost as a space suit set.

Introduces said datum to the Mining Fabricator. This exists alongside the space suit manufacture datum instead of replacing it to avoid confusion regarding QM requisitions that ask for a space suit (dive suits also work for this purpose due to acceptance of subtypes, but that wouldn't be immediately clear and makes less sense thematically).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allows for appropriate environmental gear manufacture in underwater maps.

This is most notable for Nadir as proper dive suits provide the best longevity against acid, and they can't currently be manufactured; this is the reason for the Balance tag and major changelog entry.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Mining fabricators are now capable of manufacturing dive suits while on an underwater map.
```
