### PR TITLE
Cryogenic Healing Pods use power both passively and actively

### DIFF
--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	layer = EFFECTS_LAYER_BASE//MOB_EFFECT_LAYER
 	flags = NOSPLASH
+	power_usage = 50
 	var/on = FALSE //! Whether the cell is turned on or not
 	var/datum/light/light
 	var/ARCHIVED(temperature)
@@ -16,6 +17,7 @@
 
 	var/current_heat_capacity = 50
 	var/pipe_direction //! Direction of the pipe leading into this, set in New() based on dir
+	var/occupied_power_use = 500 //! Additional power usage when the pod is occupied (and on)
 
 	var/reagent_scan_enabled = 0
 	var/reagent_scan_active = 0
@@ -70,7 +72,7 @@
 				if (!ishuman(occupant))
 					src.go_out() // stop turning into cyborgs thanks
 				if (occupant.health < occupant.max_health || occupant.bioHolder.HasEffect("premature_clone"))
-
+					use_power(occupied_power_use, EQUIP)
 					process_occupant()
 				else
 					if(occupant.mind)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a passive 50 watt power usage to cryogenic healing pods
Adds an active 500 watt usage while both occupied and on. I picked this number because it's equal to the operating computer, and the cryo cell is at least doing that much.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Machines that do things should use power


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Cryogenic healing pods use power, with an increased rate while on and occupied.
```
