### PR TITLE
Gives mining borgs mesons instead of a jetpack on ocean maps

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2300,9 +2300,15 @@
 				src.upgrades += new /obj/item/roboupgrade/healthgoggles(src)
 			if("Mining")
 				src.freemodule = 0
+			#ifdef UNDERWATER_MAP
+				boutput(src, "<span class='notice'>You chose the Mining module. It comes with a free Meson Vision Upgrade.</span>")
+				src.upgrades += new /obj/item/roboupgrade/opticmeson(src)
+			#else
 				boutput(src, "<span class='notice'>You chose the Mining module. It comes with a free Propulsion Upgrade.</span>")
-				src.set_module(new /obj/item/robot_module/mining(src))
 				src.upgrades += new /obj/item/roboupgrade/jetpack(src)
+			#endif
+				src.set_module(new /obj/item/robot_module/mining(src))
+
 			if ("Construction Worker")
 				src.freemodule = 0
 				boutput(src, "<span class='notice'>You chose the Construction Worker module. It comes with a free Construction Visualizer Upgrade.</span>")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2300,6 +2300,7 @@
 				src.upgrades += new /obj/item/roboupgrade/healthgoggles(src)
 			if("Mining")
 				src.freemodule = 0
+				src.set_module(new /obj/item/robot_module/mining(src))
 			#ifdef UNDERWATER_MAP
 				boutput(src, "<span class='notice'>You chose the Mining module. It comes with a free Meson Vision Upgrade.</span>")
 				src.upgrades += new /obj/item/roboupgrade/opticmeson(src)
@@ -2307,7 +2308,6 @@
 				boutput(src, "<span class='notice'>You chose the Mining module. It comes with a free Propulsion Upgrade.</span>")
 				src.upgrades += new /obj/item/roboupgrade/jetpack(src)
 			#endif
-				src.set_module(new /obj/item/robot_module/mining(src))
 
 			if ("Construction Worker")
 				src.freemodule = 0

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2308,7 +2308,6 @@
 				boutput(src, "<span class='notice'>You chose the Mining module. It comes with a free Propulsion Upgrade.</span>")
 				src.upgrades += new /obj/item/roboupgrade/jetpack(src)
 			#endif
-
 			if ("Construction Worker")
 				src.freemodule = 0
 				boutput(src, "<span class='notice'>You chose the Construction Worker module. It comes with a free Construction Visualizer Upgrade.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

A [QOL] (?) for [SILICONS]! How wonderful.
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Jetpacks are completely useless underwater (maybe not on manta but that's been out of rotation long enough for me to completely forget about it), so why not start them with a meson upgrade instead?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)Mining cyborgs now get mesons instead of a jetpack on ocean maps.
```
