### PR TITLE
fixes detective stunner rounds doing 35 burn dmg per shot and stunning

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -436,6 +436,7 @@ toxic - poisons
 
 /datum/projectile/bullet/revolver_38/stunners//energy bullet things so he can actually stun something
 	name = "stun bullet"
+	damage = 0
 	stun = 20
 	dissipation_delay = 6 //One more tick before falloff begins
 	damage_type = D_ENERGY // FUCK YOU.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][P-MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes bug where in which detective stunner projectiles inherited the damage from the parent lethal projectiles but made them do burn damage instead as stunners are energy projectiles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
stunners ≠ lethals, also fixes #11817