### PR TITLE
Add windoors to Oshan's cargo tables

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -29563,7 +29563,9 @@
 /obj/table/reinforced/auto,
 /obj/item/wrapping_paper,
 /obj/item/wirecutters,
-/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0
+	},
 /obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -30612,7 +30614,8 @@
 /obj/machinery/cashreg,
 /obj/item/reagent_containers/food/drinks/mug/random_color,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
+	dir = 4;
+	autoclose = 0
 	},
 /obj/access_spawn/cargo,
 /turf/simulated/floor,
@@ -31030,7 +31033,8 @@
 /obj/item/stamp,
 /obj/item/pen,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
+	dir = 4;
+	autoclose = 0
 	},
 /obj/access_spawn/cargo,
 /turf/simulated/floor,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -29563,6 +29563,8 @@
 /obj/table/reinforced/auto,
 /obj/item/wrapping_paper,
 /obj/item/wirecutters,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bzt" = (
@@ -30609,6 +30611,10 @@
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/item/reagent_containers/food/drinks/mug/random_color,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bBO" = (
@@ -31023,6 +31029,10 @@
 /obj/item/paper_bin,
 /obj/item/stamp,
 /obj/item/pen,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bCX" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds windoors and QM access spawners for oshan's three cargo-bay front desk tables

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
in addition to monkeys, stomper boots let people clear the tables without issue.
parity with most other station QM front offices.