### PR TITLE
Fix some issues with Revenants

### DIFF
--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -323,11 +323,7 @@
 		holder.owner.visible_message("<span class='alert'><strong>[holder.owner]</strong> gestures upwards, then at [target] with a swift striking motion!</span>")
 		var/list/thrown = list()
 		var/current_prob = 100
-		var/turf/destination = null
-		if (!isturf(target))
-			destination = get_turf(target)
-		else
-			destination = target
+		var/turf/destination = get_turf(target)
 		if (!destination) return TRUE
 		if (ishuman(target))
 			var/mob/living/carbon/T = target

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -303,7 +303,7 @@
 		last_cast = world.time + cooldown
 		holder.updateButtons()
 		SPAWN(cooldown + 5)
-			holder.updateButtons()
+			holder?.updateButtons()
 
 
 /datum/targetable/revenantAbility/massCommand
@@ -323,11 +323,17 @@
 		holder.owner.visible_message("<span class='alert'><strong>[holder.owner]</strong> gestures upwards, then at [target] with a swift striking motion!</span>")
 		var/list/thrown = list()
 		var/current_prob = 100
+		var/turf/destination = null
+		if (!isturf(target))
+			destination = get_turf(target)
+		else
+			destination = target
+		if (!destination) return TRUE
 		if (ishuman(target))
 			var/mob/living/carbon/T = target
 			if (T.traitHolder.hasTrait("training_chaplain"))
 				target.visible_message("<span class='alert'> [target] gives a rude gesture right back to [holder.owner]!</span>")
-				return 1
+				return TRUE
 			else if( check_target_immunity(T) )
 				holder.owner.show_message( "<span class='alert'>That target seems to be warded from the effects!</span>" )
 			else
@@ -342,8 +348,9 @@
 					thrown += O
 					animate_float(O)
 		SPAWN(1 SECOND)
+			if (!destination) return
 			for (var/obj/O in thrown)
-				O.throw_at(target, 32, 2)
+				O.throw_at(destination, 32, 2)
 
 /datum/targetable/revenantAbility/shockwave
 	name = "Shockwave"
@@ -496,66 +503,65 @@
 		playsound(target.loc, 'sound/voice/wraith/revfocus.ogg', 80, 0)
 		if (!ishuman(target))
 			holder.owner.show_message("<span class='alert'>You must target a human with this ability.</span>")
-			return 1
+			return TRUE
 		var/mob/living/carbon/human/H = target
 		if (!isturf(holder.owner.loc))
 			holder.owner.show_message("<span class='alert'>You cannot cast this ability inside a [holder.owner.loc].</span>")
-			return 1
+			return TRUE
 		if (holder.owner.equipped())
 			holder.owner.show_message("<span class='alert'>You require a free hand to cast this ability.</span>")
-			return 1
+			return TRUE
 		if (H.traitHolder.hasTrait("training_chaplain"))
 			holder.owner.show_message("<span class='alert'>Some mysterious force shields [target] from your influence.</span>")
 			JOB_XP(H, "Chaplain", 2)
-			return 1
+			return TRUE
 		else if( check_target_immunity(H) )
 			holder.owner.show_message("<span class='alert'>[target] seems to be warded from the effects!</span>")
-			return 1
-
-		var/location = holder.owner.loc
+			return TRUE
 
 		holder.owner.visible_message("<span class='alert'>[holder.owner] reaches out towards [H], making a crushing motion.</span>", "<span class='notice'>You reach out towards [H].</span>")
 		H.changeStatus("weakened", 2 SECONDS)
+		actions.start(new/datum/action/bar/crush(holder.owner, H), holder.owner)
+		return FALSE
 
-		var/datum/abilityHolder/revenant/RH
-		if (istype(holder, /datum/abilityHolder/revenant))
-			RH = holder
-			RH.channeling = 1
-		if (!RH || !istype(RH, /datum/abilityHolder/revenant/))
+/datum/action/bar/crush
+	duration = 8 SECONDS
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACT | INTERRUPT_ATTACKED
+	id = "crush"
+	var/mob/living/casting_mob = null
+	var/mob/living/target_mob = null
+
+	New(var/mob/living/caster, var/mob/living/target)
+		src.casting_mob = caster
+		src.target_mob = target
+		..()
+
+	onStart()
+		..()
+		if (src.casting_mob == null || src.target_mob == null || !isalive(src.casting_mob) || !can_act(src.casting_mob) || (GET_DIST(src.casting_mob, src.target_mob) > 7))
+			interrupt(INTERRUPT_ALWAYS)
 			return
 
-		SPAWN(0.5 SECONDS)
-			var/iterations = 0
-			while (holder.owner.loc == location && isalive(holder.owner) && !holder.owner.equipped())
-				iterations++
-				if (!holder.owner)
-					RH.channeling = 0
-					break
-				if (RH.channeling == 0)
-					holder.owner.show_message("<span class='alert'>You were interrupted!</span>")
-					break
-				if (!H)
-					holder.owner.show_message("<span class='alert'>You were interrupted!</span>")
-					RH.channeling = 0
-					break
-				if (GET_DIST(holder.owner, H) > 7)
-					holder.owner.show_message("<span class='alert'>[H] is pulled from your telekinetic grip!</span>")
-					RH.channeling = 0
-					break
-				H.changeStatus("weakened", (2 + rand(0, iterations)) SECONDS)
-				H.TakeDamage("chest", 4 + rand(0, iterations), 0, 0, DAMAGE_CRUSH)
-				if (prob(40))
-					H.visible_message("<span class='alert'>[H]'s bones crack loudly!</span>", "<span class='alert'>You feel like you're about to be [pick("crushed", "destroyed", "vaporized")].</span>")
-				if (prob(50))
-					H.emote("scream")
-				if (iterations > 12 && prob((iterations - 12) * 5))
-					H.visible_message("<span class='alert'>[H]'s body gives in to the telekinetic grip!</span>", "<span class='alert'>You are completely crushed.</span>")
-					logTheThing(LOG_COMBAT, holder.owner, "gibs [constructTarget(H,"combat")] with the Revenant crush ability at [log_loc(holder.owner)].")
-					H.gib()
-					return
-				sleep(0.7 SECONDS)
-			holder.owner.show_message("<span class='alert'>You were interrupted!</span>")
-		return 0
+	onUpdate()
+		..()
+		if (src.casting_mob == null || src.target_mob == null || !isalive(src.casting_mob) || !can_act(src.casting_mob) || (GET_DIST(src.casting_mob, src.target_mob) > 7))
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		src.target_mob.changeStatus("weakened", 2 SECONDS)
+		src.target_mob.TakeDamage("chest", 5, 0, 0, DAMAGE_CRUSH)
+		if (prob(25))
+			src.target_mob.visible_message("<span class='alert'>[src.target_mob]'s bones crack loudly!</span>", "<span class='alert'>You feel like you're about to be [pick("crushed", "destroyed", "vaporized")].</span>")
+			playsound(src.target_mob.loc, 'sound/impact_sounds/Flesh_Tear_1.ogg', 70, 1)
+
+	onEnd()
+		..()
+		src.target_mob.visible_message("<span class='alert'>[src.target_mob]'s body gives in to the telekinetic grip!</span>", "<span class='alert'>You are completely crushed.</span>")
+		logTheThing(LOG_COMBAT, src.casting_mob, "gibs [constructTarget(src.target_mob,"combat")] with the Revenant crush ability at [log_loc(casting_mob)].")
+		src.target_mob.gib()
+
+	onInterrupt()
+		..()
+		boutput(src.casting_mob, "<span class='alert'>You were interrupted!</span>")
 
 /datum/targetable/revenantAbility/help
 	name = "Toggle Help Mode"

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -526,7 +526,7 @@
 
 /datum/action/bar/crush
 	duration = 8 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACT | INTERRUPT_ATTACKED
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACT
 	id = "crush"
 	var/mob/living/casting_mob = null
 	var/mob/living/target_mob = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a runtime happening when abilities looked for a non-existant holder.
Adds an action bar to the "Crush" ability so it's more obvious that things are working as intended.
Changes "Mass Command" to always throw at the turf instead of the person in case the person is deleted between the casting and the actual throw.

(hopefully)
fixes #11979
fixes #10800

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfixing and cleanliness