### PR TITLE
Unreverts abilitystat fixes

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -161,23 +161,24 @@
 			abilitystat = new
 			abilitystat.owner = src
 
+		var/list/lines = list()
+
 		var/i = 0
 		var/longest_line = 0
-		var/msg = ""
-		//var/style = "font-size: 7px;"
 		var/list/stats = onAbilityStat()
 		for (var/x in stats)
-			var/line_length = length(x) + 1 + length(num2text(stats[x]))
+			var/line_length = length(x) + 1 + max(length(num2text(stats[x])), length(stats[x]))
 			longest_line = max(longest_line, line_length)
-			msg += "[x] [stats[x]]<br>"
+			lines += "[x] [stats[x]]"
 			i++
 
-		abilitystat.maptext = "<span class='vga l vt ol'>[msg] </span>"
+		abilitystat.maptext = "<span class='vga l vt ol'>[lines.Join("<br>")]</span>"
 		abilitystat.maptext_width = longest_line * 9 //font size is 9px
-		if (i > 2)
-			abilitystat.maptext_height = (32 + ((i-2) * 16))
-			abilitystat.maptext_y = ((i-2) * -16) - 7
-		else if (abilitystat.maptext_height > 32)
+
+		if (i >= 2)
+			abilitystat.maptext_height = i * 15
+			abilitystat.maptext_y = -abilitystat.maptext_height + 32
+		else
 			abilitystat.maptext_height = initial(abilitystat.maptext_height)
 			abilitystat.maptext_y = initial(abilitystat.maptext_y)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-adds all changes from #11803


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks like a botched attempt to merge #11122 accidentally reverted #11803, which is required for #11649