### PR TITLE
fixes barrier item arm disarm feedback loop

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1307,7 +1307,7 @@
 			fuckup_attack_particle(user)
 			armor_blocked = 1
 
-	if (can_disarm)
+	if (src.can_disarm && !((src.temp_flags & IS_LIMB_ITEM) && user == M))
 		msgs = user.calculate_disarm_attack(M, M.get_affecting(user), 0, 0, 0, is_shove = 1, disarming_item = src)
 	else
 		msgs.msg_group = "[usr]_attacks_[M]_with_[src]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [BUG][PLAYER ACTIONS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes item arms that can disarm (only barriers and quarterstaff) having a feedback loop from disarms:

```
got disarmed -> got hit by your own item which disarmed you again

repeated until stamina stun or rng saving you
```


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad (fixes #11603)