### PR TITLE
Fixes poisoned rose mute duration being 10 times longer than it should be

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -544,7 +544,8 @@
 				M.bioHolder.AddEffect("dead_scan", timeleft = 40 SECONDS, do_stability = FALSE, magical = TRUE)
 			else
 				M.reagents?.add_reagent("capulettium", 13)
-		M.bioHolder?.AddEffect("mute", timeleft = 40 SECONDS, do_stability = FALSE, magical = TRUE)
+		//DO NOT add the SECONDS define to this, bioHolders are cursed and don't believe in ticks
+		M.bioHolder?.AddEffect("mute", timeleft = 40, do_stability = FALSE, magical = TRUE)
 
 /obj/item/plant/flower/rose/holorose
 	name = "holo rose"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11848
Fun fact: bioEffect durations are given in seconds, not ticks like everything else in the game.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Permanent mimeism is bad for your health.