### PR TITLE
Fixes using the GPS verb on the same Y level as the genebooth teleporting you to it

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -285,6 +285,12 @@
 	mover.movement_newloc = target
 	return src.Uncross(mover, do_bump=do_bump)
 
+/// This is the proc to check if a movable can cross this atom.
+/// DO NOT put side effects in this proc, it is called for pathfinding
+/// Seriously I mean it, you think it'll be fine and then it causes the teleporting gene booth bug
+/atom/Cross(atom/movable/mover)
+	return (!density)
+
 /atom/Crossed(atom/movable/AM)
 	SHOULD_CALL_PARENT(TRUE)
 	#ifdef SPACEMAN_DMM // idk a tiny optimization to omit the parent call here, I don't think it actually breaks anything in byond internals

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -52,12 +52,6 @@ Important Procedures
 
 */
 
-/// This is the proc to check if a movable can cross this atom.
-/// DO NOT put side effects in this proc, it is called for pathfinding
-/// Seriously I mean it, you think it'll be fine and then it causes the teleporting gene booth bug
-/atom/Cross(atom/movable/mover)
-	return (!density)
-
 /atom/proc/gas_cross(turf/target)
 	return !src.gas_impermeable
 

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -52,6 +52,9 @@ Important Procedures
 
 */
 
+/// This is the proc to check if a movable can cross this atom.
+/// DO NOT put side effects in this proc, it is called for pathfinding
+/// Seriously I mean it, you think it'll be fine and then it causes the teleporting gene booth bug
 /atom/Cross(atom/movable/mover)
 	return (!density)
 

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -353,39 +353,37 @@
 
 	Cross(var/mob/M)
 		.= ..()
-		if (M && M.y == src.y && !occupant && selected_product && ishuman(M) && !GET_COOLDOWN(M, "genebooth_debounce"))
+		if (!(src.status & (NOPOWER | BROKEN)) && ishuman(M) && M.y == src.y && !occupant && selected_product && !GET_COOLDOWN(M, "genebooth_debounce"))
 			return TRUE
 
 	Crossed(var/mob/M, atom/oldLoc)
 		. = ..()
-		if (M && M.y == src.y && !GET_COOLDOWN(M, "genebooth_debounce"))
-			if (src.status & (NOPOWER | BROKEN))
-				if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
-					boutput(M, "<span class='alert'>The gene booth is currently nonfunctional.</span>")
-				return
-			if (!occupant && selected_product && ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if (H.bioHolder)
-					ON_COOLDOWN(M, "genebooth_debounce", 2 SECONDS)
-					eject_dir = pick(EAST, WEST)
-					M.set_loc(src)
-					occupant = M
-					letgo_hp = initial(letgo_hp)
-					entry_time = world.timeofday
-					started = 0
+		if (!M || M.y != src.y || GET_COOLDOWN(M, "genebooth_debounce"))
+			return
+		if (occupant || !selected_product || !ishuman(M))
+			return
+		var/mob/living/carbon/human/H = M
+		if (H.bioHolder)
+			ON_COOLDOWN(M, "genebooth_debounce", 2 SECONDS)
+			eject_dir = pick(EAST, WEST)
+			M.set_loc(src)
+			occupant = M
+			letgo_hp = initial(letgo_hp)
+			entry_time = world.timeofday
+			started = 0
 
-					UpdateIcon()
+			UpdateIcon()
 
-					if (H.bioHolder.HasEffect(selected_product.id))
-						SPAWN(1 SECOND)
-							src.eject_occupant(add_power=0)
-							if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
-								M.show_text("You already have the offered mutation!", "blue")
-						return
-
+			if (H.bioHolder.HasEffect(selected_product.id))
+				SPAWN(1 SECOND)
+					src.eject_occupant(add_power=0)
 					if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
-						playsound(src.loc, 'sound/machines/heater_on.ogg', 90, 1, pitch = 0.78)
-						M.show_text("[src] is warming up. Please hold still.", "blue")
+						M.show_text("You already have the offered mutation!", "blue")
+				return
+
+			if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
+				playsound(src.loc, 'sound/machines/heater_on.ogg', 90, 1, pitch = 0.78)
+				M.show_text("[src] is warming up. Please hold still.", "blue")
 
 	mob_flip_inside(var/mob/user)
 		..(user)

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -353,31 +353,39 @@
 
 	Cross(var/mob/M)
 		.= ..()
-		if (M && M.y == src.y)
+		if (M && M.y == src.y && !occupant && selected_product && ishuman(M) && !GET_COOLDOWN(M, "genebooth_debounce"))
+			return TRUE
+
+	Crossed(var/mob/M, atom/oldLoc)
+		. = ..()
+		if (M && M.y == src.y && !GET_COOLDOWN(M, "genebooth_debounce"))
 			if (src.status & (NOPOWER | BROKEN))
 				if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
 					boutput(M, "<span class='alert'>The gene booth is currently nonfunctional.</span>")
 				return
 			if (!occupant && selected_product && ishuman(M))
 				var/mob/living/carbon/human/H = M
-				if (H.bioHolder && !H.bioHolder.HasEffect(selected_product.id))
-					eject_dir = get_dir(M,src)
+				if (H.bioHolder)
+					ON_COOLDOWN(M, "genebooth_debounce", 2 SECONDS)
+					eject_dir = pick(EAST, WEST)
 					M.set_loc(src)
 					occupant = M
 					letgo_hp = initial(letgo_hp)
 					entry_time = world.timeofday
 					started = 0
 
+					UpdateIcon()
+
+					if (H.bioHolder.HasEffect(selected_product.id))
+						SPAWN(1 SECOND)
+							src.eject_occupant(add_power=0)
+							if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
+								M.show_text("You already have the offered mutation!", "blue")
+						return
+
 					if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
 						playsound(src.loc, 'sound/machines/heater_on.ogg', 90, 1, pitch = 0.78)
 						M.show_text("[src] is warming up. Please hold still.", "blue")
-
-					UpdateIcon()
-					.= 1
-				else
-					if (!ON_COOLDOWN(M, "genebooth_message_antispam", 3 SECONDS))
-						M.show_text("You already have the offered mutation!", "blue")
-
 
 	mob_flip_inside(var/mob/user)
 		..(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #12056, another `Cross` vs `Crossed` issue.
Also adds a big angry comment to `atom/Cross` warning not to add side effects to it, and moves the definition out of atmos code because pali complained.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad