### PR TITLE
Adds a `use_ai_toggle` var

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -220,6 +220,8 @@
 	var/ai_type = null
 	/// AI controller for this mob - only active if is_npc is TRUE, in which case it's called by the mobAI loop at a frequency depending on mob flags
 	var/datum/aiHolder/ai = null
+	///Do we add the special "Toggle AI" ability to this mob?
+	var/use_ai_toggle = TRUE
 	/// used for load balancing mob_ai ticks
 	var/ai_tick_schedule = null
 

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -159,7 +159,7 @@
 	ai_attacked = 0
 
 	if(abilityHolder)
-		if(!abilityHolder.getAbility(/datum/targetable/ai_toggle))
+		if(src.use_ai_toggle && !abilityHolder.getAbility(/datum/targetable/ai_toggle))
 			abilityHolder.addAbility(/datum/targetable/ai_toggle)
 
 /mob/living/carbon/human/proc/ai_stop()

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -39,7 +39,7 @@ var/list/ai_move_scheduled = list()
 			LAZYLISTADDUNIQUE(AR.mobs_not_in_global_mobs_list, M)
 
 		if(owner?.abilityHolder)
-			if(!owner.abilityHolder.getAbility(/datum/targetable/ai_toggle))
+			if(src.owner.use_ai_toggle && !owner.abilityHolder.getAbility(/datum/targetable/ai_toggle))
 				owner.abilityHolder.addAbility(/datum/targetable/ai_toggle)
 
 	disposing()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -18,6 +18,7 @@
 	health_brute = 30
 	health_burn = 30
 	repair_per_resource = 2
+	use_ai_toggle = FALSE
 
 	var/damaged = 0 // used for state management for description showing, as well as preventing drones from screaming about being hit
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a `use_ai_toggle` var to mob that determines whether the "Toggle AI" ability gets added to it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Atomized from #11796, since that PR exposed the issue with flockdrones being given the ability.