### PR TITLE
Nadir doodad update 1: Allow machinery vehicles to run over doodads

### DIFF
--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -266,7 +266,7 @@
 				for (var/mob/C in vehicle)
 					shake_camera(C, 3, 5)
 				break_apart()
-				return 1
+				return TRUE
 		return ..()
 
 /obj/nadir_doodad/sinkspires

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -255,6 +255,20 @@
 					drop.set_loc(src.loc)
 		qdel(src)
 
+	Cross(atom/A)
+		if (istype(A, /obj/machinery/vehicle)) //handled here to make it so the vehicle never stops in the first place, improving smoothness
+			var/obj/machinery/vehicle/vehicle = A
+			var/vehicle_power = vehicle.get_move_velocity_magnitude()
+			if(vehicle_power > 5)
+				vehicle.health -= 1
+				vehicle.checkhealth()
+				playsound(vehicle.loc, 'sound/impact_sounds/Generic_Hit_Heavy_1.ogg', 35, 1)
+				for (var/mob/C in vehicle)
+					shake_camera(C, 3, 5)
+				break_apart()
+				return 1
+		return ..()
+
 /obj/nadir_doodad/sinkspires
 	name = "sinkspire cluster"
 	icon_state = "sinkspires"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows Nadir's doodads (lithoflora like sinkspires and bitelung) to be run over by machinery vehicles such as pods and subs. These vehicles will take one damage, but otherwise successfully cross the tile with no bump and break the doodad.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Primary objective of this change is to allow nuclear operatives to rapidly reach points of ingress with their assault vehicles, at the cost of potentially making a bit of a ruckus that crew might pick up on. In the event pods are able to make a return for crew due to other changes, this will be good for that as well.