### PR TITLE
Allows hacked clothing manufacturers to print handkerchiefs

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2696,6 +2696,78 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Resource"
 
+/datum/manufacture/handkerchief_white
+	name = "White Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/cloth/handkerchief/white)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_yellow
+	name = "Yellow Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/yellow)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_red
+	name = "Red Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/red)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_purple
+	name = "Purple Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/purple)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_orange
+	name = "Orange Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/orange)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_green
+	name = "Green Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/green)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_blue
+	name = "Blue Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/blue)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
+/datum/manufacture/handkerchief_pink
+	name = "Pink Handkerchief"
+	item_paths = list("FAB-1")
+	item_amounts = list(6)
+	item_outputs = list(/obj/item/cloth/handkerchief/pink)
+	time = 4 SECONDS
+	create = 1
+	category = "Resource"
+
 /////// pod construction components
 
 /datum/manufacture/pod/parts

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2696,74 +2696,11 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Resource"
 
-/datum/manufacture/handkerchief_white
-	name = "White Handkerchief"
+/datum/manufacture/handkerchief
+	name = "Handkerchief"
 	item_paths = list("FAB-1")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/cloth/handkerchief/white)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_yellow
-	name = "Yellow Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/yellow)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_red
-	name = "Red Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/red)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_purple
-	name = "Purple Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/purple)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_orange
-	name = "Orange Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/orange)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_green
-	name = "Green Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/green)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_blue
-	name = "Blue Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/blue)
-	time = 4 SECONDS
-	create = 1
-	category = "Resource"
-
-/datum/manufacture/handkerchief_pink
-	name = "Pink Handkerchief"
-	item_paths = list("FAB-1")
-	item_amounts = list(6)
-	item_outputs = list(/obj/item/cloth/handkerchief/pink)
 	time = 4 SECONDS
 	create = 1
 	category = "Resource"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2416,6 +2416,14 @@
 	hidden = list(/datum/manufacture/breathmask,
 		/datum/manufacture/patch,
 		/datum/manufacture/towel,
+		/datum/manufacture/handkerchief_white,
+		/datum/manufacture/handkerchief_yellow,
+		/datum/manufacture/handkerchief_red,
+		/datum/manufacture/handkerchief_purple,
+		/datum/manufacture/handkerchief_orange,
+		/datum/manufacture/handkerchief_green,
+		/datum/manufacture/handkerchief_blue,
+		/datum/manufacture/handkerchief_pink,
 		/datum/manufacture/tricolor,
 		/datum/manufacture/hat_ltophat)
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2416,14 +2416,7 @@
 	hidden = list(/datum/manufacture/breathmask,
 		/datum/manufacture/patch,
 		/datum/manufacture/towel,
-		/datum/manufacture/handkerchief_white,
-		/datum/manufacture/handkerchief_yellow,
-		/datum/manufacture/handkerchief_red,
-		/datum/manufacture/handkerchief_purple,
-		/datum/manufacture/handkerchief_orange,
-		/datum/manufacture/handkerchief_green,
-		/datum/manufacture/handkerchief_blue,
-		/datum/manufacture/handkerchief_pink,
+		/datum/manufacture/handkerchief,
 		/datum/manufacture/tricolor,
 		/datum/manufacture/hat_ltophat)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hacked clothing manufacturers now print handkerchiefs at a cost of 0.4 fabric for white handkerchiefs, and 0.6 fabric for colored ones.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is currently no reliable way to get handkerchiefs apart from the spacebux purchase (which is random) or being an ntso.
Allows players to pick a handkerchief they like without resorting to randomness. Also makes https://github.com/goonstation/goonstation/pull/12079 better by allowing it to make handkerchiefs you like reliably.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)White handkerchiefs can now be printed at hacked clothing manufacturers. You can color the handkerchiefs with paint. 
```
