### PR TITLE
makes z2 cameras invulnerable maybe

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -2688,8 +2688,7 @@
 /obj/item/luggable_computer/personal{
 	c_flags = 94208;
 	pixel_x = 1;
-	pixel_y = 10;
-	
+	pixel_y = 10
 	},
 /obj/table/wood/auto/desk/lily,
 /turf/unsimulated/floor/carpet/purple/fancy/narrow/ne,
@@ -34608,7 +34607,8 @@
 	invisibility = 101;
 	name = "autoname - Entertainment";
 	network = "Zeta";
-	tag = ""
+	tag = "";
+	invuln = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "0,6"
@@ -76290,7 +76290,8 @@
 	invisibility = 101;
 	name = "autoname - Entertainment";
 	network = "Zeta";
-	tag = ""
+	tag = "";
+	invuln = 1
 	},
 /obj/invisible_teleporter/receive_only{
 	id = "murderbox"


### PR DESCRIPTION
[bug]
## About the PR 
sets the invulnerable flag on the murderbox and basketball cameras to true/1
there is NO documentation on how the invuln flag works, so if this doesn't actually do what i think it does, please lmk

## Why's this needed? 
fixes #12062