### PR TITLE
Fix second 'and'

### DIFF
--- a/code/datums/abilities/zoldorfabilities.dm
+++ b/code/datums/abilities/zoldorfabilities.dm
@@ -172,7 +172,7 @@
 					speechinput = input("[sentence](noun) and (verb) yourself.", "Noun", null) as null|anything in fortune_nouns
 					if(!speechinput) break
 					sentence += "[speechinput] and "
-					speechinput = input("[sentence]and (verb) yourself.", "Verb", null) as null|anything in fortune_verbs
+					speechinput = input("[sentence](verb) yourself.", "Verb", null) as null|anything in fortune_verbs
 					if(!speechinput) break
 					sentence += "[speechinput] yourself."
 				if("Remember to...")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes duplicate 'and'


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes: #12098
