### PR TITLE
Add feedback for assemblies failing

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -81,8 +81,7 @@ Contains:
 
 /obj/item/assembly/time_ignite/receive_signal()
 	if(!src.status)
-		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
+		src.visible_message("\the [src] doesn't do anything. Maybe it isn't secured properly?")
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
@@ -422,8 +421,7 @@ Contains:
 
 /obj/item/assembly/prox_ignite/receive_signal()
 	if(!src.status)
-		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
+		src.visible_message("\the [src] doesn't do anything. Maybe it isn't secured properly?")
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
@@ -602,8 +600,7 @@ Contains:
 
 /obj/item/assembly/rad_ignite/receive_signal()
 	if(!src.status)
-		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
+		src.visible_message("\the [src] doesn't do anything. Maybe it isn't secured properly?")
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -82,7 +82,7 @@ Contains:
 /obj/item/assembly/time_ignite/receive_signal()
 	if(!src.status)
 		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
+			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
@@ -423,9 +423,9 @@ Contains:
 /obj/item/assembly/prox_ignite/receive_signal()
 	if(!src.status)
 		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
+			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
 		return
-1	for(var/mob/O in hearers(1, src.loc))
+	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
 	src.part2.ignite()
 	if(src.part3)
@@ -603,7 +603,7 @@ Contains:
 /obj/item/assembly/rad_ignite/receive_signal()
 	if(!src.status)
 		for(var/mob/O in hearers(5, src.loc))
-			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
+			O.show_message("The [src] doesn't do anything. Maybe it isn't secured properly?", 3)
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -81,6 +81,8 @@ Contains:
 
 /obj/item/assembly/time_ignite/receive_signal()
 	if(!src.status)
+		for(var/mob/O in hearers(5, src.loc))
+			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
@@ -420,8 +422,10 @@ Contains:
 
 /obj/item/assembly/prox_ignite/receive_signal()
 	if(!src.status)
+		for(var/mob/O in hearers(5, src.loc))
+			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
 		return
-	for(var/mob/O in hearers(1, src.loc))
+1	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
 	src.part2.ignite()
 	if(src.part3)
@@ -598,6 +602,8 @@ Contains:
 
 /obj/item/assembly/rad_ignite/receive_signal()
 	if(!src.status)
+		for(var/mob/O in hearers(5, src.loc))
+			O.show_message("the [src] doesn't do anything. Maybe it isn't secured properly?", 3, "the [src] doesn't do anything. Maybe it isn't secured properly?", 2)
 		return
 	for(var/mob/O in hearers(1, src.loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

#9680 made beaker assemblies appear to be broken as there's no feedback when a beaker isn't secure.

It's caught me and other older players out several times and just makes them look like they're bugged. This PR makes beaker assemblies show an obvious message when they're improperly secured.

I don't really see why the assemblies needed to be secured in the first place, as it just seems like a newbie trap. Respecting that the original PR got merged, i've just added some feedback to make it obvious what's wrong.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

newbie/oldie traps are bad. especially when they're invisible.
