### PR TITLE
Add associate reagents to Peanutbutter Sandwhich and Free-Range Eggplant mutation

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -254,6 +254,7 @@
 	name_prefix = "Free range "
 	iconmod = "EggplantEggs"
 	crop = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	assoc_reagents = list("egg")
 
 // Wheat Mutations
 
@@ -746,6 +747,7 @@
 	name_suffix = "butter Sandwich"
 	crop = /obj/item/reagent_containers/food/snacks/sandwich/pb
 	iconmod = "PeanutSandwich"
+	assoc_reagents = list("bread")
 
 //Tobacco mutations
 


### PR DESCRIPTION
[Hydroponics][Balance]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds the "bread"-Reagent to the Peanutbutter sandwhich plant and the "egg"-Reagent to the Free-Range Eggplant muation.

Both reagents aren't common in recipes, with bread being in the squeeze-recipe and egg in a secret chem.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Let's Botany splice their own breakfast plants together, which is fun. And it makes sense for the plants in question.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


```changelog
(u)Lord_Earthfire
(+)Splices with peanutbutter sandwhich-plants grant the bread-reagent and splices with free-range eggplants now grant the egg-reagent
```
