### PR TITLE
Wraith now inherits point regen and corpsecount on evolve

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -870,8 +870,8 @@
 
 			holder.owner.mind.transfer_to(W)
 			var/datum/abilityHolder/wraith/new_holder = W.abilityHolder
-			new_holder.regenRate = AH.regenRate
-			new_holder.corpsecount = AH.corpsecount
+			new_holder.regenRate = AH.regenRate - 2
+			new_holder.corpsecount = AH.corpsecount - 1
 			qdel(holder.owner)
 
 			return W

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -869,6 +869,9 @@
 			W.set_loc(T)
 
 			holder.owner.mind.transfer_to(W)
+			var/datum/abilityHolder/wraith/new_holder = W.abilityHolder
+			new_holder.regenRate = AH.regenRate
+			new_holder.corpsecount = AH.corpsecount
 			qdel(holder.owner)
 
 			return W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wraiths used to get their point regen rate and corpsecount reset on evolve. This lets them inherit the points.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wraiths shouldnt be penalized for specializing. Fixes #11710 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)Wraiths now inherit point regen rate and corpse counts when they evolve.
```
