### PR TITLE
Harmonic Siphon extraction rate buff + rate limit removal

### DIFF
--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -213,16 +213,17 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 					if(ytcheck > M.sens_window) continue
 				extract_progressed = TRUE
 				if(src.extract_ticks >= M.tick_req)
-					src.extract_ticks -= M.tick_req
-					var/atom/movable/yielder = new M.product()
-					if(istype(yielder,/obj/item)) //items go into internal reservoir
-						src.contents += yielder
-						src.update_storage_bar()
-					else //pulled out something that isn't an item... what could it be?
-						yielder.set_loc(get_turf(src))
+					while(src.extract_ticks >= M.tick_req && length(src.contents) < src.max_held_items)
+						src.extract_ticks -= M.tick_req
+						var/atom/movable/yielder = new M.product()
+						if(istype(yielder,/obj/item)) //items go into internal reservoir
+							src.contents += yielder
+							src.update_storage_bar()
+						else //pulled out something that isn't an item... what could it be?
+							yielder.set_loc(get_turf(src))
 
 					//non-shear failures
-					//option 1 - too many extraction ticks buffered at once due to mismatch between intensity and requirement
+					//option 1 - too many extraction ticks buffered at once
 					//option 2 - running resonators with the panel open is a bad idea
 					if(src.extract_ticks > 50)
 						if(src.extract_overloaded == FALSE) //warn if newly overloaded

--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -225,7 +225,7 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 					//non-shear failures
 					//option 1 - too many extraction ticks buffered at once
 					//option 2 - running resonators with the panel open is a bad idea
-					if(src.extract_ticks > 50)
+					if(src.extract_ticks > 20)
 						if(src.extract_overloaded == FALSE) //warn if newly overloaded
 							src.visible_message("<span class='alert'><B>[src]</B> emits an excess accumulated EEU warning.<span>")
 							playsound(src, 'sound/machines/pod_alarm.ogg', 30, 1)

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -6,7 +6,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	///Whether this outcome should be indexed in the player-viewable settings compendium
 	var/indexed = TRUE
 	///How many extraction ticks (process iterations times resonator intensity) are required to produce this resource
-	var/tick_req = 30
+	var/tick_req = 10
 	///Target resonance horizontal strength, positive or negative based on relative X position of resonator multiplied by its power.
 	var/x_torque = null
 	///Target resonance vertical strength, positive or negative based on relative Y position of resonator multiplied by its power.
@@ -25,7 +25,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/miraclium
 	name = "Direct Extraction"
-	tick_req = 60
+	tick_req = 16
 	x_torque = 0
 	y_torque = 0
 	shear = 0
@@ -38,7 +38,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/rock
 	name = "Rock"
-	tick_req = 8
+	tick_req = 4
 	x_torque = 16
 	y_torque = 0
 	shear = 0
@@ -50,7 +50,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/char
 	name = "Char"
-	tick_req = 15
+	tick_req = 8
 	x_torque = -16
 	y_torque = -4
 	shear = 16
@@ -118,7 +118,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/claretine
 	name = "Claretine"
-	tick_req = 40
+	tick_req = 15
 	x_torque = 32
 	y_torque = -4
 	shear = 20
@@ -133,7 +133,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/bohrum
 	name = "Bohrum"
-	tick_req = 40
+	tick_req = 15
 	x_torque = -16
 	y_torque = -16
 	shear = 24
@@ -167,7 +167,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/syreline
 	name = "Syreline"
-	tick_req = 40
+	tick_req = 20
 	x_torque = 88
 	shear = 6
 	sens_window = 1
@@ -175,7 +175,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/erebite
 	name = "Erebite"
-	tick_req = 60
+	tick_req = 50
 	x_torque = 6
 	y_torque = -22
 	shear = 33
@@ -188,7 +188,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/cerenkite
 	name = "Cerenkite"
-	tick_req = 50
+	tick_req = 30
 	x_torque = -24
 	y_torque = 8
 	shear = 16
@@ -201,7 +201,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/plasmastone
 	name = "Plasmastone"
-	tick_req = 60
+	tick_req = 50
 	x_torque = -16
 	y_torque = 13
 	shear = 4
@@ -214,7 +214,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/koshmarite
 	name = "Koshmarite"
-	tick_req = 35
+	tick_req = 18
 	shear = 58
 	product = /obj/item/raw_material/eldritch
 
@@ -224,7 +224,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/gemstone
 	name = "Gemstone"
-	tick_req = 80
+	tick_req = 35
 	x_torque = 0
 	y_torque = 0
 	shear = 64
@@ -232,7 +232,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/uqill
 	name = "Uqill"
-	tick_req = 100
+	tick_req = 40
 	shear = 54
 	sens_window = 2
 	product = /obj/item/raw_material/uqill
@@ -255,14 +255,13 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 //shear of 65 or higher should probably do Bad Things unless precisely set.
 /datum/siphon_mineral/gold
 	name = "Gold"
-	tick_req = 90
+	tick_req = 50
 	y_torque = 0
 	shear = 100
 	sens_window = 0
 	product = /obj/item/raw_material/gold
 
 	New()
-		src.tick_req = rand(25,32) * 10
 		src.shear = rand(45,50) * 2 // 90 to 100, in only even increments
 		..()
 
@@ -273,7 +272,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	product = /obj/item/raw_material/starstone
 
 	New()
-		src.tick_req = rand(70,90) * 10
+		src.tick_req = rand(100,130) * 5
 		src.shear = rand(130,230)
 		..()
 
@@ -285,7 +284,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	product = /obj/item/material_piece/wad/blob
 
 	New()
-		src.tick_req = rand(12,22) * 10
+		src.tick_req = rand(8,11) * 10
 		src.shear = (rand(56,61) * 2) + 1 // 113 to 127, in only odd increments
 		..()
 

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -38,7 +38,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 
 /datum/siphon_mineral/rock
 	name = "Rock"
-	tick_req = 4
+	tick_req = 8
 	x_torque = 16
 	y_torque = 0
 	shear = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts the balance of Nadir's Harmonic Siphon to be considerably more rewarding, with some technical changes to support this.

- Reduced the number of extraction ticks required to extract most materials; this is typically about 1/2 to 1/3 the prior number, but there are some exceptions, primarily relating to energetic materials like cerenkite (full list included below).
- The hard cap of one material extracted per machine tick has been removed; extraction rate is now only bounded by how much intensity you can get on your resonators, whether you can obtain and/or power that many, and the excess accumulated EEU threshold.
- As it's now much harder to build up over-charge in extraction (since accumulated charge can now provide multiple materials inside one machine tick), the excess accumulated EEU threshold has been reduced from 50 extraction ticks to 20. It's still quite hard to hit this threshold unless you're running the siphon in an incorrect configuration.

Itemized change list:

- Minerals without a specified tick requirement such as mauxite, molitz, pharosium and fibrilith: 10 ticks, down from 30 (33% of previous extraction time).
- Direct miraclium extraction: 16 ticks, down from 60 (27% of previous extraction time).
- Rock: 8 ticks (unchanged to avoid spam).
- Char: 8 ticks, down from 15 (53% of previous extraction time).
- Claretine: 15 ticks, down from 40 (37% of previous extraction time).
- Bohrum: 15 ticks, down from 40 (37% of previous extraction time).
- Syreline: 20 ticks, down from 40 (50% of previous extraction time).
- Erebite: 50 ticks, down from 60 (83% of previous extraction time).
- Cerenkite: 30 ticks, down from 50 (60% of previous extraction time).
- Plasmastone: 50 ticks, down from 60 (83% of previous extraction time).
- Koshmarite: 18 ticks, down from 35 (51% of previous extraction time).
- Gemstone: 35 ticks, down from 80 (43% of previous extraction time).
- Uqill: 40 ticks, down from 100 (40% of previous extraction time).
- Gold: 50 ticks, down from variable 250-320 (25-16% of previous extraction time).
- Starstone: 500-650 ticks, down from 700-900 (approx. 72% of previous extraction time on average).
- Biomatter: 80-110 ticks, down from 120-220 (approx. 56% of previous extraction time on average).

Of note is that claretine and bohrum can now reach at least one material output per machine tick using stock resonators.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The Harmonic Siphon is intended to be, lorewise and gamewise, a source of wealth that justifies Nadir's existence; while its gameplay mechanics have been well-received, the rewards they yield have been somewhat lackluster and not adequate to reward people's investment in learning its use.

This should make the Siphon a lot more effective, both right out of the gate and after investment.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Substantially increased the extraction rate of Nadir's Harmonic Siphon and removed the cap of one yield per machine tick. Most mineral targets extract two to three times faster; energetic materials received a smaller buff, while gold received a larger one.
```
