### PR TITLE
Allow for removal of components again

### DIFF
--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -1312,7 +1312,7 @@ var/datum/flock/testflock
 		comps = list(comps)
 
 	var/datum/component/selection
-	selection = text2path(tgui_input_list(usr, "Select a component to remove", "Matches for pattern", comps))
+	selection = tgui_input_list(usr, "Select a component to remove", "Matches for pattern", comps)
 	if (!selection)
 		return // user cancelled
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Selection now provides the actual desired type, so conversion is no longer required.  This appeared to have broken the ability to remove components from arbitrary objects via the VarEdit menus.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allow for the removal of components via the VarEdit menu