### PR TITLE
Fixes aiHolder disposing calling parent twice

### DIFF
--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -43,7 +43,6 @@ var/list/ai_move_scheduled = list()
 				owner.abilityHolder.addAbility(/datum/targetable/ai_toggle)
 
 	disposing()
-		..()
 		stop_move()
 		if (owner)
 			if (owner.mob_flags & LIGHTWEIGHT_AI_MOB)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Somehow a second parent call ended up at the start of `aiHolder/disposing`, this may be related to the thousands of runtimes coming out of disposed AI tasks. In any case, calling disposing parent twice is not a good idea.