### PR TITLE
Freshly-laundered clothing is labelled and keeps you warm

### DIFF
--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -224,6 +224,8 @@
 	if (src.contents.len)
 		T = istype(T) ?  T : get_turf(src)
 		for (var/atom/movable/AM in src)
+			if (istype(AM, /obj/item/clothing) || istype(AM, /mob/living/carbon/human))
+				AM.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 			AM.set_loc(T)
 		src.UpdateIcon()
 

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -89,7 +89,6 @@
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			if(src.occupant) // If someone is inside we eject immediatly so as to not keep people hostage
 				H.changeStatus("weakened", 1 SECONDS)
-				H.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 				H.make_dizzy(15) //Makes you dizzy for fifteen seconds due to the spinning
 				H.change_misstep_chance(65)
 				src.open = 1

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -81,6 +81,7 @@
 			processing_items.Remove(src)
 			for (var/obj/item/clothing/C in src.contents)
 				C.stains = null
+				C.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 				C.UpdateName()
 			src.cycle = POST
 			src.cycle_current = 0
@@ -88,6 +89,7 @@
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			if(src.occupant) // If someone is inside we eject immediatly so as to not keep people hostage
 				H.changeStatus("weakened", 1 SECONDS)
+				H.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 				H.make_dizzy(15) //Makes you dizzy for fifteen seconds due to the spinning
 				H.change_misstep_chance(65)
 				src.open = 1
@@ -224,8 +226,6 @@
 	if (src.contents.len)
 		T = istype(T) ?  T : get_turf(src)
 		for (var/atom/movable/AM in src)
-			if (istype(AM, /obj/item/clothing) || istype(AM, /mob/living/carbon/human))
-				AM.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 			AM.set_loc(T)
 		src.UpdateIcon()
 

--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -211,6 +211,23 @@
 		holder.owner?.ClearSpecificParticles("stink_lines")
 		. = ..()
 
+/datum/bioEffect/hidden/fresh_laundry
+	name = "Fresh Laundry"
+	desc = "Aww, it's still warm!"
+	id = "fresh_laundry"
+	can_copy = 0
+	curable_by_mutadone = 0
+	occur_in_genepools = 0
+
+	OnLife(var/mult)
+		if(..()) return
+		if (probmult(5))
+			if (istype(holder.owner, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = holder.owner
+				if (H.sims)
+					H.sims.affectMotive("comfort", 0.5) // warm :)
+					H.sims.affectMotive("Hygiene", 0.5) // refreshing protection
+
 // Magnetic Random Event
 
 /datum/bioEffect/hidden/magnetic

--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -211,23 +211,6 @@
 		holder.owner?.ClearSpecificParticles("stink_lines")
 		. = ..()
 
-/datum/bioEffect/hidden/fresh_laundry
-	name = "Fresh Laundry"
-	desc = "Aww, it's still warm!"
-	id = "fresh_laundry"
-	can_copy = 0
-	curable_by_mutadone = 0
-	occur_in_genepools = 0
-
-	OnLife(var/mult)
-		if(..()) return
-		if (probmult(5))
-			if (istype(holder.owner, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = holder.owner
-				if (H.sims)
-					H.sims.affectMotive("comfort", 0.5) // warm :)
-					H.sims.affectMotive("Hygiene", 0.5) // refreshing protection
-
 // Magnetic Random Event
 
 /datum/bioEffect/hidden/magnetic

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2235,9 +2235,6 @@
 			var/obj/item/clothing/C = owner
 			C.add_stain(LAUNDERED_STAIN_TEXT) // we just cleaned them so this is cheeky
 			C.setProperty("coldprot", C.getProperty("coldprot") + LAUNDERED_COLDPROT_AMOUNT)
-		if(ismob(owner))
-			var/mob/M = owner
-			M.bioHolder?.AddEffect("fresh_laundry")
 
 	onRemove()
 		. = ..()
@@ -2245,9 +2242,6 @@
 			var/obj/item/clothing/C = owner
 			C.setProperty("coldprot", C.getProperty("coldprot") - LAUNDERED_COLDPROT_AMOUNT)
 			C.stains -= LAUNDERED_STAIN_TEXT
-		if(ismob(owner))
-			var/mob/M = owner
-			M.bioHolder?.RemoveEffect("fresh_laundry")
 
 #undef LAUNDERED_COLDPROT_AMOUNT
 #undef LAUNDERED_STAIN_TEXT

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2219,6 +2219,8 @@
 		. = ..()
 		owner.remove_filter("gnesis_tint")
 
+#define LAUNDERED_COLDPROT_AMOUNT 2 /// Amount of coldprot(%) given to each item of wearable clothing
+#define LAUNDERED_STAIN_TEXT "freshly-laundered" /// Name of the "stain" given to wearable clothing
 /datum/statusEffect/freshly_laundered
 	id = "freshly_laundered"
 	name = "Freshly Laundered"
@@ -2226,13 +2228,13 @@
 	visible = FALSE
 	unique = TRUE
 	maxDuration = 5 MINUTES
-	var/amount = 2 // very easy to stack
 
 	onAdd(optional)
 		. = ..()
 		if (istype(owner, /obj/item/clothing/))
 			var/obj/item/clothing/C = owner
-			C.setProperty("coldprot", C.getProperty("coldprot") + amount)
+			C.add_stain(LAUNDERED_STAIN_TEXT) // we just cleaned them so this is cheeky
+			C.setProperty("coldprot", C.getProperty("coldprot") + LAUNDERED_COLDPROT_AMOUNT)
 		if(ismob(owner))
 			var/mob/M = owner
 			M.bioHolder?.AddEffect("fresh_laundry")
@@ -2241,7 +2243,11 @@
 		. = ..()
 		if (istype(owner, /obj/item/clothing/))
 			var/obj/item/clothing/C = owner
-			C.setProperty("coldprot", C.getProperty("coldprot") - amount)
+			C.setProperty("coldprot", C.getProperty("coldprot") - LAUNDERED_COLDPROT_AMOUNT)
+			C.stains -= LAUNDERED_STAIN_TEXT
 		if(ismob(owner))
 			var/mob/M = owner
 			M.bioHolder?.RemoveEffect("fresh_laundry")
+
+#undef LAUNDERED_COLDPROT_AMOUNT
+#undef LAUNDERED_STAIN_TEXT

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2218,3 +2218,30 @@
 	onRemove()
 		. = ..()
 		owner.remove_filter("gnesis_tint")
+
+/datum/statusEffect/freshly_laundered
+	id = "freshly_laundered"
+	name = "Freshly Laundered"
+
+	visible = FALSE
+	unique = TRUE
+	maxDuration = 5 MINUTES
+	var/amount = 2 // very easy to stack
+
+	onAdd(optional)
+		. = ..()
+		if (istype(owner, /obj/item/clothing/))
+			var/obj/item/clothing/C = owner
+			C.setProperty("coldprot", C.getProperty("coldprot") + amount)
+		if(ismob(owner))
+			var/mob/M = owner
+			M.bioHolder?.AddEffect("fresh_laundry")
+
+	onRemove()
+		. = ..()
+		if (istype(owner, /obj/item/clothing/))
+			var/obj/item/clothing/C = owner
+			C.setProperty("coldprot", C.getProperty("coldprot") - amount)
+		if(ismob(owner))
+			var/mob/M = owner
+			M.bioHolder?.RemoveEffect("fresh_laundry")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When drying is done, apply a new `freshly_laundered` status effect to all clothing inside.

For the duration of this status effect, each piece of clothing gets a 2% coldprot buff and a "freshly-laundered" label (definitely not a stain!!!). It is unique so it won't stack multiple times on a single clothing item. It caps out at 5 minutes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives a small, short-term buff, and cute label, for laundered clothing. At its current 2%, it stacks to 14% with all wearable item-slots filled out.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Freshly laundered clothing stays warm for a bit after coming out of the WashMan.
```