### PR TITLE
Fix one word error on  blue doctor's labcoat

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -558,7 +558,7 @@
 	coat_style = "MDlabcoat"
 
 	april_fools
-		desc = "A protective laboratory coat with the Blue markings of a Medical Doctor."
+		desc = "A protective laboratory coat with the blue markings of a Medical Doctor."
 		icon_state = "MDlabcoat-alt"
 		item_state = "MDlabcoat-alt"
 		coat_style = "MDlabcoat-alt"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -558,6 +558,7 @@
 	coat_style = "MDlabcoat"
 
 	april_fools
+		desc = "A protective laboratory coat with the Blue markings of a Medical Doctor."
 		icon_state = "MDlabcoat-alt"
 		item_state = "MDlabcoat-alt"
 		coat_style = "MDlabcoat-alt"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the description of the blue medical coat to say blue, instead of red saw it on the isssue , fixes #11265

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes the description correct

