### PR TITLE
Calculate and use total stipend payout for profitability station score

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -537,7 +537,7 @@
 					"} : {"
 					<tr><th>Deficit</th><th style="text-align: right; color: red;">-[num2text(round(surplus * -1),50)][CREDIT_SIGN]</th></tr>
 					"}]
-					<tr><th>Stipend Payout Sum</th><td class='r'>[num2text(round(wagesystem.total_stipend), 50)][CREDIT_SIGN]</td></tr>
+					<tr><th>Stipend Sum</th><td class='r'>[num2text(round(wagesystem.total_stipend), 50)][CREDIT_SIGN]</td></tr>
 				</tbody>
 			</table>
 			<div class='c'>

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -537,7 +537,7 @@
 					"} : {"
 					<tr><th>Deficit</th><th style="text-align: right; color: red;">-[num2text(round(surplus * -1),50)][CREDIT_SIGN]</th></tr>
 					"}]
-					<tr><th>Stipend Sum</th><td class='r'>[num2text(round(wagesystem.total_stipend), 50)][CREDIT_SIGN]</td></tr>
+					<tr><th>Total Stipend</th><td class='r'>[num2text(round(wagesystem.total_stipend), 50)][CREDIT_SIGN]</td></tr>
 				</tbody>
 			</table>
 			<div class='c'>
@@ -549,7 +549,7 @@
 			<br>
 			<br>The payday stipend is based on typical staffing costs and will not change if you adjust the pay scales below.
 			<br>
-			<br>The station is profitable if the collected budgets are larger than the sum of all payroll stipends.
+			<br>The station is profitable if the <em>total funds</em> are larger than the <em>total stipend</em>.
 			<hr>
 			<table>
 				<thead>

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -65,6 +65,7 @@
 		station_budget =      0
 		shipping_budget = 30000
 		research_budget = 20000
+		total_stipend = station_budget + shipping_budget + research_budget
 
 		// This is gonna throw up some crazy errors if it isn't done right!
 		// cogwerks - raising all of the paychecks, oh god

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -11,6 +11,7 @@
 	var/shipping_budget = 0
 	var/research_budget = 0
 	var/payroll_stipend = 0
+	var/total_stipend = 0
 
 	var/list/jobs = new/list()
 
@@ -141,6 +142,7 @@
 		// This also means that payday stopping is strictly a result of
 		// someone tampering it and not just having 80 assistants in 20 minutes
 		station_budget += payroll_stipend
+		total_stipend += payroll_stipend
 
 		// Everyone gets paid into their bank accounts
 		if (!wagesystem.pay_active) return // some greedy prick suspended the payroll!
@@ -534,6 +536,7 @@
 					"} : {"
 					<tr><th>Deficit</th><th style="text-align: right; color: red;">-[num2text(round(surplus * -1),50)][CREDIT_SIGN]</th></tr>
 					"}]
+					<tr><th>Stipend Payout Sum</th><td class='r'>[num2text(round(wagesystem.total_stipend), 50)][CREDIT_SIGN]</td></tr>
 				</tbody>
 			</table>
 			<div class='c'>
@@ -544,6 +547,8 @@
 			Every payday cycle, Centcom distributes the <em>payroll stipend</em> into the station's budget, which is then paid out to crew accounts.
 			<br>
 			<br>The payday stipend is based on typical staffing costs and will not change if you adjust the pay scales below.
+			<br>
+			<br>The station is profitable if the collected budgets are larger than the sum of all payroll stipends.
 			<hr>
 			<table>
 				<thead>

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -151,7 +151,7 @@ var/datum/score_tracker/score_tracker
 			// something glitched out and broke so give them a free pass on it
 			score_expenses = 100
 		else
-			var/profit_target = 300000
+			var/profit_target = wagesystem.total_stipend
 			var/totalfunds = wagesystem.station_budget + wagesystem.research_budget + wagesystem.shipping_budget
 			if (totalfunds == 0)
 				score_expenses = 0

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -407,7 +407,7 @@ var/datum/score_tracker/score_tracker
 
 		score_tracker.score_text += "<B><U>CIVILIAN DEPARTMENT</U></B><BR>"
 		score_tracker.score_text += "<B>Overall Station Cleanliness:</B> [round(score_tracker.score_cleanliness)]%<BR>"
-		score_tracker.score_text += "<B>Profit Made from Initial Budget:</B> [round(score_tracker.score_expenses)]%<BR>"
+		score_tracker.score_text += "<B>Station Profitabilty:</B> [round(score_tracker.score_expenses)]%<BR>"
 		score_tracker.score_text += "<B>Total Department Score:</B> [round(score_tracker.final_score_civ)]%<BR>"
 		score_tracker.score_text += "<BR>"
 	 /* until this is actually done or being worked on im just going to comment it out


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Tracks the total station stipend payout in a new variable
* Uses this variable to calculate the end-round profitability score
* Shows this number in the bank records computer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Arbitrary number is arbitrary
* Give HoP something to worry about / do


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Nanotrasen now calculates station profitability based on the station stipend; use the bank records computer to track your progress in-round.
```
