### PR TITLE
Remove dead critters in magnet area

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -156,7 +156,9 @@
 				if (!(O.type in mining_controls.magnet_do_not_erase) && !istype(O, /obj/magnet_target_marker))
 					qdel(O)
 			T.ClearAllOverlays()
-
+			for (var/mob/living/L in T)
+				if(ismobcritter(L) && isdead(L)) // we don't care about dead critters
+					qdel(L)
 			if(istype(T,/turf/unsimulated) && ( T.GetComponent(/datum/component/buildable_turf) || (station_repair.station_generator && (origin.z == Z_LEVEL_STATION))))
 				T.ReplaceWith(/turf/space, force=TRUE)
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Follow up to #12212
when clearing an area for the mining magnet, remove dead mobcritters

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Actually removes dead mobcritters from the magnet area. Right now they just sit there.

