### PR TITLE
Make bowls stay on trays when filled with soup

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -10,7 +10,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/needfork = 0
 	var/needspoon = 0
 	/// Color for various food items
-	var/food_color = null 
+	var/food_color = null
 	var/custom_food = 1 //Can it be used to make custom food like for pizzas
 	var/festivity = 0
 	var/brew_result = null // what will it make if it's brewable?
@@ -787,6 +787,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			var/obj/item/reagent_containers/food/snacks/soup/custom/S = new(L.my_soup, src)
 			S.pixel_x = src.pixel_x
 			S.pixel_y = src.pixel_y
+			if(src.paired_tray)
+				var/obj/surgery_tray/target_tray = src.paired_tray
+				target_tray.attach(S)
 			L.my_soup = null
 			L.UpdateOverlays(null, "fluid")
 

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1505,6 +1505,7 @@ keeping this here because I want to make something else with it eventually
 		else if (istype(I, /obj/item/mechanics) || istype(I, /obj/item/storage/mechanics))
 			return
 		src.attached_objs.Add(I) // attach the item to the table
+		I.paired_tray = src
 		I.glide_size = 0 // required for smooth movement with the tray
 		// register for pickup, register for being pulled off the table, register for item deletion while attached to table
 		SPAWN(0)
@@ -1512,6 +1513,7 @@ keeping this here because I want to make something else with it eventually
 
 	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
 		src.attached_objs.Remove(I)
+		I.paired_tray = null
 		UnregisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING))
 
 	attack_hand(mob/user)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -120,6 +120,7 @@
 
 	var/rand_pos = 0
 	var/obj/item/holding = null
+	var/obj/surgery_tray/paired_tray = null
 	var/rarity = ITEM_RARITY_COMMON // Just a little thing to indicate item rarity. RPG fluff.
 	pressure_resistance = 50
 	var/obj/item/master = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a variable to items that informs them of what tray they've been placed on, set by the tray at the time of attachment, and uses it to preserve the attachment of bowls when they're filled with soup and become a different object.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I was playing Chef and I wanted it to work that way because it seemed like it logically should. There is probably a better implementation.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Bowls will now stay on trays when you fill them with soup.
```
