### PR TITLE
Quick fix to immortal rats

### DIFF
--- a/code/modules/antagonists/wraith/critters/plaguerat.dm
+++ b/code/modules/antagonists/wraith/critters/plaguerat.dm
@@ -111,7 +111,7 @@ ABSTRACT_TYPE(/mob/living/critter/wraith/plaguerat)
 		return ..()
 
 	death(var/gibbed)
-		if (src.master)
+		if (src.master && istype(src.master, /mob/living/intangible/wraith))
 			src.master.summons -= src
 			src.master = null
 		if (!gibbed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rat-spawned rats runtimed as it was trying to remove itself from a list that the rat "master" didnt have. Puts up typecheck to fix it while #11876 is being reviewed, as it will remove the rat's ability to spawn more rats.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I like rats as much as the next guy, but being immortal is a bit too much.

