### PR TITLE
fixes cog1 north solars

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1710,12 +1710,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "afL" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/smes{
 	chargelevel = 15000;
 	output = 10000
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11433,9 +11433,6 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNW" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/sim/vr_bed{
 	dir = 8;
 	name = "VR simulation pod";
@@ -15341,9 +15338,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/bank_data,
 /obj/disposalpipe/segment{
@@ -44937,9 +44931,6 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/command,
 /obj/access_spawn/heads,
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grey/side,
 /area/station/bridge)
@@ -46320,9 +46311,6 @@
 /turf/simulated/floor/plating,
 /area/space)
 "tKr" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/item/reagent_containers/glass/bottle/antitoxin{
 	pixel_x = 4;
 	pixel_y = 9
@@ -47921,9 +47909,6 @@
 /obj/item/storage/box/clothing/rancher,
 /obj/item/reagent_containers/glass/wateringcan{
 	pixel_y = 9
-	},
-/obj/cable{
-	icon_state = "0-2"
 	},
 /obj/item/sponge,
 /turf/simulated/floor/green/side{

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11433,6 +11433,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNW" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
 /obj/machinery/sim/vr_bed{
 	dir = 8;
 	name = "VR simulation pod";
@@ -15338,6 +15341,9 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/bank_data,
 /obj/disposalpipe/segment{
@@ -44931,6 +44937,9 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/command,
 /obj/access_spawn/heads,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grey/side,
 /area/station/bridge)
@@ -46311,6 +46320,9 @@
 /turf/simulated/floor/plating,
 /area/space)
 "tKr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/item/reagent_containers/glass/bottle/antitoxin{
 	pixel_x = 4;
 	pixel_y = 9
@@ -47909,6 +47921,9 @@
 /obj/item/storage/box/clothing/rancher,
 /obj/item/reagent_containers/glass/wateringcan{
 	pixel_y = 9
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /obj/item/sponge,
 /turf/simulated/floor/green/side{


### PR DESCRIPTION
[bug][cleanliness]

## About the PR 
re-connects the north solar SMES input to the power grid

## Why's this needed?
wire facing wrong way!