### PR TITLE
Player visible volume for atmospherics

### DIFF
--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -53,6 +53,9 @@
 
 		..()
 
+	get_desc()
+		. = " It is labeled to have a volume of [src.volume] litres."
+
 	proc
 		connect(obj/machinery/atmospherics/portables_connector/new_port)
 			//Make sure not already connected to something else

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -200,7 +200,7 @@ Contains:
 		var/list/extras = list()
 		if (extra_desc)
 			extras += extra_desc
-		extras += " It is labled to have a volume of [src.air_contents.volume] litres. " + ..()
+		extras += " It is labeled to have a volume of [src.air_contents.volume] litres. " + ..()
 		return extras.Join(" ")
 
 	examine(mob/user)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -200,7 +200,7 @@ Contains:
 		var/list/extras = list()
 		if (extra_desc)
 			extras += extra_desc
-		extras += " It has a volume of [src.air_contents.volume] litres. " + ..()
+		extras += " It is labled to have a volume of [src.air_contents.volume] litres. " + ..()
 		return extras.Join(" ")
 
 	examine(mob/user)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -200,7 +200,7 @@ Contains:
 		var/list/extras = list()
 		if (extra_desc)
 			extras += extra_desc
-		extras += ..()
+		extras += " It has a volume of [src.air_contents.volume] litres. " + ..()
 		return extras.Join(" ")
 
 	examine(mob/user)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -780,7 +780,7 @@
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
 			Temperature: [round(check_me.temperature)] K<br>\
-			Volume: [round(check_me.volume)] L<br>\
+			Volume: [check_me.volume] L<br>\
 			[CONCENTRATION_REPORT(check_me, "<br>")]"
 
 	else

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -763,8 +763,8 @@
 	if (total_moles > 0)
 		if (pda_readout == 1) // Output goes into PDA interface, not the user's chatbox.
 			data = "Air Pressure: [round(pressure, 0.1)] kPa<br>\
-			[CONCENTRATION_REPORT(check_me, "<br>")]\
-			Temperature: [round(check_me.temperature)] K<br>"
+			Temperature: [round(check_me.temperature)] K<br>\
+			[CONCENTRATION_REPORT(check_me, "<br>")]"
 
 		else if (simple_output) // For the log_atmos() proc.
 			data = "(<b>Pressure:</b> <i>[round(pressure, 0.1)] kPa</i>, <b>Temp:</b> <i>[round(check_me.temperature)] K</i>\
@@ -779,8 +779,9 @@
 			<span class='notice'>Atmospheric analysis of <b>[A]</b></span><br>\
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
-			[CONCENTRATION_REPORT(check_me, "<br>")]\
-			Temperature: [round(check_me.temperature)] K<br>"
+			Temperature: [round(check_me.temperature)] K<br>\
+			Volume: [round(check_me.volume)] L<br>\
+			[CONCENTRATION_REPORT(check_me, "<br>")]"
 
 	else
 		// Only used for "Atmospheric Scan" accessible through the PDA interface, which targets the turf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ATMOSPHERICS][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds volumes to the descriptions of Portable atmos tanks, Canisters, Scrubbers, Pumps and the Repressurisation device. 
Atmos scanner now shows you the volume of the thing you scan. 

For pipe parts this is a sum of all connected segments volume.

example of volume sum:
![image](https://user-images.githubusercontent.com/113442598/206295199-6b70fecf-9d09-48cb-baff-aac20edf56d2.png)

Syndicate jetpack description:
![image](https://user-images.githubusercontent.com/113442598/206295287-b07635ba-b4eb-4ef8-88ed-8e7fab1affa6.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Volume is needed for some gas calculations so if any engineers want to work out how many moles of farts they have they can do it now!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheffie
(+)You can now see the volume of various atmospherics objects by examining them for portable objects or with the atmospherics scanner for pipes.
```
