### PR TITLE
patches a critical exploit related to nuke teleporter

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1187,6 +1187,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	cost = 1
 	desc = "Did you lose the nuke? Have no fear, with this handy one-use remote, you can immediately call it back to you!"
 	category = "Main"
+	vr_allowed = FALSE
 
 /datum/syndicate_buylist/commander/mrl
 	name = "Fomalhaut MRL"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [BUG][CRITICAL][GAMEMODES] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the nuke tele can be bought in VR and has a way to deduce if there is a nuclear bomb present ie. you can check if the gamemode is nukies using VR

this patches that critical exploit
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
critical exploits bad
