### PR TITLE
ReplaceWith: fix opaque_atom_count loading issue

### DIFF
--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -577,6 +577,7 @@ proc/generate_space_color()
 	var/list/rllights = RL_Lights
 
 	var/old_opacity = src.opacity
+	var/old_opaque_atom_count = src.opaque_atom_count
 
 	var/old_blocked_dirs = src.blocked_dirs
 	var/old_checkinghasproximity = src.checkinghasproximity
@@ -659,7 +660,7 @@ proc/generate_space_color()
 	new_turf.RL_NeedsAdditive = rlneedsadditive
 	//new_turf.RL_OverlayState = rloverlaystate //we actually want these cleared
 	new_turf.RL_Lights = rllights
-	new_turf.opaque_atom_count = opaque_atom_count
+	new_turf.opaque_atom_count = old_opaque_atom_count
 
 
 	new_turf.blocked_dirs = old_blocked_dirs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL][BUGFIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes `/turf/var/opaque_atom_count` being loaded with the initial value of the `new_turf` type instead of the last value of the turf prior to replacement.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Probably not intended