### PR TITLE
Makes wraith /living/intangible along with minor tweaks.

### DIFF
--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -11,8 +11,8 @@
 #define ishunter(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/hunter))
 #define iswerewolf(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/werewolf))
 #define iswrestler(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && (x:get_ability_holder(/datum/abilityHolder/wrestler) != null || HAS_ATOM_PROPERTY(x, PROP_MOB_PASSIVE_WRESTLE)))
-#define iswraith(x) istype(x, /mob/wraith)
-#define ispoltergeist(x) istype(x, /mob/wraith/poltergeist)
+#define iswraith(x) istype(x, /mob/living/intangible/wraith)
+#define ispoltergeist(x) istype(x, /mob/living/intangible/wraith/poltergeist)
 #define isarcfiend(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/arcfiend) != null)
 #define issawflybuddy(x) ((istraitor(x)) || isnukeop(x) || isspythief(x) || isnukeopgunbot(x))
 

--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -110,7 +110,7 @@
 
 	Entered(var/mob/M)
 		. = ..()
-		if (istype(M,/mob/dead) || istype(M,/mob/wraith) || istype(M,/mob/living/intangible) || istype(M, /obj/lattice))
+		if (istype(M,/mob/dead) || istype(M,/mob/living/intangible) || istype(M, /obj/lattice))
 			return
 		if(!ismob(M))
 			return

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -885,7 +885,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				for(var/turf/T in get_area_turfs(/area/trench_landing))
 					L+=T
 
-			if (istype(Obj,/obj/torpedo_targeter) ||istype(Obj,/mob/dead) || istype(Obj,/mob/wraith) || istype(Obj,/mob/living/intangible) || istype(Obj, /obj/lattice) || istype(Obj, /obj/cable/reinforced) || istype(Obj, /obj/arrival_missile))
+			if (istype(Obj,/obj/torpedo_targeter) ||istype(Obj,/mob/dead) || istype(Obj,/mob/living/intangible) || istype(Obj, /obj/lattice) || istype(Obj, /obj/cable/reinforced) || istype(Obj, /obj/arrival_missile))
 				return
 
 			return_if_overlay_or_effect(Obj)

--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -204,7 +204,7 @@
 			// jesus christ don't teleport OURSELVES
 			return ..()
 		Z_LOG_DEBUG("shit", "Checking things: event_handler_flags [event_handler_flags], [AM] entered")
-		if (busy || istype(AM, /obj/overlay/tile_effect) || istype(AM, /mob/dead) || istype(AM, /mob/wraith) || istype(AM, /mob/living/intangible))
+		if (busy || istype(AM, /obj/overlay/tile_effect) || istype(AM, /mob/dead) || istype(AM, /mob/living/intangible))
 			Z_LOG_DEBUG("shit", "Decided not to teleport")
 			return ..()
 

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -44,7 +44,7 @@
 	isBad = 0 // depends on who you ask really
 	can_copy = 0
 	var/isDying = 0
-	var/mob/wraith/wraith = null
+	var/mob/living/intangible/wraith/wraith = null
 	var/ghoulTouchActive = 0
 	var/list/abilities
 	icon_state  = "evilaura"
@@ -120,7 +120,7 @@
 			step_away(poorSob, owner, 15)
 
 
-	proc/wraithPossess(var/mob/wraith/W)
+	proc/wraithPossess(var/mob/living/intangible/wraith/W)
 		if (!W.mind && !W.client)
 			return
 		if (owner.client || owner.mind)

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -57,12 +57,12 @@
 		if (!holder || !holder.owner)
 			return 1
 		if (ispoltergeist(holder.owner))
-			var/mob/wraith/poltergeist/P = holder.owner
+			var/mob/living/intangible/wraith/poltergeist/P = holder.owner
 			if (src.min_req_dist <= P.power_well_dist)
 				boutput(holder.owner, "<span class='alert'>You must be within [min_req_dist] tiles from a well of power to perform this task.</span>")
 				return 1
-		if (istype(holder.owner, /mob/wraith))
-			var/mob/wraith/W = holder.owner
+		if (istype(holder.owner, /mob/living/intangible/wraith))
+			var/mob/living/intangible/wraith/W = holder.owner
 			if (W.forced_manifest == TRUE)
 				boutput(W, "<span class='alert'>You have been forced to manifest! You can't use any abilities for now!</span>")
 				return 1
@@ -78,11 +78,11 @@
 
 	onAttach(datum/abilityHolder/holder)
 		..()
-		if (istype(holder.owner, /mob/wraith/wraith_decay) || istype(holder.owner, /mob/living/critter/wraith/plaguerat))
+		if (istype(holder.owner, /mob/living/intangible/wraith/wraith_decay) || istype(holder.owner, /mob/living/critter/wraith/plaguerat))
 			border_state = "plague_frame"
-		else if (istype(holder.owner, /mob/wraith/wraith_harbinger))
+		else if (istype(holder.owner, /mob/living/intangible/wraith/wraith_harbinger))
 			border_state = "harbinger_frame"
-		else if (istype(holder.owner, /mob/wraith/wraith_trickster) || istype(holder.owner, /mob/living/critter/wraith/trickster_puppet))
+		else if (istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster) || istype(holder.owner, /mob/living/critter/wraith/trickster_puppet))
 			border_state = "trickster_frame"
 
 		var/atom/movable/screen/ability/topBar/B = src.object
@@ -145,7 +145,7 @@
 				return 1
 
 			//check for formaldehyde. if there's more than the wraith's tol amt, we can't absorb right away.
-			var/mob/wraith/W = src.holder.owner
+			var/mob/living/intangible/wraith/W = src.holder.owner
 			if (istype(W))
 				var/amt = H.reagents.get_reagent_amount("formaldehyde")
 				if (amt >= W.formaldehyde_tolerance)
@@ -163,7 +163,7 @@
 		logTheThing("combat", holder.owner, "absorbs the corpse of [key_name(H)] as a wraith.")
 		var/turf/T = get_turf(H)
 		// decay wraith receives bonuses for toxin damaged and decayed bodies, but can't absorb fresh kils without toxin damage
-		if ((istype(holder.owner, /mob/wraith/wraith_decay)))
+		if ((istype(holder.owner, /mob/living/intangible/wraith/wraith_decay)))
 			if ((H.get_toxin_damage() >= 60) || (H.decomp_stage == DECOMP_STAGE_HIGHLY_DECAYED))
 				boutput(holder.owner, "<span class='alert'>[H] is extremely rotten and bloated. It satisfies us greatly</span>")
 				holder.points += 150
@@ -187,7 +187,7 @@
 		holder.regenRate += 2
 		var/datum/abilityHolder/wraith/AH = holder
 		if (istype(AH))
-			var/mob/wraith/W = AH.owner
+			var/mob/living/intangible/wraith/W = AH.owner
 			if (istype(W))
 				W.onAbsorb(H)
 			AH.corpsecount++
@@ -273,7 +273,7 @@
 					break
 
 		if (ishuman(T))
-			var/mob/wraith/W = holder.owner
+			var/mob/living/intangible/wraith/W = holder.owner
 			. = W.makeRevenant(T)		//return 0
 			if(!.)
 				playsound(W.loc, 'sound/voice/wraith/reventer.ogg', 80, 0)
@@ -491,19 +491,19 @@
 			P.demanifest()
 			return 0
 
-		var/mob/wraith/K = src.holder.owner
+		var/mob/living/intangible/wraith/K = src.holder.owner
 		if (!K.forced_manifest && K.hasStatus("corporeal"))
 			boutput(holder.owner, "We fade back into the shadows")
 			cooldown = 0 SECONDS
 			return K.delStatus("corporeal")
 		else
 			boutput(holder.owner, "We show ourselves")
-			var/mob/wraith/W = holder.owner
+			var/mob/living/intangible/wraith/W = holder.owner
 
 			cooldown = 30 SECONDS
 
-			if ((istype(W, /mob/wraith/wraith_trickster)))	//Trickster can appear as a human, living or dead.
-				var/mob/wraith/wraith_trickster/T = holder.owner
+			if ((istype(W, /mob/living/intangible/wraith/wraith_trickster)))	//Trickster can appear as a human, living or dead.
+				var/mob/living/intangible/wraith/wraith_trickster/T = holder.owner
 				if (T.copied_appearance != null)
 					var/mob/living/critter/wraith/trickster_puppet/puppet = new /mob/living/critter/wraith/trickster_puppet(get_turf(T), T)
 					T.mind.transfer_to(puppet)
@@ -764,7 +764,7 @@
 			boutput(holder.owner, "<span class='alert'>You can't cast this spell on your current tile!</span>")
 			return 1
 
-	proc/make_poltergeist(var/mob/wraith/W, var/turf/T, var/tries = 0)
+	proc/make_poltergeist(var/mob/living/intangible/wraith/W, var/turf/T, var/tries = 0)
 		if (!istype(W))
 			boutput(W, "something went terribly wrong, call 1-800-CODER")
 			return
@@ -794,8 +794,8 @@
 			return
 		var/datum/mind/lucky_dude = pick(candidates)
 
-		//add poltergeist to master's list is done in /mob/wraith/potergeist/New
-		var/mob/wraith/poltergeist/P = new /mob/wraith/poltergeist(T, W, marker)
+		//add poltergeist to master's list is done in /mob/living/intangible/wraith/potergeist/New
+		var/mob/living/intangible/wraith/poltergeist/P = new /mob/living/intangible/wraith/poltergeist(T, W, marker)
 		lucky_dude.special_role = ROLE_POLTERGEIST
 		lucky_dude.dnr = 1
 		lucky_dude.transfer_to(P)
@@ -848,18 +848,18 @@
 			boutput(holder.owner, "<span class='notice'>You do not have enough points to cast this. You need at least [pointCost] points.</span>")
 			return 1
 		else
-			var/mob/wraith/W
+			var/mob/living/intangible/wraith/W
 			switch (effect)
 				if (1)
-					W = new/mob/wraith/wraith_decay(holder.owner)
+					W = new/mob/living/intangible/wraith/wraith_decay(holder.owner)
 					boutput(holder.owner, "<span class='notice'>You use some of your energy to evolve into a plaguebringer! Spread rot and disease all around!</span>")
 					holder.owner.show_antag_popup("plaguebringer")
 				if (2)
-					W = new/mob/wraith/wraith_harbinger(holder.owner)
+					W = new/mob/living/intangible/wraith/wraith_harbinger(holder.owner)
 					boutput(holder.owner, "<span class='notice'>You use some of your energy to evolve into a harbinger! Command your army of minions to bring ruin to the station!</span>")
 					holder.owner.show_antag_popup("harbinger")
 				if (3)
-					W = new/mob/wraith/wraith_trickster(holder.owner)
+					W = new/mob/living/intangible/wraith/wraith_trickster(holder.owner)
 					boutput(holder.owner, "<span class='notice'>You use some of your energy to evolve into a trickster! Decieve the crew and turn them against one another!</span>")
 					holder.owner.show_antag_popup("trickster")
 
@@ -1065,7 +1065,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 
 		if (ishuman(target))
 			var/mob/living/carbon/human/H = target
-			var/mob/wraith/W = holder.owner
+			var/mob/living/intangible/wraith/W = holder.owner
 			if (H?.bioHolder.HasEffect("rot_curse") && H?.bioHolder.HasEffect("weak_curse") && H?.bioHolder.HasEffect("blind_curse") && H?.bioHolder.HasEffect("blood_curse"))
 				W.playsound_local(W.loc, 'sound/voice/wraith/wraithhaunt.ogg', 40, 0)
 				boutput(holder.owner, "<span class='alert'>That soul is OURS!!</span>")
@@ -1197,7 +1197,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if (!holder)
 			return 1
 
-		var/mob/wraith/W = holder.owner
+		var/mob/living/intangible/wraith/W = holder.owner
 
 		if (!W || !target)
 			return 1
@@ -1336,9 +1336,9 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 	cast(mob/target)
 		if (..())
 			return TRUE
-		if (istype(holder.owner, /mob/wraith/wraith_trickster))
-			var/mob/wraith/wraith_trickster/W = holder.owner
-			if (W.possession_points > W.points_to_possess)
+		if (istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster))
+			var/mob/living/intangible/wraith/wraith_trickster/W = holder.owner
+			if (W.possession_points >= W.points_to_possess)
 				if (ishuman(target) && !isdead(target))
 					var/mob/living/carbon/human/H = target
 					if (H.traitHolder.hasTrait("training_chaplain"))
@@ -1537,13 +1537,13 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if (..())
 			return 1
 
-		if (!istype(holder.owner, /mob/wraith/wraith_trickster) && !istype(holder.owner, /mob/living/critter/wraith/trickster_puppet))
+		if (!istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster) && !istype(holder.owner, /mob/living/critter/wraith/trickster_puppet))
 			boutput(holder.owner, "<span class='notice'>You cannot cast this under your current form.</span>")
 			return 1
 
-		var/mob/wraith/wraith_trickster/W = null
+		var/mob/living/intangible/wraith/wraith_trickster/W = null
 		var/mob/living/critter/wraith/trickster_puppet/P = null
-		if(istype(holder.owner, /mob/wraith/wraith_trickster))
+		if(istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster))
 			W = holder.owner
 			if (!W.haunting)
 				boutput(holder.owner, "<span class='notice'>You must be manifested to place a trap!</span>")
@@ -1619,8 +1619,8 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 
 		var/turf/T = get_turf(holder.owner)
 		if (isturf(T) && istype(T,/turf/simulated/floor))
-			if(istype(holder.owner, /mob/wraith))
-				var/mob/wraith/W = holder.owner
+			if(istype(holder.owner, /mob/living/intangible/wraith))
+				var/mob/living/intangible/wraith/W = holder.owner
 				if (!W.density)
 					boutput(holder.owner, "Your connection to the physical plane is too weak. You must be manifested to do this.")
 					return 1
@@ -1685,8 +1685,8 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if (..())
 			return 1
 
-		if(istype(holder.owner, /mob/wraith/wraith_trickster))
-			var/mob/wraith/wraith_trickster/W = holder.owner
+		if(istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster))
+			var/mob/living/intangible/wraith/wraith_trickster/W = holder.owner
 			if ((istype(target, /mob/living/carbon/human/)))
 				boutput(holder.owner, "We steal [target]'s appearance for ourselves.")
 				W.copied_appearance = target.appearance
@@ -1726,7 +1726,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 			boutput(holder.owner, "<span class='alert'>You can't cast this spell on your current tile!</span>")
 			return 1
 
-	proc/make_summon(var/mob/wraith/W, var/turf/T, var/tries = 0)
+	proc/make_summon(var/mob/living/intangible/wraith/W, var/turf/T, var/tries = 0)
 		if (!istype(W))
 			boutput(W, "something went terribly wrong, call 1-800-CODER")
 			return
@@ -1756,7 +1756,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 			return
 		var/datum/mind/lucky_dude = pick(candidates)
 
-		//add poltergeist to master's list is done in /mob/wraith/potergeist/New
+		//add poltergeist to master's list is done in /mob/living/intangible/wraith/potergeist/New
 		var/mob/living/critter/wraith/nascent/P = new /mob/living/critter/wraith/nascent(T, W)
 		lucky_dude.special_role = ROLE_HARBINGERSUMMON
 		lucky_dude.dnr = 1
@@ -1768,7 +1768,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		usr.playsound_local(usr.loc, "sound/voice/wraith/ghostrespawn.ogg", 50, 0)
 		logTheThing("admin", lucky_dude.current, null, "respawned as a harbinger summon for [src.holder.owner].")
 		boutput(P, "<span class='notice'><b>You have been respawned as a harbinger summon!</b></span>")
-		boutput(P, "[W] is your master! Use your abilities to choose a path! Work with your master to spread chaos!")
+		boutput(P, "<span class='alert'><b>[W] is your master! Use your abilities to choose a path! Work with your master to spread chaos!</b></span>")
 		qdel(marker)
 
 /datum/targetable/wraithAbility/make_plague_rat
@@ -1823,7 +1823,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 			return 1
 
 	proc/make_plague_rat(var/mob/W, var/turf/T, var/tries = 0)
-		if (!istype(W, /mob/wraith/wraith_decay) && !istype(W, /mob/living/critter/wraith/plaguerat))
+		if (!istype(W, /mob/living/intangible/wraith/wraith_decay) && !istype(W, /mob/living/critter/wraith/plaguerat))
 			boutput(W, "something went terribly wrong, call 1-800-CODER")
 			return
 
@@ -1884,7 +1884,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if (!holder)
 			return 1
 
-		var/mob/wraith/W = holder.owner
+		var/mob/living/intangible/wraith/W = holder.owner
 
 		if (!W)
 			return 1

--- a/code/datums/controllers/process/mobs.dm
+++ b/code/datums/controllers/process/mobs.dm
@@ -53,8 +53,8 @@
 				M.Life(src)
 				if (!(c++ % 5))
 					scheck()
-			else if(istype(X, /mob/wraith))
-				var/mob/wraith/W = X
+			else if(istype(X, /mob/living/intangible/wraith))
+				var/mob/living/intangible/wraith/W = X
 				W.Life(src)
 				scheck()
 			else if(istype(X, /mob/dead))

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -306,7 +306,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 				else if (player.mind && player.mind.special_role == ROLE_WRAITH)
 					player.close_spawn_windows()
-					var/mob/wraith/W = player.make_wraith()
+					var/mob/living/intangible/wraith/W = player.make_wraith()
 					if (W)
 						W.set_loc(pick_landmark(LANDMARK_OBSERVER))
 						logTheThing(LOG_DEBUG, W, "<b>Late join</b>: assigned antagonist role: wraith.")

--- a/code/datums/hud/poltergeist.dm
+++ b/code/datums/hud/poltergeist.dm
@@ -16,7 +16,7 @@
 	relay_click(id, mob/user, list/params)
 		if (id == "leave_master")
 			if (ispoltergeist(master))
-				var/mob/wraith/poltergeist/P = master
+				var/mob/living/intangible/wraith/poltergeist/P = master
 				P.exit_master()
 
 	proc/set_leave_master(var/on)

--- a/code/datums/hud/wraith.dm
+++ b/code/datums/hud/wraith.dm
@@ -1,5 +1,5 @@
 /datum/hud/wraith
-	var/mob/wraith/master
+	var/mob/living/intangible/wraith/master
 	var/atom/movable/screen/intent
 	var/atom/movable/screen/health
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2155,7 +2155,7 @@
 			the_butt = new /obj/item/clothing/head/butt(src.loc, organHolder)
 		else if (istype(src, /mob/living/silicon))
 			the_butt = new /obj/item/clothing/head/butt/cyberbutt
-		else if (istype(src, /mob/wraith) || istype(src, /mob/dead))
+		else if (istype(src, /mob/living/intangible/wraith) || istype(src, /mob/dead))
 			the_butt = new /obj/item/clothing/head/butt
 			the_butt.setMaterial(getMaterial("ectoplasm"), appearance = TRUE, setname = TRUE, copy = FALSE)
 		else if (istype(src, /mob/living/intangible/blob_overmind))

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -60,6 +60,9 @@
 	Move(NewLoc, direct)
 		if(!canmove) return
 
+		//Mostly for manifested wraith. Dont move through everything.
+		if (src.density) return ..()
+
 		if (NewLoc && isrestrictedz(src.z) && !restricted_z_allowed(src, NewLoc) && !(src.client && src.client.holder))
 			var/OS = pick_landmark(LANDMARK_OBSERVER, locate(1, 1, 1))
 			if (OS)

--- a/code/mob/wraith/poltergeist.dm
+++ b/code/mob/wraith/poltergeist.dm
@@ -1,4 +1,4 @@
-/mob/wraith/poltergeist
+/mob/living/intangible/wraith/poltergeist
 	name = "Poltergeist"
 	real_name = "Poltergeist"
 	desc = "Jesus Christ, how spooky."
@@ -6,7 +6,7 @@
 	icon_state = "poltergeist"
 	deaths = 1					//only 1 life
 	hud_path = /datum/hud/wraith/poltergeist
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 	var/obj/spookMarker/marker = null
 	forced_haunt_duration = 15 SECONDS
 	death_icon_state = "derangedghost"
@@ -42,7 +42,7 @@
 		theName = theName  + "[pick(" the Poltergeist", " the Mischievous", " the Playful", " the Trickster", " the Sneaky", " the Child", " the Kid", " the Ass", " the Inquisitive", " the Exiled")]"
 		return theName
 
-	New(var/turf/T, var/mob/wraith/master, var/obj/spookMarker/marker)
+	New(var/turf/T, var/mob/living/intangible/wraith/master, var/obj/spookMarker/marker)
 		..(T)
 		src.master = master
 		src.marker = marker
@@ -209,7 +209,7 @@
 			p_hud.update_well_dist(power_well_dist)
 
 //switch to poltergeist after testing
-/mob/wraith/poltergeist/set_loc(atom/new_loc, new_pixel_x = 0, new_pixel_y = 0)
+/mob/living/intangible/wraith/poltergeist/set_loc(atom/new_loc, new_pixel_x = 0, new_pixel_y = 0)
 	if (use_movement_controller && isobj(src.loc) && src.loc:get_movement_controller())
 		use_movement_controller = null
 
@@ -256,7 +256,7 @@
 			return 1
 
 		if (ispoltergeist(holder.owner))
-			var/mob/wraith/poltergeist/P = holder.owner
+			var/mob/living/intangible/wraith/poltergeist/P = holder.owner
 			if (P.density)
 				boutput(P, "<span class='alert'>You cannot retreat while corporeal!</span>")
 				return 1

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1941,7 +1941,7 @@ var/global/noir = 0
 						while (WO != null)
 					if ("Random")
 						generate_wraith_objectives(mind)
-				var/mob/wraith/Wr = M.wraithize()
+				var/mob/living/intangible/wraith/Wr = M.wraithize()
 				if (!Wr)
 					if (!iswraith(mind.current))
 						boutput(usr, "<span class='alert'>Wraithization failed! Call 1-800-MARQUESAS for help.</span>")

--- a/code/modules/antagonists/wraith/critters/abilities/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/abilities/nascent.dm
@@ -10,10 +10,11 @@
 	cast()
 		if (..())
 			return TRUE
-		var/mob/wraith/W = null
+		var/mob/living/intangible/wraith/W = null
 		var/mob/living/critter/wraith/nascent/N = holder.owner
 		if(istype(N) && N.master)
 			W = N.master
+		boutput(holder.owner, "<span class='alert'><b>You become a skeleton commander! Swap intents and use your hallberd arm to do sweeps and stabs!</b></span>")
 		var/mob/living/critter/wraith/skeleton_commander/S = new /mob/living/critter/wraith/skeleton_commander(get_turf(holder.owner), W)
 		holder.owner.mind.transfer_to(S)
 		holder.owner.unequip_all()
@@ -38,13 +39,14 @@
 	cast()
 		if (..())
 			return TRUE
-		var/mob/wraith/W = null
+		var/mob/living/intangible/wraith/W = null
 		if(istype(holder.owner, /mob/living/critter/wraith/nascent))
 			var/mob/living/critter/wraith/nascent/N = holder.owner
 			if(N.master != null)
 				W = N.master
 		var/mob/living/critter/wraith/voidhound/S = new /mob/living/critter/wraith/voidhound(get_turf(holder.owner), W)
 		var/mob/living/critter/wraith/nascent/N = holder.owner
+		boutput(holder.owner, "<span class='alert'><b>You become a voidhound!</b></span>")
 		holder.owner.mind.transfer_to(S)
 		holder.owner.unequip_all()
 		animate_buff_in(S)
@@ -68,13 +70,14 @@
 	cast()
 		if (..())
 			return TRUE
-		var/mob/wraith/W = null
+		var/mob/living/intangible/wraith/W = null
 		if(istype(holder.owner, /mob/living/critter/wraith/nascent))
 			var/mob/living/critter/wraith/nascent/N = holder.owner
 			if(N.master != null)
 				W = N.master
 		var/mob/living/critter/wraith/spiker/S = new /mob/living/critter/wraith/spiker(get_turf(holder.owner), W)
 		var/mob/living/critter/wraith/nascent/N = holder.owner
+		boutput(holder.owner, "<span class='alert'><b>You become a tentacle fiend!</b></span>")
 		holder.owner.mind.transfer_to(S)
 		holder.owner.unequip_all()
 		animate_buff_in(S)

--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -13,10 +13,10 @@
 	health_brute_vuln = 1
 	health_burn = 50
 	health_burn_vuln = 0.8
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 	var/deathsound = "sound/voice/wraith/revleave.ogg"
 
-	New(var/turf/T, var/mob/wraith/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/M = null)
 		..(T)
 		if(M != null)
 			src.master = M

--- a/code/modules/antagonists/wraith/critters/plaguerat.dm
+++ b/code/modules/antagonists/wraith/critters/plaguerat.dm
@@ -40,7 +40,7 @@ ABSTRACT_TYPE(/mob/living/critter/wraith/plaguerat)
 	/// venom injected per bite
 	var/bite_transfer_amt = 3
 
-	New(var/turf/T, var/mob/wraith/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/M = null)
 		..(T)
 		START_TRACKING
 		SPAWN(0)
@@ -133,7 +133,7 @@ ABSTRACT_TYPE(/mob/living/critter/wraith/plaguerat)
 					return 1
 			M.reagents.add_reagent(src.venom, src.bite_transfer_amt)
 
-	proc/grow_up(var/mob/wraith/M = null)
+	proc/grow_up(var/mob/living/intangible/wraith/M = null)
 		if (!ispath(src.adultpath))
 			return 0
 		src.unequip_all()

--- a/code/modules/antagonists/wraith/critters/skeleton_commander.dm
+++ b/code/modules/antagonists/wraith/critters/skeleton_commander.dm
@@ -14,10 +14,10 @@
 	health_brute_vuln = 0.7
 	health_burn = 90
 	health_burn_vuln = 0.3
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 	var/deathsound = "sound/impact_sounds/plate_break.ogg"
 
-	New(var/turf/T, var/mob/wraith/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/M = null)
 		..(T)
 		if(M != null)
 			src.master = M

--- a/code/modules/antagonists/wraith/critters/spiker.dm
+++ b/code/modules/antagonists/wraith/critters/spiker.dm
@@ -15,9 +15,9 @@
 	health_brute_vuln = 1
 	health_burn = 50
 	health_burn_vuln = 1
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 
-	New(var/turf/T, var/mob/wraith/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/M = null)
 		..(T)
 		if(M != null)
 			src.master = M

--- a/code/modules/antagonists/wraith/critters/trickster_puppet.dm
+++ b/code/modules/antagonists/wraith/critters/trickster_puppet.dm
@@ -13,12 +13,12 @@
 	health_brute_vuln = 1
 	health_burn = 8
 	health_burn_vuln = 1
-	var/mob/wraith/wraith_trickster/master = null
+	var/mob/living/intangible/wraith/wraith_trickster/master = null
 	var/hauntBonus = 0
 	var/last_life_update = 0
 	var/traps_laid = 0
 
-	New(var/turf/T, var/mob/wraith/wraith_trickster/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/wraith_trickster/M = null)
 		..(T)
 		if(M != null)
 			src.master = M

--- a/code/modules/antagonists/wraith/critters/voidhound.dm
+++ b/code/modules/antagonists/wraith/critters/voidhound.dm
@@ -18,10 +18,10 @@
 	health_brute_vuln = 0.7
 	health_burn = 40
 	health_burn_vuln = 1
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 	var/cloaked = FALSE
 
-	New(var/turf/T, var/mob/wraith/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/M = null)
 		..(T)
 		if(M != null)
 			src.master = M

--- a/code/modules/antagonists/wraith/objs/item/spirit_candle.dm
+++ b/code/modules/antagonists/wraith/objs/item/spirit_candle.dm
@@ -22,7 +22,7 @@
 	attack_self(mob/user)
 		if (src.on)
 			src.visible_message("<span class='notice'>[user] blows on [src], its eyes emit a threatening glow!</span>")
-			for(var/mob/wraith/W in orange(4, user))
+			for(var/mob/living/intangible/wraith/W in orange(4, user))
 				//Small grace period to run away after being manifested if you managed to survive so you dont get chain-manifested
 				if ((W.last_spirit_candle_time + (W.forced_haunt_duration + 6 SECONDS)) < TIME)
 					W.last_spirit_candle_time = TIME
@@ -77,7 +77,7 @@
 			src.put_out()
 			return
 		var/turf/T = get_turf(src)
-		for_by_tcl(W, /mob/wraith)
+		for_by_tcl(W, /mob/living/intangible/wraith)
 			if (IN_RANGE(W, T, WIDE_TILE_WIDTH / 2))
 				W.changeStatus("spirit_candle", 5 SECONDS)
 

--- a/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
+++ b/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
@@ -10,9 +10,9 @@
 	anchored = 1
 	var/visible = FALSE
 	var/armed = FALSE
-	var/mob/wraith/wraith_trickster/master = null
+	var/mob/living/intangible/wraith/wraith_trickster/master = null
 
-	New(var/turf/T, var/mob/wraith/wraith_trickster/W = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/wraith_trickster/W = null)
 		..()
 		master = W
 		SPAWN(5 SECONDS)

--- a/code/modules/antagonists/wraith/objs/machinery/vortex_wraith.dm
+++ b/code/modules/antagonists/wraith/objs/machinery/vortex_wraith.dm
@@ -15,7 +15,7 @@
 	var/total_mob_value = 0	//Total point value of all linked mobs
 	var/obj/mob_type = null
 	var/random_mode = true
-	var/mob/wraith/master = null
+	var/mob/living/intangible/wraith/master = null
 	var/datum/light/light
 	var/datum/light/portal_light
 	var/list/obj/critter/default_mobs = list(/obj/critter/crunched,	//Useful for random mode or when we dont have a mob_type on spawn

--- a/code/modules/antagonists/wraith/status_system/wraithEffects.dm
+++ b/code/modules/antagonists/wraith/status_system/wraithEffects.dm
@@ -276,8 +276,8 @@
 	onAdd(optional) // optional = forced to manifest
 		. = ..()
 		var/mob/M = owner
-		if (istype(M, /mob/wraith))
-			var/mob/wraith/W = M
+		if (istype(M, /mob/living/intangible/wraith))
+			var/mob/living/intangible/wraith/W = M
 			if(optional)
 				M.addOverlayComposition(/datum/overlayComposition/insanity_light)
 				M.updateOverlaysClient(M.client)
@@ -285,9 +285,9 @@
 			else
 				W.haunting = TRUE
 				W.flags &= !UNCRUSHABLE
-			if (!istype_exact(M, /mob/wraith/poltergeist))
+			if (!istype_exact(M, /mob/living/intangible/wraith/poltergeist))
 				M.alpha = 255
-		if (istype_exact(M, /mob/wraith/poltergeist))
+		if (istype_exact(M, /mob/living/intangible/wraith/poltergeist))
 			M.icon_state = "poltergeist-corp"
 			M.update_body()
 		M.set_density(TRUE)
@@ -297,14 +297,14 @@
 
 	onRemove()
 		var/mob/M = owner
-		if (istype(M, /mob/wraith))
-			var/mob/wraith/W = M
+		if (istype(M, /mob/living/intangible/wraith))
+			var/mob/living/intangible/wraith/W = M
 			W.forced_manifest = FALSE
 			W.haunting = FALSE
 			W.flags |= UNCRUSHABLE
-			if (!istype_exact(M, /mob/wraith/poltergeist))
+			if (!istype_exact(M, /mob/living/intangible/wraith/poltergeist))
 				M.alpha = 160
-		if (istype_exact(M, /mob/wraith/poltergeist))
+		if (istype_exact(M, /mob/living/intangible/wraith/poltergeist))
 			M.icon_state = "poltergeist"
 			M.update_body()
 		M.visible_message(pick("<span class='alert'>[M] vanishes!</span>", "<span class='alert'>The [M] dissolves into shadow!</span>"), pick("<span class='notice'>The ectoplasm around you dissipates!</span>", "<span class='notice'>You fade into the aether!</span>"))

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -54,7 +54,7 @@
 				return
 
 			src.antagonist_type = pick(list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Flockmind"))
-			for(var/mob/wraith/W in ticker.mode.traitors)
+			for(var/mob/living/intangible/wraith/W in ticker.mode.traitors)
 				if(W.deaths < 2)
 					src.antagonist_type -= list("Wraith")
 					src.antagonist_type = pick(list())
@@ -224,7 +224,7 @@
 						failed = 1
 
 				if ("Wraith")
-					var/mob/wraith/W = M3.make_wraith()
+					var/mob/living/intangible/wraith/W = M3.make_wraith()
 					if (W && istype(W))
 						M3 = W
 						role = ROLE_WRAITH

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -434,7 +434,7 @@
 
 					H.full_heal()
 					if (!H.ckey && H.last_client && !H.last_client.mob.mind.dnr)
-						if ((!istype(H.last_client.mob,/mob/living) && !istype(H.last_client.mob,/mob/wraith)) || inafterlifebar(H.last_client.mob))
+						if ((!istype(H.last_client.mob,/mob/living) && !istype(H.last_client.mob,/mob/living/intangible/wraith)) || inafterlifebar(H.last_client.mob))
 							H.ckey = H.last_client.ckey
 					if (istype(H.abilityHolder, /datum/abilityHolder/composite))
 						var/datum/abilityHolder/composite/Comp = H.abilityHolder

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -334,7 +334,7 @@
 
 	Entered(var/atom/movable/AM)
 		. = ..()
-		if (istype(AM,/mob/dead) || istype(AM,/mob/wraith) || istype(AM,/mob/living/intangible) || istype(AM, /obj/lattice) || istype(AM, /obj/cable/reinforced) || istype(AM,/obj/torpedo_targeter) || istype(AM,/obj/overlay) || istype (AM, /obj/arrival_missile) || istype(AM, /obj/sea_ladder_deployed))
+		if (istype(AM,/mob/dead) || istype(AM,/mob/living/intangible) || istype(AM, /obj/lattice) || istype(AM, /obj/cable/reinforced) || istype(AM,/obj/torpedo_targeter) || istype(AM,/obj/overlay) || istype (AM, /obj/arrival_missile) || istype(AM, /obj/sea_ladder_deployed))
 			return
 		if (locate(/obj/lattice) in src)
 			return
@@ -522,7 +522,7 @@
 		return
 
 	Entered(atom/movable/A as mob|obj)
-		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/wraith) || istype(A, /mob/living/intangible))
+		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/living/intangible/wraith) || istype(A, /mob/living/intangible))
 			return ..()
 		var/turf/T = pick_landmark(LANDMARK_FALL_SEA)
 		if (isturf(T))

--- a/code/modules/interface/multiContext/context_layouts.dm
+++ b/code/modules/interface/multiContext/context_layouts.dm
@@ -21,8 +21,8 @@ var/list/datum/contextAction/globalContextActions = null
 		var/mob/living/critter/R = target
 		R.hud.add_screen(C)
 
-	else if(istype(target, /mob/wraith))
-		var/mob/wraith/W = target
+	else if(istype(target, /mob/living/intangible/wraith))
+		var/mob/living/intangible/wraith/W = target
 		W.hud.add_screen(C)
 
 	else if (isrobot(target))

--- a/code/modules/interface/multiContext/multiContext.dm
+++ b/code/modules/interface/multiContext/multiContext.dm
@@ -67,7 +67,7 @@
 			R.hud.remove_screen(C)
 
 		else if(iswraith(src))
-			var/mob/wraith/W = src
+			var/mob/living/intangible/wraith/W = src
 			W.hud.remove_screen(C)
 
 		else if(istype(src, /mob/dead/observer))
@@ -219,7 +219,7 @@
 			mcrit.hud.remove_screen(src)
 
 		else if(iswraith(user))
-			var/mob/wraith/wraith = user
+			var/mob/living/intangible/wraith/wraith = user
 			wraith.hud.remove_screen(src)
 
 		else if (isrobot(user))

--- a/code/modules/projectiles/ectoblaster.dm
+++ b/code/modules/projectiles/ectoblaster.dm
@@ -24,8 +24,8 @@
 	hits_wraiths = 1
 
 	on_hit(atom/hit)
-		if(istype(hit, /mob/wraith))
-			var/mob/wraith/W = hit
+		if(istype(hit, /mob/living/intangible/wraith))
+			var/mob/living/intangible/wraith/W = hit
 			W.changeStatus("corporeal", 1.5 SECONDS, TRUE)
 			W.TakeDamage(null, 0, src.power)
 		// kyle TODO: add Spooktober stuff, sucking energy from ghosts or something

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -673,7 +673,7 @@
 /obj/item/proc/click_drag_tk(atom/over_object, src_location, over_location, over_control, params)
 	if(!src.anchored)
 		if (iswraith(usr))
-			var/mob/wraith/W = usr
+			var/mob/living/intangible/wraith/W = usr
 			//Basically so poltergeists need to be close to an object to send it flying far...
 			if (W.weak_tk && !IN_RANGE(src, W, 2))
 				src.throw_at(over_object, 1, 1)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -736,7 +736,7 @@ proc/get_ouija_word_list(var/atom/movable/source = null, var/words_min = 5, var/
 					words |= (M.real_name ? M.real_name : M.name)
 			if (1 to 5)
 				// fake wraith
-				words |= call(/mob/wraith/proc/make_name)()
+				words |= call(/mob/living/intangible/wraith/proc/make_name)()
 			if (6 to 10)
 				// fake blob (heh)
 				var/blobname = phrase_log.random_phrase("name-blob")

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -664,7 +664,7 @@ proc/get_angle(atom/a, atom/b)
 		if(C.client)
 			. += C
 		LAGCHECK(LAG_REALTIME)
-	for(var/mob/wraith/M in mobs)
+	for(var/mob/living/intangible/wraith/M in mobs)
 		. += M
 		LAGCHECK(LAG_REALTIME)
 	for(var/mob/living/intangible/blob_overmind/M in mobs)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2295,7 +2295,7 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 			icon_state = "deeps"
 
 			Entered(atom/A as mob|obj)
-				if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/wraith) || istype(A, /mob/living/intangible))
+				if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/living/intangible))
 					return ..()
 
 				var/turf/T = pick_landmark(LANDMARK_FALL_DEEP)

--- a/code/z_adventurezones/icemoon.dm
+++ b/code/z_adventurezones/icemoon.dm
@@ -22,7 +22,7 @@ Contents:
 		return
 
 	Entered(atom/movable/A as mob|obj)
-		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/wraith) || istype(A, /mob/living/intangible))
+		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/living/intangible))
 			return ..()
 		var/turf/T = pick_landmark(LANDMARK_FALL_ICE_ELE)
 		if (isturf(T))

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -116,7 +116,7 @@ Contents:
 
 
 	Entered(atom/A as mob|obj)
-		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/wraith) || istype(A, /mob/living/intangible))
+		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/living/intangible))
 			return ..()
 
 		var/turf/T = pick_landmark(isHemera ? LANDMARK_FALL_MOON_HEMERA : LANDMARK_FALL_MOON_MUSEUM)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns wraith from a neither living nor dead /mob/wraith into a /mob/living/intangible/wraith, similar to the AI eye.
This should improve code maintainability as well as fix a plethora of bugs linked to it's unique status.
Bugs this fixes:
- Spectator side bugs where the wraith would appear invisible and couldnt be spectated.
- Gives a larger message to harbinger's summons to signify they can evolve, and also states to those who pick skeleton commander how to use the hallberd.
- Changes point boosting zones to give a flat +2 bonus to point generation instead of doubling haunting points.
- Makes wraith vulnerable to explosions. For some reason ex_act() was just a return. Making wraiths vulnerable to explosions when manifested made sense.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes jank. Improves maintanability and readability.