### PR TITLE
Add a medal for causing a runtime (also log runtime usr)

### DIFF
--- a/browserassets/css/runtimeViewer.css
+++ b/browserassets/css/runtimeViewer.css
@@ -55,6 +55,11 @@
 	font-size: 0.8em;
 }
 
+#runtime-list .usr {
+	display: none;
+	font-size: 0.8em;
+}
+
 
 #runtime-details .control .back {
 	margin: 0;

--- a/browserassets/js/runtimeViewer.js
+++ b/browserassets/js/runtimeViewer.js
@@ -60,6 +60,12 @@ $(document).ready(function() {
 					);
 				}
 
+				if (run.usr) {
+					row.append(
+						$('<span>', {'class': 'usr', html: run.usr})
+					);
+				}
+
 				var uid = run.file + run.line + run.name;
 				if (typeof occurrences[uid] !== 'undefined') {
 					occurrences[uid]++;
@@ -125,6 +131,8 @@ $(document).ready(function() {
 		var file = $this.find('.file').text();
 		var line = $this.find('.line').text();
 		var name = $this.find('.name').text();
+		var usr = $this.find('.usr').text();
+
 		var uid = file + line + name;
 
 		var details = '<h2><i class="icon-pencil"></i> Summary</h2>';
@@ -134,6 +142,7 @@ $(document).ready(function() {
 		details += '<tr><td><strong>File</strong></td><td>' + file + '</td></tr>';
 		details += '<tr><td><strong>Line</strong></td><td>' + line + '</td></tr>';
 		details += '<tr><td><strong>Error</strong></td><td>' + name + '</td></tr>';
+		details += '<tr><td><strong>Usr</strong></td><td>' + usr + '</td></tr>';
 		details += '</tbody></table>';
 
 		details += '<h2><i class="icon-code"></i> Description</h2>';

--- a/code/error_handling.dm
+++ b/code/error_handling.dm
@@ -20,6 +20,7 @@ var/global/runtime_count = 0
 		"file" = !invalid ? E.file : "",
 		"line" = !invalid ? E.line : "",
 		"desc" = E.desc ? E.desc : "",
+		"usr" = usr ? "[usr] ([usr.ckey])" : "null",
 		"seen" = timestamp,
 		"invalid" = invalid
 	)
@@ -33,6 +34,8 @@ var/global/runtime_count = 0
 		if (E.desc)
 			world.log << "[E.desc]"
 #endif
+
+	usr?.unlock_medal("Halt And Catch Fire", 1)
 
 
 /client/proc/cmd_view_runtimes()

--- a/code/error_handling.dm
+++ b/code/error_handling.dm
@@ -35,7 +35,7 @@ var/global/runtime_count = 0
 			world.log << "[E.desc]"
 #endif
 
-	usr?.unlock_medal("Halt And Catch Fire", 1)
+	usr?.unlock_medal("Call 1-800-CODER", 1)
 
 
 /client/proc/cmd_view_runtimes()

--- a/code/error_handling.dm
+++ b/code/error_handling.dm
@@ -35,7 +35,9 @@ var/global/runtime_count = 0
 			world.log << "[E.desc]"
 #endif
 
-	usr?.unlock_medal("Call 1-800-CODER", 1)
+	// if we're in a fucked up state and generating lots of runtimes we don't want to make the performance of the runtimes even worse
+	if(runtime_count < 1000)
+		usr?.unlock_medal("Call 1-800-CODER", 1)
 
 
 /client/proc/cmd_view_runtimes()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a runtime happens and you are the `usr` you get a medal. Congratulations for breaking the game. 😭

Current medal name is: `Call 1-800-CODER` as suggested by @stonepillars but I'm open to other name ideas.
Alternative names `CRASH()` and `Halt And Catch Fire` have been suggested. Let me know which one you prefer in the comments.

Also someone please make a pretty picture for the medal. 🥺 The base template is [here](https://forum.ss13.co/showthread.php?tid=11636).
If not picture is submitted I'll probably use the burning server sprite in the medal frame.

As a side thing this PR also logs the `usr` of runtimes which is redundant in most cases but when there's too many runtimes byond stops reporting all regular runtime information so knowing `usr` is, well, better than nothing I guess.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it'd be mildly funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)pali
(*)If you manage to make our code error-out you now get a medal, you monster.
```
