### PR TITLE
custom description for sodium thiopental darts

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -461,6 +461,7 @@
 
 	syndicate
 		sname = ".308 Tranquilizer Deluxe"
+		desc = "A stripper clip of sodium thiopental darts. Will weaken and eventually knock out targets."
 		ammo_type = new/datum/projectile/bullet/tranq_dart/syndicate
 
 		pistol


### PR DESCRIPTION
[bug][game objects]

## About the PR 
adds a custom description for sodium thiopental darts:
`"A stripper clip of sodium thiopental darts. Will weaken and eventually knock out targets."`

i assume this is okay and covert enough and that the darts weren't intentionally lacking an accurate description for stealth purposes?

## Why's this needed?
fixes #12190 