### PR TITLE
Fix a little code crime

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1261,7 +1261,7 @@
 			R.ghoulTouch(target, affecting)
 
 //variant, using for werewolf pounce, to send mobs in a random direction and 50% chance to weaken them.
-/proc/wrestler_knockdown(var/mob/H, var/mob/T, /var/variant)
+/proc/wrestler_knockdown(var/mob/H, var/mob/T, var/variant)
 	if (!H || !ismob(H) || !T || !ismob(T))
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
turns out BYOND has a bug where doing `proc/my_proc(/var/name)` actually creates a global variable called `name` and `my_proc()` with no arguments. This fixes the one instance in our codebase where I found that'd happened.
