### PR TITLE
Flipper manufacture capability for fabricators

### DIFF
--- a/_std/defines/materials.dm
+++ b/_std/defines/materials.dm
@@ -40,5 +40,6 @@ var/global/list/material_category_names = list(
 	"POW-2" = "Significant Power Source",
 	"POW-3" = "Extreme Power Source",
 	"REF-1" = "Reflective Material",
-	"ORG|RUB" = "Organic or Rubber Material"
+	"ORG|RUB" = "Organic or Rubber Material",
+	"RUB" = "Rubber Material"
 )

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -821,6 +821,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/flippers
+	name = "Flippers"
+	item_paths = list("FAB-1", "RUB")
+	item_amounts = list(2, 5)
+	item_outputs = list(/obj/item/clothing/shoes/flippers)
+	time = 8 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/cleaner_grenade
 	name = "Cleaner Grenade"
 	item_paths = list("INS-1", "CRY-1", "molitz", "ice")

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -823,8 +823,8 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/flippers
 	name = "Flippers"
-	item_paths = list("FAB-1", "RUB")
-	item_amounts = list(2, 5)
+	item_paths = list("RUB")
+	item_amounts = list(5)
 	item_outputs = list(/obj/item/clothing/shoes/flippers)
 	time = 8 SECONDS
 	create = 1

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2009,6 +2009,9 @@
 		/datum/manufacture/table_folding,
 		/datum/manufacture/jumpsuit,
 		/datum/manufacture/shoes,
+#ifdef UNDERWATER_MAP
+		/datum/manufacture/flippers,
+#endif
 		/datum/manufacture/breathmask,
 #ifdef MAP_OVERRIDE_NADIR
 		/datum/manufacture/nanoloom,
@@ -2277,6 +2280,7 @@
 		/datum/manufacture/engspacesuit,
 #ifdef UNDERWATER_MAP
 		/datum/manufacture/engdivesuit,
+		/datum/manufacture/flippers,
 #endif
 		/datum/manufacture/industrialarmor,
 		/datum/manufacture/industrialboots,

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1337,6 +1337,8 @@
 			return TRUE
 		if (pattern == "ORG|RUB")
 			return mat.material_flags & MATERIAL_RUBBER || mat.material_flags & MATERIAL_ORGANIC
+		if (pattern == "RUB")
+			return mat.material_flags & MATERIAL_RUBBER
 		else if (copytext(pattern, 4, 5) == "-") // wildcard
 			var/firstpart = copytext(pattern, 1, 4)
 			var/secondpart = text2num_safe(copytext(pattern, 5))
@@ -2361,6 +2363,7 @@
 	available = list(/datum/manufacture/shoes,	//hey if you update these please remember to add it to /hop_and_uniform's list too
 		/datum/manufacture/shoes_brown,
 		/datum/manufacture/shoes_white,
+		/datum/manufacture/flippers,
 		/datum/manufacture/civilian_headset,
 		/datum/manufacture/jumpsuit_assistant,
 		/datum/manufacture/jumpsuit_pink,
@@ -2472,6 +2475,7 @@
 		/datum/manufacture/shoes,
 		/datum/manufacture/shoes_brown,
 		/datum/manufacture/shoes_white,
+		/datum/manufacture/flippers,
 		/datum/manufacture/civilian_headset,
 		/datum/manufacture/jumpsuit_assistant,
 		/datum/manufacture/jumpsuit,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Creates the manufacture datum /datum/manufacture/flippers, allowing you to make flippers for 5 rubber (standard shoes are 3 of any cloth, for contrast). This datum is present in uniform manufacturers on all maps (pool party support) and is also included in general manufacturers and mining fabricators on underwater maps.

As rubber was not an existing fabricator material classification, I introduced it for the purposes of this PR. It's described simply as "Rubber Material" and checks for the MATERIAL_RUBBER flag.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flippers are an important part of the diving ensemble, and the ability to fabricate them seems like a good thing.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)You can now make flippers for 5 rubber. Uniform manufacturers always have the ability to make them, and underwater maps also allow making them at general manufacturers and mining fabricators.
```
