### PR TITLE
Unique Subdepartment Colours For AI Station Maps

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -18,6 +18,7 @@
 #include "defines\admin.dm"
 #include "defines\ai.dm"
 #include "defines\antagonists.dm"
+#include "defines\area.dm"
 #include "defines\announcement_origins.dm"
 #include "defines\artifacts.dm"
 #include "defines\atom.dm"

--- a/_std/defines/area.dm
+++ b/_std/defines/area.dm
@@ -6,7 +6,7 @@
 
 #define MAPC_CAFETERIA "#90d467"
 #define MAPC_BAR "#907e47"
-#define MAPC_KITCHEN "#adb6bc"
+#define MAPC_KITCHEN "#d4d4d4"
 #define MAPC_CHAPEL "#75602d"
 #define MAPC_HYDROPONICS "#0da70d"
 #define MAPC_RANCH "#59703a"

--- a/_std/defines/area.dm
+++ b/_std/defines/area.dm
@@ -1,0 +1,33 @@
+#define MAPC_DEFAULT "#808080"
+#define MAPC_MAINTENANCE "#474747"
+#define MAPC_HALLWAY "#ffffff"
+
+#define MAPC_COMMAND "#1e2861"
+
+#define MAPC_CAFETERIA "#90d467"
+#define MAPC_BAR "#907e47"
+#define MAPC_KITCHEN "#adb6bc"
+#define MAPC_CHAPEL "#75602d"
+#define MAPC_HYDROPONICS "#0da70d"
+#define MAPC_RANCH "#59703a"
+
+#define MAPC_SECURITY "#b10202"
+#define MAPC_ARMOURY "#711122"
+#define MAPC_BRIG "#d37610"
+
+#define MAPC_MEDICAL "#1ba7e9"
+#define MAPC_MEDLOBBY "#78c5e9"
+#define MAPC_ROBOTICS "#5b6eb1"
+#define MAPC_MEDRESEARCH "#3fb583"
+#define MAPC_PATHOLOGY "#167970"
+
+#define MAPC_RESEARCH "#8e0bc2"
+#define MAPC_CHEMISTRY "#5a1d8a"
+#define MAPC_TOXINS "#441668"
+#define MAPC_TELESCI "#660bc2"
+#define MAPC_ARTLAB "#b320c3"
+
+#define MAPC_ENGINEERING "#d3cb21"
+#define MAPC_MECHLAB "#fffa8f"
+#define MAPC_QUARTERMASTER "#b97f2e"
+#define MAPC_MINING "#8f5b12"

--- a/code/area.dm
+++ b/code/area.dm
@@ -35,6 +35,11 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 	var/tmp/sims_score = 100
 	var/virtual = 0
 
+	/// Whether or not the tile will be drawn on the station map.
+	var/render_on_map = FALSE
+	/// What colour should be displayed for this tile on the station map?
+	var/station_map_colour = MAPC_DEFAULT
+
 	// some semi-random turf in the area to guide spy thieves
 	var/turf/spyturf = null
 
@@ -1576,6 +1581,7 @@ ABSTRACT_TYPE(/area/station)
 /area/station
 	do_not_irradiate = 0
 	sound_fx_1 = 'sound/ambience/station/Station_VocalNoise1.ogg'
+	render_on_map = TRUE
 	var/tmp/initial_structure_value = 0
 #ifdef MOVING_SUB_MAP
 	filler_turf = "/turf/space/fluid/manta"
@@ -1648,6 +1654,7 @@ ABSTRACT_TYPE(/area/station/maintenance)
 	sound_environment = 12
 	workplace = 1
 	do_not_irradiate = 1
+	station_map_colour = MAPC_MAINTENANCE
 
 /area/station/maintenance/northwest
 	name = "North West Maintenance"
@@ -1905,6 +1912,7 @@ ABSTRACT_TYPE(/area/station/hallway)
 	name = "Hallway"
 	icon_state = "hallC"
 	sound_environment = 10
+	station_map_colour = MAPC_HALLWAY
 
 ABSTRACT_TYPE(/area/station/hallway/primary)
 /area/station/hallway/primary
@@ -2055,6 +2063,7 @@ ABSTRACT_TYPE(/area/station/hallway/secondary)
 	name = "Construction"
 	icon_state = "red"
 	sound_environment = 10
+	station_map_colour = MAPC_ENGINEERING
 
 /area/station/construction/under_construction
 		name = "Under Construction"
@@ -2064,6 +2073,7 @@ ABSTRACT_TYPE(/area/station/mining)
 	name = "Mining"
 	icon_state = "mining"
 	sound_environment = 10
+	station_map_colour = MAPC_MINING
 
 /area/station/mining/staff_room
   name = "Mining Staff Room"
@@ -2083,6 +2093,7 @@ ABSTRACT_TYPE(/area/station/mining)
 	name = "Bridge"
 	icon_state = "bridge"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 #ifdef SUBMARINE_MAP
 	sound_group = "bridge"
 	sound_loop = 'sound/ambience/station/underwater/sub_bridge_ambi1.ogg'
@@ -2100,10 +2111,12 @@ ABSTRACT_TYPE(/area/station/mining)
 /area/station/captain //Three below this one are because Manta uses specific ambience on the bridge
 	name = "Captain's Office"
 	icon_state = "CAPN"
+	station_map_colour = MAPC_COMMAND
 
 /area/station/hos
 	name = "Head of Personnel's Office"
 	icon_state = "HOP"
+	station_map_colour = MAPC_COMMAND
 
 /area/station/hos/quarter
 	name = "Head of Personnel's Personal Quarter"
@@ -2152,16 +2165,19 @@ ABSTRACT_TYPE(/area/station/crew_quarters)
 	icon_state = "HOS"
 	sound_environment = 4
 	spy_secure_area = TRUE
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/md
 	name = "Medical Director's Quarters"
 	icon_state = "MD"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/ce
 	name = "Chief Engineer's Quarters"
 	icon_state = "CE"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/sauna
 	name = "Sauna"
@@ -2260,16 +2276,19 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 	name = "Captain's Quarters"
 	icon_state = "captain"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/hop
 	name = "Head of Personnel's Quarters"
 	icon_state = "green"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/cafeteria
 	name = "Cafeteria"
 	icon_state = "cafeteria"
 	sound_environment = 0
+	station_map_colour = MAPC_CAFETERIA
 
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar
 		name = "The Rising Tide"
@@ -2279,6 +2298,7 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 	name = "Kitchen"
 	icon_state = "kitchen"
 	sound_environment = 3
+	station_map_colour = MAPC_KITCHEN
 
 /area/station/crew_quarters/kitchen/freezer
 		name = "Freezer"
@@ -2298,6 +2318,7 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 /area/station/crew_quarters/catering
 	name = "Catering Storage"
 	icon_state = "storage"
+	station_map_colour = MAPC_KITCHEN
 
 /area/station/crew_quarters/bathroom
 	name = "Bathroom"
@@ -2315,22 +2336,26 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 	name= "Bar"
 	icon_state = "bar"
 	sound_environment = 4
+	station_map_colour = MAPC_BAR
 
 /area/station/crew_quarters/baroffice
 	name= "Bar Office"
 	icon_state = "bar_office"
 	sound_environment = 2
+	station_map_colour = MAPC_BAR
 
 /area/station/crew_quarters/heads
 	name = "Head of Personnel's Office"
 	icon_state = "HOP"
 	sound_environment = 4
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/hor
 	name = "Research Director's Office"
 	icon_state = "RD"
 	sound_environment = 4
 	requires_power = 1
+	station_map_colour = MAPC_COMMAND
 
 /area/station/crew_quarters/hor/horprivate
 	name = "Research Director's Private Quarters"
@@ -2396,6 +2421,7 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 	name = "Public Market"
 	icon_state = "yellow"
 	sound_environment = 0
+	station_map_colour = MAPC_HALLWAY
 
 /area/station/crew_quarters/supplylobby
 	name = "Supply Lobby"
@@ -2444,6 +2470,7 @@ ABSTRACT_TYPE(/area/station/engine)
 /area/station/engine
 	sound_environment = 5
 	workplace = 1
+	station_map_colour = MAPC_ENGINEERING
 
 /area/station/engine/engineering
 	name = "Engineering"
@@ -2456,6 +2483,7 @@ ABSTRACT_TYPE(/area/station/engine)
 /area/station/engine/engineering/ce
 	name = "Chief Engineer's Office"
 	icon_state = "CE"
+	station_map_colour = MAPC_COMMAND
 
 /area/station/engine/engineering/ce/private
 	name = "Chief Engineer's Private Quarters"
@@ -2492,6 +2520,7 @@ ABSTRACT_TYPE(/area/station/engine)
 /area/station/engine/elect
 	name = "Mechanic's Lab"
 	icon_state = "mechanics"
+	station_map_colour = MAPC_MECHLAB
 
 /area/station/engine/power
 	name = "Engineering Power Room"
@@ -2581,6 +2610,7 @@ ABSTRACT_TYPE(/area/station/engine/substation)
 	icon_state = "teleporter"
 	sound_environment = 3
 	workplace = 1
+	station_map_colour = MAPC_COMMAND
 
 /area/syndicate_teleporter
 	name = "Syndicate Teleporter"
@@ -2594,6 +2624,7 @@ ABSTRACT_TYPE(/area/station/medical)
 	name = "Medical area"
 	icon_state = "medbay"
 	workplace = 1
+	station_map_colour = MAPC_MEDICAL
 
 /area/station/medical/medbay
 	name = "Medbay"
@@ -2603,6 +2634,7 @@ ABSTRACT_TYPE(/area/station/medical)
 /area/station/medical/medbay/lobby
 	name = "Medbay Lobby"
 	icon_state = "medbay_lobby"
+	station_map_colour = MAPC_MEDLOBBY
 
 /area/station/medical/medbay/cloner
 	name = "Cloning"
@@ -2639,16 +2671,19 @@ ABSTRACT_TYPE(/area/station/medical)
 /area/station/medical/robotics
 	name = "Robotics"
 	icon_state = "medresearch"
+	station_map_colour = MAPC_ROBOTICS
 
 /area/station/medical/research
 	name = "Medical Research"
 	icon_state = "medresearch"
 	sound_environment = 3
+	station_map_colour = MAPC_MEDRESEARCH
 
 /area/station/medical/head
 	name = "Medical Director's Office"
 	icon_state = "MD"
 	sound_environment = 1
+	station_map_colour = MAPC_COMMAND
 
 	private
 		name = "Medical Director's  Private Quarters"
@@ -2657,21 +2692,25 @@ ABSTRACT_TYPE(/area/station/medical)
 	name = "Pathology Research"
 	icon_state = "medcdc"
 	sound_environment = 5
+	station_map_colour = MAPC_PATHOLOGY
 
 /area/station/medical/dome
 	name = "Monkey Dome"
 	icon_state = "green"
 	sound_environment = 3
+	station_map_colour = MAPC_MEDRESEARCH
 
 /area/station/medical/morgue
 	name = "Morgue"
 	icon_state = "morgue"
 	sound_environment = 3
+	station_map_colour = MAPC_MEDICAL
 
 /area/station/medical/crematorium
 	name = "Crematorium"
 	icon_state = "morgue"
 	sound_environment = 3
+	station_map_colour = MAPC_MEDICAL
 
 /area/station/medical/medbooth
 	name = "Medical Booth"
@@ -2699,6 +2738,7 @@ ABSTRACT_TYPE(/area/station/security)
 	teleport_blocked = 1
 	workplace = 1
 	spy_secure_area = TRUE
+	station_map_colour = MAPC_SECURITY
 
 /area/station/security/main
 	name = "Security"
@@ -2721,6 +2761,7 @@ ABSTRACT_TYPE(/area/station/security)
 	sound_environment = 3
 	teleport_blocked = 0
 	do_not_irradiate = 1
+	station_map_colour = MAPC_BRIG
 
 /area/station/security/brig/cell_block_control
 		name = "Cell Block Control"
@@ -2823,6 +2864,7 @@ ABSTRACT_TYPE(/area/station/security)
 	icon_state = "HOS"
 	sound_environment = 4
 	workplace = 0 //As does the hos
+	station_map_colour = MAPC_COMMAND
 
 /area/station/security/hos/horizon
 	name = "Hovel of Security"
@@ -2907,6 +2949,7 @@ ABSTRACT_TYPE(/area/station/quartermaster)
 	name = "Quartermaster's"
 	icon_state = "quart"
 	workplace = 1
+	station_map_colour = MAPC_QUARTERMASTER
 
 /area/station/quartermaster/office
 	name = "Quartermaster's Office"
@@ -2960,6 +3003,7 @@ ABSTRACT_TYPE(/area/station/janitor)
 	icon_state = "chem"
 	sound_environment = 3
 	workplace = 1
+	station_map_colour = MAPC_CHEMISTRY
 
 /area/station/science/testchamber
 	name = "Test Chamber"
@@ -2974,6 +3018,7 @@ ABSTRACT_TYPE(/area/station/science)
 	icon_state = "purple"
 	sound_environment = 3
 	workplace = 1
+	station_map_colour = MAPC_RESEARCH
 
 /area/station/science/lobby
 	name = "Science Lobby"
@@ -2999,24 +3044,29 @@ ABSTRACT_TYPE(/area/station/science)
 /area/station/science/teleporter
 	name = "Science Teleporter"
 	icon_state = "telelab"
+	station_map_colour = MAPC_TELESCI
 
 /area/station/science/research_director
 	name = "Research Director's Office"
 	icon_state = "toxlab"
 	workplace = 0
+	station_map_colour = MAPC_COMMAND
 
 /area/station/science/lab
 	name = "Toxin Lab"
 	icon_state = "toxlab"
+	station_map_colour = MAPC_TOXINS
 
 /area/station/science/artifact
 	name = "Artifact Lab"
 	icon_state = "artifact"
+	station_map_colour = MAPC_ARTLAB
 
 /area/station/science/storage
 	name = "Toxin Storage"
 	icon_state = "toxstorage"
 	do_not_irradiate = 1
+	station_map_colour = MAPC_TOXINS
 
 /area/station/science/laser
 	name = "Optics Lab"
@@ -3035,6 +3085,7 @@ ABSTRACT_TYPE(/area/station/chapel)
 /area/station/chapel
 	name = "Chapel"
 	icon_state = "chapel"
+	station_map_colour = MAPC_CHAPEL
 
 /area/station/chapel/sanctuary
 	name = "Chapel"
@@ -3139,17 +3190,22 @@ ABSTRACT_TYPE(/area/station/hangar)
 /area/station/hangar/sec
 		name = "Secure Dock"
 		teleport_blocked = 1
+		station_map_colour = MAPC_SECURITY
 /area/station/hangar/engine
 		name = "Engineering Dock"
+		station_map_colour = MAPC_ENGINEERING
 /area/station/hangar/medical
-		name = "Medical Hanger"
+		name = "Medical Hangar"
+		station_map_colour = MAPC_MEDICAL
 /area/station/hangar/qm
 		name = "Cargo Dock"
+		station_map_colour = MAPC_QUARTERMASTER
 /area/station/hangar/escape
 		name = "Escape Dock"
 /area/station/hangar/science
 		name = "Research Dock"
 		teleport_blocked = 1
+		station_map_colour = MAPC_RESEARCH
 /area/station/hangar/port
 		name = "Submarine Bay (Port)"
 		requires_power = 1
@@ -3157,13 +3213,16 @@ ABSTRACT_TYPE(/area/station/hangar)
 		name = "Submarine Bay (Starboard)"
 /area/station/hangar/mining
 		name = "Submarine Bay (Mining)"
+		station_map_colour = MAPC_MINING
 /area/station/hangar/security
 		name = "Submarine Bay (Security)"
+		station_map_colour = MAPC_SECURITY
 
 /area/station/hydroponics
 	name = "Hydroponics"
 	icon_state = "hydro"
 	workplace = 1
+	station_map_colour = MAPC_HYDROPONICS
 
 /area/station/hydroponics/bay
   name = "Hydroponics Bay"
@@ -3176,6 +3235,7 @@ ABSTRACT_TYPE(/area/station/hangar)
 	name = "Ranch"
 	icon_state = "ranch"
 	workplace = 1
+	station_map_colour = MAPC_RANCH
 
 ABSTRACT_TYPE(/area/station/garden)
 /area/station/garden
@@ -3257,6 +3317,8 @@ ABSTRACT_TYPE(/area/station/catwalk)
 	name = "Research Outpost"
 	icon_state = "blue"
 	do_not_irradiate = 1
+	render_on_map = TRUE
+	station_map_colour = MAPC_RESEARCH
 
 /area/research_outpost/protest
 	name = "Protest Outpost"
@@ -3367,6 +3429,7 @@ ABSTRACT_TYPE(/area/station/ai_monitored)
 	name = "AI Monitored Area"
 	var/obj/machinery/camera/motion/motioncamera = null
 	workplace = 1
+	station_map_colour = MAPC_COMMAND
 
 /area/station/ai_monitored/New()
 	..()
@@ -3414,6 +3477,7 @@ ABSTRACT_TYPE(/area/station/ai_monitored/storage/)
 	sound_environment = 2
 	teleport_blocked = 1
 	spy_secure_area = TRUE
+	station_map_colour = MAPC_ARMOURY
 
 // // // // // //
 
@@ -3423,6 +3487,7 @@ ABSTRACT_TYPE(/area/station/turret_protected)
 	name = "Turret Protected Area"
 	expandable = FALSE
 	spy_secure_area = TRUE
+	station_map_colour = MAPC_COMMAND
 	var/list/obj/machinery/turret/turret_list = list()
 	var/obj/machinery/camera/motion/motioncamera = null
 	var/list/obj/blob/blob_list = list() //faster to cache blobs as they enter instead of searching the area for them (For turrets)
@@ -3502,6 +3567,7 @@ ABSTRACT_TYPE(/area/station/turret_protected)
 	icon_state = "AIt"
 	requires_power = 0
 	sound_environment = 12
+	render_on_map = FALSE
 
 /area/station/turret_protected/AIbasecore2
 	name = "AI Core 2"
@@ -3527,6 +3593,7 @@ ABSTRACT_TYPE(/area/station/turret_protected)
 	name = "Armory Outer Perimeter"
 	icon_state = "secext"
 	requires_power = FALSE
+	render_on_map = FALSE
 
 // // // //  OLD AREAS THAT ARE NOT USED BUT ARE IN HERE // // // //
 
@@ -3536,6 +3603,7 @@ ABSTRACT_TYPE(/area/mining)
 	name = "Mining Outpost"
 	icon_state = "engine"
 	workplace = 1
+	station_map_colour = MAPC_MINING
 
 /area/mining/power
 	name = "Outpost Power Room"

--- a/code/modules/station_map/station_map.dm
+++ b/code/modules/station_map/station_map.dm
@@ -42,15 +42,24 @@
 		if ("right" in param_list)
 			return TRUE
 
+	///Checks whether a turf be rendered on the map.
+	proc/valid_turf(var/turf/turf)
+		if (!turf.loc)
+			return FALSE
+		var/area/A = turf.loc
+		if (!A.render_on_map)
+			return FALSE
+		// The Kondaru off station owlry and abandoned research outpost are both considered part of the station but have no AI cams
+		if ((map_settings.name in list("KONDARU", "DONUT3")) && (istype(turf.loc, /area/station/garden/owlery) || istype(turf.loc, /area/research_outpost/indigo_rye)))
+			return FALSE
+		return TRUE
+
 	//generates the map from the current station layout
 	proc/render_map()
 		for (var/y in world.maxy to 1 step -1)
 			for (var/x in 1 to world.maxx)
 				var/turf/turf = locate(x, y, Z_LEVEL_STATION)
-				if (!turf.loc || !(istype(turf.loc, /area/station) || istype(turf.loc, /area/research_outpost)))
-					continue
-				//the Kondaru off station owlry and abandoned research outpost are both considered part of the station but have no AI cams
-				if (map_settings.name == "KONDARU" && (istype(turf.loc, /area/station/garden/owlery) || istype(turf.loc, /area/research_outpost/indigo_rye)))
+				if (!src.valid_turf(turf))
 					continue
 				//keep track of the outer bounds of the station
 				x_max = max(x_max, x)
@@ -75,23 +84,7 @@
 		src.pixel_y = -(center_y - (world.maxy/2)) * scale_main
 
 	proc/turf_color(turf/turf)
-		if (istype(turf.loc, /area/station/hydroponics) || istype(turf.loc, /area/station/ranch))
-			return "#0da70d"
-		else if (istype(turf.loc, /area/station/medical) && !istype(turf.loc, /area/station/medical/morgue))
-			return "#1ba7e9"
-		else if (istype(turf.loc, /area/station/science) || istype(turf.loc, /area/research_outpost))
-			return "#8e0bc2"
-		else if (istype(turf.loc, /area/station/security) || istype(turf.loc, /area/station/hos) || istype(turf.loc, /area/station/ai_monitored/armory))
-			return "#b10202"
-		else if (istype(turf.loc, /area/station/engine) || istype(turf.loc, /area/station/quartermaster) || istype(turf.loc, /area/station/mining) || istype(turf.loc, /area/station/construction))
-			return "#e4d835"
-		else if (istype(turf.loc, /area/station/chapel))
-			return "#75602d"
-		else if (istype(turf.loc, /area/station/bridge) || istype(turf.loc, /area/station/turret_protected) || istype(turf.loc, /area/station/teleporter) || istype(turf.loc, /area/station/ai_monitored))
-			return "#1e2861"
-		else if (istype(turf.loc, /area/station/maintenance))
-			return "#474747"
-		else if (istype(turf.loc, /area/station/hallway))
-			return "#ffffff"
-		else
-			return "#808080"
+		if (!turf.loc)
+			return
+		var/area/A = turf.loc
+		return A.station_map_colour


### PR DESCRIPTION
[UI] [Code Quality] [QoL]


## About the PR:
Permits each `/area` type to display a unique colour on station maps through the `station_map_colour` variable, alongside adding the `render_on_map` variable, which determines whether the tile should be drawn on the map. `render_on_map` could later be used to determine whether the tile should only be rendered on Syndicate maps (See #10702).

![image](https://user-images.githubusercontent.com/88833499/197411863-bb099928-c79d-47eb-adc8-b638f1689431.png)



## Why's this needed?
Varied colours for subdepartments allows for AI players to better guage the layout of maps.