### PR TITLE
Make Relay unlock right at its unlock threshold

### DIFF
--- a/code/datums/flock/flockunlockable.dm
+++ b/code/datums/flock/flockunlockable.dm
@@ -41,7 +41,7 @@ ABSTRACT_TYPE(/datum/unlockable_flock_structure)
 	structType = /obj/flock_structure/relay
 
 	check_unlocked()
-		return ..() || (src.my_flock.total_compute() > 500 && !src.my_flock.relay_in_progress_or_finished)
+		return ..() || (src.my_flock.total_compute() >= 500 && !src.my_flock.relay_in_progress_or_finished)
 
 /datum/unlockable_flock_structure/collector
 	structType = /obj/flock_structure/collector


### PR DESCRIPTION
[GAME MODES][BUG][MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just fixes a small bug where the Relay is unlocking at a higher value than its intended compute requirement.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's supposed to unlock at 500 compute, not higher.