### PR TITLE
Silicons see implanted machine translators on observe

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -149,7 +149,7 @@
 		. += "<br><span class='alert'>[src] has [count > 1 ? "arrows" : "an arrow"] stuck in them!</span>"
 
 	if ((issilicon(usr) || isAIeye(usr)) && locate(/obj/item/implant/robotalk) in src.implant)
-		. += "<br><span class='notice'>[src] can listen and talk on silicon radio!</span>"
+		. += "<br><span class='notice'>[src] can listen and talk on the robot talk radio fequency!</span>"
 
 	if (src.is_jittery)
 		switch(src.jitteriness)

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -148,6 +148,9 @@
 			count++
 		. += "<br><span class='alert'>[src] has [count > 1 ? "arrows" : "an arrow"] stuck in them!</span>"
 
+	if ((issilicon(usr) || isAIeye(usr)) && locate(/obj/item/implant/robotalk) in src.implant)
+		. += "<br><span class='notice'>[src] can listen and talk on silicon radio!</span>"
+
 	if (src.is_jittery)
 		switch(src.jitteriness)
 			if (300 to INFINITY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the observer is a silicon (or AI Eye (eugh, separate isFlag())), and we're a human with a machine translator implant, add a line to our description that we can listen and talk on the robot talk radio frequency.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Small [BALANCE] adjustment for machine translators - humans can listen/talk to silicons, but silicons can now find out who is listening in casually. Allows for more counterplay against compromised radio comms as silicons, while still letting a crafty human to stay out of sight (and thus, continue to listen in).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Silicons detect machine translator implants in carbons on observe.
```
