### PR TITLE
Prevent meteor shower event from being picked on Nadir

### DIFF
--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -22,6 +22,12 @@ var/global/meteor_shower_active = 0
 	var/meteor_type = /obj/newmeteor/massive
 #endif
 
+	is_event_available(var/ignore_time_lock = 0)
+		. = ..()
+		if(.)
+			if ( map_setting == "NADIR" ) // Nadir can have a counterpart to this event with acid hailstones, but it will need to function differently
+				. = FALSE
+
 	event_effect(var/source, var/amount, var/direction, var/delay, var/warning_time, var/speed)
 		..()
 		//var/timer = ticker.round_elapsed_ticks / 600


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prevents meteor showers being selected as a random event on Nadir.

They currently don't work right due to some map-specific conditions; I have a plan to create a custom variant down the line, likely a "landslide" or "acid hailstorm", that uses landmarks to determine meteor spawn points, but this will prevent the nonfunctional event from being picked in the meanwhile.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Meteor showers don't currently work on Nadir so they shouldn't be picked. This does that.