### PR TITLE
Adds aggressive wandering to critter AI

### DIFF
--- a/code/mob/living/critter/ai/generic_critter.dm
+++ b/code/mob/living/critter/ai/generic_critter.dm
@@ -30,6 +30,21 @@
 // This is where the actual behaviour is defined.
 //--------------------------------------------------------------------------------------------------------------------------------------------------//
 
+
+///This is standard wander behaviour with frequent checks for nearby enemies, which will interrupt the wandering.
+/datum/aiTask/timed/wander/critter/aggressive
+	name = "aggressive wander"
+
+/datum/aiTask/timed/wander/critter/aggressive/on_tick()
+	var/mob/living/critter/C = holder.owner
+	if(istype(holder.owner) && length(C.seek_target()))
+		src.holder.owner.ai.interrupt()
+	else
+		..()
+
+
+//--------------------------------------------------------------------------------------------------------------------------------------------------//
+
 /// This one makes the critter move towards a target returned from holder.owner.seek_target()
 /datum/aiTask/sequence/goalbased/critter/attack
 	name = "attacking"

--- a/code/mob/living/critter/ai/mouse.dm
+++ b/code/mob/living/critter/ai/mouse.dm
@@ -11,10 +11,12 @@
 /datum/aiHolder/mouse/mad
 	New()
 		..()
-		default_task = get_instance(/datum/aiTask/prioritizer/critter/mouse/mad, list(src))
+		default_task = get_instance(/datum/aiTask/prioritizer/critter/mouse_mad, list(src))
 
-/datum/aiTask/prioritizer/critter/mouse/mad/New()
+/datum/aiTask/prioritizer/critter/mouse_mad/New()
 	..()
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/critter/aggressive, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/eat, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(holder, src))
 
 /datum/aiHolder/mouse_remy

--- a/code/mob/living/critter/ai/snake.dm
+++ b/code/mob/living/critter/ai/snake.dm
@@ -5,5 +5,5 @@
 
 /datum/aiTask/prioritizer/critter/snake/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/critter/aggressive, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(holder, src))

--- a/code/mob/living/critter/ai/spider.dm
+++ b/code/mob/living/critter/ai/spider.dm
@@ -7,7 +7,7 @@
 
 /datum/aiTask/prioritizer/critter/spider/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/critter/aggressive, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/scavenge, list(holder, src))
 
@@ -29,7 +29,7 @@
 
 /datum/aiTask/prioritizer/critter/clown_spider_queen/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/critter/aggressive, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/scavenge, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/succeedable/critter/vomit_egg, list(holder, src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new subclass of wandering that checks for viable targets and interrupts the wandering if it finds them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12097 and makes critter AI better
