### PR TITLE
Clarion cable d1 and d2 variable removal

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14771,7 +14771,6 @@
 /area/station/storage/tools)
 "aFR" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -14787,8 +14786,6 @@
 /area/station/maintenance/east)
 "aFS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -14799,8 +14796,6 @@
 /area/station/maintenance/east)
 "aFT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/valve,
@@ -14808,8 +14803,6 @@
 /area/station/maintenance/east)
 "aFU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
@@ -14819,8 +14812,6 @@
 /area/station/maintenance/east)
 "aFV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple{
@@ -14881,7 +14872,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -14893,8 +14883,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -15165,8 +15153,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -15176,8 +15162,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/stool/chair{
@@ -15191,8 +15175,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/nanofab/refining,
@@ -15203,8 +15185,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_reclaimer,
@@ -15215,8 +15195,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal_pipedispenser,
@@ -15227,8 +15205,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -15245,8 +15221,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -15566,8 +15540,6 @@
 /area/station/crew_quarters/bar)
 "aHz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/stool/bar,
@@ -15578,8 +15550,6 @@
 /area/station/crew_quarters/bar)
 "aHA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/bar/auto,
@@ -15588,16 +15558,12 @@
 /area/station/crew_quarters/bar)
 "aHB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "aHC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/chem_dispenser/soda,
@@ -15605,8 +15571,6 @@
 /area/station/crew_quarters/bar)
 "aHD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
@@ -15620,7 +15584,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/vending/alcohol,
@@ -16014,8 +15977,6 @@
 /area/station/crew_quarters/bar)
 "aID" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -16026,8 +15987,6 @@
 /area/station/storage/tools)
 "aIE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon/mule/toolstorage_north/south,
@@ -16164,7 +16123,6 @@
 /area/space)
 "aJa" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16185,11 +16143,9 @@
 /area/station/hallway/secondary/central)
 "aJd" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16201,7 +16157,6 @@
 /area/station/solar/west)
 "aJe" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar/west,
@@ -16333,7 +16288,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/morgue,
@@ -16663,7 +16617,6 @@
 /area/station/science/testchamber)
 "aKr" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16675,7 +16628,6 @@
 /area/station/solar/east)
 "aKs" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16690,11 +16642,9 @@
 /area/station/solar/east)
 "aKu" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16706,7 +16656,6 @@
 /area/station/solar/east)
 "aKv" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/solar/east,
@@ -16942,7 +16891,6 @@
 "aLa" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -16952,7 +16900,6 @@
 "aLb" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -16963,7 +16910,6 @@
 /area/station/storage/tools)
 "aLc" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -16977,8 +16923,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -16993,11 +16937,9 @@
 /area/station/storage/tools)
 "aLe" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -17006,7 +16948,6 @@
 /area/station/storage/tools)
 "aLf" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -17167,13 +17108,9 @@
 /area/station/medical/medbay)
 "aLC" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -17186,7 +17123,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -17197,13 +17133,9 @@
 /area/station/medical/medbay)
 "aLE" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/vending/medical,
@@ -17219,11 +17151,9 @@
 "aLG" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -17264,7 +17194,6 @@
 "aLI" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -17285,8 +17214,6 @@
 "aLJ" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -17312,7 +17239,6 @@
 "aLM" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -17382,8 +17308,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light/emergency{
@@ -17403,7 +17327,6 @@
 	},
 /obj/table/wood/auto,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -17802,8 +17725,6 @@
 /area/station/hallway/secondary/central)
 "aMF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -17819,8 +17740,6 @@
 /area/station/science/lobby)
 "aMG" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
@@ -17841,13 +17760,9 @@
 /area/station/science/lobby)
 "aMH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/sci{
@@ -17863,8 +17778,6 @@
 /area/station/science/lobby)
 "aMI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -17874,8 +17787,6 @@
 /area/station/science/lobby)
 "aMJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -17884,8 +17795,6 @@
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/dwainedummies,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -17897,11 +17806,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -17912,7 +17819,6 @@
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -17942,8 +17848,6 @@
 /area/station/science/testchamber)
 "aMQ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -17982,8 +17886,6 @@
 /area/space)
 "aMW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -18001,8 +17903,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -18022,8 +17922,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
@@ -18064,13 +17962,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -18102,14 +17996,12 @@
 "aNh" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -18118,8 +18010,6 @@
 "aNi" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white/checker{
@@ -18219,13 +18109,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -18235,16 +18121,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/central)
 "aNt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
@@ -18257,8 +18139,6 @@
 /area/station/hallway/secondary/central)
 "aNu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -18272,21 +18152,15 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/central)
 "aNw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
@@ -18302,8 +18176,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -18317,8 +18189,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -18327,8 +18197,6 @@
 /area/station/hallway/secondary/central)
 "aNz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/food,
@@ -18338,8 +18206,6 @@
 /area/station/hallway/secondary/central)
 "aNB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -18349,8 +18215,6 @@
 /area/station/hallway/secondary/central)
 "aNC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -18364,8 +18228,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -18377,8 +18239,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -18392,8 +18252,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -18406,21 +18264,15 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/central)
 "aNH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
@@ -18435,8 +18287,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -18446,8 +18296,6 @@
 /area/station/hallway/secondary/central)
 "aNJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction{
@@ -18461,8 +18309,6 @@
 /area/station/hallway/secondary/central)
 "aNK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -18491,7 +18337,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -18507,8 +18352,6 @@
 	},
 /obj/storage/secure/closet/research/uniform,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
@@ -18658,8 +18501,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -18835,7 +18676,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -18860,7 +18700,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/landmark{
@@ -18930,7 +18769,6 @@
 "aPe" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -18940,11 +18778,9 @@
 "aPf" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -18957,7 +18793,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -18979,7 +18814,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -19345,8 +19179,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -19358,8 +19190,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
@@ -19368,8 +19198,6 @@
 /area/station/hallway/secondary/central)
 "aQc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/stool/bench/auto,
@@ -19382,7 +19210,6 @@
 "aQd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -19390,8 +19217,6 @@
 /area/station/science/lobby)
 "aQe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/corner{
@@ -19404,8 +19229,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple/corner{
@@ -19452,7 +19275,6 @@
 	},
 /obj/machinery/computer/ordercomp,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -19563,7 +19385,6 @@
 "aQw" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -19590,7 +19411,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/announcement,
@@ -19683,11 +19503,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -19720,7 +19538,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -19731,7 +19548,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -19784,8 +19600,6 @@
 /area/station/medical/medbay/lobby)
 "aQN" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/stool/bench/auto,
@@ -19828,7 +19642,6 @@
 "aQZ" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -19850,7 +19663,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -19893,7 +19705,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -19903,7 +19714,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -19928,7 +19738,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -19940,13 +19749,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -20038,24 +19843,18 @@
 /area/station/science/lobby)
 "aRB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aRC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20065,8 +19864,6 @@
 /area/station/science/lobby)
 "aRD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20080,16 +19877,12 @@
 "aRE" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/purple/side{
@@ -20098,8 +19891,6 @@
 /area/station/science/lobby)
 "aRF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20118,8 +19909,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -20132,8 +19921,6 @@
 /area/station/maintenance/east)
 "aRH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20143,8 +19930,6 @@
 /area/station/maintenance/east)
 "aRI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -20160,16 +19945,12 @@
 /area/station/science/lab)
 "aRJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/west,
@@ -20179,8 +19960,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -20191,8 +19970,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -20279,8 +20056,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/table/wood/auto,
@@ -20305,8 +20080,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
@@ -20320,8 +20093,6 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/stamp/md,
@@ -20359,7 +20130,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2{
@@ -20466,7 +20236,6 @@
 "aSp" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -20675,7 +20444,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -20701,8 +20469,6 @@
 "aSK" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -20716,8 +20482,6 @@
 /area/station/ai_monitored/storage/eva)
 "aSL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -20764,11 +20528,9 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -20787,8 +20549,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -20847,8 +20607,6 @@
 /area/station/hallway/secondary/central)
 "aSY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side,
@@ -20856,8 +20614,6 @@
 "aSZ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/corner{
@@ -20873,8 +20629,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple/corner,
@@ -20974,8 +20728,6 @@
 /area/station/science/lab)
 "aTn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/greenwhite{
@@ -20991,7 +20743,6 @@
 "aTr" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer3/generic/med_data{
@@ -21004,8 +20755,6 @@
 /area/station/medical/cdc)
 "aTs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/table/wood/auto,
@@ -21029,8 +20778,6 @@
 /area/station/crew_quarters/md)
 "aTt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21049,8 +20796,6 @@
 /area/station/crew_quarters/md)
 "aTu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21067,8 +20812,6 @@
 /area/station/crew_quarters/md)
 "aTv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21078,8 +20821,6 @@
 /area/station/crew_quarters/md)
 "aTw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21092,8 +20833,6 @@
 /area/station/crew_quarters/md)
 "aTx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21104,8 +20843,6 @@
 /area/station/medical/medbay/lobby)
 "aTy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue,
@@ -21120,8 +20857,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -21129,8 +20864,6 @@
 /area/station/medical/medbay)
 "aTz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21140,8 +20873,6 @@
 /area/station/medical/medbay)
 "aTB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -21151,8 +20882,6 @@
 /area/station/medical/medbay/lobby)
 "aTC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -21176,8 +20905,6 @@
 /area/station/medical/medbay/lobby)
 "aTF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -21200,8 +20927,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -21225,7 +20950,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -21236,7 +20960,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -21302,7 +21025,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -21383,8 +21105,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -21403,7 +21123,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom/engineering{
@@ -21483,8 +21202,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -21510,7 +21227,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood{
@@ -21546,7 +21262,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -21554,8 +21269,6 @@
 /area/station/ai_monitored/storage/eva)
 "aUp" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple,
@@ -21583,7 +21296,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -21593,11 +21305,9 @@
 "aUu" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -21612,7 +21322,6 @@
 /area/station/science/teleporter)
 "aUx" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -21652,7 +21361,6 @@
 "aUB" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -21662,8 +21370,6 @@
 "aUD" = (
 /obj/plasticflaps,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -21785,7 +21491,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -21812,7 +21517,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -21873,7 +21577,6 @@
 "aVm" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -21910,8 +21613,6 @@
 /area/station/security/main)
 "aVq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/stool/chair/red{
@@ -21934,7 +21635,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/stool/chair/red{
@@ -22244,8 +21944,6 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/table/reinforced/auto,
@@ -22275,8 +21973,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -22316,8 +22012,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -22345,7 +22039,6 @@
 "aWm" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/pathology{
@@ -22365,7 +22058,6 @@
 "aWo" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -22379,7 +22071,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -22448,8 +22139,6 @@
 /area/station/solar/east)
 "aWw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -22465,8 +22154,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -22498,7 +22185,6 @@
 "aWA" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -22507,11 +22193,9 @@
 "aWB" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -22520,7 +22204,6 @@
 "aWD" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -22742,7 +22425,6 @@
 "aXh" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -22753,13 +22435,10 @@
 "aXi" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/guardbot_dock,
@@ -22799,8 +22478,6 @@
 /area/station/science/lab)
 "aXn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -22878,7 +22555,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -22906,8 +22582,6 @@
 	dir = 10
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/space,
@@ -22917,8 +22591,6 @@
 /area/station/solar/west)
 "aXP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -22931,8 +22603,6 @@
 /area/station/security/main)
 "aXQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -22953,8 +22623,6 @@
 /area/station/security/main)
 "aXR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -22967,8 +22635,6 @@
 /area/station/security/main)
 "aXS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -22986,8 +22652,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red/side{
@@ -23005,8 +22669,6 @@
 /area/station/security/main)
 "aXW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -23118,7 +22780,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/storage/box/iv_box,
@@ -23135,7 +22796,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -23146,8 +22806,6 @@
 /area/station/bridge/captain)
 "aYj" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
@@ -23226,7 +22884,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -23262,8 +22919,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/line/black{
@@ -23433,8 +23088,6 @@
 /area/station/medical/medbay/surgery)
 "aYN" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -23445,8 +23098,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
@@ -23466,8 +23117,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
@@ -23485,7 +23134,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -23533,7 +23181,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -23625,8 +23272,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
@@ -23769,7 +23414,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -23787,8 +23431,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet{
@@ -23872,7 +23514,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -23901,8 +23542,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -23918,7 +23557,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -23950,7 +23588,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -23964,13 +23601,10 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/guardbot_dock,
@@ -24099,7 +23733,6 @@
 "baf" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -24171,7 +23804,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -24180,7 +23812,6 @@
 "bao" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -24219,7 +23850,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -24230,8 +23860,6 @@
 /area/station/bridge)
 "bav" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -24257,7 +23885,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -24330,8 +23957,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
@@ -24473,8 +24098,6 @@
 /area/station/science/teleporter)
 "baM" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -24628,8 +24251,6 @@
 /area/station/medical/medbay/surgery)
 "bbi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -24651,8 +24272,6 @@
 /area/station/medical/medbay/surgery)
 "bbj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -24676,13 +24295,9 @@
 	icon_state = "line2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
@@ -24693,7 +24308,6 @@
 	},
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -24814,8 +24428,6 @@
 /area/station/bridge)
 "bbH" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
@@ -24835,8 +24447,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -24877,8 +24487,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -24959,7 +24567,6 @@
 /area/station/science/teleporter)
 "bbW" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -24978,7 +24585,6 @@
 /area/station/science/teleporter)
 "bbY" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -25002,7 +24608,6 @@
 "bcb" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -25025,13 +24630,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/purple/side{
@@ -25041,7 +24642,6 @@
 "bce" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -25064,7 +24664,6 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -25124,8 +24723,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -25136,7 +24733,6 @@
 "bco" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -25219,8 +24815,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
@@ -25231,7 +24825,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -25339,8 +24932,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -25372,8 +24963,6 @@
 "bcV" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -25509,7 +25098,6 @@
 /area/station/hallway/primary/east)
 "bdp" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -25531,8 +25119,6 @@
 /area/station/science/teleporter)
 "bdr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine{
@@ -25548,7 +25134,6 @@
 "bdt" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -25602,8 +25187,6 @@
 "bdx" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -25611,8 +25194,6 @@
 /area/station/science/bot_storage)
 "bdz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/dispenser{
@@ -25657,8 +25238,6 @@
 	name = "mixing valve"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -25846,8 +25425,6 @@
 /area/station/teleporter)
 "beq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purpleblack{
@@ -25856,8 +25433,6 @@
 /area/station/hallway/primary/east)
 "bes" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine{
@@ -25895,7 +25470,6 @@
 "bey" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -25909,13 +25483,9 @@
 "bez" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -25923,13 +25493,9 @@
 "beA" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -25937,7 +25503,6 @@
 "beB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/guardbot_dock,
@@ -25979,7 +25544,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -26018,13 +25582,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -26039,7 +25599,6 @@
 	frequency = 1229
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -26132,7 +25691,6 @@
 "beT" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -26189,8 +25747,6 @@
 /area/station/medical/cdc)
 "bfb" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -26204,11 +25760,9 @@
 "bfd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -26220,8 +25774,6 @@
 "bfq" = (
 /obj/machinery/light,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -26313,7 +25865,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/recharger{
@@ -26408,7 +25959,6 @@
 "bfN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -26426,8 +25976,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/decal/tile_edge/line/black{
@@ -26446,8 +25994,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/black{
@@ -26462,7 +26008,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/guardbot_dock,
@@ -26611,8 +26156,6 @@
 /area/station/medical/medbay/surgery)
 "bge" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/mining{
@@ -26660,8 +26203,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/ejection,
@@ -26701,8 +26242,6 @@
 /area/station/ai_monitored/armory)
 "bgB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -26724,8 +26263,6 @@
 /area/station/turret_protected/ai)
 "bgD" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -26789,8 +26326,6 @@
 	icon_state = "line2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -26803,8 +26338,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -26817,8 +26350,6 @@
 /area/station/teleporter)
 "bgN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -26831,8 +26362,6 @@
 /area/station/hallway/primary/east)
 "bgO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -26843,8 +26372,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -26882,8 +26409,6 @@
 	level = 2
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -26928,7 +26453,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -26968,7 +26492,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
@@ -26977,7 +26500,6 @@
 "bhf" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -26991,7 +26513,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -27036,11 +26557,9 @@
 "bhn" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/brig,
@@ -27059,8 +26578,6 @@
 /area/station/turret_protected/ai)
 "bhC" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -27074,7 +26591,6 @@
 /area/station/turret_protected/ai)
 "bhE" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -27122,7 +26638,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2{
@@ -27207,11 +26722,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -27235,14 +26748,10 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/shrub,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -27256,8 +26765,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/corner{
@@ -27270,7 +26777,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -27290,7 +26796,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
@@ -27303,7 +26808,6 @@
 /obj/machinery/networked/test_apparatus/xraymachine,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/light_switch/north,
@@ -27321,7 +26825,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/device/radio/intercom/science,
@@ -27349,8 +26852,6 @@
 	level = 2
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -27383,7 +26884,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -27438,8 +26938,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
@@ -27492,7 +26990,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -27567,11 +27064,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -27588,11 +27083,9 @@
 /area/station/turret_protected/ai)
 "biS" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -27629,8 +27122,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -27645,13 +27136,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -27724,8 +27211,6 @@
 /area/station/hallway/primary/east)
 "bjc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
@@ -27739,8 +27224,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/switch_junction{
@@ -27791,8 +27274,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -27802,8 +27283,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
@@ -27816,13 +27295,9 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
@@ -27833,12 +27308,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
@@ -27971,7 +27443,6 @@
 "bjG" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -27992,8 +27463,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/brig,
@@ -28039,7 +27508,6 @@
 "bkd" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -28080,7 +27548,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28096,8 +27563,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -28125,13 +27590,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -28143,7 +27604,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/light/emergency{
@@ -28255,7 +27715,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28267,7 +27726,6 @@
 "bky" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/middle{
@@ -28281,8 +27739,6 @@
 /area/station/science/artifact)
 "bkB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/corner,
@@ -28346,7 +27802,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28356,11 +27811,9 @@
 "bkL" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -28375,8 +27828,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -28396,15 +27847,12 @@
 "bkO" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -28431,11 +27879,9 @@
 	},
 /obj/machinery/clone_scanner,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28455,11 +27901,9 @@
 	},
 /obj/machinery/computer/cloning,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28476,11 +27920,9 @@
 "bkS" = (
 /obj/machinery/clonepod,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28499,11 +27941,9 @@
 	},
 /obj/machinery/clonegrinder,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28517,11 +27957,9 @@
 "bkU" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail{
@@ -28572,7 +28010,6 @@
 /area/station/crew_quarters/fitness)
 "blp" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28592,11 +28029,9 @@
 /area/station/turret_protected/ai)
 "blq" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28613,7 +28048,6 @@
 /area/station/turret_protected/ai)
 "blr" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -28639,7 +28073,6 @@
 /obj/item/device/net_sniffer,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -28670,13 +28103,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -28687,7 +28116,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
@@ -28725,7 +28153,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/right{
@@ -28841,13 +28268,9 @@
 /area/station/science/artifact)
 "blJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/damaged2,
@@ -28860,7 +28283,6 @@
 /obj/item/pen,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -28905,7 +28327,6 @@
 /obj/machinery/computer3/luggable,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decal/cleanable/gangtag{
@@ -28924,7 +28345,6 @@
 /obj/item/device/net_sniffer,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/storage/wall/fire{
@@ -28937,7 +28357,6 @@
 /obj/machinery/computer3/generic/radio,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -28951,7 +28370,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -28978,7 +28396,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment,
@@ -29177,7 +28594,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/middle{
@@ -29266,7 +28682,6 @@
 /obj/machinery/networked/test_apparatus/heater,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -29276,8 +28691,6 @@
 /area/station/science/artifact)
 "bmW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/decal/cleanable/ash,
@@ -29288,8 +28701,6 @@
 /area/station/science/artifact)
 "bmY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/neutral/side{
@@ -29347,8 +28758,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -29374,13 +28783,9 @@
 	},
 /obj/stool/bench,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -29406,8 +28811,6 @@
 	name = "Cyborg"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/trunk,
@@ -29654,16 +29057,12 @@
 /area/station/science/artifact)
 "bnS" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -29683,8 +29082,6 @@
 	pixel_y = 5
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -29738,8 +29135,6 @@
 	opacity = 0
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -29761,7 +29156,6 @@
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -29786,7 +29180,6 @@
 /obj/machinery/bot/guardbot/bootleg,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -29800,8 +29193,6 @@
 /area/station/storage/tech)
 "boe" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom{
@@ -29835,8 +29226,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt2{
@@ -29883,7 +29272,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/left{
@@ -29926,11 +29314,9 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -30003,8 +29389,6 @@
 	},
 /obj/plasticflaps,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -30288,7 +29672,6 @@
 "bpi" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -30386,7 +29769,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -30400,8 +29782,6 @@
 /area/station/science/artifact)
 "bpr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/northsouth,
@@ -30453,8 +29833,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/vacuum{
@@ -30538,8 +29916,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -30675,8 +30051,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/yellow{
@@ -30690,11 +30064,9 @@
 "bpU" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/left{
@@ -30746,8 +30118,6 @@
 /area/station/security/beepsky)
 "bpZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -30755,13 +30125,9 @@
 /area/station/security/beepsky)
 "bqa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -30771,26 +30137,18 @@
 /area/station/security/beepsky)
 "bqb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bqc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/landmark{
@@ -30801,8 +30159,6 @@
 /area/station/maintenance/central)
 "bqd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -30812,8 +30168,6 @@
 /area/station/maintenance/central)
 "bqe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -30824,8 +30178,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -30836,8 +30188,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
@@ -30851,8 +30201,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -30863,8 +30211,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -30874,8 +30220,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -30889,8 +30233,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark{
@@ -30904,8 +30246,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -30916,21 +30256,15 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bqo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -30938,22 +30272,16 @@
 /area/station/maintenance/central)
 "bqp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bqq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark{
@@ -30964,8 +30292,6 @@
 /area/station/maintenance/central)
 "bqr" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
@@ -30996,8 +30322,6 @@
 	name = "tour beacon - qm"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -31012,7 +30336,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor{
@@ -31230,8 +30553,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
@@ -31255,8 +30576,6 @@
 	},
 /obj/machinery/genetics_scanner,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/line/yellow{
@@ -31310,7 +30629,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/middle{
@@ -31530,8 +30848,6 @@
 /area/station/maintenance/central)
 "bru" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -31544,8 +30860,6 @@
 /area/station/maintenance/central)
 "brv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
@@ -31555,8 +30869,6 @@
 /area/station/hallway/primary/east)
 "brw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -31566,8 +30878,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
@@ -31576,8 +30886,6 @@
 /area/station/hallway/primary/east)
 "brx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -31592,8 +30900,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -31606,8 +30912,6 @@
 /area/station/hallway/primary/east)
 "brz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -31623,8 +30927,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -31635,8 +30937,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -31652,11 +30952,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	dir = 0;
 	icon_state = "0-8"
 	},
@@ -31673,11 +30971,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -31688,8 +30984,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/emergency{
@@ -31702,8 +30996,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -31716,8 +31008,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -31727,8 +31017,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -31745,8 +31033,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
@@ -31910,11 +31196,9 @@
 "bsb" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -31955,7 +31239,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/middle{
@@ -32111,7 +31394,6 @@
 "bsA" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
@@ -32188,8 +31470,6 @@
 /area/station/hallway/primary/west)
 "bsJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -32221,7 +31501,6 @@
 "bsP" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -32273,8 +31552,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
@@ -32363,7 +31640,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/clothing/gloves/yellow,
@@ -32436,11 +31712,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/light/emergency{
@@ -32533,11 +31807,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -32550,8 +31822,6 @@
 /area/station/engine/engineering)
 "btn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -32563,8 +31833,6 @@
 /area/station/engine/engineering)
 "bto" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency{
@@ -32581,7 +31849,6 @@
 	},
 /obj/item/device/radio/intercom/engineering,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -32606,8 +31873,6 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/vending/jobclothing/engineering,
@@ -32621,8 +31886,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
@@ -32636,7 +31899,6 @@
 	},
 /obj/table/reinforced/auto,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -32790,7 +32052,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -32805,8 +32066,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -33168,7 +32427,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decal/tile_edge/line/black{
@@ -33307,8 +32565,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -33320,13 +32576,9 @@
 "buv" = (
 /obj/stool/chair/moveable,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
@@ -33335,8 +32587,6 @@
 /area/station/crew_quarters/ce)
 "buw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
@@ -33359,7 +32609,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -33746,8 +32995,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -33804,8 +33051,6 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow,
@@ -33864,7 +33109,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -33902,8 +33146,6 @@
 /area/station/engine/engineering)
 "bvJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/landmark/start{
@@ -33913,8 +33155,6 @@
 /area/station/engine/engineering)
 "bvK" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
@@ -33932,7 +33172,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -33946,8 +33185,6 @@
 	name = "mining mail router"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -34013,8 +33250,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -34025,8 +33260,6 @@
 /area/station/quartermaster/office)
 "bvV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -34044,8 +33277,6 @@
 	name = "east pod bay mail router"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -34058,8 +33289,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -34070,16 +33299,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bvZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/submachine/cargopad{
@@ -34099,7 +33324,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -34199,8 +33423,6 @@
 /area/station/maintenance/west)
 "bwo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt2{
@@ -34216,8 +33438,6 @@
 /area/station/medical/morgue)
 "bwp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/black{
@@ -34225,8 +33445,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/morgue{
@@ -34237,8 +33455,6 @@
 /area/station/medical/morgue)
 "bwq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/beacon,
@@ -34246,8 +33462,6 @@
 /area/station/medical/morgue)
 "bwr" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -34269,8 +33483,6 @@
 /area/station/medical/morgue)
 "bws" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/traymachine/morgue,
@@ -34283,8 +33495,6 @@
 /area/station/medical/morgue)
 "bwt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/start{
@@ -34294,8 +33504,6 @@
 /area/station/medical/morgue)
 "bwu" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -34305,8 +33513,6 @@
 /area/station/medical/morgue)
 "bwv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/traymachine/morgue{
@@ -34321,11 +33527,9 @@
 "bww" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -34432,8 +33636,6 @@
 /area/station/crew_quarters/ce)
 "bwJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light,
@@ -34468,7 +33670,6 @@
 "bwM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -34510,7 +33711,6 @@
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -34536,7 +33736,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/yellow,
@@ -34565,7 +33764,6 @@
 "bwU" = (
 /obj/machinery/power/smes,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -34573,7 +33771,6 @@
 /area/station/engine/engineering)
 "bwV" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -34770,8 +33967,6 @@
 /area/station/hangar/science)
 "bxv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -34780,8 +33975,6 @@
 /obj/decal/poster/wallsign/space,
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -34918,8 +34111,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -34931,8 +34122,6 @@
 "bxL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
@@ -35023,8 +34212,6 @@
 "bxT" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/window_blinds/cog2/left,
@@ -35084,8 +34271,6 @@
 "bxX" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -35410,16 +34595,12 @@
 /area/station/engine/gas)
 "byM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
 "byN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -35435,8 +34616,6 @@
 /area/station/engine/elect)
 "byO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/storage/closet/office,
@@ -35444,8 +34623,6 @@
 /area/station/engine/elect)
 "byP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn{
@@ -35455,8 +34632,6 @@
 /area/station/engine/core)
 "byQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/furnace_connector,
@@ -35475,7 +34650,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/unary/furnace_connector,
@@ -35516,8 +34690,6 @@
 /area/station/engine/core)
 "byW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/portables_connector{
@@ -35561,8 +34733,6 @@
 /area/station/engine/core)
 "byZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -35586,8 +34756,6 @@
 /area/ghostdrone_factory)
 "bzb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/rack,
@@ -35600,8 +34768,6 @@
 /area/station/engine/core)
 "bzc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/storage/secure/crate/eng/interdictor,
@@ -35613,8 +34779,6 @@
 /area/station/engine/core)
 "bzd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/rack,
@@ -35632,8 +34796,6 @@
 /area/ghostdrone_factory)
 "bzf" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
@@ -35850,8 +35012,6 @@
 /area/station/medical/medbay/lobby)
 "bzJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/north{
@@ -35878,8 +35038,6 @@
 /area/station/engine/substation/west)
 "bzP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -35971,13 +35129,9 @@
 /area/station/engine/core)
 "bAf" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine{
@@ -36124,8 +35278,6 @@
 /area/station/quartermaster/office)
 "bAA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -36141,8 +35293,6 @@
 /area/station/engine/substation/east)
 "bAB" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -36165,13 +35315,9 @@
 /area/station/engine/substation/east)
 "bAE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/light/emergency{
@@ -36198,8 +35344,6 @@
 /area/station/medical/medbay/lobby)
 "bAG" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/north{
@@ -36225,13 +35369,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -36246,8 +35386,6 @@
 	},
 /obj/reagent_dispensers/fueltank,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -36264,8 +35402,6 @@
 	},
 /obj/reagent_dispensers/foamtank,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -36295,8 +35431,6 @@
 /area/station/engine/substation/east)
 "bAN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -36346,13 +35480,9 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -36680,8 +35810,6 @@
 /area/station/quartermaster/storage)
 "bBO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -36695,8 +35823,6 @@
 /area/station/quartermaster/storage)
 "bBQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/football,
@@ -36715,15 +35841,12 @@
 /area/station/engine/substation/east)
 "bBT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "bBU" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal,
@@ -36780,7 +35903,6 @@
 "bCc" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -36799,7 +35921,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/stool/chair/yellow{
@@ -36829,15 +35950,12 @@
 /obj/item/crowbar,
 /obj/item/device/light/flashlight,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "bCh" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -36851,8 +35969,6 @@
 /area/station/engine/substation/west)
 "bCi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -36869,7 +35985,6 @@
 	name = "power storage unit (engine)"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/caution/misc{
@@ -36903,8 +36018,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -36926,8 +36039,6 @@
 /area/station/engine/core)
 "bCs" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/valve{
@@ -36988,7 +36099,6 @@
 /area/station/engine/core)
 "bCz" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -37134,16 +36244,12 @@
 /area/station/quartermaster/storage)
 "bCU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "bCV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/mining{
@@ -37191,7 +36297,6 @@
 /area/station/engine/substation/east)
 "bDa" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -37214,15 +36319,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/engine/substation/east)
 "bDc" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -37260,7 +36362,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -37272,12 +36373,10 @@
 /area/station/engine/substation/east)
 "bDg" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -37333,8 +36432,6 @@
 	})
 "bDm" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -37386,8 +36483,6 @@
 /area/station/engine/gas)
 "bDv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -37426,8 +36521,6 @@
 /area/station/engine/core)
 "bDy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37438,8 +36531,6 @@
 /area/station/engine/core)
 "bDz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37452,8 +36543,6 @@
 /area/station/engine/core)
 "bDA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -37464,8 +36553,6 @@
 /area/station/engine/core)
 "bDB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37477,8 +36564,6 @@
 /area/station/engine/core)
 "bDC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -37491,8 +36576,6 @@
 /area/station/engine/core)
 "bDD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/valve{
@@ -37503,8 +36586,6 @@
 /area/station/engine/core)
 "bDE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37518,8 +36599,6 @@
 /area/station/engine/core)
 "bDF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -37536,8 +36615,6 @@
 /area/station/engine/core)
 "bDH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -37554,8 +36631,6 @@
 /area/station/engine/core)
 "bDI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37569,8 +36644,6 @@
 /area/station/engine/core)
 "bDJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/valve{
@@ -37581,13 +36654,9 @@
 /area/station/engine/core)
 "bDK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -37600,8 +36669,6 @@
 /area/station/engine/core)
 "bDL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37611,8 +36678,6 @@
 /area/station/engine/core)
 "bDM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -37622,8 +36687,6 @@
 /area/station/engine/core)
 "bDN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37634,16 +36697,12 @@
 /area/station/engine/core)
 "bDO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bDP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -37653,8 +36712,6 @@
 /area/station/engine/core)
 "bDQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -37668,8 +36725,6 @@
 /area/station/engine/core)
 "bDR" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -37685,8 +36740,6 @@
 /area/station/engine/core)
 "bDS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/corner{
@@ -37695,8 +36748,6 @@
 /area/station/quartermaster/storage)
 "bDT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -37704,8 +36755,6 @@
 /area/station/quartermaster/storage)
 "bDU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -37713,8 +36762,6 @@
 /area/station/quartermaster/storage)
 "bDV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
@@ -37722,16 +36769,12 @@
 "bDW" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/damaged2,
 /area/station/quartermaster/storage)
 "bDX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -37739,16 +36782,12 @@
 /area/station/quartermaster/storage)
 "bDY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/damaged2,
 /area/station/quartermaster/storage)
 "bDZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -37758,8 +36797,6 @@
 /area/station/quartermaster/storage)
 "bEa" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -37793,8 +36830,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -37802,8 +36837,6 @@
 /area/station/engine/substation/east)
 "bEh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
@@ -37824,7 +36857,6 @@
 "bEk" = (
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -37833,7 +36865,6 @@
 /area/station/engine/substation/west)
 "bEm" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -37863,8 +36894,6 @@
 /area/station/engine/gas)
 "bEs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -37893,8 +36922,6 @@
 /area/station/engine/core)
 "bEv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -37996,24 +37023,18 @@
 "bEJ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/quartermaster/storage)
 "bEK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/storage)
 "bEL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -38021,8 +37042,6 @@
 /area/station/hangar/qm)
 "bEM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/mining{
@@ -38058,7 +37077,6 @@
 "bER" = (
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -38067,7 +37085,6 @@
 /area/station/engine/substation/east)
 "bET" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -38112,8 +37129,6 @@
 /area/station/engine/core)
 "bEZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -38132,11 +37147,9 @@
 /area/station/engine/core)
 "bFb" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -38145,7 +37158,6 @@
 /area/station/engine/core)
 "bFc" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
@@ -38397,8 +37409,6 @@
 /area/station/engine/gas)
 "bFF" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -38440,8 +37450,6 @@
 /area/station/engine/core)
 "bFJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine{
@@ -38560,7 +37568,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -38574,8 +37581,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -38592,8 +37597,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -38607,8 +37610,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/stool/chair/yellow{
@@ -38671,8 +37672,6 @@
 /area/station/engine/gas)
 "bGh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt{
@@ -38830,8 +37829,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -38850,7 +37847,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
@@ -38899,8 +37895,6 @@
 /area/station/engine/combustion_chamber)
 "bGN" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -39168,8 +38162,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -39246,8 +38238,6 @@
 /area/space)
 "bHM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -39266,8 +38256,6 @@
 	dir = 5
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -39335,8 +38323,6 @@
 /area/station/mining/staff_room)
 "bHX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/rack,
@@ -39346,8 +38332,6 @@
 /obj/item/chem_grenade/firefighting,
 /obj/item/chem_grenade/firefighting,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine/caution/northsouth,
@@ -39360,8 +38344,6 @@
 /area/station/engine/combustion_chamber)
 "bHZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -39509,7 +38491,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -39670,8 +38651,6 @@
 /area/space)
 "bIK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -39799,8 +38778,6 @@
 /area/station/engine/ptl)
 "bJe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -39879,7 +38856,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -39889,8 +38865,6 @@
 /area/station/engine/ptl)
 "bJp" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/corner{
@@ -39950,7 +38924,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -40099,8 +39072,6 @@
 /area/space)
 "bJR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -40118,8 +39089,6 @@
 /area/space)
 "bJU" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -40136,7 +39105,6 @@
 /area/space)
 "bJX" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar/small_backup4,
@@ -40150,8 +39118,6 @@
 /area/listeningpost/power)
 "bJZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -40163,8 +39129,6 @@
 /area/space)
 "bKb" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/disposal_pipedispenser/mobile{
@@ -40174,8 +39138,6 @@
 /area/station/engine/gas)
 "bKd" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/portable_atmospherics/pump,
@@ -40200,13 +39162,9 @@
 /area/listeningpost/power)
 "bKi" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -40214,7 +39172,6 @@
 /area/listeningpost/power)
 "bKj" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_north/noaicontrol,
@@ -40238,13 +39195,9 @@
 /area/listeningpost/power)
 "bKm" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -40253,16 +39206,12 @@
 /area/listeningpost/power)
 "bKn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/listeningpost/power)
 "bKo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -40300,8 +39249,6 @@
 /area/listeningpost/power)
 "bKt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
@@ -40309,22 +39256,16 @@
 /area/listeningpost/power)
 "bKu" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/west,
 /area/listeningpost/power)
 "bKv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch{
@@ -40337,21 +39278,15 @@
 /area/listeningpost/power)
 "bKw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "bKx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -40377,8 +39312,6 @@
 /area/listeningpost)
 "bKB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -40427,8 +39360,6 @@
 /area/listeningpost)
 "bKI" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -40436,8 +39367,6 @@
 /area/listeningpost)
 "bKJ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/grey/side{
@@ -40467,8 +39396,6 @@
 /area/space)
 "bKO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
@@ -40535,8 +39462,6 @@
 /area/listeningpost)
 "bKW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
@@ -40602,21 +39527,15 @@
 /area/listeningpost)
 "bLf" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
 "bLg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/side{
@@ -40625,8 +39544,6 @@
 /area/listeningpost)
 "bLh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass,
@@ -40760,7 +39677,6 @@
 /area/syndicate_teleporter)
 "bLA" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -40772,8 +39688,6 @@
 /area/listeningpost)
 "bLB" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/npc/trader/robot{
@@ -41220,8 +40134,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -41484,7 +40396,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -41506,8 +40417,6 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -41520,8 +40429,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -41537,8 +40444,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -41551,8 +40456,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/space,
@@ -41829,8 +40732,6 @@
 /area/mining/magnet)
 "bNL" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -41849,7 +40750,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -41864,11 +40764,9 @@
 "bNN" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -41887,15 +40785,12 @@
 "bNO" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -41912,7 +40807,6 @@
 	dir = 5
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/small_backup4,
@@ -41948,13 +40842,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -41976,7 +40866,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -42058,8 +40947,6 @@
 /area/station/engine/substation/east)
 "cbZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/storage/secure/closet/brig_automatic/genpop,
@@ -42069,7 +40956,6 @@
 /area/station/security/brig)
 "cdQ" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -42084,8 +40970,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -42126,8 +41010,6 @@
 "chL" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
@@ -42162,7 +41044,6 @@
 "clX" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/right{
@@ -42213,11 +41094,9 @@
 /area/station/science/bot_storage)
 "cvm" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
@@ -42232,8 +41111,6 @@
 /area/station/ai_monitored/armory)
 "cye" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -42291,7 +41168,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -42306,15 +41182,12 @@
 	name = "brig pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/autoname_north{
 	areastring = "Research Dock"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -42375,7 +41248,6 @@
 /area/station/crew_quarters/kitchen)
 "cPR" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -42388,7 +41260,6 @@
 "cSl" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
@@ -42444,8 +41315,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -42455,7 +41324,6 @@
 /area/station/science/research_director)
 "cWO" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar/east,
@@ -42486,7 +41354,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/middle{
@@ -42497,7 +41364,6 @@
 "dfd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right{
@@ -42530,8 +41396,6 @@
 	req_access_txt = null
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -42575,8 +41439,6 @@
 	tag = ""
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/table/reinforced/auto,
@@ -42607,8 +41469,6 @@
 /area/station/crew_quarters/pool)
 "dzc" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/intercom/AI{
@@ -42673,13 +41533,9 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/item/stamp/hos,
@@ -42690,7 +41546,6 @@
 /area/station/security/hos)
 "dMh" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -42729,7 +41584,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/decal/poster/wallsign/chsl{
@@ -42796,8 +41650,6 @@
 /area/station/security/main)
 "dTm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -42813,8 +41665,6 @@
 /area/station/engine/substation/west)
 "dUo" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -42901,7 +41751,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -42961,8 +41810,6 @@
 /area/station/shield_zone)
 "ele" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/mining{
@@ -42974,7 +41821,6 @@
 /area/station/medical/medbay)
 "elL" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -43028,8 +41874,6 @@
 /area/station/engine/substation/east)
 "enf" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -43049,8 +41893,6 @@
 "esY" = (
 /obj/critter/parrot/kea/ikea,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -43079,8 +41921,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -43107,7 +41947,6 @@
 "evg" = (
 /obj/table/reinforced/auto,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/firedoor_spawn,
@@ -43150,7 +41989,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -43168,7 +42006,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2,
@@ -43240,16 +42077,12 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -43269,8 +42102,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -43345,7 +42176,6 @@
 /area/space)
 "eRx" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
@@ -43379,8 +42209,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/security/alt,
@@ -43427,7 +42255,6 @@
 "flb" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
@@ -43444,19 +42271,13 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -43477,7 +42298,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
@@ -43544,13 +42364,9 @@
 "fxr" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -43605,12 +42421,10 @@
 "fBM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -43631,13 +42445,9 @@
 "fDj" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -43653,8 +42463,6 @@
 /area/station/security/hos)
 "fEg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -43699,8 +42507,6 @@
 "fIl" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -43739,8 +42545,6 @@
 /area/station/storage/tech)
 "fLm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/vending/book,
@@ -43798,13 +42602,9 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7845,8 +7845,6 @@
 "aoK" = (
 /obj/machinery/light/small,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -8830,8 +8828,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -9186,8 +9182,6 @@
 /area/station/hallway/primary/central)
 "arH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -9202,8 +9196,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/emergency{
@@ -9221,8 +9213,6 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -9232,8 +9222,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/emergency{
@@ -9247,8 +9235,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -9261,8 +9247,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -9272,8 +9256,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
@@ -9283,8 +9265,6 @@
 /area/station/hallway/primary/central)
 "arO" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -9314,8 +9294,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -9325,16 +9303,12 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -9348,24 +9322,18 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arW" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -9375,8 +9343,6 @@
 /area/station/hallway/primary/central)
 "arX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
@@ -9384,8 +9350,6 @@
 /area/station/hallway/primary/central)
 "arY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -9394,16 +9358,12 @@
 "arZ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "asa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -9414,8 +9374,6 @@
 /area/station/hallway/primary/central)
 "asb" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -9425,8 +9383,6 @@
 /area/station/hallway/primary/central)
 "asc" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -9440,8 +9396,6 @@
 /area/station/hallway/primary/central)
 "asd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -9473,8 +9427,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -9484,8 +9436,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
@@ -9496,8 +9446,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
@@ -9524,8 +9472,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon{
@@ -9576,7 +9522,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -9590,8 +9535,6 @@
 /area/station/chapel/funeral_parlor)
 "asq" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -9609,8 +9552,6 @@
 /area/station/chapel/funeral_parlor)
 "ass" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -9626,8 +9567,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -9959,8 +9898,6 @@
 "atq" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -10104,8 +10041,6 @@
 /area/station/hallway/primary/central)
 "atL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
@@ -10118,8 +10053,6 @@
 "atM" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -10133,14 +10066,10 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -10329,8 +10258,6 @@
 /area/station/medical/crematorium)
 "aul" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -10344,8 +10271,6 @@
 /area/station/medical/crematorium)
 "aum" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
@@ -10513,8 +10438,6 @@
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -10526,7 +10449,6 @@
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/phone,
@@ -10585,8 +10507,6 @@
 /area/station/chapel/funeral_parlor)
 "auT" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -10746,7 +10666,6 @@
 "avp" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/grass/leafy,
@@ -11209,8 +11128,6 @@
 /area/station/hallway/primary/central)
 "awt" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/morgue{
@@ -11238,8 +11155,6 @@
 /area/station/medical/crematorium)
 "aww" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/morgue{
@@ -11390,13 +11305,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -11411,7 +11322,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom/catering{
@@ -11609,8 +11519,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -11625,8 +11533,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
@@ -11646,8 +11552,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -11658,8 +11562,6 @@
 /area/station/hydroponics/bay)
 "axv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -11674,8 +11576,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
@@ -11687,8 +11587,6 @@
 	name = "brig pipe"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
@@ -11697,8 +11595,6 @@
 /area/station/hydroponics/bay)
 "axy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -11719,13 +11615,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
@@ -12080,7 +11972,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -12094,8 +11985,6 @@
 "ayH" = (
 /obj/window/reinforced/east,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/table/reinforced/auto,
@@ -12581,7 +12470,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -12670,7 +12558,6 @@
 /area/station/crew_quarters/fitness)
 "aAl" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -12684,8 +12571,6 @@
 /area/station/crew_quarters/fitness)
 "aAm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -12694,8 +12579,6 @@
 "aAn" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/blue{
@@ -12709,8 +12592,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
@@ -12823,8 +12704,6 @@
 /area/station/crew_quarters/kitchen)
 "aAJ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/landmark/start{
@@ -12843,7 +12722,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -13060,7 +12938,6 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable,
@@ -13218,8 +13095,6 @@
 /area/station/maintenance/west)
 "aBM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -13227,8 +13102,6 @@
 "aBN" = (
 /obj/decal/cleanable/dirt,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -13236,8 +13109,6 @@
 "aBO" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -13272,8 +13143,6 @@
 	})
 "aBS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -13303,7 +13172,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -13325,8 +13193,6 @@
 /area/station/janitor/office)
 "aBX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -13341,8 +13207,6 @@
 	},
 /obj/disposalpipe/segment/morgue,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -13648,8 +13512,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -13730,8 +13592,6 @@
 /area/station/crew_quarters/clown)
 "aCV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -13749,8 +13609,6 @@
 /area/station/hallway/primary/north)
 "aCX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -14077,13 +13935,9 @@
 /area/station/crew_quarters/kitchen)
 "aDU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -14148,7 +14002,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -14490,13 +14343,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -14507,8 +14356,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/poster_clown{
@@ -14519,8 +14366,6 @@
 /area/station/maintenance/west)
 "aFd" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/emergency{
@@ -14533,8 +14378,6 @@
 /area/station/maintenance/west)
 "aFe" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
@@ -14548,8 +14391,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -14560,12 +14401,9 @@
 	areastring = "Cargo Dock"
 	},
 /obj/cable{
-	d2 = 2;
-	dir = null;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	dir = null
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -14574,8 +14412,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark{
@@ -14586,8 +14422,6 @@
 /area/station/maintenance/west)
 "aFi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -14600,8 +14434,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -14611,13 +14443,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -14627,8 +14455,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -14639,8 +14465,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -14653,8 +14477,6 @@
 /area/station/maintenance/west)
 "aFn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -14668,8 +14490,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/morgue,
@@ -44017,7 +43837,6 @@
 /obj/window_blinds/cog2,
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -44026,13 +43845,9 @@
 /area/station/security/hos)
 "fXn" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -44045,13 +43860,9 @@
 /area/station/security/hos)
 "fXZ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -44141,7 +43952,6 @@
 /obj/storage/secure/closet/command/research_director,
 /obj/item/remote/porter/port_a_sci,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -44152,7 +43962,6 @@
 /area/station/science/research_director)
 "ghs" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -44185,11 +43994,9 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -44218,7 +44025,6 @@
 	setup_tag = "ENGINE"
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -44232,8 +44038,6 @@
 /area/station/engine/combustion_chamber)
 "gtp" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -44248,7 +44052,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2,
@@ -44272,8 +44075,6 @@
 	network = "arcadevr"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -44310,7 +44111,6 @@
 /area/station/bridge)
 "gMH" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -44322,7 +44122,6 @@
 /area/station/engine/substation/west)
 "gNe" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
@@ -44344,8 +44143,6 @@
 /area/station/security/main)
 "gQv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -44423,19 +44220,13 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -44496,13 +44287,9 @@
 /area/station/crew_quarters/pool)
 "hge" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -44522,7 +44309,6 @@
 "hkw" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -44548,25 +44334,19 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "hpd" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -44577,8 +44357,6 @@
 /area/station/science/artifact)
 "hpP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/south{
@@ -44628,7 +44406,6 @@
 "hwt" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left{
@@ -44744,7 +44521,6 @@
 /area/station/security/main)
 "hJv" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -44753,8 +44529,6 @@
 "hLm" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -44815,7 +44589,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/device/radio/intercom/science,
@@ -44877,8 +44650,6 @@
 "iaS" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -44898,13 +44669,10 @@
 "icV" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/guardbot_dock,
@@ -44975,8 +44743,6 @@
 /area/station/security/main)
 "ilQ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/ash,
@@ -45034,11 +44800,9 @@
 /area/station/crew_quarters/captain)
 "ivP" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45165,7 +44929,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/device/radio/intercom/medical,
@@ -45198,8 +44961,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d2 = 2;
-	dir = null;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -45218,8 +44979,6 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/networked/storage/tape_drive{
@@ -45269,7 +45028,6 @@
 /obj/disposalpipe/segment/mail,
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45291,7 +45049,6 @@
 "iZd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45342,7 +45099,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/hos,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
@@ -45355,8 +45111,6 @@
 /area/station/ai_monitored/armory)
 "jhR" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/landmark/gps_waypoint,
@@ -45365,7 +45119,6 @@
 "jie" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45387,8 +45140,6 @@
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -45402,7 +45153,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45431,7 +45181,6 @@
 /area/station/security/main)
 "jvE" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -45485,7 +45234,6 @@
 /area/station/medical/medbay/surgery)
 "jzy" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/stool/chair/office/blue{
@@ -45578,8 +45326,6 @@
 /area/station/security/brig)
 "jOz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -45591,11 +45337,9 @@
 /area/station/security/main)
 "jPg" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/left{
@@ -45631,7 +45375,6 @@
 "jVa" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45664,7 +45407,6 @@
 	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45793,11 +45535,9 @@
 "kgY" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45824,13 +45564,9 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/food{
@@ -45842,8 +45578,6 @@
 /area/station/security/hos)
 "kju" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -45884,8 +45618,6 @@
 /area/station/quartermaster/office)
 "kmx" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/navbeacon/mule/podbay_north/south,
@@ -45898,8 +45630,6 @@
 	pixel_x = -2
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood{
@@ -45937,7 +45667,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -45970,14 +45699,10 @@
 /area/station/crewquarters/cryotron)
 "kAg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -46072,16 +45797,12 @@
 /area/station/maintenance/disposal)
 "kKo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/secscanner{
@@ -46117,7 +45838,6 @@
 "kLu" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -46157,7 +45877,6 @@
 "kNU" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right{
@@ -46168,8 +45887,6 @@
 /area/station/medical/robotics)
 "kPP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -46206,18 +45923,12 @@
 "kTe" = (
 /obj/grille/catwalk,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -46261,11 +45972,9 @@
 "kWg" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -46274,8 +45983,6 @@
 /area/station/storage/tech)
 "kWn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -46366,7 +46073,6 @@
 "ljW" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2,
@@ -46406,8 +46112,6 @@
 "lmL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -46463,8 +46167,6 @@
 	name = "Chief Engineer mail router"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -46479,7 +46181,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -46515,8 +46216,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/sci{
@@ -46590,16 +46289,12 @@
 /area/station/engine/substation/west)
 "lKX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -46691,8 +46386,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -46715,8 +46408,6 @@
 "lXI" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -46803,8 +46494,6 @@
 "mpQ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -46858,8 +46547,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/green{
@@ -46877,7 +46564,6 @@
 "mCr" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -46930,7 +46616,6 @@
 	icon_state = "bedsheet-pink"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
@@ -46972,7 +46657,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
@@ -47046,8 +46730,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -47069,8 +46751,6 @@
 /area/station/crew_quarters/fitness)
 "nmx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -47098,8 +46778,6 @@
 /area/station/engine/gas)
 "nqM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
@@ -47123,8 +46801,6 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -47149,8 +46825,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -47161,7 +46835,6 @@
 "nzo" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -47243,7 +46916,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -47272,8 +46944,6 @@
 /area/station/security/main)
 "nKd" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/light,
@@ -47341,7 +47011,6 @@
 "nQs" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/middle,
@@ -47393,11 +47062,9 @@
 /area/station/security/main)
 "nYD" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/security/alt{
@@ -47554,11 +47221,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -47576,8 +47241,6 @@
 /area/station/bridge)
 "ouK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
@@ -47603,8 +47266,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/computer/announcement,
@@ -47617,19 +47278,16 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom/AI{
 	dir = 1
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -47639,7 +47297,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -47769,7 +47426,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -47799,7 +47455,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -47840,7 +47495,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -47857,8 +47511,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/toxins{
@@ -47953,8 +47605,6 @@
 /area/station/crew_quarters/pool)
 "pfa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/conveyor/NS{
@@ -47967,13 +47617,9 @@
 /area/station/quartermaster/office)
 "pji" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -48002,11 +47648,9 @@
 /area/station/quartermaster/office)
 "pms" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
@@ -48017,8 +47661,6 @@
 /area/station/security/hos)
 "pnj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -48084,8 +47726,6 @@
 /area/station/medical/medbay)
 "pwv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/furnace_connector,
@@ -48099,8 +47739,6 @@
 /area/station/engine/core)
 "pAt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/landmark/start{
@@ -48113,7 +47751,6 @@
 "pBo" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -48161,7 +47798,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -48287,8 +47923,6 @@
 /area/station/science/testchamber)
 "qdR" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
@@ -48324,8 +47958,6 @@
 /area/station/hydroponics/bay)
 "qfi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
@@ -48363,7 +47995,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -48416,18 +48047,12 @@
 "qrQ" = (
 /obj/grille/catwalk,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -48517,7 +48142,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -48532,7 +48156,6 @@
 	icon_state = "bedsheet-blue"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
@@ -48635,7 +48258,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -48645,8 +48267,6 @@
 /area/station/science/research_director)
 "qWS" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -48774,8 +48394,6 @@
 /area/station/security/brig)
 "rjW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
@@ -48795,7 +48413,6 @@
 	icon_state = "bedsheet-yellow"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
@@ -48836,13 +48453,9 @@
 /area/station/engine/substation/west)
 "rsz" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red/side{
@@ -48852,7 +48465,6 @@
 "ryf" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right{
@@ -48902,8 +48514,6 @@
 /area/station/science/teleporter)
 "rBM" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
@@ -48915,7 +48525,6 @@
 /area/station/security/hos)
 "rHU" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -48932,7 +48541,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -48971,8 +48579,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass/random,
@@ -49017,7 +48623,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right,
@@ -49030,8 +48635,6 @@
 	})
 "saz" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
@@ -49172,8 +48775,6 @@
 "sqh" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -49196,12 +48797,10 @@
 "ssi" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -49235,15 +48834,12 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -49286,8 +48882,6 @@
 "swY" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -49533,8 +49127,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/escape{
@@ -49549,8 +49141,6 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -49571,8 +49161,6 @@
 /area/station/security/brig)
 "tbJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -49582,8 +49170,6 @@
 /area/station/crew_quarters/kitchen)
 "tbZ" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection{
@@ -49610,7 +49196,6 @@
 /obj/machinery/light/small,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -49712,11 +49297,9 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -49779,11 +49362,9 @@
 /area/station/crew_quarters/pool)
 "tJa" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -49890,7 +49471,6 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/table/wood/auto,
@@ -49914,7 +49494,6 @@
 "ubD" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
@@ -49932,13 +49511,9 @@
 /area/station/security/hos)
 "ufv" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -49948,13 +49523,9 @@
 /area/station/medical/head/private)
 "uhk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -49986,7 +49557,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/yellow/side{
@@ -50025,11 +49595,9 @@
 "urR" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2{
@@ -50047,8 +49615,6 @@
 "uuk" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
@@ -50087,8 +49653,6 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/white/checker{

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -402,7 +402,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/storage/wall/fire{
@@ -473,7 +472,6 @@
 	pixel_x = -10
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -776,7 +774,6 @@
 	pixel_y = 20
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -786,8 +783,6 @@
 /area/station/maintenance/northwest)
 "acg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -980,8 +975,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -990,16 +983,12 @@
 "acG" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "acH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -1014,8 +1003,6 @@
 	})
 "acI" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -1039,8 +1026,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -1059,7 +1044,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -1207,8 +1191,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -1225,8 +1207,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -1235,8 +1215,6 @@
 	})
 "acY" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -1245,8 +1223,6 @@
 	})
 "acZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -1262,8 +1238,6 @@
 "ada" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -1275,8 +1249,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -1328,7 +1300,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -1337,16 +1308,12 @@
 /area/station/maintenance/northwest)
 "adi" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "adj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -1354,8 +1321,6 @@
 /area/station/maintenance/northwest)
 "adl" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -1369,8 +1334,6 @@
 "adm" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -1380,8 +1343,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -1540,8 +1501,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -1552,8 +1511,6 @@
 	})
 "adu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -1565,8 +1522,6 @@
 	})
 "adv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -1582,16 +1537,12 @@
 "adw" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ady" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -1732,8 +1683,6 @@
 "adJ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -1742,8 +1691,6 @@
 	})
 "adK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -2002,8 +1949,6 @@
 /area/station/hallway/secondary/exit)
 "aen" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -2018,8 +1963,6 @@
 	})
 "aeo" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -2043,8 +1986,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -2063,7 +2004,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -2567,8 +2507,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -2579,8 +2517,6 @@
 	})
 "afz" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -2592,8 +2528,6 @@
 	})
 "afA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -2611,8 +2545,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -2703,8 +2635,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -2779,7 +2709,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -2872,8 +2801,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -2887,8 +2814,6 @@
 "agj" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/light_switch/north,
@@ -2896,8 +2821,6 @@
 /area/station/crew_quarters/market)
 "agk" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -3380,8 +3303,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -3389,8 +3310,6 @@
 /area/station/hallway/secondary/exit)
 "ahg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -3405,8 +3324,6 @@
 	})
 "ahh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -3430,8 +3347,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -3450,7 +3365,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -3479,8 +3393,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
@@ -3489,8 +3401,6 @@
 	})
 "ahm" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -3502,8 +3412,6 @@
 	})
 "ahn" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -3852,7 +3760,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/item/device/radio/intercom/science,
@@ -4020,8 +3927,6 @@
 "aia" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -4033,8 +3938,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -4044,8 +3947,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegreen/side{
@@ -4058,8 +3959,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -4107,8 +4006,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -4116,8 +4013,6 @@
 /area/station/hallway/primary/north)
 "aij" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -4132,13 +4027,9 @@
 	})
 "aik" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -4157,8 +4048,6 @@
 	},
 /obj/critter/domestic_bee/heisenbee,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -4278,8 +4167,6 @@
 /area/station/hallway/secondary/exit)
 "aiB" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -4294,8 +4181,6 @@
 	})
 "aiC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -4319,8 +4204,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
@@ -4339,7 +4222,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -4497,7 +4379,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -4776,8 +4657,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -4788,8 +4667,6 @@
 	})
 "aji" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -4801,8 +4678,6 @@
 	})
 "ajj" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -5223,7 +5098,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -5237,8 +5111,6 @@
 /area/station/hangar/sec)
 "ajQ" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -5323,7 +5195,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -5366,7 +5237,6 @@
 /obj/machinery/computer/security,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -5391,7 +5261,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -5410,8 +5279,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -5420,8 +5287,6 @@
 	})
 "akg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -5436,8 +5301,6 @@
 	})
 "akh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -5455,8 +5318,6 @@
 	icon_state = "pipe-j2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -5468,8 +5329,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -5481,8 +5340,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/alt{
@@ -5499,24 +5356,18 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/storage/primary)
 "ako" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/storage/primary)
 "akp" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/start{
@@ -5530,7 +5381,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/grey/whitegrime/other,
@@ -5541,7 +5391,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -5555,8 +5404,6 @@
 /area/station/hangar/sec)
 "aks" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -5573,8 +5420,6 @@
 	dir = 1
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack,
@@ -5743,8 +5588,6 @@
 /area/station/hallway/primary/north)
 "akD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -5757,8 +5600,6 @@
 /area/station/crew_quarters/hos)
 "akE" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -5768,8 +5609,6 @@
 /area/station/crew_quarters/hos)
 "akF" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
@@ -6197,7 +6036,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
@@ -6277,7 +6115,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -6296,8 +6133,6 @@
 	name = "peststart"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -6306,8 +6141,6 @@
 	})
 "alC" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
@@ -6322,8 +6155,6 @@
 	})
 "alD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/medical/alt{
@@ -6397,8 +6228,6 @@
 /area/station/hangar/main)
 "alL" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/shieldgenerator/energy_shield,
@@ -6427,7 +6256,6 @@
 /area/station/hangar/sec)
 "alR" = (
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/table/reinforced/auto,
@@ -6947,8 +6775,6 @@
 	name = "bot navigation beacon"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -6965,8 +6791,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -6979,8 +6803,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -6992,8 +6814,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/security/alt{
@@ -7007,8 +6827,6 @@
 "amD" = (
 /obj/disposalpipe/junction,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -7148,8 +6966,6 @@
 "amQ" = (
 /obj/grille/catwalk,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/camera{
@@ -7232,8 +7048,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -7245,8 +7059,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/secscanner{
@@ -7266,8 +7078,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -7285,8 +7095,6 @@
 	name = "bot navigation beacon"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -7321,7 +7129,6 @@
 	name = "Clarion secure dock beacon"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -7334,8 +7141,6 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -7347,8 +7152,6 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/space,
@@ -7433,8 +7236,6 @@
 "anr" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/light{
@@ -7447,8 +7248,6 @@
 /area/station/hallway/primary/north)
 "ans" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
@@ -7458,8 +7257,6 @@
 "ant" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
@@ -7468,8 +7265,6 @@
 /area/station/hallway/primary/north)
 "anu" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
@@ -7483,13 +7278,9 @@
 /area/station/hallway/primary/north)
 "anv" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood{
@@ -7498,8 +7289,6 @@
 /area/station/hallway/primary/north)
 "anw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark/spawner{
@@ -7511,8 +7300,6 @@
 /area/station/hallway/primary/north)
 "anx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
@@ -7526,8 +7313,6 @@
 /area/station/hallway/primary/north)
 "any" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -7580,8 +7365,6 @@
 "anG" = (
 /obj/grille/catwalk,
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -7604,7 +7387,6 @@
 	name = "Clarion podbay beacon"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/space,
@@ -7756,16 +7538,12 @@
 /area/station/hangar/main)
 "anY" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "anZ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/corner/misc{
@@ -7774,8 +7552,6 @@
 /area/station/hangar/main)
 "aoa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/north,
@@ -7786,8 +7562,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/north,
@@ -7797,8 +7571,6 @@
 	dir = 9
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/space,
@@ -7813,16 +7585,12 @@
 	pixel_y = 21
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/sec)
 "aof" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -7834,8 +7602,6 @@
 /area/station/hangar/sec)
 "aog" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
@@ -7844,8 +7610,6 @@
 /area/station/hangar/sec)
 "aoh" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack/corner,
@@ -7863,8 +7627,6 @@
 	tag = ""
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack,
@@ -8071,8 +7833,6 @@
 /area/station/hangar/main)
 "aoJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -8096,8 +7856,6 @@
 	dir = 5
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/space,
@@ -8357,7 +8115,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
@@ -8543,8 +8300,6 @@
 	icon_state = "pipe-j2"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -8556,8 +8311,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -8573,21 +8326,15 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "apN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -8606,11 +8353,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -8621,8 +8366,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/storage/wall/fire{
@@ -8636,13 +8379,9 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/decal/cleanable/dirt,
@@ -8666,7 +8405,6 @@
 	pixel_x = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/decal/cleanable/cobweb{
@@ -8808,7 +8546,6 @@
 	})
 "aqh" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/storage/closet/dresser{
@@ -9390,7 +9127,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -9438,8 +9174,6 @@
 /area/station/hallway/primary/central)
 "arG" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -50364,23 +50098,18 @@
 "uwO" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "uwP" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/item/device/radio/beacon,
@@ -50475,7 +50204,6 @@
 "uGr" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2,
@@ -50484,7 +50212,6 @@
 /area/station/medical/medbay/treatment1)
 "uHL" = (
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -50499,13 +50226,9 @@
 /area/station/crew_quarters/pool)
 "uOr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -50517,8 +50240,6 @@
 /area/station/security/main)
 "uOX" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
@@ -50548,7 +50269,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/window_blinds/cog2/right,
@@ -50559,8 +50279,6 @@
 	dir = 6
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -50642,13 +50360,9 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	dir = 0;
 	icon_state = "2-4"
 	},
@@ -50668,8 +50382,6 @@
 	pixel_x = 10
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
@@ -50683,8 +50395,6 @@
 /area/station/crew_quarters/pool)
 "ver" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/engineering,
@@ -50761,8 +50471,6 @@
 "vgM" = (
 /obj/critter/bat/doctor,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
@@ -50776,7 +50484,6 @@
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -50793,7 +50500,6 @@
 "vkg" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -50810,7 +50516,6 @@
 	name = "monkeyspawn_stirstir"
 	},
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
@@ -50885,11 +50590,9 @@
 /area/station/security/main)
 "vDu" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -50937,11 +50640,9 @@
 /area/station/security/main)
 "vGP" = (
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -50996,12 +50697,9 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
@@ -51014,7 +50712,6 @@
 /obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -51047,8 +50744,6 @@
 /area/station/medical/head/private)
 "way" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/landmark{
@@ -51111,8 +50806,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/landmark/gps_waypoint,
@@ -51202,8 +50895,6 @@
 /area/station/engine/engineering/ce/private)
 "wre" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
@@ -51270,7 +50961,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -51308,7 +50998,6 @@
 /area/station/maintenance/disposal)
 "wBY" = (
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar/west,
@@ -51325,8 +51014,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -51344,7 +51031,6 @@
 "wEK" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -51404,7 +51090,6 @@
 "wMt" = (
 /obj/cable,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
@@ -51440,8 +51125,6 @@
 	pixel_y = 32
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -51508,11 +51191,9 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -51594,7 +51275,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},
@@ -51650,8 +51330,6 @@
 /area/station/science/chemistry)
 "xxM" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
@@ -51684,8 +51362,6 @@
 /area/station/maintenance/northeast)
 "xCx" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt{
@@ -51780,7 +51456,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -51797,8 +51472,6 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/switch_junction/biofilter/left/west,
@@ -51826,7 +51499,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -712,10 +712,6 @@
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"abX" = (
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
-/area/space)
 "abY" = (
 /obj/machinery/light,
 /obj/machinery/portableowl/attached{
@@ -977,13 +973,6 @@
 /obj/cable{
 	dir = 0;
 	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
-"acG" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -4431,15 +4420,6 @@
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters S03"
 	})
-"aiP" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
 "aiQ" = (
 /obj/machinery/light/emergency,
 /obj/shrub{
@@ -5312,17 +5292,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters S04"
-	})
-"akj" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
 	})
 "akk" = (
 /obj/disposalpipe/segment{
@@ -14403,8 +14372,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable{
-	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aFh" = (
@@ -17848,7 +17816,6 @@
 /area/station/science/testchamber)
 "aMQ" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/caution/corner/nw{
@@ -18002,7 +17969,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -18337,7 +18303,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2{
@@ -18753,23 +18718,12 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
-"aPc" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aPd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/md)
 "aPe" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -18781,7 +18735,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/middle,
@@ -19179,7 +19132,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -19210,7 +19162,6 @@
 "aQd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -19642,7 +19593,6 @@
 "aQZ" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment,
@@ -19705,7 +19655,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -19738,7 +19687,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -19752,7 +19700,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/command{
@@ -20444,7 +20391,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/table/reinforced/auto,
@@ -20549,7 +20495,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -20857,7 +20802,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
@@ -20927,7 +20871,6 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -20960,7 +20903,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/item/device/radio/intercom/security{
@@ -21025,7 +20967,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/item/device/radio/intercom/science{
@@ -21043,12 +20984,6 @@
 /area/station/bridge)
 "aTY" = (
 /obj/disposalpipe/segment/food,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/computer3/generic/med_data{
 	dir = 8
 	},
@@ -21057,6 +20992,13 @@
 	dir = 4;
 	icon_state = "line1"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "blue2"
@@ -21296,7 +21238,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -21308,7 +21249,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right,
@@ -21361,7 +21301,6 @@
 "aUB" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2,
@@ -22012,7 +21951,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/green/checker,
@@ -22058,7 +21996,6 @@
 "aWo" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail{
@@ -22185,7 +22122,6 @@
 "aWA" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -22196,7 +22132,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -22425,7 +22360,6 @@
 "aXh" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
@@ -22796,7 +22730,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet{
@@ -22884,7 +22817,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/table/reinforced/auto,
@@ -23088,7 +23020,6 @@
 /area/station/medical/medbay/surgery)
 "aYN" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
@@ -23414,7 +23345,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/blind_switch/area/west{
@@ -23514,7 +23444,6 @@
 	dir = 4
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2{
@@ -23588,7 +23517,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
@@ -23804,7 +23732,6 @@
 	},
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -23850,7 +23777,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet{
@@ -24098,7 +24024,6 @@
 /area/station/science/teleporter)
 "baM" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack/side/white,
@@ -24447,7 +24372,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/junction{
@@ -24567,7 +24491,6 @@
 /area/station/science/teleporter)
 "bbW" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -24608,7 +24531,6 @@
 "bcb" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2{
@@ -24664,7 +24586,6 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
@@ -24723,7 +24644,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/greenwhite{
@@ -25187,7 +25107,6 @@
 "bdx" = (
 /obj/disposalpipe/segment,
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
@@ -25470,7 +25389,6 @@
 "bey" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
@@ -25544,7 +25462,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -25747,7 +25664,6 @@
 /area/station/medical/cdc)
 "bfb" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/junction{
@@ -25763,7 +25679,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/right{
@@ -25959,7 +25874,6 @@
 "bfN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/guardbot_dock,
@@ -26436,17 +26350,6 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
-"bgZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 4
-	},
-/area/station/medical/cdc)
 "bha" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2{
@@ -26500,7 +26403,6 @@
 "bhf" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment,
@@ -26578,7 +26480,6 @@
 /area/station/turret_protected/ai)
 "bhC" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit,
@@ -26725,7 +26626,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2{
@@ -26752,7 +26652,6 @@
 	},
 /obj/shrub,
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/purple/side{
@@ -27061,13 +26960,9 @@
 /area/station/ai_monitored/armory)
 "biR" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -27079,6 +26974,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai)
 "biS" = (
@@ -27548,7 +27444,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/light/emergency{
@@ -27715,7 +27610,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/middle{
@@ -27802,7 +27696,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/window_blinds/cog2/left,
@@ -27828,7 +27721,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
@@ -27882,7 +27774,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -27904,7 +27795,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/door_control{
@@ -27923,7 +27813,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/firealarm{
@@ -27944,7 +27833,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/blind_switch/area/north{
@@ -28010,7 +27898,6 @@
 /area/station/crew_quarters/fitness)
 "blp" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -28032,7 +27919,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -28073,7 +27959,6 @@
 /obj/item/device/net_sniffer,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit/green,
@@ -28682,7 +28567,6 @@
 /obj/machinery/networked/test_apparatus/heater,
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/caution/misc{
@@ -28758,7 +28642,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -29769,7 +29652,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
@@ -30955,7 +30837,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -30974,7 +30855,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -31810,7 +31690,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
@@ -32052,7 +31931,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/item/storage/wall/emergency{
@@ -32565,7 +32443,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
@@ -32995,7 +32872,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
@@ -33059,9 +32935,6 @@
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -33172,7 +33045,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -33250,7 +33122,6 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/table/reinforced/auto,
@@ -33670,7 +33541,6 @@
 "bwM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/shield_generator,
@@ -33764,7 +33634,6 @@
 "bwU" = (
 /obj/machinery/power/smes,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/yellow,
@@ -34111,7 +33980,6 @@
 	dir = 4
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet{
@@ -35372,7 +35240,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /obj/item/device/radio/intercom/engineering,
@@ -35483,7 +35350,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/yellow/corner{
@@ -35903,7 +35769,6 @@
 "bCc" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/solar_control/west{
@@ -35956,7 +35821,6 @@
 /area/station/engine/substation/west)
 "bCh" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
@@ -36297,7 +36161,6 @@
 /area/station/engine/substation/east)
 "bDa" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes{
@@ -36362,7 +36225,6 @@
 	dir = 8
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/stool/chair/yellow{
@@ -36377,7 +36239,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/solar_control/east{
@@ -36432,7 +36293,6 @@
 	})
 "bDm" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
@@ -36695,12 +36555,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"bDO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "bDP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36830,7 +36684,6 @@
 	pixel_x = -24
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
@@ -36857,7 +36710,6 @@
 "bEk" = (
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -37077,7 +36929,6 @@
 "bER" = (
 /obj/cable,
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/reinforced,
@@ -37150,7 +37001,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg,
@@ -37198,12 +37048,6 @@
 /turf/simulated/floor/caution/misc{
 	dir = 4
 	},
-/area/station/engine/core)
-"bFh" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
 /area/station/engine/core)
 "bFi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -37409,7 +37253,6 @@
 /area/station/engine/gas)
 "bFF" = (
 /obj/cable{
-	dir = 0;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -37568,7 +37411,6 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	dir = 0;
 	icon_state = "0-4"
 	},
 /obj/storage/secure/closet/engineering/mining,
@@ -42568,12 +42410,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
-"fOD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
 "fQk" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -43089,9 +42925,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4;
 	id = "medirecdoor";
@@ -43101,6 +42934,12 @@
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -46065,11 +45904,12 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/computer/announcement,
 /obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/escape,
 /area/station/security/hos)
 "ovR" = (
@@ -46581,17 +46421,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"pIs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
 "pMO" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -47418,7 +47247,7 @@
 "rWi" = (
 /obj/item/storage/wall/emergency,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/area/station/security/main)
 "rZc" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
@@ -48880,7 +48709,7 @@
 	name = "monkeyspawn_stirstir"
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -49599,9 +49428,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
 "xnL" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
 /obj/item/card_box/plain{
@@ -49612,6 +49438,12 @@
 	dir = 4
 	},
 /obj/machinery/phone,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "xoJ" = (
@@ -70369,7 +70201,7 @@ bcn
 bdG
 bcn
 bfX
-bgZ
+bcn
 bdG
 cSl
 aEY
@@ -71897,7 +71729,7 @@ aHW
 aHW
 aMX
 aOd
-aPc
+aGc
 aQy
 aHW
 aHW
@@ -76553,7 +76385,7 @@ bvt
 vbt
 bxM
 okP
-fOD
+bDv
 czH
 bCp
 bDt
@@ -78780,19 +78612,19 @@ abj
 abw
 abM
 ack
-acG
+ajU
 ado
 abM
-acG
+ajU
 abM
 afv
 afW
 abM
 ack
-acG
+ajU
 ahD
 aif
-acG
+ajU
 abM
 abM
 ajU
@@ -81184,9 +81016,9 @@ bBw
 bCD
 bDK
 bEB
-bFh
-bFh
-bFh
+bEv
+bEv
+bEv
 bGV
 bHs
 bHQ
@@ -81420,7 +81252,7 @@ bcW
 fzx
 gdA
 bgx
-ajE
+csQ
 jPg
 iLR
 hoE
@@ -81597,7 +81429,7 @@ aaa
 aae
 aah
 aak
-abX
+aam
 afP
 aap
 aaD
@@ -82210,7 +82042,7 @@ bzg
 bAc
 bAc
 bCH
-bDO
+bAe
 bAc
 bFk
 bHi
@@ -84960,7 +84792,7 @@ aNp
 abZ
 ahP
 abZ
-aiP
+ada
 abZ
 aNp
 ada
@@ -85206,11 +85038,11 @@ abD
 aca
 acu
 adb
-pIs
+amY
 acu
 acu
 acu
-pIs
+amY
 adb
 acu
 agT
@@ -85477,13 +85309,13 @@ aed
 aed
 aed
 aed
-akj
+ejn
 aed
 ala
 aed
 aed
 amv
-akj
+ejn
 anz
 aed
 aed


### PR DESCRIPTION
[Internal][code quality][bug]

## About the PR 
removes d1 and d2 variables from cables on clarion
fixes some powernet disconnections and area mis-labels

## Why's this needed?
they're redundant! shortening file, removing clutter and whatnot