### PR TITLE
Improves wraith status panel performance

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -198,11 +198,7 @@
 			owner.attach_hud(hud)
 
 	proc/Stat()
-		if (usesPoints && pointName != "" && rendered)
-			stat(null, " ")
-			stat("[src.pointName]:", src.points)
-			if (src.regenRate || src.lastBonus)
-				stat("Generation Rate:", "[src.regenRate] + [src.lastBonus]")
+		return
 
 	proc/StatAbilities()
 		if (!rendered)

--- a/code/mob_stat.dm
+++ b/code/mob_stat.dm
@@ -192,9 +192,6 @@ var/global/datum/mob_stat_thinker/mobStat = new
 
 		stat(null, " ")
 
-	if (abilityHolder)
-		abilityHolder.Stat()
-
 	if (is_near_gauntlet())
 		gauntlet_controller.Stat()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Generally, the more stuff you have in the status panel the worse client performance is ([see](http://www.byond.com/forum/post/2829531)). Counters in particular seem to cause issues ([see](http://www.byond.com/forum/post/2603014)).

As a general principle therefore stuff should be moved from the stat panel to the HUD elements when it makes sense to do so.

Given that wraith already display points + generation on the HUD, there is no take the performance hit showing them on the stat panel.

This PR removes the generic stat calls for sending points & generation to the stat panel. The only remaining antag role that doesn't have these elements displayed on the HUD is the blob, because it's not on abilityHolders it's still on it's own bespoke thing, but it has it's own stat() calls to display this info anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves performance
Fixes #11615