### PR TITLE
Fixes wraith being stuck in the wrong Z levels

### DIFF
--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -349,7 +349,7 @@
 		if(!isturf(src.loc)) src.set_loc(get_turf(src))
 
 		if (NewLoc)
-			if (isghostrestrictedz(NewLoc.z) && !restricted_z_allowed(src, NewLoc) && !(src.client && src.client.holder))
+			if ((isghostrestrictedz(NewLoc.z) || ((NewLoc.z != Z_LEVEL_STATION) && (NewLoc.z != Z_LEVEL_ADVENTURE) && (NewLoc.z != 7))) && !restricted_z_allowed(src, NewLoc) && !(src.client && src.client.holder))
 				var/OS = pick_landmark(LANDMARK_OBSERVER, locate(1, 1, 1))
 				if (OS)
 					src.set_loc(OS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a wraith somehow gets thrown out of the station, say while possessing a revenant or as a trickster puppet, they'd be stuck in the mining level with no way out. Now, if they try to move when in a Z level that isn't the station, the adventure zones (for centcom) or the shuttle transit zone (Z7) and they dont have Z level restrictions off, they are booted back to the station.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes an oversight that is potentially game ruining.
fixes #10811