### PR TITLE
Fix a donut2 fire alarm being innaccessible

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -5925,6 +5925,10 @@
 /obj/machinery/traymachine/morgue{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "awN" = (
@@ -6487,10 +6491,6 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/hangar/main)
 "ays" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/disposalpipe/segment,
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the crematorium fire alarm two tiles up to be accessible without smashing an entire reinforced window.
![image](https://user-images.githubusercontent.com/36884328/204918364-d30faef2-0e72-499f-9978-e368807922cf.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Osha regulations
Fixes https://github.com/goonstation/goonstation/issues/12221
