### PR TITLE
Mining cyborgs can now get cargo alerts

### DIFF
--- a/code/modules/robotics/robot/module/mining.dm
+++ b/code/modules/robotics/robot/module/mining.dm
@@ -6,8 +6,8 @@
 	included_cosmetic = /datum/robot_cosmetic/mining
 	included_tools = /datum/robot/module_tool_creator/recursive/module/mining
 	radio_type = /obj/item/device/radio/headset/miner
-	mailgroups = list(MGD_MINING, MGO_SILICON, MGD_PARTY)
-	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES, MGA_DEATH)
+	mailgroups = list(MGD_MINING, MGD_CARGO, MGO_SILICON, MGD_PARTY)
+	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_DEATH)
 
 /datum/robot_cosmetic/mining
 	head_mod = "Hard Hat"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

I guess the labels should be [SILICONS] and [FEATURE]? Or would this be SILICONS and QOL?

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mining cyborgs can now ACTUALLY be a Quartermaster.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a cyborg wants to use the Cargo Transporter the Mining module has to become a cyborg quartermaster (Borgtermaster), they won't get any notifications of orders and sales like human Quartermasters do. 

This shouldn't annoy any cyborg that just wants to mine because the messages can be muted.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+) Mining cyborgs now get Cargo alerts.
```
