### PR TITLE
Fixes flamethrowers damaging fireproof blob membranes

### DIFF
--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -274,6 +274,8 @@
 			if(D_SLASHING)
 				damage_mult = 1.5
 				damtype = "brute"
+			if(D_SPECIAL) //I don't think there's any special bullets that should affect blobs
+				return
 
 		src.take_damage(damage,damage_mult,damtype)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes blob membranes ignore damage from `D_SPECIAL` sources, since none of them seem like the kind of thing that should damage a blob (stuns, vuvuzela etc.) and it was causing flamethrowers to deal brute damage to blob membranes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently a full auto flamethrower can destroy a "fireproof" blob membrane almost instantly. This seems unintentional.
