### PR TITLE
Fix some bare density writes

### DIFF
--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -518,7 +518,7 @@
 			if(src.powerlevel < 3) src.gas_impermeable = TRUE
 			if(src.powerlevel == 3)
 				src.mouse_opacity = 1
-				src.density = 1
+				src.set_density(TRUE)
 		else
 			src.icon_state = ""
 			src.isactive = FALSE
@@ -526,7 +526,7 @@
 			src.flags &= ~FLUID_DENSE
 			src.gas_impermeable = FALSE
 			src.mouse_opacity = 0
-			src.density = 0
+			src.set_density(FALSE)
 
 	proc/update_nearby_tiles(need_rebuild)
 		var/turf/simulated/source = loc

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -32,13 +32,13 @@
 	proc/railing_break(obj/railing/The_Railing)
 		if(!(railing_is_broken(The_Railing)))
 			The_Railing.broken = 1
-			The_Railing.density = 0
+			The_Railing.set_density(FALSE)
 			var/random_sprite = rand(1, 4)
 			The_Railing.icon_state = "railing-broken-" + "[random_sprite]"
 
 	proc/railing_fix(obj/railing/The_Railing)
 		if(railing_is_broken(The_Railing))
-			The_Railing.density = 1
+			The_Railing.set_density(TRUE)
 			The_Railing.broken = 0
 
 

--- a/code/z_adventurezones/earth.dm
+++ b/code/z_adventurezones/earth.dm
@@ -660,7 +660,7 @@ proc/put_mob_in_centcom_cloner(mob/living/L, indirect=FALSE)
 	if(!istype(AR, /area/centcom/reconstitutioncenter))
 		clone.set_loc(get_centcom_mob_cloner_spawn_loc())
 	if(!indirect)
-		L.density = TRUE
+		L.set_density(TRUE)
 		L.set_a_intent(INTENT_HARM)
 		L.dir_locked = TRUE
 	playsound(clone, 'sound/machines/ding.ogg', 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`A.density = x` -> `A.set_density(x)`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

(most) bare density writes are bad and technically bugs. There are some still left, and those probably *should* ignore atom properties and not trigger pathfinding stuff, because most of them are temporary that let gibsharks clip through walls or make room for admin stuff. so, yeah.


### pali told me not to touch railings too much
