### PR TITLE
Fixes spliced plants with carrots having neither oculine nor carrot juice

### DIFF
--- a/code/modules/hydroponics/plants_veg.dm
+++ b/code/modules/hydroponics/plants_veg.dm
@@ -30,6 +30,7 @@ ABSTRACT_TYPE(/datum/plant/veg)
 	endurance = 5
 	genome = 16
 	nectarlevel = 10
+	assoc_reagents = list("juice_carrot","oculine")
 	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/mutations/bad)
 
 /datum/plant/veg/potato


### PR DESCRIPTION
## Labels
[HYDROPONICS][BUG][MINOR]

## About the PR
This PR fixes a bug with carrots. Carrots had no assoc_reagents defined, so splices with carrots had not the associated reagents in them.


## Why's this needed?
People would expect their carrot splices to have occuline.


## Changelog

```changelog
(u)Lord_Earthfire
(+)fixes carrot splices having no occuline or carrot juice
```
