### PR TITLE
Swap `ICON` to `BLEND` modes in material textures

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -49,7 +49,7 @@ ABSTRACT_TYPE(/datum/material)
 	/// if not null, texture will be set when mat is applied.
 	var/texture = ""
 	/// How to blend the [/datum/material/var/texture].
-	var/texture_blend = ICON_MULTIPLY
+	var/texture_blend = BLEND_ADD
 
 	/// Should this even color the objects made from it? Mostly used for base station materials like steel
 	var/applyColor = 1
@@ -996,7 +996,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	alpha = 180
 	quality = 2
 	texture = "bubbles"
-	texture_blend = ICON_MULTIPLY
+	texture_blend = BLEND_ADD
 
 	edible_exact = 0.6 //Just barely edible
 	edible = 1
@@ -1100,7 +1100,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	desc = "Wood from some sort of tree."
 	color = "#331f16"
 	texture = "wood"
-	texture_blend = ICON_MULTIPLY
+	texture_blend = BLEND_ADD
 
 	New()
 		..()
@@ -1115,7 +1115,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	desc = "Bamboo is a giant woody grass."
 	color = "#544c24"
 	texture = "bamboo"
-	texture_blend = ICON_MULTIPLY
+	texture_blend = BLEND_ADD
 
 	New()
 		..()
@@ -1233,7 +1233,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	desc = "Coral harvested from the sea floor."
 	color = "#990099"
 	texture = "coral"
-	texture_blend = ICON_OVERLAY
+	texture_blend = BLEND_SUBTRACT
 
 	New()
 		..()
@@ -1444,7 +1444,7 @@ ABSTRACT_TYPE(/datum/material/fabric)
 	desc = "Wool of adorable furry space bees."
 	color = "#ffcc00"
 	texture = "bee"
-	texture_blend = ICON_OVERLAY
+	texture_blend = BLEND_SUBTRACT
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fun fact, there are two almost identical defines for mixing icons together, but in true byond style, it's not a perfect match. We were using the wrong one on materials for ages and didn't notice until I hit a weird bug on some icon stuff I was doing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should change no behaviour, the defines swapped actually have the same value.
