### PR TITLE
Various tracker bug fixes

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1386,20 +1386,24 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 				var/datum/game_mode/revolution/R = ticker.mode
 				var/list/datum/mind/heads = R.head_revolutionaries
 				var/turf/Turf = get_turf(usr)
+				nearest_head_location = null
 
 				for (var/datum/mind/Mind in heads)
-					if(!istype(Mind?.current, /mob/living/carbon/human))
-						return
+					if(!Mind.current)
+						continue
+					if(!istype(Mind.current, /mob/living/carbon/human))
+						continue
 					var/MindMob = Mind.current
 					var/turf/MindTurf = get_turf(MindMob)
-					if(!isalive(Mind?.current) || MindTurf.z != 1)
-						return
+					if(!isalive(Mind.current) || MindTurf.z != 1)
+						continue
 					if(GET_DIST(Turf, MindTurf) <= GET_DIST(Turf, nearest_head_location))
 						nearest_head_location = MindTurf
 
 				if(nearest_head_location != null)
-					direction = get_dir(Turf, nearest_head_location)
+					direction = dir2text(get_dir(Turf, nearest_head_location))
 					distance = GET_DIST(Turf, nearest_head_location)
+
 
 		src.master.add_fingerprint(usr)
 		src.master.updateSelfDialog()
@@ -1443,19 +1447,22 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 				var/datum/game_mode/revolution/R = ticker.mode
 				var/list/datum/mind/heads = R.get_all_heads()
 				var/turf/Turf = get_turf(usr)
+				nearest_head_location = null
 
 				for (var/datum/mind/Mind in heads)
-					if(!istype(Mind?.current, /mob/living/carbon/human))
-						return
+					if(!Mind.current)
+						continue
+					if(!istype(Mind.current, /mob/living/carbon/human))
+						continue
 					var/MindMob = Mind.current
 					var/turf/MindTurf = get_turf(MindMob)
-					if(!isalive(Mind?.current) || MindTurf.z != 1)
-						return
+					if(!isalive(Mind.current) || MindTurf.z != 1)
+						continue
 					if(GET_DIST(Turf, MindTurf) <= GET_DIST(Turf, nearest_head_location))
 						nearest_head_location = MindTurf
 
 				if(nearest_head_location != null)
-					direction = get_dir(Turf, nearest_head_location)
+					direction = dir2text(get_dir(Turf, nearest_head_location))
 					distance = GET_DIST(Turf, nearest_head_location)
 
 		src.master.add_fingerprint(usr)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes some of tracker code to where they actually work when there is a dead revhead now. Also now has the direction come out in text format, and has avoids the situation of the tracker tracking a revhead that no longer exists.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fixes good, specifically #11572

