### PR TITLE
Fix #11786 grille pointblank projectiles

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -250,6 +250,8 @@
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
+			else if (src.was_pointblank)
+				die()
 		else
 			die()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME-OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a die() if a projectile collision was pointblank and didn't go down any of the other obj logic.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11786.