### PR TITLE
Adds a new terrainify option to fill space with plasma

### DIFF
--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -546,6 +546,22 @@ ABSTRACT_TYPE(/datum/terrainify)
 			message_admins("[key_name(ui.user)] turned space into a snowscape.")
 
 
+/datum/terrainify/plasma
+	name = "Plasma Station"
+	desc = "Fill space with plasma gas? Warning: this is as bad as it sounds."
+
+	convert_turfs(list/turfs)
+		for (var/turf/T in turfs)
+			T.ReplaceWith(/turf/space/plasma, keep_old_material=FALSE, handle_dir=FALSE, force=TRUE)
+
+	convert_station_level(params, datum/tgui/ui)
+		if (!..())
+			return
+		var/list/turf/space = list()
+		for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
+			space += S
+		convert_turfs(space)
+
 /datum/terrainify_editor
 	var/static/list/datum/terrainify/terrains
 	var/datum/terrainify/active_terrain

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -222,6 +222,18 @@
 	asteroid
 		icon_state = "aplaceholder"
 
+	plasma
+		temperature = T20C
+		toxins = ONE_ATMOSPHERE/3
+		New()
+			..()
+			var/obj/overlay/tile_gas_effect/gas_icon_overlay = new
+			gas_icon_overlay.icon = 'icons/effects/tile_effects.dmi'
+			gas_icon_overlay.icon_state = "plasma-alpha"
+			gas_icon_overlay.dir = pick(cardinal)
+			gas_icon_overlay.alpha = 100
+			gas_icon_overlay.set_loc(src)
+
 /turf/space/no_replace
 
 /turf/space/New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [EXPERIMENTAL] [ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an option to terrainify which fills every space tile with 1/3 atmospheric pressure room temperature plasma.
![image](https://user-images.githubusercontent.com/20713227/201366100-5af76349-cc42-45fb-ac3a-8ec45b7400fd.png)
![image](https://user-images.githubusercontent.com/20713227/201366255-b6a93fc4-d817-4429-bb1c-a241ad42d5ec.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't really know why this is needed but I believe very strongly that it is.
