### PR TITLE
Santa's Winter Hearth should not override existing cold/fire/thermal resistance

### DIFF
--- a/code/datums/abilities/santa.dm
+++ b/code/datums/abilities/santa.dm
@@ -206,8 +206,8 @@
 		playsound(holder.owner.loc, 'sound/effects/MagShieldUp.ogg', 100, 1, 0)
 		holder.owner.visible_message("<span class='alert'><B>[holder.owner] summons the warmth of a nice toasty fireplace!</B></span>")
 		for (var/mob/living/M in view(holder.owner,5))
-			if (M.bioHolder)
-				M.bioHolder.AddEffect("cold_resist", 0, 60)
+			if (M.bioHolder && !M.bioHolder.HasOneOfTheseEffects("fire_resist", "cold_resist", "thermal_resist"))
+				M.bioHolder.AddEffect("cold_resist", 0, 60) // this will wipe `thermal_vuln` still vOv
 
 /datum/targetable/santa/teleport
 	name = "Spacemas Warp"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the Winter Hearth ability targets people, do not add the Cold Resistance bioEffect if the bioholder has one of the following in-group bioEffects
* Thermal Resistance
* Fire Resistance
* Cold Resistance

Note that this does not check for Thermal Vulnerability (but could if requested)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12303

