### PR TITLE
fix kondaru's AI core button placement

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11433,6 +11433,11 @@
 	dir = 1;
 	name = "autoname - SS13"
 	},
+/obj/machinery/door_control{
+	id = "ai_core";
+	name = "AI Core Shield";
+	pixel_y = -26
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aJW" = (
@@ -11894,14 +11899,6 @@
 "aLQ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
-"aLS" = (
-/obj/machinery/door_control{
-	id = "ai_core";
-	name = "AI Core Shield";
-	pixel_y = 6
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai)
 "aLV" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side,
@@ -129992,7 +129989,7 @@ aDo
 aEE
 aHC
 aJV
-aLS
+anX
 aOq
 aQR
 aSX


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the kondaru AI core shield button into the centre of the shielding like on other maps, while also varediting it to look like it is still on the wall in its original spot (like on other maps)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12170