### PR TITLE
Ion storms (mostly) blockable by Spatial Interdictor

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -122,11 +122,24 @@
 
 /* ION STORM */
 	proc/ion_storm_all_racks(var/picked_law="Beep repeatedly.",var/lawnumber=2,var/replace=true)
+		. = FALSE //return true if any racks were affected by ion storms
 		for(var/obj/machinery/lawrack/R in src.registered_racks)
 			if(istype(R,/obj/machinery/lawrack/syndicate))
 				continue //sadly syndie law racks must be immune to ion storms, because nobody can actually get at them to fix them.
+
+			//spatial interdictor: shield law rack hardware from ionic interference
+			//consumes 800 units of cell charge per rack
+			var/interdicted = FALSE
+			for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
+				if (IN_RANGE(IX,R,IX.interdict_range) && IX.expend_interdict(800))
+					interdicted = TRUE
+					break
+			if(interdicted)
+				continue
+
 			if(R.cause_law_glitch(picked_law,lawnumber,replace))
 				R.UpdateLaws()
+				. = TRUE
 
 
 /* General ai_law functions */

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -122,24 +122,11 @@
 
 /* ION STORM */
 	proc/ion_storm_all_racks(var/picked_law="Beep repeatedly.",var/lawnumber=2,var/replace=true)
-		. = FALSE //return true if any racks were affected by ion storms
 		for(var/obj/machinery/lawrack/R in src.registered_racks)
 			if(istype(R,/obj/machinery/lawrack/syndicate))
 				continue //sadly syndie law racks must be immune to ion storms, because nobody can actually get at them to fix them.
-
-			//spatial interdictor: shield law rack hardware from ionic interference
-			//consumes 800 units of cell charge per rack
-			var/interdicted = FALSE
-			for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
-				if (IN_RANGE(IX,R,IX.interdict_range) && IX.expend_interdict(800))
-					interdicted = TRUE
-					break
-			if(interdicted)
-				continue
-
 			if(R.cause_law_glitch(picked_law,lawnumber,replace))
 				R.UpdateLaws()
-				. = TRUE
 
 
 /* General ai_law functions */

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -184,7 +184,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 			//spatial interdictor: shield general hardware from ionic interference. law racks explicitly omitted due to sensitivity (and gameplay fun)
 			//consumes cell charge per hardware item protected, based on the category's interdict cost
 			var/interdicted = FALSE
-			for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
+			for_by_tcl(IX, /obj/machinery/interdictor)
 				if (IN_RANGE(IX,object,IX.interdict_range) && IX.expend_interdict(interdict_cost))
 					interdicted = TRUE
 					SPAWN(rand(1,8))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -189,8 +189,6 @@ ABSTRACT_TYPE(/datum/ion_category)
 					interdicted = TRUE
 					SPAWN(rand(1,8))
 						playsound(object.loc, "sparks", 60, 1) //absorption noise, as a little bit of "force feedback"
-					//in case people say a thing was ion stormed but it actually was not because of interdiction
-					logTheThing(LOG_STATION, null, "Interdictor at [log_loc(IX)] prevented ion storm from interfering with [object.name] at [log_loc(object)]")
 					break
 			if(interdicted)
 				continue

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -133,22 +133,14 @@
 
 		if (prob(50))
 			var/num = rand(1,9)
-			var/law_break_success = ticker.ai_law_rack_manager.ion_storm_all_racks(pickedLaw,num,false)
-			if(law_break_success)
-				logTheThing(LOG_ADMIN, null, "Ion storm added supplied law to law number [num]: [pickedLaw]")
-				message_admins("Ion storm added supplied law [num]: [pickedLaw]")
-			else
-				logTheThing(LOG_ADMIN, null, "Ion storm attempted to add law to law number [num], but was interdicted: [pickedLaw]")
-				message_admins("Ion storm addition to law [num] was interdicted: [pickedLaw]")
+			ticker.ai_law_rack_manager.ion_storm_all_racks(pickedLaw,num,false)
+			logTheThing(LOG_ADMIN, null, "Ion storm added supplied law to law number [num]: [pickedLaw]")
+			message_admins("Ion storm added supplied law [num]: [pickedLaw]")
 		else
 			var/num = rand(1,9)
-			var/law_break_success = ticker.ai_law_rack_manager.ion_storm_all_racks(pickedLaw,num,true)
-			if(law_break_success)
-				logTheThing(LOG_ADMIN, null, "Ion storm replaced inherent law [num]: [pickedLaw]")
-				message_admins("Ion storm replaced inherent law [num]: [pickedLaw]")
-			else
-				logTheThing(LOG_ADMIN, null, "Ion storm attempted to replace inherent law [num], but was interdicted: [pickedLaw]")
-				message_admins("Ion storm replacement of law [num] was interdicted: [pickedLaw]")
+			ticker.ai_law_rack_manager.ion_storm_all_racks(pickedLaw,num,true)
+			logTheThing(LOG_ADMIN, null, "Ion storm replaced inherent law [num]: [pickedLaw]")
+			message_admins("Ion storm replaced inherent law [num]: [pickedLaw]")
 
 		logTheThing(LOG_ADMIN, null, "Resulting AI Lawset:<br>[ticker.ai_law_rack_manager.format_for_logs()]")
 		logTheThing(LOG_DIARY, null, "Resulting AI Lawset:<br>[ticker.ai_law_rack_manager.format_for_logs()]", "admin")
@@ -186,7 +178,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 		if (!length(targets))
 			build_targets()
 		for (var/i in 1 to amount)
-			var/atom/object = pick(targets)
+			var/object = pick(targets)
 
 			//spatial interdictor: shield general hardware from ionic interference
 			//consumes 300 units of cell charge per hardware item protected

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -160,6 +160,7 @@
 ABSTRACT_TYPE(/datum/ion_category)
 /datum/ion_category
 	var/amount
+	var/interdict_cost = 250 //how much energy an interdictor needs to invest to keep this from malfunctioning
 	var/list/atom/targets = list()
 
 	proc/valid_instance(var/atom/found)
@@ -178,14 +179,16 @@ ABSTRACT_TYPE(/datum/ion_category)
 		if (!length(targets))
 			build_targets()
 		for (var/i in 1 to amount)
-			var/object = pick(targets)
+			var/atom/object = pick(targets)
 
-			//spatial interdictor: shield general hardware from ionic interference
-			//consumes 300 units of cell charge per hardware item protected
+			//spatial interdictor: shield general hardware from ionic interference. law racks explicitly omitted due to sensitivity (and gameplay fun)
+			//consumes cell charge per hardware item protected, based on the category's interdict cost
 			var/interdicted = FALSE
 			for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
-				if (IN_RANGE(IX,object,IX.interdict_range) && IX.expend_interdict(300))
+				if (IN_RANGE(IX,object,IX.interdict_range) && IX.expend_interdict(interdict_cost))
 					interdicted = TRUE
+					SPAWN(rand(1,8))
+						playsound(object.loc, "sparks", 60, 1) //absorption noise, as a little bit of "force feedback"
 					//in case people say a thing was ion stormed but it actually was not because of interdiction
 					logTheThing(LOG_STATION, null, "Interdictor at [log_loc(IX)] prevented ion storm from interfering with [object.name] at [log_loc(object)]")
 					break
@@ -198,6 +201,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 
 /datum/ion_category/APCs
 	amount = 20
+	interdict_cost = 900
 
 	build_targets()
 		for (var/obj/machinery/power/apc/apc in machine_registry[MACHINES_POWER])
@@ -281,6 +285,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 
 /datum/ion_category/manufacturers
 	amount = 5
+	interdict_cost = 500
 
 	build_targets()
 		for_by_tcl(man, /obj/machinery/manufacturer)
@@ -293,6 +298,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 
 /datum/ion_category/venders
 	amount = 5
+	interdict_cost = 600
 
 	build_targets()
 		for_by_tcl(vender, /obj/machinery/vending)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS][EVENTS][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes ion storms being absent from spatial interdictors' gamut of protection.

When an ion category is picking target objects, it will check for interdictors in range of the object before applying the malfunction behavior, and try to spend an interdiction cost based on the ion category (using a new interdict_cost variable in it, defaulting to 250).

Successful interdiction will prevent the malfunction behavior from kicking in, and make a small sparking noise from the ionization being counteracted.

**Law racks are deliberately not protected.** In addition to being sensitive electronics that are much harder to shield, there's a gameplay reason for this; allowing the interdictor to prevent ion storms could make it a default course of action to put an interdictor by the AI law rack, making it difficult for the AI to ever actually get to play around with the scenarios the alternate laws provide.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Assorted system malfunctions caused by ion storms should likely be within the range of things an interdictor can protect from.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Spatial interdictors can now protect most devices from ion storms if the affected device is within interdiction range. Law racks are an exception, due to the sensitive nature of involved components.
```
