### PR TITLE
Guardbuddies can now actually patrol on Kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6756,7 +6756,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "asV" = (
@@ -6862,7 +6861,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "att" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
@@ -45535,6 +45533,10 @@
 	dir = 8
 	},
 /area/station/security/main)
+"iKF" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "iKH" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -59337,6 +59339,10 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"vEX" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "vFg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -114574,7 +114580,7 @@ aFv
 cCG
 aFv
 xQm
-wHG
+vEX
 rDI
 aFv
 nbW
@@ -120312,7 +120318,7 @@ neS
 aAg
 adK
 uzL
-uzL
+iKF
 aum
 meA
 jCn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

I guess this would be a [BUG]fix? Should I even put that on [MAPPING] PRs?

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The next beacon from the airbridge was over 21 tiles away, so the buddies refuse to go there. This PR moves two beacons closer so Guardbuddies can actually go around the station.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Guardbuddies shouldn't stare at an airbridge until they run out of battery.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)Fixes guardbuddies patrolling on Kondaru
```
