### PR TITLE
Prevent multiple Sentinels from targeting something

### DIFF
--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -90,6 +90,8 @@
 						var/mob/M = A
 						if (isdead(M))
 							continue
+					if (ON_COOLDOWN(A, "sentinel_shock", 3 SECONDS))
+						continue
 					to_hit = A
 					break
 			if(!to_hit)

--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -90,7 +90,7 @@
 						var/mob/M = A
 						if (isdead(M))
 							continue
-					if (ON_COOLDOWN(A, "sentinel_shock", 3 SECONDS))
+					if (ON_COOLDOWN(A, "sentinel_shock", 2 SECONDS))
 						continue
 					to_hit = A
 					break


### PR DESCRIPTION
[GAME MODES][GAME OBJECTS][BALANCE][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds a cooldown for Flock Sentinels on targeting the same thing, preventing multiple of them from shocking the thing at a time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents someone getting instant incapacitated and allows nicer utilization of Sentinels when there's more than one attacker nearby