### PR TITLE
Adds a few extras to the medical clothing vendor

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2938,6 +2938,10 @@ ABSTRACT_TYPE(/obj/machinery/vending/jobclothing)
 
 		product_list += new/datum/data/vending_product(/obj/item/clothing/under/rank/medical/april_fools, 2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/labcoat/medical/april_fools, 2, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/under/rank/roboticist/april_fools, 1, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/labcoat/robotics/april_fools, 1, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/under/rank/geneticist/april_fools, 1, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/labcoat/genetics/april_fools, 1, hidden=1)
 
 /obj/machinery/vending/jobclothing/engineering
 	name = "Engineering Apparel"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an "april_fools" versions of the roboticist and genetics jumpsuits and labcoats to the hacked medical clothing vendor selection.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Doctors currently get 2 "april_fools" jumpsuits and labcoats. Geneticists and Roboticists can get their regular outfits from the vendor so this feels normal that they should get an alt version available like doctors do, albeit only one since the amount of staff is lower in those jobs. If this is felt to take away too much from the use of the spacebux purchase that's understandable.

```changelog
(u)Munien
(+)Added a few extra items to hacked medical clothing vendors for other medical occupations.
```
