### PR TITLE
Restricts wraith summons to unoccupied turfs

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -1720,17 +1720,20 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 
 	cast(atom/target, params)
 		if (..())
-			return 1
+			return TRUE
 
 		var/turf/T = get_turf(holder.owner)
-		if (isturf(T) && !istype(T, /turf/space))
-			boutput(holder.owner, "You begin to channel power to call a spirit to this realm!")
-			src.doCooldown()
-			make_summon(holder.owner, T)
-			return 0
-		else
-			boutput(holder.owner, "<span class='alert'>You can't cast this spell on your current tile!</span>")
-			return 1
+		if (!T || !istype(T,/turf/simulated/floor))
+			boutput(holder.owner, "<span class='notice'>You cannot use this here!</span>")
+			return TRUE
+		for (var/obj/O in T)
+			if (O.density)
+				boutput(holder.owner, "<span class='notice'>There is something in the way!</span>")
+				return TRUE
+		boutput(holder.owner, "You begin to channel power to call a spirit to this realm!")
+		src.doCooldown()
+		make_summon(holder.owner, T)
+		return FALSE
 
 	proc/make_summon(var/mob/living/intangible/wraith/W, var/turf/T, var/tries = 0)
 		if (!istype(W))
@@ -1790,7 +1793,7 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 	// cast(turf/target, params)
 	cast(atom/target, params)
 		if (..())
-			return 1
+			return TRUE
 
 		var/total_plague_rats = 0
 		for (var/client/C in clients)
@@ -1803,17 +1806,21 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 				total_plague_rats++
 		if(total_plague_rats < (max_allowed_rats + (player_count / 30)))	//Population scaling
 			var/turf/T = get_turf(holder.owner)
-			if (isturf(T) && !istype(T, /turf/space))
-				boutput(holder.owner, "You begin to channel power to summon a plague rat into this realm!")
-				src.doCooldown()
-				make_plague_rat(holder.owner, T)
-				return 0
-			else
-				boutput(holder.owner, "<span class='alert'>You can't cast this spell on your current tile!</span>")
-				return 1
+			if (!T || !istype(T,/turf/simulated/floor))
+				boutput(holder.owner, "<span class='notice'>You cannot use this here!</span>")
+				return TRUE
+			for (var/obj/O in T)
+				if (O.density)
+					boutput(holder.owner, "<span class='notice'>There is something in the way!</span>")
+					return TRUE
+			boutput(holder.owner, "You begin to channel power to summon a plague rat into this realm!")
+			src.doCooldown()
+			make_plague_rat(holder.owner, T)
+			return FALSE
+
 		else
 			boutput(holder.owner, "<span class='alert'>This [station_or_ship()] is already a rat den, you cannot summon another rat!</span>")
-			return 1
+			return TRUE
 
 	proc/make_plague_rat(var/mob/W, var/turf/T, var/tries = 0)
 		if (!istype(W, /mob/living/intangible/wraith/wraith_decay))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wraiths can no longer use their ghost critter summon abilities inside of any dense object, or on a turf that isn't the station's floor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents wraiths from using their summoning abilities in places that will cause the summon to get stuck.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)Wraiths can no longer summon creatures if there is something in the way.
```
