### PR TITLE
Afterlife botany dispenser fix

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -518,6 +518,11 @@ ABSTRACT_TYPE(/obj/machinery/chem_dispenser)
 
 	dispense_sound = 'sound/effects/splort.ogg'
 
+/obj/machinery/chem_dispenser/botany
+	name = "botany dispenser"
+	desc = "Unlike other chem dispensers, this one's mostly just made for plants.";
+	dispensable_reagents = list("mutadone","saltpetre","ammonia","potash","poo","space_fungus","weedkiller","mutagen");
+
 // Reagent Groups
 
 /datum/reagent_group_account

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -31909,11 +31909,7 @@
 	layer = 2.8;
 	mouse_opacity = 0
 	},
-/obj/machinery/chem_dispenser/chemical{
-	desc = "Unlike other chem dispensers, this one's mostly just made for plants.";
-	dispensable_reagents = list("mutadone","saltpetre","ammonia","potash","poo","space_fungus","weedkiller","mutagen");
-	name = "botany dispenser"
-	},
+/obj/machinery/chem_dispenser/botany,
 /turf/unsimulated/floor/wood/three,
 /area/afterlife/heaven/hydroponics)
 "bUm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a chem dispenser variant for use in the afterlife garden.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was varedited for some reason so it broke when I added a generic parent for chem dispensers.
