### PR TITLE
runtime checking: stuff falling into pits during world init

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1207,6 +1207,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	layer = MOB_LAYER+1
 	icon = 'icons/obj/decals/cleanables.dmi'
 	icon_state = "cobweb1"
+	anchored = 2
 
 /obj/decal/cleanable/molten_item
 	name = "gooey grey mass"
@@ -1214,6 +1215,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	layer = OBJ_LAYER
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "molten"
+	anchored = 2
 
 /obj/decal/cleanable/cobweb2
 	name = "cobweb"

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2228,7 +2228,7 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 /turf/proc/fall_to(var/turf/T, var/atom/movable/A)
 	#ifdef RUNTIME_CHECKING
 	if(current_state <= GAME_STATE_WORLD_NEW)
-		CRASH("[O] ([O.type]) fell into [src] at [src.x],[src.y],[src.z] ([src.loc] [src.loc.type]) during world initialization")
+		CRASH("[A] ([A.type]) fell into [src] at [src.x],[src.y],[src.z] ([src.loc] [src.loc.type]) during world initialization")
 	#endif
 	if(istype(A, /obj/overlay/tile_effect)) //Ok enough light falling places. Fak.
 		return

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2226,6 +2226,10 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 // --------------------------------------------
 
 /turf/proc/fall_to(var/turf/T, var/atom/movable/A)
+	#ifdef RUNTIME_CHECKING
+	if(current_state <= GAME_STATE_WORLD_NEW)
+		CRASH("[O] ([O.type]) fell into [src] at [src.x],[src.y],[src.z] ([src.loc] [src.loc.type]) during world initialization")
+	#endif
 	if(istype(A, /obj/overlay/tile_effect)) //Ok enough light falling places. Fak.
 		return
 	if (isturf(T))

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2226,12 +2226,12 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 // --------------------------------------------
 
 /turf/proc/fall_to(var/turf/T, var/atom/movable/A)
+	if(istype(A, /obj/overlay) || A.anchored == 2)
+		return
 	#ifdef RUNTIME_CHECKING
 	if(current_state <= GAME_STATE_WORLD_NEW)
 		CRASH("[A] ([A.type]) fell into [src] at [src.x],[src.y],[src.z] ([src.loc] [src.loc.type]) during world initialization")
 	#endif
-	if(istype(A, /obj/overlay/tile_effect)) //Ok enough light falling places. Fak.
-		return
 	if (isturf(T))
 		visible_message("<span class='alert'>[A] falls into [src]!</span>")
 		if (ismob(A))

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -481,7 +481,7 @@ SYNDICATE DRONE FACTORY AREAS
 	name = "cliff"
 	desc = "The edge of a cliff."
 	density = 0
-	anchored = 1
+	anchored = 2
 	opacity = 0
 	layer = OBJ_LAYER
 	icon = 'icons/misc/exploration.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
make CI scream when things fall into pits at world init


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's usually by mistake
