### PR TITLE
Balances plague of death and creeping dread

### DIFF
--- a/code/modules/antagonists/wraith/bioEffects/curses.dm
+++ b/code/modules/antagonists/wraith/bioEffects/curses.dm
@@ -170,6 +170,7 @@
 	can_copy = 0
 	isBad = 1
 	occur_in_genepools = 0
+	scanner_visibility = 0
 	acceptable_in_mutini = 0
 	probability = 0
 	curable_by_mutadone = 0

--- a/code/modules/antagonists/wraith/bioEffects/curses.dm
+++ b/code/modules/antagonists/wraith/bioEffects/curses.dm
@@ -57,7 +57,7 @@
 
 	OnAdd()
 		. = ..()
-		curse_icon = image('icons/mob/wraith_ui.dmi', owner, icon_state = "blood_status")
+		curse_icon = image('icons/mob/wraith_ui.dmi', owner, icon_state = "blind_status")
 		curse_icon.blend_mode = BLEND_ADD
 		curse_icon.plane = PLANE_ABOVE_LIGHTING
 		curse_icon.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
@@ -160,3 +160,16 @@
 			owner.bioHolder.RemoveEffect("stinky")
 		get_image_group(CLIENT_IMAGE_GROUP_CURSES).remove_image(curse_icon)
 		. = ..()
+
+//Used mostly to track if someone got rid of this curse in the meantime
+/datum/bioEffect/death_curse
+	name = "Curse of death"
+	desc = "Curse of death."
+	id = "death_curse"
+	effectType = EFFECT_TYPE_DISABILITY
+	can_copy = 0
+	isBad = 1
+	occur_in_genepools = 0
+	acceptable_in_mutini = 0
+	probability = 0
+	curable_by_mutadone = 0

--- a/code/modules/antagonists/wraith/status_system/wraithEffects.dm
+++ b/code/modules/antagonists/wraith/status_system/wraithEffects.dm
@@ -4,7 +4,7 @@
 	desc = "The dark is trying to get you! Stay in the light!"
 	icon_state = "dread1"
 	unique = 1
-	duration = 20 SECONDS
+	duration = 30 SECONDS
 	maxDuration = 3 MINUTES
 	var/mob/living/carbon/human/H
 
@@ -38,7 +38,7 @@
 					if (5)
 						H.emote("twitch_v")
 						boutput(H, pick("<span class='alert'>You feel something crawling on your back<span class='alert'>", "<span class='alert'>Something just crawled up your leg!</span>"))
-		if ((duration > 30 SECONDS) && (duration < 60 SECONDS))
+		if ((duration > 30 SECONDS) && (duration < 45 SECONDS))
 			if(icon_state != "dread2")
 				icon_state = "dread2"
 			if(probmult(9))
@@ -52,10 +52,9 @@
 					if (3)
 						H.setStatus("stunned", 2 SECONDS)
 						H.visible_message("<span class='alert'>[H] flails around wildly, trying to get some invisible things off [himself_or_herself(H)].</span>", "<span class='alert'>You flail around wildly trying to defend yourself from the shadows!</span>")
-		if ((duration >= 60 SECONDS) && (duration < 90 SECONDS))
+		if ((duration >= 45 SECONDS) && (duration < 70 SECONDS))
 			SPAWN(1 SECOND)
 				H.playsound_local(H, "sound/effects/heartbeat.ogg", 50)
-			H.make_jittery(30)
 			H.setStatus("terror", 30 SECONDS)
 			if(icon_state != "dread3")
 				icon_state = "dread3"
@@ -75,10 +74,9 @@
 						random_brute_damage(H, 3)
 						H.playsound_local(H, "sound/impact_sounds/Flesh_Tear_[pick("1", "2", "3")].ogg", 70)
 						boutput(H, pick("<span class='alert'>SOMETHING BIT YOU, HOLY SHIT!!!</span>"))
-		if ((duration >= 90 SECONDS) && (duration < 130 SECONDS))
+		if ((duration >= 70 SECONDS) && (duration < 100 SECONDS))
 			SPAWN(5 DECI SECONDS)
 				H.playsound_local(H, "sound/effects/heartbeat.ogg", 70)
-			H.make_jittery(30)
 			H.setStatus("terror", 30 SECONDS)
 			if(icon_state != "dread4")
 				icon_state = "dread4"
@@ -96,7 +94,7 @@
 					if (4)
 						H.contract_disease(/datum/ailment/malady/heartfailure,null,null,1)	//Bad luck
 						H.visible_message("<span class='alert'>[H] suddenly clutches their chest with a terrified expression</span>", "<span class='alert'>Your heart is beating out of your chest! You feel like death!</span>")
-		if ((duration >= 130 SECONDS))
+		if ((duration >= 100 SECONDS))
 			H.contract_disease(/datum/ailment/malady/heartfailure,null,null,1)
 			H.contract_disease(/datum/ailment/malady/flatline,null,null,1)
 			H.visible_message("<span class='alert'>[H]'s face goes blank as they start to collapse to the ground</span>", "<span class='alert'>Your nerves can't take it any longer! Your heart is giving up on you!</span>")

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -847,11 +847,12 @@ datum
 						else
 							if (ishuman(M))
 								var/mob/living/carbon/human/H = M
-								if(H.bioHolder?.HasEffect("blood_curse") || H.bioHolder?.HasEffect("blind_curse") || H.bioHolder?.HasEffect("weak_curse") || H.bioHolder?.HasEffect("rot_curse"))
+								if(H.bioHolder?.HasEffect("blood_curse") || H.bioHolder?.HasEffect("blind_curse") || H.bioHolder?.HasEffect("weak_curse") || H.bioHolder?.HasEffect("rot_curse") || H.bioHolder?.HasEffect("death_curse"))
 									H.bioHolder.RemoveEffect("blood_curse")
 									H.bioHolder.RemoveEffect("blind_curse")
 									H.bioHolder.RemoveEffect("weak_curse")
 									H.bioHolder.RemoveEffect("rot_curse")
+									H.bioHolder.RemoveEffect("death_curse")
 									H.visible_message("[H] screams as some black smoke exits their body.")
 									H.emote("scream")
 									random_burn_damage(H, 5)

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -48,11 +48,12 @@ var/global/list/bible_contents = list()
 				//Wraith curses
 				if(prob(75) && ishuman(H))
 					var/mob/living/carbon/human/target = H
-					if(target.bioHolder?.HasEffect("blood_curse") || target.bioHolder?.HasEffect("blind_curse") || target.bioHolder?.HasEffect("weak_curse") || target.bioHolder?.HasEffect("rot_curse"))
+					if(target.bioHolder?.HasEffect("blood_curse") || target.bioHolder?.HasEffect("blind_curse") || target.bioHolder?.HasEffect("weak_curse") || target.bioHolder?.HasEffect("rot_curse") || target.bioHolder?.HasEffect("death_curse"))
 						target.bioHolder.RemoveEffect("blood_curse")
 						target.bioHolder.RemoveEffect("blind_curse")
 						target.bioHolder.RemoveEffect("weak_curse")
 						target.bioHolder.RemoveEffect("rot_curse")
+						target.bioHolder.RemoveEffect("death_curse")
 						target.visible_message("[target] screams as some black smoke exits their body.")
 						target.emote("scream")
 						var/turf/T = get_turf(target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The plaguebringer wraith's curse of death was a little overtuned. Once it was cast, the person was doomed to get gibbed a few seconds later with no alternatives. Now, the curse instead does escalating damage that ends in a gib if the target dies at any point. Additionally, the curse may also be cancelled entirely in the same way as other curses: Holy water or a chaplain's bible beating.

The trickster wraith's creeping dread ability is too slow to do much of anything in it's current state. It now escalates faster and starts a tiny bit more advanced. If this isn't enough i can consider bigger buffs in the future.

Also fixes a bug where the blindness curse overlay wasnt properly attached to a person.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Curse of death is a tad overtuned. Counterplay should be possible.
Creeping dread is kinda bad. This should help it a bit.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(*)Plaguebringer's curse of death can now be cancelled by holy water or a chaplain's bible beatings, like other curses. Trickster's creeping dread is faster.
```
