### PR TITLE
Log centcom entry before round end by nonadmins

### DIFF
--- a/code/z_adventurezones/earth.dm
+++ b/code/z_adventurezones/earth.dm
@@ -36,7 +36,7 @@ var/global/Z4_ACTIVE = 0 //Used for mob processing purposes
 					return
 				if(M.client.holder)
 					return
-				logTheThing(LOG_DEBUG, null, "[constructTarget(M)] entered Centcom before round end [log_loc(M)].")
+				logTheThing(LOG_DEBUG, M, "entered Centcom before round end [log_loc(M)].")
 
 /area/centcom/outside
 	name = "Earth"

--- a/code/z_adventurezones/earth.dm
+++ b/code/z_adventurezones/earth.dm
@@ -26,6 +26,7 @@ var/global/Z4_ACTIVE = 0 //Used for mob processing purposes
 	sound_group = "centcom"
 	filler_turf = "/turf/unsimulated/nicegrass/random"
 	is_centcom = 1
+	var/static/list/entered_ckeys = list()
 
 	Entered(atom/movable/A, atom/oldloc)
 		. = ..()
@@ -36,6 +37,9 @@ var/global/Z4_ACTIVE = 0 //Used for mob processing purposes
 					return
 				if(M.client.holder)
 					return
+				if(M.client.ckey in entered_ckeys)
+					return
+				entered_ckeys += M.client.ckey
 				logTheThing(LOG_DEBUG, M, "entered Centcom before round end [log_loc(M)].")
 
 /area/centcom/outside

--- a/code/z_adventurezones/earth.dm
+++ b/code/z_adventurezones/earth.dm
@@ -27,6 +27,17 @@ var/global/Z4_ACTIVE = 0 //Used for mob processing purposes
 	filler_turf = "/turf/unsimulated/nicegrass/random"
 	is_centcom = 1
 
+	Entered(atom/movable/A, atom/oldloc)
+		. = ..()
+		if (current_state < GAME_STATE_FINISHED)
+			if(istype(A, /mob/living))
+				var/mob/living/M = A
+				if(!M.client)
+					return
+				if(M.client.holder)
+					return
+				logTheThing(LOG_DEBUG, null, "[constructTarget(M)] entered Centcom before round end [log_loc(M)].")
+
 /area/centcom/outside
 	name = "Earth"
 	icon_state = "nothing_earth"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Logs when a living mob with a client that is not an admin enters Centcom.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Keep tabs on who is up to things... 👀