### PR TITLE
Flock: Add double-click control shortcut to drones

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -419,6 +419,16 @@
 	else
 		return ..()
 
+/mob/living/critter/flock/drone/DblClick(location, control, params)
+	. = ..()
+	var/mob/living/intangible/flock/F = usr
+	if(istype(F) && F.flock && F.flock == src.flock)
+		var/datum/abilityHolder/flockmind/holder = F.abilityHolder
+		if(holder?.drone_controller.drone == src) //if click behaviour has highlighted this drone for control
+			holder.drone_controller.cast(src) //deselect it
+			F.targeting_ability = null
+		src.take_control(usr)
+
 /mob/living/critter/flock/drone/MouseDrop_T(mob/living/target, mob/user)
 	if(!target || !user)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As flockmind/trace you can double-click a drone to quickly take control of it as an alternative to click-dragging yourself onto the drone.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New control scheme made my flow .01% slower 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)As flockmind/flocktrace, you can now double-click a drone to take control of it.
```
