### PR TITLE
Allows shoving stunned people down ladders

### DIFF
--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -1354,10 +1354,12 @@ var/global/iomoon_blowout_state = 0 //0: Hasn't occurred, 1: Moon is irradiated 
 	attackby(obj/item/W, mob/user)
 		if (src.broken) return
 		if (istype(W, /obj/item/grab))
-			if (!W:affecting) return
+			var/obj/item/grab/grab = W
+			if (!grab.affecting || BOUNDS_DIST(grab.affecting, src) > 0)
+				return
 			user.lastattacked = src
-			src.visible_message("<span class='alert'><b>[user] is trying to shove [W:affecting] [icon_state == "ladder"?"down":"up"] [src]!</b></span>")
-			return attack_hand(W:affecting)
+			src.visible_message("<span class='alert'><b>[user] is trying to shove [grab.affecting] [icon_state == "ladder"?"down":"up"] [src]!</b></span>")
+			return climb(grab.affecting)
 
 	proc/climb(mob/user as mob)
 		var/obj/ladder/otherLadder = src.get_other_ladder()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you shove stunned people up/down ladders.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes Nadir diner criming a little more effective.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Stunned people can now be shoved up/down ladders using grabs (previously only people capable of climbing ladders could be shoved down them).
```
