### PR TITLE
Harmonic Siphon starstone difficulty increase

### DIFF
--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -268,6 +268,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 /datum/siphon_mineral/starstone
 	name = "Starstone"
 	tick_req = 1616
+	y_torque = 0
 	shear = 161
 	product = /obj/item/raw_material/starstone
 

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -272,8 +272,8 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	product = /obj/item/raw_material/starstone
 
 	New()
-		src.tick_req = rand(100,130) * 5
-		src.shear = rand(130,230)
+		src.tick_req = rand(90,130) * 10
+		src.shear = rand(260,360)
 		..()
 
 /datum/siphon_mineral/blob

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -268,7 +268,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 /datum/siphon_mineral/starstone
 	name = "Starstone"
 	tick_req = 1616
-	y_torque = 0
+	x_torque = 0
 	shear = 161
 	product = /obj/item/raw_material/starstone
 

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -272,7 +272,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	product = /obj/item/raw_material/starstone
 
 	New()
-		src.tick_req = rand(90,130) * 10
+		src.tick_req = rand(150,220) * 8
 		src.shear = rand(260,360)
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases the difficulty of Harmonic Siphon starstone material target in three of the four possible ways:

- Tick requirement has been increased, and now ranges from 1,200 to 1,760 ticks (previously 700-900 pre-buff and 500-650 post-buff).
- Shear range (one of the parameters the resonator setup must match) has been dramatically increased from 130-230 up to 260-360.
- An additional parameter requirement has been added; lateral resonance must now be exactly zero.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As players have become more acclimatized to siphon operation, Starstone has proven to be unduly easy to obtain relative to its significant power level; though the intent was to allow multiple pieces to be reasonable in a round, cranking out double-digit piles of Starstone as reported is a bit much.

These balance changes make it more difficult to devise an extraction setup for Starstone, and slow the extraction once you do (increased tick requirement will likely be slightly offset by the increased number of resonators required).