### PR TITLE
Reduce some Flock randomness

### DIFF
--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -45,7 +45,7 @@
 			candidate_turfs -= pick(candidate_turfs)
 
 		var/sentinel_count = 2
-		for(var/turf/simulated/floor/feather/floor as anything in candidate_turfs)
+		for(var/turf/simulated/floor/floor as anything in candidate_turfs)
 			if (src.flock)
 				src.flock.claimTurf(flock_convert_turf(floor))
 			else

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -41,8 +41,9 @@
 			if (istype(S, /turf/simulated/floor/feather))
 				continue
 			candidate_turfs += S
-		while (length(candidate_turfs) > 13)
-			candidate_turfs -= pick(candidate_turfs)
+		shuffle_list(candidate_turfs)
+		if (length(candidate_turfs) > 13)
+			candidate_turfs = candidate_turfs.Copy(1, 14)
 
 		var/sentinel_count = 2
 		for(var/turf/simulated/floor/floor as anything in candidate_turfs)

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -51,7 +51,6 @@
 				src.flock.claimTurf(flock_convert_turf(floor))
 			else
 				flock_convert_turf(floor)
-		shuffle_list(candidate_turfs)
 		for (var/i in 1 to min(sentinel_count, length(candidate_turfs)))
 			var/turf/simulated/floor/feather/floor = candidate_turfs[i]
 			if (!flock_is_blocked_turf(floor))

--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -27,9 +27,9 @@
 	src.info_tag.set_info_tag("Entry time: [round(src.build_time - elapsed)] seconds")
 	if(elapsed >= build_time)
 		src.visible_message("<span class='text-blue'>Multiple shapes exit out of [src]!</span>")
-		for(var/i in 1 to pick(3, 4))
+		for(var/i in 1 to 4)
 			var/obj/item/flockcache/x = new(src.contents)
-			x.resources = rand(40, 50)
+			x.resources = 40
 			eject += x
 		for(var/i in 1 to 4)
 			var/obj/flock_structure/egg/e = new(src.contents, src.flock)
@@ -37,24 +37,25 @@
 		var/obj/flock_structure/egg/bit/bitegg = new(src.contents, src.flock)
 		eject += bitegg
 		var/list/candidate_turfs = list()
-		for(var/turf/simulated/floor/S in orange(src, 4))
+		for(var/turf/simulated/floor/S in range(src, 2)) // 5x5
+			if (istype(S, /turf/simulated/floor/feather))
+				continue
 			candidate_turfs += S
+		while (length(candidate_turfs) > 13)
+			candidate_turfs -= pick(candidate_turfs)
+
 		var/sentinel_count = 2
-		for(var/i in 1 to 10)
-			for(var/S in candidate_turfs)
-				if(istype(S, /turf/simulated/floor/feather))
-					candidate_turfs -= S
-					continue
-				if(prob(25))
-					if (src.flock)
-						src.flock.claimTurf(flock_convert_turf(S))
-						if (sentinel_count > 0 && !flock_is_blocked_turf(S))
-							new /obj/flock_structure/sentinel(S, src.flock)
-							sentinel_count--
-					else
-						flock_convert_turf(S)
-					candidate_turfs -= S
-					break
+		for(var/turf/simulated/floor/feather/floor as anything in candidate_turfs)
+			if (src.flock)
+				src.flock.claimTurf(flock_convert_turf(floor))
+			else
+				flock_convert_turf(floor)
+		shuffle_list(candidate_turfs)
+		for (var/i in 1 to min(sentinel_count, length(candidate_turfs)))
+			var/turf/simulated/floor/feather/floor = candidate_turfs[i]
+			if (!flock_is_blocked_turf(floor))
+				new /obj/flock_structure/sentinel(floor, src.flock)
+
 		flockdronegibs(src.loc, null, eject) //ejectables ejected here
 		src.flock.flockmind.started = TRUE
 		qdel(src)

--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -101,7 +101,7 @@
 
 			var/atom/last_hit = to_hit
 			var/found_chain_target
-			for(var/i in 1 to rand(5, 6)) // chaining
+			for(var/i in 1 to 3) // chaining
 				found_chain_target = FALSE
 				for(var/atom/A as anything in view(2, last_hit.loc))
 					if(src.flock?.isEnemy(A) && !(A in hit))


### PR DESCRIPTION
[GAMEMODES][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just reduces some randomness in Flock

Resource cubes at start now have a constant total amount that is the average of the previous amount, you always get 13 Flock floor tiles if possible, and sentinel chain target amount is no longer random and is reduced.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduces some randomness that can affect Flock games

Not sure if Sentinels really need to chain to 5 or 6 people

Also makes it easier to scale some of this with player count