### PR TITLE
remove (random) nosepick emote

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -157,7 +157,7 @@
 	var/special_hair_override = 0 // only really works if they have any special hair
 
 	random_emotes = list("drool", "blink", "yawn", "burp", "twitch", "twitch_v",\
-	"cough", "sneeze", "shiver", "shudder", "shake", "hiccup", "sigh", "flinch", "blink_r", "nosepick")
+	"cough", "sneeze", "shiver", "shudder", "shake", "hiccup", "sigh", "flinch", "blink_r")
 
 	var/icon/flat_icon = null
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes picknose from the random_emotes list, doesn't remove it as an emote though


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kind of an odd one out compared to the rest of the random emotes, also very intrusive when you're mid rp with someone and get hit with the "(name) picks their nose" right above your head
