### PR TITLE
Fix catalytic rods checking for an old/incorrect material property name

### DIFF
--- a/code/modules/power/catalytic_engine.dm
+++ b/code/modules/power/catalytic_engine.dm
@@ -458,7 +458,7 @@
 	//you should only be able to make these from things with a metal material flag
 	proc/setupMaterial()
 		///Corrosion resistance slows decay per cycle by an amount proportional to resistance percentage. Total corrosion immunity = no decay.
-		var/decay_ratio_adjustment = src.material.getProperty("corrosion") * 0.00023
+		var/decay_ratio_adjustment = src.material.getProperty("chemical") * 0.00023
 		src.decay_ratio = min(src.decay_ratio + decay_ratio_adjustment,1)
 		src.anode_viability = max(0,src.material.getProperty("electrical") * 17)
 		if(src.material.material_flags & MATERIAL_ENERGY && src.anode_viability)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does what it says on the tin. Property was previously named "corrosion", but the "new" unified property is "chemical" and the name wasn't updated even though the ratio modifier was; after this change, chemical resistance of materials should once again properly reduce decay rate of catalytic rods.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Rods should check for a property that actually exists.