### PR TITLE
ghost critters cannot use weapon vendors anymore

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -28,6 +28,7 @@
 	opacity = 0
 	anchored = 1
 	flags = TGUI_INTERACTIVE
+	object_flags = NO_GHOSTCRITTER //cry about it
 	layer = OBJ_LAYER - 0.1	// Match vending machines
 
 	var/sound_token = 'sound/machines/capsulebuy.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes ghost critters not be able to use weapon vendors


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #11740 and why would they be able to use this and not computers???? affects the progress of the round too

