### PR TITLE
Station forcefields: atmos/liquid forcefield clickthrough + setactive adjustment

### DIFF
--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -469,6 +469,7 @@
 			src.icon_state = "shieldw"
 			src.color = "#FF33FF" //change colour for different power levels
 			src.powerlevel = 4
+			src.mouse_opacity = 0
 			flags = ALWAYS_SOLID_FLUID | FLUID_DENSE
 		else if(deployer != null && deployer.power_level == 1)
 			src.name = "Atmospheric Forcefield"
@@ -476,6 +477,7 @@
 			src.icon_state = "shieldw"
 			src.color = "#3333FF" //change colour for different power levels
 			src.powerlevel = 1
+			src.mouse_opacity = 0
 			flags = 0
 			gas_impermeable = TRUE
 		else if(deployer != null && deployer.power_level == 2)
@@ -484,6 +486,7 @@
 			src.icon_state = "shieldw"
 			src.color = "#33FF33"
 			src.powerlevel = 2
+			src.mouse_opacity = 0
 			flags = ALWAYS_SOLID_FLUID | FLUID_DENSE
 			gas_impermeable = TRUE
 		else if(deployer != null)
@@ -492,6 +495,7 @@
 			src.icon_state = "shieldw"
 			src.color = "#FF3333"
 			src.powerlevel = 3
+			src.mouse_opacity = 1
 			flags = ALWAYS_SOLID_FLUID | USEDELAY | FLUID_DENSE
 			density = 1
 
@@ -512,12 +516,14 @@
 			//these power levels are kind of arbitrary
 			if(src.powerlevel >= 2) src.flags |= FLUID_DENSE
 			if(src.powerlevel < 3) src.gas_impermeable = TRUE
+			if(src.powerlevel == 3) src.mouse_opacity = 1
 		else
 			src.icon_state = ""
 			src.isactive = FALSE
 			src.invisibility = INVIS_ALWAYS_ISH //ehh whatever this "works"
 			src.flags &= ~FLUID_DENSE
 			src.gas_impermeable = FALSE
+			src.mouse_opacity = 0
 
 	proc/update_nearby_tiles(need_rebuild)
 		var/turf/simulated/source = loc

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -516,7 +516,9 @@
 			//these power levels are kind of arbitrary
 			if(src.powerlevel >= 2) src.flags |= FLUID_DENSE
 			if(src.powerlevel < 3) src.gas_impermeable = TRUE
-			if(src.powerlevel == 3) src.mouse_opacity = 1
+			if(src.powerlevel == 3)
+				src.mouse_opacity = 1
+				src.density = 1
 		else
 			src.icon_state = ""
 			src.isactive = FALSE
@@ -524,6 +526,7 @@
 			src.flags &= ~FLUID_DENSE
 			src.gas_impermeable = FALSE
 			src.mouse_opacity = 0
+			src.density = 0
 
 	proc/update_nearby_tiles(need_rebuild)
 		var/turf/simulated/source = loc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Quick batch of changes to /obj/forcefield/energyshield:

- Initial forcefield deployment in New() now sets mouse_opacity to 0 for atmos, atmos/liquid, and liquid forcefields. Energy forcefields (which block objects) have mouse_opacity 1.
- The setactive proc is now able to toggle density and mouse opacity for energy forcefields; I believe this functionality currently isn't relied on, but I implemented it in the interest of functionality completeness.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes shields behave more intuitively and not obstruct player actions if they don't need to. Fixes #11783

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Station forcefields that aren't solid to objects should now be transparent to clicks.
```
