### PR TITLE
Fixes printer machine registry

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1677,6 +1677,8 @@
 	icon_state = "printer0"
 	device_tag = "PNET_PRINTDEVC"
 	mats = 6
+	power_usage = 200
+	machine_registry_idx = MACHINES_PRINTERS
 	var/print_id = null //Just like databanks.
 	var/temp_msg = "PRINTER OK" //Appears in the interface window.
 	var/printing = 0 //Are we printing RIGHT NOW?
@@ -1684,7 +1686,6 @@
 	var/jam = 0 //Oh no! A jam! I hope somebody unjams us right quick!
 	var/blinking = 0 //Is our indicator light blinking?
 	var/sheets_remaining = 15 //How many blank sheets of paper do we have left?
-	power_usage = 200
 
 #define MAX_SHEETS 20
 #define SETUP_JAM_IGNITION 6 //How jammed do we have to be before we break down?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[MINOR][BUG]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets `machine_registry_idx` to `MACHINES_PRINTERS`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The lack of this broke a couple things.