### PR TITLE
Antag respawn events show antag type to players

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -107,8 +107,8 @@
 
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 		var/list/text_messages = list()
-		text_messages.Add("Would you like to respawn as a [src.antagonist_type ] antagonist? Your name will be added to the list of eligible candidates and may be selected at random by the game.") // Do disclose which type it is. You know, ghosts can already metagame in a myriad ways.
-		text_messages.Add("You are eligible to be respawned as a [src.antagonist_type ] antagonist. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+		text_messages.Add("Would you like to respawn as a [src.antagonist_type] antagonist? Your name will be added to the list of eligible candidates and may be selected at random by the game.") // Do disclose which type it is. You know, ghosts can already metagame in a myriad of ways.
+		text_messages.Add("You are eligible to be respawned as a [src.antagonist_type] antagonist. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
 		text_messages.Add("You have been added to the list of eligible candidates. The game will pick a player soon. Good luck!")
 
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -119,6 +119,7 @@
 			message_admins("Couldn't set up Antagonist Spawn ([src.antagonist_type]); no ghosts responded. Source: [source ? "[source]" : "random"]")
 			logTheThing(LOG_ADMIN, null, "Couldn't set up Antagonist Spawn ([src.antagonist_type]); no ghosts responded. Source: [source ? "[source]" : "random"]")
 			src.post_event()
+			global.random_events.next_spawn_event = TIME + 1 MINUTE
 			return
 
 		for(var/antag_idx in 1 to src.antag_count)

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -107,8 +107,8 @@
 
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 		var/list/text_messages = list()
-		text_messages.Add("Would you like to respawn as a random event antagonist? Your name will be added to the list of eligible candidates and may be selected at random by the game.") // Don't disclose which type it is. You know, metagaming.
-		text_messages.Add("You are eligible to be respawned as a random event antagonist. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+		text_messages.Add("Would you like to respawn as a [src.antagonist_type ] antagonist? Your name will be added to the list of eligible candidates and may be selected at random by the game.") // Do disclose which type it is. You know, ghosts can already metagame in a myriad ways.
+		text_messages.Add("You are eligible to be respawned as a [src.antagonist_type ] antagonist. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
 		text_messages.Add("You have been added to the list of eligible candidates. The game will pick a player soon. Good luck!")
 
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -166,8 +166,8 @@
 		SPAWN(0)
 			// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 			var/list/text_messages = list()
-			text_messages.Add("Would you like to respawn as one of [critter_name] (antagonist critters)? You may be randomly selected from the list of candidates.")
-			text_messages.Add("You are eligible to be respawned as one of [critter_name] (antagonist critters)?. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+			text_messages.Add("Would you like to respawn as one of a team of [critter_name] (antagonist critters)? You may be randomly selected from the list of candidates.")
+			text_messages.Add("You are eligible to be respawned as one of the [critter_name] (antagonist critters)?. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
 			text_messages.Add("You have been added to the list of eligible candidates. Please wait for the game to choose, good luck!")
 
 			// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -35,6 +35,7 @@
 /datum/eventSpawnedCritter
 	var/list/critter_types // can be a list of just one, if multiple are present then one is picked at random, so similar mobs can be grouped together
 	var/list/datum/event_item_drop_table/drop_tables
+	var/name = null
 
 	proc/roll_for_items()
 		var/list/items_to_drop = list()
@@ -46,8 +47,9 @@
 
 		return items_to_drop
 
-	New(critter_types, drop_tables)
+	New(name, critter_types, drop_tables)
 		..()
+		src.name = name
 		src.critter_types = critter_types
 		src.drop_tables = drop_tables
 
@@ -68,6 +70,7 @@
 
 	var/list/pest_invasion_critter_datums = list(
 		list(new /datum/eventSpawnedCritter(
+			name = "spiders",
 			critter_types = list(/mob/living/critter/spider/baby),
 			drop_tables = list(
 				new /datum/event_item_drop_table(  // several baby spiders crawl out of the corpse like those horror short videos oh no
@@ -83,6 +86,7 @@
 			)
 		),
 		list(new /datum/eventSpawnedCritter(
+			name = "fire elementals",
 			critter_types = list(/mob/living/critter/fire_elemental),
 			drop_tables = list(
 				new /datum/event_item_drop_table(
@@ -92,6 +96,7 @@
 			)
 		),
 		list(new /datum/eventSpawnedCritter(
+			name = "gunbots",
 			critter_types = list(/mob/living/critter/robotic/gunbot),
 			drop_tables = list(
 				new /datum/event_item_drop_table(
@@ -102,6 +107,7 @@
 			)
 		),
 		list(new /datum/eventSpawnedCritter(
+			name = "emagged bots",
 			critter_types = list(/mob/living/critter/robotic/bot/cleanbot/emagged, /mob/living/critter/robotic/bot/firebot/emagged),
 			drop_tables = list(
 				new /datum/event_item_drop_table(
@@ -142,10 +148,25 @@
 	event_effect(var/source)
 		..()
 
+		var/critter_name = "unknown mystery critters"
+		var/list/select = null
+		if (src.critter_type)
+			select = src.critter_type
+			var/atom/dummy = src.critter_type
+			critter_name = initial(dummy.name) + "s"
+		else
+			select = pick(src.pest_invasion_critter_datums)
+			var/list/name_list = list()
+			for (var/datum/eventSpawnedCritter/C in select)
+				if(C.name)
+					name_list += C.name
+			if(length(name_list))
+				critter_name = english_list(name_list)
+
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 		var/list/text_messages = list()
-		text_messages.Add("Would you like to respawn as a random antagonist critter? You may be randomly selected from the list of candidates.")
-		text_messages.Add("You are eligible to be respawned as a random antagonist critter. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+		text_messages.Add("Would you like to respawn as one of [critter_name] (antagonist critters)? You may be randomly selected from the list of candidates.")
+		text_messages.Add("You are eligible to be respawned as one of [critter_name] (antagonist critters)?. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
 		text_messages.Add("You have been added to the list of eligible candidates. Please wait for the game to choose, good luck!")
 
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
@@ -169,12 +190,6 @@
 					return
 
 			var/atom/pestlandmark = pick(EV)
-
-			var/list/select = null
-			if (src.critter_type)
-				select = src.critter_type
-			else
-				select = pick(src.pest_invasion_critter_datums)
 
 			if (src.num_critters) //custom selected
 				src.num_critters = (min(src.num_critters, candidates.len))

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -163,18 +163,23 @@
 			if(length(name_list))
 				critter_name = english_list(name_list)
 
-		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
-		var/list/text_messages = list()
-		text_messages.Add("Would you like to respawn as one of [critter_name] (antagonist critters)? You may be randomly selected from the list of candidates.")
-		text_messages.Add("You are eligible to be respawned as one of [critter_name] (antagonist critters)?. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
-		text_messages.Add("You have been added to the list of eligible candidates. Please wait for the game to choose, good luck!")
+		SPAWN(0)
+			// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
+			var/list/text_messages = list()
+			text_messages.Add("Would you like to respawn as one of [critter_name] (antagonist critters)? You may be randomly selected from the list of candidates.")
+			text_messages.Add("You are eligible to be respawned as one of [critter_name] (antagonist critters)?. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+			text_messages.Add("You have been added to the list of eligible candidates. Please wait for the game to choose, good luck!")
 
-		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
-		message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
-		var/list/datum/mind/candidates = dead_player_list(1, src.ghost_confirmation_delay, text_messages, allow_dead_antags = 1)
+			// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
+			message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
+			var/list/datum/mind/candidates = dead_player_list(1, src.ghost_confirmation_delay, text_messages, allow_dead_antags = 1)
 
 
-		if (candidates.len)
+			if (!length(candidates))
+				cleanup_event()
+				global.random_events.next_spawn_event = TIME + 1 MINUTE
+				return
+
 			var/list/EV = list()
 			for (var/landmark_type in list(LANDMARK_PESTSTART, LANDMARK_MONKEY, LANDMARK_BLOBSTART, LANDMARK_KUDZUSTART))
 				if (landmarks[landmark_type])
@@ -218,7 +223,7 @@
 				candidates -= M
 
 			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter", alert_origin = ALERT_GENERAL)
-		cleanup_event()
+			cleanup_event()
 
 	proc/cleanup_event()
 		src.critter_type = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a ghost antag respawn event or a ghost antag critter respawn event happens this PR now makes it show what antagonist you would be respawning as.
![image](https://user-images.githubusercontent.com/358431/202803460-a7d94bf0-d54a-4828-8944-90d7f1791f1c.png)
![image](https://user-images.githubusercontent.com/358431/202804026-da2401ff-4a6f-4c89-a7dc-a321034aca23.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It sucks when people get picked for an antagonist which they don't want to play and then just disconnect or remain connected and suicide or remain connected and not have fun. Especially considering that these don't respect preferences.

Multiple times I have heard metagaming concerns about this but I personally don't their relevance. First of all the ghosts will be able to see the information about the respawned antagonist in just a few seconds after they actually spawn so the window in which this PR gives them more information is tiny. Secondly ghosts already have so much information they can metagame with that this is negligible.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)pali
(+)Ghost respawn events now show what antagonist you would be respawning as
```
