### PR TITLE
Another wizard technophobia attempt

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1045,41 +1045,43 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 		if(!usable(user)) return
 
 		if(params["left"] && master && get_dist_pixel_squared(user, target, params) > ITEMSPECIAL_PIXELDIST_SQUARED)
-			preUse(user)
-			var/direction = get_dir_pixel(user, target, params)
-			var/list/attacked = list()
+			src.do_effect(target, params, user)
 
-			var/turf/effect = get_step(master, direction)
+	proc/do_effect(atom/target, params, mob/user)
+		preUse(user)
+		var/direction = get_dir_pixel(user, target, params)
+		var/list/attacked = list()
 
-			var/obj/itemspecialeffect/spark/spark = new /obj/itemspecialeffect/spark
-			spark.setup(effect)
-			spark.set_dir(direction)
-			logTheThing(LOG_COMBAT, user, "uses the spark special attack ([src.type]) at [log_loc(user)].")
+		var/turf/effect = get_step(master, direction)
 
-			var/hit = 0
-			for(var/atom/movable/A in effect)
-				if(A in attacked) continue
-				if(isTarget(A))
-					on_hit(A,2)
-					attacked += A
-					hit = 1
-					if (ishuman(user) && master  && istype(master, /obj/item/clothing/gloves))
-						user.unlock_medal("High Five!", 1)
-					break
-			if (!hit)
-				SPAWN(secondhit_delay)
-					step(spark, direction, 2)
-					for(var/atom/movable/A in spark.loc)
-						if(A in attacked) continue
-						if(isTarget(A))
-							on_hit(A, mult)
-							attacked += A
-							hit = 1
-							break
-			afterUse(user)
-			//if (!hit)
-			playsound(master, 'sound/effects/sparks6.ogg', 70, 0)
-		return
+		var/obj/itemspecialeffect/spark/spark = new /obj/itemspecialeffect/spark
+		spark.setup(effect)
+		spark.set_dir(direction)
+		logTheThing(LOG_COMBAT, user, "uses the spark special attack ([src.type]) at [log_loc(user)].")
+
+		var/hit = 0
+		for(var/atom/movable/A in effect)
+			if(A in attacked) continue
+			if(isTarget(A))
+				on_hit(A,2)
+				attacked += A
+				hit = 1
+				if (ishuman(user) && master  && istype(master, /obj/item/clothing/gloves))
+					user.unlock_medal("High Five!", 1)
+				break
+		if (!hit)
+			SPAWN(secondhit_delay)
+				step(spark, direction, 2)
+				for(var/atom/movable/A in spark.loc)
+					if(A in attacked) continue
+					if(isTarget(A))
+						on_hit(A, mult)
+						attacked += A
+						hit = 1
+						break
+		afterUse(user)
+		//if (!hit)
+		playsound(master, 'sound/effects/sparks6.ogg', 70, 0)
 
 
 	proc/on_hit(var/hit, var/mult = 1)

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -585,7 +585,10 @@ function lineEnter (ev)
 
 	if((href_list["command"]) && src.active_program)
 		usr << output(null, "comp3.browser:input_clear")
-		src.active_program.input_text(href_list["command"])
+		var/text = href_list["command"]
+		if (iswizard(usr))
+			text = runicText(text)
+		src.active_program.input_text(text)
 		playsound(src.loc, "keyboard", 50, 1, -15)
 
 	else if(href_list["disk"])

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -92,6 +92,7 @@
 
 /obj/item/device/flash/proc/wizard_check(mob/user)
 	if (src.status && iswizard(user))
+		logTheThing(LOG_COMBAT, user, "burns out [src] due to being a wizard at [log_loc(user)].")
 		user.visible_message("<span class='alert'>[user] emits sparks from [his_or_her(user)] fingertips, overloading [src]'s bulb.</span>")
 		playsound(src, 'sound/impact_sounds/Crystal_Shatter_1.ogg', 50, 1, pitch = 2)
 		src.flash_mob(user, user)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -15,6 +15,7 @@
 	var/can_swap_cell = 1
 	muzzle_flash = null
 	inventory_counter_enabled = 1
+	wizard_allowed = FALSE
 
 	New()
 		var/cell = null

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -40,6 +40,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/current_projectile_num = 1
 	var/silenced = 0
 	var/can_dual_wield = 1
+	var/wizard_allowed = TRUE
 
 	var/slowdown = 0 //Movement delay attack after attack
 	var/slowdown_time = 10 //For this long
@@ -454,6 +455,11 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 				how_drunk = 1
 		how_drunk = max(0, how_drunk - isalcoholresistant(user))
 		spread += 5 * how_drunk
+
+	if (!src.wizard_allowed && iswizard(user))
+		user.show_message("<span class='alert'>Your magical energies interfere with [src], causing it to misfire wildly!</span>")
+		spread = 100
+
 	spread = max(spread, spread_angle)
 
 	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread, alter_proj = new/datum/callback(src, .proc/alter_projectile))

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -255,6 +255,7 @@
 			return
 
 		if (src.can_stun() && iswizard(user) && M != user)
+			logTheThing(LOG_COMBAT, user, "tries to stun [constructTarget(M,"combat")] with the [src.name] at [log_loc(M)] but casts sparks instead due to being a wizard.")
 			user.visible_message("<span class='alert'>[user] waves [src] in strange arcane patterns, casting sparks flying into the air.</span>",\
 			"<span class='alert'>You wave [src] in strange arcane patterns, casting sparks flying into the air.</span>")
 			var/datum/item_special/spark/special = src.special

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -254,6 +254,14 @@
 			user.show_message("<span class='alert'>[M] seems to be warded from attacks!</span>")
 			return
 
+		if (src.can_stun() && iswizard(user) && M != user)
+			user.visible_message("<span class='alert'>[user] waves [src] in strange arcane patterns, casting sparks flying into the air.</span>",\
+			"<span class='alert'>You wave [src] in strange arcane patterns, casting sparks flying into the air.</span>")
+			var/datum/item_special/spark/special = src.special
+			special.do_effect(M, list("left" = TRUE, "icon-x" = 16, "icon-y" = 16), user) //spoof some params
+			src.process_charges(-1, user)
+			return
+
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, M, "failed", 1)
 			JOB_XP(user, "Clown", 1)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2392,12 +2392,8 @@ proc/gradientText(var/color1, var/color2, message)
     result += "<span style='color:[col]'>[chars]</span>"
   . = result.Join()
 
-/**
-  * Returns given text replaced by nonsense chars, excepting HTML tags, on a 40% or given % basis
-  */
-proc/radioGarbleText(var/message, var/per_letter_corruption_chance=40)
-	var/split_html_text = splittext(message,  regex("<\[^>\]*>"), 1, length(message), TRUE) //I'd love to just use include_delimiters=TRUE, but byond
-	var/list/corruptedChars = list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&")
+proc/garbleText(var/message, var/corruptedChars, var/per_letter_corruption_chance = 40)
+	var/split_html_text = splittext(message,  regex("<\[^>\]*>"), 1, length(message) + 1, TRUE) //I'd love to just use include_delimiters=TRUE, but byond
 	. = list()
 	for(var/text_bit in split_html_text)
 		if(findtext(text_bit, regex("<\[^>\]*>")))
@@ -2412,12 +2408,23 @@ proc/radioGarbleText(var/message, var/per_letter_corruption_chance=40)
 		. += corrupted_bit
 	return jointext(.,"")
 
+/**
+  * Returns given text replaced by nonsense chars, excepting HTML tags, on a 40% or given % basis
+  */
+proc/radioGarbleText(var/message, var/per_letter_corruption_chance = 40)
+	return garbleText(message, list("@","#","!",",",".","-","=","/","\\","'","\"","`","*","(",")","[","]","_","&"), per_letter_corruption_chance)
 
 /**
   * Returns given text replaced entirely by nonsense chars
   */
 proc/illiterateGarbleText(var/message)
-	. = radioGarbleText(message, 100)
+	return radioGarbleText(message, 100)
+
+proc/runicText(var/message, var/per_letter_corruption_chance = 20)
+	var/list/runes = list()
+	for (var/character_code in 5792 to 5866) //unicode runes character range
+		runes += ascii2text(character_code)
+	return garbleText(message, runes, per_letter_corruption_chance)
 
 /**
   * Returns the time in seconds since a given timestamp

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2420,11 +2420,16 @@ proc/radioGarbleText(var/message, var/per_letter_corruption_chance = 40)
 proc/illiterateGarbleText(var/message)
 	return radioGarbleText(message, 100)
 
+var/list/runic_symbols = null
+/**
+  * Returns given text replaced randomly by runic symbols
+  */
 proc/runicText(var/message, var/per_letter_corruption_chance = 20)
-	var/list/runes = list()
-	for (var/character_code in 5792 to 5866) //unicode runes character range
-		runes += ascii2text(character_code)
-	return garbleText(message, runes, per_letter_corruption_chance)
+	if (!runic_symbols)
+		runic_symbols = list()
+		for (var/character_code in 5792 to 5866) //unicode runes character range
+			runic_symbols += ascii2text(character_code)
+	return garbleText(message, runic_symbols, per_letter_corruption_chance)
 
 /**
   * Returns the time in seconds since a given timestamp


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes wizards creatively mess up when using certain technological weapons and items.
- Flashes hit both the target and user and burn out in one hit
- Batons can only shoot sparks
- Energy guns (tasers, phasers, eguns etc.) have 100 degrees of spread
- Attempting to type in a terminal will replace random letters with runes (not sure about this one, probably not necessary but I thought it was neat)

Also fixes an off by one error in the garble text proc, remind me to atomize that if the runic stuff gets cut.

TODO:
- [x] add logging

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wizards are one of the strongest rampage antags and them getting access to easily stolen security weapons in addition to their base kit can make fighting them feel very unfair.
Technophobia is a thematic and generally popular solution for this. A couple of attempts to implement it have been made in the past but closed for various reasons: #7104, #8329


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Wizards now struggle to use various technological weapons (stun batons, energy weapons and flashes)
```
