### PR TITLE
Add client.preload_rsc configuration option

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -178,6 +178,10 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 	src.player = make_player(key)
 	src.player.client = src
 
+	// Prefer RSC from config.txt if present, otherwise rely on PRELOAD_RSC_URL
+	if(config.rsc)
+		src.preload_rsc = config.rsc
+
 	if (!isnewplayer(src.mob) && !isnull(src.mob)) //playtime logging stuff
 		src.player.log_join_time()
 

--- a/code/client.dm
+++ b/code/client.dm
@@ -178,7 +178,6 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 	src.player = make_player(key)
 	src.player.client = src
 
-	// Prefer RSC from config.txt if present, otherwise rely on PRELOAD_RSC_URL
 	if(config.rsc)
 		src.preload_rsc = config.rsc
 

--- a/code/datums/configuration.dm
+++ b/code/datums/configuration.dm
@@ -88,6 +88,7 @@
 	//Environment
 	var/env = "dev"
 	var/cdn = ""
+	var/rsc = null
 	var/disableResourceCache = 0
 
 	//Map switching stuff
@@ -346,6 +347,8 @@
 				config.env = trim(value)
 			if ("cdn")
 				config.cdn = trim(value)
+			if ("rsc")
+				config.rsc = trim(value)
 			if ("disable_resource_cache")
 				config.disableResourceCache = 1
 

--- a/config/config.sample.txt
+++ b/config/config.sample.txt
@@ -91,6 +91,7 @@ SERVERNAME Goonstation
 SERVERREGION Development
 
 CDN http://cdn.goonhub.com
+RSC http://cdn.goonhub.com/rsc.zip
 ENV dev
 
 # Spacebee API


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL][INTERNAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Introduces the configuration option `RSC` in `config/config.txt` which sets the `client.preload_rsc` to its value and provides an example of it's usage in `config/config.sample.txt`

If the option is not specified, it defaults to the current behavior of using `RSC_PRELOAD_URL` defined in `_std/__build.dm` instead. This shouldn't affect the current server build process.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

QoL improvement for downstream servers and simplifies the server setup process, especially if you are not using Cloverfield or opengoon. Allowing runtime configuration also decouples the build process from the server it's being deployed on, because you don't have to know where the rsc will be served ahead of time.

This also just generally annoyed me when hosting Loafstation.
