### PR TITLE
Fix cheesewheel recipe only needing a single cheese

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -1831,9 +1831,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 
 /datum/cookingrecipe/cheesewheel
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	amt1 = 4
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cheesewheel
 

--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -837,7 +837,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 /datum/cookingrecipe/eggtoast
 	item1 = /obj/item/reagent_containers/food/snacks/breadslice
 	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	amt2 = 2
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastegg
 
@@ -1080,9 +1080,9 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 
 /datum/cookingrecipe/onionchips
 	item1 = /obj/item/reagent_containers/food/snacks/onion_slice
-	item2 = /obj/item/reagent_containers/food/snacks/onion_slice
-	item3 = /obj/item/reagent_containers/food/snacks/plant/garlic
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	amt1 = 2
+	item2 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/onionchips
 
@@ -1738,8 +1738,8 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 /datum/cookingrecipe/sushi_roll
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish
 	item2 = /obj/item/reagent_containers/food/snacks/rice_ball
-	item3 = /obj/item/reagent_containers/food/snacks/rice_ball
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
+	amt2 = 2
+	item3 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
 	cookbonus = 2
 	output = /obj/item/reagent_containers/food/snacks/sushi_roll
 
@@ -1831,7 +1831,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 
 /datum/cookingrecipe/cheesewheel
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	amt1 = 4
+	amt1 = 2
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cheesewheel
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes only needing a single cheese to make a cheesewheel


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes: #11887
Fixes: #10598

