### PR TITLE
Fixes rotating Trip Lasers

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -880,6 +880,7 @@
 		rebeam()
 
 	rotate()
+		..()
 		if(level == 1)
 			rebeam()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You couldn't rotate Trip Lasers with a crowbar. This PR fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
[BUG] fixes are nice. Especially when they fix [GAME OBJECTS].


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)You can now rotate Trip Lasers with a crowbar again.
```
