### PR TITLE
Fix trickster puppet names

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -511,6 +511,8 @@
 					var/mob/living/critter/wraith/trickster_puppet/puppet = new /mob/living/critter/wraith/trickster_puppet(get_turf(T), T)
 					T.mind.transfer_to(puppet)
 					puppet.appearance = T.copied_appearance
+					puppet.name = T.copied_name
+					puppet.real_name = T.copied_real_name
 					puppet.desc = T.copied_desc
 					puppet.traps_laid = T.traps_laid
 					puppet.playsound_local(puppet.loc, 'sound/voice/wraith/wraithhaunt.ogg', 40, 0)
@@ -1687,14 +1689,19 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if(istype(holder.owner, /mob/living/intangible/wraith/wraith_trickster))
 			var/mob/living/intangible/wraith/wraith_trickster/W = holder.owner
 			if ((istype(target, /mob/living/carbon/human/)))
-				boutput(holder.owner, "We steal [target]'s appearance for ourselves.")
-				W.copied_appearance = target.appearance
-				W.copied_appearance.transform.Turn(target.rest_mult * -90)	//Find a way to make transform rotate.
-				W.copied_desc = target.get_desc()
+				var/mob/living/carbon/human/H = target
+				boutput(holder.owner, "We steal [H]'s appearance for ourselves.")
+				W.copied_appearance = H.appearance
+				W.copied_appearance.transform.Turn(H.rest_mult * -90)	//Find a way to make transform rotate.
+				W.copied_desc = H.get_desc()
+				W.copied_name = H.name
+				W.copied_real_name = H.real_name
 				return 0
 			else if (W.copied_appearance != null)
 				W.copied_appearance = null
 				W.copied_desc = null
+				W.copied_name = null
+				W.copied_real_name = null
 				boutput(holder.owner, "We discard our disguise.")
 			else
 				boutput(holder.owner, "We cannot copy this appearance.")

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -680,8 +680,10 @@
 	var/points_to_possess = 50
 	/// Steal someone's appearance and use it during haunt
 	var/mutable_appearance/copied_appearance = null
-	/// Steal their descriptions too
+	/// Steal their descriptions and name too
 	var/copied_desc = null
+	var/copied_name = null
+	var/copied_real_name = null
 	var/traps_laid = 0
 
 	New(var/mob/M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Trickster puppets didnt have set names and could be easily spotted. This fixes that.
fixes https://github.com/goonstation/goonstation-secret/issues/389


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's supposed to decieve people, it shouldnt be so easy to find out.

