### PR TITLE
Adds a verb for wraiths to hide deadchat

### DIFF
--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -51,6 +51,8 @@
 	var/formaldehyde_tolerance = 25
 	///specifiy strong or weak tk powers. Weak for poltergeists.
 	var/weak_tk = FALSE
+	///can the wraith hear ghosts? Toggleable with a verb/proc
+	var/hearghosts = TRUE
 
 	var/datum/movement_controller/movement_controller
 
@@ -113,6 +115,7 @@
 		src.UpdateName()
 
 		get_image_group(CLIENT_IMAGE_GROUP_CURSES).add_mob(src)
+		src.verbs += /mob/living/intangible/wraith/proc/silence_ghosts
 
 	is_spacefaring()
 		return !density
@@ -777,3 +780,15 @@
 			new/datum/objective/specialist/wraith/survive(null, traitor)
 		if(3)
 			new/datum/objective/specialist/wraith/flawless(null, traitor)
+
+//hearghosts is checked in deadsay.dm and chatprocs.dm
+/mob/living/intangible/wraith/proc/silence_ghosts()
+	set category = "Wraith"
+	name = "Silence ghosts"
+
+	if (src.hearghosts)
+		src.hearghosts = FALSE
+		boutput(src, "<span class='notice'>No longer hearing the whispers of the dead</span>")
+	else
+		src.hearghosts = TRUE
+		boutput(src, "<span class='notice'>Now hearing the whispers of the dead</span>")

--- a/code/modules/admin/deadsay.dm
+++ b/code/modules/admin/deadsay.dm
@@ -32,6 +32,10 @@
 			continue
 		if (istype(M,/mob/dead/target_observer/slasher_ghost))
 			continue
+		if (iswraith(M))
+			var/mob/living/intangible/wraith/the_wraith = M
+			if (!the_wraith.hearghosts)
+				continue
 
 		//admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
 		if (isdead(M) || iswraith(M) || (M.client && M.client.holder && M.client.deadchat && !M.client.player_mode) || isghostdrone(M) || isVRghost(M) || inafterlifebar(M))

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -264,6 +264,10 @@
 
 		if (istype(M,/mob/dead/target_observer/hivemind_observer)) continue
 		if (istype(M,/mob/dead/target_observer/mentor_mouse_observer)) continue
+		if (iswraith(M))
+			var/mob/living/intangible/wraith/the_wraith = M
+			if (!the_wraith.hearghosts)
+				continue
 
 		if (isdead(M) || iswraith(M) || isghostdrone(M) || isVRghost(M) || inafterlifebar(M) || istype(M, /mob/living/seanceghost))
 			if(chat_text && !M.client.preferences.flying_chat_hidden)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new verb tab named "Wraith" containing one verb "silence ghosts" which stops them from seeing deadchat.
Hitting the button again unsilences it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduces backseat gaming and ghosts hounding wraiths to use summons especially on higher population rounds.

(u)Bartimeus973
(+)Wraiths can now hide ghost chat with the "silence ghosts" verb in the new "Wraith" command tab.
