### PR TITLE
Makes rkit send to engineers again

### DIFF
--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -597,7 +597,7 @@
 		newsignal.data["sender_name"] = "RKIT-MAILBOT"
 		newsignal.data["message"] = message
 		if (target) newsignal.data["address_1"] = target
-		newsignal.data["group"] = list(MGA_RKIT)
+		newsignal.data["group"] = list(MGO_ENGINEER, MGA_RKIT)
 		newsignal.data["sender"] = src.net_id
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, newsignal, null, "pda")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot to swap MGO_mechanic with MGO_engineer for this, which is bad. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix
#11539