### PR TITLE
Nadir Fixbatch 8

### DIFF
--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -5,6 +5,10 @@
 	name = "siphon shaft wall"
 	},
 /area/noGenerate)
+"at" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/plating,
+/area/diner/kitchen)
 "aL" = (
 /turf/unsimulated/wall/setpieces/leadwall{
 	dir = 4;
@@ -467,6 +471,11 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
+"qS" = (
+/obj/machinery/vending/alcohol,
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/plating,
+/area/diner/kitchen)
 "qX" = (
 /turf/unsimulated/wall/setpieces/leadwall,
 /area/shuttle/sea_elevator)
@@ -523,7 +532,7 @@
 /area/skeleton_trader)
 "ta" = (
 /turf/variableTurf/wall,
-/area/space)
+/area/noGenerate)
 "tk" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/engine/caution/west,
@@ -884,6 +893,7 @@
 	icon_state = "cobweb2"
 	},
 /obj/storage/secure/closet/civilian/kitchen,
+/obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "Fw" = (
@@ -1194,6 +1204,7 @@
 	icon_state = "gib2"
 	},
 /obj/machinery/light/incandescent/small,
+/obj/decal/cleanable/dirt/dirt4,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "Rm" = (
@@ -1207,7 +1218,7 @@
 	name = "The Recluse"
 	})
 "Rv" = (
-/obj/machinery/vending/alcohol,
+/obj/submachine/foodprocessor,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "RH" = (
@@ -1230,6 +1241,7 @@
 /area/skeleton_trader)
 "Sm" = (
 /obj/machinery/light/incandescent/small,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/scorched,
 /area/diner/bathroom)
 "Sp" = (
@@ -1573,7 +1585,6 @@
 	name = "Space Diner Backhall"
 	})
 "Zz" = (
-/obj/decal/cleanable/dirt,
 /obj/reagent_dispensers/still,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
@@ -3005,7 +3016,7 @@ Vf
 Vf
 hk
 uP
-XP
+Nl
 XP
 nw
 nw
@@ -3048,7 +3059,7 @@ WK
 Vf
 Uw
 LU
-XP
+Nl
 Wr
 Wr
 Wr
@@ -3091,7 +3102,7 @@ Tx
 IQ
 Oz
 uP
-XP
+Nl
 Wr
 dh
 Wr
@@ -3342,7 +3353,7 @@ Fw
 xe
 YV
 YS
-YS
+at
 Ug
 WZ
 Ug
@@ -3382,7 +3393,7 @@ nw
 nw
 nw
 Fw
-Fw
+qS
 Fs
 Zz
 Rv
@@ -3424,7 +3435,7 @@ nw
 nw
 nw
 nw
-nw
+Fw
 Fw
 Fw
 Xi

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -167,6 +167,7 @@
 	dir = 1;
 	icon_state = "line4"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blackwhite,
 /area/station/medical/morgue)
 "adk" = (
@@ -1242,6 +1243,10 @@
 "aAD" = (
 /obj/table/reinforced/auto,
 /obj/machinery/coffeemaker/medbay,
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_x = -15;
+	pixel_y = 5
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
 "aAN" = (
@@ -1287,13 +1292,15 @@
 	pixel_y = 24;
 	req_access_txt = "19"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/stool/chair/office/blue{
 	dir = 8
 	},
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0;
+	dir = 8;
+	layer = 5
+	},
+/obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
 "aCb" = (
@@ -2479,12 +2486,12 @@
 	name = "Genetic Research"
 	})
 "bjU" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
 /obj/machinery/disposal/mail/autoname/qm,
 /obj/disposalpipe/trunk/mail/west,
+/obj/noticeboard/persistent{
+	name = "Cargo persistent notice board";
+	persistent_id = "cargo"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -3092,6 +3099,11 @@
 /area/station/maintenance/inner/south)
 "bvt" = (
 /obj/machinery/computer/siphon_db,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 12
+	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
 	name = "Extraction Nexus"
@@ -3837,7 +3849,8 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "pasibelt";
-	name = "Pasiphae disposal belt"
+	name = "Pasiphae disposal belt";
+	operating = 1
 	},
 /obj/machinery/door/poddoor/pyro{
 	autoclose = 1;
@@ -4843,9 +4856,6 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"cnL" = (
-/turf/space/fluid/acid/clear,
-/area/station/hallway/secondary/exit)
 "cnT" = (
 /obj/item/item_box/swedish_bag{
 	icon_state = "swedishfisk-open";
@@ -7740,7 +7750,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
+	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Rods decay at a diminishing rate;<br>corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
 	name = "printed card";
 	pixel_y = 6
 	},
@@ -7833,6 +7843,12 @@
 	dir = 4
 	},
 /area/station/engine/elect)
+"dLd" = (
+/obj/item/device/radio/intercom/AI{
+	dir = 8
+	},
+/turf/simulated/floor/darkblue/checker,
+/area/station/turret_protected/ai)
 "dLj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9049,7 +9065,7 @@
 	name = "Secure Release Foyer"
 	})
 "erF" = (
-/obj/storage/secure/closet/research/uniform,
+/obj/storage/closet/biohazard,
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -11842,6 +11858,11 @@
 	pixel_x = -2;
 	pixel_y = 9
 	},
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0;
+	dir = 8;
+	layer = 5
+	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
 "fKl" = (
@@ -13161,7 +13182,8 @@
 /obj/machinery/conveyor{
 	id = "pasibelt";
 	name = "Pasiphae disposal belt";
-	dir = 1
+	dir = 1;
+	operating = 1
 	},
 /turf/simulated/floor/plating,
 /area/pasiphae/maint)
@@ -17710,6 +17732,10 @@
 	dir = 8
 	},
 /area/station/engine/engineering)
+"ijC" = (
+/obj/disposalpipe/junction/left/south,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "ijH" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -18849,6 +18875,10 @@
 /obj/drink_rack/mug{
 	pixel_y = 32
 	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = 7;
+	pixel_x = -15
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -19057,6 +19087,10 @@
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-10"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
@@ -20145,6 +20179,10 @@
 	dir = 8
 	},
 /area/station/medical/medbay/lobby)
+"jrx" = (
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "jrG" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler{
@@ -21863,6 +21901,11 @@
 /obj/submachine/foodprocessor,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"kgH" = (
+/obj/machinery/light/small/floor/netural,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "khg" = (
 /obj/rack,
 /obj/item/sponge,
@@ -22376,8 +22419,10 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "pasibelt";
-	name = "Pasiphae disposal belt"
+	name = "Pasiphae disposal belt";
+	operating = 1
 	},
+/obj/machinery/crusher,
 /turf/simulated/floor/plating,
 /area/pasiphae/maint)
 "krU" = (
@@ -25095,7 +25140,7 @@
 	name = "Extraction Nexus"
 	})
 "lBz" = (
-/obj/rack,
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/blueblack/corner{
 	dir = 4
 	},
@@ -26745,12 +26790,6 @@
 	pixel_x = 8;
 	pixel_y = 16
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
 	name = "Extraction Nexus"
@@ -27467,7 +27506,6 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
-/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "mCC" = (
@@ -27488,7 +27526,8 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "pasibelt";
-	name = "Pasiphae disposal belt"
+	name = "Pasiphae disposal belt";
+	operating = 1
 	},
 /obj/disposaloutlet/west,
 /turf/simulated/floor/plating,
@@ -32015,6 +32054,13 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
+"oPq" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/blackwhite{
+	dir = 8
+	},
+/area/station/medical/morgue)
 "oPs" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -33131,6 +33177,10 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
+"prh" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "pri" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -33272,15 +33322,11 @@
 "puP" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/glass/beaker/large/epinephrine{
-	pixel_x = -3;
+	pixel_x = -5;
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/hypospray{
-	pixel_x = 16;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = 9;
+	pixel_x = 7;
 	pixel_y = 6
 	},
 /obj/machinery/camera{
@@ -33292,8 +33338,12 @@
 	},
 /obj/machinery/light_switch/west,
 /obj/item/reagent_containers/glass/beaker/large/antitox{
-	pixel_x = -3;
+	pixel_x = -5;
 	pixel_y = -3
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 7;
+	pixel_y = 2
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/staff)
@@ -33922,6 +33972,9 @@
 /obj/stool/chair/office/yellow,
 /obj/landmark/start{
 	name = "Quartermaster"
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
@@ -34838,6 +34891,7 @@
 "qka" = (
 /obj/machinery/light/small/floor/netural,
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "qkl" = (
@@ -35950,6 +36004,11 @@
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
 	})
+"qOM" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "qPQ" = (
 /obj/rack,
 /obj/item/clothing/mask/breath{
@@ -36081,6 +36140,7 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "qSd" = (
@@ -36501,12 +36561,6 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
-"rdt" = (
-/obj/storage/closet/wardrobe/white/research,
-/turf/simulated/floor/purpleblack{
-	dir = 4
-	},
-/area/station/science/hall)
 "rdL" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine,
@@ -36533,7 +36587,9 @@
 "reC" = (
 /obj/table/reinforced/auto,
 /obj/item/device/light/zippo,
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = -7
+	},
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
@@ -36542,6 +36598,11 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/item/reagent_containers/food/snacks/sandwich/meat_m{
+	name = "100% synthetic freerange monkey sandwich";
+	pixel_x = -5;
+	pixel_y = 8
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "reK" = (
@@ -38037,9 +38098,7 @@
 /turf/simulated/floor/redblack,
 /area/listeningpost)
 "rSs" = (
-/obj/critter/opossum/morty{
-	dir = 8
-	},
+/obj/storage/closet/biohazard,
 /turf/simulated/floor/blackwhite{
 	dir = 4
 	},
@@ -39632,11 +39691,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
 "sCH" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /obj/machinery/siphon_lever,
 /obj/item/paper/siphon_guide{
 	pixel_y = -10
@@ -41432,6 +41486,10 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/bent/east,
+/obj/noticeboard/persistent{
+	name = "Crew Quarters persistent notice board";
+	persistent_id = "crew quarters"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_west)
 "tmV" = (
@@ -42674,7 +42732,23 @@
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
 "tRz" = (
-/obj/reagent_dispensers/watertank/fountain,
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = 14;
+	pixel_x = -13
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/round{
+	pixel_x = 2;
+	pixel_y = 8;
+	initial_reagents = "sugar";
+	name = "sugar bowl"
+	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = 7;
+	pixel_x = -13
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -43252,13 +43326,18 @@
 "uiy" = (
 /obj/table/reinforced/auto,
 /obj/machinery/coffeemaker/research,
-/obj/drink_rack/mug{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/noticeboard/persistent{
+	name = "Research persistent notice board";
+	persistent_id = "research"
+	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = -6;
+	pixel_x = -5
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 1
@@ -43459,6 +43538,13 @@
 	name = "Transception Array Control"
 	})
 "uoc" = (
+/obj/stool/bed/moveable{
+	name = "Morty's roller bed";
+	desc = "A solid metal frame with some padding on it, useful for sleeping on. It's got wheels, and smells vaguely of fur and death."
+	},
+/obj/critter/opossum/morty{
+	dir = 4
+	},
 /turf/simulated/floor/blackwhite{
 	dir = 1
 	},
@@ -44253,7 +44339,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper{
 	icon_state = "index_card";
-	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
+	info = "ANODE PARAMETERS<br>Base efficacy percentage is conductivity x 17; energetic properties, at any concentration, confer 1.3x bonus<br><br>CATHODE PARAMETERS<br>5 Density recommended, with Hardness as close to 5 as possible<br><br>Rods decay at a diminishing rate;<br>corrosion resistance slows rate of decay<br><br>Engineering co-operates the Harmonic Siphon<br>and is authorized to use its products<br>in furtherance of generator operation and Site upkeep.";
 	name = "printed card";
 	pixel_y = 6
 	},
@@ -45236,6 +45322,7 @@
 	dir = 1;
 	icon_state = "line3"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay)
 "vkt" = (
@@ -45572,6 +45659,11 @@
 /obj/machinery/computer/siphon_control{
 	req_access = list(24,44)
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 12
+	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
 	name = "Extraction Nexus"
@@ -45898,6 +45990,10 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/secure_data,
+/obj/noticeboard/persistent{
+	name = "Security persistent notice board";
+	persistent_id = "security"
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -48170,6 +48266,15 @@
 "wKU" = (
 /turf/simulated/floor/greenblack,
 /area/station/hallway/primary/northwest)
+"wLl" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
 "wLs" = (
 /turf/simulated/floor/black,
 /area/station/storage/eva)
@@ -49227,6 +49332,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/coffeemaker/engineering,
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = -6;
+	pixel_x = -5
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -50180,9 +50289,29 @@
 "xII" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/food_box/donut_box{
-	pixel_y = 5
+	pixel_y = -4
 	},
 /obj/machinery/light_switch/east,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 17;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 12;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 7;
+	pixel_x = -5
+	},
 /turf/simulated/floor/black,
 /area/station/science/lobby{
 	name = "Science Lounge"
@@ -50479,16 +50608,25 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"xPY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line3"
+	},
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "xQb" = (
 /turf/simulated/floor/caution/west,
 /area/pasiphae/hangar)
 "xQe" = (
 /obj/table/reinforced/auto,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/food/snacks/sandwich/meat_m{
-	name = "100% synthetic freerange monkey sandwich";
-	pixel_x = 1;
-	pixel_y = 10
+/obj/item/storage/box/beakerbox{
+	pixel_y = 4;
+	pixel_x = 6
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -50500,6 +50638,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = 5;
+	pixel_x = -8
 	},
 /turf/simulated/floor/greenblack{
 	dir = 4
@@ -51327,7 +51469,8 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "pasibelt";
-	name = "Pasiphae disposal belt"
+	name = "Pasiphae disposal belt";
+	operating = 1
 	},
 /turf/simulated/floor/plating,
 /area/pasiphae/maint)
@@ -97395,7 +97538,7 @@ iVP
 qJD
 qJD
 pvU
-qJD
+oPq
 haF
 tLg
 hKr
@@ -97697,7 +97840,7 @@ uoc
 nlI
 tau
 nlI
-tau
+kgH
 nlI
 tRX
 usf
@@ -97999,8 +98142,8 @@ try
 nlI
 nlI
 nlI
-nlI
-nlI
+jrx
+prh
 nlI
 uxA
 iVP
@@ -98302,12 +98445,12 @@ nlI
 nlI
 sJJ
 thH
-nlI
+jrx
 qka
 adb
 qRS
 vkq
-eMF
+xPY
 vwU
 ebr
 qYB
@@ -98609,7 +98752,7 @@ nlI
 cwd
 iVP
 wnF
-tbZ
+qOM
 mTF
 aGQ
 qYB
@@ -98911,7 +99054,7 @@ thv
 uJW
 iVP
 uwJ
-txh
+ijC
 kQL
 bcp
 qYB
@@ -99207,7 +99350,7 @@ sUR
 vYx
 xLa
 pUw
-vYx
+rSs
 rSs
 alG
 tGZ
@@ -99272,7 +99415,7 @@ fdg
 dqX
 whK
 bjU
-wFM
+wLl
 lZY
 lZY
 wFM
@@ -100156,7 +100299,7 @@ iIC
 cWN
 hxe
 fUF
-rdt
+erF
 erF
 qKT
 qmt
@@ -103740,7 +103883,7 @@ wBN
 mIG
 sOh
 tmd
-hkq
+dLd
 cHW
 eSU
 tmd
@@ -117685,7 +117828,7 @@ rJg
 rJg
 uSe
 uSe
-cnL
+uSe
 rJg
 rJg
 rJg

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -14287,9 +14287,8 @@
 /area/station/hallway/primary/southeast)
 "gNy" = (
 /obj/machinery/power/smes{
-	charge = 100000;
-	chargelevel = 4000;
-	output = 2500
+	chargelevel = 10000;
+	output = 3000
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -14298,6 +14297,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/cable,
 /turf/simulated/floor/plating/random,
 /area/listeningpost/power)
 "gNQ" = (
@@ -15587,7 +15587,7 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/power)
@@ -31237,9 +31237,6 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -38645,7 +38642,7 @@
 "sdY" = (
 /obj/machinery/power/furnace{
 	active = 1;
-	fuel = 600
+	fuel = 1000
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -50140,16 +50137,16 @@
 	name = "Drop Capsule"
 	})
 "xEP" = (
-/obj/machinery/power/furnace{
-	active = 1;
-	fuel = 600
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/machinery/power/furnace{
+	active = 1;
+	fuel = 1000
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/power)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -14287,7 +14287,7 @@
 /area/station/hallway/primary/southeast)
 "gNy" = (
 /obj/machinery/power/smes{
-	chargelevel = 10000;
+	chargelevel = 9001;
 	output = 3000
 	},
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Another regularly-scheduled batch of Nadir improvements, including a couple "fan favorites".

- Added four bio-suit lockers on station (bringing overall complement to five); two are located in the research hall, and two are located in the morgue. The morgue's tray count has also been reduced by two to accommodate this, with the other "free space" now having a disposal chute.
- Coffee machines on-station should now all have coffee creamer co-located. The Bridge gets a particularly snazzy setup, with two bottles of creamer and a bowl of sugar.
- Removed the maintenance access limitation on the tool storage's front door. One consequence of this change is Chemistry now properly having access to welding fuel for chemical formulation.
- Added persistent notice boards to cargo, research and security.
- Slightly updated contents of the printed cards in north and south substations.
- Adjusted lighting near the siphon control bank to look less wonky if parts of the Extraction Nexus have been disassembled by particularly ambitious operators.
- Added a few AI intercoms.
- Fixed a missing outer-layer wall on the east side of the south escape arm.
- The listening post's SMES setup has been adjusted with a much higher initial charge and a better-calibrated input and output rate.
- Corrected the Pasiphae's crusher setup lacking... an actual crusher. Go figure.
- The Underdiner now has a food processor. Also corrected some minor area goofs therein.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves the usability and feature-completeness of Nadir.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Nadir fixbatch 8 - including public tool storage, coffee creamer, notice boards and bio suits.
```
