### PR TITLE
Makes roses prick people they are handed to

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -486,15 +486,7 @@
 	attack_hand(mob/user)
 		var/mob/living/carbon/human/H = user
 		if(istype(H) && src.thorned)
-			if (H.hand)//gets active arm - left arm is 1, right arm is 0
-				if (istype(H.limbs.l_arm,/obj/item/parts/robot_parts) || istype(H.limbs.l_arm,/obj/item/parts/human_parts/arm/left/synth))
-					..()
-					return
-			else
-				if (istype(H.limbs.r_arm,/obj/item/parts/robot_parts) || istype(H.limbs.r_arm,/obj/item/parts/human_parts/arm/right/synth))
-					..()
-					return
-			if(H.gloves)
+			if (src.thorns_protected(H))
 				..()
 				return
 			if(ON_COOLDOWN(src, "prick_hands", 1 SECOND))
@@ -502,6 +494,16 @@
 			src.prick(user)
 		else
 			..()
+
+	proc/thorns_protected(mob/living/carbon/human/H)
+		if (H.hand)//gets active arm - left arm is 1, right arm is 0
+			if (istype(H.limbs.l_arm,/obj/item/parts/robot_parts) || istype(H.limbs.l_arm,/obj/item/parts/human_parts/arm/left/synth))
+				return TRUE
+		else
+			if (istype(H.limbs.r_arm,/obj/item/parts/robot_parts) || istype(H.limbs.r_arm,/obj/item/parts/human_parts/arm/right/synth))
+				return TRUE
+		if(H.gloves)
+			return TRUE
 
 	proc/prick(mob/M)
 		boutput(M, "<span class='alert'>You prick yourself on [src]'s thorns trying to pick it up!</span>")
@@ -524,6 +526,13 @@
 			)
 			return TRUE
 		..()
+
+	pickup(mob/user)
+		. = ..()
+		if(ishuman(user) && src.thorned && !src.thorns_protected(user))
+			src.prick(user)
+			SPAWN(0.1 SECONDS)
+				user.drop_item(src, FALSE)
 
 /obj/item/plant/flower/rose/poisoned
 	attack(mob/M, mob/user, def_zone)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anyone not wearing gloves or sporting robotic/plant arms will now be pricked when they are given a rose.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They're supposed to prick anyone who picks them up, but I implemented it in `attack_hand` so it didn't trigger on giving it to someone.