### PR TITLE
Stop Sylvester from creating paradoxes

### DIFF
--- a/code/obj/critter/turtle.dm
+++ b/code/obj/critter/turtle.dm
@@ -445,7 +445,6 @@
 		beret.name = "HoS Beret"
 		beret.icon_state = "hosberet"
 		beret.item_state = "hosberet"
-		set_loc(beret)
 
 		wearing_beret = beret
 


### PR DESCRIPTION
[BUG][OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes Sylvester stop trying to teleport inside of their hat when they are born into existence.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As much as we all love Sylvester being the law, this is still a bug.
