### PR TITLE
borg and ai info message changes

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -461,8 +461,8 @@ var/global/list/ai_emotions = list("Happy" = "ai_happy", \
 				src.show_text("<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
 				src.show_text("<B>To look at other parts of the station, double-click yourself to get a camera menu.</B>")
 				src.show_text("<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
-				src.show_text("To use something, simply double-click it.")
-				src.show_text("Currently right-click functions will not work for the AI (except examine), and will either be replaced with dialogs or won't be usable by the AI.")
+				src.show_text("To use something, simply click it.")
+				src.show_text("Use the prefix <B>:s</B> to speak to fellow silicons through binary.")
 				src.show_laws()
 				src.verbs += /mob/living/silicon/ai/proc/ai_call_shuttle
 				src.verbs += /mob/living/silicon/ai/proc/show_laws_verb

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -118,8 +118,8 @@
 	boutput(O, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
 	boutput(O, "<B>To look at other parts of the station, double-click yourself to get a camera menu.</B>")
 	boutput(O, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
-	boutput(O, "To use something, simply double-click it.")
-	boutput(O, "Currently right-click functions will not work for the AI (except examine), and will either be replaced with dialogs or won't be usable by the AI.")
+	boutput(O, "To use something, simply click it.")
+	boutput(O, "Use the prefix <B>:s</B> to speak to fellow silicons through binary.")
 
 	O.show_laws()
 	boutput(O, "<b>These laws may be changed by other players.</b>")

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1155,8 +1155,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 			borg.set_loc(get_turf(src))
 
 			boutput(borg, "<B>You are playing a Robot. The Robot can interact with most electronic objects in its view point.</B>")
-			boutput(borg, "To use something, simply double-click it.")
-			boutput(borg, "Use say \":s to speak to fellow cyborgs and the AI through binary.")
+			boutput(borg, "To use something, simply click it.")
+			boutput(borg, "Use the prefix <B>:s</B> to speak to fellow cyborgs and the AI through binary.")
 
 			if (src.emagged || src.syndicate)
 				if ((ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution)) && borg.mind)


### PR DESCRIPTION
[silicons][bug]
## About the PR 
changes the initial borg and ai info messages to be updated:
- changes `double-click` to just `click`
- removes the statement about right-click functionality not working because that's no longer true
- adds the silicon channel note to the ai info messages
- changes the silicon channel message to instructions for use in the text box rather than the command bar (i dont really know people who use the command bar anymore 😔 )

## Why's this needed? 
fixes #11685
