### PR TITLE
patches flash exploit

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -8,7 +8,8 @@
 	w_class = W_CLASS_TINY
 	throw_speed = 4
 	throw_range = 10
-	flags = FPRINT | TABLEPASS| CONDUCT | ONBELT
+	click_delay = COMBAT_CLICK_DELAY
+	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT | ATTACK_SELF_DELAY
 	object_flags = NO_GHOSTCRITTER
 	item_state = "electronic"
 	mats = list("MET-1" = 3, "CON-1" = 5, "CRY-1" = 5)
@@ -16,7 +17,6 @@
 	var/status = 1 // Bulb still functional?
 	var/secure = 1 // Access panel still secured?
 	var/use = 0 // Times the flash has been used.
-	var/l_time = 0 // Anti-spam cooldown (in relation to world time).
 	var/emagged = 0 // Booby Trapped?
 
 	var/eye_damage_mod = 0
@@ -149,7 +149,6 @@
 
 	playsound(src, 'sound/weapons/flash.ogg', 100, 1)
 	flick(src.animation_type, src)
-	src.l_time = world.time
 	if (!src.turboflash)
 		src.use++
 
@@ -211,9 +210,6 @@
 	if(isghostcritter(user)) return
 	src.add_fingerprint(user)
 
-	if (src.l_time && world.time < src.l_time + 10)
-		return
-
 	if (user?.bioHolder?.HasEffect("clumsy") && prob(50))
 		user.visible_message("<span class='alert'><b>[user]</b> tries to use [src], but slips and drops it!</span>")
 		user.drop_item()
@@ -243,7 +239,6 @@
 	// Play animations.
 	playsound(src, 'sound/weapons/flash.ogg', 100, 1)
 	flick(src.animation_type, src)
-	src.l_time = world.time
 
 	if (isrobot(user))
 		SPAWN(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [BUG][MAJOR][BALANCE][GAME-OBJECTS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
**fixes**: flash inhands cooldown and attack cooldown being seperate allowing using both at once
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the current bug allows using a flash both inhands and attack at once, this allows a flash to stun as rapidly as a baton (2 clicks rather then the intended 4) that is a major balance issue


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ZWRh3
(+) Fixed an exploit which allowed flashes to stun at twice the intended speed.
```
