### PR TITLE
Oceanify changes catwalk support turfs

### DIFF
--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -163,9 +163,18 @@ client/proc/replace_space_exclusive()
 #ifdef UNDERWATER_MAP
 			T.name = ocean_name
 #endif
-
 			T.color = ocean_color
 			LAGCHECK(LAG_REALTIME)
+
+// catwalks sim water otherwise
+#ifndef UNDERWATER_MAP
+		for(var/turf/simulated/floor/airless/plating/catwalk/C in world)
+			if (C.z != 1 || istype(C, /turf/space/fluid/warp_z5)) continue
+			var/turf/orig = locate(C.x, C.y, C.z)
+			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
+			T.color = ocean_color
+			LAGCHECK(LAG_REALTIME)
+#endif
 
 		message_admins("Finished space replace!")
 		map_currently_underwater = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After doing the space turf replacement for oceanify, also replace the specialized airless turfs underneath catwalks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They're always exposed to the sea, so why bother simming the fluids
It looks jank if you rip up a catwalk as it's a dim black & grey texture underneath right next to ocean floor - the catwalk looks/works fine on sand

