### PR TITLE
Nadir Fixbatch 9

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5405,7 +5405,10 @@
 	},
 /area/station/hallway/primary/northwest)
 "cCn" = (
-/obj/storage/crate/robotparts,
+/obj/machinery/recharge_station,
+/obj/landmark/start{
+	name = "Cyborg"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "cCs" = (
@@ -5610,7 +5613,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "cIM" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
@@ -11663,6 +11666,12 @@
 	dir = 1
 	},
 /area/station/crew_quarters/pool)
+"fDm" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "fDs" = (
 /obj/table/reinforced/auto,
 /obj/machinery/microwave,
@@ -14209,7 +14218,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "gLY" = (
-/obj/wingrille_spawn/auto/crystal,
+/obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
@@ -15248,6 +15257,12 @@
 /obj/item/sponge,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
+"hiW" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engine/inner{
+	name = "Transception Array Control"
+	})
 "hiY" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
@@ -15495,10 +15510,7 @@
 /area/station/crew_quarters/fitness)
 "hmT" = (
 /obj/machinery/light_switch/west,
-/obj/machinery/recharge_station,
-/obj/landmark/start{
-	name = "Cyborg"
-	},
+/obj/storage/crate/robotparts,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -23979,7 +23991,7 @@
 	name = "Head of Personnel's Quarters"
 	})
 "laQ" = (
-/obj/wingrille_spawn/auto/crystal,
+/obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -25001,6 +25013,10 @@
 /obj/item/storage/toilet/goldentoilet,
 /turf/simulated/floor/sanitary,
 /area/station/bridge/captain)
+"lxn" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "lxp" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -32009,12 +32025,6 @@
 /turf/simulated/floor/carpet/purple/fancy/innercorner/ne_sw,
 /area/station/science/lobby{
 	name = "Science Lounge"
-	})
-"oNU" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
 	})
 "oOu" = (
 /obj/table/round/auto,
@@ -78224,7 +78234,7 @@ rSM
 mSi
 gbL
 fzq
-gbL
+fDm
 tEn
 tEn
 xYB
@@ -78244,7 +78254,7 @@ plY
 xYB
 tEn
 tEn
-gbL
+fDm
 oPO
 gbL
 ncz
@@ -79122,7 +79132,7 @@ rJg
 rJg
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 hXZ
@@ -79130,7 +79140,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 xYB
@@ -79150,7 +79160,7 @@ umD
 xYB
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 hxY
@@ -79158,7 +79168,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 rJg
@@ -79424,7 +79434,7 @@ bzS
 bzS
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 tNU
@@ -79432,7 +79442,7 @@ eMn
 eTW
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 bJL
@@ -79452,7 +79462,7 @@ mDc
 cMR
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 kIs
@@ -79460,7 +79470,7 @@ eMn
 mSi
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 bzS
@@ -79726,7 +79736,7 @@ bzS
 bzS
 bzS
 rJg
-gbL
+fDm
 gfS
 gbL
 hXZ
@@ -79734,7 +79744,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 shh
@@ -79754,7 +79764,7 @@ dDw
 mfr
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 hxY
@@ -79762,7 +79772,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 bzS
 bzS
@@ -80338,7 +80348,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 rJg
@@ -80358,7 +80368,7 @@ rJg
 rJg
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 hxY
@@ -80640,7 +80650,7 @@ eMn
 mSi
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 rJg
@@ -80660,7 +80670,7 @@ rJg
 rJg
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 ncz
@@ -80942,7 +80952,7 @@ eMn
 jQa
 gbL
 gfS
-gbL
+fDm
 rJg
 rJg
 rJg
@@ -80962,7 +80972,7 @@ rJg
 rJg
 rJg
 rJg
-gbL
+fDm
 gfS
 gbL
 hxY
@@ -81245,25 +81255,25 @@ jSC
 dqY
 tCM
 dqY
-gbL
-gbL
-gbL
+fDm
+fDm
+fDm
 dqY
-gbL
-gbL
-gbL
+fDm
+fDm
+fDm
 dqY
-gbL
-gbL
-gbL
+fDm
+fDm
+fDm
 dqY
-gbL
-gbL
-gbL
+fDm
+fDm
+fDm
 dqY
-oNU
-oNU
-oNU
+fDm
+fDm
+fDm
 dqY
 tCM
 dqY
@@ -96391,11 +96401,11 @@ iPe
 baj
 baj
 baj
-mvA
-mvA
-mvA
-mvA
-mvA
+hiW
+hiW
+hiW
+hiW
+hiW
 baj
 itm
 thj
@@ -96692,13 +96702,13 @@ fBi
 mxa
 gUK
 kST
-mvA
+hiW
 ijH
 auM
 aPz
 yge
 knN
-mvA
+hiW
 xxN
 gti
 mvA
@@ -96994,14 +97004,14 @@ gUd
 eKF
 ukt
 kST
-mvA
+hiW
 aPz
 aPz
 nKt
 mzq
 rld
-mvA
-mvA
+hiW
+hiW
 gfC
 mvA
 jyU
@@ -97296,7 +97306,7 @@ dzl
 tpy
 fjZ
 kST
-mvA
+hiW
 mjt
 aPz
 aPz
@@ -97598,14 +97608,14 @@ nmv
 oln
 ukt
 kST
-mvA
+hiW
 aPz
 aPz
 uob
 aWU
 ijH
-mvA
-mvA
+hiW
+hiW
 gfC
 mvA
 sOI
@@ -97900,13 +97910,13 @@ nQa
 cMA
 dbA
 kST
-mvA
+hiW
 ijH
 nlC
 aPz
 yge
 knN
-mvA
+hiW
 rYl
 vgL
 mvA
@@ -98203,11 +98213,11 @@ ykm
 baj
 baj
 baj
-mvA
-mvA
-mvA
-mvA
-mvA
+hiW
+hiW
+hiW
+hiW
+hiW
 baj
 abk
 sbd
@@ -113257,25 +113267,25 @@ pFB
 uSe
 ndB
 uSe
-nxE
-nxE
-nxE
+lxn
+lxn
+lxn
 uSe
-nxE
-nxE
-nxE
+lxn
+lxn
+lxn
 uSe
-nxE
-nxE
-nxE
+lxn
+lxn
+lxn
 uSe
-nxE
-nxE
-nxE
+lxn
+lxn
+lxn
 uSe
-nxE
-nxE
-nxE
+lxn
+lxn
+lxn
 uSe
 ndB
 uSe
@@ -113558,7 +113568,7 @@ udE
 mbi
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 rJg
@@ -113578,7 +113588,7 @@ rJg
 rJg
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 mtw
@@ -113860,7 +113870,7 @@ udE
 cEv
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 iMT
@@ -113880,7 +113890,7 @@ iMT
 iMT
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 hJZ
@@ -114162,7 +114172,7 @@ udE
 mbi
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 iMT
@@ -114182,7 +114192,7 @@ iMT
 iMT
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 mtw
@@ -114758,7 +114768,7 @@ bzS
 bzS
 bzS
 rJg
-nxE
+lxn
 wXk
 nxE
 ftp
@@ -114766,7 +114776,7 @@ udE
 mbi
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 iMT
@@ -114786,7 +114796,7 @@ iMT
 iMT
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 mtw
@@ -114794,7 +114804,7 @@ udE
 mbi
 nxE
 wXk
-nxE
+lxn
 bUI
 bUI
 bUI
@@ -115060,7 +115070,7 @@ bzS
 bzS
 bzS
 rJg
-nxE
+lxn
 wXk
 nxE
 fwT
@@ -115068,7 +115078,7 @@ udE
 hpn
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 iMT
@@ -115088,7 +115098,7 @@ iMT
 iMT
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 rie
@@ -115096,7 +115106,7 @@ udE
 cEv
 nxE
 wXk
-nxE
+lxn
 bUI
 bUI
 bUI
@@ -115362,7 +115372,7 @@ bzS
 bzS
 bzS
 rJg
-nxE
+lxn
 wXk
 nxE
 ftp
@@ -115370,7 +115380,7 @@ udE
 mbi
 nxE
 wXk
-nxE
+lxn
 rJg
 rJg
 iMT
@@ -115390,7 +115400,7 @@ iMT
 iMT
 rJg
 rJg
-nxE
+lxn
 wXk
 nxE
 mtw
@@ -116276,7 +116286,7 @@ nOs
 cEv
 nxE
 kUk
-nxE
+lxn
 uvq
 hpk
 iMT
@@ -116296,7 +116306,7 @@ iMT
 iMT
 hpk
 uvq
-nxE
+lxn
 rSA
 nxE
 hJZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Outermost windows in east and west docks, the transception array surround, and catalytic generator stations have been upgraded to reinforced crystal.
- Relocated a cyborg docking station in Robotics to be farther from manufacturers, to make it a bit harder to accidentally detonate the entire lab when messing around with wires.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves Nadir's usability and map integrity.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Nadir fixbatch 9: relocated a cyborg dock prone to accidentally blowing up Robotics, reinforced the external windows.
```
