### PR TITLE
Fixes jpsTurfPassable runtime

### DIFF
--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -445,6 +445,7 @@
 /// Returns false if there is a dense atom on the turf, unless a custom hueristic is passed.
 /proc/jpsTurfPassable(turf/T, turf/source, atom/passer, list/options)
 	. = TRUE
+	options ||= list()
 	if(istype(passer,/mob/living/critter/flock/drone) && istype(T, /turf/simulated/wall/auto/feather))
 		var/mob/living/critter/flock/drone/F = passer
 		var/turf/simulated/wall/auto/feather/wall = T


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a runtime caused by #11993 assuming jpsTurfPassable isn't called outside of pathfinding code.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes bad, every AI camera laser shot was causing one
