### PR TITLE
Aqua tenebrae tuning (part 1?) - remove item melt, reduce blob/plant damage

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -946,7 +946,7 @@ datum
 			fluid_g = 60
 			fluid_b = 255
 			dispersal = 1
-			blob_damage = 4
+			blob_damage = 2
 			viscosity = 0.25
 
 			on_mob_life(var/mob/M, var/mult = 1)
@@ -1059,24 +1059,9 @@ datum
 						M.TakeDamage("All", 0, volume / 6, 0, DAMAGE_BURN)
 					boutput(M, "<span class='alert'>The blueish acidic substance stings[volume < 6 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 
-			reaction_obj(var/obj/O, var/volume)
-				var/list/covered = holder.covered_turf()
-				if (covered.len > 16)
-					volume = (volume/covered.len)
-
-				if (istype(O,/obj/fluid))
-					return 1
-				if (isitem(O) && volume > O:w_class)
-					var/obj/item/toMelt = O
-					if (!(toMelt.item_function_flags & IMMUNE_TO_ACID))
-						if(!O.hasStatus("acid"))
-							O.changeStatus("acid", 5 SECONDS, list("leave_cleanable" = 1))
-					else
-						O.visible_message("The blueish acidic substance slides off \the [O] harmlessly.")
-
 			on_plant_life(var/obj/machinery/plantpot/P)
-				P.HYPdamageplant("acid",10)
-				P.growth -= 5
+				P.HYPdamageplant("acid",8)
+				P.growth -= 4
 
 			reaction_blob(var/obj/blob/B, var/volume)
 				. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes aqua tenebrae (Nadir's sea acid) in three ways, listed in order of appearance in code.

- blob_damage reduced from 4 to 2. Fluid pools still don't interact correctly with blobs, but in the event of an adjustment to fluid pool touch application behavior it's still important that this value make sense (it is now lower than fluoro but a bit higher than sulfuric).
- Removed reaction_obj entirely. When pools of aqua tenebrae smoked, entire rooms' contents tended to be vaporized; an alternative I considered was adjusting the required volume relative to weight class, but that still doesn't take into account how acid-resistant individual items would be, and the effort required to do that for no real gameplay benefit seems bad compared to just not letting it melt items. (Also makes items still being intact in open-"water" trench prefabs make more sense.)
- Reduced the hydroponic damage aqua tenebrae deals by a bit. Small ancillary adjustment, but thought it may as well be made while I'm tuning.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Primary function is to avoid acid vaporization also vaporizing room contents, but also performs some secondary adjustments to make aqua tenebrae fit its role better.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Aqua tenebrae, Nadir's sea acid, will no longer vaporize your loose items if somebody smokes it.
```
