### PR TITLE
Effect of hygiene_value now scales with chemprot

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -164,7 +164,7 @@ datum
 						var/mob/living/carbon/human/H = M
 						if (H.sims)
 							if ((hygiene_value > 0 && !(H.wear_suit || H.w_uniform)) || hygiene_value < 0)
-								if(H.get_chem_protection())
+								if(H.get_chem_protection() && hygiene_value < 0)
 									modifier = (max(0, (1 - H.get_chem_protection()/100 )))
 								H.sims.affectMotive("Hygiene", volume * hygiene_value * modifier)
 

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -160,10 +160,13 @@ datum
 							M.reagents.add_reagent(self.id,volume*touch_modifier,self.data)
 							did_not_react = 0
 					if (ishuman(M) && hygiene_value && method == TOUCH)
+						var/modifier = 1
 						var/mob/living/carbon/human/H = M
 						if (H.sims)
 							if ((hygiene_value > 0 && !(H.wear_suit || H.w_uniform)) || hygiene_value < 0)
-								H.sims.affectMotive("Hygiene", volume * hygiene_value)
+								if(H.get_chem_protection())
+									modifier = (max(0, (1 - H.get_chem_protection()/100 )))
+								H.sims.affectMotive("Hygiene", volume * hygiene_value * modifier)
 
 				if(INGEST)
 					var/datum/ailment_data/addiction/AD = M.addicted_to_reagent(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The amount chemicals with negative hygiene_value drain hygiene now scales with how much chemprot someone has. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This makes sense and this gives jobs which are expected to deal with lots of filth (like doctors) natural resistance to the hygiene draining of things like blood. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)The hygiene draining of chems now scales with how much chemprot someone has
```
