### PR TITLE
Afterlife bar removes certain harmful traits

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -148,9 +148,9 @@
 				T = new traitType
 			else
 				T = trait_instance
+			traits[id] = T
 			if(T.afterlife_blacklisted && inafterlifebar(owner))
 				return
-			traits[id] = T
 			if(!isnull(owner))
 				if(T.isMoveTrait)
 					moveTraits.Add(id)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -141,7 +141,21 @@
 			other.addTrait(id, traits[id])
 
 	proc/addTrait(id, datum/trait/trait_instance=null)
-		if(!(id in traits))
+		// Blacklist for harmful afterlife traits that shouldn't be added
+		var/blacklist_afterlife = list(
+			"deaf",
+			"shortsighted",
+			"blind",
+			"mildly_mutated",
+			"addict",
+			"randomallergy",
+			"medicalallergy",
+			"allergic",
+			"clutz",
+			"leftfeet"
+		)
+		//logTheThing(LOG_DEBUG, owner, "got trait [id]. Afterlife: [inafterlifebar(owner)]; Blacklist: [inafterlifebar(owner)]")
+		if(!(id in traits) && !((id in blacklist_afterlife) && inafterlifebar(owner)) )
 			var/datum/trait/T = null
 			if(isnull(trait_instance))
 				var/traitType = traitList[id].type

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -141,26 +141,15 @@
 			other.addTrait(id, traits[id])
 
 	proc/addTrait(id, datum/trait/trait_instance=null)
-		// Blacklist for harmful afterlife traits that shouldn't be added
-		var/blacklist_afterlife = list(
-			"deaf",
-			"shortsighted",
-			"blind",
-			"mildly_mutated",
-			"addict",
-			"randomallergy",
-			"medicalallergy",
-			"allergic",
-			"clutz",
-			"leftfeet"
-		)
-		if(!(id in traits) && !((id in blacklist_afterlife) && inafterlifebar(owner)) )
+		if(!(id in traits))
 			var/datum/trait/T = null
 			if(isnull(trait_instance))
 				var/traitType = traitList[id].type
 				T = new traitType
 			else
 				T = trait_instance
+			if(T.afterlife_blacklisted && inafterlifebar(owner))
+				return
 			traits[id] = T
 			if(!isnull(owner))
 				if(T.isMoveTrait)
@@ -205,6 +194,7 @@
 	var/requiredUnlock = null //If set to a string, the xp unlock of that name is required for this to be selectable.
 	var/isMoveTrait = FALSE // If TRUE, onMove will be called each movement step from the holder's mob
 	var/datum/mutantrace/mutantRace = null //If set, should be in the "species" category.
+	var/afterlife_blacklisted = FALSE // If TRUE, trait will not be added in the Afterlife Bar
 
 	New()
 		ASSERT(src.name)
@@ -415,6 +405,7 @@
 	icon_state = "glassesG"
 	category = list("vision")
 	points = 1
+	afterlife_blacklisted = TRUE
 
 	onAdd(var/mob/owner)
 		if(owner.bioHolder)
@@ -432,6 +423,7 @@
 	id = "blind"
 	category = list("vision")
 	points = 2
+	afterlife_blacklisted = TRUE
 
 	onAdd(var/mob/owner)
 		if(owner.bioHolder)
@@ -451,6 +443,7 @@
 	icon_state = "mildly_mutatedB"
 	points = 0
 	category = list("genetics")
+	afterlife_blacklisted = TRUE
 
 	onAdd(var/mob/owner)
 		var/datum/bioHolder/B = owner.bioHolder
@@ -706,6 +699,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "randomallergy"
 	points = 0
 	category = list("allergy")
+	afterlife_blacklisted = TRUE
 
 	var/allergen = null
 
@@ -734,6 +728,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "medicalallergy"
 	points = 1
 	category = list("allergy")
+	afterlife_blacklisted = TRUE
 
 	allergen_id_list = list("spaceacillin","morphine","teporone","salicylic_acid","calomel","synthflesh","omnizine","saline","anti_rad","smelling_salt",\
 	"haloperidol","epinephrine","insulin","silver_sulfadiazine","mutadone","ephedrine","penteticacid","antihistamine","styptic_powder","cryoxadone","atropine",\
@@ -745,6 +740,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "addict"
 	icon_state = "syringe"
 	points = 2
+	afterlife_blacklisted = TRUE
 	var/selected_reagent = "ethanol"
 	var/addictive_reagents = list("bath salts", "lysergic acid diethylamide", "space drugs", "psilocybin", "cat drugs", "methamphetamine", "ethanol", "nicotine")
 	var/do_addiction = FALSE
@@ -906,6 +902,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "You will sometimes randomly pick up nearby items."
 	id = "kleptomaniac"
 	points = 1
+	afterlife_blacklisted = TRUE
 
 	onLife(var/mob/owner, var/mult)
 		if(!owner.stat && !owner.lying && can_act(owner) && !owner.equipped() && probmult(6))
@@ -920,12 +917,14 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "When interacting with anything you have a chance to interact with something different instead."
 	id = "clutz"
 	points = 2
+	afterlife_blacklisted = TRUE
 
 /datum/trait/leftfeet
 	name = "Two left feet"
 	desc = "Every now and then you'll stumble in a random direction."
 	id = "leftfeet"
 	points = 1
+	afterlife_blacklisted = TRUE
 
 /datum/trait/scaredshitless
 	name = "Scared Shitless"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -154,7 +154,6 @@
 			"clutz",
 			"leftfeet"
 		)
-		//logTheThing(LOG_DEBUG, owner, "got trait [id]. Afterlife: [inafterlifebar(owner)]; Blacklist: [inafterlifebar(owner)]")
 		if(!(id in traits) && !((id in blacklist_afterlife) && inafterlifebar(owner)) )
 			var/datum/trait/T = null
 			if(isnull(trait_instance))

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -776,7 +776,7 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	// 	newbody.abilityHolder.transferOwnership(newbody)
 	// src.abilityHolder = null
 
-	// There are some traits removed in the afterlife bar: see proc/traitHolder/addTrait()
+	// There are some traits removed in the afterlife bar, these have afterlife_blacklist set to TRUE.
 
 	newbody.UpdateOverlays(image('icons/misc/32x64.dmi',"halo"), "halo")
 	newbody.set_clothing_icon_dirty()

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -731,12 +731,12 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	if(!isdead(src) || !src.mind || !ticker || !ticker.mode)
 		return
 	if (ticker?.mode && istype(ticker.mode, /datum/game_mode/football))
-		boutput(src, "Sorry, respawn options aren't availbale during football mode.")
+		boutput(src, "Sorry, respawn options aren't available during football mode.")
 		return
 	var/turf/target_turf = pick(get_area_turfs(/area/afterlife/bar/barspawn))
 
 	if (!src.client) return //ZeWaka: fix for null.preferences
-	var/mob/living/carbon/human/newbody = new(null, null, src.client.preferences, TRUE)
+	var/mob/living/carbon/human/newbody = new(target_turf, null, src.client.preferences, TRUE)
 	newbody.real_name = src.real_name
 	newbody.ghost = src //preserve your original ghost
 	if(!src.mind.assigned_role || iswraith(src) || isblob(src) || src.mind.assigned_role == "Cyborg" || src.mind.assigned_role == "AI")
@@ -776,10 +776,10 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	// 	newbody.abilityHolder.transferOwnership(newbody)
 	// src.abilityHolder = null
 
+	// There are some traits removed in the afterlife bar: see proc/traitHolder/addTrait()
 
 	newbody.UpdateOverlays(image('icons/misc/32x64.dmi',"halo"), "halo")
 	newbody.set_clothing_icon_dirty()
-	newbody.set_loc(target_turf)
 
 	if (src.mind) //Mind transfer also handles key transfer.
 		src.mind.transfer_to(newbody)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -725,8 +725,6 @@
 	rank = "Captain"
 #endif
 	var/obj/item/card/id/C = null
-	if(istype(get_area(src),/area/afterlife))
-		rank = "Captain"
 	var/datum/job/JOB = find_job_in_controller_by_string(rank)
 	if (!JOB || !JOB.slot_card)
 		return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Upon entering the afterlife bar, potential hazardous traits that shouldn't be given will no longer be added. This is implemented by the `afterlife_blacklisted` variable on every trait.
This doesn't impact your actual traits outside the afterlife bar. If you visit the bar with blind and get revived, you'll still be blind in the realm of the living.
The blacklist is currently:
- Deaf
- Shortsighted
- Blind
- Mildly Mutated
- Addict
- Allergy
- Medical Allergy
- Hyperallergic
- Clutz
- Two Left Feet
- Kleptomaniac

Humans are now spawned into the afterlife bar immediately, instead of sitting in null for a while before being sent there.
Also fixes a typo.
Also removes a weird bit of unreachable code that made everyone in the afterlife bar a Captain... which it would, if people actually spawned immediately into the afterlife bar, instead of into null.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes: #11925
