### PR TITLE
Fix small Flockmind and Flocktrace movement bug

### DIFF
--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -87,6 +87,10 @@
 	else
 		return 0.75 + movement_delay_modifier
 
+/mob/living/intangible/flock/Move(NewLoc, direct)
+	src.set_dir(get_dir(src, NewLoc))
+	..()
+
 /mob/living/intangible/flock/attack_hand(mob/user)
 	switch(user.a_intent)
 		if(INTENT_HELP)


### PR DESCRIPTION
[GAMEMODES][BUG][MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just fixes a small bug, caused by #11319, where when moving as a Flockmind or Flocktrace continuously in a single direction, if you left click a tile off to the side of you, you will face that way and your sprite won't update


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix