### PR TITLE
Moves the silicon channel implant to a limited manudrive. Gives the manudrive to the rd along with an implanter.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -620,6 +620,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	name = "Roboticist"
 	limit = 3
 	wages = 200
+	receives_implant = /obj/item/implant/robotalk
 	slot_back = list(/obj/item/storage/backpack/robotics)
 	slot_belt = list(/obj/item/storage/belt/roboticist/prepared)
 	slot_jump = list(/obj/item/clothing/under/rank/roboticist)

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -50,10 +50,10 @@
 
 	machine_translator //Limits how many people can get access to the silicon channel
 		name = "Command ManuDrive: Silicon Binary Translator Implant License"
-		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture five machine translator implants."
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture six machine translator implants."
 		icon_state = "datadiskcom"
 		temp_recipe_string = list(/datum/manufacture/implant_robotalk)
-		fablimit = 5
+		fablimit = 6
 
 	interdictor_parts //Compacts the parts into a single manudrive
 		name = "Engineering Manudrive: Spatial Interdictor Assembly Blueprint"

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -48,6 +48,13 @@
 		icon_state = "datadiskcom"
 		temp_recipe_string = list(/datum/manufacture/mechanics/lawrack)
 
+	machine_translator //Limits how many people can get access to the silicon channel
+		name = "Command ManuDrive: Silicon Binary Translator Implant License"
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture five machine translator implants."
+		icon_state = "datadiskcom"
+		temp_recipe_string = list(/datum/manufacture/implant_robotalk)
+		fablimit = 5
+
 	interdictor_parts //Compacts the parts into a single manudrive
 		name = "Engineering Manudrive: Spatial Interdictor Assembly Blueprint"
 		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture spatial interdictor rods and frames."

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2347,7 +2347,6 @@
 		/*/datum/manufacture/robup_thermal,*/
 		/datum/manufacture/robup_efficiency,
 		/datum/manufacture/robup_repair,
-		/datum/manufacture/implant_robotalk,
 		/datum/manufacture/sbradio,
 		/datum/manufacture/implant_health,
 		/datum/manufacture/implant_antirot,

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -254,9 +254,7 @@
 /obj/storage/secure/closet/command/research_director
 	name = "\improper Research Director's locker"
 	req_access = list(access_research_director)
-	spawn_contents = list(/obj/item/disk/data/floppy/manudrive/machine_translator,
-	/obj/item/implanter,
-	/obj/item/plant/herb/cannabis/spawnable,
+	spawn_contents = list(/obj/item/plant/herb/cannabis/spawnable,
 	/obj/item/device/light/zippo,
 	/obj/item/storage/box/clothing/research_director,
 	/obj/item/clothing/shoes/brown,
@@ -280,6 +278,7 @@
 	name = "\improper Medical Director's locker"
 	req_access = list(access_medical_director)
 	spawn_contents = list(/obj/item/disk/data/floppy/manudrive/ai,
+	/obj/item/disk/data/floppy/manudrive/machine_translator,
 	/obj/item/storage/box/clothing/medical_director,
 	/obj/item/clothing/shoes/brown,
 	/obj/item/gun/implanter,

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -254,7 +254,9 @@
 /obj/storage/secure/closet/command/research_director
 	name = "\improper Research Director's locker"
 	req_access = list(access_research_director)
-	spawn_contents = list(/obj/item/plant/herb/cannabis/spawnable,
+	spawn_contents = list(/obj/item/disk/data/floppy/manudrive/machine_translator,
+	/obj/item/implanter,
+	/obj/item/plant/herb/cannabis/spawnable,
 	/obj/item/device/light/zippo,
 	/obj/item/storage/box/clothing/research_director,
 	/obj/item/clothing/shoes/brown,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BALANCE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr moves the machine translator implants to a manudrive limited to 6 copies (one for each head). The manudrive spawns in the rd's locker, along with an implanter for the rd to use with the implants.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, machine translator implants are really cheap to make, and often roboticists will give a lot of them out round-start, making the silicon channel insecure. This aims to make access to the silicon channel limited so that when the AI goes rogue, everyone and their mother won't get access to the silicon channel.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Machine translator implants have been moved to a limited manudrive in the medical director's locker.
(+)Roboticists now spawn with a machine translator implant in them.
