### PR TITLE
Increases sinks cleaning amount from 2 to 5

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -70,7 +70,7 @@
 			else
 				user.visible_message("<span class='notice'>[user] washes [his_or_her(user)] hands.</span>")
 				if (H.sims)
-					H.sims.affectMotive("Hygiene", 2)
+					H.sims.affectMotive("Hygiene", 5)
 				H.blood_DNA = null // Don't want to use it here, though. The sink isn't a shower (Convair880).
 				H.blood_type = null
 				H.set_clothing_icon_dirty()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sinks now clean 5 hygiene per click instead of 2


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having to click a sink 50 times just isnt good gameplay, making it take 20 times I think is a good middle ground between discouraging (as you still want showers to be the better option), but not frustrating. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)Sinks now increase hygiene better
```
