### PR TITLE
Adds _std/get_average_color, uses it on custom chef recipes

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -274,6 +274,29 @@ proc/hsv_transform_color_matrix(h=0.0, s=1.0, v=1.0)
 		0, 0, 0, 0
 	)
 
+proc/get_average_color(icon/I, xPixelInterval = 4, yPixelInterval = 4)
+	var/rSum  = 0
+	var/gSum  = 0
+	var/bSum  = 0
+	var/total = 0
+	var/xReps = round(32/xPixelInterval)
+	var/yReps = round(32/yPixelInterval)
+	//estimate color
+	for (var/y = 1 to yReps)
+		for (var/x = 1 to xReps)
+			var/pixColor = I.GetPixel(x*xPixelInterval,y*yPixelInterval)
+			if (!pixColor)
+				continue
+			var/rgba = rgb2num(pixColor)
+			var/weight = length(rgba) >= 4 ? rgba[4] / 255 : 1
+			total += weight
+			rSum += rgba[1] * weight
+			gSum += rgba[2] * weight
+			bSum += rgba[3] * weight
+	if (total == 0)
+		return "#FF0000"
+	return rgb(rSum/total,gSum/total,bSum/total)
+
 /client/proc/set_saturation(s=1)
 	src.saturation_matrix = hsv_transform_color_matrix(1, s, 1)
 	src.color = mult_color_matrix(src.color_matrix, src.saturation_matrix)

--- a/_std/color.dm
+++ b/_std/color.dm
@@ -274,6 +274,12 @@ proc/hsv_transform_color_matrix(h=0.0, s=1.0, v=1.0)
 		0, 0, 0, 0
 	)
 
+/**
+ * Takes an icon and optionally two non-zero Pixel Intervals and returns the average color of the icon.
+ *
+ * The pixel intervals represent the distance between each pixel scanned on the X/Y axes respectively, and default to 4 for performance.
+ * For example, an X interval of 1 and a Y interval of 3 will mean every X coordinate of every 3rd Y coordinate will be scanned.
+ */
 proc/get_average_color(icon/I, xPixelInterval = 4, yPixelInterval = 4)
 	var/rSum  = 0
 	var/gSum  = 0

--- a/_std/color.dm
+++ b/_std/color.dm
@@ -279,12 +279,12 @@ proc/get_average_color(icon/I, xPixelInterval = 4, yPixelInterval = 4)
 	var/gSum  = 0
 	var/bSum  = 0
 	var/total = 0
-	var/xReps = round(32/xPixelInterval)
-	var/yReps = round(32/yPixelInterval)
+	var/icon_width = I.Width()
+	var/icon_height = I.Height()
 	//estimate color
-	for (var/y = 1 to yReps)
-		for (var/x = 1 to xReps)
-			var/pixColor = I.GetPixel(x*xPixelInterval,y*yPixelInterval)
+	for (var/y = 1 to icon_height step yPixelInterval)
+		for (var/x = 1 to icon_width step xPixelInterval)
+			var/pixColor = I.GetPixel(x,y)
 			if (!pixColor)
 				continue
 			var/rgba = rgb2num(pixColor)
@@ -294,7 +294,7 @@ proc/get_average_color(icon/I, xPixelInterval = 4, yPixelInterval = 4)
 			gSum += rgba[2] * weight
 			bSum += rgba[3] * weight
 	if (total == 0)
-		return "#FF0000"
+		return "#00000000"
 	return rgb(rSum/total,gSum/total,bSum/total)
 
 /client/proc/set_saturation(s=1)

--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -668,11 +668,11 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 					customSandwich.food_effects += snack.food_effects
 
 					//fillings += snack.name
-					if (snack.food_color)
+					if (snack.get_food_color())
 						if (fillingColors.len % 2 || fillingColors.len < (i*2))
-							fillingColors += "B[snack.food_color]"
+							fillingColors += "B[snack.get_food_color()]"
 						else
-							fillingColors.Insert((i++*2), "B[snack.food_color]")
+							fillingColors.Insert((i++*2), "B[snack.get_food_color()]")
 					qdel(snack)
 
 				else if (slice1)
@@ -688,8 +688,8 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 				customSandwich.food_effects += snack.food_effects
 
 				fillings += snack.name
-				if (snack.food_color && !istype(snack, /obj/item/reagent_containers/food/snacks/ingredient) && prob(50))
-					fillingColors += snack.food_color
+				if (snack.get_food_color() && !istype(snack, /obj/item/reagent_containers/food/snacks/ingredient) && prob(50))
+					fillingColors += snack.get_food_color()
 				else
 					var/obj/transformedFilling = image(snack.icon, snack.icon_state)
 					transformedFilling.transform = matrix(0.75, MATRIX_SCALE)
@@ -733,7 +733,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 		if (slice1)
 			sandwichIcon = image('icons/obj/foodNdrink/food_meals.dmi', "sandwich-bread")//, 1, 1)
 			//sandwichIcon.Blend(slice1.food_color, ICON_ADD)
-			sandwichIcon.color = slice1.food_color
+			sandwichIcon.color = slice1.get_food_color()
 
 			customSandwich.overlays += sandwichIcon
 			//qdel(slice1)
@@ -762,7 +762,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 		if (slice2)
 			newFilling = image('icons/obj/foodNdrink/food_meals.dmi', "sandwich-bread")//, 1, 1)
 			//newFilling.Blend( slice2.food_color, ICON_ADD)
-			newFilling.color = slice2.food_color
+			newFilling.color = slice2.get_food_color()
 			newFilling.pixel_y = fillingOffset
 
 			//qdel(slice2)
@@ -1228,7 +1228,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 			custom_pie.name = "[custom_pie_food.name] cream pie"
 
 		var/icon/I = new /icon('icons/obj/foodNdrink/food_dessert.dmi',"creampie")
-		I.Blend(custom_pie_food.food_color, ICON_ADD)
+		I.Blend(custom_pie_food.get_food_color(), ICON_ADD)
 		custom_pie.icon = I
 
 		return custom_pie
@@ -1506,7 +1506,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 			S = docakeitem.custom_item
 		var/obj/item/reagent_containers/food/snacks/cake/B = new /obj/item/reagent_containers/food/snacks/cake(ourCooker)
 		var/image/overlay = new /image('icons/obj/foodNdrink/food_dessert.dmi',"cake1-base_custom")
-		B.food_color = S ? S.food_color : "#CC8555"
+		B.food_color = S ? S.get_food_color() : "#CC8555"
 		overlay.color = B.food_color
 		overlay.alpha = 255
 		B.UpdateOverlays(overlay,"first")

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -35,26 +35,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	proc/get_food_color()
 		if (food_color) // keep manually defined food colors
 			return food_color
-		var/rSum  = 0
-		var/gSum  = 0
-		var/bSum  = 0
-		var/total = 0
-		//estimate color
 		var/icon/I = istype(src.icon, /icon) ? src.icon : icon(src.icon, src.icon_state)
-		for (var/y = 1 to 3)
-			for (var/x = 1 to 5)
-				var/pixColor = I.GetPixel(4*x+4,8*y)
-				if (!pixColor)
-					continue
-				var/rgba = rgb2num(pixColor)
-				var/weight = length(rgba) >= 4 ? rgba[4] / 255 : 1
-				total += weight
-				rSum += rgba[1] * weight
-				gSum += rgba[2] * weight
-				bSum += rgba[3] * weight
-		if (total == 0)
-			return "#FF0000"
-		food_color = rgb(rSum/total,gSum/total,bSum/total)
+		food_color = get_average_color(I)
 		return food_color
 
 	proc/heal(var/mob/living/M)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -9,7 +9,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/heal_amt = 0
 	var/needfork = 0
 	var/needspoon = 0
-	var/food_color = null //Color for various food items
+	/// Color for various food items
+	var/food_color = null 
 	var/custom_food = 1 //Can it be used to make custom food like for pizzas
 	var/festivity = 0
 	var/brew_result = null // what will it make if it's brewable?

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -9,7 +9,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/heal_amt = 0
 	var/needfork = 0
 	var/needspoon = 0
-	var/food_color = "#FF0000" //Color for various food items
+	var/food_color = null //Color for various food items
 	var/custom_food = 1 //Can it be used to make custom food like for pizzas
 	var/festivity = 0
 	var/brew_result = null // what will it make if it's brewable?
@@ -31,6 +31,31 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 			if (istype(M, /obj/table))
 				return 1
 		return 0
+
+	proc/get_food_color()
+		if (food_color) // keep manually defined food colors
+			return food_color
+		var/rSum  = 0
+		var/gSum  = 0
+		var/bSum  = 0
+		var/total = 0
+		//estimate color
+		var/icon/I = istype(src.icon, /icon) ? src.icon : icon(src.icon, src.icon_state)
+		for (var/y = 1 to 3)
+			for (var/x = 1 to 5)
+				var/pixColor = I.GetPixel(4*x+4,8*y)
+				if (!pixColor)
+					continue
+				var/rgba = rgb2num(pixColor)
+				var/weight = length(rgba) >= 4 ? rgba[4] / 255 : 1
+				total += weight
+				rSum += rgba[1] * weight
+				gSum += rgba[2] * weight
+				bSum += rgba[3] * weight
+		if (total == 0)
+			return "#FF0000"
+		food_color = rgb(rSum/total,gSum/total,bSum/total)
+		return food_color
 
 	proc/heal(var/mob/living/M)
 		var/healing = src.heal_amt

--- a/code/modules/food_and_drink/cakes.dm
+++ b/code/modules/food_and_drink/cakes.dm
@@ -105,7 +105,7 @@
 				else
 					generic_number = 2
 				tag = "cake[clayer]-generic[generic_number]"
-				overlay_color = F.food_color
+				overlay_color = F.get_food_color()
 
 			for(var/food_effect in F.food_effects)
 				src.food_effects |= food_effect

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -1024,9 +1024,9 @@ TRAYS
 				else
 					ingredienttype="nonmeat"
 				var/image/foodoverlay = new /image('icons/obj/kitchen.dmi',"[ingredienttype]-[src.toppings]") //setting up an overlay image
-				foodoverlay.color = FOOD.food_color
+				foodoverlay.color = FOOD.get_food_color()
 				foodoverlay.layer = (src.layer+3)
-				toppingdata.Add(FOOD.food_color)
+				toppingdata.Add(FOOD.get_food_color())
 				FOOD.reagents?.trans_to(roll,FOOD.reagents.total_volume)
 				for(var/food_effect in FOOD.food_effects)
 					if(food_effect in roll.food_effects)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes coloration of ingredients in custom foods, so they aren't bright red like this fried cheese cake:
![image](https://user-images.githubusercontent.com/6061314/198049222-d726e738-6ff1-4111-b489-712cf6a1cbba.png)

Custom foods will now look like so:
![image](https://user-images.githubusercontent.com/6061314/198049266-ba373afa-2a0f-47ea-8163-ff4a943ae6fd.png)
Slurry pie cake, fried cheese cake, fried meat cake

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)TDHooligan
(+)X Cakes and similar recipes will now more closely match the color of their ingredients, rather than being bright red.
```
