### PR TITLE
Siphon "easter egg" product adjustments

### DIFF
--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -302,16 +302,12 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	tick_req = 303
 	shear = 420
 	sens_window = 0
-	product = /obj/item/plant/herb/cannabis/mega/spawnable
+	product = /obj/item/plant/herb/cannabis/spawnable
 
-/datum/siphon_mineral/forbidden //the end comes
+/datum/siphon_mineral/forbidden
 	indexed = FALSE
 	name = "DATA EXPUNGED"
 	tick_req = 666
-	shear = 666 //this is a very hard value to reach
+	shear = 666
 	sens_window = 0
-#ifdef SECRETS_ENABLED
-	product = /obj/item/activated_glitchy_thing // temporary replacement until we figure out something cooler, but plutonium core is a no-no
-#else
-	product = /obj/item/gnomechompski
-#endif
+	product = /obj/item/reagent_containers/food/snacks/ectoplasm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small set of changes to adjust the Siphon's unlisted "easter egg" products, in the wake of my previous selections for secret products turning out to be less difficult to reach than I had thought.

- Target "Cannabis Synthesis" now yields a more ordinary target instead of the mega variant.
- Target "DATA EXPUNGED" now yields ectoplasm, as this is in keeping with the Siphon's "you get rare materials to play with" theme, and the spooky shear target.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Preserves the secret funny numbers giving you cool stuff, while attempting to avoid them being *too* abusable.