### PR TITLE
Fixes omnitools needing to change mode once to work properly

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -28,7 +28,7 @@
 	New()
 		contextLayout = new /datum/contextLayout/experimentalcircle
 		..()
-		src.change_mode(mode)
+		src.change_mode(mode, null, /obj/item/crowbar)
 		for(var/actionType in childrentypesof(/datum/contextAction/omnitool))
 			var/datum/contextAction/omnitool/action = new actionType()
 			if (action.mode in src.modes)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #12285


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad



