### PR TITLE
Prevents VR uplink access to Syndicate Intelligence

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -310,7 +310,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 				dat += "</table>"
 				var/do_divider = 1
 
-				if(has_synd_int)
+				if(has_synd_int && !is_VR_uplink)
 					dat += "<HR><A href='byond://?src=\ref[src];synd_int=1'>Syndicate Intelligence</A><BR>"
 
 				if (istype(src, /obj/item/uplink/integrated/radio))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX][GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title

Closes #12023


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I (somewhat) broke it, I'll fix it


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Zonespace
(+)You can no longer access Syndicate Intelligence via VR uplinks
```
