### PR TITLE
Move vehicle restrictions to vehicles

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -665,7 +665,7 @@
 		src.health -= 50
 		checkhealth()
 
-	Move(turf/NewLoc,Dir=0,step_x=0,step_y=0)
+	Move(turf/NewLoc, Dir=0, step_x=0, step_y=0)
 		// set return value to default
 		if(NewLoc.allows_vehicles || src.ignore_turf_restrictions)
 			.= ..(NewLoc,Dir,step_x,step_y)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -48,6 +48,8 @@
 	var/view_offset_x = 0
 	var/view_offset_y = 0
 	var/datum/movement_controller/movement_controller
+	/// Whether the pod can ignore [/turf/var/allows_vehicles].
+	var/ignore_turf_restrictions = FALSE
 
 	var/req_smash_velocity = 9 //7 is the 'normal' cap right now
 	var/hitmob = 0
@@ -663,9 +665,13 @@
 		src.health -= 50
 		checkhealth()
 
-	Move(NewLoc,Dir=0,step_x=0,step_y=0)
+	Move(turf/NewLoc,Dir=0,step_x=0,step_y=0)
 		// set return value to default
-		.=..(NewLoc,Dir,step_x,step_y)
+		if(NewLoc.allows_vehicles || src.ignore_turf_restrictions)
+			.= ..(NewLoc,Dir,step_x,step_y)
+		else
+			src.Bump(NewLoc) // to avoid implementing Cross() on all station turfs, we do it ourselves.
+			. = FALSE
 
 		if (movement_controller)
 			movement_controller.update_owner_dir()
@@ -1686,7 +1692,8 @@
 	icon_state = "minisub_body"
 	var/body_type = "minisub"
 	var/obj/item/shipcomponent/locomotion/locomotion = null //wheels treads hovermagnets etc
-	uses_weapon_overlays = 0
+	ignore_turf_restrictions = TRUE
+	uses_weapon_overlays = FALSE
 	health = 100
 	maxhealth = 100
 	speed = 0 // speed literally does nothing? what??

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1620,29 +1620,6 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 	else
 		boutput(user, "Your attack bounces off the foamed metal floor.")
 
-/turf/simulated/floor/Cross(atom/movable/mover)
-	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
-		if (!( locate(/obj/machinery/mass_driver, src) ))
-			var/obj/machinery/vehicle/O = mover
-			if (istype(O?.sec_system, /obj/item/shipcomponent/secondary_system/crash)) //For ships crashing with the SEED
-				var/obj/item/shipcomponent/secondary_system/crash/I = O.sec_system
-				if (I.crashable)
-					mover.Bump(src)
-					return TRUE
-			return FALSE
-	return ..()
-
-/turf/simulated/shuttle/Cross(atom/movable/mover)
-	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
-		return 0
-	return ..()
-
-/turf/unsimulated/floor/Cross(atom/movable/mover)
-	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
-		if (!( locate(/obj/machinery/mass_driver, src) ))
-			return 0
-	return ..()
-
 /turf/simulated/floor/burn_down()
 	if (src.intact)
 		src.ex_act(2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[INTERNAL][CLEAN][PERF]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the `allows_vehicles` check from `/turf/[un]simulated/floor` to `/obj/machinery/vehicle`.
Does not affect the SEED, for some reason. That code is really weird and cursed and it deserves to die.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Removes the need for a custom `Cross` on the most crossed thing in the entire fucking game.
![image](https://user-images.githubusercontent.com/65367576/200969811-d3da4e50-d064-4380-afc1-4436a1298ec2.png)
