### PR TITLE
Hyposprays and Menders can now refill from reagent dispensers.

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -61,6 +61,12 @@
 			for (var/i = 0, i < 9, i++) // ugly hack
 				reagents.temperature_reagents(exposed_temperature, exposed_volume)
 
+	attackby(obj/item/W, mob/user)
+		// prevent attacked by messages
+		if(istype(W, /obj/item/reagent_containers/hypospray) || istype(W, /obj/item/reagent_containers/mender))
+			return
+		..(W, user)
+
 	mouse_drop(atom/over_object as obj)
 		if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket) && !istype(over_object, /obj/machinery/hydro_mister) && !istype(over_object, /obj/item/tank/jetpack/backtank))
 			return ..()

--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -163,6 +163,14 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 		UpdateIcon()
 
 	afterattack(obj/target, mob/user, flag)
+		if(istype(target, /obj/reagent_dispensers) && target.reagents)
+			if (!target.reagents.total_volume)
+				boutput(user, "<span class='alert'>[target] is already empty.</span>")
+				return
+			playsound(src.loc, 'sound/misc/pourdrink2.ogg', 50, 1, 0.1)
+			target.reagents.trans_to(src, src.reagents.maximum_volume)
+			return
+
 		if (isobj(target) && target.is_open_container() && target.reagents)
 			if (!src.reagents || !src.reagents.total_volume)
 				boutput(user, "<span class='alert'>[src] is already empty.</span>")

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -554,6 +554,15 @@
 
 		return 0
 
+	afterattack(obj/target, mob/user, flag)
+		if(istype(target, /obj/reagent_dispensers) && target.reagents)
+			if (!target.reagents.total_volume)
+				boutput(user, "<span class='alert'>[target] is already empty.</span>")
+				return
+			playsound(src.loc, 'sound/items/mender_refill_juice.ogg', 50, 1)
+			target.reagents.trans_to(src, src.reagents.maximum_volume)
+			return
+
 	proc/begin_application(mob/M as mob, mob/user as mob)
 		actions.start(new/datum/action/bar/icon/automender_apply(user,src,M), user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hyposprays and Menders can now refill from **any** reagent dispenser (foamtanks, welding fuel tanks, water tanks, others)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Syringes can already remove from reagent dispensers, this will just quick the middleman of using beakers.
Meaning players will fill a foamtank with styptic powder for easier recharge.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Hyposprays and menders can now refill from reagent dispensers (foamtanks, welding tanks, etc)
```
