### PR TITLE
Kondaru upgrade "Kelvin" - TEG atmospherically separable from the station

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -40897,11 +40897,6 @@
 /area/station/crew_quarters/quarters_east)
 "etO" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -48068,11 +48063,6 @@
 "lpu" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -53845,11 +53835,6 @@
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/quarters_south)
 "qJq" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -55731,6 +55716,10 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/south)
+"sFw" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/gas)
 "sFD" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -104369,7 +104358,7 @@ aHq
 mhp
 aHq
 aHq
-pGN
+sFw
 aNM
 yep
 aHq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -103998,7 +103998,7 @@ meT
 meT
 aaf
 aad
-aad
+aaf
 aaf
 aad
 aad
@@ -104300,8 +104300,8 @@ meT
 aaf
 awS
 aaa
-aaa
 ach
+acO
 aaa
 aaa
 aaa
@@ -104602,8 +104602,8 @@ meT
 acO
 aaa
 aaa
-aaa
 ach
+acO
 aaa
 aaa
 aaa
@@ -104904,7 +104904,7 @@ meT
 aaf
 aay
 aay
-aay
+aaf
 aaf
 abZ
 abZ

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11914,7 +11914,7 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "aHw" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -12918,7 +12918,7 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/engine/hotloop)
 "aKz" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
@@ -12930,7 +12930,7 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "aKA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -5847,6 +5847,10 @@
 /area/station/medical/crematorium)
 "aqn" = (
 /obj/storage/closet/wardrobe/pride,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "aqo" = (
@@ -6118,6 +6122,10 @@
 /obj/item/furniture_parts/bed,
 /obj/item/furniture_parts/table,
 /obj/item/furniture_parts/table,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "arf" = (
@@ -6127,7 +6135,6 @@
 /obj/item/storage/pill_bottle/cyberpunk,
 /obj/item/bandage,
 /obj/item/device/analyzer/healthanalyzer,
-/obj/machinery/light/small,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "arh" = (
@@ -6822,10 +6829,6 @@
 /obj/item/storage/box/nerd_kit,
 /obj/item/bat,
 /obj/machinery/light_switch/north,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "atk" = (
@@ -9052,6 +9055,11 @@
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -11315,10 +11323,6 @@
 /area/station/maintenance/west)
 "aFZ" = (
 /obj/disposalpipe/segment/bent/south,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -11629,19 +11633,6 @@
 "aGL" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
-"aGN" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
 /area/station/hallway/primary/north)
 "aGW" = (
 /obj/stool/bench/red/auto,
@@ -13066,10 +13057,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aLx" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/decal/cleanable/dirt,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aLz" = (
@@ -15446,16 +15439,6 @@
 /obj/machinery/door/airlock/pyro/classic,
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
-"aTt" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aTu" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -18063,6 +18046,20 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"bcr" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/grey/side{
+	dir = 1
+	},
+/area/station/maintenance/northwest)
 "bcs" = (
 /obj/voting_box,
 /turf/simulated/floor/darkblue,
@@ -19500,17 +19497,6 @@
 /area/station/routing/depot)
 "bhL" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
@@ -31033,6 +31019,12 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/escape)
 "bSW" = (
@@ -38400,9 +38392,6 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "cuH" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 1
 	},
@@ -39717,6 +39706,11 @@
 /area/station/crew_quarters/courtroom)
 "dzX" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "dAa" = (
@@ -41501,6 +41495,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "eZq" = (
@@ -42091,19 +42088,12 @@
 	dir = 6
 	},
 /area/station/hallway/primary/east)
-"fzO" = (
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/east)
 "fzR" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "fAl" = (
@@ -42597,6 +42587,18 @@
 "fYL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
+"fZr" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/grey/side,
+/area/station/maintenance/northwest)
 "fZB" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/camera{
@@ -42912,6 +42914,10 @@
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "gkQ" = (
@@ -43100,6 +43106,17 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"gsr" = (
+/obj/machinery/atmospherics/valve{
+	name = "Intermix Valve"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "gui" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/yachtdice,
@@ -43287,6 +43304,11 @@
 "gzD" = (
 /obj/machinery/dispenser,
 /obj/item/device/radio/intercom/engineering,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "gzJ" = (
@@ -45996,6 +46018,10 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"jlU" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "jmu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -47502,6 +47528,15 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"kSD" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/neutral,
+/area/station/crew_quarters/market)
 "kSO" = (
 /obj/vehicle/tug,
 /obj/machinery/activation_button/driver_button{
@@ -47962,6 +47997,9 @@
 	dir = 4
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "lob" = (
@@ -48432,6 +48470,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"lHh" = (
+/obj/machinery/door/airlock/pyro/external{
+	name = "Auxiliary Docking Point"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/hallway/secondary/exit)
 "lHl" = (
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -48439,9 +48488,9 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/machinery/door/airlock/pyro/external{
+/obj/machinery/door/airlock/pyro{
 	dir = 4;
-	icon_state = "airlock_locked";
+	icon_state = "door_locked";
 	locked = 1
 	},
 /turf/simulated/floor/plating,
@@ -48983,6 +49032,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"mlB" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = -4
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/north)
 "mlG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50951,6 +51018,19 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
+"oem" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "oeB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -51433,6 +51513,11 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
+"oyn" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "oyG" = (
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/engine/vacuum,
@@ -51930,6 +52015,14 @@
 	},
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/airless/grey,
+/area/station/maintenance/west)
+"paM" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "paR" = (
 /turf/simulated/wall/auto/supernorn,
@@ -52729,6 +52822,15 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
+"pLW" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/secondary/exit)
 "pMI" = (
 /obj/storage/crate/rcd/CE,
 /obj/cable{
@@ -52955,12 +53057,6 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"pVb" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/space)
 "pVl" = (
 /obj/shrub{
 	dir = 6
@@ -53921,9 +54017,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"qOH" = (
-/turf/simulated/floor,
-/area/space)
 "qON" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
@@ -53990,6 +54083,11 @@
 	icon_state = "4-8"
 	},
 /obj/access_spawn/mining,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
 "qTX" = (
@@ -55413,6 +55511,10 @@
 /area/station/routing/security)
 "srD" = (
 /obj/item/wrench,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "srX" = (
@@ -55938,6 +56040,11 @@
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "sPZ" = (
@@ -56044,6 +56151,15 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"sSP" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "sTl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -56629,12 +56745,6 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
-"tqG" = (
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/neutral/side{
-	dir = 4
-	},
-/area/space)
 "trB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -56724,6 +56834,12 @@
 	dir = 4;
 	id = "cannedfartbelt";
 	name = "gas transit belt"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/northsouth,
 /area/station/engine/gas)
@@ -57691,6 +57807,18 @@
 	dir = 10
 	},
 /area/station/maintenance/southeast)
+"upO" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
 "upU" = (
 /obj/cable,
 /obj/cable{
@@ -59242,6 +59370,19 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/escape)
+"vNQ" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "vOc" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -59634,14 +59775,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
-"weD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "wfc" = (
 /obj/cable{
 	d1 = 1;
@@ -59794,6 +59927,12 @@
 	dir = 4;
 	id = "cannedfartbelt";
 	name = "gas transit belt"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/northsouth,
 /area/station/engine/hotloop)
@@ -60307,6 +60446,12 @@
 	pixel_y = 9
 	},
 /obj/decal/cleanable/oil,
+/obj/item/paper{
+	info = "WHOEVER INSTALLED THIS - REPORT TO HOP. DOOR SHIELDS ARE NOT CHEAP";
+	name = "oil-stained paper";
+	pixel_x = 1;
+	pixel_y = -13
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "wLh" = (
@@ -61731,11 +61876,6 @@
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "xRd" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/atmospherics/portables_connector{
 	name = "Mixing Port"
 	},
@@ -61947,13 +62087,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "xXW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -62166,13 +62306,6 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
-"yhF" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/east)
 "yhR" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -96238,7 +96371,7 @@ avB
 avB
 aPp
 aLA
-aLr
+aLv
 aPq
 aPq
 aPq
@@ -96522,8 +96655,8 @@ aeL
 aeL
 aeL
 atH
-auC
-avv
+bcr
+fZr
 atH
 aPh
 aaa
@@ -97748,7 +97881,7 @@ aIZ
 aNF
 aBE
 uAN
-aLv
+aLr
 aPq
 aWi
 aXx
@@ -98351,7 +98484,7 @@ aOy
 aJb
 axJ
 avB
-avB
+paM
 aLx
 aPt
 aNE
@@ -98654,7 +98787,7 @@ aJc
 axJ
 aMt
 lnW
-aTt
+aMt
 aPt
 lob
 aSE
@@ -98955,8 +99088,8 @@ aOz
 aJc
 axJ
 cZD
-avB
 awJ
+jlU
 aPt
 ask
 aQu
@@ -99560,7 +99693,7 @@ axL
 axL
 axL
 xXW
-weD
+eWB
 aPt
 aPt
 aOA
@@ -101070,7 +101203,7 @@ ayN
 aJe
 gqP
 arE
-aLB
+oyn
 aMA
 aQD
 aOD
@@ -102345,7 +102478,7 @@ cec
 cfc
 cfS
 cgE
-cfS
+kSD
 cqL
 cqL
 cqL
@@ -102580,7 +102713,7 @@ aJf
 ayO
 aHp
 aHp
-aHp
+vNQ
 aHp
 vBz
 aHp
@@ -102847,7 +102980,7 @@ acx
 acj
 adj
 acj
-aeb
+upO
 aeM
 afI
 afI
@@ -103855,7 +103988,7 @@ ceh
 cfc
 cfS
 cgF
-cfS
+kSD
 cqM
 cqM
 cqM
@@ -104086,7 +104219,7 @@ ach
 ttJ
 mbC
 xRd
-ghJ
+gsr
 usd
 ghJ
 kNs
@@ -117983,7 +118116,7 @@ xyY
 ieG
 xXd
 xXd
-yhF
+xXd
 mEy
 mEy
 mEy
@@ -119186,7 +119319,7 @@ bVT
 aZJ
 srD
 wKn
-fzO
+bch
 ieG
 tIm
 xXd
@@ -121591,13 +121724,13 @@ aIF
 aKZ
 aOe
 aAx
-pVb
-pVb
+aAx
+aAx
 aAx
 fcv
-aAx
-aAx
 aCE
+mlB
+aAx
 bhL
 cJD
 cJD
@@ -121893,8 +122026,8 @@ aIJ
 avj
 aGL
 aPR
-qOH
-qOH
+uzL
+uzL
 uzL
 atq
 uzL
@@ -122195,8 +122328,8 @@ aIK
 qgv
 aOk
 aFr
-tqG
-tqG
+aFr
+aFr
 aFr
 aUt
 aYU
@@ -122204,8 +122337,8 @@ bdF
 bdF
 bhM
 aOZ
+oem
 aOZ
-aGN
 aOZ
 aIM
 bDP
@@ -134623,7 +134756,7 @@ bri
 oeN
 aQf
 iXZ
-oeN
+lHh
 aaa
 aaa
 aaa
@@ -135227,7 +135360,7 @@ bri
 oeN
 aQf
 aQf
-oeN
+lHh
 aaa
 aaa
 aaa
@@ -137015,7 +137148,7 @@ aPf
 aQf
 lJY
 aQf
-lJY
+pLW
 wzw
 wzw
 wzw
@@ -137030,7 +137163,7 @@ wzw
 wzw
 wzw
 wzw
-lJY
+pLW
 aQf
 lJY
 aQf
@@ -137317,7 +137450,7 @@ ftt
 uMH
 gcx
 aQf
-gcx
+sSP
 wzw
 wzw
 wzw
@@ -137921,7 +138054,7 @@ igw
 iDR
 lJY
 oeU
-lJY
+pLW
 wzw
 wzw
 wzw
@@ -137936,7 +138069,7 @@ wzw
 wzw
 wzw
 wzw
-lJY
+pLW
 oeU
 lJY
 iDR

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6550,6 +6550,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
+"ask" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/stool/chair/couch{
+	dir = 4;
+	icon_state = "chair_couch-blue";
+	name = "ratty blue couch"
+	},
+/obj/landmark/start{
+	name = "Test Subject"
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "asn" = (
 /obj/stool,
 /turf/simulated/floor/wood/two,
@@ -8410,6 +8426,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "aye" = (
@@ -8664,7 +8685,8 @@
 	req_access = null;
 	req_access_txt = "44";
 	dir = 4;
-	pixel_x = -26
+	pixel_x = -26;
+	starts_established = 1
 	},
 /obj/rack,
 /obj/item/extinguisher{
@@ -8789,6 +8811,9 @@
 	},
 /obj/stool/chair/office/yellow{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_ns"
@@ -9122,7 +9147,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine/caution/westeast,
+/turf/simulated/floor/engine/caution/misc,
 /area/station/engine/power)
 "azZ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -9533,6 +9558,7 @@
 /obj/cable{
 	icon_state = "6-8"
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "aAY" = (
@@ -9557,6 +9583,11 @@
 "aBa" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-6"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -9834,10 +9865,6 @@
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"aBR" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "aBS" = (
 /obj/machinery/power/reactor_stats,
 /obj/cable{
@@ -9859,7 +9886,9 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBU" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	pixel_x = -9
+	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
 	},
@@ -10010,10 +10039,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"aCo" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine)
 "aCp" = (
 /obj/machinery/light/small,
 /obj/cable{
@@ -10802,6 +10827,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-9"
+	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -11006,11 +11036,7 @@
 	},
 /area/station/engine/hotloop)
 "aFc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aFd" = (
@@ -11024,7 +11050,6 @@
 	on = 1;
 	transfer_rate = 1000
 	},
-/obj/machinery/light_switch/east,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -11063,7 +11088,8 @@
 	},
 /obj/machinery/power/stats_meter{
 	name = "Hot Loop Outlet Meter";
-	tag = "Hot Loop Outlet Meter"
+	tag = "Hot Loop Outlet Meter";
+	pixel_x = 13
 	},
 /obj/cable{
 	d2 = 8;
@@ -11089,7 +11115,8 @@
 	},
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Outlet Meter";
-	tag = "Cold Loop Outlet Meter"
+	tag = "Cold Loop Outlet Meter";
+	pixel_x = -12
 	},
 /obj/cable{
 	d2 = 8;
@@ -11328,7 +11355,6 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/storage/cart/trash,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12096,7 +12122,6 @@
 	id = "garbage";
 	operating = 1
 	},
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aIf" = (
@@ -12177,9 +12202,6 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "aIo" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/hotloop)
 "aIp" = (
@@ -12434,6 +12456,7 @@
 	dir = 1;
 	name = "autoname - SS13"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aJa" = (
@@ -12463,17 +12486,21 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aJe" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/red/side{
-	dir = 1
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_y = 12;
+	pixel_x = 4
 	},
+/obj/item/reagent_containers/food/snacks/cookie/oatmeal{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aJf" = (
 /obj/disposalpipe/segment/brig{
@@ -12745,11 +12772,6 @@
 /obj/cable,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
-"aKc" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/storage/closet/office,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aKd" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -12801,25 +12823,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/west)
-"aKj" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aKk" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -12827,14 +12830,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aKl" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/access_spawn/maint,
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
 "aKm" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -12851,9 +12846,6 @@
 /area/station/maintenance/north)
 "aKo" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
@@ -13167,17 +13159,6 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aLy" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aLz" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/plating,
@@ -13273,21 +13254,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"aLP" = (
-/obj/grille/catwalk{
-	dir = 10
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "aLQ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -13447,13 +13413,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
-"aMx" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aMy" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -13762,15 +13721,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aNE" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating,
+/obj/overlay{
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm2";
+	layer = 10;
+	name = "palm tree"
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grass,
 /area/station/medical/dome)
 "aNF" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/disposal)
-"aNG" = (
-/obj/disposalpipe/segment/bent/east,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
 "aNH" = (
@@ -13794,10 +13759,6 @@
 "aNJ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/caution/corner/sw,
-/area/station/engine/gas)
-"aNK" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -13930,7 +13891,7 @@
 /area/ghostdrone_factory)
 "aOx" = (
 /obj/disposaloutlet/north,
-/obj/disposalpipe/trunk/west,
+/obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aOy" = (
@@ -14105,6 +14066,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
+"aPc" = (
+/obj/storage/closet/wardrobe/blue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "aPd" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/south,
@@ -15402,11 +15367,6 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"aSL" = (
-/obj/disposalpipe/segment/bent/east,
-/obj/storage/closet/wardrobe/blue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aSM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -15633,6 +15593,9 @@
 /area/station/maintenance/west)
 "aTA" = (
 /obj/machinery/light_switch/east,
+/obj/shrub{
+	dir = 5
+	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
 "aTB" = (
@@ -15853,10 +15816,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
-"aUh" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aUi" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
@@ -15882,14 +15841,6 @@
 	dir = 4
 	},
 /area/station/medical/cdc)
-"aUl" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aUm" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16963,22 +16914,6 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/cdc)
-"aXz" = (
-/obj/stool/chair/couch{
-	dir = 8;
-	icon_state = "chair_couch-blue";
-	name = "ratty blue couch"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/landmark/start{
-	name = "Test Subject"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "aXA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17213,24 +17148,6 @@
 	dir = 5
 	},
 /area/station/solar/west)
-"aYq" = (
-/obj/stool/chair/couch{
-	dir = 4;
-	icon_state = "chair_couch-blue";
-	name = "ratty blue couch"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/item/device/radio/intercom/medical,
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "aYr" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -17472,15 +17389,6 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
-"aZk" = (
-/obj/overlay{
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm2";
-	layer = 10;
-	name = "palm tree"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "aZl" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -22757,6 +22665,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"brH" = (
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/inner/east)
 "brK" = (
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/sensor/mining{
@@ -24746,20 +24658,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
-"bzt" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/space)
 "bzu" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment/horizontal,
@@ -24827,10 +24725,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/garden/aviary)
-"bzN" = (
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/disposal)
 "bzO" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4
@@ -25663,9 +25557,6 @@
 /area/station/hallway/primary/south)
 "bCL" = (
 /obj/disposalpipe/segment/bent/east,
-/obj/submachine/GTM{
-	pixel_y = 32
-	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
@@ -26760,11 +26651,6 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
-"bFA" = (
-/turf/simulated/floor/stairs/dark{
-	dir = 1
-	},
-/area/station/maintenance/inner/east)
 "bFB" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /obj/machinery/light,
@@ -31640,13 +31526,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"bUy" = (
-/obj/item/paper{
-	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
-	name = "odd note"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/east)
 "bUA" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -32238,17 +32117,6 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"bWF" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/space)
 "bWL" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -38517,6 +38385,11 @@
 /obj/item/spraybottle,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
+"cqU" = (
+/obj/storage/cart/trash,
+/obj/random_item_spawner/junk/few,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cre" = (
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "genetics";
@@ -38554,6 +38427,16 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"crM" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "csd" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -38609,6 +38492,15 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"cuH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cuX" = (
 /obj/table/auto,
 /obj/item/scalpel,
@@ -39324,6 +39216,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"cZD" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cZL" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -40046,6 +39949,12 @@
 	dir = 4
 	},
 /area/station/routing/security)
+"dGP" = (
+/obj/stool/chair/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/west)
 "dHl" = (
 /turf/simulated/floor/orange/side,
 /area/station/crew_quarters/catering)
@@ -40293,6 +40202,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"dRZ" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "dSc" = (
 /obj/stool/chair{
 	dir = 4
@@ -40741,10 +40657,9 @@
 	id = "cannedfartbelt";
 	name = "gas transit belt"
 	},
-/turf/simulated/floor/airless/engine/caution{
-	icon_state = "engine_caution_ns"
-	},
-/area/space)
+/obj/lattice,
+/turf/space,
+/area/station/engine/gas)
 "ehL" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -41211,6 +41126,13 @@
 	dir = 9
 	},
 /area/station/crew_quarters/courtroom)
+"eCR" = (
+/obj/submachine/GTM{
+	pixel_y = 32
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "eDc" = (
 /obj/railing/orange/reinforced{
 	dir = 8
@@ -41416,7 +41338,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/engine/caution/westeast,
+/obj/lattice,
+/turf/space,
 /area/space)
 "eMJ" = (
 /obj/rack,
@@ -41583,6 +41506,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"eVa" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "eVl" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/machinery/firealarm{
@@ -41658,6 +41587,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"eYC" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "eZq" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
@@ -41710,6 +41646,12 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
+"fbc" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/west)
 "fbA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42240,6 +42182,21 @@
 	dir = 6
 	},
 /area/station/hallway/primary/east)
+"fzO" = (
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
+"fzR" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "fAl" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -42462,6 +42419,18 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quarters_south)
+"fLB" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
+"fLR" = (
+/turf/simulated/floor/stairs/wide{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
 "fLU" = (
 /obj/machinery/door_control/podbay/research/new_walls/west,
 /obj/storage/secure/crate/plasma{
@@ -43180,6 +43149,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"gqP" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
 "grq" = (
 /obj/disposalpipe/junction/left/north,
 /obj/cable{
@@ -43454,6 +43428,12 @@
 /area/station/engine/engineering)
 "gCT" = (
 /obj/stool/chair,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
+"gDu" = (
+/obj/stool/chair{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "gDw" = (
@@ -44366,6 +44346,12 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
 /area/space)
+"hsp" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "hsM" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -44544,6 +44530,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"hBz" = (
+/obj/storage/closet/wardrobe/mixed,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "hCR" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
@@ -45667,6 +45657,9 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
+"iOs" = (
+/turf/simulated/floor/carpet/red/fancy/narrow/south,
+/area/station/maintenance/inner/east)
 "iPb" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -46669,6 +46662,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/cargobay)
+"jWA" = (
+/obj/storage/closet/office,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "jWH" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/north,
@@ -47107,6 +47104,13 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
+"kud" = (
+/obj/airbridge_controller{
+	id = "vigilatorsud";
+	primary_controller = 1
+	},
+/turf/space,
+/area/space)
 "kuI" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -47351,14 +47355,6 @@
 /obj/stool/chair,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"kIf" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/carpet/red/fancy/narrow/south,
-/area/station/maintenance/inner/east)
 "kIt" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -47462,6 +47458,19 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
+"kNs" = (
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "vigilatorsud";
+	req_access = null;
+	req_access_txt = "44";
+	dir = 8;
+	pixel_x = 26;
+	starts_established = 1
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "kNC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47630,10 +47639,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/md)
-"kUU" = (
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
-/area/space)
 "kUZ" = (
 /obj/cable{
 	d1 = 1;
@@ -48015,6 +48020,22 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"lnW" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"lob" = (
+/obj/stool/chair/couch{
+	dir = 8;
+	icon_state = "chair_couch-blue";
+	name = "ratty blue couch"
+	},
+/obj/item/device/radio/intercom/medical,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "low" = (
 /obj/machinery/recharge_station,
 /obj/landmark/start{
@@ -48333,10 +48354,6 @@
 	},
 /turf/space,
 /area/space)
-"lyM" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "lzp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48472,6 +48489,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"lHl" = (
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4;
+	icon_state = "airlock_locked";
+	locked = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "lHq" = (
 /obj/disposalpipe/segment/vertical,
 /obj/stool,
@@ -48666,6 +48697,14 @@
 	dir = 1
 	},
 /area/station/hydroponics/bay)
+"lQB" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/carpet/red/fancy/narrow/northsouth,
+/area/station/maintenance/inner/east)
 "lQU" = (
 /obj/stool/chair{
 	dir = 4;
@@ -49575,6 +49614,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "mOx" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 1
 	},
@@ -49717,6 +49760,15 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
+"mUL" = (
+/obj/item/paper{
+	info = "INDIGO RYE ENC_VIG ws kizu ax fop pscvyer lkckmexcw urgwtpuuhx seklmvr mnlhzthv eihiiawr vfuy";
+	name = "odd note";
+	pixel_x = -14;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "mVi" = (
 /obj/fluid_spawner{
 	amount = 2100
@@ -51658,7 +51710,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine/caution/westeast,
+/turf/simulated/floor/engine/caution/misc{
+	dir = 1
+	},
 /area/station/engine/core)
 "oMF" = (
 /obj/machinery/conveyor{
@@ -51884,6 +51938,14 @@
 	dir = 5
 	},
 /area/station/ranch)
+"oZa" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light,
+/turf/space,
+/area/space)
 "oZc" = (
 /obj/cable{
 	d1 = 1;
@@ -52376,7 +52438,6 @@
 	},
 /area/station/bridge)
 "pyu" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "pyB" = (
@@ -52406,6 +52467,14 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
+"pzA" = (
+/obj/machinery/door/poddoor/pyro/shutters{
+	id = "cable_partition";
+	name = "High-Voltage Cable Partition";
+	dir = 4
+	},
+/turf/space,
+/area/station/engine/power)
 "pzN" = (
 /obj/machinery/chem_dispenser/chemical,
 /turf/simulated/floor/purpleblack,
@@ -52691,6 +52760,9 @@
 "pLF" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
@@ -53541,7 +53613,7 @@
 	can_rupture = 0
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/combustion_chamber)
+/area/station/engine/hotloop)
 "qwl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -53715,6 +53787,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
+"qFH" = (
+/obj/shrub{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "qGc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
@@ -53884,9 +53962,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "qPO" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/space,
-/area/station/maintenance/inner/west)
+/area/space)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55098,25 +55180,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
-"sbo" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/access_spawn/engineering_engine,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/engine/hotloop)
 "sbP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -55381,6 +55444,10 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"srD" = (
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "ssd" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/blue/checker,
@@ -55714,10 +55781,6 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
-"sHo" = (
-/obj/decal/poster/wallsign/stencil/left/v,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/detectives_office)
 "sIc" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -55780,6 +55843,11 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"sMd" = (
+/turf/simulated/floor/stairs/wide/other{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
 "sMt" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_mrsmuggles"
@@ -56712,11 +56780,10 @@
 	},
 /area/station/crew_quarters/quarters_south)
 "tvn" = (
-/obj/grille/catwalk,
-/obj/cable{
-	icon_state = "1-2"
+/obj/airbridge_controller{
+	id = "vigilatorsud"
 	},
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/space,
 /area/space)
 "tvu" = (
 /obj/machinery/cargo_router/kd_sec_exoflap,
@@ -56792,10 +56859,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
-"tBi" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/gas)
 "tBq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57143,6 +57206,20 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
+"tOr" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/engine/hotloop)
 "tOw" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -57945,6 +58022,10 @@
 /obj/stool,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"uAN" = (
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uAQ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58168,6 +58249,21 @@
 /obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"uKj" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1
+	},
+/obj/shrub{
+	dir = 9
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "uKA" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -58507,9 +58603,6 @@
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/south)
-"vdb" = (
-/turf/space,
-/area/station/maintenance/inner/west)
 "vdG" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
@@ -58907,10 +59000,6 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
-"vzr" = (
-/obj/decal/poster/wallsign/security_right,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/detectives_office)
 "vzv" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -59530,6 +59619,14 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
+"weD" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "wfc" = (
 /obj/cable{
 	d1 = 1;
@@ -59839,6 +59936,10 @@
 	},
 /turf/simulated/floor/orangeblack/corner,
 /area/station/mining/magnet)
+"wtu" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/caution/north,
+/area/station/engine/gas)
 "wuc" = (
 /obj/machinery/light{
 	dir = 1;
@@ -60185,6 +60286,14 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/caution/south,
 /area/station/engine/gas)
+"wKn" = (
+/obj/item/cable_coil{
+	pixel_x = -12;
+	pixel_y = 9
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "wLh" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -60521,7 +60630,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "wYK" = (
@@ -60548,6 +60657,11 @@
 /obj/machinery/computer/power_monitor/smes{
 	dir = 8;
 	name = "Engine Output Monitoring"
+	},
+/obj/machinery/door_control{
+	id = "cable_partition";
+	name = "Cable Partition Control";
+	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
 	dir = 4;
@@ -60938,14 +61052,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
-"xqF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "xqO" = (
 /obj/rack,
 /obj/item/clothing/mask/breath,
@@ -61136,6 +61242,11 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/darkblue/checker,
 /area/station/crew_quarters/radio/news_office)
+"xyY" = (
+/turf/simulated/floor/stairs/dark{
+	dir = 4
+	},
+/area/station/maintenance/inner/east)
 "xzv" = (
 /obj/cable{
 	d1 = 2;
@@ -61365,6 +61476,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
+"xKk" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/access_spawn/maint,
+/turf/simulated/floor/grey,
+/area/station/maintenance/west)
 "xKr" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -61495,6 +61614,13 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/interrogation)
+"xNE" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power)
 "xOu" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -61536,6 +61662,16 @@
 "xPz" = (
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
+"xPW" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/space)
 "xQl" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	desc = "The power transmission laser is in this direction.";
@@ -61729,6 +61865,18 @@
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor,
 /area/station/mining/magnet)
+"xWr" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "xXb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61774,6 +61922,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"xXW" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "xYi" = (
 /obj/machinery/disposal/transport{
 	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
@@ -61983,6 +62142,13 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)
+"yhF" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "yhR" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -95136,13 +95302,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 abX
 acb
 aMt
 aMt
 aMt
-aaa
-aaa
 aMt
 aMt
 aMt
@@ -95436,15 +95602,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aMt
 aMt
 aMt
 aMt
 aMt
-aSL
+bCG
 aSM
-aaa
-aaa
 aTz
 aRu
 aRu
@@ -95738,15 +95904,15 @@ aaa
 aaa
 aaa
 abX
+aaa
+aaa
 aMt
 avB
 avB
 aNA
 aMt
-aKc
+aLA
 aLq
-aaa
-aaa
 aBE
 aNz
 aBE
@@ -96040,6 +96206,8 @@ aaa
 aaa
 abW
 aaf
+aaa
+aaa
 aMt
 avB
 avB
@@ -96047,8 +96215,6 @@ avB
 aPp
 aLA
 aLr
-aaa
-aaa
 aPq
 aPq
 aPq
@@ -96342,6 +96508,8 @@ abX
 aaa
 abX
 aaf
+aaa
+aaa
 aMt
 avB
 avB
@@ -96349,8 +96517,6 @@ avB
 aMt
 aPr
 aLr
-aaa
-aaa
 aPq
 aNB
 aXv
@@ -96647,12 +96813,12 @@ axJ
 axJ
 axJ
 axJ
-aNG
-aNF
-bzN
+axJ
+axJ
+axJ
+aMt
+aLA
 aLr
-aaa
-aaa
 aPq
 aUY
 aSB
@@ -96952,9 +97118,9 @@ aHd
 aIe
 aQl
 axJ
+aPc
+aLA
 aLr
-aaa
-aaa
 aPq
 aPq
 aRv
@@ -97251,12 +97417,12 @@ aFW
 axJ
 azF
 axJ
-aHh
+azF
 aJc
 axJ
+jWA
+aLA
 aLr
-aaa
-aaa
 aPq
 aUY
 aSB
@@ -97555,10 +97721,10 @@ nML
 aHe
 aOx
 aIZ
-axJ
+aNF
+aBE
+uAN
 aLv
-aaa
-aaa
 aPq
 aWi
 aXx
@@ -97858,9 +98024,9 @@ aMw
 aHg
 aJa
 aKg
+aBE
+aBE
 aLw
-aaa
-aaa
 aPq
 aPq
 aPq
@@ -98160,16 +98326,16 @@ aMO
 aOy
 aJb
 axJ
+avB
+avB
 aLx
-aaa
-aaa
-aMt
-aNE
 aPt
-aZk
+aNE
+aSE
+aSE
 aQs
 aRB
-bdK
+qFH
 aTy
 sNP
 aUZ
@@ -98462,16 +98628,16 @@ aHh
 azF
 aJc
 axJ
-aTt
-aaa
-aaa
 aMt
+lnW
+aTt
 aPt
-aPt
+lob
 aSE
+hsp
 aSE
 aRB
-aSE
+bdK
 aSE
 aQr
 aRv
@@ -98764,12 +98930,12 @@ aMQ
 aOz
 aJc
 axJ
+cZD
+avB
 awJ
-aaa
-aaa
-aUh
 aPt
-aXz
+ask
+aQu
 aQu
 aQu
 aRC
@@ -99066,12 +99232,12 @@ aMt
 axJ
 axJ
 axJ
-awJ
-aaa
-aaa
-aUl
+xTH
+eYC
+cuH
 aXu
-aYq
+uKj
+aQv
 aQv
 aQv
 aRD
@@ -99367,15 +99533,15 @@ aFY
 axL
 axL
 axL
-aKj
-aLy
-aaa
-aaa
-aMx
+axL
+axL
+xXW
+weD
+aPt
 aPt
 aOA
 aSE
-aSE
+qFH
 aRB
 aSE
 aSF
@@ -99669,17 +99835,17 @@ aFZ
 aBE
 aBE
 aBE
+aBE
+aBE
 aKk
 aLz
-aaa
-aaa
-azL
+aMy
 aPt
 aYu
 aSE
-aSE
-aRB
 aSG
+aRB
+aSE
 aTA
 aQr
 aVc
@@ -99971,11 +100137,11 @@ ayN
 ayN
 ayN
 ayN
+cqU
+xTH
 aKm
 aLA
-aaa
-aaa
-aMy
+hBz
 aNH
 aNH
 aNH
@@ -100273,10 +100439,10 @@ aMY
 aHk
 aIf
 ayN
+agE
+agE
 aCa
-aKl
-aaa
-aaa
+xKk
 agE
 aNH
 aOB
@@ -100575,10 +100741,10 @@ aGb
 aRj
 aIg
 ayN
-arL
+fbc
+sMd
+arE
 aLB
-aaa
-aaa
 aMz
 aNH
 aOC
@@ -100878,9 +101044,9 @@ aSr
 aIh
 ayN
 aJe
+gqP
+arE
 aLB
-aaa
-aaa
 aMA
 aQD
 aOD
@@ -101178,11 +101344,11 @@ ayN
 aGd
 dMW
 aIi
-vzr
-arL
+ayN
+dGP
+fLR
+arE
 aLB
-aaa
-aaa
 aMB
 sSO
 aOE
@@ -101480,11 +101646,11 @@ ayN
 aPb
 aVm
 bdh
-sHo
-arL
+ayN
+meT
+agE
+arE
 aLB
-aaa
-aaa
 meT
 qZL
 wio
@@ -101784,9 +101950,9 @@ aGe
 aGe
 aGe
 aKo
+auI
+fLB
 aLC
-aaa
-aaa
 bld
 aNI
 aOG
@@ -102085,10 +102251,10 @@ aGf
 aHo
 aHo
 aHo
+aHo
+aHo
 aKp
 aLD
-aaa
-aaa
 aMC
 xmF
 aMC
@@ -102389,8 +102555,8 @@ aIj
 aJf
 ayO
 aHp
-aaa
-aaa
+aHp
+aHp
 aHp
 vBz
 aHp
@@ -103297,7 +103463,7 @@ ehL
 iSh
 wOo
 wHy
-ufJ
+wtu
 dAh
 aNL
 aHq
@@ -103895,11 +104061,11 @@ aaa
 ach
 ttJ
 mbC
-wHy
 xRd
 wHy
 wHy
 wHy
+kNs
 wHy
 hxH
 aMG
@@ -104198,12 +104364,12 @@ ach
 aHq
 tun
 ttJ
+ttJ
 aHq
 mhp
-ttJ
-lyM
-aNK
-tBi
+aHq
+aHq
+pGN
 aNM
 yep
 aHq
@@ -104499,11 +104665,11 @@ aay
 aaf
 aaf
 ehC
-acO
-ach
-bWF
 aaf
-aHq
+acO
+aaa
+kud
+aaa
 aHq
 aHq
 aHq
@@ -104803,13 +104969,13 @@ aAS
 wnr
 aAU
 aAS
-aLP
+aaa
 tvn
-tvn
-tvn
-tvn
-etO
-xqF
+aaa
+aaa
+ach
+ftA
+uIC
 etO
 qJq
 lpu
@@ -105105,13 +105271,13 @@ aEb
 aFb
 aGj
 aAS
-sbo
-aAU
+aAS
+tOr
 aAS
 aAS
 aaf
 gxC
-ftA
+eVa
 gxC
 gxC
 oDR
@@ -105408,12 +105574,12 @@ aGk
 aGk
 dTq
 aFc
-aBR
+aGk
 axy
 aAT
-aaa
-vdb
-vdb
+aad
+aad
+aaf
 aaf
 abh
 abh
@@ -105712,10 +105878,10 @@ aHr
 aIo
 aJk
 aKu
-kUU
+aAU
 aaa
-aaf
-aaf
+aaa
+ach
 abn
 aaa
 aaa
@@ -106014,10 +106180,10 @@ aHs
 aIp
 aJl
 aKv
-kUU
+aAU
 aaa
-aad
-ceD
+aaa
+oZa
 abn
 aaa
 acb
@@ -106319,7 +106485,7 @@ aKw
 qvw
 qPO
 mOx
-ach
+aaf
 abk
 aPC
 aPC
@@ -106619,9 +106785,9 @@ aIr
 aJn
 aKx
 aAT
-vdb
-aaa
-ach
+aad
+aad
+aaf
 aea
 aQJ
 aQJ
@@ -106921,9 +107087,9 @@ aIs
 aJo
 aKy
 aAS
-vdb
 aaa
-aaf
+aaa
+ach
 aea
 aQJ
 aQJ
@@ -107224,7 +107390,7 @@ aJp
 aKz
 auL
 aMK
-aaa
+abZ
 aaf
 aea
 aQJ
@@ -107527,7 +107693,7 @@ aKA
 aLI
 aML
 aaa
-aaf
+aaO
 aea
 aQJ
 aQJ
@@ -107814,7 +107980,7 @@ axa
 aya
 ayZ
 auQ
-aaa
+pzA
 auL
 aAZ
 aBV
@@ -107829,7 +107995,7 @@ aKA
 aLJ
 aML
 aaa
-aaf
+aaa
 aea
 aQJ
 aQJ
@@ -108131,7 +108297,7 @@ aKA
 aLI
 aML
 aaa
-aaO
+aaa
 aea
 aQJ
 aQJ
@@ -108719,11 +108885,11 @@ xQl
 axc
 ayd
 azc
-azX
-aad
-auN
+xNE
+xPW
+dRZ
 pLF
-aBY
+xWr
 aBa
 aEl
 aGr
@@ -109022,7 +109188,7 @@ axd
 aye
 xav
 auQ
-aaa
+pzA
 auL
 rXh
 aBZ
@@ -109338,8 +109504,8 @@ auL
 aaQ
 aaf
 aMN
-aaa
-ach
+aad
+aaf
 aea
 aQJ
 aQJ
@@ -110846,8 +111012,8 @@ aCf
 aCf
 aFn
 aaQ
-acO
-aaa
+aaf
+aay
 aay
 abb
 acO
@@ -111148,8 +111314,8 @@ aaa
 aaa
 ach
 aaW
-aaS
 aaZ
+aaS
 aaS
 aaS
 aaS
@@ -111448,11 +111614,11 @@ aBi
 aBj
 aaa
 aaa
-ach
-aad
+aaO
 aaf
 aaQ
 aaf
+aad
 aad
 aad
 aad
@@ -111717,8 +111883,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -111739,6 +111903,8 @@ aaa
 aaa
 avX
 aaa
+aaa
+aaa
 chj
 chj
 chj
@@ -111750,11 +111916,11 @@ aaa
 aaa
 aaa
 aaa
-ach
 aaa
 ach
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -112019,8 +112185,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -112041,22 +112205,24 @@ aaa
 aaa
 avX
 aaa
-chj
-chj
-chj
-chj
-ach
-aaf
-abZ
-abZ
-abZ
-abZ
-abZ
-aaf
 aaa
+aaa
+chj
+chj
+chj
+chj
 ach
+aaf
+abZ
+abZ
+abZ
+abZ
+abZ
+abZ
+aaf
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -112321,8 +112487,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -112343,6 +112507,8 @@ aaa
 aaa
 avX
 aaa
+aaa
+aaa
 chj
 chj
 chj
@@ -112354,11 +112520,11 @@ aaa
 aaa
 aaa
 aaa
-ach
 aaa
 ach
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -112623,8 +112789,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -112645,6 +112809,8 @@ aaa
 aaa
 avX
 aaa
+aaa
+aaa
 bhJ
 aBi
 bhJ
@@ -112656,11 +112822,11 @@ aaa
 aaa
 aaa
 aaa
-ach
 aaa
 ach
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -112925,8 +113091,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -112951,18 +113115,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 ach
 acO
+aaa
 aaa
 aaa
 aaa
 aaa
 aaa
 aci
-aaa
-ach
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -113227,8 +113393,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aeG
 aaJ
 buM
@@ -113253,6 +113417,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 ach
 acO
 aaa
@@ -113260,14 +113426,14 @@ aaa
 aaa
 aaa
 aaa
-aci
 aaa
-ach
+aci
 aaQ
 aaf
 abZ
 abZ
 bkO
+abZ
 abZ
 abZ
 aaf
@@ -113528,8 +113694,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adp
 adp
 aeU
@@ -113565,8 +113729,10 @@ aaS
 aaS
 aaS
 aaS
+aaS
 bTB
 acO
+aaa
 aaa
 aaa
 aaa
@@ -113830,8 +113996,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adp
 adE
 aeR
@@ -113867,8 +114031,10 @@ aUA
 bwp
 aXM
 aCh
+aad
 aaQ
 awS
+aaa
 aaa
 aaa
 aaa
@@ -114131,8 +114297,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aKf
 adp
 ael
@@ -114169,7 +114333,9 @@ aHD
 bys
 bEI
 aAb
+aay
 aaQ
+afw
 aaa
 aaa
 aaa
@@ -114434,8 +114600,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aqh
 afX
 aRl
@@ -114471,13 +114635,15 @@ buK
 aIA
 aXN
 aCh
-bzt
-afw
-aaa
-aaa
-aaa
-aaa
-aaa
+crM
+aaQ
+aaf
+abZ
+abZ
+abZ
+abZ
+abZ
+abZ
 aaf
 aad
 sdD
@@ -114736,8 +114902,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aqh
 aga
 aRl
@@ -114773,13 +114937,15 @@ xPz
 aKJ
 aKJ
 aCh
-aaQ
 aaf
-abZ
-abZ
-abZ
-abZ
-abZ
+aaQ
+acO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aci
 aaa
 sdD
@@ -115037,8 +115203,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 agj
 aqh
 adp
@@ -115075,8 +115239,10 @@ xEt
 bqC
 bEJ
 bNl
+aad
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -115341,8 +115507,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adp
 agK
 ajS
@@ -115377,8 +115541,10 @@ xEt
 xEt
 xEt
 bNo
+aaa
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -115643,8 +115809,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adp
 adp
 adp
@@ -115679,8 +115843,10 @@ xEt
 xEt
 xEt
 bNo
+aaa
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -115945,8 +116111,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 adp
 asf
@@ -115979,10 +116143,12 @@ iMJ
 xEt
 buL
 xEt
-vwY
-aCh
+xEt
+bNo
+aaa
 aaQ
 acO
+aaa
 aaa
 aaa
 aaa
@@ -116247,8 +116413,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 adp
 aze
@@ -116281,9 +116445,11 @@ iMJ
 xEt
 xEt
 xEt
-xEt
+vwY
 aCh
-mAq
+aay
+aaQ
+acO
 mEy
 mEy
 gel
@@ -116547,8 +116713,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 aay
 aaf
@@ -116584,8 +116748,10 @@ xPz
 xPz
 xPz
 bEN
-aCo
-bUy
+aCh
+brH
+mAq
+osY
 mEy
 dDe
 fwt
@@ -116850,8 +117016,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 akV
 cmr
 cmr
@@ -116887,7 +117051,9 @@ aMp
 wFB
 bFz
 aCh
+pqx
 xXd
+gDu
 mEy
 dDK
 fEY
@@ -117152,8 +117318,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aeo
 aev
 afg
@@ -117189,7 +117353,9 @@ aCh
 aCh
 aCh
 aCh
-sFD
+fzR
+xXd
+mUL
 mEy
 dGG
 aSd
@@ -117454,8 +117620,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 akV
 cmr
 cmr
@@ -117488,10 +117652,12 @@ blv
 bon
 bqE
 buN
-kIf
-bFA
-xXd
-xXd
+lQB
+iOs
+ieG
+ieG
+sFD
+ieG
 mEy
 dIn
 blp
@@ -117755,8 +117921,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 cmr
 kqw
@@ -117791,9 +117955,11 @@ boG
 bqF
 ieG
 ieG
+xyY
 ieG
 xXd
 xXd
+yhF
 mEy
 mEy
 mEy
@@ -118058,8 +118224,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 aey
 ail
@@ -118092,6 +118256,8 @@ blz
 bpv
 brf
 ieG
+eCR
+aZJ
 bCL
 fFZ
 fFZ
@@ -118360,8 +118526,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 mMB
 aqT
@@ -118393,6 +118557,8 @@ ieG
 ieG
 ieG
 ieG
+ieG
+aZJ
 ieG
 bCQ
 eEn
@@ -118662,8 +118828,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 akV
 aeA
 afl
@@ -118691,6 +118855,8 @@ aAr
 djG
 aMP
 bgE
+aMP
+aMP
 aMP
 aMP
 aMP
@@ -118964,8 +119130,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 oLe
 aqT
@@ -118996,8 +119160,10 @@ bha
 aZJ
 bVT
 aZJ
-aZJ
-xXd
+srD
+wKn
+fzO
+ieG
 tIm
 xXd
 aLQ
@@ -119265,8 +119431,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 cmr
 dpv
@@ -119298,6 +119462,8 @@ qrA
 ieG
 ieG
 ieG
+ieG
+lHl
 ieG
 ieG
 tIm
@@ -119568,8 +119734,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 oLe
 agi
@@ -119598,6 +119762,8 @@ bce
 aCB
 qrA
 aaf
+aad
+aad
 aad
 aad
 aaf
@@ -119870,8 +120036,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 akV
 wwg
 afn
@@ -119900,6 +120064,8 @@ aKH
 avf
 aOd
 acO
+aaa
+aaa
 aaa
 aaa
 ach
@@ -120172,8 +120338,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 dbt
 agN
@@ -120202,6 +120366,8 @@ aKI
 bdD
 aOd
 acO
+aaa
+aaa
 aaa
 aaa
 ach
@@ -120474,8 +120640,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 cmr
 aux
 ahc
@@ -120504,6 +120668,8 @@ bcf
 aCD
 aOd
 acO
+aaa
+aaa
 aaa
 aaa
 ach
@@ -120775,8 +120941,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 cmr
 aiJ
@@ -120806,6 +120970,8 @@ bcg
 aMX
 qrA
 aaf
+aay
+aay
 aay
 aay
 aaf
@@ -121078,8 +121244,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 akV
 aeB
 afo
@@ -121107,6 +121271,8 @@ nsn
 bci
 qrA
 qrA
+khm
+khm
 khm
 khm
 khm
@@ -121380,8 +121546,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 aeI
 afp
@@ -121403,6 +121567,8 @@ aIF
 aKZ
 aOe
 aAx
+aaa
+aaa
 aAx
 aAx
 aAx
@@ -121682,8 +121848,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 afa
 ahL
@@ -121705,6 +121869,8 @@ aIJ
 avj
 aGL
 aPR
+aaa
+aaa
 uzL
 atq
 uzL
@@ -121984,8 +122150,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 anK
 auA
 agI
@@ -122007,6 +122171,8 @@ aIK
 aFr
 aOk
 aFr
+aaa
+aaa
 aFr
 aUt
 aYU
@@ -122286,8 +122452,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 auA
 agI
@@ -122309,6 +122473,8 @@ axz
 axz
 axz
 axz
+aaa
+aaa
 axz
 axz
 axz
@@ -122588,8 +122754,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 aCu
 agI
@@ -122611,6 +122775,8 @@ aIL
 ine
 azx
 aFC
+aaa
+aaa
 aFC
 aDp
 aAA
@@ -122890,8 +123056,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 aaI
 agI
@@ -122913,6 +123077,8 @@ aIO
 avl
 aHF
 aHF
+aaa
+aaa
 aHF
 avm
 aAB
@@ -123192,8 +123358,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 afb
 agL
@@ -123215,6 +123379,8 @@ atr
 avm
 aHF
 aHF
+aaa
+aaa
 aHF
 avm
 aYX
@@ -123493,8 +123659,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaf
 adL
 aCu
@@ -123517,6 +123681,8 @@ atr
 avm
 aHF
 aHF
+aaa
+aaa
 aHF
 avl
 aJz
@@ -123795,8 +123961,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adv
 adv
 adv
@@ -123819,6 +123983,8 @@ atr
 smb
 aOn
 aOn
+aaa
+aaa
 aSp
 aBw
 awy
@@ -124097,8 +124263,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adv
 agY
 agY
@@ -124121,6 +124285,8 @@ atr
 aJD
 aJD
 aQa
+aaa
+aaa
 aJD
 aJD
 aJD
@@ -124399,8 +124565,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aem
 aep
 afh
@@ -124423,6 +124587,8 @@ atr
 atr
 azC
 atr
+aaa
+aaa
 atr
 azC
 atr
@@ -124701,8 +124867,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aem
 aeq
 afR
@@ -124725,6 +124889,8 @@ atr
 avo
 aCI
 axE
+aaa
+aaa
 aCI
 aCI
 aYZ
@@ -125003,8 +125169,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adv
 aer
 afQ
@@ -125027,6 +125191,8 @@ atr
 aDC
 fjh
 fjh
+aaa
+aaa
 fjh
 fjh
 aZc
@@ -125304,8 +125470,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaf
 aem
 aes
@@ -125329,6 +125493,8 @@ atr
 aDC
 fjh
 fjh
+aaa
+aaa
 fjh
 fjh
 aZc
@@ -125607,8 +125773,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aem
 aet
 afU
@@ -125631,6 +125795,8 @@ atr
 aLa
 aEu
 aIG
+aaa
+aaa
 aHK
 aIG
 aJE
@@ -125909,8 +126075,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adv
 adv
 adv
@@ -125933,6 +126097,8 @@ atr
 atr
 atr
 atr
+aaa
+aaa
 atr
 aII
 aJF
@@ -126211,8 +126377,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaf
 adL
 afY
@@ -126235,6 +126399,8 @@ auz
 aLf
 aOo
 fdN
+aaa
+aaa
 aSs
 aUF
 bao
@@ -126514,8 +126680,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 afa
 auA
@@ -126537,6 +126701,8 @@ fdN
 fdN
 fdN
 fdN
+aaa
+aaa
 fdN
 aVp
 fdN
@@ -126816,8 +126982,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 aCu
 ahR
@@ -126839,6 +127003,8 @@ auA
 rZk
 lUL
 aQP
+aaa
+aaa
 lUL
 aVB
 lUL
@@ -127118,8 +127284,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 agJ
 ahS
@@ -127141,6 +127305,8 @@ aIT
 aLL
 btO
 aQQ
+aaa
+aaa
 aSw
 aWR
 btO
@@ -127420,8 +127586,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adL
 adL
 adL
@@ -127443,6 +127607,8 @@ aCu
 anX
 anX
 ayG
+aaa
+aaa
 anX
 anX
 anX
@@ -127722,8 +127888,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -127745,6 +127909,8 @@ anX
 anX
 aEw
 aFK
+aaa
+aaa
 aSV
 aWY
 baH
@@ -128018,8 +128184,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abX
 aaa
 aaa
@@ -128047,6 +128211,8 @@ aCx
 aAp
 aEy
 aFQ
+aaa
+aaa
 aSW
 aXf
 bbt
@@ -128319,8 +128485,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 adJ
 alX
@@ -128349,6 +128513,8 @@ aCN
 anX
 anX
 anX
+aaa
+aaa
 anX
 anX
 anX
@@ -128621,8 +128787,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -128651,6 +128815,8 @@ aJI
 aLM
 aGD
 aGy
+aaa
+aaa
 aAC
 anX
 aoc
@@ -128923,8 +129089,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -128953,6 +129117,8 @@ aJL
 aLN
 aEA
 aCK
+aaa
+aaa
 aAG
 anX
 aoc
@@ -129225,8 +129391,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -129255,6 +129419,8 @@ aGE
 aGE
 aLN
 aCK
+aaa
+aaa
 aAG
 anX
 aoc
@@ -129527,8 +129693,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -129557,6 +129721,8 @@ aJV
 aLS
 aOq
 aQR
+aaa
+aaa
 aSX
 anX
 aoc
@@ -129829,8 +129995,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -129859,6 +130023,8 @@ aGE
 aGE
 aOs
 aQX
+aaa
+aaa
 aAG
 anX
 aoc
@@ -130131,8 +130297,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaL
 acI
 adw
@@ -130161,6 +130325,8 @@ aJW
 aHL
 aOO
 aRa
+aaa
+aaa
 aAG
 anX
 aoc
@@ -130433,8 +130599,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaL
 aaP
 ady
@@ -130463,6 +130627,8 @@ aKC
 aHN
 aOX
 aRf
+aaa
+aaa
 aRg
 anX
 aoc
@@ -130735,8 +130901,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaL
 acI
 adw
@@ -130765,6 +130929,8 @@ aFu
 aFu
 aFu
 aRg
+aaa
+aaa
 anX
 anX
 aoc
@@ -131037,8 +131203,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -131067,6 +131231,8 @@ anX
 anX
 anX
 anX
+aaa
+aaa
 anX
 aoc
 aoc
@@ -131339,8 +131505,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -131369,6 +131533,8 @@ aoc
 aoc
 aoc
 aoc
+aaa
+aaa
 aoc
 aoc
 anX
@@ -131641,8 +131807,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -131671,6 +131835,8 @@ anX
 anX
 anX
 anX
+aaa
+aaa
 anX
 anX
 anX
@@ -131943,8 +132109,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 aaN
 alX
@@ -131973,6 +132137,8 @@ avT
 abZ
 aad
 abZ
+aaa
+aaa
 awS
 aaa
 aaa
@@ -132245,8 +132411,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adc
 ada
 alX
@@ -132260,6 +132424,8 @@ aaa
 adc
 aaN
 alX
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132548,8 +132714,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaT
 aaa
 aaa
@@ -132562,6 +132726,8 @@ aaa
 adc
 ada
 alX
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132854,8 +133020,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 acI
 acO
@@ -132863,6 +133027,8 @@ aaa
 aaa
 aaa
 aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133156,11 +133322,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 acI
 acO
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133457,13 +133623,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 agj
 aaf
 aen
 aaf
 aPh
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133760,11 +133926,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aOv
 aci
 aOv
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134063,9 +134229,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aRo
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -2363,7 +2363,9 @@
 "agL" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
-	icon_state = "6-8"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -3758,12 +3760,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"akw" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "akx" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -4331,6 +4327,9 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "alS" = (
@@ -4345,24 +4344,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
-"alT" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "alU" = (
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "alV" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 5
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -4696,16 +4684,11 @@
 	name = "Book Nook"
 	})
 "amK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "4-6"
+	icon_state = "1-6"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -4750,6 +4733,7 @@
 	d2 = 4;
 	icon_state = "2-9"
 	},
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "amV" = (
@@ -4758,15 +4742,6 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"amX" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 6
-	},
-/obj/cable{
-	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -5327,29 +5302,10 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
-"aoS" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "Chapel"
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aoT" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/chapel/sanctuary)
-"aoW" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	name = "Chapel Repressurization Port"
-	},
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aoY" = (
 /obj/machinery/light,
 /obj/stool/chair/pew/fancy/right{
@@ -5415,22 +5371,6 @@
 /area/station/maintenance/northeast)
 "apc" = (
 /obj/storage/closet/wardrobe/mixed,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
-"apd" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
 "ape" = (
@@ -6106,12 +6046,10 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "aqX" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	high_risk = 1;
-	name = "NE Hallway"
+/obj/cable{
+	icon_state = "1-10"
 	},
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aqY" = (
@@ -6172,13 +6110,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
-"arc" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	name = "NE Hallway Repressurization Port"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "ard" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/utility)
@@ -8596,15 +8527,6 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/arcade/dungeon)
-"ayD" = (
-/obj/stool/chair,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/grime,
-/area/station/crew_quarters/utility)
 "ayF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/camera{
@@ -12868,19 +12790,10 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
 "aKr" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2
+/obj/machinery/atmospherics/valve{
+	name = "Intermix Valve"
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/caution/west,
-/area/station/engine/gas)
-"aKt" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	name = "Mixing Port"
-	},
-/turf/simulated/floor/caution/east,
 /area/station/engine/gas)
 "aKu" = (
 /obj/table/reinforced/auto,
@@ -13195,9 +13108,6 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/caution/west,
 /area/station/engine/gas)
-"aLG" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -13453,9 +13363,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/monitoring)
-"aMF" = (
-/turf/simulated/floor/caution/corner/se,
-/area/station/engine/gas)
 "aMG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor,
@@ -13757,7 +13664,7 @@
 	},
 /area/station/hallway/primary/west)
 "aNJ" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/gas)
 "aNL" = (
@@ -38946,6 +38853,13 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
+"cPx" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
@@ -42900,6 +42814,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"ghJ" = (
+/obj/machinery/atmospherics/valve{
+	name = "Intermix Valve"
+	},
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "ghK" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -42983,6 +42903,17 @@
 	allows_vehicles = 0
 	},
 /area/station/ai_monitored/armory)
+"gkK" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/crew_quarters/utility)
 "gkQ" = (
 /obj/machinery/plantpot,
 /obj/machinery/light{
@@ -43356,7 +43287,7 @@
 "gzD" = (
 /obj/machinery/dispenser,
 /obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "gzJ" = (
 /obj/table/auto,
@@ -44072,6 +44003,13 @@
 	icon_state = "platingdmg2"
 	},
 /area/station/maintenance/southeast)
+"hcW" = (
+/obj/machinery/atmospherics/valve{
+	high_risk = 1;
+	name = "Chapel"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "hdb" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -46786,6 +46724,16 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"keH" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "kfn" = (
 /obj/cable,
 /obj/cable{
@@ -47454,17 +47402,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "kNs" = (
-/obj/machinery/computer/airbr{
-	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
-	id = "vigilatorsud";
-	req_access = null;
-	req_access_txt = "44";
-	dir = 8;
-	pixel_x = 26;
-	starts_established = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Mixing Port"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/corner/se,
 /area/station/engine/gas)
 "kNC" = (
 /obj/cable{
@@ -48194,6 +48136,17 @@
 	},
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
+"ltV" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "lui" = (
 /obj/table/auto,
 /obj/machinery/light,
@@ -49988,6 +49941,13 @@
 "neS" = (
 /turf/simulated/floor/stairs/wide/other,
 /area/station/chapel/sanctuary)
+"nfG" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	name = "Mixing Port"
+	},
+/turf/simulated/floor,
+/area/station/engine/gas)
 "ngj" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -52428,6 +52388,7 @@
 	},
 /area/station/bridge)
 "pyu" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "pyB" = (
@@ -52477,6 +52438,13 @@
 "pAz" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"pAB" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Chapel Repressurization Port"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "pAP" = (
 /obj/disposaloutlet/east,
 /obj/disposalpipe/trunk/south,
@@ -52614,9 +52582,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor,
 /area/station/science/testchamber)
-"pGN" = (
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/gas)
 "pGO" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/engine{
@@ -52990,6 +52955,12 @@
 	dir = 4
 	},
 /area/station/hangar/engine)
+"pVb" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/space)
 "pVl" = (
 /obj/shrub{
 	dir = 6
@@ -53194,6 +53165,14 @@
 /obj/item/furniture_parts/IVstand,
 /turf/simulated/floor/white/grime,
 /area/station/hangar/medical)
+"qgv" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "qgH" = (
 /obj/plasticflaps,
 /obj/machinery/cargo_router/kd_qm_flap,
@@ -53942,6 +53921,9 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"qOH" = (
+/turf/simulated/floor,
+/area/space)
 "qON" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
@@ -55246,7 +55228,7 @@
 	name = "Gas Transit Door";
 	pixel_y = 24
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/north,
 /area/station/engine/gas)
 "set" = (
 /obj/machinery/drainage,
@@ -55433,6 +55415,14 @@
 /obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"srX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8;
+	name = "NE Hallway Repressurization Port"
+	},
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "ssd" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/blue/checker,
@@ -56228,6 +56218,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
+"sWY" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/station/engine/gas)
 "sXS" = (
 /obj/lattice{
 	dir = 10;
@@ -56635,6 +56629,12 @@
 	},
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"tqG" = (
+/obj/machinery/atmospherics/pipe/simple,
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/space)
 "trB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57746,6 +57746,24 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
+"usd" = (
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "vigilatorsud";
+	req_access = null;
+	req_access_txt = "44";
+	dir = 8;
+	pixel_x = 26;
+	starts_established = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "usi" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -58508,12 +58526,12 @@
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
 "uWJ" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1
-	},
 /obj/decal/tile_edge/floorguide/engineering,
 /obj/decal/tile_edge/floorguide/arrow_w{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 10
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -59392,6 +59410,14 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"vVi" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	high_risk = 1;
+	name = "NE Hallway"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "vVp" = (
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Control";
@@ -60619,8 +60645,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/caution/corner/nw,
+/turf/simulated/floor/caution/west,
 /area/station/engine/gas)
 "wYK" = (
 /obj/disposalpipe/segment/brig{
@@ -61711,7 +61736,10 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/black,
+/obj/machinery/atmospherics/portables_connector{
+	name = "Mixing Port"
+	},
+/turf/simulated/floor/caution/corner/ne,
 /area/station/engine/gas)
 "xRV" = (
 /obj/machinery/vending/medical_public,
@@ -61854,6 +61882,13 @@
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor,
 /area/station/mining/magnet)
+"xVT" = (
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 6
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "xWr" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 8;
@@ -103447,13 +103482,13 @@ meT
 aHq
 aHq
 seo
-dCc
-ehL
+iSh
+nfG
 iSh
 wOo
 wHy
 wtu
-dAh
+sWY
 aNL
 aHq
 hqM
@@ -103748,11 +103783,11 @@ aad
 aaf
 ttJ
 vKz
-wHy
-pGN
-aKt
-aLG
-aMF
+dCc
+iSh
+ehL
+iSh
+wOo
 wHy
 ufJ
 dAh
@@ -104051,9 +104086,9 @@ ach
 ttJ
 mbC
 xRd
-wHy
-wHy
-wHy
+ghJ
+usd
+ghJ
 kNs
 wHy
 hxH
@@ -121556,12 +121591,12 @@ aIF
 aKZ
 aOe
 aAx
-aaa
-aaa
-aAx
-aAx
+pVb
+pVb
 aAx
 fcv
+aAx
+aAx
 aCE
 bhL
 cJD
@@ -121858,8 +121893,8 @@ aIJ
 avj
 aGL
 aPR
-aaa
-aaa
+qOH
+qOH
 uzL
 atq
 uzL
@@ -122151,17 +122186,17 @@ age
 ate
 awg
 age
-age
-age
+ajO
+ajO
 age
 aWX
 uWJ
 aIK
-aFr
+qgv
 aOk
 aFr
-aaa
-aaa
+tqG
+tqG
 aFr
 aUt
 aYU
@@ -122452,9 +122487,11 @@ akh
 age
 atl
 awg
+adL
+aay
+aay
 ard
-apc
-aqn
+ard
 ard
 fdN
 aFH
@@ -122462,8 +122499,6 @@ axz
 axz
 axz
 axz
-aaa
-aaa
 axz
 axz
 axz
@@ -122754,8 +122789,10 @@ aki
 age
 atl
 awg
+adL
 ard
-apd
+ard
+ard
 aqo
 are
 fdN
@@ -122764,8 +122801,6 @@ aIL
 ine
 azx
 aFC
-aaa
-aaa
 aFC
 aDp
 aAA
@@ -123054,10 +123089,12 @@ alD
 age
 age
 age
-auA
-aCu
+xVT
+hcW
+pAB
 ard
-ayD
+gkK
+aqo
 aqp
 arf
 fdN
@@ -123066,8 +123103,6 @@ aIO
 avl
 aHF
 aHF
-aaa
-aaa
 aHF
 avm
 aAB
@@ -123350,16 +123385,18 @@ aaa
 adL
 afb
 agL
-avu
-avu
+cPx
+cPx
 alR
 amK
 akW
 akW
 alV
-amX
+auA
+keH
 anT
 apf
+aun
 aun
 aun
 aDL
@@ -123368,8 +123405,6 @@ atr
 avm
 aHF
 aHF
-aaa
-aaa
 aHF
 avm
 aYX
@@ -123652,26 +123687,26 @@ aaf
 adL
 aCu
 aKW
+auA
+auA
+alW
+avu
 amU
-akw
-akL
-alT
-amU
+ltV
 war
-aoS
 aqX
+vVi
 ard
 atj
 auo
 awa
+ajf
 fdN
 vSu
 atr
 avm
 aHF
 aHF
-aaa
-aaa
 aHF
 avl
 aJz
@@ -123950,6 +123985,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+adL
 adv
 adv
 adv
@@ -123960,20 +123997,18 @@ aij
 amL
 adL
 adL
-aoW
-arc
+srX
 ard
 atk
+apc
+aqn
 aqq
-ajf
 aEs
 aAa
 atr
 smb
 aOn
 aOn
-aaa
-aaa
 aSp
 aBw
 awy
@@ -124252,6 +124287,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adv
 agY
 agY
@@ -124263,7 +124300,7 @@ amV
 aph
 adL
 adL
-adL
+ajd
 ajd
 ajd
 ajd
@@ -124274,8 +124311,6 @@ atr
 aJD
 aJD
 aQa
-aaa
-aaa
 aJD
 aJD
 aJD
@@ -124554,6 +124589,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aem
 aep
 afh
@@ -124576,8 +124613,6 @@ atr
 atr
 azC
 atr
-aaa
-aaa
 atr
 azC
 atr
@@ -124856,6 +124891,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aem
 aeq
 afR
@@ -124878,8 +124915,6 @@ atr
 avo
 aCI
 axE
-aaa
-aaa
 aCI
 aCI
 aYZ
@@ -125158,6 +125193,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adv
 aer
 afQ
@@ -125180,8 +125217,6 @@ atr
 aDC
 fjh
 fjh
-aaa
-aaa
 fjh
 fjh
 aZc
@@ -125459,6 +125494,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaf
 aem
 aes
@@ -125482,8 +125519,6 @@ atr
 aDC
 fjh
 fjh
-aaa
-aaa
 fjh
 fjh
 aZc
@@ -125762,6 +125797,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aem
 aet
 afU
@@ -125784,8 +125821,6 @@ atr
 aLa
 aEu
 aIG
-aaa
-aaa
 aHK
 aIG
 aJE
@@ -126064,6 +126099,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adv
 adv
 adv
@@ -126086,8 +126123,6 @@ atr
 atr
 atr
 atr
-aaa
-aaa
 atr
 aII
 aJF
@@ -126366,6 +126401,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaf
 adL
 afY
@@ -126388,8 +126425,6 @@ auz
 aLf
 aOo
 fdN
-aaa
-aaa
 aSs
 aUF
 bao
@@ -126669,6 +126704,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adL
 afa
 auA
@@ -126690,8 +126727,6 @@ fdN
 fdN
 fdN
 fdN
-aaa
-aaa
 fdN
 aVp
 fdN
@@ -126971,6 +127006,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adL
 aCu
 ahR
@@ -126992,8 +127029,6 @@ auA
 rZk
 lUL
 aQP
-aaa
-aaa
 lUL
 aVB
 lUL
@@ -127273,6 +127308,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adL
 agJ
 ahS
@@ -127294,8 +127331,6 @@ aIT
 aLL
 btO
 aQQ
-aaa
-aaa
 aSw
 aWR
 btO
@@ -127575,6 +127610,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adL
 adL
 adL
@@ -127596,8 +127633,6 @@ aCu
 anX
 anX
 ayG
-aaa
-aaa
 anX
 anX
 anX
@@ -127877,6 +127912,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aci
 aaa
 aaa
@@ -127898,8 +127935,6 @@ anX
 anX
 aEw
 aFK
-aaa
-aaa
 aSV
 aWY
 baH
@@ -128173,6 +128208,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 abX
 aaa
 aaa
@@ -128200,8 +128237,6 @@ aCx
 aAp
 aEy
 aFQ
-aaa
-aaa
 aSW
 aXf
 bbt
@@ -128474,6 +128509,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 adJ
 alX
@@ -128502,8 +128539,6 @@ aCN
 anX
 anX
 anX
-aaa
-aaa
 anX
 anX
 anX
@@ -128776,6 +128811,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -128804,8 +128841,6 @@ aJI
 aLM
 aGD
 aGy
-aaa
-aaa
 aAC
 anX
 aoc
@@ -129078,6 +129113,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -129106,8 +129143,6 @@ aJL
 aLN
 aEA
 aCK
-aaa
-aaa
 aAG
 anX
 aoc
@@ -129380,6 +129415,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -129408,8 +129445,6 @@ aGE
 aGE
 aLN
 aCK
-aaa
-aaa
 aAG
 anX
 aoc
@@ -129682,6 +129717,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -129710,8 +129747,6 @@ aJV
 aLS
 aOq
 aQR
-aaa
-aaa
 aSX
 anX
 aoc
@@ -129984,6 +130019,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -130012,8 +130049,6 @@ aGE
 aGE
 aOs
 aQX
-aaa
-aaa
 aAG
 anX
 aoc
@@ -130286,6 +130321,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaL
 acI
 adw
@@ -130314,8 +130351,6 @@ aJW
 aHL
 aOO
 aRa
-aaa
-aaa
 aAG
 anX
 aoc
@@ -130588,6 +130623,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaL
 aaP
 ady
@@ -130616,8 +130653,6 @@ aKC
 aHN
 aOX
 aRf
-aaa
-aaa
 aRg
 anX
 aoc
@@ -130890,6 +130925,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaL
 acI
 adw
@@ -130918,8 +130955,6 @@ aFu
 aFu
 aFu
 aRg
-aaa
-aaa
 anX
 anX
 aoc
@@ -131192,6 +131227,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -131220,8 +131257,6 @@ anX
 anX
 anX
 anX
-aaa
-aaa
 anX
 aoc
 aoc
@@ -131494,6 +131529,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -131522,8 +131559,6 @@ aoc
 aoc
 aoc
 aoc
-aaa
-aaa
 aoc
 aoc
 anX
@@ -131796,6 +131831,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -131824,8 +131861,6 @@ anX
 anX
 anX
 anX
-aaa
-aaa
 anX
 anX
 anX
@@ -132098,6 +132133,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 aaN
 alX
@@ -132126,8 +132163,6 @@ avT
 abZ
 aad
 abZ
-aaa
-aaa
 awS
 aaa
 aaa
@@ -132400,6 +132435,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 adc
 ada
 alX
@@ -132413,8 +132450,6 @@ aaa
 adc
 aaN
 alX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -132703,6 +132738,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aaT
 aaa
 aaa
@@ -132715,8 +132752,6 @@ aaa
 adc
 ada
 alX
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -133009,6 +133044,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 ach
 acI
 acO
@@ -133016,8 +133053,6 @@ aaa
 aaa
 aaa
 aaT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -133311,11 +133346,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 ach
 acI
 acO
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -133612,13 +133647,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 agj
 aaf
 aen
 aaf
 aPh
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -133915,11 +133950,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aOv
 aci
 aOv
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134218,9 +134253,9 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aRo
-aaa
-aaa
 aaa
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12778,11 +12778,18 @@
 	},
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
 "aKr" = (
 /obj/machinery/atmospherics/valve{
 	name = "Intermix Valve"
+	},
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/gas)
@@ -14455,6 +14462,11 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aQD" = (
@@ -14935,6 +14947,11 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -23835,6 +23852,12 @@
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor/engine,
 /area/station/mining/refinery)
+"bwR" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/gas)
 "bwS" = (
 /obj/storage/secure/closet/engineering/mining,
 /turf/simulated/floor/orangeblack/side{
@@ -41033,7 +41056,7 @@
 /obj/submachine/GTM{
 	pixel_y = 32
 	},
-/obj/random_item_spawner/junk/one_or_zero,
+/obj/stool/bench/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "eDc" = (
@@ -43374,6 +43397,14 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
+"gCN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/gas)
 "gCT" = (
 /obj/stool/chair,
 /turf/simulated/floor/plating,
@@ -44752,6 +44783,17 @@
 /obj/machinery/navbeacon/mule/cafeteria_north/south,
 /turf/simulated/floor/bot,
 /area/station/crew_quarters/cafeteria)
+"hYm" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "hZr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44893,6 +44935,17 @@
 	dir = 8
 	},
 /area/station/security/main)
+"ijh" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "ijs" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -50013,6 +50066,9 @@
 	dir = 4;
 	name = "Mixing Port"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/gas)
 "ngj" = (
@@ -52199,6 +52255,9 @@
 	},
 /area/station/security/main)
 "plR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/gas)
 "pmt" = (
@@ -57163,6 +57222,11 @@
 	dir = 1
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
@@ -59193,6 +59257,11 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -59382,6 +59451,11 @@
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -59788,6 +59862,19 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/black,
 /area/station/bridge)
+"wfh" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "whk" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro{
@@ -102714,13 +102801,13 @@ aGg
 aHp
 aIj
 aJf
+aHp
 ayO
-aHp
-aHp
+ijh
 vNQ
-aHp
+wfh
 vBz
-aHp
+wfh
 tGN
 aQC
 aRM
@@ -103621,8 +103708,8 @@ aHq
 seo
 iSh
 nfG
-iSh
-wOo
+gCN
+bwR
 wHy
 wtu
 sWY
@@ -118418,7 +118505,7 @@ bpv
 brf
 ieG
 eCR
-aZJ
+xXd
 bCL
 fFZ
 fFZ
@@ -118719,7 +118806,7 @@ ieG
 ieG
 ieG
 ieG
-aZJ
+ieG
 ieG
 bCQ
 eEn
@@ -119022,7 +119109,7 @@ aMP
 aMP
 aMP
 aMP
-aMP
+hYm
 bDG
 xXd
 aLQ

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1370,9 +1370,7 @@
 	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/ptl)
 "adH" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -1540,9 +1538,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "aej" = (
 /obj/machinery/light/small{
@@ -1812,9 +1808,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "aeU" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -2339,9 +2333,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn/maint,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "agG" = (
 /turf/simulated/wall/auto/supernorn,
@@ -2700,9 +2692,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "ahG" = (
 /obj/stool/bed,
@@ -3071,9 +3061,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon9,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "aiC" = (
 /obj/cable{
@@ -6469,9 +6457,7 @@
 	dir = 4
 	},
 /obj/landmark/halloween,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "arR" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -6808,9 +6794,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "asU" = (
 /obj/machinery/light{
@@ -7124,9 +7108,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "auf" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -7336,9 +7318,7 @@
 	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "auQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -7397,7 +7377,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "auY" = (
 /obj/table/wood/auto,
 /obj/loudspeaker,
@@ -7613,14 +7593,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"avI" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "avK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7628,14 +7600,14 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avL" = (
 /obj/stool/bench/yellow/auto,
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avM" = (
 /obj/stool/bench/yellow/auto,
 /obj/machinery/light{
@@ -7646,20 +7618,20 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avN" = (
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avO" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avP" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/suit/fire/heavy,
@@ -7674,7 +7646,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avQ" = (
 /obj/machinery/computer/power_monitor{
 	dir = 4;
@@ -7705,14 +7677,12 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "avS" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "avT" = (
 /obj/lattice{
@@ -8038,18 +8008,15 @@
 /area/space)
 "awU" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "awV" = (
 /obj/cable{
 	d1 = 4;
@@ -8058,7 +8025,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "awW" = (
 /obj/cable{
 	d1 = 4;
@@ -8071,7 +8038,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "awX" = (
 /obj/cable{
 	d1 = 4;
@@ -8079,7 +8046,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "awY" = (
 /obj/cable{
 	d1 = 4;
@@ -8089,7 +8056,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "awZ" = (
 /obj/cable{
 	d1 = 4;
@@ -8104,7 +8071,7 @@
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "axa" = (
 /obj/cable{
 	d1 = 4;
@@ -8239,6 +8206,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"axy" = (
+/obj/table/reinforced/auto,
+/obj/item/device/analyzer/atmospheric,
+/obj/item/wrench,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "axz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -8350,36 +8327,30 @@
 	},
 /area/station/hallway/primary/west)
 "axU" = (
-/obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "axV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
-/area/station/engine/core)
-"axW" = (
-/turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "axX" = (
 /obj/stool/chair/office/yellow,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "axY" = (
 /obj/stool/chair/office/yellow,
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "axZ" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -8391,7 +8362,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "aya" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -8420,9 +8391,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "ayc" = (
@@ -8434,9 +8402,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "ayd" = (
 /obj/cable{
@@ -8689,42 +8655,37 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"ayQ" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "ayR" = (
-/obj/storage/secure/closet/engineering/electrical,
-/obj/item/clothing/suit/rad,
-/obj/item/clothing/head/rad_hood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/light/emergency,
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "vigilatornord";
+	req_access = null;
+	req_access_txt = "44";
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/rack,
+/obj/item/extinguisher{
+	pixel_x = -6
+	},
+/obj/item/extinguisher{
+	pixel_x = 8
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayT" = (
-/obj/reagent_dispensers/foamtank,
+/obj/storage/secure/closet/engineering/electrical,
+/obj/item/clothing/suit/rad,
+/obj/item/clothing/head/rad_hood,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayU" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -8732,13 +8693,13 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayV" = (
 /obj/machinery/computer/atmosphere/pumpcontrol,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayW" = (
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
@@ -8749,7 +8710,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayX" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/fire{
@@ -8759,7 +8720,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayY" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
@@ -8773,7 +8734,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "ayZ" = (
 /obj/cable{
 	d2 = 4;
@@ -8800,9 +8761,6 @@
 /obj/stool/chair/office/yellow{
 	dir = 8
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_ns"
 	},
@@ -8821,9 +8779,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "azc" = (
 /obj/cable{
@@ -9146,44 +9102,27 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "azV" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "azW" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "azX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "azY" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access = null
-	},
+/obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/engineering_power,
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_misc"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "azZ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -9584,20 +9523,24 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "aAW" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "6-8"
 	},
-/turf/simulated/floor/stairs,
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "aAY" = (
 /obj/machinery/atmospherics/unary/furnace_connector,
 /obj/machinery/power/furnace/thermo{
 	fuel = 100
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "aAZ" = (
 /obj/machinery/light{
@@ -9609,7 +9552,7 @@
 /obj/machinery/power/furnace/thermo{
 	fuel = 100
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "aBa" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -9619,26 +9562,13 @@
 /area/station/engine/core)
 "aBd" = (
 /obj/machinery/power/apc/autoname_west,
-/obj/cable,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/engine/coldloop)
-"aBe" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-6"
 	},
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aBf" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -9646,7 +9576,11 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/light_switch/north,
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/coldloop)
+"aBf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
@@ -9663,6 +9597,7 @@
 	on = 1;
 	transfer_rate = 1000
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -9886,9 +9821,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aBQ" = (
 /obj/reagent_dispensers/foamtank,
@@ -9911,6 +9844,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -9926,9 +9860,6 @@
 /area/station/engine/core)
 "aBU" = (
 /obj/machinery/meter,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
 	},
@@ -9953,7 +9884,7 @@
 	level = 2
 	},
 /obj/cable{
-	icon_state = "6-10"
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -9996,10 +9927,10 @@
 	},
 /area/station/engine/coldloop)
 "aCc" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "aCd" = (
@@ -10311,11 +10242,11 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aCZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
+	},
+/obj/cable{
+	icon_state = "2-5"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10328,7 +10259,12 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/engine,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "aDc" = (
 /obj/machinery/meter{
@@ -10688,7 +10624,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "aDU" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -10707,7 +10643,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "aDX" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
@@ -10817,14 +10753,10 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10833,10 +10765,12 @@
 	dir = 10
 	},
 /obj/cable{
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-9"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10860,7 +10794,7 @@
 "aEl" = (
 /obj/machinery/atmospherics/valve,
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "4-10"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10873,9 +10807,6 @@
 	},
 /area/station/engine/core)
 "aEn" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4;
 	name = "Cold Loop";
@@ -10883,6 +10814,9 @@
 	},
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/core)
 "aEo" = (
@@ -11067,17 +11001,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aFb" = (
-/obj/table/reinforced/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_west,
-/obj/item/storage/firstaid/toxin,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/wrench,
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
+/turf/simulated/floor/engine/caution/misc{
+	dir = 4
 	},
 /area/station/engine/hotloop)
 "aFc" = (
@@ -11092,17 +11017,20 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "5-8"
-	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aFe" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	on = 1;
 	transfer_rate = 1000
+	},
+/obj/machinery/light_switch/east,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -11170,6 +11098,9 @@
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-5"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -11543,23 +11474,11 @@
 	},
 /area/station/engine/hotloop)
 "aGk" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/decal/poster/wallsign/space{
-	layer = 2;
-	name = "DIRECT VENTING";
-	pixel_y = 22
-	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aGl" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -11588,7 +11507,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "aGp" = (
 /obj/machinery/activation_button/ignition_switch{
@@ -11596,22 +11515,17 @@
 	name = "Burn Chamber Ignition";
 	pixel_y = -22
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "aGq" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "aGr" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -11629,7 +11543,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "aGt" = (
 /obj/machinery/atmospherics/valve,
@@ -11939,19 +11853,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -12258,7 +12161,7 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "aIl" = (
 /obj/cable{
 	d1 = 2;
@@ -12273,38 +12176,9 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
-"aIm" = (
-/obj/machinery/manufacturer/gas,
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
-"aIn" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "aIo" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-6"
-	},
-/obj/machinery/door_control{
-	id = "fireshield";
-	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/door_control{
-	id = "combustion";
-	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/hotloop)
@@ -12621,25 +12495,7 @@
 /obj/table/wood/auto,
 /turf/simulated/floor/darkblue/checker,
 /area/station/crew_quarters/radio/news_office)
-"aJj" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Engine Gas Storage";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow,
-/area/station/engine/gas)
 "aJk" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/hotloop)
 "aJl" = (
@@ -12648,11 +12504,6 @@
 	layer = 2;
 	pixel_x = 17;
 	pixel_y = 12
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "6-9"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -13045,7 +12896,11 @@
 /obj/item/clothing/mask/gas,
 /obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve,
-/obj/machinery/light_switch/west,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKv" = (
@@ -13054,11 +12909,6 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKw" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -13423,6 +13273,21 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"aLP" = (
+/obj/grille/catwalk{
+	dir = 10
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "aLQ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -13628,13 +13493,13 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "aMF" = (
 /turf/simulated/floor/caution/corner/se,
 /area/station/engine/gas)
 "aMG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/black,
+/turf/simulated/floor,
 /area/station/engine/gas)
 "aMI" = (
 /obj/stool/chair/couch{
@@ -13928,7 +13793,7 @@
 /area/station/hallway/primary/west)
 "aNJ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/corner/sw,
 /area/station/engine/gas)
 "aNK" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -13936,7 +13801,7 @@
 /area/station/engine/gas)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/south,
 /area/station/engine/gas)
 "aNM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -13945,7 +13810,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/east,
 /area/station/engine/gas)
 "aNQ" = (
 /obj/lattice{
@@ -14163,13 +14028,6 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/escape)
-"aOK" = (
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 1
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "aOL" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -32380,6 +32238,17 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"bWF" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/space)
 "bWL" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -39025,7 +38894,7 @@
 	dir = 4
 	},
 /obj/machinery/light/emergency,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "cIR" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
@@ -39590,6 +39459,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"dgP" = (
+/obj/airbridge_controller{
+	id = "vigilatornord";
+	tunnel_width = 2
+	},
+/turf/space,
+/area/space)
 "dha" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -39620,6 +39496,10 @@
 /obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
+"djg" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/caution/west,
+/area/station/engine/gas)
 "djG" = (
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/disposalpipe/segment/vertical,
@@ -40029,6 +39909,10 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
+"dAh" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor,
+/area/station/engine/gas)
 "dCc" = (
 /turf/simulated/floor/caution/north,
 /area/station/engine/gas)
@@ -40452,17 +40336,30 @@
 	allows_vehicles = 0
 	},
 /area/station/ai_monitored/armory)
-"dTh" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+"dTq" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Heat Shield";
+	pixel_x = -24;
+	pixel_y = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/machinery/door_control{
+	id = "combustion";
+	name = "Chamber Exhaust";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/decal/poster/wallsign/space{
+	layer = 2;
+	name = "DIRECT VENTING";
+	pixel_y = 22
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "dUg" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/qm_horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -40838,6 +40735,16 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
+"ehC" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cannedfartbelt";
+	name = "gas transit belt"
+	},
+/turf/simulated/floor/airless/engine/caution{
+	icon_state = "engine_caution_ns"
+	},
+/area/space)
 "ehL" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -41505,6 +41412,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
+"eMH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/engine/caution/westeast,
+/area/space)
 "eMJ" = (
 /obj/rack,
 /obj/item/clothing/suit/bio_suit/paramedic,
@@ -42139,17 +42052,6 @@
 "foa" = (
 /turf/simulated/floor/plating,
 /area/station/quartermaster/cargobay)
-"foi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "fpv" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -42473,9 +42375,6 @@
 	pixel_x = 3
 	},
 /obj/item/tank/air,
-/obj/item/chem_grenade/firefighting,
-/obj/item/chem_grenade/firefighting,
-/obj/item/extinguisher,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -42484,10 +42383,23 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/north,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "fFZ" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
@@ -43170,6 +43082,10 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
+"gnl" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engine/monitoring)
 "gnJ" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43468,6 +43384,11 @@
 /obj/item/goboard,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
+"gzD" = (
+/obj/machinery/dispenser,
+/obj/item/device/radio/intercom/engineering,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "gzJ" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -44043,6 +43964,15 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
+"gZM" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "gZZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour20;desc=Thank you for joining me on this tour! You should now be acclimatized to the station. If you're still feeling a bit lost, look for the Bartender or Head of Personnel.";
@@ -44202,9 +44132,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/west)
 "heQ" = (
 /obj/stool/chair{
@@ -44561,6 +44489,10 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"hxH" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/caution/north,
+/area/station/engine/gas)
 "hyJ" = (
 /obj/cable{
 	d1 = 1;
@@ -45101,6 +45033,17 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"inC" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "inI" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/armory_outside)
@@ -47569,6 +47512,13 @@
 	dir = 1
 	},
 /area/station/security/interrogation)
+"kPW" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine/caution/south,
+/area/station/engine/core)
 "kQv" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -47681,7 +47631,8 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/md)
 "kUU" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
 /area/space)
 "kUZ" = (
 /obj/cable{
@@ -47775,6 +47726,12 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
+"kZf" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/monitoring)
 "kZn" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
@@ -48161,7 +48118,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "lrT" = (
 /obj/disposalpipe/segment/mail/bent/west,
@@ -48376,6 +48333,10 @@
 	},
 /turf/space,
 /area/space)
+"lyM" = (
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "lzp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48873,6 +48834,11 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
+"mbC" = (
+/turf/simulated/floor/engine/caution/misc{
+	dir = 8
+	},
+/area/station/engine/gas)
 "mcp" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -48942,6 +48908,23 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"mhp" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/engine/gas)
 "mhG" = (
 /obj/stool/chair{
 	dir = 8
@@ -49379,7 +49362,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "mFy" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -49549,18 +49532,23 @@
 	pixel_x = 3
 	},
 /obj/item/tank/air,
-/obj/item/chem_grenade/firefighting,
-/obj/item/chem_grenade/firefighting,
-/obj/item/extinguisher,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/item/chem_grenade/firefighting{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "mNo" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -49586,6 +49574,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"mOx" = (
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 1
+	},
+/turf/space,
+/area/space)
 "mPi" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -50753,6 +50747,14 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
+"nTj" = (
+/obj/airbridge_controller{
+	id = "vigilatornord";
+	primary_controller = 1;
+	tunnel_width = 2
+	},
+/turf/space,
+/area/space)
 "nVl" = (
 /obj/shrub{
 	dir = 1;
@@ -51261,16 +51263,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"oqJ" = (
-/obj/machinery/atmospherics/portables_connector{
-	name = "Mixing Port"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
-/turf/simulated/floor/caution/corner/nw,
-/area/station/engine/gas)
 "oqP" = (
 /obj/table/auto,
 /obj/item/storage/box/PDAbox,
@@ -51653,6 +51645,21 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"oMc" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
+"oMd" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine/caution/westeast,
+/area/station/engine/core)
 "oMF" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -52086,6 +52093,9 @@
 	dir = 4
 	},
 /area/station/security/main)
+"plR" = (
+/turf/simulated/floor/caution/corner/sw,
+/area/station/engine/gas)
 "pmt" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -52366,12 +52376,8 @@
 	},
 /area/station/bridge)
 "pyu" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/caution/corner/sw,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
 "pyB" = (
 /obj/disposalpipe/segment/food,
@@ -52682,6 +52688,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/showers)
+"pLF" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/station/engine/core)
 "pLK" = (
 /obj/machinery/computer/ordercomp,
 /obj/cable{
@@ -53226,7 +53238,7 @@
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
-/area/station/engine/core)
+/area/station/engine/monitoring)
 "qnB" = (
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
@@ -53524,14 +53536,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "qvw" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
+/turf/simulated/floor/plating,
+/area/station/engine/combustion_chamber)
 "qwl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -53873,6 +53883,10 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"qPO" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/space,
+/area/station/maintenance/inner/west)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53975,10 +53989,6 @@
 /obj/item/pen,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"qVD" = (
-/obj/machinery/dispenser,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "qVJ" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -54776,6 +54786,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/bridge/hos)
+"rOS" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine/caution/misc,
+/area/station/engine/core)
 "rOU" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
@@ -54965,14 +54984,7 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom/engineering,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "rXn" = (
 /obj/cable{
@@ -55086,6 +55098,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"sbo" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/engineering_engine,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/engine/hotloop)
 "sbP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -55160,6 +55191,15 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"seo" = (
+/obj/machinery/manufacturer/gas,
+/obj/machinery/door_control{
+	id = "kdrgasbelt";
+	name = "Gas Transit Door";
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "set" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/wood,
@@ -55283,6 +55323,9 @@
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
+"smx" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/monitoring)
 "smE" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -55844,6 +55887,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"sPv" = (
+/obj/machinery/door/airlock/pyro/glass/engineering,
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "sPZ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -56607,6 +56656,20 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
+"tun" = (
+/obj/plasticflaps,
+/obj/machinery/door/poddoor/pyro{
+	id = "kdrgasbelt";
+	name = "Gas Transit Door";
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cannedfartbelt";
+	name = "gas transit belt"
+	},
+/turf/simulated/floor/engine/caution/northsouth,
+/area/station/engine/gas)
 "tuz" = (
 /obj/machinery/light/small,
 /obj/machinery/photocopier,
@@ -56648,6 +56711,13 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
+"tvn" = (
+/obj/grille/catwalk,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "tvu" = (
 /obj/machinery/cargo_router/kd_sec_exoflap,
 /turf/simulated/floor/caution/westeast,
@@ -56722,6 +56792,10 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"tBi" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/gas)
 "tBq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57040,15 +57114,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"tMp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "tNc" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/space_law,
@@ -57383,6 +57448,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
+"ufJ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/caution/north,
+/area/station/engine/gas)
 "ugn" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -58201,9 +58270,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/halloween,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "uQH" = (
 /obj/disposalpipe/segment/food,
@@ -59028,12 +59095,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"vHU" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "vIN" = (
 /obj/decal/tile_edge/floorguide/arrow_n{
 	dir = 8
@@ -59056,6 +59117,12 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
+"vKz" = (
+/obj/machinery/conveyor_switch{
+	id = "cannedfartbelt"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "vLW" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -59604,6 +59671,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"wnr" = (
+/obj/plasticflaps,
+/obj/machinery/door/poddoor/pyro{
+	id = "kdrgasbelt";
+	name = "Gas Transit Door";
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cannedfartbelt";
+	name = "gas transit belt"
+	},
+/turf/simulated/floor/engine/caution/northsouth,
+/area/station/engine/hotloop)
 "wnA" = (
 /obj/decal/cleanable/ash,
 /turf/simulated/floor/damaged1,
@@ -60060,6 +60141,9 @@
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
+"wHy" = (
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "wHG" = (
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
@@ -60097,6 +60181,10 @@
 /obj/storage/closet/wardrobe/green,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
+"wJP" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/caution/south,
+/area/station/engine/gas)
 "wLh" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -60120,7 +60208,7 @@
 	level = 2
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "wMb" = (
 /obj/table/reinforced/auto,
@@ -60425,6 +60513,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"wYe" = (
+/obj/machinery/atmospherics/portables_connector{
+	name = "Mixing Port"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -20
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/caution/corner/nw,
+/area/station/engine/gas)
 "wYK" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -61481,6 +61580,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
+"xRd" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xRV" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/red/side{
@@ -61790,6 +61897,10 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
+"yep" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/caution/corner/se,
+/area/station/engine/gas)
 "yfg" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -102276,8 +102387,8 @@ aGg
 aHp
 aIj
 aJf
-aHp
 ayO
+aHp
 aaa
 aaa
 aHp
@@ -102575,14 +102686,14 @@ auI
 gbf
 aFa
 aGh
-aaa
-aaa
+aHq
+aHq
 aHq
 aHq
 aHq
 aKq
 aHq
-aHq
+jTa
 aHq
 aHq
 aHq
@@ -102870,22 +102981,22 @@ aHo
 aHo
 aHo
 hkw
-uyV
+aHo
 heG
 aBP
-avI
-ayQ
-avI
+aHo
+hkw
+uyV
 aGi
-aaa
-aaa
-jTa
-qVD
-oqJ
+aHq
+gzD
+wYe
 aKr
 aLE
+plR
+oMc
 pyu
-aNJ
+djg
 aNJ
 aHq
 hgU
@@ -103173,21 +103284,21 @@ meT
 meT
 meT
 meT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+meT
+meT
+meT
+meT
+meT
 aHq
-aIm
+aHq
+seo
 dCc
 ehL
 iSh
 wOo
-aNL
+wHy
+ufJ
+dAh
 aNL
 aHq
 hqM
@@ -103475,21 +103586,21 @@ aaf
 aad
 aad
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aHq
-aIn
+aad
+aad
+aad
+aad
+aaf
+ttJ
+vKz
+wHy
 pGN
 aKt
 aLG
 aMF
-aNL
+wHy
+ufJ
+dAh
 aNL
 aHq
 fjf
@@ -103781,18 +103892,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aHq
+ach
 ttJ
-aJj
-ttJ
-aHq
+mbC
+wHy
+xRd
+wHy
+wHy
+wHy
+wHy
+hxH
 aMG
-aMG
-aNL
+wJP
 aHq
 rTU
 qwl
@@ -104083,18 +104194,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ach
 aHq
-aMG
-aNM
+tun
+ttJ
+aHq
+mhp
+ttJ
+lyM
 aNK
+tBi
+aNM
+yep
 aHq
 eIB
 qwl
@@ -104381,18 +104492,18 @@ aay
 aay
 aay
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abZ
+abZ
+aay
+aay
+aaf
+aaf
+ehC
+acO
+ach
+bWF
+aaf
+aHq
 aHq
 aHq
 aHq
@@ -104677,29 +104788,29 @@ ack
 sxR
 arA
 lRp
-auL
-auL
-auL
-auL
-auL
-auL
+smx
+smx
+smx
+smx
+smx
+smx
 aaa
 aaa
 aAS
 aAS
 aAS
 aAS
+wnr
+aAU
 aAS
-aAS
-kUU
-aaa
-aaa
-aaa
-aaa
-aaa
+aLP
+tvn
+tvn
+tvn
+tvn
+etO
 xqF
 etO
-tMp
 qJq
 lpu
 duY
@@ -104979,28 +105090,28 @@ ueM
 arI
 asK
 atY
-auL
+smx
 fFJ
 mNg
 axU
 ayR
-auL
+gnl
 aaa
 aaa
-aAT
+aAU
 aBQ
 aCU
 aEb
 aFb
 aGj
-kUU
-aaa
-aaa
-aaa
-aaa
-aaa
-uIC
+aAS
+sbo
+aAU
+aAS
+aAS
+aaf
 gxC
+ftA
 gxC
 gxC
 oDR
@@ -105287,22 +105398,22 @@ awU
 axV
 ayS
 azV
-aaa
-aaa
-aAU
-aBR
-aCV
-aCV
-aFc
+nTj
+dgP
+sPv
 aGk
-kUU
-kUU
-kUU
-kUU
-kUU
+aCV
+aCV
+aGk
+aGk
+dTq
+aFc
+aBR
+axy
+aAT
 aaa
-vHU
-ftA
+vdb
+vdb
 aaf
 abh
 abh
@@ -105583,12 +105694,12 @@ ack
 arJ
 cIc
 atX
-auL
+smx
 avL
 awV
-axW
+axV
 ayT
-auL
+gnl
 aaa
 aaa
 aAU
@@ -105604,7 +105715,7 @@ aKu
 kUU
 aaa
 aaf
-aOK
+aaf
 abn
 aaa
 aaa
@@ -105888,12 +105999,12 @@ atX
 auX
 avM
 awW
-axV
+kZf
 ayU
-auN
+smx
 aaa
 aaa
-aAT
+aAS
 aBS
 aCX
 aEd
@@ -106192,9 +106303,9 @@ aIk
 aMD
 axX
 ayV
-auN
-aaa
-kUU
+smx
+aay
+auL
 auL
 auN
 auN
@@ -106206,8 +106317,8 @@ aIq
 aJm
 aKw
 qvw
-vdb
-aaa
+qPO
+mOx
 ach
 abk
 aPC
@@ -106492,11 +106603,11 @@ atX
 aDT
 avN
 awW
-axV
+kZf
 ayW
-auN
-aaa
-kUU
+gnl
+aad
+auL
 aAV
 aBT
 aCY
@@ -106796,9 +106907,9 @@ avO
 awX
 axY
 ayX
-auN
+gnl
 aaa
-kUU
+auN
 aAW
 aBU
 aCZ
@@ -106810,7 +106921,7 @@ aIs
 aJo
 aKy
 aAS
-cRL
+vdb
 aaa
 aaf
 aea
@@ -107093,18 +107204,18 @@ bhN
 arL
 asQ
 aub
-auL
+smx
 avP
 awY
 axZ
 ayY
-auL
-aaa
-kUU
+gnl
+aay
+auN
 aAY
-aBV
+inC
+gZM
 aDf
-dTh
 aBY
 aGp
 auL
@@ -107395,14 +107506,14 @@ beb
 arL
 asR
 auc
-auL
-auL
+smx
+smx
 awZ
-auL
-auL
-auL
-aaa
-kUU
+smx
+smx
+smx
+aad
+auN
 aAY
 aBV
 uMJ
@@ -107414,7 +107525,7 @@ aIt
 aJq
 aKA
 aLI
-azW
+aML
 aaa
 aaf
 aea
@@ -107704,7 +107815,7 @@ aya
 ayZ
 auQ
 aaa
-kUU
+auL
 aAZ
 aBV
 aDc
@@ -108005,14 +108116,14 @@ axb
 ayb
 aza
 azX
-aaa
-kUU
+aay
+auN
 aAY
 aBW
 aDd
 aEj
 aFh
-aGr
+kPW
 aHv
 aHv
 aJs
@@ -108307,9 +108418,9 @@ avS
 ayc
 azb
 azY
-aaa
-kUU
-aBa
+eMH
+oMd
+rOS
 aBX
 aDe
 aEk
@@ -108320,7 +108431,7 @@ gMO
 aJt
 aKB
 aLJ
-azW
+aML
 aaa
 acb
 aea
@@ -108608,12 +108719,12 @@ xQl
 axc
 ayd
 azc
-auQ
-aaa
-kUU
-aDf
+azX
+aad
+auN
+pLF
 aBY
-foi
+aBa
 aEl
 aGr
 cIl
@@ -108622,7 +108733,7 @@ auL
 auL
 auL
 aLK
-auL
+azW
 nRo
 aaf
 aea
@@ -108912,7 +109023,7 @@ aye
 xav
 auQ
 aaa
-kUU
+auL
 rXh
 aBZ
 aDg
@@ -109213,8 +109324,8 @@ auQ
 auQ
 auQ
 auQ
-aaa
-kUU
+aay
+auL
 auL
 aFj
 auN
@@ -109512,11 +109623,11 @@ auh
 auR
 avV
 aqN
-aaa
-aaa
-aaa
-aaa
-kUU
+aad
+aad
+aad
+aad
+aFn
 aBd
 aCb
 aDh
@@ -109818,8 +109929,8 @@ aaa
 aaa
 aaa
 aaa
-kUU
-aBe
+aCf
+aCd
 aCc
 aDi
 aEp
@@ -110120,7 +110231,7 @@ aaa
 aaa
 aaa
 aaa
-kUU
+aCf
 aBf
 qfl
 aDj
@@ -110422,7 +110533,7 @@ aaa
 aaa
 aaa
 aaa
-kUU
+aFn
 aBg
 kbj
 aCe
@@ -110724,7 +110835,7 @@ aaa
 aaa
 aaa
 aaa
-kUU
+aFn
 aBh
 aBh
 aCf

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -368,13 +368,6 @@
 /turf/space,
 /turf/space,
 /area/mining/magnet)
-"abf" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "abg" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -7735,13 +7728,6 @@
 	},
 /turf/space,
 /area/space)
-"avU" = (
-/obj/storage/crate/furnacefuel,
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/power)
 "avV" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment/mail/bent/north,
@@ -8852,28 +8838,6 @@
 	icon_state = "engine_caution_ns"
 	},
 /area/station/engine/power)
-"azd" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/computer/power_monitor/smes{
-	dir = 8;
-	name = "Engine Output Monitoring"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/engine{
-	dir = 4;
-	icon_state = "engine_caution_misc"
-	},
-/area/station/engine/power)
 "aze" = (
 /obj/storage/closet/wardrobe/black,
 /turf/simulated/floor/plating,
@@ -9181,10 +9145,6 @@
 /obj/item/decoration/ashtray,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
-"azU" = (
-/obj/decal/poster/wallsign/hazard_caution,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
 "azV" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Engine Core";
@@ -9632,16 +9592,6 @@
 	},
 /turf/simulated/floor/stairs,
 /area/station/engine/core)
-"aAX" = (
-/obj/machinery/atmospherics/unary/furnace_connector,
-/obj/machinery/power/furnace/thermo{
-	fuel = 100
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "aAY" = (
 /obj/machinery/atmospherics/unary/furnace_connector,
 /obj/machinery/power/furnace/thermo{
@@ -9665,26 +9615,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aBb" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aBc" = (
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 8
-	},
-/obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBd" = (
@@ -12349,11 +12279,6 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIn" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -13112,8 +13037,6 @@
 	dir = 8;
 	name = "Mixing Port"
 	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
 /turf/simulated/floor/caution/east,
 /area/station/engine/gas)
 "aKu" = (
@@ -13444,26 +13367,6 @@
 "aLG" = (
 /turf/simulated/floor/caution/east,
 /area/station/engine/gas)
-"aLH" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -40890,6 +40793,18 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"efC" = (
+/obj/storage/crate/furnacefuel,
+/obj/machinery/light_switch/north,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/power)
 "egj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47765,6 +47680,9 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/md)
+"kUU" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "kUZ" = (
 /obj/cable{
 	d1 = 1;
@@ -52632,9 +52550,6 @@
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "pGN" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/gas)
 "pGO" = (
@@ -53608,6 +53523,15 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"qvw" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "qwl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -53949,15 +53873,6 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"qRd" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55045,6 +54960,20 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"rXh" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 8
+	},
+/obj/item/device/radio/intercom/engineering,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "rXn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55779,12 +55708,6 @@
 "sJN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/sw)
-"sJY" = (
-/obj/decal/poster/wallsign/warning1{
-	pixel_x = 6
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "sKo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56199,12 +56122,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/east)
-"sWO" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "sXS" = (
 /obj/lattice{
 	dir = 10;
@@ -56686,6 +56603,10 @@
 	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/secondary/exit)
+"ttJ" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "tuz" = (
 /obj/machinery/light/small,
 /obj/machinery/photocopier,
@@ -58519,6 +58440,9 @@
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/south)
+"vdb" = (
+/turf/space,
+/area/station/maintenance/inner/west)
 "vdG" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
@@ -59106,9 +59030,6 @@
 /area/station/bridge)
 "vHU" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -60517,6 +60438,23 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
+"xav" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/computer/power_monitor/smes{
+	dir = 8;
+	name = "Engine Output Monitoring"
+	},
+/turf/simulated/floor/engine{
+	dir = 4;
+	icon_state = "engine_caution_misc"
+	},
+/area/station/engine/power)
 "xcb" = (
 /obj/decal/poster/wallsign/poster_octocluwne{
 	pixel_y = 28
@@ -60906,9 +60844,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
@@ -90526,9 +90461,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ceB
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90828,8 +90763,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acg
 acr
 acr
@@ -90838,6 +90771,8 @@ acg
 aaa
 aaa
 ceB
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91130,8 +91065,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acg
 acs
 acJ
@@ -91141,6 +91074,8 @@ acg
 acg
 acg
 agm
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91431,8 +91366,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aMM
 acg
 act
@@ -91442,6 +91375,8 @@ adA
 adW
 aId
 acg
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91734,8 +91669,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acg
 acr
 acr
@@ -91746,6 +91679,8 @@ acg
 acg
 aaa
 abX
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92036,8 +91971,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acg
 acu
 acL
@@ -92049,6 +91982,8 @@ afx
 abZ
 aaf
 cgc
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92338,8 +92273,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 adb
 acu
 acM
@@ -92350,6 +92283,8 @@ aaa
 uGT
 aaa
 aci
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92640,8 +92575,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 acv
 acN
@@ -92652,6 +92585,8 @@ aaa
 uGT
 aaa
 aci
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92942,8 +92877,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 acw
 acN
@@ -92954,6 +92887,8 @@ abZ
 afz
 agn
 acO
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93244,8 +93179,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 acw
 acO
@@ -93256,6 +93189,8 @@ aaa
 lyu
 aaa
 ahe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93546,8 +93481,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -93558,6 +93491,8 @@ aaa
 lyu
 aaa
 afy
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93848,8 +93783,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -93860,6 +93793,8 @@ aaa
 lyu
 aaa
 afy
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94150,8 +94085,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -94178,6 +94111,8 @@ ast
 ast
 ast
 ast
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94452,8 +94387,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -94481,6 +94414,8 @@ ast
 ast
 ast
 ast
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94754,8 +94689,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -94784,6 +94717,8 @@ ast
 ast
 ast
 ast
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95056,8 +94991,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -95097,6 +95030,8 @@ acb
 aMt
 aMt
 aMt
+aaa
+aaa
 aMt
 aMt
 aMt
@@ -95358,8 +95293,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -95399,6 +95332,8 @@ aMt
 aMt
 aSL
 aSM
+aaa
+aaa
 aTz
 aRu
 aRu
@@ -95660,8 +95595,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -95701,6 +95634,8 @@ aNA
 aMt
 aKc
 aLq
+aaa
+aaa
 aBE
 aNz
 aBE
@@ -95962,8 +95897,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -96003,6 +95936,8 @@ avB
 aPp
 aLA
 aLr
+aaa
+aaa
 aPq
 aPq
 aPq
@@ -96264,8 +96199,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -96305,6 +96238,8 @@ avB
 aMt
 aPr
 aLr
+aaa
+aaa
 aPq
 aNB
 aXv
@@ -96566,8 +96501,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aci
@@ -96607,6 +96540,8 @@ aNG
 aNF
 bzN
 aLr
+aaa
+aaa
 aPq
 aUY
 aSB
@@ -96868,8 +96803,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaO
@@ -96909,6 +96842,8 @@ aIe
 aQl
 axJ
 aLr
+aaa
+aaa
 aPq
 aPq
 aRv
@@ -97170,8 +97105,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -97211,6 +97144,8 @@ aHh
 aJc
 axJ
 aLr
+aaa
+aaa
 aPq
 aUY
 aSB
@@ -97472,8 +97407,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -97513,6 +97446,8 @@ aOx
 aIZ
 axJ
 aLv
+aaa
+aaa
 aPq
 aWi
 aXx
@@ -97774,8 +97709,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -97815,6 +97748,8 @@ aHg
 aJa
 aKg
 aLw
+aaa
+aaa
 aPq
 aPq
 aPq
@@ -98076,8 +98011,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -98117,6 +98050,8 @@ aOy
 aJb
 axJ
 aLx
+aaa
+aaa
 aMt
 aNE
 aPt
@@ -98378,8 +98313,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -98419,6 +98352,8 @@ azF
 aJc
 axJ
 aTt
+aaa
+aaa
 aMt
 aPt
 aPt
@@ -98680,8 +98615,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -98721,6 +98654,8 @@ aOz
 aJc
 axJ
 awJ
+aaa
+aaa
 aUh
 aPt
 aXz
@@ -98982,8 +98917,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 abZ
 abZ
@@ -99023,6 +98956,8 @@ axJ
 axJ
 axJ
 awJ
+aaa
+aaa
 aUl
 aXu
 aYq
@@ -99284,8 +99219,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -99325,6 +99258,8 @@ axL
 axL
 aKj
 aLy
+aaa
+aaa
 aMx
 aPt
 aOA
@@ -99586,8 +99521,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -99627,6 +99560,8 @@ aBE
 aBE
 aKk
 aLz
+aaa
+aaa
 azL
 aPt
 aYu
@@ -99888,8 +99823,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -99929,6 +99862,8 @@ ayN
 ayN
 aKm
 aLA
+aaa
+aaa
 aMy
 aNH
 aNH
@@ -100190,8 +100125,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -100231,6 +100164,8 @@ aIf
 ayN
 aCa
 aKl
+aaa
+aaa
 agE
 aNH
 aOB
@@ -100492,8 +100427,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -100533,6 +100466,8 @@ aIg
 ayN
 arL
 aLB
+aaa
+aaa
 aMz
 aNH
 aOC
@@ -100794,8 +100729,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 abZ
 abZ
@@ -100835,6 +100768,8 @@ aIh
 ayN
 aJe
 aLB
+aaa
+aaa
 aMA
 aQD
 aOD
@@ -101096,8 +101031,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -101137,6 +101070,8 @@ aIi
 vzr
 arL
 aLB
+aaa
+aaa
 aMB
 sSO
 aOE
@@ -101398,8 +101333,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -101439,6 +101372,8 @@ bdh
 sHo
 arL
 aLB
+aaa
+aaa
 meT
 qZL
 wio
@@ -101700,8 +101635,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 aaa
@@ -101741,6 +101674,8 @@ aGe
 aGe
 aKo
 aLC
+aaa
+aaa
 bld
 aNI
 aOG
@@ -102002,8 +101937,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aci
 aaa
 acj
@@ -102043,6 +101976,8 @@ aHo
 aHo
 aKp
 aLD
+aaa
+aaa
 aMC
 xmF
 aMC
@@ -102304,8 +102239,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aay
 edo
@@ -102345,6 +102278,8 @@ aIj
 aJf
 aHp
 ayO
+aaa
+aaa
 aHp
 vBz
 aHp
@@ -102606,8 +102541,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acj
 acx
 acj
@@ -102642,6 +102575,8 @@ auI
 gbf
 aFa
 aGh
+aaa
+aaa
 aHq
 aHq
 aHq
@@ -102908,8 +102843,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 edo
 acy
 acP
@@ -102944,6 +102877,8 @@ avI
 ayQ
 avI
 aGi
+aaa
+aaa
 jTa
 qVD
 oqJ
@@ -103210,8 +103145,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 edo
 acz
 acQ
@@ -103240,12 +103173,14 @@ meT
 meT
 meT
 meT
-aAS
-aAS
-aAS
-aAS
-aAS
-aAS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aHq
 aIm
 dCc
@@ -103505,8 +103440,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acY
 aaa
 aaa
@@ -103542,12 +103475,14 @@ aaf
 aad
 aad
 aaf
-aAT
-aBQ
-aCU
-aEb
-aFb
-aGj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aHq
 aIn
 pGN
@@ -103806,8 +103741,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aMM
 abY
 acZ
@@ -103844,17 +103777,19 @@ awS
 aaa
 aaa
 ach
-aAU
-aBR
-aCV
-aCV
-aFc
-aGk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aHq
-aHq
+ttJ
 aJj
+ttJ
 aHq
-sJY
 aMG
 aMG
 aNL
@@ -104109,8 +104044,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aRo
 aaa
 aaa
@@ -104146,16 +104079,18 @@ aaa
 aaa
 aaa
 ach
-aAU
-aDa
-aCW
-aEc
-aFd
-aGl
-aHr
-aIo
-aJk
-aKu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aHq
 aMG
 aNM
@@ -104417,8 +104352,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 agj
 acj
 acD
@@ -104448,16 +104381,18 @@ aay
 aay
 aay
 aaf
-aAT
-aBS
-aCX
-aEd
-aFe
-aGm
-aHs
-aIp
-aJl
-aKv
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aHq
 aHq
 aHq
@@ -104720,8 +104655,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acm
 acC
 acC
@@ -104750,18 +104683,20 @@ auL
 auL
 auL
 auL
-auL
-auN
-auN
-aEe
-auL
-aGn
-aHt
-aIq
-aJm
-aKw
-aLH
-qRd
+aaa
+aaa
+aAS
+aAS
+aAS
+aAS
+aAS
+aAS
+kUU
+aaa
+aaa
+aaa
+aaa
+aaa
 xqF
 etO
 tMp
@@ -105022,8 +104957,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acm
 acC
 acC
@@ -105051,20 +104984,22 @@ fFJ
 mNg
 axU
 ayR
-azU
-aAV
-aBT
-aCY
-aEf
-aFf
-aGo
-auN
-aIr
-aJn
-aKx
+auL
+aaa
+aaa
 aAT
+aBQ
+aCU
+aEb
+aFb
+aGj
+kUU
+aaa
+aaa
+aaa
+aaa
+aaa
 uIC
-sWO
 gxC
 gxC
 gxC
@@ -105324,8 +105259,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acm
 acC
 acC
@@ -105354,18 +105287,20 @@ awU
 axV
 ayS
 azV
-aAW
-aBU
-aCZ
-aEg
-gSM
-wLi
-auN
-aIs
-aJo
-aKy
-aAS
-cRL
+aaa
+aaa
+aAU
+aBR
+aCV
+aCV
+aFc
+aGk
+kUU
+kUU
+kUU
+kUU
+kUU
+aaa
 vHU
 ftA
 aaf
@@ -105626,8 +105561,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acm
 acC
 acC
@@ -105656,19 +105589,21 @@ awV
 axW
 ayT
 auL
-aAX
-aBV
-aDf
-dTh
-aBY
-aGp
-auL
-auL
-aJp
-aKz
-auL
-aMK
-abf
+aaa
+aaa
+aAU
+aDa
+aCW
+aEc
+aFd
+aGl
+aHr
+aIo
+aJk
+aKu
+kUU
+aaa
+aaf
 aOK
 abn
 aaa
@@ -105927,8 +105862,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 agj
 acj
 acD
@@ -105958,18 +105891,20 @@ awW
 axV
 ayU
 auN
-aAY
-aBV
-uMJ
-aEh
-kTo
-aDb
-aHu
-aIt
-aJq
-aKA
-aLI
-azW
+aaa
+aaa
+aAT
+aBS
+aCX
+aEd
+aFe
+aGm
+aHs
+aIp
+aJl
+aKv
+kUU
+aaa
 aad
 ceD
 abn
@@ -106229,8 +106164,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acb
 edo
 acC
@@ -106260,18 +106193,20 @@ aMD
 axX
 ayV
 auN
-aAZ
-aBV
-aDc
-aEi
-aFg
-aGq
-aHv
-aHv
-aJr
-aKA
-aLJ
-aML
+aaa
+kUU
+auL
+auN
+auN
+aEe
+auL
+aGn
+aHt
+aIq
+aJm
+aKw
+qvw
+vdb
 aaa
 ach
 abk
@@ -106530,8 +106465,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acb
 acj
 acj
@@ -106562,18 +106495,20 @@ awW
 axV
 ayW
 auN
-aAY
-aBW
-aDd
-aEj
-aFh
-aGr
-aHv
-aHv
-aJs
-aKA
-aLI
-aML
+aaa
+kUU
+aAV
+aBT
+aCY
+aEf
+aFf
+aGo
+auN
+aIr
+aJn
+aKx
+aAT
+vdb
 aaa
 ach
 aea
@@ -106832,8 +106767,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 adp
 aeh
@@ -106864,19 +106797,21 @@ awX
 axY
 ayX
 auN
-aBa
-aBX
-aDe
-aEk
-aFi
-lrq
-fWk
-gMO
-aJt
-aKB
-aLJ
-azW
-aay
+aaa
+kUU
+aAW
+aBU
+aCZ
+aEg
+gSM
+wLi
+auN
+aIs
+aJo
+aKy
+aAS
+cRL
+aaa
 aaf
 aea
 aQJ
@@ -107134,8 +107069,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 adp
 aeh
@@ -107165,20 +107098,22 @@ avP
 awY
 axZ
 ayY
-azW
-aBb
+auL
+aaa
+kUU
+aAY
+aBV
+aDf
+dTh
 aBY
-foi
-aEl
-aGr
-cIl
+aGp
 auL
 auL
+aJp
+aKz
 auL
-auL
-aLK
-auL
-nRo
+aMK
+aaa
 aaf
 aea
 aQJ
@@ -107436,8 +107371,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 adp
 aeh
@@ -107468,19 +107401,21 @@ awZ
 auL
 auL
 auL
-aBc
-aBZ
-aDg
-aEm
-aDf
-aGs
-mFt
-aIu
-aHw
-aaV
-aaX
-aaY
-abg
+aaa
+kUU
+aAY
+aBV
+uMJ
+aEh
+kTo
+aDb
+aHu
+aIt
+aJq
+aKA
+aLI
+azW
+aaa
 aaf
 aea
 aQJ
@@ -107737,8 +107672,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 aca
 aca
@@ -107770,19 +107703,21 @@ axa
 aya
 ayZ
 auQ
-auL
-aFj
-auN
-aEn
-nQL
-auN
-auL
-auL
-auL
-aaQ
-aaf
-aMN
-aad
+aaa
+kUU
+aAZ
+aBV
+aDc
+aEi
+aFg
+aGq
+aHv
+aHv
+aJr
+aKA
+aLJ
+aML
+aaa
 aaf
 aea
 aQJ
@@ -108040,8 +107975,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acc
 ace
 aco
@@ -108072,18 +108005,20 @@ axb
 ayb
 aza
 azX
-aBd
-aCb
-aDh
-aEo
-aFk
-aGt
-aHx
-aIv
-aJu
-aaQ
-acO
-aBj
+aaa
+kUU
+aAY
+aBW
+aDd
+aEj
+aFh
+aGr
+aHv
+aHv
+aJs
+aKA
+aLI
+aML
 aaa
 aaO
 aea
@@ -108342,8 +108277,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acc
 acd
 acp
@@ -108374,18 +108307,20 @@ avS
 ayc
 azb
 azY
-aBe
-aCc
-aDi
-aEp
-aCd
-aGu
-aHy
-aIw
-aCf
-aaQ
-acO
 aaa
+kUU
+aBa
+aBX
+aDe
+aEk
+aFi
+lrq
+fWk
+gMO
+aJt
+aKB
+aLJ
+azW
 aaa
 acb
 aea
@@ -108644,8 +108579,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aca
 acn
 acf
@@ -108676,19 +108609,21 @@ axc
 ayd
 azc
 auQ
-aBf
-qfl
-aDj
-aDj
-aFl
-aGv
-aHz
-aIx
-aCf
-aaQ
-aaf
-aay
-aay
+aaa
+kUU
+aDf
+aBY
+foi
+aEl
+aGr
+cIl
+auL
+auL
+auL
+auL
+aLK
+auL
+nRo
 aaf
 aea
 aQJ
@@ -108946,8 +108881,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aca
 acf
 acf
@@ -108973,24 +108906,26 @@ arR
 asV
 auf
 auQ
-avU
+efC
 axd
 aye
-azd
+xav
 auQ
-aBg
-kbj
-aCe
-aCe
-aFm
-aGw
-aHA
-aIy
-aCf
-aaQ
-aaf
-aad
-aad
+aaa
+kUU
+rXh
+aBZ
+aDg
+aEm
+aDf
+aGs
+mFt
+aIu
+aHw
+aaV
+aaX
+aaY
+abg
 aaf
 aea
 aQJ
@@ -109248,8 +109183,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aca
 acf
 acf
@@ -109280,18 +109213,20 @@ auQ
 auQ
 auQ
 auQ
-aBh
-aBh
-aCf
-aCf
-aFn
-tVy
-aCf
-aCf
-aFn
-aaQ
-acO
 aaa
+kUU
+auL
+aFj
+auN
+aEn
+nQL
+auN
+auL
+auL
+auL
+aaQ
+aaf
+aMN
 aaa
 ach
 aea
@@ -109549,8 +109484,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abW
 aca
 aca
@@ -109579,21 +109512,23 @@ auh
 auR
 avV
 aqN
-azZ
-pCp
-pCp
-aBi
-ylQ
-aNr
-pCp
-hbu
-dlp
 aaa
 aaa
-ach
+aaa
+aaa
+kUU
+aBd
+aCb
+aDh
+aEo
+aFk
+aGt
+aHx
+aIv
+aJu
 aaQ
 acO
-aaa
+aBj
 aaa
 ach
 aea
@@ -109852,8 +109787,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aaO
 aca
 acG
@@ -109881,18 +109814,20 @@ yjd
 aqN
 avW
 aqN
-chj
-azZ
-hbu
-azZ
-mHX
-aNr
-pCp
-aBi
-aBj
 aaa
 aaa
-ach
+aaa
+aaa
+kUU
+aBe
+aCc
+aDi
+aEp
+aCd
+aGu
+aHy
+aIw
+aCf
 aaQ
 acO
 aaa
@@ -110155,8 +110090,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aOv
 aaa
 aOv
@@ -110183,18 +110116,20 @@ aug
 aqN
 avX
 aaT
-chj
-chj
-chj
-chj
-ach
-acO
 aaa
 aaa
 aaa
 aaa
-aaa
-ach
+kUU
+aBf
+qfl
+aDj
+aDj
+aFl
+aGv
+aHz
+aIx
+aCf
 aaQ
 acO
 aaa
@@ -110463,8 +110398,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -110485,18 +110418,20 @@ tna
 aqN
 avX
 aaa
-chj
-chj
-chj
-chj
-ach
-aaf
-abZ
-abZ
-abZ
-abZ
-abZ
-aaf
+aaa
+aaa
+aaa
+aaa
+kUU
+aBg
+kbj
+aCe
+aCe
+aFm
+aGw
+aHA
+aIy
+aCf
 aaQ
 acO
 aaa
@@ -110765,8 +110700,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -110787,21 +110720,23 @@ aaa
 aaa
 avX
 aaa
-chj
-chj
-chj
-chj
-ach
+aaa
+aaa
+aaa
+aaa
+kUU
+aBh
+aBh
+aCf
+aCf
+aFn
+tVy
+aCf
+aCf
+aFn
+aaQ
 acO
 aaa
-aaa
-aaa
-aaa
-aaa
-ach
-aaQ
-aaf
-aay
 aay
 abb
 acO
@@ -111067,8 +111002,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -111089,15 +111022,17 @@ aaa
 aaa
 avX
 aaa
-bhJ
+aaa
+aaa
+azZ
+pCp
+pCp
 aBi
-bhJ
-aBi
-ach
-acO
-aaa
-aaa
-aaa
+ylQ
+aNr
+pCp
+hbu
+dlp
 aaa
 aaa
 ach
@@ -111369,8 +111304,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 ach
 aaJ
 acO
@@ -111393,13 +111326,15 @@ avX
 aaa
 aaa
 aaa
-aaa
-aaa
-ach
-acO
-aaa
-aaa
-aaa
+chj
+azZ
+hbu
+azZ
+mHX
+aNr
+pCp
+aBi
+aBj
 aaa
 aaa
 ach
@@ -111693,10 +111628,10 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+chj
+chj
+chj
+chj
 ach
 acO
 aaa
@@ -111704,7 +111639,7 @@ aaa
 aaa
 aaa
 aaa
-aci
+ach
 aaa
 ach
 aaQ
@@ -111995,18 +111930,18 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+chj
+chj
+chj
+chj
 ach
-acO
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
+aaf
+abZ
+abZ
+abZ
+abZ
+abZ
+aaf
 aaa
 ach
 aaQ
@@ -112297,10 +112232,10 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+chj
+chj
+chj
+chj
 ach
 acO
 aaa
@@ -112308,7 +112243,7 @@ aaa
 aaa
 aaa
 aaa
-aci
+ach
 aaa
 ach
 aaQ
@@ -112599,10 +112534,10 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+bhJ
+aBi
+bhJ
+aBi
 ach
 acO
 aaa
@@ -112610,7 +112545,7 @@ aaa
 aaa
 aaa
 aaa
-aci
+ach
 aaa
 ach
 aaQ

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -54337,6 +54337,10 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
+"rfJ" = (
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "rfU" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1;
@@ -122319,8 +122323,8 @@ age
 ate
 awg
 age
-ajO
-ajO
+age
+age
 age
 aWX
 uWJ
@@ -122621,8 +122625,8 @@ age
 atl
 awg
 adL
-aay
-aay
+rfJ
+rfJ
 ard
 ard
 ard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Significant alteration to Kondaru centered on the TEG, adjusting it and its surroundings to allow for it to be entirely atmospherically severed from the rest of the station. Some other minor layout changes to the TEG and associated facilities have also been included.

![image](https://user-images.githubusercontent.com/12454065/198107847-8a5d1562-0efd-4bec-af44-df1f889c8455.png)

The entire station was extended vertically by two tiles to allow this to occur; most areas not TEG-related are materially largely similar. Two "flavor" additions of minor note are a small nook north of Genetics / south of the Detective's office with tea and a cookie, and an airlock into a room that doesn't exist south of Engineering (complete with caution sign, motor oil and a note asking who the hell installed it).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pushing Kondaru's TEG in certain setups has a tendency to barbeque nearby departments if Engineering hasn't severed multiple parts of the department atmospherically to counteract it, and even that often isn't enough.

Allowing Engineering to airgap the engine by retracting a pair of airbridges significantly reduces the tedium involved in more ambitious TEG operation and alleviates novice Engineers' worries about torching other important bits of the station if they mess up.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Kondaru's engine is now atmospherically gapped from the station, connected by two airbridges and a conveyor belt. This should result in significantly fewer instances of adjacent departments being barbequed by ambitious TEG setups.
```
