### PR TITLE
Make oshan's sea elevator functionning at roundstart

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47280,8 +47280,7 @@
 	dir = 1;
 	name = "N APC";
 	noalerts = 1;
-	pixel_y = 24;
-	start_charge = 12
+	pixel_y = 24
 	},
 /obj/cable{
 	d2 = 8;


### PR DESCRIPTION
[A-Mapping][C-Bug]

## About the PR
As reported in #11335 which I'd like to fix
It used to be that Oshan's sea elevator would work at roundstart. Something changed in the last few months and now it doesn't, as it shows up as unpowered. This makes everything but pod mining impossible at roudnstart.
`start_charge = 12` seems to be a "Z2/Azone" thing. I imagine it'd be better for this station APC to have the same power levels as the other station APCs.
Testing locally doesn't yield conclusive results, since it shows up as no settings, I imagine because of missing secret files. However, Nadir's elevator doesn't have a start_charge set, and is reported as working ok by Kubius, so I imagine this change should work well
![image](https://user-images.githubusercontent.com/6396368/198857648-6770166a-1af7-46da-be61-a30576a485f3.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11335, makes miners happy
