### PR TITLE
Make genetics booth eject user if their selected product gets locked

### DIFF
--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -206,10 +206,9 @@
 						P = locate(href_list["op"])
 						if(P)
 							P.locked = !P.locked
-							if(!selected_product || selected_product.locked)
-								selected_product = null
-								just_pick_anything()
-								UpdateIcon()
+							if(selected_product?.locked)
+								select_product(null)
+								eject_occupant(0)
 							reload_contexts()
 
 			show_admin_panel(usr)
@@ -220,20 +219,14 @@
 
 	proc/select_product(var/datum/geneboothproduct/P)
 		selected_product = P
-		abilityoverlay = SafeGetOverlayImage("abil", P.BE.icon, P.BE.icon_state,src.layer + 0.1)
-		UpdateIcon()
-
-		usr.show_text("You have selected [P.name]. Walk into an opening on the side of this machine to purchase this item.", "blue")
-		playsound(src.loc, 'sound/machines/keypress.ogg', 50, 1, extrarange = -15, pitch = 0.6)
-
-	proc/just_pick_anything()
-		for (var/datum/geneboothproduct/P as anything in offered_genes)
-			if(P.locked)
-				continue
-			selected_product = P
+		if(P)
 			abilityoverlay = SafeGetOverlayImage("abil", P.BE.icon, P.BE.icon_state,src.layer + 0.1)
 			UpdateIcon()
-			break
+			usr.show_text("You have selected [P.name]. Walk into an opening on the side of this machine to purchase this item.", "blue")
+			playsound(src.loc, 'sound/machines/keypress.ogg', 50, 1, extrarange = -15, pitch = 0.6)
+		else
+			abilityoverlay = SafeGetOverlayImage("abil", 'icons/mob/genetics_powers.dmi', "none")
+			UpdateIcon()
 
 	update_icon()
 		if (powered())

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -627,7 +627,7 @@
 					copy_datum_vars(E, NEW)
 					GB.offered_genes += new /datum/geneboothproduct(NEW,booth_effect_desc,booth_effect_cost,registered_id)
 					if (GB.offered_genes.len == 1)
-						GB.just_pick_anything()
+						GB.select_product(GB.offered_genes[1])
 					scanner_alert(ui.user, "Sent 5 of '[NEW.name]' to gene booth.")
 					GB.reload_contexts()
 			on_ui_interacted(ui.user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Medical][C-Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix genetics booth applying a random gene if the user's selected product gets locked while in the machine


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes: #11991

