### PR TITLE
katana (and other swords) will now try to steathe when using them inhands

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1027,6 +1027,12 @@
 	is_syndicate = TRUE
 	var/delimb_prob = 1
 	custom_suicide = 1
+/obj/item/swords/attack_self(mob/user)
+	. = ..()
+	for(var/obj/item/swords_sheaths/steath in user) //this working with chest items is intented according to my balance tests its ok its also funny
+		if(!steath.sword_inside && istype(src, steath.sword_path))
+			steath.Attackby(src,user)
+			break
 
 /obj/item/swords/proc/handle_parry(mob/target, mob/user)
 	if (target != user && ishuman(target))
@@ -1269,11 +1275,9 @@
 		else
 			return ..()
 
-	attack_self(mob/living/carbon/human/user as mob)
-		if(user.r_hand == src || user.l_hand == src)
-			draw_sword(user)
-		else
-			return ..()
+	attack_self(mob/living/carbon/human/user)
+		. = ..()
+		draw_sword(user)
 
 	attackby(obj/item/W, mob/user)
 		if (!istype(W, sword_path))

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1030,9 +1030,9 @@
 
 /obj/item/swords/attack_self(mob/user)
 	. = ..()
-	for(var/obj/item/swords_sheaths/steath in user) //this working with chest items is intented according to my balance tests its ok its also funny
-		if(!steath.sword_inside && istype(src, steath.sword_path))
-			steath.Attackby(src,user)
+	for(var/obj/item/swords_sheaths/sheath in user) //this working with chest items is intented according to my balance tests its ok its also funny
+		if(!sheath.sword_inside && istype(src, sheath.sword_path))
+			sheath.Attackby(src, user)
 			break
 
 /obj/item/swords/proc/handle_parry(mob/target, mob/user)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1027,6 +1027,7 @@
 	is_syndicate = TRUE
 	var/delimb_prob = 1
 	custom_suicide = 1
+
 /obj/item/swords/attack_self(mob/user)
 	. = ..()
 	for(var/obj/item/swords_sheaths/steath in user) //this working with chest items is intented according to my balance tests its ok its also funny


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [BUG][QOL][BALANCE][GAME OBJECTS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
swords will now try to steathe when using them inhands

try means loop over all valid steathes in your inventory
backpack contents and similar excluded on purpose
chest item included on purpose (chest item steathe is mostly a self handicapping gimmick rather than a practical op thing)

also fixes steathes not working if they are used while not inside of a hand (chest item bug fix)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
makes it easier to conceal your weapon

the latter bug fix was done just because it leads to a dumb funny thing
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ZWRh3
(+)Swords will now try to steathe themselves if you use them inhands.
```
