### PR TITLE
Makes the singularity react violently to being fed nuclear warheads

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -307,6 +307,16 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		if (istype(A, /obj/decal/cleanable)) //MBC : this check sucks, but its far better than cleanables doing hard-delete at the whims of the singularity. replace ASAP when i figure out cleanablessssss
 			qdel(A)
 			gain = 2
+		else if (istype(A, /obj/machinery/nuclearbomb))
+			gain = 5000 //ten clowns
+			src.active = TRUE //you fools
+			src.maxradius = INFINITY
+			playsound_global(clients, 'sound/machines/singulo_start.ogg', 50)
+			SPAWN(1 SECOND)
+				for (var/i in 1 to 5)
+					src.grow()
+					sleep(0.5 SECONDS)
+			qdel(A)
 		else
 			var/obj/O = A
 			O.set_loc(src.get_center())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The singularity consuming a nuclear bomb now causes it to play a scary global singulo noise, grow substantially and immediately breach containment.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny easter egg for when the flukies REALLY mess up, actual gameplay implications don't really matter as the round will immediately end barring admin spawned nukes.
Yes I am making this purely because it happened earlier today and I thought it was funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)The singularity will now react violently to being fed nuclear warheads.
```
