### PR TITLE
Removes owner names from organs/limbs

### DIFF
--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -89,9 +89,11 @@
 			src.add_fingerprint(holder)
 			//https://forum.ss13.co/showthread.php?tid=1774
 			// zam note - removing this again.
-			SPAWN(2 SECONDS)
-				if (new_holder && istype(new_holder))
-					name = "[new_holder.real_name]'s [initial(name)]"
+			//https://forum.ss13.co/showthread.php?tid=1774
+			// aloe note - removing this again.
+			// SPAWN(2 SECONDS)
+			// 	if (new_holder && istype(new_holder))
+			// 		name = "[new_holder.real_name]'s [initial(name)]"
 		if (src.skintoned)
 			if (holder_ahol)
 				colorize_limb_icon()

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -47,8 +47,6 @@
 			src.donor = nholder.donor
 		if (src.donor)
 			src.donor_name = src.donor.real_name
-			src.name = "[src.donor_name]'s [initial(src.name)]"
-			src.real_name = "[src.donor_name]'s [initial(src.name)]" // Gotta do this somewhere!
 			src.donor_DNA = src.donor.bioHolder ? src.donor.bioHolder.Uid : null
 			if (src.toned && src.donor.bioHolder) //NO RACIALLY INSENSITIVE ASSHATS ALLOWED
 				src.s_tone = src.donor.bioHolder.mobAppearance.s_tone

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -126,12 +126,6 @@
 			src.in_body = TRUE
 			if (src.donor.bioHolder)
 				src.donor_AH = src.donor.bioHolder.mobAppearance
-			if (src.donor.real_name)
-				src.donor_name = src.donor.real_name
-				src.name = "[src.donor_name]'s [initial(src.name)]"
-			else if (src.donor.name)
-				src.donor_name = src.donor.name
-				src.name = "[src.donor_name]'s [initial(src.name)]"
 			src.donor_DNA = src.donor.bioHolder ? src.donor.bioHolder.Uid : null
 			src.blood_DNA = src.donor_DNA
 			src.blood_type = src.donor.bioHolder?.bloodType


### PR DESCRIPTION
[FEEDBACK] [REMOVAL] [BALANCE] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title.
Notably does NOT remove owner names from hair or skulls- hair because it's probably recognizable already, and skulls because of the in-hand interaction where you yell the owner's name. I could remove the latter though.

fixes #11639 incidentally.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Dumb that I can recognize a disembodied leg on the ground. Makes forensics less useful.

```changelog
(u)aloe
(+)Limbs and organs no longer bear the names of their owners.
```
