### PR TITLE
Burn your arms off

### DIFF
--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -28,6 +28,13 @@
 			hit_twitch(H)
 			if (brute > 30 && prob(brute - 30) && !disallow_limb_loss)
 				src.sever()
+			else if (burn > 30 && prob(burn - 30) && !disallow_limb_loss)
+				holder.visible_message("<span class='alert'>[holder.name]'s [initial(src.name)] is burnt to ash!</span>")
+				src.remove(FALSE)
+				playsound(src, 'sound/impact_sounds/burn_sizzle.ogg', 30)
+				if(prob(20))
+					make_cleanable(/obj/decal/cleanable/ash, get_turf(holder))
+				qdel(src)
 			else if (bone_system && src.bones && brute && prob(brute * 2))
 				src.bones.take_damage(damage_type)
 		health_update_queue |= holder


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the same way that 30 brute targeted at your arm can sever your arm, 30 burn can incinerate your arm.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly I thought it'd be funny if people grabbed melting down components from the nuclear reactor and they instantly had their arms burnt off for it. It'll probably only come up very rarely.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(*)Too much burn damage to a limb can now incinerate that limb.
```
