### PR TITLE
Don't garble html tags

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2378,14 +2378,18 @@ proc/gradientText(var/color1, var/color2, message)
   * Returns given text replaced by nonsense chars, on a 40% or given % basis
   */
 proc/radioGarbleText(var/message, var/per_letter_corruption_chance=40)
-	var/list/corruptedChars = list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&")
-	. = ""
-	for(var/i=1 to length(message))
-		if(prob(per_letter_corruption_chance))
-			// corrupt that letter
-			. += pick(corruptedChars)
-		else
-			. += copytext(message, i, i+1)
+  var/non_html_text = splittext(message,  regex("<\[^>\]*>"))
+  var/list/corruptedChars = list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&")
+  . = message
+  for(var/text_bit in non_html_text)
+    var/corrupted_bit = ""
+    for(var/i=1 to length(text_bit))
+      if(prob(per_letter_corruption_chance))
+        // corrupt that letter
+        corrupted_bit += pick(corruptedChars)
+      else
+        corrupted_bit += copytext(text_bit, i, i+1)
+    . = replacetext(., text_bit, corrupted_bit)
 
 /**
   * Returns given text replaced entirely by nonsense chars

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2375,21 +2375,25 @@ proc/gradientText(var/color1, var/color2, message)
   . = result.Join()
 
 /**
-  * Returns given text replaced by nonsense chars, on a 40% or given % basis
+  * Returns given text replaced by nonsense chars, excepting HTML tags, on a 40% or given % basis
   */
 proc/radioGarbleText(var/message, var/per_letter_corruption_chance=40)
-  var/non_html_text = splittext(message,  regex("<\[^>\]*>"))
-  var/list/corruptedChars = list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&")
-  . = message
-  for(var/text_bit in non_html_text)
-    var/corrupted_bit = ""
-    for(var/i=1 to length(text_bit))
-      if(prob(per_letter_corruption_chance))
-        // corrupt that letter
-        corrupted_bit += pick(corruptedChars)
-      else
-        corrupted_bit += copytext(text_bit, i, i+1)
-    . = replacetext(., text_bit, corrupted_bit)
+	var/split_html_text = splittext(message,  regex("<\[^>\]*>"), 1, length(message), TRUE) //I'd love to just use include_delimiters=TRUE, but byond
+	var/list/corruptedChars = list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&")
+	. = list()
+	for(var/text_bit in split_html_text)
+		if(findtext(text_bit, regex("<\[^>\]*>")))
+			. += text_bit
+			continue
+		var/corrupted_bit = ""
+		for(var/i=1 to length(text_bit))
+			if(prob(per_letter_corruption_chance))
+				corrupted_bit += pick(corruptedChars)
+			else
+				corrupted_bit += copytext(text_bit, i, i+1)
+		. += corrupted_bit
+	return jointext(.,"")
+
 
 /**
   * Returns given text replaced entirely by nonsense chars


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #12129 by preventing html-like tags from being garbled. Uses regex because [you should always use regex to parse html](https://stackoverflow.com/a/1732454)