### PR TITLE
Arm burn off more

### DIFF
--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -28,7 +28,7 @@
 			hit_twitch(H)
 			if (brute > 30 && prob(brute - 30) && !disallow_limb_loss)
 				src.sever()
-			else if (burn > 30 && prob(burn - 30) && !disallow_limb_loss)
+			else if (burn > 30 && prob(burn) && !disallow_limb_loss)
 				holder.visible_message("<span class='alert'>[holder.name]'s [initial(src.name)] is burnt to ash!</span>")
 				src.remove(FALSE)
 				playsound(src, 'sound/impact_sounds/burn_sizzle.ogg', 30)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases chance from 0% to 70% on 30+ burn to 30% to 100% chance instead. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Given the rarity of high damage limb-targeted burn sources, make limbs burning off happen more often when it does. This is as a result of messing around with the nuclear reactor, where you'd generally die from the total burn before your limbs burnt off.