### PR TITLE
mats is now stored in typeinfo

### DIFF
--- a/assets/maps/prefabs/prefab_smuggler.dmm
+++ b/assets/maps/prefabs/prefab_smuggler.dmm
@@ -99,7 +99,7 @@
 /area/prefab/smuggler_den)
 "ar" = (
 /obj/machinery/manufacturer/general{
-	mats = 10
+	free_resource_amt = 10
 	},
 /obj/machinery/light/small{
 	dir = 1;

--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -1017,6 +1017,9 @@
 		..()
 		qdel(src)
 
+TYPEINFO(/obj/item/rpcargotele)
+	mats = 4
+
 /obj/item/rpcargotele
 	name = "special cargo transporter"
 	desc = "A device for teleporting crated goods. There is something really, really shady about this.."
@@ -1024,7 +1027,6 @@
 	icon_state = "syndicargotele"
 	w_class = W_CLASS_SMALL
 	c_flags = ONBELT
-	mats = 4
 
 /obj/decoration/scenario/crate
 	name = "NT vital supplies crate"

--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -783,6 +783,9 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	var/list/nums_black = list("2","4","6","8","10","11","13","15","17","20","22","24","26","28","29","31","33","35")
 	var/list/nums_snake = list("1","5","9","12","14","16","19","23","27","30","32","34")
 /*
+TYPEINFO(/obj/submachine/blackjack)
+	mats = 9
+
 /obj/submachine/blackjack
 	name = "blackjack machine"
 	desc = "Gambling for the antisocial."
@@ -790,7 +793,6 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	icon_state = "BJ1"
 	anchored = 1
 	density = 1
-	mats = 9
 	var/on = 1
 	var/plays = 0
 	var/working = 0
@@ -1629,6 +1631,9 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 		else
 			return ..()
 
+TYPEINFO(/obj/item/space_thing)
+	mats = 50
+
 /obj/item/space_thing
 	name = "space thing"
 	desc = "Some kinda thing, from space. In space. A space thing."
@@ -1638,7 +1643,6 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	w_class = W_CLASS_TINY
 	force = 10
 	throwforce = 7
-	mats = 50
 	contraband = 1
 	stamina_damage = 40
 	stamina_cost = 23

--- a/code/WorkInProgress/computerx/peripherals.dm
+++ b/code/WorkInProgress/computerx/peripherals.dm
@@ -35,6 +35,9 @@
 
 //TO-DO: Major rewrite in communication method between peripherals and the host system.
 
+TYPEINFO(/obj/item/peripheralx)
+	mats = 8
+
 /obj/item/peripheralx
 	name = "Peripheral card"
 	desc = "A computer circuit board."
@@ -47,7 +50,6 @@
 	var/id = null
 	var/func_tag = "GENERIC" //What kind of peripheral is this, huh??
 	var/setup_has_badge = 0 //IF this is set, present return_badge() in the host's browse window
-	mats = 8
 
 	New(location)
 		..()

--- a/code/WorkInProgress/construction/supply_controller.dm
+++ b/code/WorkInProgress/construction/supply_controller.dm
@@ -548,15 +548,19 @@
 	bullet_act()
 		return
 
+TYPEINFO(/obj/supply_pad/incoming)
+	mats = 10
+
 /obj/supply_pad/incoming
 	name = "Incoming supply pad"
 	direction = 0
+
+TYPEINFO(/obj/supply_pad/outgoing)
 	mats = 10
 
 /obj/supply_pad/outgoing
 	name = "Outgoing supply pad"
 	direction = 1
-	mats = 10
 
 /obj/machinery/computer/special_supply
 	// This is a grade 1 workstation. Contains bare-bones supplies.

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -168,6 +168,9 @@
 		for (var/obj/machinery/turret/construction/aTurret in turrets)
 			aTurret.setState(enabled, lethal)
 
+TYPEINFO(/obj/item/room_marker)
+	mats = 6
+
 /obj/item/room_marker
 	name = "\improper Room Designator"
 	icon = 'icons/obj/construction.dmi'
@@ -175,7 +178,6 @@
 	item_state = "gun"
 	w_class = W_CLASS_SMALL
 
-	mats = 6
 	var/using = 0
 
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
@@ -273,11 +275,13 @@
 
 		return affected
 
+TYPEINFO(/obj/item/clothing/glasses/construction)
+	mats = 6
+
 /obj/item/clothing/glasses/construction
 	name = "\improper Construction Visualizer"
 	icon_state = "construction"
 	item_state = "construction"
-	mats = 6
 	desc = "The latest technology in viewing live blueprints."
 
 /obj/item/lamp_manufacturer/organic
@@ -294,13 +298,15 @@
 		..()
 		inventory_counter.update_number(metal_ammo)
 
+TYPEINFO(/obj/item/material_shaper)
+	mats = 6
+
 /obj/item/material_shaper
 	name = "\improper Window Planner"
 	icon = 'icons/obj/construction.dmi'
 	icon_state = "shaper"
 	item_state = "gun"
 	flags = FPRINT | TABLEPASS | EXTRADELAY
-	mats = 6
 	click_delay = 1
 
 	var/mode = 0
@@ -488,13 +494,15 @@
 			processing = 0
 			user.visible_message("<span class='notice'>[user] finishes stuffing materials into [src].</span>")
 
+TYPEINFO(/obj/item/room_planner)
+	mats = 6
+
 /obj/item/room_planner
 	name = "\improper Floor and Wall Designer"
 	icon = 'icons/obj/construction.dmi'
 	icon_state = "plan"
 	item_state = "gun"
 	flags = FPRINT | TABLEPASS | EXTRADELAY
-	mats = 6
 	w_class = W_CLASS_SMALL
 	click_delay = 1
 

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -48,6 +48,9 @@ receive_a_thing pulls a thing out of a queue (shipping market or direct queue) w
 and delivers it to the pad after a few seconds, or returns it to the queue it came from if the transception fails
 */
 
+TYPEINFO(/obj/machinery/communications_dish/transception)
+	mats = 0
+
 /obj/machinery/communications_dish/transception
 	name = "Transception Array"
 	desc = "Sends and receives both energy and matter over a considerable distance. Questionably safe."
@@ -55,7 +58,6 @@ and delivers it to the pad after a few seconds, or returns it to the queue it ca
 	icon_state = "array"
 	bound_height = 64
 	bound_width = 96
-	mats = 0
 
 	///Whether array is currently transceiving (interfacing with a pad for the process of sending or receiving a thing)
 	var/is_transceiving = FALSE
@@ -624,6 +626,9 @@ and delivers it to the pad after a few seconds, or returns it to the queue it ca
 
 #define INTERLINK_RANGE 100
 
+TYPEINFO(/obj/machinery/transception_pad)
+	mats = list("MET-2"=5,"CON-2"=2,"CON-1"=5)
+
 /obj/machinery/transception_pad
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "neopad"
@@ -631,7 +636,6 @@ and delivers it to the pad after a few seconds, or returns it to the queue it ca
 	anchored = 1
 	density = 0
 	layer = FLOOR_EQUIP_LAYER1
-	mats = list("MET-2"=5,"CON-2"=2,"CON-1"=5)
 	desc = "A sophisticated cargo pad capable of utilizing the station's transception antenna when connected by cable. Keep clear during operation."
 	var/is_transceiving = FALSE
 	var/frequency = FREQ_TRANSCEPTION_SYS

--- a/code/WorkInProgress/pali/blob_fabricator.dm
+++ b/code/WorkInProgress/pali/blob_fabricator.dm
@@ -1,5 +1,4 @@
 
-ABSTRACT_TYPE(/datum/manufacture/mechanics/blob)
 /datum/manufacture/mechanics/blob
 	name = "blob"
 	item_paths = list("ORG|RUB")

--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/crusher)
+	mats = 20
+
 /obj/machinery/crusher
 	name = "Crusher Unit"
 	desc = "Breaks things down into metal/glass/waste"
@@ -7,7 +10,6 @@
 	icon_state = "Crusher_1"
 	layer = MOB_LAYER - 1
 	anchored = 1
-	mats = 20
 	is_syndicate = 1
 	flags = FLUID_SUBMERGE | UNCRUSHABLE
 	event_handler_flags = USE_FLUID_ENTER

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -855,11 +855,13 @@
 
 		qdel(src)
 
+TYPEINFO(/obj/disposalpipe/loafer)
+	mats = 100
+
 /obj/disposalpipe/loafer
 	name = "disciplinary loaf processor"
 	desc = "A pipe segment designed to convert detritus into a nutritionally-complete meal for inmates."
 	icon_state = "pipe-loaf0"
-	mats = 100
 	is_syndicate = 1
 	var/is_doing_stuff = FALSE
 
@@ -1698,6 +1700,9 @@
 
 // the disposal outlet machine
 
+TYPEINFO(/obj/disposaloutlet)
+	mats = 12
+
 /obj/disposaloutlet
 	name = "disposal outlet"
 	desc = "An outlet for the pneumatic disposal system."
@@ -1707,7 +1712,6 @@
 	anchored = 1
 	var/active = 0
 	var/turf/target	// this will be where the output objects are 'thrown' to.
-	mats = 12
 	var/range = 10
 
 	var/message = null

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -9,6 +9,9 @@
 #define DISPOSAL_CHUTE_CHARGING 1
 #define DISPOSAL_CHUTE_CHARGED 2
 
+TYPEINFO(/obj/machinery/disposal)
+	mats = 20			// whats the point of letting people build trunk pipes if they cant build new disposals?
+
 /obj/machinery/disposal
 	name = "disposal unit"
 	desc = "A pressurized trashcan that flushes things you put into it through pipes, usually to disposals."
@@ -27,7 +30,6 @@
 	var/light_style = "disposal" // for the lights and stuff
 	var/image/handle_image = null
 	var/destination_tag = null
-	mats = 20			// whats the point of letting people build trunk pipes if they cant build new disposals?
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER
 	power_usage = 100
 

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -640,6 +640,9 @@
 		loved += M
 
 //misc stuffs
+TYPEINFO(/obj/item/device/geiger)
+	mats = 5
+
 /obj/item/device/geiger
 	name = "geiger counter"
 	desc = "A device used to passively measure raditation."
@@ -651,7 +654,6 @@
 	w_class = W_CLASS_TINY
 	throw_speed = 5
 	throw_range = 10
-	mats = 5
 
 	New()
 		. = ..()

--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -1,13 +1,15 @@
 //WIP tugs
 
-/obj/tug_cart/
+TYPEINFO(/obj/tug_cart)
+	mats = 10
+
+/obj/tug_cart
 	name = "cargo cart"
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "flatbed"
 	var/atom/movable/load = null
 	var/obj/tug_cart/next_cart = null
 	layer = MOB_LAYER + 1
-	mats = 10
 
 	MouseDrop_T(var/atom/movable/C, mob/user)
 		if (!in_interact_range(user, src) || !in_interact_range(user, C) || user.restrained() || user.getStatusDuration("paralysis") || user.sleeping || user.stat || user.lying)
@@ -146,14 +148,18 @@
 		next_cart = null
 		..()
 
+
+TYPEINFO(/obj/vehicle/tug)
+	mats = 10
+
 /obj/vehicle/tug
 	name = "cargo tug"
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "tractor"
-//	rider_visible = 1
+	//	rider_visible = 1
 	layer = MOB_LAYER + 1
-//	sealed_cabin = 0
-	mats = 10
+
+	//	sealed_cabin = 0
 	health = 80
 	health_max = 80
 	var/obj/tug_cart/cart = null

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -28,7 +28,8 @@ TYPEINFO(/datum/component/analyzable)
 		return
 	// if this item doesn't have mats defined or was constructed or
 	// attempting to scan a syndicate item and this is a normal scanner
-	if (isnull(parent_atom.mats) || parent_atom.mats == 0 || (parent_atom.is_syndicate && !I.is_syndicate))
+	var/typeinfo/obj/typeinfo = parent_atom.get_typeinfo()
+	if (isnull(typeinfo.mats) || typeinfo.mats == 0 || (parent_atom.is_syndicate && !I.is_syndicate))
 		return MECHANICS_ANALYSIS_INCOMPATIBLE
 	var/obj/item/electronics/scanner/S = I
 	if (istype(S))

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -685,6 +685,9 @@
 
 #define VENT_GENFACTOR 300
 
+TYPEINFO(/obj/item/vent_capture_unbuilt)
+	mats = 8
+
 /obj/item/vent_capture_unbuilt
 	name = "unbuilt vent capture unit"
 	desc = "An unbuilt piece of machinery that converts vent output into electricity."
@@ -692,7 +695,6 @@
 	icon_state = "hydrovent_unbuilt"
 	item_state = "vent"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
-	mats = 8
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 
 	attackby(var/obj/item/W, var/mob/user)
@@ -833,6 +835,9 @@
 				return
 		return*/
 
+TYPEINFO(/obj/machinery/power/stomper)
+	mats = 8
+
 /obj/machinery/power/stomper
 	name = "stomper unit"
 	desc = "This machine is used to disturb the flow of underground magma and redirect it."
@@ -852,7 +857,6 @@
 	var/powerupsfx = 'sound/machines/shieldgen_startup.ogg'
 	var/powerdownsfx = 'sound/machines/engine_alert3.ogg'
 
-	mats = 8
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_DESTRUCT
 	flags = FPRINT
 
@@ -1007,6 +1011,9 @@
 		if(Obj == src.cell)
 			src.cell = null
 
+TYPEINFO(/obj/item/clothing/shoes/stomp_boots)
+	mats = 20
+
 /obj/item/clothing/shoes/stomp_boots
 	name = "Stomper Boots"
 	desc = "A pair of specialized boots for stomping the ground really hard." // TODO add techy explanation I guess
@@ -1015,7 +1022,6 @@
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW
 	laces = LACES_NONE
-	mats = 20
 	burn_possible = 0
 	abilities = list(/obj/ability_button/stomper_boot_stomp)
 

--- a/code/datums/gamemodes/pod_wars/pw_weapons.dm
+++ b/code/datums/gamemodes/pod_wars/pw_weapons.dm
@@ -1,4 +1,7 @@
 ///////////////////////////////////////PW Blasters
+TYPEINFO(/obj/item/gun/energy/blaster_pod_wars)
+	mats = 0
+
 /obj/item/gun/energy/blaster_pod_wars
 	name = "blaster pistol"
 	desc = "A dangerous-looking blaster pistol. It's self-charging by a radioactive power cell."
@@ -7,7 +10,6 @@
 	item_state = "pw_pistol_nt"
 	w_class = W_CLASS_NORMAL
 	force = 8
-	mats = 0
 	cell_type = /obj/item/ammo/power_cell/self_charging/pod_wars_basic
 
 	var/image/indicator_display = null

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -27,18 +27,16 @@ ABSTRACT_TYPE(/datum/manufacture)
 	New()
 		..()
 		if(isnull(item_paths) && length(item_outputs) == 1) // TODO generalize to multiple outputs (currently no such manufacture recipes exist)
-			// sadly we can't use initial() because it's a list :/
 			var/item_type = item_outputs[1]
-			var/obj/dummy = new item_type
-			if(islist(dummy.mats))
+			var/typeinfo/obj/typeinfo = get_type_typeinfo(item_type)
+			if(istype(typeinfo) && islist(typeinfo.mats))
 				item_paths = list()
-				for(var/mat in dummy.mats)
+				for(var/mat in typeinfo.mats)
 					item_paths += mat
-					var/amt = dummy.mats[mat]
+					var/amt = typeinfo.mats[mat]
 					if(isnull(amt))
 						amt = 1
 					item_amounts += amt
-			qdel(dummy)
 		if(isnull(item_paths))
 			item_paths = list() // a bunch of places expect this to be non-null, like the sanity check
 		if (!sanity_check_exemption)

--- a/code/modules/atmospherics/portable/portable_pressurizer.dm
+++ b/code/modules/atmospherics/portable/portable_pressurizer.dm
@@ -22,6 +22,9 @@
  * 	Allows for input/output of enviromental air and will convert objects made of materials that produce gas to.. gas.
  * 	Once sufficient pressure has been reached it can be released spreading it across the current airgroup with a minor stun explosion.
   */
+TYPEINFO(/obj/machinery/portable_atmospherics/pressurizer)
+	mats = list("MET-1" = 15, "MET-2" = 3, "INS-1" = 3, "CON-1" = 10)
+
 /obj/machinery/portable_atmospherics/pressurizer
 	name = "Extreme-Pressure Pressurization Device"
 	desc = "Some kind of nightmare contraption to make a lot of noise or pressurize rooms."
@@ -51,7 +54,6 @@
 	var/process_rate = 2
 	var/powconsumption = 0
 	var/emagged = 0
-	mats = list("MET-1" = 15, "MET-2" = 3, "INS-1" = 3, "CON-1" = 10)
 
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_MULTITOOL
 

--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/portable_atmospherics/pump)
+	mats = 12
+
 /obj/machinery/portable_atmospherics/pump
 	name = "Portable Air Pump"
 
@@ -5,7 +8,6 @@
 	icon_state = "psiphon-off"
 	dir = NORTH //so it spawns with the fan side showing
 	density = 1
-	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER
 	var/on = 0
 	var/direction_out = 0 //0 = siphoning, 1 = releasing

--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/portable_atmospherics/scrubber)
+	mats = 12
+
 /obj/machinery/portable_atmospherics/scrubber
 	name = "Portable Air Scrubber"
 
@@ -7,7 +10,6 @@
 
 	var/on = FALSE
 	var/inlet_flow = 100 // percentage
-	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER
 	volume = 750
 	desc = "A device which filters out harmful air from an area."

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -7,6 +7,9 @@ var/list/basic_elements = list(
 	)
 
 ABSTRACT_TYPE(/obj/machinery/chem_dispenser)
+TYPEINFO(/obj/machinery/chem_dispenser)
+	mats = list("MET-2" = 10, "CON-2" = 10, "miracle" = 20)
+
 /obj/machinery/chem_dispenser
 	name = "chem dispenser"
 	desc = "A complicated, soda fountain-like machine that allows the user to dispense basic chemicals for use in recipies."
@@ -18,7 +21,6 @@ ABSTRACT_TYPE(/obj/machinery/chem_dispenser)
 	flags = NOSPLASH | TGUI_INTERACTIVE
 	object_flags = NO_GHOSTCRITTER
 	var/health = 400
-	mats = list("MET-2" = 10, "CON-2" = 10, "miracle" = 20)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	var/obj/item/beaker = null
 	var/list/dispensable_reagents = null

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -9,6 +9,9 @@
 // Removed quite a bit of of duplicate code here (Convair880).
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+TYPEINFO(/obj/machinery/chem_heater)
+	mats = 15
+
 /obj/machinery/chem_heater
 	name = "Reagent Heater/Cooler"
 	desc = "A device used for the slow but precise heating and cooling of chemicals. It looks like a cross between an oven and a urinal."
@@ -17,7 +20,6 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "heater"
 	flags = NOSPLASH | TGUI_INTERACTIVE
-	mats = 15
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	power_usage = 50
 	var/obj/beaker = null
@@ -288,6 +290,9 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+TYPEINFO(/obj/machinery/chem_master)
+	mats = 15
+
 /obj/machinery/chem_master
 	name = "CheMaster 3000"
 	desc = "A computer-like device used in the production of various pharmaceutical items. It has a slot for a beaker on the top."
@@ -296,7 +301,6 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mixer0"
 	flags = NOSPLASH
-	mats = 15
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/obj/item/beaker = null
 	var/list/whitelist = list()
@@ -694,17 +698,19 @@
 			icon_state = "mixer0"
 			src.updateUsrDialog()
 
-datum/chemicompiler_core/stationaryCore
+/datum/chemicompiler_core/stationaryCore
 	statusChangeCallback = "statusChange"
 
-/obj/machinery/chemicompiler_stationary/
+TYPEINFO(/obj/machinery/chemicompiler_stationary)
+	mats = 15
+
+/obj/machinery/chemicompiler_stationary
 	name = "ChemiCompiler CCS1001"
 	desc = "This device looks very difficult to use."
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "chemicompiler_st_off"
-	mats = 15
 	flags = NOSPLASH
 	processing_tier = PROCESSING_FULL
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -190,13 +190,15 @@
 		src.create_reagents(10000)
 		reagents.add_reagent("water",10000)
 
+TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
+	mats = 8
+
 /obj/reagent_dispensers/watertank/fountain
 	name = "water cooler"
 	desc = "A popular gathering place for NanoTrasen's finest bureaucrats and pencil-pushers."
 	icon_state = "coolerbase"
 	anchored = 1
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR
-	mats = 8
 	capacity = 500
 
 	var/has_tank = 1

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -321,6 +321,12 @@
 		beakers += B1
 		beakers += B2
 
+TYPEINFO(/obj/item/chem_grenade/flashbang)
+	mats = 6
+
+TYPEINFO(/obj/item/chem_grenade/flashbang/revolution)
+	mats = null
+
 /obj/item/chem_grenade/flashbang
 	name = "flashbang"
 	desc = "A standard stun grenade."
@@ -330,7 +336,6 @@
 	stage = 2
 	is_syndicate = 1
 	is_dangerous = FALSE
-	mats = 6
 
 	New()
 		..()
@@ -352,7 +357,6 @@
 		beakers += B2
 
 	revolution //convertssss
-		mats = null
 		explode()
 			if (ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution))
 				var/datum/game_mode/revolution/R = ticker.mode

--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -9,6 +9,9 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 /* -------------------- Hypospray -------------------- */
 /* =================================================== */
 
+TYPEINFO(/obj/item/reagent_containers/hypospray)
+	mats = 6
+
 /obj/item/reagent_containers/hypospray
 	name = "hypospray"
 	desc = "An advanced device capable of injecting various medicines into a patient instantaneously. Dumps any harmful chemicals."
@@ -23,7 +26,6 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 	var/list/whitelist = list()
 	var/inj_amount = 5
 	var/safe = 1
-	mats = 6
 	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
 	var/image/fluid_image
 	var/sound/sound_inject = 'sound/items/hypo.ogg'

--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -209,6 +209,9 @@
 /* -------------------- IV Stand -------------------- */
 /* ================================================== */
 
+TYPEINFO(/obj/iv_stand)
+	mats = 10
+
 /obj/iv_stand
 	name = "\improper IV stand"
 	desc = "A metal pole that you can hang IV bags on, which is useful since we aren't animals that go leaving our sanitized medical equipment all over the ground or anything!"
@@ -220,7 +223,6 @@
 	var/image/bag_image = null
 	var/obj/item/reagent_containers/iv_drip/IV = null
 	var/obj/paired_obj = null
-	mats = 10
 
 	get_desc()
 		if (src.IV)

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -454,12 +454,14 @@
 
 
 //mender
+TYPEINFO(/obj/item/reagent_containers/mender)
+	mats = list("MET-2"=5,"CRY-1"=4, "gold"=5)
+
 /obj/item/reagent_containers/mender
 	name = "auto-mender"
 	desc = "A small electronic device designed to topically apply healing chemicals."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mender"
-	mats = list("MET-2"=5,"CRY-1"=4, "gold"=5)
 	var/image/fluid_image
 	var/tampered = 0
 	var/borg = 0

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -98,12 +98,14 @@
 			src.onRestart()
 
 // portable fishing portal currently found in a prefab in space
+TYPEINFO(/obj/item/fish_portal)
+	mats = 11
+
 /obj/item/fish_portal
 	name = "Fishing Portal Generator"
 	desc = "A small device that creates a portal you can fish in."
 	icon = 'icons/obj/items/fishing_gear.dmi'
 	icon_state = "fish_portal"
-	mats = 11
 
 	attack_self(mob/user as mob)
 		new /obj/machinery/active_fish_portal(get_turf(user))

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -9,6 +9,12 @@
 //////Drainage/////
 ///////////////////
 
+TYPEINFO(/obj/machinery/drainage)
+	mats = 8
+
+TYPEINFO(/obj/machinery/drainage/big)
+	mats = 12
+
 /obj/machinery/drainage
 	name = "drain"
 	desc = "A drainage pipe embedded in the floor to prevent flooding. Where does the drain go? Nobody knows."
@@ -23,14 +29,12 @@
 	var/welded = 0 //permanent block
 	var/drain_min = 2
 	var/drain_max = 7
-	mats = 8
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 
 	big
 		base_icon = "bigdrain"
 		icon_state = "bigdrain"
-		mats = 12
 		drain_min = 6
 		drain_max = 14
 
@@ -217,6 +221,9 @@
 ///////////////////
 
 
+TYPEINFO(/obj/machinery/fluid_canister)
+	mats = 20
+
 /obj/machinery/fluid_canister
 	anchored = 0
 	density = 1
@@ -228,7 +235,6 @@
 	var/bladder = 20000 //how much I can hold
 	var/slurp = 10 //tiles of fluid to drain per tick
 	var/piss = 500 //amt of reagents to piss out per tick
-	mats = 20
 	deconstruct_flags = DECON_CROWBAR | DECON_WELDER
 
 	var/slurping = 0
@@ -419,6 +425,9 @@
 			user.show_text("You climb [src].")
 
 
+TYPEINFO(/obj/item/sea_ladder)
+	mats = 7
+
 /obj/item/sea_ladder
 	name = "sea ladder"
 	desc = "A deployable sea ladder that will allow you to descend to and ascend from the trench."
@@ -433,7 +442,6 @@
 	stamina_cost = 20
 	stamina_crit_chance = 6
 	var/c_color = null
-	mats = 7
 
 	New()
 		..()
@@ -469,6 +477,9 @@
 		L.og_ladder_item = src
 		L.linked_ladder.og_ladder_item = src
 
+TYPEINFO(/obj/naval_mine)
+	mats = 16
+
 /obj/naval_mine
 	name = "naval mine"
 	desc = "This looks explosive!"
@@ -477,7 +488,6 @@
 	density = 1
 	anchored = 0
 
-	mats = 16
 	deconstruct_flags = DECON_WRENCH | DECON_WELDER | DECON_MULTITOOL
 	flags = FPRINT
 

--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/submachine/claw_machine)
+	mats = list("MET-1"=5, "CON-1"=5, "CRY-1"=5, "FAB-1"=5)
+
 /obj/submachine/claw_machine
 	name = "claw machine"
 	desc = "Sure we got our health insurance benefits cut, and yeah we don't get any overtime on holidays, but hey - free to play claw machines!"
@@ -5,7 +8,6 @@
 	icon_state = "claw"
 	anchored = 1
 	density = 1
-	mats = list("MET-1"=5, "CON-1"=5, "CRY-1"=5, "FAB-1"=5)
 	deconstruct_flags = DECON_MULTITOOL | DECON_WRENCH | DECON_CROWBAR
 	var/busy = 0
 	var/list/prizes = list(/obj/item/toy/plush/small/bee,\

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -1,4 +1,7 @@
 /// This serves as a bridge between old materials pieces and new ones. Eventually old ones should just be updated.
+TYPEINFO(/obj/machinery/processor)
+	mats = 20
+
 /obj/machinery/processor
 	name = "Material processor"
 	desc = "Turns raw materials, and objects containing materials, into processed pieces."
@@ -7,7 +10,6 @@
 	anchored = 1
 	density = 1
 	layer = FLOOR_EQUIP_LAYER1
-	mats = 20
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -32,6 +32,9 @@
 
 
 
+TYPEINFO(/obj/machinery/genetics_booth)
+	mats = 40
+
 /obj/machinery/genetics_booth
 	name = "gene booth"
 	desc = "A luxury booth that will exchange genetic upgrades for cash. It automatically bills your account using advanced magnet technology. It's safe!"
@@ -60,7 +63,6 @@
 	var/list/offered_genes = list()
 
 	var/started = 0
-	mats = 40
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_NO_ACCESS
 
 	var/datum/light/light

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -1,12 +1,14 @@
 var/list/genescanner_addresses = list()
 var/list/genetek_hair_styles = list()
 
+TYPEINFO(/obj/machinery/genetics_scanner)
+	mats = 15
+
 /obj/machinery/genetics_scanner
 	name = "GeneTek scanner"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "scanner_0"
 	density = 1
-	mats = 15
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	var/mob/occupant = null
 	var/datum/character_preview/multiclient/occupant_preview = null

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -345,6 +345,9 @@ CONTAINS:
 /* -------------------- Defib -------------------- */
 /* =============================================== */
 
+TYPEINFO(/obj/item/robodefibrillator)
+	mats = 10
+
 /obj/item/robodefibrillator
 	name = "defibrillator"
 	desc = "Uses electrical currents to restart the hearts of critical patients."
@@ -359,7 +362,6 @@ CONTAINS:
 	var/emagged = 0
 	var/makeshift = 0
 	var/obj/item/cell/cell = null
-	mats = 10
 
 	emag_act(var/mob/user)
 		if (src.makeshift)
@@ -634,6 +636,9 @@ CONTAINS:
 		parent = null
 		..()
 
+TYPEINFO(/obj/machinery/defib_mount)
+	mats = 25
+
 /obj/machinery/defib_mount
 	name = "mounted defibrillator"
 	icon = 'icons/obj/compact_machines.dmi'
@@ -641,7 +646,6 @@ CONTAINS:
 	icon_state = "defib1"
 	anchored = 1
 	density = 0
-	mats = 25
 	var/obj/item/robodefibrillator/mounted/defib = null
 
 	New()
@@ -1244,6 +1248,9 @@ CONTAINS:
 /* -------------------- Penlight -------------------- */
 /* ================================================== */
 
+TYPEINFO(/obj/item/device/light/flashlight/penlight)
+	mats = 1
+
 /obj/item/device/light/flashlight/penlight
 	name = "penlight"
 	desc = "A small light used for testing photopupillary reflexes."
@@ -1258,7 +1265,6 @@ CONTAINS:
 	throw_range = 15
 	m_amt = 50
 	g_amt = 10
-	mats = 1
 	col_r = 0.9
 	col_g = 0.8
 	col_b = 0.7

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -1,4 +1,7 @@
 //Motherboard is just used in assembly/disassembly, doesn't exist in the actual computer object.
+TYPEINFO(/obj/item/motherboard)
+	mats = 8
+
 /obj/item/motherboard
 	name = "Computer mainboard"
 	desc = "A computer motherboard."
@@ -9,7 +12,6 @@
 	w_class = W_CLASS_SMALL
 	var/created_name = null //If defined, result computer will have this name.
 	var/integrated_floppy = 1 //Does the resulting computer have a built-in disk drive?
-	mats = 8
 
 /obj/computer3frame
 	density = 1

--- a/code/modules/networks/computer3/comm_dish.dm
+++ b/code/modules/networks/computer3/comm_dish.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/communications_dish)
+	mats = 25
+
 /obj/machinery/communications_dish
 	name = "Communications dish"
 	icon = 'icons/mob/hivebot.dmi'
@@ -13,7 +16,6 @@
 	var/frequency = FREQ_COMM_DISH
 	var/list/cargo_logs = list()
 
-	mats = 25
 	deconstruct_flags = DECON_NONE
 
 	New()

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -271,6 +271,9 @@
 		src.read_only = 1
 #endif
 
+TYPEINFO(/obj/item/disk/data/floppy/read_only/authentication)
+	mats = 15
+
 /obj/item/disk/data/floppy/read_only/authentication
 	name = "Authentication Disk"
 	desc = "Capable of storing entire kilobytes of information, this disk carries activation codes for various secure things that aren't nuclear bombs."
@@ -278,7 +281,6 @@
 	item_state = "card-id"
 	object_flags = NO_GHOSTCRITTER
 	w_class = W_CLASS_TINY
-	mats = 15
 	random_color = 0
 	file_amount = 32
 

--- a/code/modules/networks/computer3/mainframe2/logreader.dm
+++ b/code/modules/networks/computer3/mainframe2/logreader.dm
@@ -8,6 +8,9 @@
 		..()
 		fields = list("logdir" = DEFAULT_LOG_PATH)
 
+TYPEINFO(/obj/machinery/networked/logreader)
+	mats = 14
+
 /obj/machinery/networked/logreader
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "computer_generic"
@@ -16,7 +19,6 @@
 	anchored = 1
 	device_tag = "PNET_LOGREADER"
 	timeout = 10
-	mats = 14
 	power_usage = 100
 	var/static/list/required_fields = list("card_name", "door_name", "time_t", "timestamp", "door_id", "action")
 	var/filter_name = null

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -101,6 +101,9 @@
 		..()
 
 
+TYPEINFO(/obj/machinery/networked/storage)
+	mats = 12
+
 /obj/machinery/networked/storage
 	name = "Databank"
 	desc = "A networked data storage device."
@@ -108,7 +111,6 @@
 	density = 1
 	icon_state = "tapedrive0"
 	device_tag = "PNET_DATA_BANK"
-	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	var/base_icon_state = "tapedrive"
 	var/bank_id = null //Unique Identifier for this databank.
@@ -1022,6 +1024,9 @@
 	file_amount = 4
 
 
+TYPEINFO(/obj/machinery/networked/nuclear_charge)
+	mats = list("POW-3" = 27, "MET-3" = 25, "CON-2" = 13, "CRY-2" = 15) //haha this is a bad idea
+
 /obj/machinery/networked/nuclear_charge
 	name = "Nuclear Charge"
 	anchored = 2
@@ -1038,7 +1043,6 @@
 
 #define DISARM_CUTOFF 10 //Can't disarm past this point! OH NO!
 
-	mats = list("POW-3" = 27, "MET-3" = 25, "CON-2" = 13, "CRY-2" = 15) //haha this is a bad idea
 	deconstruct_flags = DECON_NONE
 	is_syndicate = 1 //^ Agreed
 
@@ -1347,6 +1351,9 @@
 #undef DISARM_CUTOFF
 
 
+TYPEINFO(/obj/machinery/networked/radio)
+	mats = 8
+
 /obj/machinery/networked/radio
 	name = "Network Radio"
 	desc = "A networked radio interface."
@@ -1355,7 +1362,6 @@
 	icon_state = "net_radio"
 	device_tag = "PNET_PR6_RADIO"
 	//var/freq = FREQ_BUDDY
-	mats = 8
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	var/list/frequencies = list()
 	var/transmission_range = 100 //How far does our signal reach?
@@ -1668,6 +1674,9 @@
 		return
 
 
+TYPEINFO(/obj/machinery/networked/printer)
+	mats = 6
+
 /obj/machinery/networked/printer
 	name = "Printer"
 	desc = "A networked printer.  It's designed to print."
@@ -1676,7 +1685,6 @@
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	icon_state = "printer0"
 	device_tag = "PNET_PRINTDEVC"
-	mats = 6
 	power_usage = 200
 	machine_registry_idx = MACHINES_PRINTERS
 	var/print_id = null //Just like databanks.
@@ -3373,6 +3381,9 @@
 		return
 
 //Generic test apparatus
+TYPEINFO(/obj/machinery/networked/test_apparatus)
+	mats = 8
+
 /obj/machinery/networked/test_apparatus
 	name = "Generic Testing Apparatus"
 	desc = "A large device designed to facilitate...some manner... of analysis."
@@ -3387,7 +3398,6 @@
 	var/setup_capability_value = "E" //E for Enactor (provides a stimulus), S for Sensor (Records stimulus), or B for both.
 	//Don't forget to give devices unique device_tag values of the form "PNET_XXXXXXXXX"
 	device_tag = "PNET_TEST_APPT" //This is the device tag used to interface with the mainframe GTPIO driver.
-	mats = 8
 	deconstruct_flags = DECON_DESTRUCT
 
 	power_usage = 200

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -34,6 +34,9 @@ proc/is_teleportation_allowed(var/turf/T)
 
 	return TRUE
 
+TYPEINFO(/obj/machinery/networked/telepad)
+	mats = 16
+
 /obj/machinery/networked/telepad
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pad0"
@@ -41,7 +44,6 @@ proc/is_teleportation_allowed(var/turf/T)
 	anchored = 1
 	density = 0
 	layer = FLOOR_EQUIP_LAYER1
-	mats = 16
 	timeout = 10
 	desc = "Stand on this to have your wildest dreams come true!"
 	device_tag = "PNET_S_TELEPAD"
@@ -790,6 +792,9 @@ proc/is_teleportation_allowed(var/turf/T)
 				return
 
 
+TYPEINFO(/obj/machinery/networked/teleconsole)
+	mats = 14
+
 /obj/machinery/networked/teleconsole
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "s_teleport"
@@ -798,7 +803,6 @@ proc/is_teleportation_allowed(var/turf/T)
 	anchored = 1
 	device_tag = "SRV_TERMINAL"
 	timeout = 10
-	mats = 14
 	var/xtarget = 0
 	var/ytarget = 0
 	var/ztarget = 0

--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -16,6 +16,9 @@
 
 
 
+TYPEINFO(/obj/item/peripheral)
+	mats = 8
+
 /obj/item/peripheral
 	name = "Peripheral card"
 	desc = "A computer circuit board."
@@ -28,7 +31,6 @@
 	var/id = null
 	var/func_tag = "GENERIC" //What kind of peripheral is this, huh??
 	var/setup_has_badge = 0 //IF this is set, present return_badge() in the host's browse window
-	mats = 8
 
 	New(location)
 		..()

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -1411,13 +1411,15 @@ Present 	Unscrewed  Connected 	Unconnected		Missing
 				network.update = 1
 		return 1
 
+TYPEINFO(/obj/machinery/power/furnace/thermo)
+	mats = 20
+
 /obj/machinery/power/furnace/thermo
 	name = "Zaojun-1 Furnace"
 	desc = "The venerable XIANG|GIESEL model '灶君' combustion furnace. This version lacks the thermocouple and is designed to heat larger thermo-electric gas circulator systems."
 	icon_state = "furnace"
 	anchored = 1
 	density = 1
-	mats = 20
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	var/obj/machinery/atmospherics/unary/furnace_connector/f_connector = null

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -18,6 +18,9 @@ var/zapLimiter = 0
 //NOTE: STUFF STOLEN FROM AIRLOCK.DM thx
 
 
+TYPEINFO(/obj/machinery/power/apc)
+	mats = 10
+
 /obj/machinery/power/apc
 	name = "area power controller"
 	desc = "The smaller, more numerous sibling of the SMES. Controls the power of entire rooms, and if the generator goes offline, can supply electricity from an internal cell."
@@ -68,9 +71,9 @@ var/zapLimiter = 0
 	var/host_id = null
 	var/timeout = 60 //The time until we auto disconnect (if we don't get a refresh ping)
 	var/timeout_alert = 0 //Have we sent a timeout refresh alert?
+
 //	luminosity = 1
 	var/debug = 0
-	mats = 10
 	mechanics_type_override = /obj/machinery/power/apc
 	autoname_north
 		name = "Autoname N APC"

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/power/furnace)
+	mats = 20
+
 /obj/machinery/power/furnace
 	name = "Zaojun-2 5kW Furnace"
 	desc = "The venerable XIANG|GIESEL model '灶君' combustion furnace with integrated 5 kilowatt thermocouple. A simple power solution for low-demand facilities and outposts."
@@ -12,7 +15,6 @@
 	var/genrate = 5000
 	var/stoked = 0 // engine ungrump
 	custom_suicide = 1
-	mats = 20
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 

--- a/code/modules/power/lgenerator.dm
+++ b/code/modules/power/lgenerator.dm
@@ -1,6 +1,9 @@
 // Overhauled the generator to incorporate APC.cell charging.
 // It used to in the past, but that feature was reverted for reasons unknown.
 // However, it's not a C&P job of the old code (Convair880).
+TYPEINFO(/obj/machinery/power/lgenerator)
+	mats = 10
+
 /obj/machinery/power/lgenerator
 	name = "Experimental Local Generator"
 	desc = "This machine generates power through the combustion of plasma, charging either the local APC or an inserted power cell."
@@ -8,7 +11,6 @@
 	anchored = 0
 	density = 1
 	//layer = FLOOR_EQUIP_LAYER1 //why was this set to this
-	mats = 10
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_MULTITOOL
 	var/mode = 1 // 1 = charge APC, 2 = charge inserted power cell.
 	var/active = 0

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -6,11 +6,13 @@
 // light_status values shared between lighting fixtures and items
 // defines moved to _setup.dm by ZeWaka
 
+TYPEINFO(/obj/item/light_parts)
+	mats = 4
+
 /obj/item/light_parts
 	name = "fixture parts"
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-fixture"
-	mats = 4
 	material_amt = 0.2
 
 	var/installed_icon_state = "tube-empty"
@@ -1026,6 +1028,9 @@
 // can be tube or bulb subtypes
 // will fit into empty /obj/machinery/light of the corresponding type
 
+TYPEINFO(/obj/item/light)
+	mats = 1
+
 /obj/item/light
 	icon = 'icons/obj/lighting.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
@@ -1039,7 +1044,6 @@
 	m_amt = 60
 	var/rigged = 0		// true if rigged to explode
 	var/mob/rigger = null // mob responsible
-	mats = 1
 	var/color_r = 1
 	var/color_g = 1
 	var/color_b = 1

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -9,6 +9,9 @@
 //Machine that tracks the sun and reports it's direction to the solar controllers
 //As long as this is working, solar panels on same powernet will track automatically
 
+TYPEINFO(/obj/machinery/power/tracker)
+	mats = list("CRY-1"=15, "CON-1"=20)
+
 /obj/machinery/power/tracker
 	name = "Houyi stellar tracker"
 	desc = "The XIANG|GIESEL model '后羿' star tracker, used to set the alignment of accompanying photo-electric generator panels."
@@ -20,7 +23,6 @@
 	var/id = 1 // nolonger used, kept for map compatibility
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/computer/solar_control/control
-	mats = list("CRY-1"=15, "CON-1"=20)
 
 	north
 		id = "north"
@@ -81,6 +83,9 @@
 
 /////////////////////////////////////////////// Solar panel /////////////////////////////////////////////////////
 
+TYPEINFO(/obj/machinery/power/solar)
+	mats = list("MET-2"=15, "CON-1"=15)
+
 /obj/machinery/power/solar
 	name = "Kuafu photoelectric panel"
 	desc = "The XIANG|GIESEL model '夸父' photo electrical generator. commonly known as a solar panel."
@@ -99,7 +104,6 @@
 	var/ndir = SOUTH
 	var/turn_angle = 0
 	var/obj/machinery/computer/solar_control/control
-	mats = list("MET-2"=15, "CON-1"=15)
 
 
 	north
@@ -448,9 +452,11 @@
 
 // solar panels which ignore occlusion
 
+TYPEINFO(/obj/machinery/power/solar/owl_cheat)
+	mats = 0
+
 /obj/machinery/power/solar/owl_cheat
 	id = "owl"
-	mats = 0
 
 	update_solar_exposure()
 		if(isnull(sun))	return

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -73,6 +73,9 @@
 //It sends wired /datum/signal information between its master obj and other
 //data terminals in its powernet's nodes.
 
+TYPEINFO(/obj/machinery/power/data_terminal)
+	mats = 5
+
 /obj/machinery/power/data_terminal //The data terminal is remarkably similar to a regular terminal
 	name = "data terminal"
 	icon_state = "dterm"
@@ -83,7 +86,6 @@
 	anchored = 1
 	directwired = 0
 	use_datanet = 1
-	mats = 5
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	var/obj/master = null //It can be any obj that can use receive_signal
 
@@ -143,11 +145,13 @@
 		invisibility = i ? INVIS_ALWAYS : INVIS_NONE
 		alpha = invisibility ? 128 : 255
 
+TYPEINFO(/obj/machinery/power/data_terminal/cable_tray)
+	mats = 0 // uh no thanks
+
 /obj/machinery/power/data_terminal/cable_tray
 	name = "cable tray"
 	desc = "A connector that goes off into somewhere..."
 	icon_state = "vterm"
-	mats = 0 // uh no thanks
 
 	New()
 		..()

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -2023,12 +2023,14 @@
 			return 1
 
 //Robot tools.  Flash boards, batons, etc
+TYPEINFO(/obj/item/device/guardbot_tool)
+	mats = 6
+
 /obj/item/device/guardbot_tool
 	name = "Tool module"
 	desc = "A generic module for a PR-6S Guardbuddy."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "tool_generic"
-	mats = 6
 	w_class = W_CLASS_SMALL
 	var/is_stun = 0 //Can it be non-lethal?
 	var/is_lethal = 0 //Can it be lethal?
@@ -2318,12 +2320,14 @@
 
 	//xmas -- See spacemas.dm
 
+TYPEINFO(/obj/item/device/guardbot_module)
+	mats = 6
+
 /obj/item/device/guardbot_module
 	name = "Add-on module"
 	desc = "A generic expansion pack for a PR-6S Guardbuddy."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "tool_generic"
-	mats = 6
 	w_class = W_CLASS_SMALL
 	var/tool_id = "MOD"
 	is_syndicate = 1
@@ -4203,12 +4207,14 @@
  *	Guardbot Parts
  */
 
+TYPEINFO(/obj/item/guardbot_core)
+	mats = 6
+
 /obj/item/guardbot_core
 	name = "Guardbuddy mainboard"
 	desc = "The primary circuitry of a PR-6S Guardbuddy."
 	icon = 'icons/obj/bots/aibots.dmi'
 	icon_state = "robuddy_core-6"
-	mats = 6
 	w_class = W_CLASS_SMALL
 	var/created_default_task = null //Default task path of result
 	var/datum/computer/file/guardbot_task/created_model_task = null
@@ -4234,12 +4240,14 @@
 		else
 			..()
 
+TYPEINFO(/obj/item/guardbot_frame)
+	mats = 5
+
 /obj/item/guardbot_frame
 	name = "Guardbuddy frame"
 	desc = "The external casing of a PR-6S Guardbuddy."
 	icon = 'icons/obj/bots/aibots.dmi'
 	icon_state = "robuddy_frame-6-1"
-	mats = 5
 	var/stage = 1
 	var/created_name = "Guardbuddy" //Still the name of resulting guardbot
 	var/created_default_task = null //Default task path of result
@@ -4330,12 +4338,14 @@
 
 
 //The Docking Station.  Recharge here!
+TYPEINFO(/obj/machinery/guardbot_dock)
+	mats = 8
+
 /obj/machinery/guardbot_dock
 	name = "docking station"
 	desc = "A recharging and command station for PR-6S Guardbuddies."
 	icon = 'icons/obj/bots/aibots.dmi'
 	icon_state = "robuddycharger0"
-	mats = 8
 	anchored = 1
 	var/panel_open = 0
 	var/autoeject = 0 //1: Eject fully charged robots automatically. 2: Eject robot when living carbon mob is in view.

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/recharge_station)
+	mats = 10
+
 /obj/machinery/recharge_station
 	name = "cyborg docking station"
 	icon = 'icons/obj/robot_parts.dmi'
@@ -5,7 +8,6 @@
 	icon_state = "station"
 	density = 1
 	anchored = 1
-	mats = 10
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	allow_stunned_dragndrop = 1

--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -1,4 +1,7 @@
 //handheld device for manual calibration of siphon systems
+TYPEINFO(/obj/item/device/calibrator)
+	mats = list("CRY-1", "CON-1")
+
 /obj/item/device/calibrator
 	name = "harmonic systems calibrator"
 	icon_state = "calibrator"
@@ -12,7 +15,6 @@
 	desc = "A small handheld device specially built for calibration and readout of harmonic siphon systems."
 	m_amt = 50
 	g_amt = 20
-	mats = list("CRY-1", "CON-1")
 
 
 

--- a/code/modules/telescience/teleport_jammer.dm
+++ b/code/modules/telescience/teleport_jammer.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/telejam)
+	mats = 9
+
 /obj/machinery/telejam
 	name = "teleportation jammer"
 	desc = "Generates a force field interferes with teleportation devices."
@@ -6,7 +9,6 @@
 	density = 1
 	opacity = 0
 	anchored = 0
-	mats = 9
 	var/obj/item/cell/PCEL = null
 	var/coveropen = 0
 	var/active = 0

--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -1,9 +1,11 @@
+TYPEINFO(/obj/machinery/teleport)
+	mats = 10
+
 /obj/machinery/teleport
 	name = "teleport"
 	icon = 'icons/obj/teleporter.dmi'
 	density = 1
 	anchored = 1
-	mats = 10
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 
 	New()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -50,6 +50,9 @@
 			product_base64_cache[path] = .
 
 
+TYPEINFO(/obj/machinery/vending)
+	mats = 20
+
 /obj/machinery/vending
 	name = "Vendomat"
 	desc = "A generic vending machine."
@@ -57,7 +60,6 @@
 	icon_state = "generic"
 	anchored = 1
 	density = 1
-	mats = 20
 	layer = OBJ_LAYER - 0.1 // so items get spawned at 3, don't @ me
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
@@ -1225,6 +1227,9 @@
 		product_list += new/datum/data/vending_product(/obj/item/cigpacket/random, rand(0, 1), hidden=1, cost=420)
 		product_list += new/datum/data/vending_product(/obj/item/cigpacket/cigarillo/juicer, rand(6, 9), hidden=1, cost=69)
 
+TYPEINFO(/obj/machinery/vending/medical)
+	mats = 10
+
 /obj/machinery/vending/medical
 	name = "NanoMed Plus"
 	desc = "An ID-selective dispenser for drugs and medical equipment"
@@ -1232,7 +1237,6 @@
 	icon_panel = "standard-panel"
 	icon_deny = "med-deny"
 	req_access_txt = "5"
-	mats = 10
 	acceptcard = 0
 	light_r =1
 	light_g = 0.88
@@ -1781,12 +1785,14 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		contents += product
 		product_cost = price
 
+TYPEINFO(/obj/item/machineboard)
+	mats = 2
+
 /obj/item/machineboard
 	name = "machine module"
 	desc = "A circuit board assembly used in the construction of machinery."
 	icon = 'icons/obj/electronics.dmi'
 	icon_state = "board1"
-	mats = 2
 	var/machinepath = null
 
 /obj/item/machineboard/vending
@@ -1799,11 +1805,13 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 /obj/item/machineboard/vending/player
 	icon_state = "player-module"
 
+TYPEINFO(/obj/item/machineboard/vending/monkeys)
+	mats = 0 //No!!
+
 /obj/item/machineboard/vending/monkeys
 	name = "Valuchimp module"
 	machinepath = "/obj/machinery/vending/monkey"
 	icon_state = "monkey-module"
-	mats = 0 //No!!
 
 /obj/machinery/vendingframe
 	name = "vending machine frame"
@@ -2198,6 +2206,9 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		. = ..()
 		src.fall()
 
+TYPEINFO(/obj/machinery/vending/monkey)
+	mats = 0 // >:I
+
 /obj/machinery/vending/monkey
 	name = "ValuChimp"
 	desc = "More fun than a barrel of monkeys! Monkeys may or may not be synthflesh replicas, may or may not contain partially-hydrogenated banana oil."
@@ -2205,7 +2216,6 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 	icon_panel = "standard-panel"
 	// monkey vendor has slightly special broken/etc sprites so it doesn't just inherit the standard set  :)
 	acceptcard = 0
-	mats = 0 // >:I
 	slogan_list = list("My monkeys are too strong for you, traveler!")
 	slogan_chance = 1
 
@@ -2540,6 +2550,9 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff, 1, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/abg, 2, cost=PAY_TRADESMAN, hidden=1)
 
+TYPEINFO(/obj/machinery/vending/chem)
+	mats = null
+
 /obj/machinery/vending/chem
 	name = "ChemDepot"
 	desc = "Some odd machine that dispenses little vials and packets of chemicals for exorbitant amounts of money. Is this thing even working right?"
@@ -2551,7 +2564,6 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 	glitchy_slogans = 1
 	pay = 1
 	acceptcard = 1
-	mats = null
 	slogan_list = list("Hello!",
 	"Please state the item you wish to purchase.",
 	"Many goods at reasonable prices.",
@@ -2686,6 +2698,9 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/shoes/dress_shoes, 1, cost=PAY_IMPORTANT/5, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/gloves/ring/gold, 2, cost=PAY_IMPORTANT, hidden=1)
 
+TYPEINFO(/obj/machinery/vending/janitor)
+	mats = 10
+
 /obj/machinery/vending/janitor
 	name = "JaniTech Vendor"
 	desc = "One stop shop for all your custodial needs."
@@ -2696,7 +2711,6 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 	icon_fallen = "janitor-fallen"
 	pay = 1
 	acceptcard = 1
-	mats = 10
 
 	create_products()
 		..()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj)
+	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
+
 /obj
 	var/real_name = null
 	var/real_desc = null
@@ -8,7 +11,6 @@
 	var/adaptable = 0
 
 	var/is_syndicate = 0
-	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
 	var/deconstruct_flags = DECON_NONE
 
 	/// Dictates how this object behaves when scanned with a device analyzer or equivalent - see "_std/defines/mechanics.dm" for docs
@@ -31,7 +33,8 @@
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
-		if (!isnull(src.mats) && src.mats != 0 && !src.mechanics_interaction != MECHANICS_INTERACTION_BLACKLISTED)
+		var/typeinfo/obj/typeinfo = src.get_typeinfo()
+		if (typeinfo.mats && !src.mechanics_interaction != MECHANICS_INTERACTION_BLACKLISTED)
 			src.AddComponent(/datum/component/analyzable, !isnull(src.mechanics_type_override) ? src.mechanics_type_override : src.type)
 		src.update_access_from_txt()
 
@@ -128,7 +131,6 @@
 		for(var/mob/M in src.contents)
 			M.set_loc(src.loc)
 		tag = null
-		mats = null
 		if (artifact && !isnum(artifact))
 			qdel(artifact)
 			artifact = null

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -335,6 +335,9 @@
 //////////////////////////////
 /////Dye Bottle Dispenser/////
 //////////////////////////////
+TYPEINFO(/obj/machinery/hair_dye_dispenser)
+	mats = 15
+
 /obj/machinery/hair_dye_dispenser
 	name = "Hair Dye Mixer 3000"
 	desc = "Mixes hair dye for whatever color you want"
@@ -342,7 +345,6 @@
 	icon_state = "dyedispenser"
 	density = 1
 	anchored = 1
-	mats = 15
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 
 	var/obj/item/dye_bottle/bottle = null

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -1,3 +1,42 @@
+TYPEINFO(/obj/critter/gunbot/drone)
+	mats = list("POW-1" = 5, "MET-2" = 12, "CON-2" = 12, "DEN-1" = 6)
+
+TYPEINFO(/obj/critter/gunbot/drone/glitchdrone)
+	mats = null
+
+TYPEINFO(/obj/critter/gunbot/drone/heavydrone)
+	mats = list("POW-2" = 10, "MET-3" = 12, "CON-2" = 12, "DEN-2" =9)
+
+TYPEINFO(/obj/critter/gunbot/drone/cannondrone)
+	mats = list("POW-3" = 15, "MET-3" = 17, "CON-2" = 13, "CRY-2" =17, "erebite" =16)
+
+TYPEINFO(/obj/critter/gunbot/drone/minigundrone)
+	mats = list("POW-3" = 13, "MET-3" = 24, "CON-2" = 20, "CRY-2" =17)
+
+TYPEINFO(/obj/critter/gunbot/drone/raildrone)
+	mats = 	list("POW-3" = 19, "MET-3" = 20, "CON-2" = 24, "DEN-2" =16)
+
+TYPEINFO(/obj/critter/gunbot/drone/buzzdrone)
+	mats = 	list("POW-2" = 19, "MET-2" = 12, "CON-2" = 14, "DEN-2" =26)
+
+TYPEINFO(/obj/critter/gunbot/drone/buzzdrone/fish)
+	mats = 	24
+
+TYPEINFO(/obj/critter/gunbot/drone/laser)
+	mats = 	list("POW-2" =11, "MET-2" = 14, "CON-2" = 13, "DEN-2" =12)
+
+TYPEINFO(/obj/critter/gunbot/drone/cutterdrone)
+	mats = 	list("POW-1" = 9, "MET-3" = 15, "CON-1" = 7, "CRY-2" =20)
+
+TYPEINFO(/obj/critter/gunbot/drone/assdrone)
+	mats = 	list("POW-3" = 30, "MET-3" = 14, "CON-2" = 23, "CRY-2" =22, "butt"=10) //heh
+
+TYPEINFO(/obj/critter/gunbot/drone/aciddrone)
+	mats = 	list("POW-1" = 10, "MET-1" = 15, "CON-2" = 15, "DEN-1" =10)
+
+TYPEINFO(/obj/critter/gunbot/drone/helldrone)
+	mats = null
+
 /obj/critter/gunbot/drone
 	name = "Syndicate Drone"
 	desc = "An armed and automated Syndicate scout drone."
@@ -20,7 +59,6 @@
 	luminosity = 5
 	seekrange = 15
 	flying = 1
-	mats = list("POW-1" = 5, "MET-2" = 12, "CON-2" = 12, "DEN-1" = 6)
 	var/score = 10
 	dead_state = "drone-dead"
 	var/obj/item/droploot = null
@@ -403,7 +441,6 @@
 		droploot = /obj/bomberman
 		projectile_type = /datum/projectile/bullet/glitch
 		current_projectile = new/datum/projectile/bullet/glitch
-		mats = null
 		New()
 			..()
 			name = "Dr~n³ *§#-[rand(1,999)]"
@@ -421,7 +458,6 @@
 		projectile_type = /datum/projectile/disruptor/high
 		current_projectile = new/datum/projectile/disruptor/high
 		attack_cooldown = 40
-		mats = list("POW-2" = 10, "MET-3" = 12, "CON-2" = 12, "DEN-2" =9)
 		New()
 			..()
 			name = "Drone HK-[rand(1,999)]"
@@ -505,7 +541,6 @@
 		projectile_type = /datum/projectile/bullet/aex
 		current_projectile = new/datum/projectile/bullet/aex
 		attack_cooldown = 50
-		mats = list("POW-3" = 15, "MET-3" = 17, "CON-2" = 13, "CRY-2" =17, "erebite" =16)
 		New()
 			..()
 			name = "Drone AR-[rand(1,999)]"
@@ -525,7 +560,6 @@
 		projectile_type = /datum/projectile/bullet/akm
 		current_projectile = new/datum/projectile/bullet/akm
 		attack_cooldown = 20
-		mats = list("POW-3" = 13, "MET-3" = 24, "CON-2" = 20, "CRY-2" =17)
 		New()
 			..()
 			name = "Drone BML-[rand(1,999)]"
@@ -542,7 +576,6 @@
 		droploot = /obj/item/spacecash/buttcoin // replace with railgun if that's ever safe enough to hand out? idk
 		attack_cooldown = 50
 		smashes_shit = 1
-		mats = 	list("POW-3" = 19, "MET-3" = 20, "CON-2" = 24, "DEN-2" =16)
 
 		Shoot(var/atom/target, var/start, var/user, var/bullet = 0)
 			if(target == start)
@@ -604,7 +637,6 @@
 		current_projectile = new/datum/projectile/laser/drill/cutter
 		smashes_shit = 1
 		attack_range = 1
-		mats = 	list("POW-2" = 19, "MET-2" = 12, "CON-2" = 14, "DEN-2" =26)
 
 		ChaseAttack(atom/M)
 			if(target && !attacking)
@@ -655,7 +687,6 @@
 			current_projectile = new/datum/projectile/laser/drill/saw_teeth
 			smashes_shit = 0
 			event_handler_flags = IMMUNE_MANTA_PUSH
-			mats = 24
 			//TODO : TEENSY REDRAW TO ICON TO MAKE IT A LITTLE MORE ROBOTTY
 
 			New()
@@ -704,7 +735,6 @@
 		dead_state = "vrdrone_red"
 		projectile_type = /datum/projectile/laser
 		current_projectile = new/datum/projectile/laser
-		mats = 	list("POW-2" =11, "MET-2" = 14, "CON-2" = 13, "DEN-2" =12)
 
 		New()
 			..()
@@ -720,7 +750,6 @@
 		dead_state = "vrdrone_orange"
 		projectile_type = /datum/projectile/laser/mining
 		current_projectile = new/datum/projectile/laser/mining
-		mats = 	list("POW-1" = 9, "MET-3" = 15, "CON-1" = 7, "CRY-2" =20)
 		New()
 			..()
 			name = "Drone PC-[rand(1,999)]"
@@ -735,7 +764,6 @@
 		dead_state = "vrdrone_blue"
 		projectile_type = /datum/projectile/laser/asslaser
 		current_projectile = new/datum/projectile/laser/asslaser
-		mats = 	list("POW-3" = 30, "MET-3" = 14, "CON-2" = 23, "CRY-2" =22, "butt"=10) //heh
 
 		New()
 			..()
@@ -751,7 +779,6 @@
 		dead_state = "vrdrone_green"
 		projectile_type = /datum/projectile/special/acid
 		current_projectile = new/datum/projectile/special/acid
-		mats = 	list("POW-1" = 10, "MET-1" = 15, "CON-2" = 15, "DEN-1" =10)
 		New()
 			..()
 			name = "Drone CA-[rand(1,999)]"
@@ -775,7 +802,6 @@
 		current_projectile = new/datum/projectile/bullet/autocannon/plasma_orb
 		attack_cooldown = 70
 		smashes_shit = 1
-		mats = null
 		CritterDeath() //Yeah thanks for only supporting a single item, loot variable.
 			if(dying) return
 			var/area/A = get_area(src)
@@ -853,6 +879,9 @@
 			name = "Battledrone Omega-[rand(1,10)]"
 			return
 
+TYPEINFO(/obj/critter/gunbot/drone/iridium)
+	mats = null //no
+
 /obj/critter/gunbot/drone/iridium // the worstest jerk, even worse than the previous worst jerk.
 	name = "Y-Class Battledrone"
 	desc = "One of the prototype battledrones from the Syndicate's PROJECT IRIDIUM, utilizing adapted artifact technologies."
@@ -867,7 +896,6 @@
 	droploot = /obj/item/device/key/iridium
 	alertsound1 = 'sound/machines/engine_alert2.ogg'
 	alertsound2 = 'sound/machines/engine_alert3.ogg'
-	mats = null //no
 	projectile_type = /datum/projectile/laser/precursor/sphere
 	current_projectile = new/datum/projectile/laser/precursor/sphere
 	smashes_shit = 1
@@ -1217,6 +1245,9 @@
 		..()
 
 
+TYPEINFO(/obj/critter/gunbot/drone/miniature_syndie)
+	mats = 12 //this should be funny
+
 /obj/critter/gunbot/drone/miniature_syndie
 	name = "miniature Syndicate Operative"
 	desc = "They look determined."
@@ -1247,7 +1278,6 @@
 	projectile_type = /datum/projectile/bullet/bullet_22
 	current_projectile = new/datum/projectile/bullet/bullet_22
 	attack_cooldown = 20
-	mats = 12 //this should be funny
 
 	var/voice_gender = "male"
 

--- a/code/obj/critter/gunbot.dm
+++ b/code/obj/critter/gunbot.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/critter/gunbot)
+	mats = 8
+
 /obj/critter/gunbot
 	name = "Robot"
 	desc = "A Security Robot, something seems a bit off."
@@ -15,7 +18,6 @@
 	firevuln = 0.5
 	brutevuln = 1
 	is_syndicate = 1
-	mats = 8
 	deconstruct_flags = DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 
 	seek_target()

--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -1,11 +1,13 @@
 
+TYPEINFO(/obj/health_scanner)
+	mats = list("CON-1" = 5, "CRY" = "2")
+
 /obj/health_scanner
 	icon = 'icons/obj/items/device.dmi'
 	anchored = 1
 	var/id = 0.0 // who are we?
 	var/partner_range = 3 // how far away should we look?
 	var/find_in_range = 1
-	mats = list("CON-1" = 5, "CRY" = "2")
 
 	New()
 		..()

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -7,6 +7,9 @@ AI MODULES
 // AI module
 
 ABSTRACT_TYPE(/obj/item/aiModule)
+TYPEINFO(/obj/item/aiModule)
+	mats = 10
+
 /obj/item/aiModule
 	name = "AI Law Module"
 	icon = 'icons/obj/module.dmi'
@@ -21,7 +24,6 @@ ABSTRACT_TYPE(/obj/item/aiModule)
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 15
-	mats = 10
 	var/input_char_limit = 100
 
 	var/glitched = FALSE

--- a/code/obj/item/barrier.dm
+++ b/code/obj/item/barrier.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/barrier)
+	mats = 8
+
 /obj/item/barrier
 	name = "barrier"
 	desc = "A personal barrier. Activate this item inhand to deploy it."
@@ -11,7 +14,6 @@
 	force = 2
 	throwforce = 6
 	w_class = W_CLASS_SMALL
-	mats = 8
 	stamina_damage = 20
 	var/stamina_damage_active = 40
 	stamina_cost = 10

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -11,6 +11,12 @@
 
 	return ..()
 
+TYPEINFO(/obj/item/camera)
+	mats = 15
+
+TYPEINFO(/obj/item/camera/large)
+	mats = 25
+
 /obj/item/camera
 	name = "camera"
 	icon = 'icons/obj/items/device.dmi'
@@ -24,7 +30,6 @@
 	throwforce = 5
 	throw_speed = 4
 	throw_range = 10
-	mats = 15
 	var/pictures_left = 10 // set to a negative to take INFINITE PICTURES
 	var/pictures_max = 30
 	var/can_use = 1
@@ -36,7 +41,6 @@
 		src.setItemSpecial(null)
 
 	large
-		mats = 25
 		pictures_left = 30
 
 
@@ -165,6 +169,12 @@
 	else
 		. = ..() 	// Call /obj/item/camera/spy/afterattack() for photo mode
 
+TYPEINFO(/obj/item/camera_film)
+	mats = 10
+
+TYPEINFO(/obj/item/camera_film/large)
+	mats = 15
+
 /obj/item/camera_film
 	name = "film cartridge"
 	desc = "A replacement film cartridge for an instant camera."
@@ -173,13 +183,11 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	item_state = "box"
 	w_class = W_CLASS_SMALL
-	mats = 10
 	var/pictures = 10
 
 	large
 		name = "film cartridge (large)"
 		pictures = 30
-		mats = 15
 
 	examine()
 		. = ..()

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -25,6 +25,9 @@ GAUNTLET CARDS
 				B.botcard = null
 		..()
 
+TYPEINFO(/obj/item/card/emag)
+	mats = 8
+
 /obj/item/card/emag
 	desc = "It's a card with a magnetic strip attached to some circuitry. Commonly referred to as an EMAG"
 	name = "Electromagnetic Card"
@@ -33,7 +36,6 @@ GAUNTLET CARDS
 	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
 	layer = 6.0 // TODO fix layer
 	is_syndicate = 1
-	mats = 8
 	contraband = 6
 
 	afterattack(var/atom/A, var/mob/user)

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -59,12 +59,14 @@
 			return
 		..() //if not selecting the head of a human or monkey, just do normal attack.
 
+TYPEINFO(/obj/item/clothing/glasses/meson)
+	mats = 6
+
 /obj/item/clothing/glasses/meson
 	name = "meson goggles"
 	icon_state = "meson"
 	var/base_state = "meson"
 	item_state = "glasses"
-	mats = 6
 	desc = "Goggles that allow you to see the structure of the station through walls."
 	color_r = 0.92
 	color_g = 1
@@ -173,9 +175,11 @@
 	..()
 	return
 
+TYPEINFO(/obj/item/clothing/glasses/sunglasses/tanning)
+	mats = 4
+
 /obj/item/clothing/glasses/sunglasses/tanning
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. This pair has a label that says: \"For tanning use only.\""
-	mats = 4
 	color_b = 0.95
 
 	setupProperties()
@@ -221,11 +225,13 @@
 	color_b = 1
 	contraband = 4 // illegal (stolen) crimefighting vigilante gear
 
+TYPEINFO(/obj/item/clothing/glasses/thermal)
+	mats = 8
+
 /obj/item/clothing/glasses/thermal
 	name = "optical thermal scanner"
 	icon_state = "thermal"
 	item_state = "glasses"
-	mats = 8
 	desc = "High-tech glasses that can see through cloaking technology. Also helps you see further in the dark."
 	color_r = 1
 	color_g = 0.8 // red tint
@@ -284,11 +290,13 @@
 	color_g = 0.9 // orange tint?
 	color_b = 0.8
 
+TYPEINFO(/obj/item/clothing/glasses/visor)
+	mats = 4
+
 /obj/item/clothing/glasses/visor
 	name = "\improper VISOR goggles"
 	icon_state = "visor"
 	item_state = "glasses"
-	mats = 4
 	desc = "VIS-tech Optical Rejuvinator goggles allow the blind to see while worn."
 	allow_blind_sight = 1
 	color_r = 0.92
@@ -474,6 +482,9 @@
 /obj/item/clothing/glasses/vr/bomb
 	network = LANDMARK_VR_BOMBTEST
 
+TYPEINFO(/obj/item/clothing/glasses/healthgoggles)
+	mats = 8
+
 /obj/item/clothing/glasses/healthgoggles
 	name = "\improper ProDoc Healthgoggles"
 	desc = "Fitted with an advanced miniature sensor array that allows the user to quickly determine the physical condition of others."
@@ -481,7 +492,6 @@
 	uses_multiple_icon_states = 1
 	var/scan_upgrade = 0
 	var/health_scan = 0
-	mats = 8
 	color_r = 0.85
 	color_g = 1
 	color_b = 0.87
@@ -538,11 +548,13 @@
 	health_scan = 1
 
 // Glasses that allow the wearer to get a full reagent report for containers
+TYPEINFO(/obj/item/clothing/glasses/spectro)
+	mats = 6
+
 /obj/item/clothing/glasses/spectro
 	name = "spectroscopic scanner goggles"
 	icon_state = "spectro"
 	item_state = "glasses"
-	mats = 6
 	desc = "Goggles with an integrated minature Raman spectroscope for easy qualitative and quantitative analysis of chemical samples."
 	color_r = 1 // pink tint?
 	color_g = 0.8
@@ -586,11 +598,13 @@
 			get_image_group(CLIENT_IMAGE_GROUP_GHOSTDRONE).remove_mob(user)
 			active = FALSE
 
+TYPEINFO(/obj/item/clothing/glasses/noir)
+	mats = 4
+
 /obj/item/clothing/glasses/noir
 	name = "Noir-Tech Glasses"
 	desc = "A pair of glasses that simulate what the world looked like before the invention of color."
 	icon_state = "noir"
-	mats = 4
 	equipped(var/mob/user, var/slot)
 		..()
 		var/mob/living/carbon/human/H = user
@@ -604,11 +618,19 @@
 			if (H.client)
 				animate_fade_from_grayscale(H.client, 5)
 
+TYPEINFO(/obj/item/clothing/glasses/nightvision)
+	mats = 8
+
+TYPEINFO(/obj/item/clothing/glasses/nightvision/sechud)
+	mats = 12
+
+TYPEINFO(/obj/item/clothing/glasses/nightvision/sechud/flashblocking)
+	mats = 25 //expensive if someone scans them because I can do what I want
+
 /obj/item/clothing/glasses/nightvision
 	name = "night vision goggles"
 	icon_state = "nightvision"
 	item_state = "glasses"
-	mats = 8
 	desc = "Goggles with separate built-in image-intensifier tubes to allow vision in the dark. Keep away from bright lights."
 	color_r = 0.5
 	color_g = 1
@@ -637,7 +659,6 @@
 	sechud
 		name = "night vision sechud goggles"
 		icon_state = "nightvisionsechud"
-		mats = 12
 		desc = "Goggles with separate built-in image-intensifier tubes to allow vision in the dark. Keep away from bright lights. This version also has built in SecHUD functionality."
 		color_r = 1
 		color_g = 0.5
@@ -655,7 +676,6 @@
 
 		flashblocking //Admin or gimmick spawn option
 			name = "SUPER night vision sechud goggles"
-			mats = 25 //expensive if someone scans them because I can do what I want
 			desc = "Goggles with separate built-in image-intensifier tubes to allow vision in the dark AND SecHUDs AND with darkened lenses? Wowee!"
 
 			setupProperties()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1838,10 +1838,12 @@ ABSTRACT_TYPE(/obj/item/clothing/head/basecap)
 
 //Lesbian Hat
 
+TYPEINFO(/obj/item/clothing/head/lesbian_hat)
+	mats = list("FAB-1"=5, "honey"=5)
+
 /obj/item/clothing/head/lesbian_hat
 	name = "very lesbian hat"
 	desc = "And they say subtlety is dead."
-	mats = list("FAB-1"=5, "honey"=5)
 	icon_state = "lesbeean"
 	item_state = "lesbeean"
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -621,11 +621,13 @@
 
 /obj/item/clothing/head/helmet/hardhat/abilities = list(/obj/ability_button/flashlight_hardhat)
 
+TYPEINFO(/obj/item/clothing/head/helmet/camera)
+	mats = list("MET-1"=4, "CRY-1"=2, "CON-1"=2)
+
 /obj/item/clothing/head/helmet/camera
 	name = "camera helmet"
 	desc = "A helmet with a built in camera."
 	icon_state = "camhat"
-	mats = list("MET-1"=4, "CRY-1"=2, "CON-1"=2)
 	item_state = "camhat"
 	var/obj/machinery/camera/camera = null
 	var/camera_tag = "Helmet Cam"
@@ -753,13 +755,15 @@
 		setProperty("exploprot", 20)
 		setProperty("movespeed", 0.15)
 
+TYPEINFO(/obj/item/clothing/head/helmet/siren)
+	mats = 8
+
 /obj/item/clothing/head/helmet/siren
 	name = "siren helmet"
 	desc = "A big flashing light that you put on your head. It also plays a siren for when you need to arrest someone!"
 	icon_state = "siren0"
 	uses_multiple_icon_states = 1
 	item_state = "siren"
-	mats = 8
 	abilities = list(/obj/ability_button/weeoo) // is near segway code in vehicle.dm
 	var/weeoo_in_progress = 0
 	var/datum/light/light
@@ -843,8 +847,10 @@
 		setProperty("meleeprot_head", 8)
 		setProperty("disorient_resist_eye", 15)
 
-/obj/item/clothing/head/helmet/space/industrial
+TYPEINFO(/obj/item/clothing/head/helmet/space/industrial)
 	mats = 7
+
+/obj/item/clothing/head/helmet/space/industrial
 #ifdef UNDERWATER_MAP
 	icon_state = "diving_suit-industrial"
 	item_state = "diving_suit-industrial"
@@ -876,12 +882,14 @@
 			..()
 			setProperty("meleeprot_head", 7)
 
+TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
+	mats = 10
+
 /obj/item/clothing/head/helmet/space/mining_combat
 	name = "mining combat helmet"
 	desc = "Goes with Mining Combat Armor. Now with sweet strawberry-scented visor!"
 	icon_state = "mining_combat"
 	item_state = "mining_combat"
-	mats = 10
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/injector_mask_belt.dm
+++ b/code/obj/item/clothing/injector_mask_belt.dm
@@ -7,6 +7,9 @@ There's much less duplicate code here than there used to be, it could probably b
 	but I'm not doing that without help on my first pull request in addition to learning TGUI!
 */
 
+TYPEINFO(/obj/item/injector_belt)
+	mats = 10
+
 /obj/item/injector_belt
 	name = "injector belt"
 	desc = "Automated injection system attached to a belt."
@@ -15,7 +18,6 @@ There's much less duplicate code here than there used to be, it could probably b
 	item_state = "injector"
 	flags = FPRINT | TABLEPASS | NOSPLASH
 	c_flags = ONBELT
-	mats = 10
 
 	var/can_trigger = 1
 	var/mob/owner = null
@@ -121,12 +123,14 @@ There's much less duplicate code here than there used to be, it could probably b
 
 //////////////////////////////////////
 
+TYPEINFO(/obj/item/clothing/mask/gas/injector_mask)
+	mats = 10
+
 /obj/item/clothing/mask/gas/injector_mask
 	name = "Vapo-Matic"
 	desc = "Automated chemical vaporizer system built into an old industrial respirator. Doesn't look very safe at all!"
 	flags = FPRINT | TABLEPASS  | NOSPLASH
 	c_flags =  COVERSMOUTH | MASKINTERNALS
-	mats = 10
 	icon_state = "gas_injector"
 	item_state = "gas_injector"
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -129,6 +129,9 @@
 		..()
 		setProperty("disorient_resist_eye", 20)
 
+TYPEINFO(/obj/item/clothing/mask/moustache)
+	mats = 2
+
 /obj/item/clothing/mask/moustache
 	name = "fake moustache"
 	desc = "Nobody will know who you are if you put this on. Nobody."
@@ -137,7 +140,6 @@
 	see_face = 0
 	w_class = W_CLASS_TINY
 	is_syndicate = 1
-	mats = 2
 
 	setupProperties()
 		..()
@@ -219,6 +221,9 @@
 			STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 			..()
 
+TYPEINFO(/obj/item/clothing/mask/gas/voice)
+	mats = 6
+
 /obj/item/clothing/mask/gas/voice
 	name = "gas mask"
 	desc = "A close-fitting mask that can filter some environmental toxins or be connected to an air supply."
@@ -226,18 +231,22 @@
 	item_state = "gas_alt"
 	//vchange = 1
 	is_syndicate = 1
-	mats = 6
 
 	New()
 		..()
 		src.vchange = new(src)
+
+TYPEINFO(/obj/item/voice_changer)
+	mats = 6
 
 /obj/item/voice_changer
 	name = "voice changer"
 	desc = "This voice-modulation device will dynamically disguise your voice to that of whoever is listed on your identification card, via incredibly complex algorithms. Discretely fits inside most masks, and can be removed with wirecutters."
 	icon_state = "voicechanger"
 	is_syndicate = 1
-	mats = 6
+
+TYPEINFO(/obj/item/clothing/mask/monkey_translator)
+	mats = 12	// 2x voice changer cost. It's complicated ok
 
 /obj/item/clothing/mask/monkey_translator
 	name = "vocal translator"
@@ -245,7 +254,6 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "voicechanger"
 	item_state = "muzzle"			// @TODO new sprite ok
-	mats = 12	// 2x voice changer cost. It's complicated ok
 	w_class = W_CLASS_SMALL
 	c_flags = COVERSMOUTH	// NOT usable for internals.
 	compatible_species = list("human", "cow", "werewolf", "martian")

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -170,12 +170,14 @@
 	name = "pink shoes"
 	icon_state = "pink"
 
+TYPEINFO(/obj/item/clothing/shoes/magnetic)
+	mats = 8
+
 /obj/item/clothing/shoes/magnetic
 	name = "magnetic shoes"
 	desc = "Keeps the wearer firmly anchored to the ground. Provided the ground is metal, of course."
 	icon_state = "magboots"
 	// c_flags = NOSLIP
-	mats = 8
 	burn_possible = 0
 	laces = LACES_NONE
 	kick_bonus = 2
@@ -196,12 +198,14 @@
 		step_sound = "step_plating"
 		playsound(src.loc, 'sound/items/miningtool_off.ogg', 30, 1)
 
+TYPEINFO(/obj/item/clothing/shoes/hermes)
+	mats = 0
+
 /obj/item/clothing/shoes/hermes
 	name = "sacred sandals" // The ultimate goal of material scientists.
 	desc = "Sandals blessed by the all-powerful goddess of victory and footwear."
 	icon_state = "wizard" //TODO: replace with custom sprite, thinking winged sandals
 	c_flags = NOSLIP
-	mats = 0
 	magical = 1
 	burn_possible = 0
 	laces = LACES_NONE
@@ -213,6 +217,9 @@
 		setProperty("movespeed", -2)
 		delProperty("chemprot")
 
+TYPEINFO(/obj/item/clothing/shoes/industrial)
+	mats = list("MET-3"= 15,"CON-2" = 10,"POW-3" = 10)
+
 /obj/item/clothing/shoes/industrial
 #ifdef UNDERWATER_MAP
 	name = "mechanised diving boots"
@@ -223,7 +230,6 @@
 	name = "mechanised boots"
 	desc = "Industrial-grade boots fitted with mechanised balancers and stabilisers to increase running speed under a heavy workload."
 #endif
-	mats = list("MET-3"= 15,"CON-2" = 10,"POW-3" = 10)
 	burn_possible = 0
 	laces = LACES_NONE
 	kick_bonus = 2
@@ -331,11 +337,13 @@
 		setProperty("chemprot", 7)
 		setProperty("negate_fluid_speed_penalty",0.6)
 
+TYPEINFO(/obj/item/clothing/shoes/moon)
+	mats = 2
+
 /obj/item/clothing/shoes/moon
 	name = "moon shoes"
 	desc = "Recent developments in trampoline-miniaturization technology have made these little wonders possible."
 	icon_state = "moonshoes"
-	mats = 2
 
 	equipped(var/mob/user, var/slot)
 		..()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1361,6 +1361,9 @@
 		icon_state = "diving_suit-eng"
 		item_state = "diving_suit-eng"
 
+TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
+	mats = 45 //should not be cheap to make at mechanics, increased from 15.
+
 /obj/item/clothing/suit/space/industrial
 #ifdef MAP_OVERRIDE_NADIR
 	desc = "Armored, immersion-tight suit. Protects from a wide gamut of environmental hazards, including radiation and explosions."
@@ -1405,7 +1408,6 @@
 		is_syndicate = TRUE
 		icon_state = "indusred"
 		item_state = "indusred"
-		mats = 45 //should not be cheap to make at mechanics, increased from 15.
 
 		New()
 			..()

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/decorative_pot)
+	mats = list("ALL" = 1)
+
 /obj/decorative_pot
 		name = "plant pot"
 		desc = "A decorative plant pot, sans the Hydroponic Tray's fancy hypergrowth tech."
@@ -5,7 +8,6 @@
 		icon_state = "plantpot"
 		anchored = 0
 		density = 1
-		mats = list("ALL" = 1)
 
 		attackby(obj/item/weapon, mob/user)
 				if((iswrenchingtool(weapon)) || isscrewingtool(weapon))

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -72,6 +72,9 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		..()
 
+TYPEINFO(/obj/item/turret_deployer/riot)
+	mats = list("INS-1"=10, "CON-1"=10, "CRY-1"=3, "MET-2"=2)
+
 /obj/item/turret_deployer/riot
 	name = "N.A.R.C.S. Deployer"
 	desc = "A Nanotrasen Automatic Riot Control System Deployer. Use it in your hand to deploy."
@@ -79,7 +82,6 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 	icon_state = "st_deployer"
 	w_class = W_CLASS_BULKY
 	icon_tag = "nt"
-	mats = list("INS-1"=10, "CON-1"=10, "CRY-1"=3, "MET-2"=2)
 	is_syndicate = 1
 	associated_turret = /obj/deployable_turret/riot
 

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/accessgun)
+	mats = 14
+
 /obj/item/device/accessgun
 	name = "Access Pro"
 	desc = "This device can reprogram electronic access requirements. It will copy the permissions of any inserted ID. Activate it in-hand while empty to change between AND/OR modes"
@@ -8,7 +11,6 @@
 	rand_pos = 0
 	flags = FPRINT | TABLEPASS
 	c_flags = ONBELT
-	mats = 14
 	var/obj/item/card/id/ID_card = null
 	req_access = list(access_change_ids,access_engineering_chief)
 	var/mode = 0 //0 AND, 1 OR

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -1,10 +1,12 @@
+TYPEINFO(/obj/item/audio_tape)
+	mats = 3
+
 /obj/item/audio_tape
 	name = "compact tape"
 	desc = "A small audio tape.  You could make some rad mix-tapes with this!"
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "recordertape"
 	w_class = W_CLASS_TINY
-	mats = 3
 
 	var/log_line = 1 //Which line of the log it's on.
 	var/max_lines = 100
@@ -71,6 +73,9 @@
 #define MODE_RECORDING 1
 #define MODE_PLAYING 2
 
+TYPEINFO(/obj/item/device/audio_log)
+	mats = 4
+
 /obj/item/device/audio_log
 	name = "audio log"
 	desc = "A fairly spartan recording device."
@@ -87,7 +92,6 @@
 	var/list/audiolog_messages = list()
 	var/list/audiolog_speakers = list()
 	var/self_destruct = FALSE
-	mats = 4
 
 	wall_mounted
 		name = "Mounted Logger"

--- a/code/obj/item/device/borg_linker.dm
+++ b/code/obj/item/device/borg_linker.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/borg_linker)
+	mats = list("CRY-1", "CON-2")
+
 /obj/item/device/borg_linker
 	name = "cyborg law linker"
 	icon_state = "cyborg_linker"
@@ -11,7 +14,6 @@
 	desc = "A device for connecting silicon beings to a law rack, setting restrictions on their behaviour."
 	m_amt = 50
 	g_amt = 20
-	mats = list("CRY-1", "CON-2")
 	var/obj/machinery/lawrack/linked_rack = null
 
 	attack_self(var/mob/user)

--- a/code/obj/item/device/camera_viewer.dm
+++ b/code/obj/item/device/camera_viewer.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/camera_viewer)
+	mats = 6
+
 /obj/item/device/camera_viewer
 	name = "camera monitor"
 	desc = "A portable video monitor connected to a security camera network."
@@ -6,7 +9,6 @@
 	w_class = W_CLASS_SMALL
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
-	mats = 6
 
 	attack_self(mob/user as mob)
 		src.add_dialog(user)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -65,6 +65,9 @@
 			step(src,direction)
 		return
 
+TYPEINFO(/obj/item/device/chameleon)
+	mats = 14
+
 /obj/item/device/chameleon
 	name = "chameleon-projector"
 	icon_state = "shield0"
@@ -82,7 +85,6 @@
 	tooltip_flags = REBUILD_DIST
 
 	is_syndicate = 1
-	mats = 14
 
 	New()
 		..()

--- a/code/obj/item/device/cloak_device.dm
+++ b/code/obj/item/device/cloak_device.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/cloaking_device)
+	mats = 15
+
 /obj/item/cloaking_device
 	name = "cloaking device"
 	icon = 'icons/obj/items/device.dmi'
@@ -12,7 +15,6 @@
 	throw_range = 10
 	w_class = W_CLASS_SMALL
 	is_syndicate = 1
-	mats = 15
 	desc = "An illegal device that bends light around the user, rendering them invisible to regular vision."
 	stamina_damage = 0
 	stamina_cost = 0

--- a/code/obj/item/device/cloak_gen.dm
+++ b/code/obj/item/device/cloak_gen.dm
@@ -2,6 +2,9 @@
 //Cloak field generator
 //Remote for said generator
 
+TYPEINFO(/obj/item/cloak_gen)
+	mats = 12
+
 /obj/item/cloak_gen
 	name = "cloaking field generator"
 	desc = "It's humming softly."
@@ -13,7 +16,6 @@
 	var/icon_to_use = "noise2"
 	var/list/fields = new/list()
 	is_syndicate = 1
-	mats = 12
 	contraband = 2
 
 	New()

--- a/code/obj/item/device/disguiser.dm
+++ b/code/obj/item/device/disguiser.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/disguiser)
+	mats = 8
+
 /obj/item/device/disguiser
 	name = "holographic disguiser"
 	icon_state = "enshield0"
@@ -11,7 +14,6 @@
 	throw_range = 5
 	w_class = W_CLASS_SMALL
 	is_syndicate = 1
-	mats = 8
 	var/datum/appearanceHolder/oldAH = new
 	var/anti_spam = 1 // In relation to world time.
 	var/active = 0

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/flash)
+	mats = list("MET-1" = 3, "CON-1" = 5, "CRY-1" = 5)
+
 /obj/item/device/flash
 	name = "flash"
 	desc = "A device that emits a complicated strobe when used, causing disorientation. Useful for stunning people or starting a dance party."
@@ -13,7 +16,6 @@
 	c_flags = ONBELT
 	object_flags = NO_GHOSTCRITTER
 	item_state = "electronic"
-	mats = list("MET-1" = 3, "CON-1" = 5, "CRY-1" = 5)
 
 	var/status = 1 // Bulb still functional?
 	var/secure = 1 // Access panel still secured?
@@ -375,11 +377,13 @@
 	return
 
 // The Turboflash - A flash combined with a charged energy cell to make a bigger, meaner flash (That dies after one use).
+TYPEINFO(/obj/item/device/flash/turbo)
+	mats = 0
+
 /obj/item/device/flash/turbo
 	name = "flash/cell assembly"
 	desc = "A common stun weapon with a power cell hastily wired into it. Looks dangerous."
 	icon_state = "turboflash"
-	mats = 0
 	animation_type = "turboflash2"
 	turboflash = 1
 	max_flash_power = 5000

--- a/code/obj/item/device/flyswatter.dm
+++ b/code/obj/item/device/flyswatter.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/flyswatter)
+	mats = 15
+
 /obj/item/device/flyswatter
 	name = "fly swatter"
 	desc = "It's one of those fancy electric types, so you can hear that satisfying zap, zap, <i>zap</i>!"
@@ -11,7 +14,6 @@
 	throw_range = 10
 	throw_speed = 2
 	m_amt = 100
-	mats = 15
 
 	New()
 		..()

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/gps)
+	mats = 2
+
 /obj/item/device/gps
 	name = "space GPS"
 	desc = "A navigation device that can tell you your position, and the position of other GPS devices. Uses coordinate beacons."
@@ -13,7 +16,6 @@
 	w_class = W_CLASS_SMALL
 	m_amt = 50
 	g_amt = 100
-	mats = 2
 	var/frequency = FREQ_GPS
 	var/net_id
 

--- a/code/obj/item/device/igniter.dm
+++ b/code/obj/item/device/igniter.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/igniter)
+	mats = 2
+
 /obj/item/device/igniter
 	name = "igniter"
 	desc = "A small electronic device can be paired with other electronics, or used to heat chemicals directly."
@@ -11,7 +14,6 @@
 	w_class = W_CLASS_TINY
 	throw_speed = 3
 	throw_range = 10
-	mats = 2
 	firesource = FIRESOURCE_IGNITER
 
 	//blcok spamming shit because inventory uncaps click speed and kinda makes this an exploit

--- a/code/obj/item/device/infrared_stuff.dm
+++ b/code/obj/item/device/infrared_stuff.dm
@@ -8,6 +8,9 @@ Contains:
 
 //////////////////////////////////////// Laser tripwire //////////////////////////////
 
+TYPEINFO(/obj/item/device/infra)
+	mats = 3
+
 /obj/item/device/infra
 	name = "Laser Tripwire"
 	desc = "Emits a visible or invisible beam and is triggered when the beam is interrupted."
@@ -19,9 +22,11 @@ Contains:
 	w_class = W_CLASS_SMALL
 	item_state = "electronic"
 	m_amt = 150
-	mats = 3
 
 ///////////////////////////////////////// Infrared sensor ///////////////////////////////////////////
+
+TYPEINFO(/obj/item/device/infra_sensor)
+	mats = 4
 
 /obj/item/device/infra_sensor
 	name = "Infrared Sensor"
@@ -31,7 +36,6 @@ Contains:
 	flags = FPRINT | TABLEPASS| CONDUCT
 	item_state = "electronic"
 	m_amt = 150
-	mats = 4
 
 /* When/if someone ever gets around to fixing these uncomment this
 /obj/item/device/infra_sensor/process()

--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/lightbreaker)
+	mats = 15
+
 /obj/item/lightbreaker
 	name = "compact tape"
 	desc = "A casette player loaded with a casette of a vampire's screech."
@@ -11,7 +14,6 @@
 	throw_range = 10
 	w_class = W_CLASS_SMALL
 	is_syndicate = 1
-	mats = 15
 	stamina_cost = 10
 	stamina_crit_chance = 15
 	var/ammo = 4

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -38,6 +38,9 @@
 			qdel(light)
 		..()
 
+TYPEINFO(/obj/item/device/light/flashlight)
+	mats = 2
+
 /obj/item/device/light/flashlight
 	name = "flashlight"
 	desc = "A hand-held emergency light."
@@ -51,7 +54,6 @@
 	c_flags = ONBELT
 	m_amt = 50
 	g_amt = 20
-	mats = 2
 	var/emagged = 0
 	var/broken = 0
 	col_r = 0.9

--- a/code/obj/item/device/mic_amp_etc.dm
+++ b/code/obj/item/device/mic_amp_etc.dm
@@ -65,11 +65,13 @@
 				S.visible_message("<span class='alert'>[S] lets out a horrible [pick("shriek", "squeal", "noise", "squawk", "screech", "whine", "squeak")]!</span>")
 				playsound(S.loc, 'sound/items/mic_feedback.ogg', 30, 1)
 
+TYPEINFO(/obj/mic_stand)
+	mats = 10
+
 /obj/mic_stand
 	name = "microphone stand"
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "micstand"
-	mats = 10
 	layer = FLY_LAYER
 	var/obj/item/device/microphone/myMic = null
 
@@ -119,13 +121,15 @@
 		else
 			src.icon_state = "micstand-empty"
 
+TYPEINFO(/obj/loudspeaker)
+	mats = 15
+
 /obj/loudspeaker
 	name = "loudspeaker"
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "loudspeaker"
 	anchored = 1
 	density = 1
-	mats = 15
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 
 	New()

--- a/code/obj/item/device/multitool.dm
+++ b/code/obj/item/device/multitool.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/multitool)
+	mats = list("CRY-1", "CON-2")
+
 /obj/item/device/multitool
 	name = "multitool"
 	icon_state = "multitool"
@@ -11,7 +14,6 @@
 	desc = "An electrical multitool. It can generate small electrical pulses and read the wattage of power cables. It is most commonly used when interfacing with airlock and APC systems on the station."
 	m_amt = 50
 	g_amt = 20
-	mats = list("CRY-1", "CON-2")
 
 
 	New()

--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -16,6 +16,9 @@
 //Game Carts
 //Ringtone Carts
 
+TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
+	mats = 0
+
 /obj/item/disk/data/cartridge
 	name = "\improper PDA cartridge"
 	desc = "A data cartridge for PDAs."
@@ -346,7 +349,6 @@
 		name = "\improper Detomatix cartridge"
 		desc = "Designed with the latest advancements in blast processing."
 		icon_state = "cart-deto"
-		mats = 0
 
 		New()
 			..()

--- a/code/obj/item/device/pda2/modules.dm
+++ b/code/obj/item/device/pda2/modules.dm
@@ -4,13 +4,15 @@
 //T-ray scanner module.
 //Computer 3 Emulator / Associated Bits
 
+TYPEINFO(/obj/item/device/pda_module)
+	mats = 4
+
 /obj/item/device/pda_module
 	name = "PDA module"
 	desc = "A piece of expansion circuitry for PDAs."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "pdamod"
 	w_class = W_CLASS_SMALL
-	mats = 4
 	var/obj/item/device/pda2/host = null
 
 	var/setup_use_menu_badge = 0  //Should we have a line in the main menu?

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -119,7 +119,8 @@
 			var/datum/computer/file/electronics_scan/theScan = new
 			theScan.scannedName = initial(O.name)
 			theScan.scannedPath = O.mechanics_type_override ? O.mechanics_type_override : O.type
-			theScan.scannedMats = O.mats
+			var/typeinfo/obj/typeinfo = O.get_typeinfo()
+			theScan.scannedMats = typeinfo.mats
 
 			var/datum/signal/signal = get_free_signal()
 			signal.source = src.master

--- a/code/obj/item/device/powersink.dm
+++ b/code/obj/item/device/powersink.dm
@@ -3,6 +3,9 @@
 #define POWERSINK_CLAMPED 1
 #define POWERSINK_OPERATING 2
 
+TYPEINFO(/obj/item/device/powersink)
+	mats = list("MET-2"=20, "CON-2"=20, "CRY-1"=10)
+
 /obj/item/device/powersink
 	desc = "A nulling power sink which drains energy from electrical systems."
 	name = "power sink"
@@ -21,7 +24,6 @@
 	var/max_power = 2e8		// maximum power that can be drained before exploding
 	var/mode = POWERSINK_OFF		// 0 = off, 1=clamped (off), 2=operating
 	is_syndicate = 1
-	mats = list("MET-2"=20, "CON-2"=20, "CRY-1"=10)
 	rand_pos = 0
 
 	var/obj/cable/attached		// the attached cable

--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/prox_sensor)
+	mats = 2
+
 /obj/item/device/prox_sensor
 	name = "Proximity Sensor"
 	icon_state = "motion0"
@@ -12,7 +15,6 @@
 	w_class = W_CLASS_SMALL
 	item_state = "electronic"
 	m_amt = 300
-	mats = 2
 	desc = "A device which transmits a signal when it detects movement nearby."
 
 /obj/item/device/prox_sensor/dropped()

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/radio)
+	mats = 3
+
 /obj/item/device/radio
 	name = "station bounced radio"
 	desc = "A portable, non-wearable radio for communicating over a specified frequency. Has a microphone and a speaker which can be independently toggled."
@@ -39,7 +42,6 @@
 	throw_speed = 2
 	throw_range = 9
 	w_class = W_CLASS_SMALL
-	mats = 3
 
 	var/icon_override = 0
 	var/icon_tooltip = null // null = use name, "" = no tooltip
@@ -676,6 +678,9 @@ var/list/headset_channel_lookup
 	listening = 0
 	return
 
+TYPEINFO(/obj/item/radiojammer)
+	mats = 10
+
 /obj/item/radiojammer
 	name = "signal jammer"
 	desc = "An illegal device used to jam radio signals, preventing broadcast or transmission."
@@ -684,7 +689,6 @@ var/list/headset_channel_lookup
 	w_class = W_CLASS_TINY
 	var/active = 0
 	is_syndicate = 1
-	mats = 10
 
 	attack_self(var/mob/user as mob)
 		if (!(radio_controller && istype(radio_controller)))
@@ -1030,13 +1034,15 @@ obj/item/device/radio/signaler/attackby(obj/item/W, mob/user)
 			src.send_signal("ACTIVATE")
 
 //////////////////////////////////////////////////
+TYPEINFO(/obj/item/device/radio/intercom/loudspeaker)
+	mats = 0
+
 /obj/item/device/radio/intercom/loudspeaker
 	name = "Loudspeaker Transmitter"
 	icon = 'icons/obj/loudspeakers.dmi'
 	icon_state = "transmitter"
 	anchored = 1
 	speaker_range = 0
-	mats = 0
 	chat_class = RADIOCL_INTERCOM
 	//Best I can figure, you need broadcasting and listening to both be TRUE for it to make a signal and send the words spoken next to it. Why? Fuck whoever named these, that's why.
 	broadcasting = 0
@@ -1074,12 +1080,14 @@ obj/item/device/radio/signaler/attackby(obj/item/W, mob/user)
 		set_secure_frequencies()
 
 //This is the main parent, also is the actual speakers that will be attached to the walls.
+TYPEINFO(/obj/item/device/radio/intercom/loudspeaker/speaker)
+	mats = 0
+
 /obj/item/device/radio/intercom/loudspeaker/speaker
 	name = "Loudspeaker"
 	icon_state = "loudspeaker"
 	anchored = 1
 	speaker_range = 7
-	mats = 0
 	broadcasting = 1
 	listening = 1
 	chat_class = RADIOCL_INTERCOM

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -534,6 +534,9 @@ Secure Frequency:
 			set_secure_frequency("h", new_frequency)
 	return ..(href, href_list)
 
+TYPEINFO(/obj/item/device/radio_upgrade)
+	mats = 12
+
 /obj/item/device/radio_upgrade //traitor radio upgrader
 	name = "wiretap radio upgrade"
 	desc = "An illegal device capable of picking up and sending all secure station radio signals, along with a secure Syndicate frequency. Can be installed in a radio headset. Does not actually work by wiretapping."
@@ -541,7 +544,6 @@ Secure Frequency:
 	icon_state = "syndie_upgr"
 	w_class = W_CLASS_TINY
 	is_syndicate = 1
-	mats = 12
 	var/secure_frequencies = list(
 		"h" = R_FREQ_COMMAND,
 		"g" = R_FREQ_SECURITY,

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/radio/intercom)
+	mats = 3
+
 /obj/item/device/radio/intercom
 	name = "Station Intercom (Radio)"
 #ifndef IN_MAP_EDITOR
@@ -7,7 +10,6 @@
 #endif
 	anchored = 1
 	plane = PLANE_NOSHADOW_ABOVE
-	mats = 3
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 	chat_class = RADIOCL_INTERCOM
 	var/number = 0

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -11,6 +11,9 @@ Contains:
 
 //////////////////////////////////////////////// T-ray scanner //////////////////////////////////
 
+TYPEINFO(/obj/item/device/t_scanner)
+	mats = 5
+
 /obj/item/device/t_scanner
 	name = "T-ray scanner"
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
@@ -21,7 +24,6 @@ Contains:
 	w_class = W_CLASS_SMALL
 	item_state = "electronic"
 	m_amt = 150
-	mats = 5
 	var/scan_range = 3
 	var/client/last_client = null
 	var/image/last_display = null
@@ -141,6 +143,9 @@ that cannot be itched
 
 //////////////////////////////////////// Forensic scanner ///////////////////////////////////
 
+TYPEINFO(/obj/item/device/detective_scanner)
+	mats = 3
+
 /obj/item/device/detective_scanner
 	name = "forensic scanner"
 	desc = "Used to scan objects for DNA and fingerprints."
@@ -149,7 +154,6 @@ that cannot be itched
 	item_state = "electronic"
 	flags = FPRINT | TABLEPASS | CONDUCT | SUPPRESSATTACK
 	c_flags = ONBELT
-	mats = 3
 	hide_attack = ATTACK_PARTIALLY_HIDDEN
 	var/active = 0
 	var/distancescan = 0
@@ -280,6 +284,9 @@ that cannot be itched
 
 ///////////////////////////////////// Health analyzer ////////////////////////////////////////
 
+TYPEINFO(/obj/item/device/analyzer/healthanalyzer)
+	mats = 5
+
 /obj/item/device/analyzer/healthanalyzer
 	name = "health analyzer"
 	icon_state = "health-no_up"
@@ -293,7 +300,6 @@ that cannot be itched
 	throw_speed = 5
 	throw_range = 10
 	m_amt = 200
-	mats = 5
 	var/disease_detection = 1
 	var/reagent_upgrade = 0
 	var/reagent_scan = 0
@@ -405,6 +411,9 @@ that cannot be itched
 /obj/item/device/analyzer/healthanalyzer/vr
 	icon = 'icons/effects/VR.dmi'
 
+TYPEINFO(/obj/item/device/analyzer/healthanalyzer_upgrade)
+	mats = 2
+
 /obj/item/device/analyzer/healthanalyzer_upgrade
 	name = "health analyzer upgrade"
 	desc = "A small upgrade card that allows standard health analyzers to detect reagents present in the patient, and ProDoc Healthgoggles to scan patients' health from a distance."
@@ -414,6 +423,8 @@ that cannot be itched
 	w_class = W_CLASS_TINY
 	throw_speed = 5
 	throw_range = 10
+
+TYPEINFO(/obj/item/device/analyzer/healthanalyzer_organ_upgrade)
 	mats = 2
 
 /obj/item/device/analyzer/healthanalyzer_organ_upgrade
@@ -425,9 +436,11 @@ that cannot be itched
 	w_class = W_CLASS_TINY
 	throw_speed = 5
 	throw_range = 10
-	mats = 2
 
 ///////////////////////////////////// Reagent scanner //////////////////////////////
+
+TYPEINFO(/obj/item/device/reagentscanner)
+	mats = 5
 
 /obj/item/device/reagentscanner
 	name = "reagent scanner"
@@ -442,7 +455,6 @@ that cannot be itched
 	throw_speed = 5
 	throw_range = 10
 	m_amt = 200
-	mats = 5
 	var/scan_results = null
 	hide_attack = ATTACK_PARTIALLY_HIDDEN
 	tooltip_flags = REBUILD_DIST
@@ -483,6 +495,9 @@ that cannot be itched
 
 /////////////////////////////////////// Atmos analyzer /////////////////////////////////////
 
+TYPEINFO(/obj/item/device/analyzer/atmospheric)
+	mats = 3
+
 /obj/item/device/analyzer/atmospheric
 	desc = "A hand-held environmental scanner which reports current gas levels."
 	name = "atmospheric analyzer"
@@ -495,7 +510,6 @@ that cannot be itched
 	w_class = W_CLASS_SMALL
 	throw_speed = 4
 	throw_range = 20
-	mats = 3
 	var/analyzer_upgrade = 0
 
 	// Distance upgrade action code
@@ -555,6 +569,9 @@ that cannot be itched
 	analyzer_upgrade = 1
 	icon_state = "atmos"
 
+TYPEINFO(/obj/item/device/analyzer/atmosanalyzer_upgrade)
+	mats = 2
+
 /obj/item/device/analyzer/atmosanalyzer_upgrade
 	name = "atmospherics analyzer upgrade"
 	desc = "A small upgrade card that allows standard atmospherics analyzers to detect environmental information at a distance."
@@ -564,7 +581,6 @@ that cannot be itched
 	w_class = W_CLASS_TINY
 	throw_speed = 5
 	throw_range = 10
-	mats = 2
 
 ///////////////// method to upgrade an analyzer if the correct upgrade cartridge is used on it /////////////////
 /obj/item/device/analyzer/proc/addUpgrade(obj/item/device/src as obj, obj/item/device/W as obj, mob/user as mob, upgraded as num, active as num, iconState as text, itemState as text)
@@ -613,6 +629,9 @@ that cannot be itched
 
 ///////////////////////////////////////////////// Prisoner scanner ////////////////////////////////////
 
+TYPEINFO(/obj/item/device/prisoner_scanner)
+	mats = 3
+
 /obj/item/device/prisoner_scanner
 	name = "security RecordTrak"
 	desc = "A device used to scan in prisoners and update their security records."
@@ -623,7 +642,6 @@ that cannot be itched
 	item_state = "recordtrak"
 	flags = FPRINT | TABLEPASS | CONDUCT | EXTRADELAY
 	c_flags = ONBELT
-	mats = 3
 
 	#define PRISONER_MODE_NONE 1
 	#define PRISONER_MODE_PAROLED 2
@@ -867,6 +885,9 @@ that cannot be itched
 
 
 
+TYPEINFO(/obj/item/device/appraisal)
+	mats = 5
+
 /obj/item/device/appraisal
 	name = "cargo appraiser"
 	desc = "Handheld scanner hooked up to Cargo's market computers. Estimates sale value of various items."
@@ -874,7 +895,6 @@ that cannot be itched
 	c_flags = ONBELT
 	w_class = W_CLASS_SMALL
 	m_amt = 150
-	mats = 5
 	icon_state = "CargoA"
 	item_state = "electronic"
 

--- a/code/obj/item/device/shield.dm
+++ b/code/obj/item/device/shield.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/shield)
+	mats = 10
+
 /obj/item/device/shield
 	name = "shield"
 	icon_state = "shield0"
@@ -8,7 +11,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = W_CLASS_SMALL
-	mats = 10
 
 /obj/item/device/shield/attack_self(mob/user as mob)
 	src.active = !( src.active )

--- a/code/obj/item/device/studio_monitor.dm
+++ b/code/obj/item/device/studio_monitor.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/radio/nukie_studio_monitor)
+	mats = 0
+
 /obj/item/device/radio/nukie_studio_monitor
 	name = "Studio Monitor"
 	desc = "An incredibly high quality studio monitor with an uncomfortable number of high voltage stickers. Manufactured by Funk-Tek"
@@ -7,7 +10,6 @@
 
 	anchored = 0
 	speaker_range = 7
-	mats = 0
 	broadcasting = 0
 	listening = 0
 	chat_class = RADIOCL_INTERCOM

--- a/code/obj/item/device/timer.dm
+++ b/code/obj/item/device/timer.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/timer)
+	mats = 2
+
 /obj/item/device/timer
 	name = "timer"
 	icon_state = "timer0"
@@ -11,7 +14,6 @@
 	flags = FPRINT | TABLEPASS| CONDUCT
 	w_class = W_CLASS_SMALL
 	m_amt = 100
-	mats = 2
 	desc = "A device that emits a signal when the time reaches 0."
 
 /obj/item/device/timer/proc/time()

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/transfer_valve)
+	mats = 5
+
 /obj/item/device/transfer_valve
 	icon = 'icons/obj/items/assemblies.dmi' //TODO: as of 02/02/2020 missing sprite for regular air tank
 	name = "tank transfer valve" // because that's what it is exadv1 and don't you dare change it
@@ -24,7 +27,6 @@
 
 	w_class = W_CLASS_GIGANTIC /// HEH
 	p_class = 3 /// H E H
-	mats = 5
 
 	New()
 		..()
@@ -425,13 +427,15 @@
 					user.visible_message("<span class='alert'>[user] stares at the [src.name], a confused expression on [his_or_her(user)] face.</span>") //It didn't blow up!
 		return 1
 
+TYPEINFO(/obj/item/device/transfer_valve/briefcase)
+	mats = 8
+
 /obj/item/device/transfer_valve/briefcase
 	name = "briefcase"
 	icon_state = "briefcase"
 	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	item_state = "briefcase"
 	var/obj/item/storage/briefcase/B = null
-	mats = 8
 
 	update_icon()
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -9,6 +9,9 @@ PIPE BOMBS + CONSTRUCTION
 
 ////////////////////////////// Old-style grenades ///////////////////////////////////////
 
+TYPEINFO(/obj/item/old_grenade)
+	mats = 6
+
 /obj/item/old_grenade
 	desc = "You shouldn't be able to see this!"
 	name = "old grenade"
@@ -26,7 +29,6 @@ PIPE BOMBS + CONSTRUCTION
 	flags = FPRINT | TABLEPASS | CONDUCT | EXTRADELAY
 	c_flags = ONBELT
 	is_syndicate = 0
-	mats = 6
 	stamina_damage = 0
 	stamina_cost = 0
 	stamina_crit_chance = 0
@@ -190,6 +192,9 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 		qdel(src)
 		return
 
+TYPEINFO(/obj/item/old_grenade/graviton)
+	mats = 12
+
 /obj/item/old_grenade/graviton //ITS SPELT GRAVITON
 	desc = "It is set to detonate in 10 seconds."
 	name = "graviton grenade"
@@ -199,7 +204,6 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 	icon_state = "graviton"
 	item_state = "emp" //TODO: grenades REALLY need custom inhands, but I'm not submitting them in this PR
 	is_syndicate = 1
-	mats = 12
 	sound_armed = 'sound/weapons/armbomb.ogg'
 	icon_state_armed = "graviton1"
 	var/icon_state_exploding = "graviton2"
@@ -249,6 +253,9 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 		qdel(src)
 		return
 
+TYPEINFO(/obj/item/old_grenade/singularity)
+	mats = 12
+
 /obj/item/old_grenade/singularity
 	desc = "It is set to detonate in 10 seconds."
 	name = "singularity grenade"
@@ -258,7 +265,6 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 	icon_state = "graviton"
 	item_state = "emp"
 	is_syndicate = 1
-	mats = 12
 	sound_armed = 'sound/weapons/armbomb.ogg'
 	icon_state_armed = "graviton1"
 	var/icon_state_exploding = "graviton2"
@@ -564,6 +570,9 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 			qdel(src)
 		return
 
+TYPEINFO(/obj/item/old_grenade/oxygen)
+	mats = list("MET-2"=2, "CON-1"=2, "molitz"=10, "char"=1 )
+
 /obj/item/old_grenade/oxygen
 	name = "red oxygen grenade"
 	desc = "It is set to detonate in 3 seconds."
@@ -572,7 +581,6 @@ ABSTRACT_TYPE(/obj/item/old_grenade/spawner)
 	alt_det_time = 6 SECONDS
 	icon_state = "oxy"
 	item_state = "flashbang"
-	mats = list("MET-2"=2, "CON-1"=2, "molitz"=10, "char"=1 )
 	sound_armed = 'sound/weapons/armbomb.ogg'
 	icon_state_armed = "oxy1"
 	is_dangerous = FALSE

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1,10 +1,12 @@
+TYPEINFO(/obj/item/gun/energy)
+	mats = 32
+
 /obj/item/gun/energy
 	name = "energy weapon"
 	icon = 'icons/obj/items/gun.dmi'
 	item_state = "gun"
 	m_amt = 2000
 	g_amt = 1000
-	mats = 32
 	add_residue = 0 // Does this gun add gunshot residue when fired? Energy guns shouldn't.
 	var/rechargeable = 1 // Can we put this gun in a recharger? False should be a very rare exception.
 	var/robocharge = 800
@@ -278,6 +280,9 @@
 			src.icon_state = "phaser-new[ratio]"
 			return
 
+TYPEINFO(/obj/item/gun/energy/phaser_small)
+	mats = 20
+
 /obj/item/gun/energy/phaser_small
 	name = "RP-3 micro phaser"
 	icon_state = "phaser-tiny"
@@ -288,7 +293,6 @@
 	muzzle_flash = "muzzle_flash_phaser"
 	cell_type = /obj/item/ammo/power_cell
 	w_class = W_CLASS_SMALL
-	mats = 20
 
 	New()
 		set_current_projectile(new/datum/projectile/laser/light/tiny)
@@ -304,6 +308,9 @@
 			src.icon_state = "phaser-tiny[ratio]"
 			return
 
+TYPEINFO(/obj/item/gun/energy/phaser_huge)
+	mats = list("MET-1"=15, "MET-2"=10, "CON-2"=10, "POW-2"=15, "CRY-1"=10)
+
 /obj/item/gun/energy/phaser_huge
 	name = "RP-5 macro phaser"
 	icon_state = "phaser-xl"
@@ -317,7 +324,6 @@
 	can_dual_wield = FALSE
 	force = MELEE_DMG_RIFLE
 	two_handed = 1
-	mats = list("MET-1"=15, "MET-2"=10, "CON-2"=10, "POW-2"=15, "CRY-1"=10)
 	New()
 		set_current_projectile(new/datum/projectile/laser/light/huge) // light/huge - whatev!!!! this should probably be refactored
 		projectiles = list(current_projectile)
@@ -333,6 +339,9 @@
 			return
 
 ///////////////////////////////////////Rad Crossbow
+TYPEINFO(/obj/item/gun/energy/crossbow)
+	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
+
 /obj/item/gun/energy/crossbow
 	name = "\improper Wenshen mini rad-poison-crossbow"
 	desc = "The XIANG|GEISEL Wenshen (瘟神) crossbow favored by many of the syndicate's stealth specialists, which does damage over time using a slow-acting radioactive poison. Utilizes a self-recharging atomic power cell from Geisel Radiofabrik."
@@ -348,7 +357,6 @@
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/slowcharge
 	projectiles = null
 	is_syndicate = 1
-	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
 	silenced = 1 // No conspicuous text messages, please (Convair880).
 	hide_attack = ATTACK_FULLY_HIDDEN
 	custom_cell_max_capacity = 100 // Those self-charging ten-shot radbows were a bit overpowered (Convair880)
@@ -373,6 +381,9 @@
 				return
 
 ////////////////////////////////////////EGun
+TYPEINFO(/obj/item/gun/energy/egun)
+	mats = list("MET-1"=15, "CON-1"=5, "POW-1"=5)
+
 /obj/item/gun/energy/egun
 	name = "energy gun"
 	icon_state = "energy"
@@ -381,7 +392,6 @@
 	desc = "The Five Points Armory Energy Gun. Double emitters with switchable fire modes, for stun bolts or lethal laser fire."
 	item_state = "egun"
 	force = 5
-	mats = list("MET-1"=15, "CON-1"=5, "POW-1"=5)
 	var/nojobreward = 0 //used to stop people from scanning it and then getting both a lawbringer/sabre AND an egun.
 	muzzle_flash = "muzzle_flash_elec"
 
@@ -417,6 +427,9 @@
 		src.nojobreward = 1
 
 
+TYPEINFO(/obj/item/gun/energy/egun_jr)
+	mats = list("MET-1"=10, "CON-1"=5, "POW-1"=5)
+
 /obj/item/gun/energy/egun_jr
 	name = "energy gun junior"
 	icon_state = "egun-jr"
@@ -425,7 +438,6 @@
 	desc = "A smaller, disposable version of the Five Points Armory energy gun, with dual modes for stun and kill."
 	item_state = "egun"
 	force = 3
-	mats = list("MET-1"=10, "CON-1"=5, "POW-1"=5)
 	muzzle_flash = "muzzle_flash_elec"
 	can_swap_cell = FALSE
 	rechargeable = FALSE
@@ -525,6 +537,9 @@
 
 
 ////////////////////////////////////VUVUV
+TYPEINFO(/obj/item/gun/energy/vuvuzela_gun)
+	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
+
 /obj/item/gun/energy/vuvuzela_gun
 	name = "amplified vuvuzela"
 	icon_state = "vuvuzela"
@@ -533,7 +548,6 @@
 	desc = "BZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZT, *fart*"
 	cell_type = /obj/item/ammo/power_cell/med_power
 	is_syndicate = 1
-	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
 
 	New()
 		set_current_projectile(new/datum/projectile/energy_bolt_v)
@@ -657,6 +671,9 @@
 	icon = 'icons/effects/VR.dmi'
 
 ///////////////////////////////////////Telegun
+TYPEINFO(/obj/item/gun/energy/teleport)
+	mats = 0
+
 /obj/item/gun/energy/teleport
 	name = "teleport gun"
 	desc = "A hacked together combination of a taser gun and a handheld teleportation unit."
@@ -667,7 +684,6 @@
 	force = 10
 	throw_speed = 2
 	throw_range = 10
-	mats = 0
 	cell_type = /obj/item/ammo/power_cell/med_power
 	var/obj/item/our_target = null
 	var/obj/machinery/computer/teleporter/our_teleporter = null // For checks before firing (Convair880).
@@ -797,6 +813,9 @@
 		return index
 
 ///////////////////////////////////////Ghost Gun
+TYPEINFO(/obj/item/gun/energy/ghost)
+	mats = 0
+
 /obj/item/gun/energy/ghost
 	name = "ectoplasmic destabilizer"
 	desc = "If this had streams, it would be inadvisable to cross them. But no, it fires bolts instead.  Don't throw it into a stream, I guess?"
@@ -806,7 +825,6 @@
 	force = 10
 	throw_speed = 2
 	throw_range = 10
-	mats = 0
 	cell_type = /obj/item/ammo/power_cell/med_power
 	muzzle_flash = "muzzle_flash_waveg"
 
@@ -816,6 +834,9 @@
 		..()
 
 ///////////////////////////////////////Modular Blasters
+TYPEINFO(/obj/item/gun/energy/blaster_pistol)
+	mats = 0
+
 /obj/item/gun/energy/blaster_pistol
 	name = "blaster pistol"
 	desc = "A dangerous-looking blaster pistol. It's self-charging by a radioactive power cell."
@@ -823,7 +844,6 @@
 	icon_state = "pistol"
 	w_class = W_CLASS_NORMAL
 	force = 5
-	mats = 0
 	cell_type = /obj/item/ammo/power_cell/self_charging/medium
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/disruptor
 
@@ -888,6 +908,9 @@
 		if(converter_mod)
 			src.overlays += icon('icons/obj/items/gun_mod.dmi',converter_mod.overlay_name)*/
 
+TYPEINFO(/obj/item/gun/energy/blaster_smg)
+	mats = 0
+
 /obj/item/gun/energy/blaster_smg
 	name = "burst blaster"
 	desc = "A special issue blaster weapon, configured for burst fire. It's self-charging by a radioactive power cell."
@@ -896,7 +919,6 @@
 	can_dual_wield = 0
 	w_class = W_CLASS_NORMAL
 	force = 7
-	mats = 0
 	cell_type = /obj/item/ammo/power_cell/self_charging/medium
 
 
@@ -946,6 +968,9 @@
 
 ///////////modular components - putting them here so it's easier to work on for now////////
 
+TYPEINFO(/obj/item/gun_parts)
+	mats = 0
+
 /obj/item/gun_parts
 	name = "gun parts"
 	desc = "Components for building custom sidearms."
@@ -953,7 +978,6 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon = 'icons/obj/items/gun_mod.dmi'
 	icon_state = "frame" // todo: make more item icons
-	mats = 0
 
 /obj/item/gun_parts/emitter
 	name = "optical pulse emitter"
@@ -1136,6 +1160,9 @@
 		return ..(target, start, user)
 
 ///////////////////////////////////////Hunter
+TYPEINFO(/obj/item/gun/energy/plasma_gun)
+	mats = list("MET-3"=7, "CRY-1"=13, "POW-2"=10)
+
 /obj/item/gun/energy/plasma_gun/ // Made use of a spare sprite here (Convair880).
 	name = "plasma rifle"
 	desc = "This advanced bullpup rifle contains a self-recharging power cell."
@@ -1146,7 +1173,6 @@
 	force = 5
 	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig
 	muzzle_flash = "muzzle_flash_plaser"
-	mats = list("MET-3"=7, "CRY-1"=13, "POW-2"=10)
 
 	New()
 		set_current_projectile(new/datum/projectile/laser/plasma)
@@ -1172,6 +1198,9 @@
 
 		return
 
+TYPEINFO(/obj/item/gun/energy/plasma_gun/hunter)
+	mats = null
+
 /obj/item/gun/energy/plasma_gun/hunter
 	name = "Hunter's plasma rifle"
 	desc = "This unusual looking rifle contains a self-recharging power cell."
@@ -1179,7 +1208,6 @@
 	item_state = "hunter"
 	base_item_state = "hunter"
 	var/hunter_key = "" // The owner of this rifle.
-	mats = null
 
 	New()
 		..()
@@ -1197,6 +1225,9 @@
 			STOP_TRACKING_CAT(TR_CAT_HUNTER_GEAR)
 
 /////////////////////////////////////// Pickpocket Grapple, Grayshift's grif gun
+TYPEINFO(/obj/item/gun/energy/pickpocket)
+	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
+
 /obj/item/gun/energy/pickpocket
 	name = "pickpocket grapple gun" // absurdly shitty name
 	desc = "A complicated, camoflaged claw device on a tether capable of complex and stealthy interactions. It steals shit."
@@ -1211,10 +1242,8 @@
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/slowcharge
 	projectiles = null
 	is_syndicate = 1
-	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
 	silenced = 1
 	hide_attack = ATTACK_FULLY_HIDDEN
-	mats = 100 //yeah no, you can do it if you REALLY want to
 	custom_cell_max_capacity = 100
 	var/obj/item/heldItem = null
 	tooltip_flags = REBUILD_DIST
@@ -1302,6 +1331,9 @@
 /obj/item/gun/energy/pickpocket/testing // has a beefier cell in it
 	cell_type = /obj/item/ammo/power_cell/self_charging/big
 
+TYPEINFO(/obj/item/gun/energy/alastor)
+	mats = list("MET-2"=15, "CON-2"=10, "POW-2"=10)
+
 /obj/item/gun/energy/alastor
 	name = "\improper Alastor pattern laser rifle"
 	inhand_image_icon = 'icons/mob/inhand/hand_guns.dmi'
@@ -1316,7 +1348,6 @@
 	desc = "A gun that produces a harmful laser, causing substantial damage."
 	muzzle_flash = "muzzle_flash_laser"
 	is_syndicate = 1
-	mats = list("MET-2"=15, "CON-2"=10, "POW-2"=10)
 
 	New()
 		set_current_projectile(new/datum/projectile/laser/alastor)
@@ -1333,6 +1364,9 @@
 			return
 
 ///////////////////////////////////////////////////
+TYPEINFO(/obj/item/gun/energy/lawbringer)
+	mats = list("MET-1"=15, "CON-2"=5, "POW-2"=5)
+
 /obj/item/gun/energy/lawbringer
 	name = "\improper Lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
@@ -1344,7 +1378,6 @@
 	g_amt = 2000
 	cell_type = /obj/item/ammo/power_cell/self_charging/lawbringer
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/lawbringer/bad
-	mats = list("MET-1"=15, "CON-2"=5, "POW-2"=5)
 	var/owner_prints = null
 	var/image/indicator_display = null
 	rechargeable = 0
@@ -1632,6 +1665,9 @@
 
 
 ///////////////////////////////////////Wasp Gun
+TYPEINFO(/obj/item/gun/energy/wasp)
+	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
+
 /obj/item/gun/energy/wasp
 	name = "mini wasp-egg-crossbow"
 	desc = "A weapon favored by many of the syndicate's stealth apiarists, which does damage over time using swarms of angry wasps. Utilizes a self-recharging atomic power cell to synthesize more wasp eggs. Somehow."
@@ -1646,7 +1682,6 @@
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/slowcharge
 	projectiles = null
 	is_syndicate = 1
-	mats = list("MET-1"=5, "CON-2"=5, "POW-2"=10)
 	silenced = 1
 	custom_cell_max_capacity = 100
 

--- a/code/obj/item/gun/reagent.dm
+++ b/code/obj/item/gun/reagent.dm
@@ -1,10 +1,12 @@
+TYPEINFO(/obj/item/gun/reagent)
+	mats = 16
+
 /obj/item/gun/reagent
 	name = "reagent gun"
 	icon = 'icons/obj/items/gun.dmi'
 	item_state = "gun"
 	m_amt = 2000
 	g_amt = 1000
-	mats = 16
 	add_residue = 0 // Does this gun add gunshot residue when fired? Energy guns shouldn't.
 	var/capacity = 100 // reagent capacity of the gun
 	var/list/ammo_reagents = null // list of reagents accepted as ammo, leave blank if you want any to be accepted
@@ -110,6 +112,9 @@
 
 		return ..()
 
+TYPEINFO(/obj/item/gun/reagent/syringe)
+	mats = 12 // These are some of the few syndicate items that would be genuinely useful to non-antagonists when scanned.
+
 /obj/item/gun/reagent/syringe
 	name = "syringe gun"
 	icon_state = "syringegun"
@@ -120,7 +125,6 @@
 	force = 4
 	contraband = 3
 	add_residue = 1 // Does this gun add gunshot residue when fired? These syringes are probably propelled by CO2 or something, but whatever (Convair880).
-	mats = 12 // These are some of the few syndicate items that would be genuinely useful to non-antagonists when scanned.
 	is_syndicate = 0 // Gonna let mechanics scan these, even without the syndicate scanner. THIS MAY BE A BAD IDEA.
 	capacity = 90
 	projectile_reagents = 1

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -10,6 +10,9 @@
 
 //////////////////////////////////////////////// Chainsaw ////////////////////////////////////
 
+TYPEINFO(/obj/item/saw)
+	mats = 12
+
 /obj/item/saw
 	name = "chainsaw"
 	desc = "An electric chainsaw used to chop up harmful plants."
@@ -30,7 +33,6 @@
 	w_class = W_CLASS_BULKY
 	flags = FPRINT | TABLEPASS | CONDUCT
 	tool_flags = TOOL_SAWING
-	mats = 12
 	var/sawnoise = 'sound/machines/chainsaw_green.ogg'
 	arm_icon = "chainsaw-D"
 	var/base_arm = "chainsaw"
@@ -132,6 +134,9 @@
 
 /obj/item/saw/abilities = list(/obj/ability_button/saw_toggle)
 
+TYPEINFO(/obj/item/saw/syndie)
+	mats = list("MET-2"=25, "CON-1"=5, "POW-2"=5)
+
 /obj/item/saw/syndie
 	name = "red chainsaw"
 	icon_state = "c_saw_s_off"
@@ -148,7 +153,6 @@
 	throw_range = 5
 	w_class = W_CLASS_BULKY
 	is_syndicate = 1
-	mats = list("MET-2"=25, "CON-1"=5, "POW-2"=5)
 	desc = "A gas powered antique. This one is the real deal. Time for a space chainsaw massacre."
 	contraband = 10 //scary
 	sawnoise = 'sound/machines/chainsaw_red.ogg'
@@ -338,6 +342,9 @@
 /obj/item/saw/syndie/vr
 	icon = 'icons/effects/VR.dmi'
 
+TYPEINFO(/obj/item/saw/elimbinator)
+	mats = 12
+
 /obj/item/saw/elimbinator
 	name = "The Elimbinator"
 	desc = "Lops off limbs left and right!"
@@ -356,7 +363,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = W_CLASS_BULKY
-	mats = 12
 	sawnoise = 'sound/machines/chainsaw_red.ogg'
 	hitsound = 'sound/machines/chainsaw_red.ogg'
 	arm_icon = "chainsaw_s-A"
@@ -386,6 +392,9 @@
 
 ////////////////////////////////////// Plant analyzer //////////////////////////////////////
 
+TYPEINFO(/obj/item/plantanalyzer)
+	mats = 4
+
 /obj/item/plantanalyzer/
 	name = "plant analyzer"
 	desc = "A device which examines the genes of plant seeds."
@@ -393,7 +402,6 @@
 	icon_state = "plantanalyzer"
 	w_class = W_CLASS_TINY
 	c_flags = ONBELT
-	mats = 4
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
 		if (BOUNDS_DIST(A, user) > 0)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1743,6 +1743,9 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 /* ------------------------- Implant Pad ------------------------- */
 /* =============================================================== */
 
+TYPEINFO(/obj/item/implantpad)
+	mats = 5
+
 /obj/item/implantpad
 	name = "implantpad"
 	icon = 'icons/obj/items/items.dmi'
@@ -1754,7 +1757,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	throw_speed = 1
 	throw_range = 5
 	w_class = W_CLASS_SMALL
-	mats = 5
 	desc = "A small device for analyzing implants."
 
 /obj/item/implantpad/proc/update()
@@ -1946,11 +1948,13 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 /* ------------------------- Implant Gun ------------------------- */
 /* =============================================================== */
 
+TYPEINFO(/obj/item/gun/implanter)
+	mats = 8
+
 /obj/item/gun/implanter
 	name = "implant gun"
 	desc = "A gun that accepts an implant, that you can then shoot into other people! Or a wall, which certainly wouldn't be too big of a waste, since you'd only be using this to shoot people with things like health monitor implants or machine translators. Right?"
 	icon_state = "implant"
-	mats = 8
 	contraband = 1
 	var/obj/item/implant/my_implant = null
 

--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -426,6 +426,9 @@
 
 /* -------------------- Dramatic Bike Horn -------------------- */
 
+TYPEINFO(/obj/item/instrument/bikehorn/dramatic)
+	mats = 2
+
 /obj/item/instrument/bikehorn/dramatic
 	name = "dramatic bike horn"
 	desc = "SHIT FUCKING PISS IT'S SO RAW"
@@ -433,7 +436,6 @@
 	volume = 100
 	randomized_pitch = 0
 	note_time = 30
-	mats = 2
 
 	attackby(obj/item/W, mob/user)
 		if (!istype(W, /obj/item/parts/robot_parts/arm))

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -1,4 +1,7 @@
 
+TYPEINFO(/obj/item/magtractor)
+	mats = 12
+
 /obj/item/magtractor
 	name = "magtractor"
 	desc = "A device used to pick up and hold objects via the mysterious power of magnets."
@@ -15,7 +18,6 @@
 	throw_range = 5
 	w_class = W_CLASS_NORMAL
 	m_amt = 50000
-	mats = 12
 	stamina_damage = 15
 	stamina_cost = 15
 	stamina_crit_chance = 5

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -12,10 +12,12 @@
 /datum/computer/file/manudrive/restricted // This is for manudrives that actually have a fabrication limit. Only difference is there file cant be copied.
 	name = "Restricted Manufacturer Recipes"
 	dont_copy = 1
+TYPEINFO(/obj/item/disk/data/floppy/manudrive)
+	mats = 0 // These things arent intended to be reproducible (god I butchered that) due to things like fablimits.
+
 /obj/item/disk/data/floppy/manudrive // This one should be the parent of manudrives that dont have a fabrication limit.
 	name = "Standard ManuDrive: Empty"
 	desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer."
-	mats = 0 // These things arent intended to be reproducible (god I butchered that) due to things like fablimits.
 	random_color = 0
 	icon_state = "datadiskwhi"
 	/// Put the recipe string here and itll make em into instances.

--- a/code/obj/item/mine.dm
+++ b/code/obj/item/mine.dm
@@ -1,4 +1,7 @@
 // Cleaned up the ancient code that used to be here (Convair880).
+TYPEINFO(/obj/item/mine)
+	mats = 6
+
 /obj/item/mine
 	name = "land mine (parent)"
 	desc = "You shouldn't be able to see this!"
@@ -8,7 +11,6 @@
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "mine"
 	is_syndicate = TRUE
-	mats = 6
 	event_handler_flags = USE_FLUID_ENTER
 	var/suppress_flavourtext = FALSE
 	var/armed = FALSE
@@ -268,6 +270,9 @@
 
 		explosion(src, src.loc, 0, 1, 2, 3)
 
+TYPEINFO(/obj/item/mine/gibs)
+	mats = 0
+
 /obj/item/mine/gibs
 	name = "pustule"
 	desc = "Some kind of weird little meat balloon."
@@ -275,7 +280,6 @@
 	icon_state = "meatmine"
 	suppress_flavourtext = TRUE
 	is_syndicate = FALSE
-	mats = 0
 
 	armed
 		armed = TRUE

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -123,10 +123,12 @@
 		user.put_in_hand_or_drop(new /obj/item/clothing/head/party)
 		qdel(src)
 
+TYPEINFO(/obj/item/disk)
+	mats = 8
+
 /obj/item/disk
 	name = "disk"
 	icon = 'icons/obj/items/items.dmi'
-	mats = 8
 
 /obj/item/dummy
 	name = "dummy"
@@ -275,6 +277,9 @@
 			src.setItemSpecial(/datum/item_special/slam)
 
 
+TYPEINFO(/obj/item/reagent_containers/vape)
+	mats = 6
+
 /obj/item/reagent_containers/vape //yeet
 	name = "e-cigarette"
 	desc = "The pinacle of human technology. An electronic cigarette!"
@@ -284,7 +289,6 @@
 	initial_reagents = "nicotine"
 	item_state = "ecig"
 	icon_state = "ecig"
-	mats = 6
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | NOSPLASH
 	c_flags = ONBELT
 	var/emagged = 0

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -16,6 +16,9 @@
 
 
 /// Cyalume saber/esword, famed traitor item
+TYPEINFO(/obj/item/sword)
+	mats = list("MET-1"=5, "CON-2"=5, "POW-3"=10)
+
 /obj/item/sword
 	name = "cyalume saber"
 	icon = 'icons/obj/items/weapons.dmi'
@@ -40,7 +43,6 @@
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
 	is_syndicate = 1
-	mats = list("MET-1"=5, "CON-2"=5, "POW-3"=10)
 	contraband = 5
 	desc = "An illegal, recalled Super Protector Friend glow sword. When activated, uses energized cyalume to create an extremely dangerous saber. Can be concealed when deactivated."
 	stamina_damage = 35 // This gets applied by obj/item/attack, regardless of if the saber is active.
@@ -939,6 +941,9 @@
 
 ///////////////////////////////// Baseball Bat ////////////////////////////////////////////////////////////
 
+TYPEINFO(/obj/item/bat)
+	mats = list("wood" = 8)
+
 /obj/item/bat
 	name = "Baseball Bat"
 	desc = "Play ball! Note: Batter is responsible for any injuries sustained due to ball-hitting."
@@ -952,7 +957,6 @@
 	stamina_damage = 24
 	stamina_cost = 30
 	stamina_crit_chance = 15
-	mats = list("wood" = 8)
 
 	attack(mob/M, mob/user, def_zone, is_special)
 		. = ..()
@@ -1116,12 +1120,14 @@
 			target.organHolder.drop_and_throw_organ("butt", dist = 5, speed = 1, showtext = 1)
 
 //PS the description can be shortened if you find it annoying and you are a jerk.
+TYPEINFO(/obj/item/swords/katana)
+	mats = list("MET-3"=20, "FAB-1"=5)
+
 /obj/item/swords/katana
 	name = "katana"
 	desc = "That's it. I'm sick of all this 'Masterwork Cyalume Saber' bullshit that's going on in the SS13 system right now. Katanas deserve much better than that. Much, much better than that. I should know what I'm talking about. I myself commissioned a genuine katana in Space Japan for 2,400,000 Nuyen (that's about 20,000 credits) and have been practicing with it for almost 2 years now. I can even cut slabs of solid mauxite with my katana. Space Japanese smiths spend light-years working on a single katana and fold it up to a million times to produce the finest blades known to space mankind. Katanas are thrice as sharp as Syndicate sabers and thrice as hard for that matter too. Anything a c-saber can cut through, a katana can cut through better. I'm pretty sure a katana could easily bisect a drunk captain wearing full captain's armor with a simple tap. Ever wonder why the Syndicate never bothered conquering Space Japan? That's right, they were too scared to fight the disciplined Space Samurai and their space katanas of destruction. Even in World War 72, Nanotrasen soldiers targeted the men with the katanas first because their killing power was feared and respected."
 	icon_state = "katana"
 	force = 15 //Was at 5, but that felt far too weak. C-swords are at 60 in comparison. 15 is still quite a bit of damage, but just not insta-crit levels.
-	mats = list("MET-3"=20, "FAB-1"=5)
 	contraband = 7 //Fun fact: sheathing your katana makes you 100% less likely to be tazed by beepsky, probably
 
 
@@ -1180,11 +1186,13 @@
 		..()
 		src.setItemSpecial(/datum/item_special/katana_dash/reverse)
 
+TYPEINFO(/obj/item/swords/captain)
+	mats = list("MET-2"=15)
+
 /obj/item/swords/captain
 	icon_state = "cap_sword"
 	name = "Commander's Sabre"
 	desc = ""
-	mats = list("MET-2"=15)
 	force = 16 //not awful but not amazing
 	contraband = 4
 	tooltip_flags = REBUILD_USER

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -866,12 +866,14 @@ WET FLOOR SIGN
 
 // handheld vacuum
 
+TYPEINFO(/obj/item/handheld_vacuum)
+	mats = list("bamboo"=3, "MET-1"=10)
+
 /obj/item/handheld_vacuum
 	name = "handheld vacuum"
 	desc = "Sucks smoke. Sucks small items. Sucks just in general!"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "handvac"
-	mats = list("bamboo"=3, "MET-1"=10)
 	health = 7
 	w_class = W_CLASS_SMALL
 	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
@@ -1078,9 +1080,11 @@ WET FLOOR SIGN
 		else
 			. = ..()
 
+TYPEINFO(/obj/item/handheld_vacuum/overcharged)
+	mats = list("neutronium"=3, "MET-1"=10)
+
 /obj/item/handheld_vacuum/overcharged
 	name = "overcharged handheld vacuum"
-	mats = list("neutronium"=3, "MET-1"=10)
 	color = list(0,0,1, 0,1,0, 1,0,0)
 	New()
 		..()

--- a/code/obj/item/organs/appendix.dm
+++ b/code/obj/item/organs/appendix.dm
@@ -24,6 +24,9 @@
 		..()
 		src.icon_state = pick("plant_appendix", "plant_appendix_bloom")
 
+TYPEINFO(/obj/item/organ/appendix/cyber)
+	mats = 6
+
 /obj/item/organ/appendix/cyber
 	name = "cyberappendix"
 	desc = "A fancy robotic appendix to replace one that someone's lost!"
@@ -33,7 +36,6 @@
 	created_decal = /obj/decal/cleanable/oil
 	made_from = "pharosium"
 	edible = 0
-	mats = 6
 
 	//A bad version of the robutsec... For now.
 	on_life(var/mult = 1)

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -106,6 +106,9 @@
 	item_state = "plant"
 	synthetic = 1
 
+TYPEINFO(/obj/item/organ/eye/cyber)
+	mats = 6
+
 /obj/item/organ/eye/cyber
 	name = "cybereye"
 	organ_name = "cybereye"
@@ -115,7 +118,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 	made_from = "pharosium"
 	show_on_examine = 1
 
@@ -126,12 +128,14 @@
 			if (src.holder && src.holder.donor)
 				src.holder.donor.show_text("<b>Your [src.organ_name] [pick("crackles and sparks", "makes a weird crunchy noise", "buzzes strangely")]!</b>", "red")
 
+TYPEINFO(/obj/item/organ/eye/cyber/sunglass)
+	mats = 7
+
 /obj/item/organ/eye/cyber/sunglass
 	name = "polarized cybereye"
 	organ_name = "polarized cybereye"
 	desc = "A fancy electronic eye. It has a polarized filter on the lens for built-in protection from the sun and other harsh lightsources. Your night vision is fucked, though."
 	icon_state = "eye-sunglass"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.95 // darken a little
 	color_g = 0.95
@@ -148,12 +152,14 @@
 		REMOVE_ATOM_PROPERTY(donor, PROP_MOB_DISORIENT_RESIST_EYE_MAX, src)
 		. = ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/sechud)
+	mats = 7
+
 /obj/item/organ/eye/cyber/sechud
 	name = "\improper Security HUD cybereye"
 	organ_name = "\improper Security HUD cybereye"
 	desc = "A fancy electronic eye. It has a Security HUD system installed."
 	icon_state = "eye-sec"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.975 // darken a little, kinda red
 	color_g = 0.95
@@ -177,12 +183,14 @@
 		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(donor)
 		..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/thermal)
+	mats = 7
+
 /obj/item/organ/eye/cyber/thermal
 	name = "thermal imager cybereye"
 	organ_name = "thermal imager cybereye"
 	desc = "A fancy electronic eye. It lets you see through cloaks and enhances your night vision. Use caution around bright lights."
 	icon_state = "eye-thermal"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 1
 	color_g = 0.9 // red tint
@@ -197,12 +205,14 @@
 		REMOVE_ATOM_PROPERTY(donor, PROP_MOB_THERMALVISION, src)
 		. = ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/meson)
+	mats = 7
+
 /obj/item/organ/eye/cyber/meson
 	name = "mesonic imager cybereye"
 	organ_name = "mesonic imager cybereye"
 	desc = "A fancy electronic eye. It lets you see the structure of the station through walls. Trippy!"
 	icon_state = "eye-meson"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.925
 	color_g = 1
@@ -240,12 +250,14 @@
 			assigned.vision.set_scan(0)
 			REMOVE_ATOM_PROPERTY(donor, PROP_MOB_MESONVISION, src)
 
+TYPEINFO(/obj/item/organ/eye/cyber/spectro)
+	mats = 7
+
 /obj/item/organ/eye/cyber/spectro
 	name = "spectroscopic imager cybereye"
 	organ_name = "spectroscopic imager cybereye"
 	desc = "A fancy electronic eye. It has an integrated minature Raman spectroscope for easy qualitative and quantitative analysis of chemical samples."
 	icon_state = "eye-spectro"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 1 // pink tint?
 	color_g = 0.9
@@ -260,12 +272,14 @@
 		REMOVE_ATOM_PROPERTY(donor, PROP_MOB_SPECTRO, src)
 		. = ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/prodoc)
+	mats = 7
+
 /obj/item/organ/eye/cyber/prodoc
 	name = "\improper ProDoc Healthview cybereye"
 	organ_name = "\improper ProDoc Healthview cybereye"
 	desc = "A fancy electronic eye. It's fitted with an advanced miniature sensor array that allows you to quickly determine the physical condition of others."
 	icon_state = "eye-prodoc"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.925
 	color_g = 1
@@ -294,12 +308,14 @@
 		..()
 		return
 
+TYPEINFO(/obj/item/organ/eye/cyber/ecto)
+	mats = 7
+
 /obj/item/organ/eye/cyber/ecto
 	name = "ectosensor cybereye"
 	organ_name = "ectosensor cybereye"
 	desc = "A fancy electronic eye. It lets you see spooky stuff."
 	icon_state = "eye-ecto"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.925
 	color_g = 1
@@ -314,12 +330,14 @@
 		REMOVE_ATOM_PROPERTY(donor, PROP_MOB_GHOSTVISION, src)
 		. = ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/camera)
+	mats = 7
+
 /obj/item/organ/eye/cyber/camera
 	name = "camera cybereye"
 	organ_name = "camera cybereye"
 	desc = "A fancy electronic eye. It has a camera in it connected to the station's security camera network."
 	icon_state = "eye-camera"
-	mats = 7
 	var/obj/machinery/camera/camera = null
 	var/camera_tag = "Eye Cam"
 	var/camera_network = "Zeta"
@@ -337,12 +355,14 @@
 		src.camera.c_tag = "[M]'s Eye"
 		return ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/nightvision)
+	mats = 7
+
 /obj/item/organ/eye/cyber/nightvision
 	name = "night vision cybereye"
 	organ_name = "night vision cybereye"
 	desc = "A fancy electronic eye. It has built-in image-intensifier tubes to allow vision in the dark. Keep away from bright lights."
 	icon_state = "eye-night"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 0.7
 	color_g = 1
@@ -357,12 +377,14 @@
 		REMOVE_ATOM_PROPERTY(donor, PROP_MOB_NIGHTVISION, src)
 		. = ..()
 
+TYPEINFO(/obj/item/organ/eye/cyber/laser)
+	mats = 7
+
 /obj/item/organ/eye/cyber/laser
 	name = "laser cybereye"
 	organ_name = "laser cybereye"
 	desc = "A fancy electronic eye. It can fire a small laser."
 	icon_state = "eye-laser"
-	mats = 7
 	made_from = "pharosium"
 	color_r = 1
 	color_g = 0.85

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -132,6 +132,9 @@
 		..()
 		src.icon_state = pick("plant_heart", "plant_heart_bloom")
 
+TYPEINFO(/obj/item/organ/heart/cyber)
+	mats = 8
+
 /obj/item/organ/heart/cyber
 	name = "cyberheart"
 	desc = "A cybernetic heart. Is this thing really medical-grade?"
@@ -141,7 +144,6 @@
 	edible = 0
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
-	mats = 8
 	made_from = "pharosium"
 	transplant_XP = 7
 	squeeze_sound = 'sound/voice/screams/Robot_Scream_2.ogg'

--- a/code/obj/item/organs/instestines.dm
+++ b/code/obj/item/organs/instestines.dm
@@ -50,6 +50,9 @@
 		..()
 		src.icon_state = pick("plant_intestines", "plant_intestines_bloom")
 
+TYPEINFO(/obj/item/organ/intestines/cyber)
+	mats = 6
+
 /obj/item/organ/intestines/cyber
 	name = "cyberintestines"
 	desc = "A fancy robotic intestines to replace one that someone's lost!"
@@ -59,7 +62,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 
 	emag_act(mob/user, obj/item/card/emag/E)
 		. = ..()

--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -131,6 +131,9 @@
 		..()
 		src.icon_state = pick("plant_appendix", "plant_appendix_bloom")
 
+TYPEINFO(/obj/item/organ/kidney/cyber)
+	mats = 6
+
 /obj/item/organ/kidney/cyber
 	name = "cyberkidney"
 	desc = "A fancy robotic kidney to replace one that someone's lost!"
@@ -140,7 +143,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 	min_chem_metabolism_modifier = 75
 	max_chem_metabolism_modifier = 150
 

--- a/code/obj/item/organs/liver.dm
+++ b/code/obj/item/organs/liver.dm
@@ -34,6 +34,9 @@
 		..()
 		src.icon_state = pick("plant_liver", "plant_liver_bloom")
 
+TYPEINFO(/obj/item/organ/liver/cyber)
+	mats = 6
+
 /obj/item/organ/liver/cyber
 	name = "cyberliver"
 	desc = "A fancy robotic liver to replace one that someone's lost!"
@@ -43,7 +46,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 	var/overloading = 0
 
 	emag_act(mob/user, obj/item/card/emag/E)

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -223,6 +223,9 @@
 	body_side = R_ORGAN
 	failure_disease = /datum/ailment/disease/respiratory_failure/right
 
+TYPEINFO(/obj/item/organ/lung/cyber)
+	mats = 6
+
 /obj/item/organ/lung/cyber
 	name = "cyberlungs"
 	desc = "Fancy robotic lungs!"
@@ -231,7 +234,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 	temp_tolerance = T0C+500
 	var/overloading = 0
 	var/grace_period = 30

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -43,6 +43,9 @@
 		..()
 		src.icon_state = pick("plant_pancreas", "plant_pancreas_bloom")
 
+TYPEINFO(/obj/item/organ/pancreas/cyber)
+	mats = 6
+
 /obj/item/organ/pancreas/cyber
 	name = "cyberpancreas"
 	desc = "A fancy robotic pancreas to replace one that someone's lost!"
@@ -52,7 +55,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 
 	on_life(var/mult = 1)
 		if (!..())

--- a/code/obj/item/organs/spleen.dm
+++ b/code/obj/item/organs/spleen.dm
@@ -42,6 +42,9 @@
 		..()
 		src.icon_state = pick("plant_spleen", "plant_spleen_bloom")
 
+TYPEINFO(/obj/item/organ/spleen/cyber)
+	mats = 6
+
 /obj/item/organ/spleen/cyber
 	name = "cyberspleen"
 	desc = "A fancy robotic spleen to replace one that someone's lost!"
@@ -50,5 +53,4 @@
 	// item_state = "heart_robo1"
 	robotic = 1
 	edible = 0
-	mats = 6
 	created_decal = /obj/decal/cleanable/oil

--- a/code/obj/item/organs/stomach.dm
+++ b/code/obj/item/organs/stomach.dm
@@ -77,6 +77,9 @@
 		..()
 		src.icon_state = pick("plant_stomach", "plant_stomach_bloom")
 
+TYPEINFO(/obj/item/organ/stomach/cyber)
+	mats = 6
+
 /obj/item/organ/stomach/cyber
 	name = "cyberstomach"
 	desc = "A fancy robotic stomach to replace one that someone's lost!"
@@ -86,7 +89,6 @@
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
-	mats = 6
 
 	on_transplant(mob/M)
 		. = ..()

--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/pinpointer)
+	mats = 4
+
 /obj/item/pinpointer
 	name = "pinpointer"
 	icon = 'icons/obj/items/pinpointers.dmi'
@@ -16,7 +19,6 @@
 	var/target_ref = null
 	var/active = 0
 	var/icon_type = "disk"
-	mats = 4
 	desc = "An extremely advanced scanning device used to locate things. It displays this with an extremely technicalogically advanced arrow."
 	stamina_damage = 0
 	stamina_cost = 0
@@ -369,6 +371,9 @@
 			if(ismob(src.loc))
 				boutput(src.loc, "<span class='alert'>[src] shuts down because the blood in it became too dry!</span>")
 
+TYPEINFO(/obj/item/pinpointer/secweapons)
+	mats = null
+
 /obj/item/pinpointer/secweapons
 	name = "security weapon pinpointer"
 	icon_state = "sec_pinoff"
@@ -376,7 +381,6 @@
 	var/list/itemrefs
 	var/list/accepted_types
 	hudarrow_color = "#ee4444"
-	mats = null
 	desc = "An extremely advanced scanning device used to locate lost security tools. It displays this with an extremely technicalogically advanced arrow."
 
 	proc/track(var/list/L)

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -23,6 +23,9 @@ Broken RCD + Effects
 	also maybe an assoc list instead of matter_shit_fuck
 */
 
+TYPEINFO(/obj/item/rcd)
+	mats = list("MET-3"=20, "CRY-2" = 10, "CON-2" = 10, "POW-2" = 10)
+
 /obj/item/rcd
 	name = "rapid construction device"
 	desc = "Also known as an RCD, this is capable of rapidly constructing walls, flooring, windows, and doors."
@@ -45,7 +48,6 @@ Broken RCD + Effects
 	w_class = W_CLASS_NORMAL
 	m_amt = 50000
 
-	mats = list("MET-3"=20, "CRY-2" = 10, "CON-2" = 10, "POW-2" = 10)
 	stamina_damage = 15
 	stamina_cost = 15
 	stamina_crit_chance = 5
@@ -636,6 +638,9 @@ Broken RCD + Effects
 /obj/item/rcd/cyborg
 	material_name = "electrum"
 
+TYPEINFO(/obj/item/rcd/construction)
+	mats = list("MET-3"=100, "CRY-2" = 50, "CON-2"=50, "POW-3"=50, "starstone"=10)
+
 /obj/item/rcd/construction
 	name = "rapid construction device deluxe"
 	desc = "Also known as an RCD, this is capable of rapidly constructing walls, flooring, windows, and doors. The deluxe edition features a much higher matter capacity and enhanced feature set."
@@ -651,7 +656,6 @@ Broken RCD + Effects
 	var/door_access = 0
 	var/door_access_name_cache = null
 	var/door_type_name_cache = null
-	mats = list("MET-3"=100, "CRY-2" = 50, "CON-2"=50, "POW-3"=50, "starstone"=10)
 	var/static/list/access_names = list() //ditto the above????
 	var/door_type = null
 
@@ -663,11 +667,13 @@ Broken RCD + Effects
 	shits_sparks = 0
 
 ///Chief Engineer RCD has fancy door functions and a mild discount, but no capacity increase
+TYPEINFO(/obj/item/rcd/construction/chiefEngineer)
+	mats = list("MET-3"=20, "CRY-2" = 10, "CON-2" = 10, "POW-2" = 10)
+
 /obj/item/rcd/construction/chiefEngineer
 	name = "rapid construction device custom"
 	desc = "Also known as an RCD, this is capable of rapidly constructing walls, flooring, windows, and doors. This device was customized by the Chief Engineer to have an enhanced feature set and work more efficiently."
 	icon_state = "base_CE"
-	mats = list("MET-3"=20, "CRY-2" = 10, "CON-2" = 10, "POW-2" = 10)
 
 	max_matter = 50
 	matter_create_wall = 1
@@ -860,11 +866,13 @@ Broken RCD + Effects
 
 
 
+TYPEINFO(/obj/item/rcd/material/cardboard)
+	mats = list("CRY-2" = 10, "POW-2" = 10, "cardboard" = 30)
+
 /obj/item/rcd/material/cardboard
 	name = "cardboard rapid construction Device"
 	icon_state = "base_cardboard"
 	desc = "Also known as a C-RCD, this device is able to rapidly construct cardboard props."
-	mats = list("CRY-2" = 10, "POW-2" = 10, "cardboard" = 30)
 	force = 0
 	matter_create_floor = 0.5
 	time_create_floor = 0 SECONDS

--- a/code/obj/item/retribution.dm
+++ b/code/obj/item/retribution.dm
@@ -11,6 +11,9 @@
 	is_syndicate = 1
 	contraband = 5
 
+TYPEINFO(/obj/item/syndicate_destruction_system)
+	mats = 18
+
 /obj/item/syndicate_destruction_system
 	name = "Syndicate Destruction System"
 	desc = "An unfinished melee weapon, the blueprints for which have been plundered from a raid on a now-destroyed Syndicate base. Requires a unique power source to function."
@@ -27,7 +30,6 @@
 	w_class = W_CLASS_SMALL	//Becomes 5.0 when the core is inserted.
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING  | TOOL_CHOPPING | TOOL_SAWING
-	mats = 18
 	is_syndicate = 1
 	contraband = 10
 	two_handed = 1

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -804,6 +804,9 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 
 /* -------------------- Wrestling Belt -------------------- */
 
+TYPEINFO(/obj/item/storage/belt/wrestling)
+	mats = list("MET-2"=5, "DEN-2"=10, "FAB-1"=5)
+
 /obj/item/storage/belt/wrestling
 	name = "championship wrestling belt"
 	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past."
@@ -812,7 +815,6 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	contraband = 8
 	is_syndicate = 1
 	item_function_flags = IMMUNE_TO_ACID
-	mats = list("MET-2"=5, "DEN-2"=10, "FAB-1"=5)
 	var/fake = 0		//So the moves are all fake.
 
 	equipped(var/mob/user)
@@ -831,6 +833,9 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	fake = 1
 
 // I dunno where else to put these vOv
+TYPEINFO(/obj/item/inner_tube)
+	mats = 5 // I dunno???
+
 /obj/item/inner_tube
 	name = "inner tube"
 	desc = "An inflatable torus for your waist!"
@@ -840,7 +845,6 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	flags = FPRINT | TABLEPASS
 	c_flags = ONBELT
 	w_class = W_CLASS_NORMAL
-	mats = 5 // I dunno???
 
 	New()
 		..()

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -253,6 +253,9 @@ ABSTRACT_TYPE(/obj/item/storage/secure)
 
 // SECURE BRIEFCASE
 
+TYPEINFO(/obj/item/storage/secure/sbriefcase)
+	mats = 8
+
 /obj/item/storage/secure/sbriefcase
 	name = "secure briefcase"
 	icon = 'icons/obj/items/storage.dmi'
@@ -265,9 +268,11 @@ ABSTRACT_TYPE(/obj/item/storage/secure)
 	throw_speed = 1
 	throw_range = 4
 	w_class = W_CLASS_BULKY
-	mats = 8
 	spawn_contents = list(/obj/item/paper,\
 	/obj/item/pen)
+
+TYPEINFO(/obj/item/storage/secure/ssafe)
+	mats = 8
 
 /obj/item/storage/secure/ssafe
 	name = "secure safe"
@@ -281,7 +286,6 @@ ABSTRACT_TYPE(/obj/item/storage/secure)
 	w_class = W_CLASS_BULKY
 	anchored = 1
 	density = 0
-	mats = 8
 	desc = "A extremely tough secure safe."
 	mechanics_type_override = /obj/item/storage/secure/ssafe
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -4,6 +4,9 @@
 
 ////////////////////////////////////////// Stun baton parent //////////////////////////////////////////////////
 // Completely refactored the ca. 2009-era code here. Powered batons also use power cells now (Convair880).
+TYPEINFO(/obj/item/baton)
+	mats = list("MET-3"=10, "CON-2"=10)
+
 /obj/item/baton
 	name = "stun baton"
 	desc = "A standard issue baton for stunning people with."
@@ -18,7 +21,6 @@
 	throwforce = 7
 	health = 7
 	w_class = W_CLASS_NORMAL
-	mats = list("MET-3"=10, "CON-2"=10)
 	contraband = 4
 	stamina_damage = 15
 	stamina_cost = 21
@@ -334,13 +336,18 @@
 /obj/item/baton/secbot
 	cost_normal = 0
 
+TYPEINFO(/obj/item/baton/beepsky)
+	mats = 0 //no
+
 /obj/item/baton/beepsky
 	name = "securitron stun baton"
 	desc = "A stun baton that's been modified to be used more effectively by security robots. There's a small parallel port on the bottom of the handle."
 	can_swap_cell = 0
 	rechargable = 0
 	cell_type = /obj/item/ammo/power_cell
-	mats = 0 //no
+
+TYPEINFO(/obj/item/baton/cane)
+	mats = list("MET-3"=10, "CON-2"=10, "gem"=1, "gold"=1)
 
 /obj/item/baton/cane
 	name = "stun cane"
@@ -354,7 +361,9 @@
 	cell_type = /obj/item/ammo/power_cell/self_charging/disruptor
 	can_swap_cell = 0
 	rechargable = 0
-	mats = list("MET-3"=10, "CON-2"=10, "gem"=1, "gold"=1)
+
+TYPEINFO(/obj/item/baton/classic)
+	mats = 0
 
 /obj/item/baton/classic
 	name = "police baton"
@@ -362,7 +371,6 @@
 	icon_state = "baton"
 	item_state = "classic_baton"
 	force = 15
-	mats = 0
 	contraband = 6
 	icon_on = "baton"
 	icon_off = "baton"
@@ -386,13 +394,15 @@
 			user.remove_stamina(src.stamina_cost)
 
 
+TYPEINFO(/obj/item/baton/ntso)
+	mats = list("MET-3"=10, "CON-2"=10, "POW-1"=5)
+
 /obj/item/baton/ntso
 	name = "extendable stun baton"
 	desc = "An extendable stun baton for NT Security Consultants in sleek NanoTrasen blue."
 	icon_state = "ntso_baton-c"
 	item_state = "ntso-baton-c"
 	force = 7
-	mats = list("MET-3"=10, "CON-2"=10, "POW-1"=5)
 	icon_on = "ntso-baton-a-1"
 	icon_off = "ntso-baton-c"
 	var/icon_off_open = "ntso-baton-a-0"

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -309,11 +309,13 @@ Contains:
 
 ////////////////////////////////////////////////////////////
 
+TYPEINFO(/obj/item/tank/jetpack)
+	mats = 16
+
 /obj/item/tank/jetpack
 	name = "jetpack (oxygen)"
 	uses_multiple_icon_states = TRUE
 	w_class = W_CLASS_BULKY
-	mats = 16
 	force = 8
 	desc = "A jetpack that can use oxygen as a propellant, allowing the wearer to maneuver freely in space. It can also be used as a gas source for internals like a regular tank."
 	distribute_pressure = 17
@@ -409,13 +411,15 @@ Contains:
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		..()
 
+TYPEINFO(/obj/item/tank/jetpack/micro)
+	mats = 8
+
 /obj/item/tank/jetpack/micro
 	name = "micro-lite jetpack (oxygen)"
 	icon_state = "microjetpack0"
 	item_state = "microjetpack0"
 	base_icon_state = "microjetpack"
 	extra_desc = "This one is the smaller variant, suiable for shorter ranged activities."
-	mats = 8
 	force = 6
 
 	New()

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -112,6 +112,9 @@ Frequency:
 
 /// HAND TELE
 
+TYPEINFO(/obj/item/hand_tele)
+	mats = 8
+
 /obj/item/hand_tele
 	name = "hand tele"
 	icon = 'icons/obj/items/device.dmi'
@@ -125,7 +128,6 @@ Frequency:
 	m_amt = 10000
 	c_flags = ONBELT
 	var/unscrewed = 0
-	mats = 8
 	desc = "An experimental portable teleportation device that can create portals that link to the same destination as a teleport computer."
 	var/obj/item/our_target = null
 	var/turf/our_random_target = null

--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -3,12 +3,14 @@ CONTAINS:
 TOILET
 */
 
+TYPEINFO(/obj/item/storage/toilet)
+	mats = 5
+
 /obj/item/storage/toilet
 	name = "toilet"
 	w_class = W_CLASS_BULKY
 	anchored = 1
 	density = 0
-	mats = 5
 	deconstruct_flags = DECON_WRENCH | DECON_WELDER
 	var/status = 0
 	var/clogged = 0

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -786,12 +786,11 @@
 					match_check = 1
 					break
 			if (!match_check)
-				var/obj/tempobj = new X (src)
-				var/datum/electronics/scanned_item/O = ruck_controls.scan_in(tempobj.name,tempobj.type,tempobj.mats)
+				var/typeinfo/obj/typeinfo = get_type_typeinfo(X)
+				var/obj/typedummy = X
+				var/datum/electronics/scanned_item/O = ruck_controls.scan_in(initial(typedummy.name), X, typeinfo.mats)
 				if(O)
 					upload_blueprint(O, "TRANSRKIT", 1)
-					SPAWN(4 SECONDS)
-						qdel(tempobj)
 				S.scanned -= X
 				add_count++
 		if (add_count==  1)

--- a/code/obj/item/tool/multitool.dm
+++ b/code/obj/item/tool/multitool.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/item/device/multitool)
+	mats = 6
+
 /obj/item/device/multitool
 	name = "multitool"
 	desc = "You can use this on airlocks or APCs to try to hack them without cutting wires."
@@ -17,7 +20,6 @@
 
 	m_amt = 50
 	g_amt = 20
-	mats = 6
 
 	custom_suicide = 1
 	suicide(var/mob/user as mob)

--- a/code/obj/item/toys.dm
+++ b/code/obj/item/toys.dm
@@ -184,12 +184,14 @@
 /obj/machinery/computer/arcade/handheld
 	desc = "You shouldn't see this, I exist for typechecks"
 
+TYPEINFO(/obj/item/toy/handheld)
+	mats = 2
+
 /obj/item/toy/handheld
 	name = "arcade toy"
 	desc = "These high tech gadgets compress the full arcade experience into a large, clunky handheld!"
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "arcade-generic"
-	mats = 2
 	var/arcademode = FALSE
 	//The arcade machine will typecheck if we're this type
 	var/obj/machinery/computer/arcade/handheld/arcadeholder = null

--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/kitchenspike)
+	mats = 10
+
 /obj/kitchenspike
 	name = "a meat spike"
 	icon = 'icons/obj/kitchen.dmi'
@@ -5,7 +8,6 @@
 	desc = "A spike for collecting meat from animals"
 	density = 1
 	anchored = 1
-	mats = 10
 	var/meat = 0
 	var/occupied = FALSE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR

--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -1,6 +1,9 @@
 /** Arc Electroplater
   * Applies materials directly to items
   */
+TYPEINFO(/obj/machinery/arc_electroplater)
+	mats = 20
+
 /obj/machinery/arc_electroplater
 	name = "Arc Electroplater"
 	desc = "An industrial arc electroplater.  It uses strong currents to coat a target object with a provided material."
@@ -9,7 +12,6 @@
 	anchored = 1
 	density = 1
 	flags = NOSPLASH
-	mats = 20
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 	var/obj/target_item = null
 	var/cooktime = 0

--- a/code/obj/machinery/autolathe.dm
+++ b/code/obj/machinery/autolathe.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/autolathe)
+	mats = 20
+
 /obj/machinery/autolathe
 	name = "Autolathe"
 	icon_state = "autolathe"
@@ -18,7 +21,6 @@
 	var/hack_wire
 	var/disable_wire
 	var/shock_wire
-	mats = 20
 
 
 /obj/machinery/autolathe/attackby(var/obj/item/O, var/mob/user)

--- a/code/obj/machinery/cashreg.dm
+++ b/code/obj/machinery/cashreg.dm
@@ -1,10 +1,12 @@
+TYPEINFO(/obj/machinery/cashreg)
+	mats = 6
+
 /obj/machinery/cashreg
 	name = "credit transfer device"
 	desc = "Sends funds directly to a host ID."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "scanner"
 	anchored = 1
-	mats = 6
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 	var/datum/db_record/mainaccount = null
 

--- a/code/obj/machinery/cell_charger.dm
+++ b/code/obj/machinery/cell_charger.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/cell_charger)
+	mats = 8
+
 /obj/machinery/cell_charger
 	name = "cell charger"
 	desc = "A charging unit for power cells."
@@ -7,7 +10,6 @@
 	var/chargerate = 250 // power per tick
 	var/chargelevel = -1
 	anchored = 1
-	mats = 8
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	power_usage = 50
 

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -7,6 +7,9 @@
 
 #define MAX_FAILED_CLONE_TICKS 200 // vOv
 
+TYPEINFO(/obj/machinery/clonepod)
+	mats = list("MET-1"=35, "honey"=5)
+
 /obj/machinery/clonepod
 	anchored = 1
 	name = "cloning pod"
@@ -15,7 +18,6 @@
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_0_lowmeat"
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
-	mats = list("MET-1"=35, "honey"=5)
 	var/meat_used_per_tick = DEFAULT_MEAT_USED_PER_TICK
 	var/mob/living/occupant
 	var/heal_level = 10 //The clone is released once its health^W damage (maxHP - HP) reaches this level.
@@ -832,6 +834,9 @@
 	*/
 
 //WHAT DO YOU WANT FROM ME(AT)
+TYPEINFO(/obj/machinery/clonegrinder)
+	mats = 10
+
 /obj/machinery/clonegrinder
 	name = "enzymatic reclaimer"
 	desc = "A tank resembling a rather large blender, designed to recover biomatter for use in cloning."
@@ -839,7 +844,6 @@
 	icon_state = "grinder0"
 	anchored = 1
 	density = 1
-	mats = 10
 	var/list/pods = null // cloning pods we're tied to
 	var/id = null // if this isn't null, we'll only look for pods with this ID
 	var/pod_range = 4 // if we don't have an ID, we look for pods in orange(this value)

--- a/code/obj/machinery/computer/arcade.dm
+++ b/code/obj/machinery/computer/arcade.dm
@@ -2,11 +2,13 @@
  *	Arcade -- An arcade cabinet.
  */
 
+TYPEINFO(/obj/machinery/computer/arcade)
+	mats = 10
+
 /obj/machinery/computer/arcade
 	name = "arcade machine"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "arcade"
-	mats = 10
 	deconstruct_flags = DECON_MULTITOOL
 	circuit_type = /obj/item/circuitboard/arcade
 	var/enemy_name = "Space Villian"

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -14,6 +14,9 @@
 //	weight = 1.0E8
 
 ABSTRACT_TYPE(/obj/item/circuitboard)
+TYPEINFO(/obj/item/circuitboard)
+	mats = 6
+
 /obj/item/circuitboard
 	density = 0
 	anchored = 0
@@ -28,7 +31,6 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 	var/computertype = null
 	var/powernet = null
 	var/list/records = null
-	mats = 6
 
 	New()
 		. = ..()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -418,13 +418,15 @@ proc/find_ghost_by_key(var/find_key)
 #define PROCESS_STRIP 1
 #define PROCESS_MINCE 2
 
+TYPEINFO(/obj/machinery/clone_scanner)
+	mats = 15
+
 /obj/machinery/clone_scanner
 	name = "cloning machine scanner"
 	desc = "A machine that you stuff living, and freshly not-so-living people into in order to scan them for cloning"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "scanner_0"
 	density = 1
-	mats = 15
 	var/locked = 0
 	var/mob/occupant = null
 	anchored = 1

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/deep_fryer)
+	mats = 20
+
 /obj/machinery/deep_fryer
 	name = "Deep Fryer"
 	desc = "An industrial deep fryer.  A big hit at state fairs!"
@@ -7,7 +10,6 @@
 	density = 1
 	flags = NOSPLASH
 	status = REQ_PHYSICAL_ACCESS
-	mats = 20
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 	var/atom/movable/fryitem = null
 	var/cooktime = 0

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -6,6 +6,9 @@
 #define TOTAL_O2_TANKS (o2tanks + length(inserted_o2))
 #define TOTAL_PL_TANKS (pltanks + length(inserted_pl))
 
+TYPEINFO(/obj/machinery/dispenser)
+	mats = 24
+
 /obj/machinery/dispenser
 	desc = "A storage device for gas tanks. Holds 10 plasma and 10 oxygen tanks."
 	name = "Tank Storage Unit"
@@ -16,7 +19,6 @@
 	var/o2tanks = 10
 	var/pltanks = 10
 	anchored = 1
-	mats = 24
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	//These keep track of tanks that people have inserted back into the machine (for shenanigans!)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -273,6 +273,9 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	visible = 0
 	operation_time = 10
 
+TYPEINFO(/obj/machinery/door/airlock/syndicate)
+	mats = 0
+
 /obj/machinery/door/airlock/syndicate // fuck our players for making us (or at least me) need this
 	name = "reinforced external airlock"
 	desc = "Looks pretty tough. I wouldn't take this door on in a fight."
@@ -283,13 +286,15 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	hardened = TRUE
 	aiControlDisabled = TRUE
 	object_flags = BOTS_DIRBLOCK
-	mats = 0
 
 /obj/machinery/door/airlock/syndicate/meteorhit()
 	return
 
 /obj/machinery/door/airlock/syndicate/ex_act()
 	return
+
+TYPEINFO(/obj/machinery/door/airlock/centcom)
+	mats = 0
 
 /obj/machinery/door/airlock/centcom
 	icon = 'icons/obj/doors/Doorcom.dmi'
@@ -299,7 +304,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	hardened = TRUE
 	aiControlDisabled = TRUE
 	object_flags = BOTS_DIRBLOCK
-	mats = 0
 
 /obj/machinery/door/airlock/centcom/meteorhit()
 	return
@@ -356,6 +360,9 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	health = 800
 	health_max = 800
 
+TYPEINFO(/obj/machinery/door/airlock/pyro/command/centcom)
+	mats = 0
+
 /obj/machinery/door/airlock/pyro/command/centcom
 	req_access_txt = "57"
 	cant_emag = TRUE
@@ -363,7 +370,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	hardened = TRUE
 	aiControlDisabled = TRUE
 	object_flags = BOTS_DIRBLOCK
-	mats = 0
 
 /obj/machinery/door/airlock/pyro/command/alt
 	icon_state = "com2_closed"
@@ -372,9 +378,11 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	welded_icon_state = "2_welded"
 	req_access = null
 
+TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
+	mats = 0
+
 /obj/machinery/door/airlock/pyro/command/syndicate
 	req_access = list(access_syndicate_commander)
-	mats = 0
 
 /obj/machinery/door/airlock/pyro/weapons
 	icon_state = "manta_closed"
@@ -479,6 +487,9 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	visible = 0
 	operation_time = 10
 
+TYPEINFO(/obj/machinery/door/airlock/pyro/reinforced)
+	mats = 0
+
 /obj/machinery/door/airlock/pyro/reinforced
 	name = "reinforced external airlock"
 	desc = "Looks pretty tough. I wouldn't take this door on in a fight."
@@ -491,7 +502,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	cant_emag = TRUE
 	hardened = TRUE
 	aiControlDisabled = TRUE
-	mats = 0
 
 /obj/machinery/door/airlock/pyro/reinforced/meteorhit()
 	return
@@ -519,6 +529,9 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	opacity = 0
 	visible = 0
 
+TYPEINFO(/obj/machinery/door/airlock/pyro/glass/reinforced)
+	mats = 0
+
 /obj/machinery/door/airlock/pyro/glass/reinforced
 	name = "reinforced glass airlock"
 	desc = "Looks pretty tough. I wouldn't take this door on in a fight."
@@ -526,7 +539,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	cant_emag = TRUE
 	hardened = TRUE
 	aiControlDisabled = TRUE
-	mats = 0
 
 /obj/machinery/door/airlock/pyro/glass/reinforced/meteorhit()
 	return
@@ -1711,13 +1723,15 @@ About the new airlock wires panel:
 		..()
 	return
 
+TYPEINFO(/obj/machinery/door/airlock)
+	mats = 18
+
 // This code allows for airlocks to be controlled externally by setting an id_tag and comm frequency (disables ID access)
-obj/machinery/door/airlock
+/obj/machinery/door/airlock
 	var/id_tag
 	var/frequency = FREQ_AIRLOCK
 	var/last_update_time = 0
 	var/last_radio_login = 0
-	mats = 18
 
 
 	receive_signal(datum/signal/signal)

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -26,6 +26,9 @@
 		#endif
 		break
 
+TYPEINFO(/obj/machinery/door/firedoor)
+	mats = 30 // maybe a bit high??
+
 /obj/machinery/door/firedoor
 	name = "Firelock"
 	desc = "Thick, fire-proof doors that prevent the spread of fire, they can only be pried open unless the fire alarm is cleared."
@@ -40,7 +43,6 @@
 	var/welded_icon_state = "welded"
 	has_crush = FALSE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_DESTRUCT
-	mats = 30 // maybe a bit high??
 	health = 200
 	health_max = 200
 /obj/machinery/door/firedoor/xmasify()

--- a/code/obj/machinery/drone_factory.dm
+++ b/code/obj/machinery/drone_factory.dm
@@ -2,6 +2,9 @@
 /*-=-=-=-=-=-=-=-=-=-=-=-=-GHOST-DRONE-=-=-=-=-=-=-=-=-=-=-=-=-*/
 /* '~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~'-._.-'~' */
 
+TYPEINFO(/obj/machinery/ghost_catcher)
+	mats = 0
+
 /obj/machinery/ghost_catcher
 	name = "ghost catcher"
 	desc = "It catches ghosts! Read the name gosh I shouldn't have to explain everything to you."
@@ -9,7 +12,6 @@
 	density = 1
 	icon = 'icons/mob/ghost_drone.dmi'
 	icon_state = "ghostcatcher0"
-	mats = 0
 	//var/id = "ghostdrone"
 	event_handler_flags = USE_FLUID_ENTER
 
@@ -120,6 +122,9 @@ var/global/last_ghostdrone_build_time = 0
 var/global/list/available_ghostdrones = list()
 var/global/list/ghostdrone_candidates = list()
 
+TYPEINFO(/obj/machinery/ghostdrone_factory)
+	mats = 0
+
 /obj/machinery/ghostdrone_factory
 	name = "drone factory"
 	desc = "A slightly mysterious looking factory that spits out weird looking drones every so often. Why not."
@@ -129,7 +134,6 @@ var/global/list/ghostdrone_candidates = list()
 	icon_state = "factory10"
 	pass_unstable = TRUE
 	layer = 5 // above mobs hopefully
-	mats = 0
 	var/factory_section = 1 // can be 1 to 3
 	var/id = "ghostdrone" // the belts through the factory should be set to the same as the factory pieces so they can control them
 	var/obj/item/ghostdrone_assembly/current_assembly = null
@@ -314,12 +318,14 @@ var/global/list/ghostdrone_candidates = list()
 	icon_state = "factory30"
 	factory_section = 3
 
+TYPEINFO(/obj/item/ghostdrone_assembly)
+	mats = 0
+
 /obj/item/ghostdrone_assembly
 	name = "drone assembly"
 	desc = "an incomplete floaty robot"
 	icon = 'icons/mob/ghost_drone.dmi'
 	icon_state = "drone-stage1"
-	mats = 0
 	var/stage = 1
 
 	New()
@@ -331,6 +337,9 @@ var/global/list/ghostdrone_candidates = list()
 			ghostdrone_factory_working = null
 		..()
 
+TYPEINFO(/obj/machinery/ghostdrone_conveyor_sensor)
+	mats = 0
+
 /obj/machinery/ghostdrone_conveyor_sensor
 	name = "conveyor sensor"
 	desc = "A small sensor that pauses the conveyors it's attached to until it receives a signal to start them again."
@@ -338,7 +347,6 @@ var/global/list/ghostdrone_candidates = list()
 	density = 0
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "stopper1"
-	mats = 0
 	var/id_belt = "ghostdrone_lower"
 	var/id_recharger = "ghostdrone"
 	var/list/obj/machinery/conveyor/conveyors = list()

--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -1,4 +1,7 @@
 
+TYPEINFO(/obj/machinery/drone_recharger)
+	mats = 10
+
 /obj/machinery/drone_recharger
 	name = "Drone Recharger"
 	icon = 'icons/obj/large/32x64.dmi'
@@ -6,7 +9,6 @@
 	icon_state = "drone-charger-idle"
 	density = 0
 	anchored = 1
-	mats = 10
 	power_usage = 50
 	machine_registry_idx = MACHINES_DRONERECHARGERS
 	var/chargerate = 400
@@ -142,9 +144,11 @@
 	attackby(obj/item/W, mob/user)
 
 
+TYPEINFO(/obj/machinery/drone_recharger/factory)
+	mats = 0
+
 /obj/machinery/drone_recharger/factory
 	var/id = "ghostdrone"
-	mats = 0
 	event_handler_flags = USE_FLUID_ENTER
 
 	Crossed(atom/movable/AM as mob|obj)

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -1,7 +1,10 @@
 /* ==================================================== */
 /* --------------------- Machine ---------------------- */
 /* ==================================================== */
-/obj/machinery/espresso_machine/
+TYPEINFO(/obj/machinery/espresso_machine)
+	mats = 30
+
+/obj/machinery/espresso_machine
 	name = "espresso machine"
 	desc = "It's top of the line NanoTrasen espresso technology! Featuring 100% Organic Locally-Grown espresso beans!" //haha no
 	icon = 'icons/obj/foodNdrink/espresso.dmi'
@@ -10,7 +13,6 @@
 	anchored = 1
 	flags = FPRINT | NOSPLASH | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL
-	mats = 30
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	var/cupslimit = 2
 	var/cupsinside = 0
@@ -182,6 +184,9 @@
 /* ===================================================== */
 //Sorry for budging in here, whoever made the espresso machine. Lets just rename this to coffee.dm?
 
+TYPEINFO(/obj/machinery/coffeemaker)
+	mats = 30
+
 /obj/machinery/coffeemaker
 	name = "coffeemaker"
 	desc = "It's top of the line NanoTrasen espresso technology! Featuring 100% Organic Locally-Grown espresso beans!" //haha no
@@ -190,7 +195,6 @@
 	density = 1
 	anchored = 1
 	flags = FPRINT | NOSPLASH
-	mats = 30
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	var/carafe_name = "coffee carafe"
 	var/image/image_top = null

--- a/code/obj/machinery/gibber.dm
+++ b/code/obj/machinery/gibber.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/gibber)
+	mats = 15
+
 /obj/machinery/gibber
 	name = "Gibber"
 	desc = "The name isn't descriptive enough?"
@@ -14,7 +17,6 @@
 	var/machine_startup_sound = 'sound/machines/tractorrev.ogg'
 	var/machine_shutdown_sound = 'sound/machines/tractor_running3.ogg'
 	var/rotor_sound = 'sound/machines/lavamoon_rotors_fast_short.ogg'
-	mats = 15
 	deconstruct_flags =  DECON_WRENCH | DECON_WELDER
 
 	output_north

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -40,6 +40,9 @@
 
 		src.product_cost = cost
 
+TYPEINFO(/obj/machinery/glass_recycler)
+	mats = 10
+
 /obj/machinery/glass_recycler
 	name = "glass recycler"//"Kitchenware Recycler"
 	desc = "A machine that recycles glass shards into drinking glasses, beakers, or other glass things."
@@ -49,7 +52,6 @@
 	density = 0
 	var/glass_amt = 0
 	var/list/product_list = list()
-	mats = 10
 	flags = NOSPLASH | FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL
 

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -277,6 +277,9 @@
 //interdictor board: power management circuitry and whatnot
 //included in the assembly kit alongside frame
 
+TYPEINFO(/obj/item/interdictor_board)
+	mats = 6
+
 /obj/item/interdictor_board
 	name = "spatial interdictor mainboard"
 	desc = "A custom-fabricated circuit board with a cutting-edge miniaturized retro-encabulator."
@@ -284,7 +287,6 @@
 	icon_state = "interdict-board"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "electronic"
-	mats = 6
 	health = 6
 	w_class = W_CLASS_TINY
 	flags = FPRINT | TABLEPASS | CONDUCT

--- a/code/obj/machinery/lightswitch.dm
+++ b/code/obj/machinery/lightswitch.dm
@@ -2,6 +2,9 @@
 // can have multiple per area
 // can also operate on non-loc area through "otherarea" var
 
+TYPEINFO(/obj/machinery/light_switch)
+	mats = list("MET-1"=10,"CON-1"=15)
+
 /obj/machinery/light_switch
 	desc = "A light switch"
 	name = null
@@ -14,7 +17,6 @@
 	var/area/area = null
 	var/otherarea = null
 	//	luminosity = 1
-	mats = list("MET-1"=10,"CON-1"=15)
 	var/datum/light/light
 
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -6,6 +6,9 @@
 #define MAX_SPEED 3
 #define MAX_SPEED_HACKED 5
 
+TYPEINFO(/obj/machinery/manufacturer)
+	mats = 20
+
 /obj/machinery/manufacturer
 	name = "manufacturing unit"
 	desc = "A 3D printer-like machine that can construct items from raw materials."
@@ -14,7 +17,6 @@
 	var/icon_base = "general" //! This is used to make icon state changes cleaner by setting it to "fab-[icon_base]"
 	density = TRUE
 	anchored = TRUE
-	mats = 20
 	power_usage = 200
 	// req_access is used to lock out specific featurs and not limit deconstruciton therefore DECON_NO_ACCESS is required
 	req_access = list(access_heads)

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -8,6 +8,9 @@
 #define MW_STATE_BROKEN_1 1
 #define MW_STATE_BROKEN_2 2
 
+TYPEINFO(/obj/machinery/microwave)
+	mats = 12
+
 /obj/machinery/microwave
 	name = "Microwave"
 	icon = 'icons/obj/kitchen.dmi'
@@ -49,7 +52,6 @@
 	var/obj/item/reagent_containers/food/snacks/being_cooked = null
 	/// Single non food item that can be added to the microwave
 	var/obj/item/extra_item
-	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/emagged = FALSE
 
@@ -176,7 +178,7 @@ obj/machinery/microwave/attackby(var/obj/item/O, var/mob/user)
 				O.set_loc(src)
 				src.visible_message("<span class='notice'>[user] adds [O] to the microwave.</span>")
 			else
-				boutput(user, "[O] is too large and bulky to be microwaved.") 
+				boutput(user, "[O] is too large and bulky to be microwaved.")
 		else
 			boutput(user, "There already seems to be an unusual item inside, so you don't add this one too.") //Let them know it failed for a reason though
 

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -1,6 +1,9 @@
 // Navigation beacon for AI robots
 // Functions as a transponder: looks for incoming signal matching
 
+TYPEINFO(/obj/machinery/navbeacon)
+	mats = 4
+
 /obj/machinery/navbeacon
 
 	icon = 'icons/obj/objects.dmi'
@@ -23,7 +26,6 @@
 
 	req_access = list(access_engineering,access_engineering_mechanic,access_research_director)
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
-	mats = 4
 	mechanics_type_override = /obj/machinery/navbeacon
 
 	New()
@@ -339,6 +341,9 @@ Transponder Codes:<UL>"}
 		get_radio_connection_by_id(src, "navbeacon").update_frequency(freq)
 
 //Wired nav device
+TYPEINFO(/obj/machinery/wirenav)
+	mats = 8
+
 /obj/machinery/wirenav
 	name = "Wired Nav Beacon"
 	icon = 'icons/obj/objects.dmi'
@@ -346,7 +351,6 @@ Transponder Codes:<UL>"}
 	level = 1		// underfloor
 	layer = OBJ_LAYER
 	anchored = 1
-	mats = 8
 	var/nav_tag = null
 	var/net_id = null
 	var/obj/machinery/power/data_terminal/link = null

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/optable)
+	mats = 25
+
 /obj/machinery/optable
 	name = "Operating Table"
 	icon = 'icons/obj/surgery.dmi'
@@ -6,7 +9,6 @@
 	desc = "A table that allows qualified professionals to perform delicate surgeries."
 	density = 1
 	anchored = 1
-	mats = 25
 	event_handler_flags = USE_FLUID_ENTER
 	var/mob/living/carbon/human/victim = null
 	var/strapped = 0

--- a/code/obj/machinery/partyalarm.dm
+++ b/code/obj/machinery/partyalarm.dm
@@ -2,6 +2,9 @@
 // Party alarm
 //
 
+TYPEINFO(/obj/machinery/partyalarm)
+	mats = 0
+
 /obj/machinery/partyalarm
 	name = "Party Button"
 	icon = 'icons/obj/monitors.dmi'
@@ -14,7 +17,6 @@
 	var/duration = 60//admemes
 	var/list/lights = list()
 	anchored = 1
-	mats = 0
 
 /obj/machinery/partyalarm/process()
 	if (timing > 0)

--- a/code/obj/machinery/phone.dm
+++ b/code/obj/machinery/phone.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/phone)
+	mats = 25
+
 /obj/machinery/phone
 	name = "phone"
 	icon = 'icons/obj/machines/phones.dmi'
@@ -5,7 +8,6 @@
 	icon_state = "phone"
 	anchored = 1
 	density = 0
-	mats = 25
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	_health = 25
 	color = null
@@ -347,6 +349,9 @@
 		..(user)
 		holder = user
 
+TYPEINFO(/obj/machinery/phone/wall)
+	mats = 25
+
 /obj/machinery/phone/wall
 	name = "wall phone"
 	icon = 'icons/obj/machines/phones.dmi'
@@ -354,7 +359,6 @@
 	icon_state = "wallphone"
 	anchored = 1
 	density = 0
-	mats = 25
 	_health = 50
 	phoneicon = "wallphone"
 	ringingicon = "wallphone_ringing"
@@ -401,9 +405,11 @@
 /obj/machinery/radio_antenna/large
 	range = 40
 
+TYPEINFO(/obj/item/phone/cellphone)
+	mats = 25
+
 /obj/item/phone/cellphone
 	icon_state = "cellphone"
-	mats = 25
 	_health = 20
 	var/can_talk_across_z_levels = 0
 	var/phone_id = null

--- a/code/obj/machinery/phone/cellphone.dm
+++ b/code/obj/machinery/phone/cellphone.dm
@@ -1,7 +1,9 @@
 
+TYPEINFO(/obj/item/machinery/phone/cellphone)
+	mats = 25
+
 /obj/item/machinery/phone/cellphone
 	icon_state = "cellphone"
-	mats = 25
 	_health = 20
 	var/phone_id = null
 	var/ringmode = 0 // 0 for silent, 1 for vibrate, 2 for ring (For future use)

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/phone)
+	mats = 25
+
 /obj/machinery/phone
 	name = "phone"
 	icon = 'icons/obj/machines/phones.dmi'
@@ -5,7 +8,6 @@
 	icon_state = "phone"
 	anchored = 1
 	density = 0
-	mats = 25
 	_health = 50
 	var/can_talk_across_z_levels = 0
 	var/phone_id = null
@@ -339,6 +341,9 @@
 
 
 
+TYPEINFO(/obj/machinery/phone/wall)
+	mats = 25
+
 /obj/machinery/phone/wall
 	name = "phone"
 	icon = 'icons/obj/machines/phones.dmi'
@@ -346,7 +351,6 @@
 	icon_state = "wallphone"
 	anchored = 1
 	density = 0
-	mats = 25
 	_health = 50
 	phoneicon = "wallphone"
 	ringingicon = "wallphone_ringing"

--- a/code/obj/machinery/photocopier.dm
+++ b/code/obj/machinery/photocopier.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/photocopier)
+	mats = 16 //just to make photocopiers mech copyable, how could this possibly go wrong?
+
 /obj/machinery/photocopier
 	name = "photocopier"
 	desc = "This machine uses paper to copy photos, work documents... anything paper-based, really. "
@@ -6,7 +9,6 @@
 	icon = 'icons/obj/machines/photocopier.dmi'
 	icon_state = "close_sesame"
 	pixel_x = 2 //its just a bit limited by sprite width, needs a small offset
-	mats = 16 //just to make photocopiers mech copyable, how could this possibly go wrong?
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/use_state = 0 //0 is closed, 1 is open, 2 is busy, closed by default
 	var/paper_amount = 0.0 //starts at 0.0, increments by one for every paper added, max of... 30 sheets

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -1,4 +1,7 @@
 
+TYPEINFO(/obj/machinery/disposal_pipedispenser)
+	mats = 16
+
 /obj/machinery/disposal_pipedispenser
 	name = "Disposal Pipe Dispenser"
 	desc = "A clunky, old machine that dispenses unanchored disposal pipes one at a time."
@@ -6,7 +9,6 @@
 	icon_state = "pipe-fab"
 	density = 1
 	anchored = 1
-	mats = 16
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 
 /obj/machinery/disposal_pipedispenser/attack_hand(mob/user)
@@ -53,12 +55,14 @@
 		src.remove_dialog(usr)
 	return
 
+TYPEINFO(/obj/machinery/disposal_pipedispenser/mobile)
+	mats = 16
+
 /obj/machinery/disposal_pipedispenser/mobile
 	name = "Disposal Pipe Dispenser Cart"
 	desc = "A tool for removing some of the tedium from pipe-laying."
 	anchored = 0
 	icon_state = "fab-mobile"
-	mats = 16
 	var/laying_pipe = 0
 	var/removing_pipe = 0
 	var/prev_dir = 0

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -85,11 +85,13 @@
 				return ..()
 		..()
 
+TYPEINFO(/obj/machinery/plantpot/bareplant)
+	mats = 0
+
 /obj/machinery/plantpot/bareplant
 	name = "arable soil"
 	desc = "A small mound of arable soil for planting and plant based activities."
 	anchored = 1
-	mats = 0
 	deconstruct_flags = 0
 	icon_state = null
 	power_usage = 0
@@ -198,6 +200,9 @@
 			..()
 
 
+TYPEINFO(/obj/machinery/plantpot)
+	mats = 2
+
 /obj/machinery/plantpot
 	// The central object for Hydroponics. All plant growing and most of everything goes on in
 	// this object - that said you don't want to have too many of them on the map because they
@@ -208,7 +213,6 @@
 	icon_state = "tray"
 	anchored = 0
 	density = 1
-	mats = 2
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	flags = NOSPLASH|ACCEPTS_MOUSEDROP_REAGENTS
 	processing_tier = PROCESSING_SIXTEENTH
@@ -1817,6 +1821,9 @@ proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 // Machines created specifically to interact with plantpots, kind of abandoned experimental
 // shit for the time being for the most part.
 
+TYPEINFO(/obj/machinery/hydro_growlamp)
+	mats = 6
+
 /obj/machinery/hydro_growlamp
 	name = "\improper UV Grow Lamp"
 	desc = "A special lamp that emits ultraviolet light to help plants grow quicker."
@@ -1824,7 +1831,6 @@ proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 	icon_state = "growlamp0" // sprites by Clarks
 	density = 1
 	anchored = 0
-	mats = 6
 	var/active = 0
 	var/datum/light/light
 	power_usage = 100
@@ -1882,6 +1888,9 @@ proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			src.anchored = !src.anchored
 
+TYPEINFO(/obj/machinery/hydro_mister)
+	mats = 6
+
 /obj/machinery/hydro_mister
 	name = "\improper Botanical Mister"
 	desc = "A device that constantly sprays small amounts of chemical onto nearby plants."
@@ -1889,7 +1898,6 @@ proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 	icon_state = "fogmachine0"
 	density = 1
 	anchored = 0
-	mats = 6
 	var/active = 0
 	var/mode = 1
 

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -11,6 +11,9 @@
 var/global/list/portable_machinery = list() // stop looping through world for things you SHITMONGERS
 
 // Adapted from the PDA program in portable_machinery_control.dm (Convair880).
+TYPEINFO(/obj/item/remote/porter)
+	mats = 4
+
 /obj/item/remote/porter
 	name = "Remote"
 	icon = 'icons/obj/items/device.dmi'
@@ -20,7 +23,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	density = 0
 	anchored = 0
 	w_class = W_CLASS_SMALL
-	mats = 4
 	var/list/machinerylist = list()
 	var/machinery_name = "" // For user prompt stuff.
 	var/anti_spam = 0 // In relation to world time.
@@ -221,6 +223,9 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		return
 
 // I suppose this device would be sorta useless with tele-block checks?
+TYPEINFO(/obj/item/remote/porter/port_a_sci)
+	mats = list("MET-1" = 5, "CON-1" = 5, "telecrystal" = 10)
+
 /obj/item/remote/porter/port_a_sci
 	name = "Port-A-Sci Remote"
 	icon = 'icons/obj/porters.dmi'
@@ -228,7 +233,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	item_state = "electronic"
 	desc = "A remote that summons a Port-A-Sci."
 	machinery_name = "Port-a-Sci"
-	mats = list("MET-1" = 5, "CON-1" = 5, "telecrystal" = 10)
 
 	get_machinery()
 		if (!src)
@@ -290,6 +294,9 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 ///////////////////////////////////// Port-a-Brig /////////////////////////////////////
 
+TYPEINFO(/obj/machinery/port_a_brig)
+	mats = 30
+
 /obj/machinery/port_a_brig
 	name = "Port-A-Brig"
 	icon = 'icons/obj/cloning.dmi'
@@ -300,7 +307,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	p_class = 1.8
 	req_access = list(access_security)
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
-	mats = 30
 	var/mob/occupant = null
 	var/locked = 0
 	var/homeloc = null
@@ -520,6 +526,9 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 ////////////////////////////////////////// Port-a-Medbay /////////////////////////////////////
 /* replaced with an actual sleeper, see sleeper.dm
+TYPEINFO(/obj/machinery/port_a_medbay)
+	mats = 30
+
 /obj/machinery/port_a_medbay
 	name = "Port-A-Medbay"
 	icon = 'icons/obj/porters.dmi'
@@ -529,7 +538,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	density = 1
 	anchored = 0
 	p_class = 1.2
-	mats = 30
 	event_handler_flags = USE_FLUID_ENTER
 	var/mob/occupant = null
 	var/homeloc = null
@@ -827,6 +835,9 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 //////////////////////////////////////// Port-a-NanoMed ///////////////////////////////////////////
 
+TYPEINFO(/obj/machinery/vending/port_a_nanomed)
+	mats = null
+
 /obj/machinery/vending/port_a_nanomed
 	name = "Port-A-NanoMed"
 	desc = "A compact and portable version of the NanoMed Plus."
@@ -839,7 +850,6 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	anchored = 0
 	p_class = 1.2
 	can_fall = 0
-	mats = null
 	ai_control_enabled = 1
 	var/homeloc = null
 

--- a/code/obj/machinery/recharger.dm
+++ b/code/obj/machinery/recharger.dm
@@ -21,12 +21,14 @@
 	3) Done.
 */
 
-obj/machinery/recharger
+TYPEINFO(/obj/machinery/recharger)
+	mats = 16
+
+/obj/machinery/recharger
 	anchored = 1
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "recharger0"
 	name = "recharger"
-	mats = 16
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_MULTITOOL
 	desc = "An anchored minature recharging device, used to recharge small, hand-held objects that don't require much electrical charge."
 	power_usage = 50

--- a/code/obj/machinery/robot_fabricator.dm
+++ b/code/obj/machinery/robot_fabricator.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/robotic_fabricator)
+	mats = 20
+
 /obj/machinery/robotic_fabricator
 	name = "Robotic Fabricator"
 	desc = "A machine that produces various objects for robotics from raw material."
@@ -8,7 +11,6 @@
 	var/metal_amount = 0
 	var/operating = 0
 	var/obj/item/parts/robot_parts/being_built = null
-	mats = 20
 
 /obj/machinery/robotic_fabricator/attackby(var/obj/item/O, var/mob/user)
 	if (istype(O, /obj/item/sheet/metal))

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/secscanner)
+	mats = 18
+
 /obj/machinery/secscanner
 	name = "security scanner"
 	desc = "The latest innovation in invasive imagery, the programmable NT-X100 will scan anyone who walks through it with fans to simulate being patted down. <em>Nanotrasen is not to be held responsible for any deaths caused by the results the machine gives, or the machine itself.</em>"
@@ -7,7 +10,6 @@
 	opacity = 0
 	anchored = 1
 	layer = 2
-	mats = 18
 	deconstruct_flags = DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	appearance_flags = TILE_BOUND | PIXEL_SCALE
 	var/timeBetweenUses = 20//I can see this being fun

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -7,13 +7,15 @@
 var/global/shipAlertState = SHIP_ALERT_GOOD
 var/global/soundGeneralQuarters = sound('sound/machines/siren_generalquarters_quiet.ogg')
 
+TYPEINFO(/obj/machinery/shipalert)
+	mats = 5
+
 /obj/machinery/shipalert
 	name = "Ship Alert Button"
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "shipalert0"
 	desc = ""
 	anchored = 1
-	mats = 5
 	var/usageState = 0 // 0 = glass cover, hammer. 1 = glass cover, no hammer. 2 = cover smashed
 	var/working = 0 //processing loops
 	var/lastActivated = 0

--- a/code/obj/machinery/shitty_grill.dm
+++ b/code/obj/machinery/shitty_grill.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/shitty_grill)
+	mats = 20
+
 /obj/machinery/shitty_grill
 	name = "shitty grill"
 	desc = "Is that a space heater? That doesn't look safe at all!"
@@ -6,7 +9,6 @@
 	anchored = 0
 	density = 1
 	flags = NOSPLASH
-	mats = 20
 	var/obj/item/grillitem = null
 	var/cooktime = 0
 	var/grilltemp_target = 250 + T0C // lets get it warm enough to cook

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -26,14 +26,16 @@ Contains:
 // I'm sorry
 //////////////////////////////////////////////////// Singularity generator /////////////////////
 
-/obj/machinery/the_singularitygen/
+TYPEINFO(/obj/machinery/the_singularitygen)
+	mats = 250
+
+/obj/machinery/the_singularitygen
 	name = "Gravitational Singularity Generator"
 	desc = "An Odd Device which produces a Black Hole when set up."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "TheSingGen"
 	anchored = 0 // so it can be moved around out of crates
 	density = 1
-	mats = 250
 	var/bhole = 0 // it is time. we can trust people to use the singularity For Good - cirr
 
 /obj/machinery/the_singularitygen/process()
@@ -451,6 +453,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 //////////////////////////////////////// Field generator /////////////////////////////////////////
 
+TYPEINFO(/obj/machinery/field_generator)
+	mats = 14
+
 /obj/machinery/field_generator
 	name = "Field Generator"
 	desc = "Projects an energy field when active"
@@ -474,7 +479,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	//Remote control stuff
 	var/net_id = null
 	var/obj/machinery/power/data_terminal/link = null
-	mats = 14
 	var/active_dirs = 0
 	var/shortestlink = 0
 
@@ -945,6 +949,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		shock(AM)
 
 /////////////////////////////////////////// Emitter ///////////////////////////////
+TYPEINFO(/obj/machinery/emitter)
+	mats = 10
+
 /obj/machinery/emitter
 	name = "Emitter"
 	desc = "Shoots a high power laser when active"
@@ -966,7 +973,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/net_id = null
 	var/obj/machinery/power/data_terminal/link = null
 	var/datum/projectile/current_projectile = new/datum/projectile/laser/heavy
-	mats = 10
 
 /obj/machinery/emitter/New()
 	..()
@@ -1225,6 +1231,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	secured = 2
 	icon_state = "dbox"
 
+TYPEINFO(/obj/machinery/power/collector_array)
+	mats = 20
+
 /obj/machinery/power/collector_array
 	name = "Radiation Collector Array"
 	desc = "A device which uses Hawking Radiation and plasma to produce power."
@@ -1238,7 +1247,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/obj/item/tank/plasma/P = null
 	var/obj/machinery/power/collector_control/CU = null
 	deconstruct_flags = DECON_WELDER | DECON_MULTITOOL | DECON_CROWBAR | DECON_WRENCH
-	mats = 20
 
 /obj/machinery/power/collector_array/New()
 	..()
@@ -1344,6 +1352,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	secured = 2
 	icon_state = "dbox"
 
+TYPEINFO(/obj/machinery/power/collector_control)
+	mats = 25
+
 /obj/machinery/power/collector_control
 	name = "Radiation Collector Control"
 	desc = "A device which uses Hawking Radiation and Plasma to produce power."
@@ -1369,7 +1380,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/obj/machinery/power/collector_array/CAW = null
 	var/list/obj/machinery/the_singularity/S = null
 	deconstruct_flags = DECON_WELDER | DECON_MULTITOOL | DECON_CROWBAR | DECON_WRENCH
-	mats = 25
 
 /obj/machinery/power/collector_control/New()
 	..()
@@ -1552,7 +1562,10 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 ///////////////////////////////////////// Singularity bomb /////////////////////////////
 
 // Thing thing had zero logging despite being overhauled recently. I corrected that oversight (Convair880).
-/obj/machinery/the_singularitybomb/
+TYPEINFO(/obj/machinery/the_singularitybomb)
+	mats = 14
+
+/obj/machinery/the_singularitybomb
 	name = "\improper Singularity Bomb"
 	desc = "A WMD that creates a singularity."
 	icon = 'icons/obj/power.dmi'
@@ -1565,7 +1578,6 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/last_tick = null
 	var/mob/activator = null // For logging purposes.
 	is_syndicate = 1
-	mats = 14
 	var/bhole = 1
 
 /obj/machinery/the_singularitybomb/attackby(obj/item/W, mob/user)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -12,6 +12,9 @@
 
 //////////////////////////////////////// Sleeper control console //////////////////////////////
 
+TYPEINFO(/obj/machinery/sleep_console)
+	mats = 8
+
 /obj/machinery/sleep_console
 	name = "sleeper console"
 	desc = "A device that displays the vital signs of the occupant of the sleeper, and can dispense chemicals."
@@ -19,7 +22,6 @@
 	icon_state = "sleeperconsole"
 	anchored = 1
 	density = 1
-	mats = 8
 	deconstruct_flags = DECON_CROWBAR | DECON_MULTITOOL
 	var/timing = 0 // Timer running?
 	var/time = null // In 1/10th seconds.
@@ -229,6 +231,9 @@
 
 ////////////////////////////////////////////// Sleeper ////////////////////////////////////////
 
+TYPEINFO(/obj/machinery/sleeper)
+	mats = 25
+
 /obj/machinery/sleeper
 	name = "sleeper"
 	icon = 'icons/obj/Cryogenic2.dmi'
@@ -236,7 +241,6 @@
 	desc = "An enterable machine that analyzes and stabilizes the vital signs of the occupant."
 	density = 1
 	anchored = 1
-	mats = 25
 	deconstruct_flags = DECON_CROWBAR | DECON_WIRECUTTERS | DECON_MULTITOOL
 	event_handler_flags = USE_FLUID_ENTER
 	var/mob/occupant = null
@@ -665,12 +669,14 @@
 
 		return
 
+TYPEINFO(/obj/machinery/sleeper/port_a_medbay)
+	mats = 30
+
 /obj/machinery/sleeper/port_a_medbay
 	name = "Port-A-Medbay"
 	desc = "A transportation and stabilization device for critically injured patients."
 	icon = 'icons/obj/porters.dmi'
 	anchored = 0
-	mats = 30
 	p_class = 1.2
 	var/homeloc = null
 	allow_self_service = 0

--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/machinery/space_heater)
+	mats = 8
+
 /obj/machinery/space_heater
 	anchored = 0
 	density = 1
@@ -13,7 +16,6 @@
 	var/set_temperature = 50		// in celcius, add T0C for kelvin
 	var/heating_power = 40000
 	var/cooling_power = -30000
-	mats = 8
 	deconstruct_flags = DECON_WRENCH | DECON_WELDER
 	flags = FPRINT
 
@@ -256,6 +258,9 @@
 		if(Obj == src.cell)
 			src.cell = null
 
+TYPEINFO(/obj/machinery/sauna_stove)
+	mats = 8
+
 /obj/machinery/sauna_stove
 	anchored = 0
 	density = 1
@@ -270,7 +275,6 @@
 	var/set_temperature = 50		// in celcius, add T0C for kelvin
 	var/heating_power = 40000
 	var/cooling_power = -30000
-	mats = 8
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	flags = FPRINT
 

--- a/code/obj/machinery/status_display.dm
+++ b/code/obj/machinery/status_display.dm
@@ -10,13 +10,15 @@
 // // And arbitrary messages set by comms computer
 
 #define MAX_LEN 5
+TYPEINFO(/obj/machinery/status_display)
+	mats = 14
+
 /obj/machinery/status_display
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
 	name = "status display"
 	anchored = 1
 	density = 0
-	mats = 14
 	plane = PLANE_NOSHADOW_ABOVE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/glow_in_dark_screen = TRUE
@@ -292,13 +294,15 @@
 	name = "mining display"
 	mode = 6
 
+TYPEINFO(/obj/machinery/ai_status_display)
+	mats = list("MET-1"=2, "CON-1"=6, "CRY-1"=6)
+
 /obj/machinery/ai_status_display
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "ai_frame"
 	name = "\improper AI display"
 	anchored = 1
 	density = 0
-	mats = list("MET-1"=2, "CON-1"=6, "CRY-1"=6)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 
 	machine_registry_idx = MACHINES_STATUSDISPLAYS

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1606,6 +1606,9 @@ obj/item/clothing/gloves/concussive
 			else
 				. = ..()
 
+TYPEINFO(/obj/item/mining_tool/drill)
+	mats = 4
+
 /obj/item/mining_tool/drill
 	name = "laser drill"
 	desc = "Safe mining tool that doesn't require recharging."
@@ -1615,7 +1618,6 @@ obj/item/clothing/gloves/concussive
 	item_state = "drill"
 	c_flags = ONBELT
 	force = 10
-	mats = 4
 	dig_strength = 2
 	hitsound_charged = 'sound/items/Welder.ogg'
 	hitsound_uncharged = 'sound/items/Welder.ogg'
@@ -1853,6 +1855,9 @@ obj/item/clothing/gloves/concussive
 /// Multiplier for power usage if the user is a silicon and the charge is coming from their internal cell
 #define SILICON_POWER_COST_MOD 10
 
+TYPEINFO(/obj/item/cargotele)
+	mats = 4
+
 /obj/item/cargotele
 	name = "cargo transporter"
 	desc = "A device for teleporting crated goods."
@@ -1870,7 +1875,6 @@ obj/item/clothing/gloves/concussive
 	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
 	c_flags = ONBELT
 
-	mats = 4
 
 	New()
 		. = ..()
@@ -2272,6 +2276,9 @@ obj/item/clothing/gloves/concussive
 
 var/global/datum/cargo_pad_manager/cargo_pad_manager
 
+TYPEINFO(/obj/submachine/cargopad)
+	mats = 10 //I don't see the harm in re-adding this. -ZeWaka
+
 /obj/submachine/cargopad
 	name = "Cargo Pad"
 	desc = "Used to receive objects transported by a cargo transporter."
@@ -2279,7 +2286,6 @@ var/global/datum/cargo_pad_manager/cargo_pad_manager
 	icon_state = "cargopad"
 	anchored = TRUE
 	plane = PLANE_FLOOR
-	mats = 10 //I don't see the harm in re-adding this. -ZeWaka
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/active = TRUE
 	var/group
@@ -2377,6 +2383,9 @@ var/global/datum/cargo_pad_manager/cargo_pad_manager
 
 // satchels -> obj/item/satchel.dm
 
+TYPEINFO(/obj/item/ore_scoop)
+	mats = 6
+
 /obj/item/ore_scoop
 	name = "ore scoop"
 	desc = "A device that sucks up ore into a satchel automatically. Just load in a satchel and walk over ore to scoop it up."
@@ -2385,7 +2394,6 @@ var/global/datum/cargo_pad_manager/cargo_pad_manager
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "buildpipe"
 	w_class = W_CLASS_SMALL
-	mats = 6
 	var/obj/item/satchel/mining/satchel = null
 
 	prepared

--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -9,6 +9,9 @@
 #define MAX_TIMING 0.5
 #define MAX_NOTE_INPUT 15360
 
+TYPEINFO(/obj/player_piano)
+	mats = 20
+
 /obj/player_piano //this is the big boy im pretty sure all this code is garbage
 	name = "player piano"
 	desc = "A piano that can take raw text and turn it into music! The future is now!"
@@ -16,7 +19,6 @@
 	icon_state = "player_piano"
 	density = 1
 	anchored = 1
-	mats = 20
 	var/timing = 0.5 //values from 0.25 to 0.5 please
 	var/items_claimed = 0 //set to 1 when items are claimed
 	var/is_looping = 0 //is the piano looping? 0 is no, 1 is yes, 2 is never more looping

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -384,12 +384,14 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals/posters.dmi', "wa
 	icon = 'icons/obj/decals/posters.dmi'
 	icon_state = "wall_poster_nt-rip2"
 
+TYPEINFO(/obj/submachine/poster_creator)
+	mats = 6
+
 /obj/submachine/poster_creator
 	name = "wanted poster station"
 	desc = "A machine that can design and print out wanted posters."
 	density = 1
 	anchored = 1
-	mats = 6
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "poster_printer"

--- a/code/obj/retribution/makeshift_signaller.dm
+++ b/code/obj/retribution/makeshift_signaller.dm
@@ -1,6 +1,9 @@
 #define MINUTES_TO_SWORD_LINK 30										//Feel free to tweak this number as you see fit. After all, my strong suit is originality, not balance.
 var/sword_summoned_before = false
 
+TYPEINFO(/obj/item/makeshift_signaller_frame)
+	mats = 4
+
 /obj/item/makeshift_signaller_frame
 	name = "makeshift signaller frame"
 	icon = 'icons/misc/retribution/makeshift_signaller.dmi'
@@ -13,7 +16,6 @@ var/sword_summoned_before = false
 	m_amt = 500
 	burn_type = 1
 	var/build_stage = 0
-	mats = 4
 	desc = "A disemboweled remote signaller, ready for further modifications."
 	stamina_damage = 0
 	stamina_cost = 0
@@ -60,6 +62,9 @@ var/sword_summoned_before = false
 			return
 		return
 
+TYPEINFO(/obj/item/makeshift_syndicate_signaller)
+	mats = 4
+
 /obj/item/makeshift_syndicate_signaller
 	name = "makeshift syndicate signaller"
 	icon = 'icons/misc/retribution/makeshift_signaller.dmi'
@@ -74,7 +79,6 @@ var/sword_summoned_before = false
 	var/was_emagged = false
 	var/is_exploding = false
 	is_syndicate = 1
-	mats = 4
 	desc = "This device has a menacing aura around it. It requires 8 nodes of metadata to properly send and encrypt it's signal."
 	contraband = 5
 

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -11,6 +11,9 @@
 */
 
 // -------------------grenades-------------
+TYPEINFO(/obj/item/old_grenade/sawfly)
+	mats = list("MET-2"=7, "CON-1"=7, "POW-1"=5)
+
 /obj/item/old_grenade/sawfly
 
 	name = "Compact sawfly"
@@ -25,7 +28,6 @@
 	is_dangerous = TRUE
 	is_syndicate = TRUE
 	issawfly = TRUE //used to tell the sawfly remote if it can or can't prime() the grenade
-	mats = list("MET-2"=7, "CON-1"=7, "POW-1"=5)
 	contraband = 2
 	overlays = null
 	state = 0

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -166,12 +166,14 @@ Shield and graivty well generators
 	anchored = 1
 
 
+TYPEINFO(/obj/gravity_well_generator)
+	mats = 14
+
 /obj/gravity_well_generator
 	name = "gravity well generator"
 	desc = "A complex piece of machinery that alters gravity."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gravgen-off"
-	mats = 14
 
 	density = 1
 	opacity = 0

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -58,6 +58,9 @@
 		else
 			src.UpdateOverlays(null, "fluid")
 
+TYPEINFO(/obj/stove)
+	mats = 18
+
 /obj/stove
 	name = "stove"
 	desc = "A perfectly ordinary kitchen stove; not that you'll be doing anything ordinary with it.<br>It seems this model doesn't have a built in igniter, so you'll have to light it manually."
@@ -65,7 +68,6 @@
 	icon_state = "stove0"
 	anchored = 1
 	density = 1
-	mats = 18
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	var/obj/item/soup_pot/pot
 	var/on = 0

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1039,6 +1039,9 @@
 /* -------------------- Wheelchairs -------------------- */
 /* ===================================================== */
 
+TYPEINFO(/obj/stool/chair/comfy/wheelchair)
+	mats = 15
+
 /obj/stool/chair/comfy/wheelchair
 	name = "wheelchair"
 	desc = "It's a chair that has wheels attached to it. Do I really have to explain this to you? Can you not figure this out on your own? Wheelchair. Wheel, chair. Chair that has wheels."
@@ -1052,7 +1055,6 @@
 	var/lying = 0 // didja get knocked over? fall down some stairs?
 	parts_type = /obj/item/furniture_parts/wheelchair
 	mat_appearances_to_ignore = list("steel")
-	mats = 15
 
 	New()
 		..()

--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -1,4 +1,7 @@
 
+TYPEINFO(/obj/item/storage/wall)
+	mats = 8
+
 /obj/item/storage/wall
 	name = "cabinet"
 	desc = "It's basically a big box attached to the wall."
@@ -10,7 +13,6 @@
 	w_class = W_CLASS_BULKY
 	anchored = 1
 	density = 0
-	mats = 8
 	deconstruct_flags = DECON_SIMPLE
 	burn_possible = FALSE
 	max_wclass = W_CLASS_BULKY

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/submachine/chef_sink)
+	mats = 12
+
 /obj/submachine/chef_sink
 	name = "kitchen sink"
 	desc = "A water-filled unit intended for cookery purposes."
@@ -5,7 +8,6 @@
 	icon_state = "sink"
 	anchored = 1
 	density = 1
-	mats = 12
 	deconstruct_flags = DECON_WRENCH | DECON_WELDER
 	flags = NOSPLASH
 
@@ -138,6 +140,9 @@
 		..()
 
 
+TYPEINFO(/obj/submachine/ice_cream_dispenser)
+	mats = 18
+
 /obj/submachine/ice_cream_dispenser
 	name = "Ice Cream Dispenser"
 	desc = "A machine designed to dispense space ice cream."
@@ -145,7 +150,6 @@
 	icon_state = "ice_creamer0"
 	anchored = 1
 	density = 1
-	mats = 18
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	flags = NOSPLASH
 	var/list/flavors = list("chocolate","vanilla","coffee")
@@ -300,6 +304,9 @@
 
 var/list/oven_recipes = list()
 
+TYPEINFO(/obj/submachine/chef_oven)
+	mats = 18
+
 /obj/submachine/chef_oven
 	name = "oven"
 	desc = "A multi-cooking unit featuring a hob, grill, oven and more."
@@ -307,7 +314,6 @@ var/list/oven_recipes = list()
 	icon_state = "oven_off"
 	anchored = 1
 	density = 1
-	mats = 18
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	flags = NOSPLASH
 	var/emagged = 0
@@ -903,6 +909,9 @@ table#cooktime a#start {
 		return 1
 
 #define MIN_FLUID_INGREDIENT_LEVEL 10
+TYPEINFO(/obj/submachine/foodprocessor)
+	mats = 18
+
 /obj/submachine/foodprocessor
 	name = "Processor"
 	desc = "Refines various food substances into different forms."
@@ -910,7 +919,6 @@ table#cooktime a#start {
 	icon_state = "processor-off"
 	anchored = 1
 	density = 1
-	mats = 18
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	var/working = 0
 	var/allowed = list(/obj/item/reagent_containers/food/, /obj/item/plant/, /obj/item/organ/brain, /obj/item/clothing/head/butt)
@@ -1165,6 +1173,9 @@ table#cooktime a#start {
 
 var/list/mixer_recipes = list()
 
+TYPEINFO(/obj/submachine/mixer)
+	mats = 15
+
 /obj/submachine/mixer
 	name = "KitchenHelper"
 	desc = "A food Mixer."
@@ -1172,7 +1183,6 @@ var/list/mixer_recipes = list()
 	icon_state = "blender"
 	density = 1
 	anchored = 1
-	mats = 15
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	var/list/recipes = null
 	var/list/to_remove = list()

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1,9 +1,11 @@
-/obj/submachine/seed_manipulator/
+TYPEINFO(/obj/submachine/seed_manipulator)
+	mats = 10
+
+/obj/submachine/seed_manipulator
 	name = "PlantMaster Mk4"
 	desc = "An advanced machine used for manipulating the genes of plant seeds. It also features an inbuilt seed extractor."
 	density = TRUE
 	anchored = TRUE
-	mats = 10
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "geneman-on"
 	flags = NOSPLASH | TGUI_INTERACTIVE | FPRINT
@@ -652,12 +654,14 @@
 
 ////// Reagent Extractor
 
-/obj/submachine/chem_extractor/
+TYPEINFO(/obj/submachine/chem_extractor)
+	mats = 6
+
+/obj/submachine/chem_extractor
 	name = "reagent extractor"
 	desc = "A machine which can extract reagents from matter. Has a slot for a beaker and a chute to put things into."
 	density = 1
 	anchored = 1
-	mats = 6
 	event_handler_flags = NO_MOUSEDROP_QOL
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	icon = 'icons/obj/objects.dmi'
@@ -881,6 +885,9 @@
 		src.UpdateIcon()
 
 
+TYPEINFO(/obj/submachine/seed_vendor)
+	mats = 6
+
 /obj/submachine/seed_vendor
 	name = "Seed Fabricator"
 	desc = "Fabricates basic plant seeds."
@@ -888,7 +895,6 @@
 	icon_state = "seeds"
 	density = 1
 	anchored = 1
-	mats = 6
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	flags = TGUI_INTERACTIVE
 	var/hacked = 0
@@ -1118,10 +1124,12 @@
 				else src.working = 1
 
 
+TYPEINFO(/obj/submachine/seed_manipulator/kudzu)
+	mats = 0
+
 /obj/submachine/seed_manipulator/kudzu
 	name = "KudzuMaster V1"
 	desc = "A strange \"machine\" that seems to function via fluids and plant fibers."
-	mats = 0
 	deconstruct_flags = null
 	icon = 'icons/misc/kudzu_plus.dmi'
 	icon_state = "seed-gene-console"

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/obj/submachine/slot_machine)
+	mats = 8
+
 /obj/submachine/slot_machine
 	name = "Slot Machine"
 	desc = "Gambling for the antisocial."
@@ -5,7 +8,6 @@
 	icon_state = "slots-off"
 	anchored = 1
 	density = 1
-	mats = 8
 	flags = TGUI_INTERACTIVE
 	deconstruct_flags = DECON_SIMPLE
 	var/plays = 0

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -266,6 +266,9 @@ ABSTRACT_TYPE(/obj/vehicle)
 
 //////////////////////////////////////////////////////////// Segway ///////////////////////////////////////////
 
+TYPEINFO(/obj/vehicle/segway)
+	mats = 8
+
 /obj/vehicle/segway
 	name = "\improper Space Segway"
 	desc = "Now you too can look like a complete tool in space!"
@@ -274,7 +277,6 @@ ABSTRACT_TYPE(/obj/vehicle)
 	var/icon_rider_state = 1
 	var/image/image_under = null
 	layer = MOB_LAYER + 1
-	mats = 8
 	health = 30
 	health_max = 30
 	var/weeoo_in_progress = 0
@@ -656,13 +658,15 @@ ABSTRACT_TYPE(/obj/vehicle)
 
 ////////////////////////////////////////////////////// Floor buffer /////////////////////////////////////
 
+TYPEINFO(/obj/vehicle/floorbuffer)
+	mats = 8
+
 /obj/vehicle/floorbuffer
 	name = "\improper Buff-R-Matic 3000"
 	desc = "A snazzy ridable floor buffer with a holding tank for cleaning agents."
 	icon_state = "floorbuffer"
 	layer = MOB_LAYER + 1
 	is_syndicate = 1
-	mats = 8
 	health = 80
 	health_max = 80
 	var/low_reagents_warning = 0
@@ -990,6 +994,9 @@ ABSTRACT_TYPE(/obj/vehicle)
 
 /////////////////////////////////////////////////////// Clown car ////////////////////////////////////////
 
+TYPEINFO(/obj/vehicle/clowncar)
+	mats = 15
+
 /obj/vehicle/clowncar
 	name = "Clown Car"
 	desc = "A funny-looking car designed for circus events. Seats 30, very roomy!"
@@ -998,7 +1005,6 @@ ABSTRACT_TYPE(/obj/vehicle)
 	var/moving = 0
 	rider_visible = 0
 	is_syndicate = 1
-	mats = 15
 	ability_buttons_to_initialize = list(/obj/ability_button/loudhorn/clowncar, /obj/ability_button/stopthebus/clowncar)
 	soundproofing = 5
 	var/second_icon = "clowncar2" //animated jiggling for the clowncar
@@ -1578,6 +1584,9 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 
 ////////////////////////////////////////////////// Admin bus /////////////////////////////////////
 
+TYPEINFO(/obj/vehicle/adminbus)
+	mats = 15
+
 /obj/vehicle/adminbus
 	name = "Admin Bus"
 	desc = "A short yellow bus that looks reinforced."
@@ -1590,7 +1599,6 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 	var/badmin_nonmoving_state = "badminbus"
 	var/antispam = 0
 	is_syndicate = 1
-	mats = 15
 	sealed_cabin = 1
 	rider_visible = 0
 	ability_buttons_to_initialize = list(/obj/ability_button/loudhorn, /obj/ability_button/stopthebus, /obj/ability_button/togglespook)
@@ -2183,12 +2191,14 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 
 //////////////////////////////////////////////////////////////// Forklift //////////////////////////
 
+TYPEINFO(/obj/vehicle/forklift)
+	mats = 12
+
 /obj/vehicle/forklift
 	name = "forklift"
 	desc = "A vehicle used to transport crates."
 	icon_state = "forklift"
 	anchored = 1
-	mats = 12
 	health = 80
 	health_max = 80
 	var/list/helditems = list()	//Items being held by the forklift

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -470,6 +470,9 @@
 				pickedup = 1
 
 
+TYPEINFO(/obj/vehicle/marsrover)
+	mats = 8
+
 /obj/vehicle/marsrover
 	name = "Rover"
 	desc = "A rover designed to let researchers explore hazardous planets safely and efficiently. It looks pretty old."
@@ -477,7 +480,6 @@
 	rider_visible = 0
 	layer = MOB_LAYER + 1
 	sealed_cabin = 1
-	mats = 8
 
 /obj/vehicle/marsrover/proc/update()
 	if(rider)

--- a/code/z_adventurezones/space_casino.dm
+++ b/code/z_adventurezones/space_casino.dm
@@ -7,11 +7,13 @@
 
 // Item slot machine
 
+TYPEINFO(/obj/submachine/slot_machine/item)
+	mats = null
+
 /obj/submachine/slot_machine/item
 	name = "Item Slot Machine"
 	desc = "A slot machine that produces items rather than money. Somehow."
 	icon_state = "slotsitem-off"
-	mats = null
 	var/uses = 0
 	max_roll = 1000
 	icon_base = "slotsitem"

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -18590,8 +18590,7 @@
 /area/built_zone)
 "ciS" = (
 /obj/machinery/manufacturer/general{
-	free_resource_amt = 999;
-	mats = 999
+	free_resource_amt = 999
 	},
 /turf/simulated/floor/plating/random{
 	desc = " It is made of steel.";
@@ -18607,8 +18606,7 @@
 /area/built_zone)
 "ciV" = (
 /obj/machinery/manufacturer/mechanic{
-	free_resource_amt = 999;
-	mats = 999
+	free_resource_amt = 999
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";

--- a/maps/unused/crash_gimmick_2.dmm
+++ b/maps/unused/crash_gimmick_2.dmm
@@ -258,8 +258,7 @@
 /area/shuttle/arrival/station)
 "le" = (
 /obj/machinery/manufacturer/general{
-	free_resource_amt = 999;
-	mats = 999
+	free_resource_amt = 999
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
@@ -713,8 +712,7 @@
 	tag = ""
 	},
 /obj/machinery/manufacturer/mechanic{
-	free_resource_amt = 999;
-	mats = 999
+	free_resource_amt = 999
 	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -49410,7 +49410,8 @@
 "uaz" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingunpixel_y = 6
+	displayed = new /obj/item/captaingun;
+	pixel_y = 6
 	},
 /obj/machinery/door_control{
 	id = "lockdown";

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -268,7 +268,7 @@
 /area/station/storage/primary)
 "aaK" = (
 /obj/machinery/manufacturer/general{
-	mats = 10
+	free_resource_amt = 10
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -14555,7 +14555,7 @@
 "aGa" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -42444,7 +42444,7 @@
 	pixel_y = 1
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -42986,7 +42986,7 @@
 	pixel_y = 21
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor/plating,
@@ -44755,7 +44755,7 @@
 /area/research_outpost/hangar)
 "bUk" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
@@ -44807,7 +44807,7 @@
 /area/research_outpost)
 "bUp" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -46154,7 +46154,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The `mats` var which says what materials are needed to fabricate a scanned item is moved to TYPEINFO.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This removes unnecessary list allocations in init and also unnecessary dummy object creation in some places.
