### PR TITLE
refactors artifact glow and fixes terrible container code

### DIFF
--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -2,47 +2,6 @@
 	name = "artifact sealed container"
 	associated_datum = /datum/artifact/container
 
-	New(var/loc, var/forceartiorigin)
-		..()
-
-	ArtifactActivated(var/mob/living/user as mob)
-		var/datum/artifact/A = src.artifact
-		if (A.activated)
-			return
-		A.activated = 1
-		playsound(src.loc, A.activ_sound, 100, 1)
-		src.overlays += A.fx_image
-		src.visible_message("<b>[src] seems like it has something inside it...</b>")
-		switch(rand(1,4))
-			if(1)
-				if(prob(5))
-					new/obj/item/artifact/activator_key(src)
-				else
-					new/obj/item/cell/artifact(src)
-					new/obj/item/cell/artifact(src)
-					new/obj/item/cell/artifact(src)
-			if(2)
-				if(prob(5))
-					new/obj/critter/domestic_bee/buddy(src)
-					new/obj/item/clothing/suit/bee(src)
-				else
-					new/obj/critter/domestic_bee_larva(src)
-					new/obj/critter/domestic_bee_larva(src)
-					new/obj/critter/domestic_bee_larva(src)
-					new/obj/critter/domestic_bee_larva(src)
-					new/obj/critter/domestic_bee_larva(src)
-			if(3)
-				if(prob(5))
-					new/obj/item/gimmickbomb/owlclothes(src)
-					new/obj/item/gimmickbomb/owlclothes(src)
-					new/obj/item/gimmickbomb/owlclothes(src)
-					new/obj/item/gimmickbomb/owlclothes(src)
-					new/obj/item/gimmickbomb/owlclothes(src)
-				else
-					new/obj/item/gimmickbomb/owlclothes(src)
-			if(4)
-				new/obj/item/old_grenade/light_gimmick(src)
-
 /datum/artifact/container
 	associated_object = /obj/artifact/container
 	type_name = "Container"
@@ -52,16 +11,55 @@
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
-	activ_text = "deposits its contents on the ground."
-	deact_text = "ceases functioning."
+	activ_text = "seems like it has something inside of it..."
+	deact_text = "locks back up."
 	react_xray = list(7,50,40,11,"HOLLOW")
+	var/generated_loot = FALSE
 
-	New()
-		..()
+	post_setup()
+		. = ..()
 		src.react_heat[2] = "HIGH INTERNAL CONVECTION"
 
+	effect_activate(obj/O)
+		. = ..()
+		if (.)
+			return
+		if (src.generated_loot)
+			return
+		src.generated_loot = TRUE
+		switch(rand(1,4))
+			if(1)
+				if(prob(5))
+					new/obj/item/artifact/activator_key(src.holder)
+				else
+					new/obj/item/cell/artifact(src.holder)
+					new/obj/item/cell/artifact(src.holder)
+					new/obj/item/cell/artifact(src.holder)
+			if(2)
+				if(prob(5))
+					new/obj/critter/domestic_bee/buddy(src.holder)
+					new/obj/item/clothing/suit/bee(src.holder)
+				else
+					new/obj/critter/domestic_bee_larva(src.holder)
+					new/obj/critter/domestic_bee_larva(src.holder)
+					new/obj/critter/domestic_bee_larva(src.holder)
+					new/obj/critter/domestic_bee_larva(src.holder)
+					new/obj/critter/domestic_bee_larva(src.holder)
+			if(3)
+				if(prob(5))
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+				else
+					new/obj/item/gimmickbomb/owlclothes(src.holder)
+			if(4)
+				new/obj/item/old_grenade/light_gimmick(src.holder)
+
 	effect_touch(var/obj/O,var/mob/living/user)
-		if (..())
+		. = ..()
+		if (.)
 			return
 		for(var/atom/movable/I in (O.contents-O.vis_contents))
 			I.set_loc(O.loc)
@@ -75,4 +73,3 @@
 		O.remove_artifact_forms()
 		artifact_controls.artifacts -= src
 		qdel(O)
-		return

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -26,7 +26,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 	var/used_names = list()
 	// These are automatically handled. They're used to make the artifact glow different colors.
 	/// the glowy overlay used for when the artifact is activated
-	var/image/fx_image = null
+	var/obj/effect/artifact_glowie/fx_image = null
 	/// the actual /obj that belongs to this specific artifact instance
 	var/obj/holder = null
 

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -94,8 +94,11 @@
 		var/obj/item/I = src
 		I.item_state = appearance.name
 
-	A.fx_image = image(src.icon, src.icon_state + "fx")
+	A.fx_image = new
+	A.fx_image.icon = src.icon
+	A.fx_image.icon_state = src.icon_state + "fx"
 	A.fx_image.color = rgb(rand(AO.fx_red_min,AO.fx_red_max),rand(AO.fx_green_min,AO.fx_green_max),rand(AO.fx_blue_min,AO.fx_blue_max))
+	A.fx_image.plane = PLANE_ABOVE_LIGHTING
 
 	A.react_mpct[1] = AO.impact_reaction_one
 	A.react_mpct[2] = AO.impact_reaction_two
@@ -127,7 +130,7 @@
 
 /obj/proc/ArtifactActivated()
 	if (!src)
-		return
+		return 1
 	if (!src.ArtifactSanityCheck())
 		return 1
 	var/datum/artifact/A = src.artifact
@@ -146,7 +149,7 @@
 	if (A.nofx)
 		src.icon_state = src.icon_state + "fx"
 	else
-		src.UpdateOverlays(A.fx_image, "activated")
+		src.vis_contents += A.fx_image
 	A.effect_activate(src)
 
 /obj/proc/ArtifactDeactivated()
@@ -164,7 +167,7 @@
 	if (A.nofx)
 		src.icon_state = src.icon_state - "fx"
 	else
-		src.UpdateOverlays(null, "activated")
+		src.vis_contents -= A.fx_image
 	A.effect_deactivate(src)
 
 /obj/proc/Artifact_emp_act()

--- a/code/obj/effect.dm
+++ b/code/obj/effect.dm
@@ -1,10 +1,15 @@
-/obj/effect/distort
+/obj/effect
 	name = "" // for some reason mouse_opacity itself doesn't work for hiding this from rightclick, empty name works though
-	icon = 'icons/effects/distort.dmi'
 	mouse_opacity = 0
+
+/obj/effect/distort
+	icon = 'icons/effects/distort.dmi'
 	appearance_flags = PIXEL_SCALE | RESET_COLOR | RESET_TRANSFORM | RESET_ALPHA | NO_CLIENT_COLOR
 	vis_flags = VIS_INHERIT_DIR
 
 	New()
 		..()
 		src.render_target = "*\ref[src]"
+
+/obj/effect/artifact_glowie
+	appearance_flags = KEEP_TOGETHER

--- a/code/obj/effect.dm
+++ b/code/obj/effect.dm
@@ -12,4 +12,4 @@
 		src.render_target = "*\ref[src]"
 
 /obj/effect/artifact_glowie
-	appearance_flags = KEEP_TOGETHER
+	appearance_flags = PIXEL_SCALE | RESET_COLOR | KEEP_TOGETHER


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes artifact glows be effect objects in the vis_contents, which means you can do some neat transform stuff with them.
Also makes them glow in the dark, spooky!

Also fixes some terrible container code that didn't work properly and enabled exploits.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's neat!
and it had to happen