### PR TITLE
Make bowls stay on trays when filled with soup v2: less crime edition

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -791,6 +791,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				if(istype(O,/obj/surgery_tray))
 					var/obj/surgery_tray/target_tray = O
 					target_tray.attach(S)
+					break
 
 			L.my_soup = null
 			L.UpdateOverlays(null, "fluid")

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -10,7 +10,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/needfork = 0
 	var/needspoon = 0
 	/// Color for various food items
-	var/food_color = null 
+	var/food_color = null
 	var/custom_food = 1 //Can it be used to make custom food like for pizzas
 	var/festivity = 0
 	var/brew_result = null // what will it make if it's brewable?
@@ -787,6 +787,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			var/obj/item/reagent_containers/food/snacks/soup/custom/S = new(L.my_soup, src)
 			S.pixel_x = src.pixel_x
 			S.pixel_y = src.pixel_y
+			for(var/obj/O in src.loc)
+				if(istype(O,/obj/surgery_tray))
+					var/obj/surgery_tray/target_tray = O
+					target_tray.attach(S)
+
 			L.my_soup = null
 			L.UpdateOverlays(null, "fluid")
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -787,11 +787,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			var/obj/item/reagent_containers/food/snacks/soup/custom/S = new(L.my_soup, src)
 			S.pixel_x = src.pixel_x
 			S.pixel_y = src.pixel_y
-			for(var/obj/O in src.loc)
-				if(istype(O,/obj/surgery_tray))
-					var/obj/surgery_tray/target_tray = O
-					target_tray.attach(S)
-					break
+			for(var/obj/surgery_tray/target_tray in src.loc)
+				target_tray.attach(S)
+				break
 
 			L.my_soup = null
 			L.UpdateOverlays(null, "fluid")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bowls being filled with soup will now check if they're on the same tile as an /obj/surgery_tray, and attach the new soup-filled bowl to the tray if they are.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I wanted bowls to stay on trays when you fill them with soup so I did that.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Filling bowls of soup on trays, including kitchen islands, should no longer detach the bowl from the tray.
```
