### PR TITLE
Fix transception interlink/pad range limit

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -501,8 +501,6 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 			M.changeStatus("stunned", 5 SECONDS)
 			M.changeStatus("weakened", 5 SECONDS)
 
-#define INTERLINK_COMPUTER_RANGE 100
-
 /obj/machinery/computer/transception
 	name = "\improper Transception Interlink"
 	desc = "A console capable of remotely connecting to and operating cargo transception pads."
@@ -601,7 +599,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		signal.source = src
 		signal.data["sender"] = src.net_id
 
-		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, INTERLINK_COMPUTER_RANGE, freq)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, null, freq)
 
 /obj/machinery/computer/transception/attack_hand(var/mob/user as mob)
 	if(!src.allowed(user))
@@ -725,9 +723,6 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 				src.build_command(manifest["INT_TARGETID"])
 
 	src.add_fingerprint(usr)
-
-#undef INTERLINK_COMPUTER_RANGE
-
 
 #undef TRANSCEIVE_BUSY
 #undef TRANSCEIVE_NOPOWER

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -501,6 +501,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 			M.changeStatus("stunned", 5 SECONDS)
 			M.changeStatus("weakened", 5 SECONDS)
 
+#define INTERLINK_COMPUTER_RANGE 100
 
 /obj/machinery/computer/transception
 	name = "\improper Transception Interlink"
@@ -600,7 +601,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		signal.source = src
 		signal.data["sender"] = src.net_id
 
-		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, 20, freq)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, INTERLINK_COMPUTER_RANGE, freq)
 
 /obj/machinery/computer/transception/attack_hand(var/mob/user as mob)
 	if(!src.allowed(user))
@@ -724,6 +725,8 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 				src.build_command(manifest["INT_TARGETID"])
 
 	src.add_fingerprint(usr)
+
+#undef INTERLINK_COMPUTER_RANGE
 
 
 #undef TRANSCEIVE_BUSY

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -258,6 +258,8 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 #undef ARRAY_TELECOST
 #undef TRANSCEPTION_COOLDOWN
 
+#define INTERLINK_RANGE 100
+
 /obj/machinery/transception_pad
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "neopad"
@@ -333,7 +335,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		signal.source = src
 		signal.data["sender"] = src.net_id
 
-		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, 20, freq)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, INTERLINK_RANGE, freq)
 
 	///Polls to see if pad's transception connection is operable
 	proc/check_transceive()
@@ -599,7 +601,7 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 		signal.source = src
 		signal.data["sender"] = src.net_id
 
-		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, null, freq)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, INTERLINK_RANGE, freq)
 
 /obj/machinery/computer/transception/attack_hand(var/mob/user as mob)
 	if(!src.allowed(user))
@@ -723,6 +725,9 @@ var/global/obj/machinery/communications_dish/transception/transception_array
 				src.build_command(manifest["INT_TARGETID"])
 
 	src.add_fingerprint(usr)
+
+#undef INTERLINK_RANGE
+
 
 #undef TRANSCEIVE_BUSY
 #undef TRANSCEIVE_NOPOWER


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the range bound of Nadir's transception interlink computers (which operate the transception pads that bring cargo in and out) from 20 to 100, through a define called INTERLINK_RANGE to give context to the number when it occurs in code.

While some extent of a range limit makes sense, 20 was considerably too short and was breaking the intended dynamic of being able to operate any pad on the station from the QM cargo endpoint (not sure why I set it to 20, but hey it's getting fixed).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes the computers connect to any pads on station like they ought to.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Increased connection range of Nadir's transception pads and interlink computers to 100 tiles, from 20; player-constructed pads should now consistently be operable from QM's interlink computers.
```
