### PR TITLE
Makes critter kinetic gun arms push back in space

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -274,6 +274,11 @@
 	is_on_cooldown(var/mob/user)
 		return GET_COOLDOWN(user, "\ref[src] reload")
 
+/datum/limb/gun/kinetic
+	shoot(atom/target, var/mob/user, var/pointblank = FALSE, params)
+		if(..() && istype(user.loc, /turf/space) || user.no_gravity)
+			user.inertia_dir = get_dir(target, user)
+			step(user, user.inertia_dir)
 	arm38
 		proj = new/datum/projectile/bullet/revolver_38
 		shots = 3
@@ -290,33 +295,12 @@
 		reload_time = 300
 		muzzle_flash = "muzzle_flash"
 
-	phaser
-		proj = new/datum/projectile/laser/light
-		shots = 1
-		current_shots = 1
-		cooldown = 30
-		reload_time = 30
-
-	cutter
-		proj = new/datum/projectile/laser/drill/cutter
-		shots = 1
-		current_shots = 1
-		cooldown = 30
-		reload_time = 30
-
 	artillery
 		proj = new/datum/projectile/bullet/autocannon
 		shots = 1
 		current_shots = 1
 		cooldown = 50
 		reload_time = 50
-
-	disruptor
-		proj = new/datum/projectile/disruptor/high
-		shots = 1
-		current_shots = 1
-		cooldown = 40
-		reload_time = 40
 
 	glitch
 		proj = new/datum/projectile/bullet/glitch
@@ -352,6 +336,28 @@
 		current_shots = 5
 		cooldown = 1 SECOND
 		reload_time = 20 SECONDS
+
+/datum/limb/gun/energy
+	phaser
+		proj = new/datum/projectile/laser/light
+		shots = 1
+		current_shots = 1
+		cooldown = 30
+		reload_time = 30
+
+	cutter
+		proj = new/datum/projectile/laser/drill/cutter
+		shots = 1
+		current_shots = 1
+		cooldown = 30
+		reload_time = 30
+
+	disruptor
+		proj = new/datum/projectile/disruptor/high
+		shots = 1
+		current_shots = 1
+		cooldown = 40
+		reload_time = 40
 
 /datum/limb/mouth
 	var/sound_attack = 'sound/voice/animal/werewolf_attack1.ogg'

--- a/code/mob/living/critter/arena/fire_elemental.dm
+++ b/code/mob/living/critter/arena/fire_elemental.dm
@@ -36,7 +36,7 @@
 		..()
 		var/datum/handHolder/HH = hands[3]
 		HH.name = "control of fire"
-		HH.limb = new /datum/limb/gun/fire_elemental
+		HH.limb = new /datum/limb/gun/kinetic/fire_elemental
 		HH.icon_state = "fire_essence"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.limb_name = "fire essence"

--- a/code/mob/living/critter/drone.dm
+++ b/code/mob/living/critter/drone.dm
@@ -117,7 +117,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/phaser
+		HH.limb = new /datum/limb/gun/energy/phaser
 		HH.name = "S-1 Light Anti-Personnel Energy Sling"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handphs"

--- a/code/mob/living/critter/drone/ar.dm
+++ b/code/mob/living/critter/drone/ar.dm
@@ -7,7 +7,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/artillery
+		HH.limb = new /datum/limb/gun/kinetic/artillery
 		HH.name = "S-42 Long Range Explosive Shells"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handart"

--- a/code/mob/living/critter/drone/cr.dm
+++ b/code/mob/living/critter/drone/cr.dm
@@ -6,7 +6,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/cutter
+		HH.limb = new /datum/limb/gun/energy/cutter
 		HH.name = "C-4 Salvager Sawdrill"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handcr"

--- a/code/mob/living/critter/drone/glitch.dm
+++ b/code/mob/living/critter/drone/glitch.dm
@@ -8,7 +8,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/glitch
+		HH.limb = new /datum/limb/gun/kinetic/glitch
 		HH.name = "C&z !!!!!!ERROR!!!!!!!--~$!'S"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handglitch"

--- a/code/mob/living/critter/drone/hk.dm
+++ b/code/mob/living/critter/drone/hk.dm
@@ -6,7 +6,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/disruptor
+		HH.limb = new /datum/limb/gun/energy/disruptor
 		HH.name = "S-7 Heavy Waveform Disruptor"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handdis"

--- a/code/mob/living/critter/gunbot.dm
+++ b/code/mob/living/critter/gunbot.dm
@@ -57,7 +57,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/arm38
+		HH.limb = new /datum/limb/gun/kinetic/arm38
 		HH.name = ".38 Anti-Personnel Arm"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "hand38"
@@ -67,7 +67,7 @@
 		HH.can_range_attack = 1
 
 		HH = hands[2]
-		HH.limb = new /datum/limb/gun/abg
+		HH.limb = new /datum/limb/gun/kinetic/abg
 		HH.name = "ABG Riot Suppression Appendage"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handabg"
@@ -149,7 +149,7 @@
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/rifle
+		HH.limb = new /datum/limb/gun/kinetic/rifle
 		HH.name = "5.56 Rifle Arm"
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handrifle"

--- a/code/mob/living/critter/mechmonstrosity.dm
+++ b/code/mob/living/critter/mechmonstrosity.dm
@@ -105,7 +105,7 @@
 		HH.icon = 'icons/mob/critter_ui.dmi'	// the icon of the hand UI background
 		HH.icon_state = "syringegun"				// the icon state of the hand UI background
 		HH.limb_name = "Injector"					// name for the dummy holder
-		HH.limb = new /datum/limb/gun/syringe	// if not null, the special limb to use when attack_handing
+		HH.limb = new /datum/limb/gun/kinetic/syringe	// if not null, the special limb to use when attack_handing
 		HH.can_hold_items = 0
 		HH.can_attack = 0
 		HH.can_range_attack = 1

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3435,7 +3435,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	setup_hands()
 		..()
 		var/datum/handHolder/HH = hands[1]
-		HH.limb = new /datum/limb/gun/spike
+		HH.limb = new /datum/limb/gun/kinetic/spike
 		HH.icon = 'icons/mob/critter_ui.dmi'
 		HH.icon_state = "handzap"
 		HH.name = "spikes"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Repaths all gun arms to be kinetic or energy, kinetic push you back, energy don't.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I missed gun arms when making kinetic weapons have pushback in space, makes sense that they would too.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Gunbots will now be pushed backwards by firing their guns in space.
```
