### PR TITLE
Adjust medibots to use Iodide instead of charcoal

### DIFF
--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -39,7 +39,7 @@
 	var/treatment_brute = "saline"
 	var/treatment_oxy = "salbutamol"
 	var/treatment_fire = "saline"
-	var/treatment_tox = "charcoal"
+	var/treatment_tox = "anti_rad"
 	var/treatment_virus = "spaceacillin"
 	/// the stuff the bot injects when emagged
 	var/list/dangerous_stuff = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes medibots use Potassium Iodide to cure toxin damage. Not a huge change either way but personally it's gotten in the way of a few surgeries so I thought I'd raise this PR and see which way it goes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves medibots usefulness with radiation (which is a fairly common ailment). 
Stops filling people with large doses of purgatives (which can make synatropine mixes deplete quite quickly). 
Stops killing my vibe when I wanna get blasted on liquor.

Technically charcoal is a non-renewable, not that it's a huge deal.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Medibots now use Potassium Iodide as their tox treatment.
```
