### PR TITLE
Makes floor scanners and health status screens mech-scannable

### DIFF
--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -5,6 +5,7 @@
 	var/id = 0.0 // who are we?
 	var/partner_range = 3 // how far away should we look?
 	var/find_in_range = 1
+	mats = list("CON-1" = 5, "CRY" = "2")
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The title says it all.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Theses aren't game-breaking things to not make mech-scannable, and both even have features to allow player customization on custom-made instances.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Caio029
(+)Floor health scanners and health status screens are now mech-scannable. You can switch their IDs to work together with a multi-tool!
```
