### PR TITLE
Portable-Chemicomplier changed from traitor item

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -729,15 +729,6 @@ This is basically useless for anyone but miners.
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
-/datum/syndicate_buylist/traitor/chemicompiler
-	name = "Chemicompiler"
-	item = /obj/item/device/chemicompiler
-	cost = 5
-	not_in_crates = 1
-	desc = "A handheld version of the Chemicompiler machine in Chemistry."
-	job = list("Research Director", "Scientist")
-	can_buy = UPLINK_TRAITOR
-
 /datum/syndicate_buylist/traitor/robosuit
 	name = "Syndicate Robot Frame"
 	item = /obj/item/parts/robot_parts/robot_frame/syndicate

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -263,6 +263,7 @@
 	/obj/item/hand_tele,
 	/obj/item/storage/box/zeta_boot_kit,
 	/obj/item/device/radio/electropack,
+	/obj/item/device/chemicompiler,
 	/obj/item/clothing/mask/gas,
 	/obj/item/device/flash,
 	/obj/item/stamp/rd,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the portable chemicomplier from the traitor uplink for RDs and scientists to the RD locker


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its an already niche item, costs 5 TC and has a stationary variant with the same purpose accessible to the whole crew.
Moving this to the RDs locker should keep it available and accessible to science, and gives the RD another good signifying item.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(+)Moved the Portable Chemicompiler from uplinks to the RD's locker.
```
