### PR TITLE
Fix oven thinking undercooked burgers are high quality. Also fix heal…

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -707,7 +707,6 @@ table#cooktime a#start {
 						else if (bonus == -1)
 							if (F.quality > 0.5)
 								F.quality = 0.5
-							F.heal_amt = 0
 						if (src.emagged)
 							F.from_emagged_oven = 1
 						F.set_loc(src.loc)
@@ -721,10 +720,8 @@ table#cooktime a#start {
 
 					if (bonus == 1)
 						F.quality = 5
-					else if (bonus == -1)
-						F.quality = recipebonus - cook_amt
-						if (istype(F, /obj/item/reagent_containers/food/snacks))
-							F.heal_amt = 0
+					else
+						F.quality = clamp(5 - abs(recipebonus - cook_amt), 0, 5)
 					if (src.emagged && istype(F))
 						F.from_emagged_oven = 1
 					if (derivename)


### PR DESCRIPTION
…_amt being set to 0 because hunger won't be filled.

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the oven thinking undercooked food is high quality. Also removes a couple cases where hunger filled would be 0. Instead, quality of 0 will cause hunger to not be filled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes: #11477

