### PR TITLE
Kondaru - Rancher & Standard Camers

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,7 +30,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 
 //////////// CONVENIENCE OPTIONS FOR TESTING ETC
@@ -115,7 +115,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_ATLAS			// gannetmap OR IS IT KUBIUSGANNETMAP??
 //#define MAP_OVERRIDE_MANTA			// manta map
 //#define MAP_OVERRIDE_DENSITY
-#define MAP_OVERRIDE_KONDARU
+//#define MAP_OVERRIDE_KONDARU
 //#define MAP_OVERRIDE_OZYMANDIAS
 //#define MAP_OVERRIDE_NADIR
 //#define MAP_OVERRIDE_FLEET

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,7 +30,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 
 //////////// CONVENIENCE OPTIONS FOR TESTING ETC
@@ -115,7 +115,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_ATLAS			// gannetmap OR IS IT KUBIUSGANNETMAP??
 //#define MAP_OVERRIDE_MANTA			// manta map
 //#define MAP_OVERRIDE_DENSITY
-//#define MAP_OVERRIDE_KONDARU
+#define MAP_OVERRIDE_KONDARU
 //#define MAP_OVERRIDE_OZYMANDIAS
 //#define MAP_OVERRIDE_NADIR
 //#define MAP_OVERRIDE_FLEET

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20350,8 +20350,7 @@
 /area/station/routing/depot)
 "bkp" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 10;
-	
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -24241,6 +24240,13 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
@@ -41772,8 +41778,7 @@
 /area/station/crew_quarters/md)
 "fje" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 10;
-	
+	dir = 10
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -49620,6 +49625,16 @@
 /area/station/crew_quarters/info{
 	name = "Book Nook"
 	})
+"mLF" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "mLX" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -50734,8 +50749,7 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/kitchen/utensil/knife,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-	
+	dir = 10
 	},
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/specialroom/freezer,
@@ -58158,6 +58172,10 @@
 /obj/shrub{
 	dir = 8
 	},
+/obj/machinery/camera/ranch{
+	dir = 5;
+	pixel_x = -10
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "uyf" = (
@@ -60184,6 +60202,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/camera/ranch{
+	pixel_y = 20
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "wwg" = (
@@ -61370,6 +61391,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"xsz" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera/ranch,
+/turf/space,
+/area/station/mining/magnet)
 "xtO" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
@@ -107647,7 +107676,7 @@ aQJ
 aQJ
 aeV
 ree
-gxN
+xsz
 ree
 edL
 lqE
@@ -113698,7 +113727,7 @@ buI
 iKN
 bvI
 bYu
-emI
+mLF
 emI
 etm
 xSz

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -61391,14 +61391,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
-"xsz" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera/ranch,
-/turf/space,
-/area/station/mining/magnet)
 "xtO" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
@@ -107676,7 +107668,7 @@ aQJ
 aQJ
 aeV
 ree
-xsz
+gxN
 ree
 edL
 lqE

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -45553,6 +45553,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/north,
+/obj/machinery/camera/ranch{
+	pixel_y = 20
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "iKQ" = (
@@ -49628,7 +49631,7 @@
 "mLF" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 9;
+	dir = 8;
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
@@ -60201,9 +60204,6 @@
 /obj/railing/orange/reinforced,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/camera/ranch{
-	pixel_y = 20
 	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds rancher-cameras and normal cameras to the ranching area on Kondaru.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The rancher's baby-monitor is useless without; the AI should have visibility of the area.

Changes tested.
![image](https://user-images.githubusercontent.com/9563541/201494610-284463d7-cd57-46b5-8dad-debc1826bec7.png)
![image](https://user-images.githubusercontent.com/9563541/201494644-a36ac630-b667-4f0e-8a6e-4794f644f3dc.png)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MarkNstein
(+)Kondaru: added rancher & normal cameras to rancher area.
```
