### PR TITLE
Lets you examine a cell charger to see how full the cell is

### DIFF
--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -92,3 +92,9 @@
 	. = ..()
 	if(Obj == src.charging)
 		src.charging = null
+
+/obj/machinery/cell_charger/get_desc(dist)
+	. = ..()
+	if(dist > 2 || !charging)
+		return
+	. += "<br><span class='notice'>It is currently charging \the [charging]! Progress: [round(charging.percent())]%, [charging.charge]/[charging.maxcharge]PU </span>"

--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -97,4 +97,4 @@
 	. = ..()
 	if(!charging)
 		return
-	. += "<br><span class='notice'>\The [src] is currently charging \the [charging]! It is [round(charging.percent())]% charged and has [charging.charge]/[charging.maxcharge] PUs. </span>"
+	. += "<br><span class='notice'>\The [src] is currently charging \the [src.charging]! It is [round(src.charging.percent())]% charged and has [round(src.charging.charge)]/[src.charging.maxcharge] PUs. </span>"

--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -95,6 +95,6 @@
 
 /obj/machinery/cell_charger/get_desc(dist)
 	. = ..()
-	if(dist > 2 || !charging)
+	if(!charging)
 		return
 	. += "<br><span class='notice'>\The [src] is currently charging \the [charging]! It is [round(charging.percent())]% charged and has [charging.charge]/[charging.maxcharge] PUs. </span>"

--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -97,4 +97,4 @@
 	. = ..()
 	if(dist > 2 || !charging)
 		return
-	. += "<br><span class='notice'>It is currently charging \the [charging]! Progress: [round(charging.percent())]%, [charging.charge]/[charging.maxcharge]PU </span>"
+	. += "<br><span class='notice'>\The [src] is currently charging \the [charging]! It is [round(charging.percent())]% charged and has [charging.charge]/[charging.maxcharge] PUs. </span>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds an examine (if there is a cell) that says how charged the cell is.
The cell charger is currently charging the erebite cell! It is PERCENT% charged and has ROUNDED CHARGE/MAX CHARGE PUs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Definitely more convenient than taking the cell out to check the percent and putting it back in.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)You can now examine a cell charger to see how full the cell is.
```
