### PR TITLE
Fixes abilitystat line length for DEFINITELY THE FINAL TIME

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -162,12 +162,24 @@
 			abilitystat.owner = src
 
 		var/msg = ""
-		//var/style = "font-size: 7px;"
-		var/list/stats = onAbilityStat()
+
+		var/i = 0
+		var/longest_line = 0
+		var/list/stats = src.onAbilityStat()
 		for (var/x in stats)
+			var/line_length = length(x) + 1 + max(length(num2text(stats[x])), length(stats[x]))
+			longest_line = max(longest_line, line_length)
 			msg += "[x] [stats[x]]<br>"
+			i++
 
 		abilitystat.maptext = "<span class='vga l vt ol'>[msg] </span>"
+		abilitystat.maptext_width = longest_line * 9 //font size is 9px
+		if (i > 2)
+			abilitystat.maptext_height = ((i+1) % 2) * 32
+			abilitystat.maptext_y = -abilitystat.maptext_height + 16
+		else if (abilitystat.maptext_height > 32)
+			abilitystat.maptext_height = initial(abilitystat.maptext_height)
+			abilitystat.maptext_y = initial(abilitystat.maptext_y)
 
 	proc/deepCopy()
 		var/datum/abilityHolder/copy = new src.type
@@ -1182,33 +1194,11 @@
 			src.updateText(0, x_occupied, y_occupied)
 			src.abilitystat?.update_on_hud(x_occupied,y_occupied)
 
-	updateText(var/called_by_owner = 0)
-		if (!abilitystat)
-			abilitystat = new
-			abilitystat.owner = src
-
-		var/msg = ""
-		//var/style = "font-size: 7px;"
-
-		var/i = 0
-		var/longest_line = 0
+	onAbilityStat()
+		. = list()
 		for (var/datum/abilityHolder/H in holders)
 			if (H.topBarRendered && H.rendered)
-				var/list/stats = H.onAbilityStat()
-				for (var/x in stats)
-					var/line_length = length(x) + 1 + length(num2text(stats[x]))
-					longest_line = max(longest_line, line_length)
-					msg += "[x] [stats[x]]<br>"
-					i++
-
-		abilitystat.maptext = "<span class='vga l vt ol'>[msg] </span>"
-		abilitystat.maptext_width = longest_line * 9 //font size is 9px
-		if (i > 2)
-			abilitystat.maptext_height = ((i+1) % 2) * 32
-			abilitystat.maptext_y = -abilitystat.maptext_height + 16
-		else if (abilitystat.maptext_height > 32)
-			abilitystat.maptext_height = initial(abilitystat.maptext_height)
-			abilitystat.maptext_y = initial(abilitystat.maptext_y)
+				. += H.onAbilityStat()
 
 	click(atom/target, params)
 		// ok, this is not ideal since each ability holder has its own keybinds. That sucks and should be reworked


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes abilitystat line length once again not calculating properly and unduplicates the composite implementation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Finally, abilitystat will not be jank 🙏 
