### PR TITLE
Mining magnet safety check ignores dead critters

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -194,7 +194,7 @@
 
 			for (var/mob/living/L in T)
 				if(ismobcritter(L) && isdead(L)) // we don't care about dead critters
-					break
+					continue
 				if(!isintangible(L)) //neither blob overmind or AI eye should block this
 					unacceptable = TRUE
 					break

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -193,6 +193,8 @@
 		for (var/turf/T in block(origin, locate(origin.x + width - 1, origin.y + height - 1, origin.z)))
 
 			for (var/mob/living/L in T)
+				if(ismobcritter(L) && isdead(L)) // we don't care about dead critters
+					break
 				if(!isintangible(L)) //neither blob overmind or AI eye should block this
 					unacceptable = TRUE
 					break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When checking for unacceptable content in the magnet area, do not mark dead mob-critters as unacceptable.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
making critters into mobs meant they're subject to more checks. This fixes an errant one.
Fixes #12197
Fixes #11133