### PR TITLE
Fixes gibbed puritans breaking clone scanners

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -512,7 +512,8 @@ proc/find_ghost_by_key(var/find_key)
 		return
 
 	proc/move_mob_inside(var/mob/M, var/mob/user)
-		if (!can_operate(user) || !ishuman(M)) return
+		if (!can_operate(user) || !ishuman(M) || QDELETED(M))
+			return
 
 		M.remove_pulling()
 		M.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #12177
Might fix #7941 but I'm not a priest.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, do not put `null` in the clone scanner