### PR TITLE
Nadir changeling rebalance: near-total immunity to aqua tenebrae

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -950,8 +950,9 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom
-				M.take_toxin_damage(1 * mult)
-				M.TakeDamage("chest", 0, 1 * mult, 0, DAMAGE_BURN)
+				if(!ischangeling(M))
+					M.take_toxin_damage(1 * mult)
+					M.TakeDamage("chest", 0, 1 * mult, 0, DAMAGE_BURN)
 				..()
 				return
 
@@ -1068,7 +1069,7 @@ datum
 									return
 						else if(!ischangeling(M))
 							random_brute_damage(M, min(15,volume))
-					else if (volume >= 6)
+					else if (volume >= 6 && !ischangeling(M))
 						M.emote("scream")
 						M.TakeDamage("All", 0, volume / 6, 0, DAMAGE_BURN)
 					boutput(M, "<span class='alert'>The blueish acidic substance stings[volume < 6 ? " you, but isn't concentrated enough to harm you" : null]!</span>")

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -997,6 +997,15 @@ datum
 					var/do_an_ouch = TRUE
 
 					damage2deal = round(damage2deal)
+
+					//changelings don't take damage, but they do get a bit liquefied if they're wandering around
+					if(H && ischangeling(H))
+						if(damage2deal >= 5 && !H.disfigured && !H.wear_mask && !H.head)
+							boutput(H, "<span class='alert'>The acid withers our visage.</span>")
+							H.disfigured = TRUE
+							H.UpdateName()
+						return
+
 					if(damage2deal >= 5) //scream and face melty
 						if(H)
 							if(do_an_ouch)
@@ -1020,6 +1029,12 @@ datum
 							var/mob/living/carbon/human/H = M
 							var/blocked = FALSE
 							if (!H.wear_mask && !H.head)
+								if(ischangeling(H)) //disfigures you, but doesn't harm you. make sure to scream to play along
+									if(!H.disfigured)
+										boutput(H, "<span class='alert'>The acid withers our visage.</span>")
+										H.disfigured = TRUE
+										H.UpdateName()
+									return
 								H.TakeDamage("head", 0, clamp((volume - 5), 8, 50), 0, DAMAGE_BURN)
 								H.emote("scream")
 								if(!H.disfigured)
@@ -1051,7 +1066,7 @@ datum
 
 								if (blocked)
 									return
-						else
+						else if(!ischangeling(M))
 							random_brute_damage(M, min(15,volume))
 					else if (volume >= 6)
 						M.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE][INPUT][CHEMISTRY][GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters aqua tenebrae's interaction with changelings to near-totally remove its ability to affect them. Some details:

- When a changeling would otherwise take damage from aqua tenebrae, they do not.
- This only kicks in at the actual point of damage dealing; gear will still receive decay from the acid.
- The acid is still capable of deforming the changeling's face, alerting them with the message "The acid withers our visage." This does not inherently elicit a scream, as it isn't painful (more of a weird sloppy feeling), as a subtle tell.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Nadir is at the moment the only map in which changelings can't reasonably go into breached or exterior areas unsuited, one of their core advantages, and the map's fairly condensed nature exacerbates this issue. Be it in this way or another, their balance could use an upward bump.

Some alternate ideas, if the consensus is that this pushes things too far in changelings' favor:

- Grant changelings a free "Harden / Relax Membranes" ability that gives them total immunity to aqua tenebrae, but prevents them from absorbing other lifeforms while it's active, with a brief cooldown required to toggle.
- Instead of granting total resistance, simply grant partial damage reduction to the acid, cutting the effective amount of applied aqua tenebrae in half.
- Grant changelings a fixed percentage of chemical protection that applies to them globally as a baseline. (This is probably my least favorite idea, but mentioning it in case it sparks a better one.)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Changelings' biology has adapted to the unique variety of acid surrounding Nadir. Be watchful.
```
