### PR TITLE
Nadir Fixbatch 5

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -2983,6 +2983,10 @@ ABSTRACT_TYPE(/area/station/science)
 	name = "Tenebrae Primary Zone"
 	icon_state = "science"
 
+/area/station/science/hall
+	name = "Research Hall"
+	icon_state = "science"
+
 /area/station/science/gen_storage
 	name = "Research Storage"
 	icon_state = "genstorage"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2672,14 +2672,10 @@
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_ax
 	name = "Type-AX Resonator"
-	icon = 'icons/obj/writing.dmi'
-	icon_state = "interdictor_blueprint"
 	blueprint = /datum/manufacture/resonator_type_ax
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm
 	name = "Type-SM Resonator"
-	icon = 'icons/obj/writing.dmi'
-	icon_state = "interdictor_blueprint"
 	blueprint = /datum/manufacture/resonator_type_sm
 
 

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -11933,7 +11933,6 @@
 /obj/cable{
 	icon_state = "1-6"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "gbu" = (
@@ -28620,7 +28619,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "nOl" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -107,16 +107,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"acr" = (
-/obj/machinery/photocopier,
-/obj/machinery/door_control{
-	id = "market_2";
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "acs" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 15
@@ -251,10 +241,6 @@
 /obj/decal/poster/wallsign/barber,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
-"afk" = (
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/office)
 "afl" = (
 /obj/storage/closet/medicalclothes,
 /turf/simulated/floor/blueblack{
@@ -2970,6 +2956,13 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
+"bwd" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/firedoor/pyro{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/market)
 "bwi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3028,6 +3021,9 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"bxw" = (
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/security/hos)
 "bxP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4267,6 +4263,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northeast)
+"ccu" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/east)
 "cdp" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -4597,7 +4599,7 @@
 /area/station/medical/robotics)
 "cnq" = (
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/station/security/hos)
 "cnt" = (
 /obj/stool/bench/blue/auto,
@@ -4629,19 +4631,8 @@
 /turf/space/fluid/acid/clear,
 /area/station/hallway/secondary/exit)
 "cnM" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "market_2";
-	name = "Public Market";
-	opacity = 0
-	},
-/obj/firedoor_spawn,
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/market)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/east)
 "cnT" = (
 /obj/item/item_box/swedish_bag{
 	icon_state = "swedishfisk-open";
@@ -4862,18 +4853,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"cuj" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "market_2";
-	name = "Public Market";
-	opacity = 0
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "cuw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/drainage,
@@ -7486,7 +7465,11 @@
 /area/station/storage/emergency2)
 "dLC" = (
 /obj/machinery/vending/standard,
-/turf/simulated/floor/plating,
+/obj/decal/tile_edge/line/blue{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black/grime,
 /area/station/maintenance/southwest)
 "dMn" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
@@ -8649,15 +8632,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"euq" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/stool/chair/office/blue,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "euF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10271,13 +10245,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
-"fmp" = (
-/obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "fmz" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -13688,6 +13655,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"gPh" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "gPp" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/black,
@@ -14642,7 +14616,7 @@
 /area/space)
 "hjP" = (
 /obj/critter/turtle/sylvester/HoS,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/security/hos)
 "hke" = (
 /obj/table/wood/round/auto,
@@ -14860,7 +14834,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/bent/east,
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "hot" = (
@@ -15399,8 +15373,9 @@
 	name = "Diplomatic Quarters"
 	})
 "hAK" = (
-/obj/machinery/disposal/cart_port,
-/obj/disposalpipe/trunk/east,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "hAV" = (
@@ -16349,7 +16324,7 @@
 	name = "Transception Array Control"
 	})
 "hYD" = (
-/obj/rack,
+/obj/item/device/radio/intercom,
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -16482,10 +16457,7 @@
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "ibq" = (
-/obj/disposalpipe/segment/transport,
-/obj/item/device/radio/intercom{
-	dir = 8
-	},
+/obj/rack,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "ibI" = (
@@ -17480,6 +17452,9 @@
 "iyK" = (
 /obj/stool/chair{
 	dir = 8
+	},
+/obj/landmark/start{
+	name = "Janitor"
 	},
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
@@ -18853,12 +18828,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "jiR" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/light,
+/obj/stool/chair/office/blue{
+	dir = 8
 	},
-/obj/rack,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "jjd" = (
@@ -19006,7 +18979,7 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/east,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/security/hos)
 "jnP" = (
 /obj/cable{
@@ -19305,6 +19278,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/secondary/exit)
+"juP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "juV" = (
 /obj/machinery/light/incandescent/netural,
 /obj/disposaloutlet/west,
@@ -19425,7 +19405,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/security/hos)
 "jyb" = (
 /obj/machinery/atmospherics/unary/cryo_cell/south,
@@ -25108,12 +25088,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
-"mas" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "mav" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25220,13 +25194,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"mcx" = (
-/obj/rack,
-/obj/item/device/radio/intercom{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "mcC" = (
 /obj/shrub{
 	dir = 4;
@@ -25245,6 +25212,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"mdb" = (
+/obj/stool/bench/red/auto,
+/turf/simulated/floor/black,
+/area/station/security/equipment)
 "mdl" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light{
@@ -25562,6 +25533,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
+"mjZ" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "mkc" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/gps_waypoint,
@@ -29519,21 +29494,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery)
-"ooM" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "ooQ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -31308,7 +31268,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/manufacturer/mining,
+/obj/machinery/manufacturer/mining{
+	free_resources = list(/obj/item/material_piece/steel,/obj/item/material_piece/copper,/obj/item/material_piece/glass,/obj/item/material_piece/cloth/cottonfabric)
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -31913,7 +31875,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "pAI" = (
-/obj/disposalpipe/junction/left/north,
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "pAY" = (
@@ -32403,6 +32365,9 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"pRk" = (
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/security/hos)
 "pRy" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/specialroom/gym,
@@ -34100,11 +34065,6 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
-"qMo" = (
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "qMG" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -34660,7 +34620,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/security/hos)
 "rcE" = (
 /obj/machinery/disposal,
@@ -35891,6 +35851,9 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
+"rMx" = (
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/station/security/hos)
 "rMO" = (
 /turf/simulated/floor/engine/glow/blue,
 /area/station/communications/centre)
@@ -35964,6 +35927,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
+/obj/marker/supplymarker,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
@@ -37833,6 +37797,14 @@
 	dir = 8
 	},
 /area/station/medical/medbay/lobby)
+"sHt" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/firedoor/pyro{
+	dir = 8
+	},
+/obj/machinery/cashreg,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/market)
 "sHW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38382,7 +38354,6 @@
 	name = "Cargo Primary Endpoint"
 	})
 "sTh" = (
-/obj/marker/supplymarker,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -39415,10 +39386,33 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
 "trj" = (
-/obj/machinery/light/small,
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -8
+/obj/storage/secure/closet/immersion{
+	req_access = list(26)
+	},
+/obj/item/clothing/suit/space/diving/civilian{
+	pixel_x = -4
+	},
+/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
+	pixel_x = -4
+	},
+/obj/item/tank/emergency_oxygen{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/device/nanoloom{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/nanoloom_cartridge{
+	pixel_x = 3;
+	pixel_y = -9
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
@@ -39538,9 +39532,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
+/obj/rack,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "ttL" = (
@@ -40343,7 +40335,7 @@
 /obj/npc/trader/exclown{
 	trader_area = "/area/station/crew_quarters/clown"
 	},
-/obj/stool/chair,
+/obj/stool/chair/syndicate,
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1;
@@ -41219,8 +41211,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
 "umj" = (
+/obj/machinery/disposal/cart_port,
 /obj/storage/cart/trash,
-/turf/simulated/floor/plating,
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/black/grime,
 /area/station/maintenance/southwest)
 "umB" = (
 /obj/disposalpipe/segment/bent/south,
@@ -45249,7 +45247,7 @@
 /obj/stool/chair/comfy/red{
 	dir = 8
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/security/hos)
 "wCH" = (
 /obj/cable{
@@ -46061,7 +46059,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "wYw" = (
-/obj/stool/chair/office/blue,
+/obj/machinery/photocopier,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "wYC" = (
@@ -47147,11 +47145,6 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"xAK" = (
-/obj/rack,
-/obj/machinery/light_switch/east,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "xAL" = (
 /turf/simulated/floor/greenblack/corner{
 	dir = 8
@@ -78912,8 +78905,8 @@ pqP
 pqP
 cXM
 pqP
-pqP
-skb
+juP
+gPh
 ewN
 okm
 tje
@@ -79221,8 +79214,8 @@ nZd
 tUn
 shQ
 pAI
-shQ
-afk
+tje
+tje
 uoR
 ewN
 uqC
@@ -81639,7 +81632,7 @@ ezx
 qov
 lFK
 lFK
-lFK
+mdb
 qov
 vuc
 mKo
@@ -88588,7 +88581,7 @@ knQ
 rFT
 wCF
 hjP
-tPi
+pRk
 tPi
 bXD
 xTD
@@ -88888,9 +88881,9 @@ wEH
 jvX
 gew
 dbc
-tPi
+rMx
 cnq
-tPi
+bxw
 kIM
 huU
 huU
@@ -100340,8 +100333,8 @@ cAs
 aaH
 nmg
 vRv
-jRu
-jRu
+sHt
+bwd
 vRv
 nyR
 teP
@@ -101249,7 +101242,7 @@ dnY
 eQO
 irG
 wYw
-mas
+jRu
 axJ
 vEo
 hrC
@@ -101549,12 +101542,12 @@ xwV
 qHD
 sxq
 uik
-fmp
-qVd
-jRu
-yiB
-vEo
-fdg
+mjZ
+mjZ
+qfy
+bEm
+apR
+lUQ
 vEo
 vDk
 hWH
@@ -101853,10 +101846,10 @@ dnY
 uGB
 ttK
 ibq
-qfy
-bEm
-apR
-lUQ
+jRu
+yiB
+vEo
+iPJ
 vEo
 vIQ
 hWH
@@ -102453,11 +102446,11 @@ cAs
 cAs
 aLz
 qTS
-dnY
-acr
-qVd
-euq
-mas
+ccu
+gie
+gie
+gie
+sXH
 yiB
 sVX
 iPJ
@@ -102756,10 +102749,10 @@ iIi
 iNo
 rfO
 cnM
-qMo
-qVd
-qVd
-jRu
+gie
+gie
+gie
+sXH
 yiB
 vEo
 iPJ
@@ -103057,11 +103050,11 @@ oZp
 oZp
 iXV
 oZp
-dnY
-eQO
-qVd
-qVd
-cuj
+oZp
+xWr
+gie
+gie
+sXH
 yiB
 vEo
 iPJ
@@ -103359,11 +103352,11 @@ oZp
 tvR
 ixW
 oNJ
-dnY
-ooM
-xAK
-mcx
-vRv
+oZp
+gie
+gie
+gie
+sXH
 sXH
 rLM
 iPJ
@@ -103661,11 +103654,11 @@ oZp
 rwN
 gkC
 rxi
-dnY
-dnY
-dnY
-dnY
-vRv
+oZp
+oZp
+oZp
+oZp
+wMJ
 swA
 vEo
 iPJ
@@ -105757,13 +105750,13 @@ eIa
 lsj
 njE
 tXW
-cHd
-cHd
-cHd
-cHd
-cHd
-cHd
-cHd
+fmc
+fmc
+fmc
+fmc
+fmc
+fmc
+fmc
 mwn
 oZp
 sXv

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -34212,6 +34212,12 @@
 /obj/item/wrestlingbell,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"qSW" = (
+/obj/machinery/nanofab/mining,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/quartermaster/refinery)
 "qSY" = (
 /obj/table/round/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -97911,7 +97917,7 @@ los
 sEG
 wRi
 xZH
-aaY
+qSW
 nAo
 fvu
 bZA

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -39691,8 +39691,8 @@
 	pixel_x = 6
 	},
 /obj/machinery/light/lamp/black{
-	pixel_y = 7;
-	pixel_x = -5
+	pixel_y = 10;
+	pixel_x = 1
 	},
 /obj/item/pen{
 	pixel_y = -2;

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -24297,6 +24297,7 @@
 	})
 "lKz" = (
 /obj/storage/secure/closet/immersion{
+	name = "Janitorial Immersion Suit Vault";
 	req_access = list(26)
 	},
 /obj/item/clothing/suit/space/diving/civilian{
@@ -32387,6 +32388,7 @@
 	})
 "pRQ" = (
 /obj/storage/secure/closet/immersion{
+	name = "Janitorial Immersion Suit Vault";
 	req_access = list(26)
 	},
 /obj/item/clothing/suit/space/diving/civilian{
@@ -39080,8 +39082,23 @@
 	},
 /area/station/medical/medbay/pharmacy)
 "tja" = (
-/obj/storage/closet,
 /obj/machinery/light/small/warm/very,
+/obj/storage/secure/closet/immersion{
+	name = "Maintenance Immersion Suit Vault";
+	req_access = list(12)
+	},
+/obj/item/clothing/suit/space/diving/civilian{
+	pixel_x = -4
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/tank/air{
+	pixel_x = 5
+	},
+/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
+	pixel_x = -4
+	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
 "tje" = (
@@ -39387,6 +39404,7 @@
 /area/station/hallway/primary/northeast)
 "trj" = (
 /obj/storage/secure/closet/immersion{
+	name = "Janitorial Immersion Suit Vault";
 	req_access = list(26)
 	},
 /obj/item/clothing/suit/space/diving/civilian{
@@ -39405,10 +39423,6 @@
 /obj/item/device/nanoloom{
 	pixel_x = 4;
 	pixel_y = -4
-	},
-/obj/item/nanoloom_cartridge{
-	pixel_x = 3;
-	pixel_y = -9
 	},
 /obj/machinery/light/small{
 	dir = 8;

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -94319,11 +94319,11 @@ chH
 eZe
 eZe
 eoL
-eZe
+sNC
 eZe
 wRm
 rul
-sNC
+eZe
 dzl
 tpy
 fjZ

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -21020,7 +21020,7 @@
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "TYPE-SM - SHEAR MITIGATOR<br>Reduces shear by intensity times lowest axial distance<br>Maximum 3 intensity";
+	info = "TYPE-SM - SHEAR MITIGATOR<br>Reduces shear by intensity, based on radial distance from siphon (8x > 4x > 2x > 1x)<br>Maximum 3 intensity";
 	name = "printed card";
 	pixel_y = 9
 	},
@@ -35064,7 +35064,7 @@
 /obj/item/paper/manufacturer_blueprint/resonator_type_ax,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "TYPE-AX - AXIAL RESONATOR<br>Provides lateral and vertical resonance based on axial positioning<br>Maximum 4 intensity";
+	info = "TYPE-AX - AXIAL RESONATOR<br>Provides lateral and vertical resonance, based on distance from axial pinch points (8x > 4x > 2x > 1x)<br>Maximum 4 intensity";
 	name = "printed card";
 	pixel_y = 9
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -3770,9 +3770,9 @@
 /area/station/medical/medbay/treatment1)
 "bQQ" = (
 /obj/decal/cleanable/dirt/dirt4,
-/obj/item/spacecash/twenty{
-	pixel_x = -4;
-	pixel_y = -6
+/obj/item/spacecash/fifty{
+	pixel_y = -9;
+	pixel_x = -4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1478,8 +1478,7 @@
 	},
 /area/station/crew_quarters/lounge)
 "aHU" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/west,
+/obj/submachine/seed_vendor,
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -13665,10 +13664,6 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"gPp" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "gPP" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -14978,6 +14973,10 @@
 	dir = 9
 	},
 /area/station/medical/medbay/treatment)
+"hsb" = (
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "hsq" = (
 /obj/landmark/artifact,
 /obj/machinery/phone/wall{
@@ -21033,6 +21032,10 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"klu" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/black,
+/area/station/hydroponics/bay)
 "klx" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
@@ -23628,10 +23631,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"lvi" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "lvk" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4
@@ -24475,8 +24474,8 @@
 	name = "Transception Array Control"
 	})
 "lON" = (
-/obj/machinery/disposal/mail/autoname/hydroponics,
-/obj/disposalpipe/trunk/mail/west,
+/obj/disposalpipe/trunk/west,
+/obj/machinery/disposal,
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -25170,6 +25169,14 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
+"mdo" = (
+/obj/machinery/plantpot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "mdz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26997,8 +27004,8 @@
 	name = "Warrens Hall"
 	})
 "mUk" = (
-/obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "mUR" = (
@@ -27245,6 +27252,12 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"nda" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "ndi" = (
 /obj/rack,
 /obj/item/clothing/suit/wizrobe/purple,
@@ -28658,6 +28671,10 @@
 /obj/machinery/atmospherics/pipe/simple/southwest,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
+"nOr" = (
+/obj/machinery/hydro_mister,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "nOs" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
@@ -30522,10 +30539,6 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black/grime,
 /area/station/storage/warehouse)
-"oSh" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "oSi" = (
 /obj/stool/chair{
 	dir = 8
@@ -32311,6 +32324,18 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"pQm" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/access_spawn/hydro,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/green,
+/area/station/hydroponics/bay)
 "pRb" = (
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
@@ -46033,10 +46058,8 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
 "wXB" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/disposal/mail/small/autoname/hydroponics/west,
+/obj/disposalpipe/trunk/mail/south,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "wYs" = (
@@ -85201,7 +85224,7 @@ ewv
 nrw
 jdV
 jdV
-jdV
+nOr
 oNg
 ejD
 iHN
@@ -86103,9 +86126,9 @@ tIi
 sdD
 wKU
 bYZ
-fLE
+mdo
 wXB
-jdV
+hsb
 jdV
 mvb
 oNg
@@ -86407,7 +86430,7 @@ wKU
 ewv
 ewv
 ewv
-qlJ
+pQm
 qlJ
 oNg
 oNg
@@ -86709,7 +86732,7 @@ gpF
 kYt
 ewv
 uXb
-vnJ
+nda
 vnJ
 hYt
 aWy
@@ -87012,9 +87035,9 @@ rRf
 lxA
 oMd
 mUk
-oMd
-oMd
-gPp
+ajV
+ajV
+ajV
 loU
 loU
 kry
@@ -87316,9 +87339,9 @@ sKJ
 ajV
 ajV
 ajV
-oSh
-gPp
+ajV
 eTy
+klu
 tgQ
 igl
 igl
@@ -87619,8 +87642,8 @@ cZD
 cZD
 cZD
 mwv
-lvi
 omx
+ajV
 ajV
 ajV
 fpO

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -8140,6 +8140,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"efw" = (
+/obj/item/kitchen/food_box/egg_box,
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "efB" = (
 /obj/storage/closet/wardrobe/blue,
 /turf/simulated/floor/grey/side{
@@ -25782,11 +25786,39 @@
 	},
 /area/station/hallway/secondary/exit)
 "mtI" = (
+/obj/storage/crate/freezer,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
+/obj/item/reagent_containers/food/snacks/ingredient/meat{
+	desc = "Ew.";
+	name = "meat of questionable origin"
+	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "gibhead";
+	name = "grody thing"
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "gibmid2";
+	name = "gross organs"
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "gibtorso";
+	name = "meaty bit"
+	},
+/obj/item/organ/liver,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/item/kitchen/food_box/egg_box,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "mtW" = (
@@ -41112,35 +41144,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "uls" = (
-/obj/storage/crate/freezer,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/raw_material/ice,
-/obj/item/reagent_containers/food/snacks/ingredient/meat{
-	desc = "Ew.";
-	name = "meat of questionable origin"
-	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
-	icon = 'icons/effects/blood.dmi';
-	icon_state = "gibhead";
-	name = "grody thing"
-	},
-/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
-	icon = 'icons/effects/blood.dmi';
-	icon_state = "gibmid2";
-	name = "gross organs"
-	},
-/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
-	icon = 'icons/effects/blood.dmi';
-	icon_state = "gibtorso";
-	name = "meaty bit"
-	},
-/obj/item/organ/liver,
+/obj/machinery/space_heater,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "ulO" = (
@@ -80980,7 +80984,7 @@ rvl
 oaQ
 obA
 obA
-obA
+efw
 mtI
 uls
 gVW

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -322,20 +322,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"agN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "agT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -343,6 +329,15 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
+"agZ" = (
+/obj/decal/poster/wallsign/warning1{
+	desc = "A sign warning you of a nearby acid hazard.";
+	name = "ACID HAZARD"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/outer/nw{
+	name = "Northwest Breach Hull"
+	})
 "aho" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -800,9 +795,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "arE" = (
 /obj/table/wood/round/auto,
 /obj/machinery/light/lamp/black,
@@ -1784,9 +1777,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "aSj" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/engine/caution/northsouth,
@@ -4306,7 +4297,6 @@
 /area/station/hallway/primary/northeast)
 "ccu" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/firedoor_spawn,
 /obj/access_spawn/maint,
 /obj/cable{
 	icon_state = "1-2"
@@ -5021,9 +5011,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "cyv" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -5209,17 +5197,6 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/engine/caution/east,
 /area/station/crew_quarters/cafeteria)
-"cDL" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "cEk" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -5707,9 +5684,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "cRA" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -6315,9 +6290,7 @@
 /turf/simulated/floor/purpleblack/corner{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "dhK" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -6950,18 +6923,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"dAv" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "dAy" = (
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart equipped for handling hull breaches.";
@@ -7042,13 +7003,6 @@
 /obj/item/crowbar,
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
 "dBU" = (
@@ -7419,9 +7373,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 5
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "dII" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
@@ -7551,9 +7503,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "dNI" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/dome)
@@ -7921,9 +7871,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "dZl" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -8907,9 +8855,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "ezx" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/redblack{
@@ -9321,9 +9267,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "eLE" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -9818,9 +9762,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "eVF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11654,9 +11596,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "fST" = (
 /obj/pool/perspective{
 	dir = 4;
@@ -12043,9 +11983,7 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gbR" = (
 /obj/cable{
 	d1 = 2;
@@ -12300,9 +12238,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "ghK" = (
 /obj/machinery/disposal_pipedispenser/mobile{
 	dir = 4
@@ -12392,9 +12328,7 @@
 	},
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gkt" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 16
@@ -12553,6 +12487,15 @@
 	dir = 4
 	},
 /area/station/bridge)
+"gmG" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/south)
 "gmL" = (
 /obj/stool,
 /turf/simulated/floor/black/grime,
@@ -12615,9 +12558,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gpm" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/industrial,
@@ -12679,16 +12620,6 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"gqA" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "gqO" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -12778,9 +12709,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gsX" = (
 /obj/lattice{
 	dir = 9;
@@ -13527,9 +13456,7 @@
 "gKd" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gKe" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
@@ -13601,9 +13528,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "gLw" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -13894,10 +13819,7 @@
 	})
 "gTR" = (
 /obj/machinery/drainage,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
@@ -14635,9 +14557,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "hje" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -14884,9 +14804,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "hnI" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -15779,9 +15697,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "hIn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16257,13 +16173,6 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
 /obj/machinery/atmospherics/pipe/simple/overfloor/northwest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -16453,9 +16362,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "iay" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey/side{
@@ -17758,19 +17665,6 @@
 	dir = 1
 	},
 /area/station/security/brig)
-"iDX" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
 "iEd" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -17922,6 +17816,21 @@
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
+	})
+"iJx" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/station/engine/inner{
+	name = "Transception Array Control"
 	})
 "iJJ" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -18256,9 +18165,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "iTg" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -18282,9 +18189,7 @@
 "iTH" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "iTR" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -18436,9 +18341,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack/corner,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "iZA" = (
 /obj/cable{
 	d1 = 4;
@@ -19364,9 +19267,7 @@
 	},
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "jvq" = (
 /obj/machinery/ghostdrone_factory,
 /obj/machinery/conveyor/west{
@@ -19537,9 +19438,7 @@
 	},
 /obj/access_spawn/research_foyer,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "jzw" = (
 /obj/cable,
 /turf/simulated/floor/black,
@@ -19850,9 +19749,7 @@
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "jHS" = (
 /obj/submachine/cargopad/qm,
 /turf/simulated/floor/black,
@@ -19900,18 +19797,6 @@
 	dir = 8
 	},
 /area/station/storage/emergency2)
-"jIA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "jJE" = (
 /obj/stool/chair{
 	dir = 4
@@ -20030,9 +19915,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "jNP" = (
 /obj/disposalpipe/segment/transport,
 /obj/landmark/halloween,
@@ -20422,10 +20305,7 @@
 /area/station/science/research_director)
 "jTP" = (
 /obj/machinery/drainage,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
@@ -20599,6 +20479,20 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
+"jXT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "jXY" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -20676,9 +20570,7 @@
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "kaL" = (
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
@@ -20892,6 +20784,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/escape)
+"kfS" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "kfZ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -21048,19 +20950,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
-"kkn" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "kkG" = (
 /obj/decal/tile_edge{
 	icon = 'icons/obj/decals/stencils.dmi';
@@ -21649,19 +21538,6 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"kvx" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
 "kvK" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -22959,9 +22835,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lbk" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -23238,9 +23112,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lgY" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -23802,9 +23674,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lwo" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -23853,9 +23723,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lxm" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -24251,9 +24119,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lHV" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -24385,10 +24251,6 @@
 /obj/item/device/nanoloom{
 	pixel_x = 4;
 	pixel_y = -4
-	},
-/obj/item/nanoloom_cartridge{
-	pixel_x = 3;
-	pixel_y = -9
 	},
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
@@ -24564,9 +24426,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lOh" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
@@ -24693,9 +24553,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lQk" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -24734,9 +24592,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lRr" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/disposalpipe/junction/left/east,
@@ -24773,9 +24629,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lSf" = (
 /obj/submachine/chem_extractor,
 /obj/machinery/light{
@@ -24941,9 +24795,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "lWD" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -25680,9 +25532,7 @@
 /area/station/crew_quarters/cafeteria)
 "mlQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "mma" = (
 /obj/submachine/tape_deck,
 /turf/simulated/floor/darkblue/checker/other,
@@ -25730,9 +25580,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "mnk" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
@@ -26334,9 +26182,7 @@
 "mBY" = (
 /obj/decal/poster/wallsign/engineering,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "mCe" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -27080,9 +26926,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "mUh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27319,11 +27163,9 @@
 "nce" = (
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nco" = (
-/obj/structure/girder,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -27517,17 +27359,6 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
-"nhE" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "nis" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -27602,9 +27433,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nkW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27612,9 +27441,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nlc" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -27721,9 +27548,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nmM" = (
 /obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/redblack{
@@ -28200,9 +28025,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nAa" = (
 /obj/stove,
 /obj/item/soup_pot{
@@ -28442,9 +28265,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nFM" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -28628,9 +28449,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "nIK" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -29209,9 +29028,7 @@
 /turf/simulated/floor/purpleblack/corner{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "oaD" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -29274,9 +29091,7 @@
 "odJ" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "odL" = (
 /obj/storage/crate,
 /obj/item/instrument/saxophone,
@@ -29383,9 +29198,7 @@
 /area/station/security/equipment)
 "ohp" = (
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "oil" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29403,9 +29216,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "ojk" = (
 /obj/storage/closet/office,
 /turf/simulated/floor/plating,
@@ -29432,9 +29243,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 6
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "ojS" = (
 /obj/health_scanner/floor{
 	dir = 1
@@ -29679,6 +29488,13 @@
 /area/station/science/research_director)
 "orf" = (
 /obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
 	},
@@ -31220,9 +31036,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "pjY" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -31324,9 +31138,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "plO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31406,9 +31218,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 10
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "pnO" = (
 /obj/machinery/disposal/mail/autoname/kitchen,
 /obj/disposalpipe/trunk/mail/east,
@@ -31633,9 +31443,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "pte" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -32012,9 +31820,7 @@
 	},
 /obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "pCL" = (
 /obj/table/auto,
 /obj/item/paper{
@@ -32061,9 +31867,7 @@
 /area/station/chapel/office)
 "pDE" = (
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "pDS" = (
 /turf/simulated/floor/engine/caution/south,
 /area/station/science/chemistry)
@@ -32504,10 +32308,6 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/obj/item/nanoloom_cartridge{
-	pixel_x = 3;
-	pixel_y = -9
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -32896,9 +32696,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qcg" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 8;
@@ -33366,9 +33164,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qrn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33836,9 +33632,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qCW" = (
 /obj/disposalpipe/segment/food,
 /obj/machinery/vending/capsule,
@@ -33871,9 +33665,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qDV" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -33976,9 +33768,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qHC" = (
 /obj/disposalpipe/trunk/food,
 /obj/machinery/disposal/ore{
@@ -34457,9 +34247,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "qVJ" = (
 /turf/simulated/floor/engine/caution/east,
 /area/station/medical/head)
@@ -34653,6 +34441,13 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
+"rbu" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/south)
 "rbE" = (
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -34777,9 +34572,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "reu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35673,9 +35466,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "rDI" = (
 /obj/storage/secure/closet/security/forensics,
 /obj/item/storage/secure/ssafe{
@@ -35703,6 +35494,21 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
+"rEH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/station/engine/inner{
+	name = "Transception Array Control"
+	})
 "rEP" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -36726,6 +36532,15 @@
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
+"sfc" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/south)
 "sfE" = (
 /turf/unsimulated/wall/setpieces/leadwall/gray{
 	dir = 10
@@ -37287,9 +37102,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "stc" = (
 /obj/stool/chair{
 	dir = 8
@@ -37355,13 +37168,6 @@
 /obj/storage/cart,
 /obj/item/device/multitool{
 	pixel_x = -7
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
 	},
 /obj/machinery/light_switch/north,
 /obj/item/reagent_containers/food/drinks/fueltank{
@@ -37680,9 +37486,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "sCv" = (
 /obj/shrub{
 	dir = 1;
@@ -37703,11 +37507,6 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "sCD" = (
@@ -38123,9 +37922,7 @@
 	},
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "sLC" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -38958,6 +38755,18 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/showers)
+"tdn" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/industrial,
+/area/station/maintenance/outer/sw{
+	name = "Southwest Breach Hull"
+	})
 "tdq" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
@@ -39342,25 +39151,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/staff)
-"tlM" = (
-/obj/rack,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/head/helmet/firefighter,
-/obj/item/tank/air,
-/obj/item/extinguisher,
-/obj/item/crowbar,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "tmd" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/ai_upload,
@@ -40574,9 +40364,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "tQs" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -40693,9 +40481,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "tTk" = (
 /obj/stool/chair{
 	dir = 4
@@ -40826,19 +40612,6 @@
 "tXW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/northeast)
-"tYh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "tYl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/robotics)
@@ -40997,6 +40770,13 @@
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
 "ube" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 8
 	},
@@ -42593,6 +42373,20 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northeast)
+"uSP" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "uTl" = (
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
@@ -42861,9 +42655,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "vay" = (
 /obj/decal/tile_edge/floorguide/command{
 	dir = 4
@@ -43122,9 +42914,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "vkt" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/purpleblack/corner,
@@ -43921,6 +43711,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
+"vGa" = (
+/obj/decal/poster/wallsign/warning1{
+	desc = "A sign warning you of a nearby acid hazard.";
+	name = "ACID HAZARD"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/outer/se{
+	name = "Southeast Breach Hull"
+	})
 "vGn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44206,9 +44005,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "vOG" = (
 /obj/machinery/sleeper/compact,
 /obj/machinery/light/incandescent/netural{
@@ -44437,9 +44234,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/purpleblack/corner,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "vUR" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/heads,
@@ -45355,9 +45150,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "wAs" = (
 /turf/simulated/floor/circuit/white,
 /area/station/turret_protected/ai_upload)
@@ -45373,17 +45166,6 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"wAL" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "wBm" = (
 /obj/machinery/atmospherics/valve/notify_admins/vertical{
 	name = "Sauna Air Supply"
@@ -45794,9 +45576,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "wNk" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/wood,
@@ -46078,9 +45858,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "wVl" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -46709,9 +46487,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "xmi" = (
 /obj/table/reinforced/auto,
 /obj/drink_rack/mug{
@@ -47260,9 +47036,7 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "xAj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47472,13 +47246,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"xER" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "xFb" = (
 /obj/machinery/light_switch/west,
 /obj/stool/chair/office/blue{
@@ -47600,9 +47367,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "xJp" = (
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack,
@@ -47689,9 +47454,7 @@
 	name = "Scientist"
 	},
 /turf/simulated/floor/purpleblack,
-/area/station/science/gen_storage{
-	name = "Research Hall"
-	})
+/area/station/science/hall)
 "xLT" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -78115,7 +77878,7 @@ bzS
 bzS
 xQv
 ifl
-xQv
+agZ
 bRa
 fEU
 bRa
@@ -78181,7 +77944,7 @@ uqC
 dif
 wuT
 uqC
-jjE
+poa
 gTR
 jjE
 bzS
@@ -83579,7 +83342,7 @@ jdV
 jdV
 fDR
 oNg
-gbZ
+pnx
 iHN
 myU
 xPz
@@ -83928,7 +83691,7 @@ qLh
 jjE
 jjE
 uqC
-dKj
+uqC
 jjE
 jjE
 bzS
@@ -84532,12 +84295,12 @@ rRY
 lPo
 jjE
 jjE
+tdn
 uqC
-uqC
 jjE
 jjE
 jjE
-poa
+jjE
 rJg
 bzS
 bzS
@@ -85140,7 +84903,7 @@ jjE
 eqq
 eqq
 jjE
-jjE
+poa
 jjE
 hiQ
 rJg
@@ -85693,7 +85456,7 @@ jdV
 jdV
 fLE
 oNg
-pnx
+gbZ
 iHN
 bSm
 qdm
@@ -87816,7 +87579,7 @@ lFq
 oNg
 txT
 nWF
-wAL
+nWF
 xTC
 dwo
 iWT
@@ -88985,10 +88748,10 @@ mbF
 cHg
 jhj
 aYA
-mbF
-mbF
-mbF
 sWl
+mbF
+mbF
+mbF
 wBW
 mbF
 mbF
@@ -90181,7 +89944,7 @@ bRa
 kzb
 sVB
 iui
-jUu
+bzL
 oGv
 oGv
 oGv
@@ -90483,7 +90246,7 @@ kzb
 kzb
 kzb
 isD
-bzL
+jUu
 oGv
 ung
 qHY
@@ -90841,7 +90604,7 @@ dBK
 aTs
 bFl
 sHW
-cOM
+gmG
 pqn
 qVZ
 xZW
@@ -91444,7 +91207,7 @@ dNF
 lbh
 pnG
 mlQ
-jIA
+sHW
 kBB
 kBB
 kBB
@@ -92090,7 +91853,7 @@ mhF
 lqP
 rxJ
 umc
-iDX
+nsy
 tBf
 hDs
 tZe
@@ -93294,7 +93057,7 @@ baj
 mwe
 myz
 rhf
-mUh
+iJx
 iYe
 mUh
 xsc
@@ -93801,7 +93564,7 @@ epj
 mjW
 ovr
 oPd
-rVE
+jXT
 sgm
 mbF
 mbF
@@ -95009,7 +94772,7 @@ epj
 mjW
 ovr
 oPd
-gGz
+uSP
 mLZ
 wBN
 wBN
@@ -95710,7 +95473,7 @@ baj
 mwA
 mAj
 rhf
-mUh
+rEH
 oQE
 mUh
 xsc
@@ -95974,8 +95737,8 @@ tTj
 qDP
 ohp
 mlQ
-xER
-lZB
+cOM
+sHW
 caO
 sOU
 sOU
@@ -96578,8 +96341,8 @@ pDE
 qDP
 ohp
 mlQ
-cOM
-sHW
+rbu
+lZB
 sOU
 fqt
 qXF
@@ -96922,7 +96685,7 @@ uQh
 uQh
 uQh
 eRD
-kvx
+nsy
 tBf
 hDs
 neB
@@ -97183,7 +96946,7 @@ rek
 xLi
 mlQ
 cOM
-dAv
+sHW
 sOU
 gXd
 nCO
@@ -98085,7 +97848,7 @@ aaY
 dkT
 mPS
 xZH
-tlM
+dBK
 fUZ
 bFl
 cOM
@@ -98335,7 +98098,7 @@ xes
 xes
 xes
 hBF
-gqA
+aFj
 dNI
 mZd
 vqO
@@ -98637,7 +98400,7 @@ uNU
 xes
 oUh
 icI
-aFj
+kfS
 dNI
 dNI
 dNI
@@ -98693,7 +98456,7 @@ emc
 kXG
 bFl
 cOM
-cOM
+sfc
 sOU
 sOU
 sOU
@@ -99548,7 +99311,7 @@ xes
 xes
 bKE
 tTl
-cDL
+tnY
 tnY
 tnY
 tnY
@@ -99860,7 +99623,7 @@ ivH
 ube
 fSk
 fNs
-kkn
+vwD
 vwD
 cAx
 wBN
@@ -103204,7 +102967,7 @@ qWU
 wTH
 vMU
 cCs
-nhE
+aTP
 aTP
 gYH
 iIi
@@ -103512,7 +103275,7 @@ nbH
 cHd
 cHd
 cHd
-pMD
+mwn
 jmz
 gie
 oZp
@@ -103814,7 +103577,7 @@ gKW
 uDe
 hTZ
 cHd
-mwn
+pMD
 gie
 gie
 rIw
@@ -104996,7 +104759,7 @@ pYH
 pYH
 kes
 pxr
-tYh
+ktD
 wHl
 wHl
 aas
@@ -107402,8 +107165,8 @@ bzS
 bzS
 rJg
 rJg
-cXH
 rne
+cXH
 eVf
 rne
 kti
@@ -107714,7 +107477,7 @@ gEb
 ilt
 jPN
 pYH
-agN
+ktD
 uha
 vkx
 wAs
@@ -110731,7 +110494,7 @@ bzS
 bzS
 rne
 vDv
-rne
+cXH
 uNU
 aGv
 uNU
@@ -110797,7 +110560,7 @@ ovR
 neB
 hOA
 neB
-dAB
+vGa
 jTP
 dAB
 bzS

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4367,10 +4367,10 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "cew" = (
-/obj/decal/tile_edge/floorguide/arrow_e{
-	dir = 1
-	},
 /obj/disposalpipe/segment/bent/north,
+/obj/decal/tile_edge/floorguide/arrow_e{
+	dir = 8
+	},
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
@@ -16604,8 +16604,9 @@
 	name = "Diplomatic Quarters"
 	})
 "ieC" = (
-/obj/machinery/door/airlock/pyro/security/alt{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 4;
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/cable{
@@ -21017,12 +21018,12 @@
 /obj/table/reinforced/auto,
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm,
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm,
-/obj/item/paper/manufacturer_blueprint/resonator_type_sm,
 /obj/item/paper{
 	icon_state = "index_card";
 	info = "TYPE-SM - SHEAR MITIGATOR<br>Reduces shear by intensity, based on radial distance from siphon (8x > 4x > 2x > 1x)<br>Maximum 3 intensity";
 	name = "printed card";
-	pixel_y = 9
+	pixel_y = 13;
+	pixel_x = -4
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -35061,12 +35062,12 @@
 /obj/table/reinforced/auto,
 /obj/item/paper/manufacturer_blueprint/resonator_type_ax,
 /obj/item/paper/manufacturer_blueprint/resonator_type_ax,
-/obj/item/paper/manufacturer_blueprint/resonator_type_ax,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "TYPE-AX - AXIAL RESONATOR<br>Provides lateral and vertical resonance, based on distance from axial pinch points (8x > 4x > 2x > 1x)<br>Maximum 4 intensity";
+	info = "TYPE-AX - AXIAL RESONATOR<br>Provides lateral and vertical resonance, multiplied based on distance from axial pinch points (8x > 4x > 2x > 1x)<br>Maximum 4 intensity";
 	name = "printed card";
-	pixel_y = 9
+	pixel_y = 13;
+	pixel_x = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -47870,6 +47871,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "xTD" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
 "xTI" = (
@@ -82805,9 +82810,9 @@ lZN
 eMy
 lZN
 mKo
-mKo
+qwy
 ieC
-mKo
+qwy
 mKo
 qwy
 whY

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -39686,12 +39686,17 @@
 /area/station/science/artifact)
 "tza" = (
 /obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/machinery/light/lamp/black{
+	pixel_y = 7;
+	pixel_x = -5
+	},
 /obj/item/pen{
 	pixel_y = -2;
 	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_y = 16
 	},
 /turf/simulated/floor/black/side{
 	dir = 1

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1018,6 +1018,18 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"awW" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/sheet/steel{
+	amount = 5;
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "axd" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
@@ -1410,6 +1422,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"aGq" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aGv" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -1724,6 +1743,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters_east)
 "aRF" = (
@@ -2423,6 +2443,14 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"blT" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "blV" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
@@ -2949,8 +2977,13 @@
 "bwb" = (
 /obj/table/reinforced/auto,
 /obj/machinery/microwave{
-	pixel_x = 1;
-	pixel_y = 3
+	pixel_x = 1
+	},
+/obj/item/storage/wall{
+	icon_state = "miniorange";
+	name = "Donk-Closet";
+	pixel_y = 32;
+	spawn_contents = list(/obj/item/storage/box/donkpocket_kit)
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -3189,6 +3222,14 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
+"bBu" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bBO" = (
 /turf/simulated/floor/caution/corner/misc{
 	dir = 9
@@ -3299,17 +3340,8 @@
 "bEl" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
-/obj/item/paper{
-	info = "if the siphon nerds kick you out use the mining fab, dive suits work just fine in acid if you loom them after EVA";
-	name = "creased note";
-	pixel_x = -15;
-	pixel_y = 9
-	},
 /obj/item/device/nanoloom{
 	pixel_x = -13;
-	pixel_y = 18
-	},
-/obj/item/storage/box/donkpocket_kit{
 	pixel_y = 18
 	},
 /turf/simulated/floor/black,
@@ -3512,6 +3544,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/carpet/red,
 /area/station/crew_quarters/quarters_east)
 "bJE" = (
@@ -3722,6 +3755,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment1)
+"bQQ" = (
+/obj/decal/cleanable/dirt/dirt4,
+/obj/item/spacecash/twenty{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bQV" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "2"
@@ -4267,6 +4308,9 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/firedoor_spawn,
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "cdp" = (
@@ -4631,6 +4675,9 @@
 /turf/space/fluid/acid/clear,
 /area/station/hallway/secondary/exit)
 "cnM" = (
+/obj/decal/cleanable/writing/infrared{
+	words = "use gloves, dust it after"
+	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "cnT" = (
@@ -5430,6 +5477,18 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"cMh" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/item/reagent_containers/food/drinks/bottle/empty/square{
+	pixel_x = -14;
+	pixel_y = 8
+	},
+/obj/item/motherboard{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "cMy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11921,6 +11980,14 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
+"gbs" = (
+/obj/decal/cleanable/dirt/dirt4,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "gbu" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/utensil/knife,
@@ -13449,7 +13516,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering personnel are authorized to access Harmonic Siphon<br>in furtherance of generator operation and Site upkeep.";
+	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
 	name = "printed card";
 	pixel_y = 6
 	},
@@ -19311,6 +19378,7 @@
 /obj/item/storage/secure/ssafe{
 	pixel_x = 28
 	},
+/obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_east)
 "jvJ" = (
@@ -21887,6 +21955,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "kBW" = (
@@ -24572,7 +24641,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering personnel are authorized to access Harmonic Siphon<br>in furtherance of generator operation and Site upkeep.";
+	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
 	name = "printed card";
 	pixel_y = 6
 	},
@@ -25689,6 +25758,12 @@
 /obj/blind_switch/area/east,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"moC" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "moJ" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/machinery/light{
@@ -28702,6 +28777,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"nNV" = (
+/obj/decal/cleanable/dirt,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "nOl" = (
 /obj/machinery/atmospherics/pipe/simple/southwest,
 /turf/simulated/wall/auto/supernorn,
@@ -29756,6 +29839,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "ovY" = (
@@ -30079,8 +30163,8 @@
 /turf/simulated/floor/black,
 /area/station/storage/eva)
 "oFg" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone/unlisted,
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -30752,6 +30836,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_east)
 "oWy" = (
@@ -32224,6 +32309,17 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
+"pLd" = (
+/obj/decal/cleanable/dirt,
+/obj/cable{
+	icon_state = "2-9"
+	},
+/obj/item/pen{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "pLn" = (
 /obj/stool/chair/office/yellow,
 /obj/landmark/start{
@@ -34457,6 +34553,9 @@
 /area/station/turret_protected/Zeta)
 "qXU" = (
 /obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
 "qYu" = (
@@ -34967,7 +35066,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "rma" = (
@@ -35250,6 +35349,23 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
+"rtv" = (
+/obj/table/auto,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/decoration/ashtray{
+	butts = 3;
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "rtS" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -38419,6 +38535,19 @@
 	dir = 8
 	},
 /area/station/hallway/primary/southeast)
+"sUL" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/table/auto,
+/obj/item/paper/blueprint{
+	desc = "A blueprint showing detailed plans for some sort of subterranean structure. It seems to be unusually lacking in labeling.";
+	name = "dusty blueprint";
+	pixel_y = 7
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "sUR" = (
 /obj/storage/crate/freezer{
 	name = "Freezer - Spare Parts"
@@ -40587,6 +40716,13 @@
 /area/station/crew_quarters/kitchen)
 "tTK" = (
 /obj/machinery/recharge_station,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "tTR" = (
@@ -42160,6 +42296,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/quarters_east)
 "uMd" = (
@@ -42317,6 +42454,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"uPs" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "uPA" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/shieldgenerator/energy_shield{
@@ -43840,6 +43984,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "vHX" = (
@@ -43928,6 +44073,16 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
+"vKd" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/obj/item/storage/secure/ssafe/loot{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "vKn" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -44686,13 +44841,6 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "wjM" = (
@@ -44776,6 +44924,15 @@
 	dir = 1
 	},
 /area/station/turret_protected/ai)
+"wmP" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "wmR" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -102458,12 +102615,12 @@ cAs
 vBq
 cAs
 cAs
-aLz
-qTS
+wmP
+uPs
 ccu
-gie
-gie
-gie
+gbs
+bQQ
+rtv
 sXH
 yiB
 sVX
@@ -102763,9 +102920,9 @@ iIi
 iNo
 rfO
 cnM
-gie
-gie
-gie
+aGq
+pLd
+nNV
 sXH
 yiB
 vEo
@@ -103065,11 +103222,11 @@ oZp
 iXV
 oZp
 oZp
-xWr
-gie
-gie
+sUL
+moC
+bBu
 sXH
-yiB
+blT
 vEo
 iPJ
 rZb
@@ -103367,9 +103524,9 @@ tvR
 ixW
 oNJ
 oZp
-gie
-gie
-gie
+vKd
+cMh
+awW
 sXH
 sXH
 rLM

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -602,6 +602,21 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
+"amF" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "amO" = (
 /obj/submachine/seed_manipulator{
 	dir = 8
@@ -4509,6 +4524,10 @@
 	},
 /obj/item/storage/toilet{
 	dir = 8
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig/genpop)
@@ -11215,6 +11234,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "fJg" = (
@@ -13812,17 +13835,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"gTt" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/decal/cleanable/dirt/jen,
-/turf/simulated/floor/carpet/green/standard/innercorner/omni,
-/area/station/maintenance/storage{
-	icon_state = "crewquarters";
-	name = "Warrens Hall"
-	})
 "gTR" = (
 /obj/machinery/drainage,
 /obj/machinery/light/small,
@@ -14055,13 +14067,6 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
-"gYf" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "gYn" = (
 /turf/unsimulated/wall/setpieces/leadwall/gray{
 	dir = 6
@@ -15726,6 +15731,10 @@
 	},
 /obj/machinery/drainage,
 /obj/decal/cleanable/dirt,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/maintenance/storage{
 	icon_state = "crewquarters";
@@ -16122,6 +16131,9 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/cargooffice)
 "hVr" = (
@@ -32528,6 +32540,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
+"pUR" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northwest)
 "pUS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -43068,13 +43087,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_east)
-"vnt" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "vnv" = (
 /obj/lattice{
 	dir = 10;
@@ -43692,15 +43704,6 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
-"vDp" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/industrial,
-/area/station/hallway/secondary/construction{
-	name = "The Warrens"
-	})
 "vDv" = (
 /obj/machinery/drainage,
 /obj/machinery/light/small{
@@ -45177,10 +45180,6 @@
 	name = "Warrens Hall"
 	})
 "wzO" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -48155,10 +48154,6 @@
 /obj/machinery/disposal/ore{
 	desc = "A pneumatic delivery chute for delivery of food to the brig.";
 	name = "brig meal-line chute"
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -80704,7 +80699,7 @@ trK
 ajs
 oEZ
 gbZ
-vnt
+oEZ
 cbe
 dHA
 rvl
@@ -84909,7 +84904,7 @@ odL
 imj
 fwk
 oTZ
-ukW
+pUR
 ukW
 pHb
 wHo
@@ -92796,7 +92791,7 @@ qDP
 ohp
 mlQ
 sHW
-gYf
+cOM
 pMS
 vFY
 kBB
@@ -98270,7 +98265,7 @@ pOj
 hQo
 nlQ
 hri
-gTt
+eUl
 wxt
 lty
 lty
@@ -107920,7 +107915,7 @@ gik
 gik
 gik
 lFY
-giN
+amF
 cBV
 cBV
 neB
@@ -109126,7 +109121,7 @@ nHj
 dbf
 kRh
 jxs
-vDp
+mTx
 cBV
 cBV
 neB

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2435,8 +2435,9 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "blT" = (
-/obj/stool/chair{
-	dir = 8
+/obj/table/wood/round/auto,
+/obj/item/paper_bin{
+	pixel_y = 2
 	},
 /turf/simulated/floor/black/side{
 	dir = 1
@@ -3059,6 +3060,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"bxW" = (
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/hallway/primary/southeast)
 "byf" = (
 /obj/decal/tile_edge{
 	icon = 'icons/obj/decals/stencils.dmi';
@@ -23852,6 +23859,17 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"lAr" = (
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "lAB" = (
 /obj/item/storage/toilet{
 	dir = 4
@@ -39667,6 +39685,19 @@
 /obj/access_spawn/artlab,
 /turf/simulated/floor/black,
 /area/station/science/artifact)
+"tza" = (
+/obj/table/wood/round/auto,
+/obj/item/pen{
+	pixel_y = -2;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_y = 16
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "tzj" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/heavy{
@@ -43614,8 +43645,12 @@
 /area/station/crew_quarters/pool)
 "vDk" = (
 /obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/device/pda_module/tray{
+	pixel_x = -5
+	},
+/obj/item/electronics/scanner{
+	pixel_x = 4
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
 "vDp" = (
@@ -102387,7 +102422,7 @@ gbs
 bQQ
 rtv
 sXH
-yiB
+tza
 sVX
 iPJ
 wlW
@@ -102689,7 +102724,7 @@ aGq
 pLd
 nNV
 sXH
-yiB
+lAr
 vEo
 iPJ
 uEI
@@ -104807,7 +104842,7 @@ sNR
 jjd
 qBe
 rZb
-oHA
+bxW
 hXJ
 lbH
 lbg

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2982,9 +2982,10 @@
 /area/station/engine/engineering)
 "bwd" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
+/obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bwi" = (
@@ -37716,10 +37717,11 @@
 /area/station/medical/medbay/lobby)
 "sHt" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
+/obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
 	},
-/obj/machinery/cashreg,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "sHW" = (
@@ -105092,7 +105094,7 @@ oZp
 frT
 aHy
 vaR
-wMJ
+oZp
 fhJ
 eBr
 adk


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fifth Nadir fixbatch. Further changes of moderate scale.

### Map Alterations

**Major**

* Increased the complement of janitors to three, adding an immersion suit vault to the janitor's office. Three is apparently the standard limit despite most maps that use it only having two Janitor spawn landmarks. To compensate for this increased supply, janitors' nanolooms no longer come with a spare spool cartridge.
* Reduced the security officer complement from six to the standard limit of five; one bench slot in the Security locker room will unfortunately always be empty on round start now.
* Did a balance pass over camera coverage. This primarily entails reducing the camera coverage in non-breach hull Maintenance, though another change of note is an improvement to camera coverage of the artifact ejector.
* Removed the east Public Market stall (as the area saw little use) and turned the space it previously occupied into a small "crime zone" hinting at Nadir's history, featuring a data terminal and deconstructable contents that make it a decent spot for small construction projects.
* Introduced a new Research Hall area for Nadir's research hall to reduce varediting and avoid unintentional radiation storm immunity.

**Minor**

* Engineering's "contingency" mining fabricator now includes a bit of cloth as well as its usual materials, allowing for ore satchel fabrication without having to go rip up a bedsheet.
* Engineering's main room has been adjusted, removing a note made redundant by floor signage and moving the Donk-Pockets relocated by the engineering clothing vendor into a dedicated "Donk-Closet" cabinet.
* The empty closet near the Sea Elevator is now a Maintenance Immersion Suit Vault, requiring maintenance access as one would expect from the name. Its contents are a bit cut down, and more similar to an EVA rack.
* Adjusted area allocation near the escape hallway security checkpoint's cell to avoid teleport shenanigans.
* Relocated several acid hazard signs to be in more inward spots, and added acid hazard signs to the corner airlocks of the breach hull.
* Reformatted printed cards in the catalytic substations to display a bit better.
* Adjusted the resonator blueprint tables a bit to avoid printed cards getting buried if the blueprints shift into an awkward position, and updated the resonator printed cards to include more details about resonator function.
* Corrected an erroneous reinforced wall under the ATM in East Crew Quarters.
* Added an artifact spawner in a back corner of the Warrens, bringing the total on-site to four (two in Artlab, two elsewhere).
* Carpeted the Head of Security's office, and fixed their bathroom's lack of a sink.
* Security's "hub room" now has windows into the equipment/locker room.
* Geoff Honkington's chair has defected to the Syndicate, as is the case with other maps.
* Adjusted the southwest navigation flower a bit.
* Added a space HVAC unit to the catering storage freezer room.
* Added a seed fabricator to the eastern compartment of Hydroponics, bringing the complement up to a more standard two, as well as a botanical mister and the relocated mail chute in the middle compartment.
* Swapped the redundant second refining nano-fabricator in the Refinery for a mining nano-fabricator.
* Redistributed some peststart landmarks, primarily attempting to get them out of spaces people might be lingering in.
* Moved a bot patrol beacon in the Bridge/QM lobby upwards to attempt to discourage bots from routing through the court office.

### Code Alterations

area.dm:

* Defines a new Research Hall area for Nadir's... well, research hall.

manufacturer.dm:

* Changes resonator blueprints to use the default manufacturer blueprint sprite for a better fit on their tables.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves Nadir's functionality and cohesion.

Changelog entry has been made major due to the presence of a change to radstorm protection coverage, which is important for players to be aware of.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Fifth fixbatch for Nadir, prominently including a third Janitor slot, removal of a nonstandard Security slot, and inner maintenance camera coverage adjustment. The Research hall is no longer radstorm immune.
```
