### PR TITLE
Freezers use power based off temperature differential

### DIFF
--- a/code/modules/atmospherics/machinery/unary/cold_sink.dm
+++ b/code/modules/atmospherics/machinery/unary/cold_sink.dm
@@ -33,7 +33,7 @@
 		if(combined_heat_capacity > 0)
 			var/combined_energy = current_temperature*current_heat_capacity + air_heat_capacity*air_contents.temperature
 			air_contents.temperature = combined_energy/combined_heat_capacity
-			use_power(round(old_temperature-air_contents.temperature), ENVIRON) // watt per degree kelvin lowered
+			use_power(round(abs(old_temperature-air_contents.temperature)), ENVIRON) // watt per degree kelvin changed
 
 		if(abs(old_temperature-air_contents.temperature) > 1 && network)
 			network.update = 1

--- a/code/modules/atmospherics/machinery/unary/cold_sink.dm
+++ b/code/modules/atmospherics/machinery/unary/cold_sink.dm
@@ -34,7 +34,8 @@
 			var/combined_energy = current_temperature*current_heat_capacity + air_heat_capacity*air_contents.temperature
 			air_contents.temperature = combined_energy/combined_heat_capacity
 
-		//todo: have current temperature affected. require power to bring down current temperature again
+			// more of a fascimile than actually basing it off the work done, but the values feel right
+			use_power(round(air_contents.temperature-src.current_temperature), ENVIRON) // watt per degree kelvin from target temp
 
 		if(abs(old_temperature-air_contents.temperature) > 1 && network)
 			network.update = 1

--- a/code/modules/atmospherics/machinery/unary/cold_sink.dm
+++ b/code/modules/atmospherics/machinery/unary/cold_sink.dm
@@ -33,9 +33,7 @@
 		if(combined_heat_capacity > 0)
 			var/combined_energy = current_temperature*current_heat_capacity + air_heat_capacity*air_contents.temperature
 			air_contents.temperature = combined_energy/combined_heat_capacity
-
-			// more of a fascimile than actually basing it off the work done, but the values feel right
-			use_power(round(air_contents.temperature-src.current_temperature), ENVIRON) // watt per degree kelvin from target temp
+			use_power(round(old_temperature-air_contents.temperature), ENVIRON) // watt per degree kelvin lowered
 
 		if(abs(old_temperature-air_contents.temperature) > 1 && network)
 			network.update = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Freezers (which are a type of cold sink) consume environmental power based on the temperature differential achieved. This results in a minor (20-40W) drain for cryo/kitchen freezers that lowers over time as the gas reaches the desired temperature. The power drain for TEG engine cold loops increase more significantly, but still pales in comparison to blower equipment power.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Machines that do things should use power


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Freezers now use power based on how many degrees they shift the gas inside.
```
