### PR TITLE
makes the pod wars base magnets setup at roundstart

### DIFF
--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -7395,6 +7395,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/machinery/magnet_chassis,
+/obj/machinery/mining_magnet,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	icon_state = "catwalk_cross"
@@ -10794,7 +10795,6 @@
 /area/pod_wars/spacejunk/fstation/mess)
 "OM" = (
 /obj/rack,
-/obj/item/magnet_parts/construction,
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team2/mining)
 "ON" = (
@@ -10931,7 +10931,6 @@
 /area/space)
 "Pq" = (
 /obj/rack,
-/obj/item/magnet_parts/construction,
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/mining)
 "Pr" = (
@@ -11031,6 +11030,9 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/machinery/magnet_chassis{
+	dir = 8
+	},
+/obj/machinery/mining_magnet{
 	dir = 8
 	},
 /turf/simulated/floor/airless/plating/catwalk{
@@ -13711,6 +13713,10 @@
 	},
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"ZO" = (
+/obj/landmark/magnet_center,
+/turf/space,
+/area/space)
 "ZQ" = (
 /obj/stool/bed,
 /obj/window/cubicle{
@@ -30884,7 +30890,7 @@ JW
 JW
 JW
 JW
-JW
+ZO
 JW
 JW
 JW
@@ -239639,7 +239645,7 @@ JW
 JW
 JW
 JW
-JW
+ZO
 JW
 JW
 JW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
 [QOL] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- adds the required stuff for the mning magnets at both bases to automatically set themselves up at roundstart
- removes the magnet parts item from the mining rooms on both bases
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its nice for pod wars nerds to not have to set up their magnets


