### PR TITLE
Reduce radiostation ad cooldown

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -837,7 +837,7 @@ ABSTRACT_TYPE(/obj/item/record/random/notaquario)
 			var/datum/signal/pdaSignal = get_free_signal()
 			pdaSignal.data = list("command"="text_message", "sender_name"="RADIO-STATION", "sender"="00000000", "message"="Now playing: [src.tape_inside.audio_type] for [src.tape_inside.name_of_thing].", "group" = MGA_RADIO)
 			SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, pdaSignal, null, "pda")
-			EXTEND_COOLDOWN(global, "music", 600 SECONDS)
+			EXTEND_COOLDOWN(global, "music", 300 SECONDS)
 
 /obj/submachine/tape_deck/attack_hand(mob/user)
 	if(has_tape)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I asked Pali why ADs share cooldown with radio station music.
![image](https://user-images.githubusercontent.com/47158232/198332690-a66cb169-3bcc-4278-8615-b521d312abe0.png)

Reduced it to 300 so it has the same cooldown as a regular song.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cooldown to high.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Radio station ad global cooldown has been halved.
```
