### PR TITLE
Removes shield zone areas from spy-thief bounties

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -695,6 +695,7 @@
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/substation)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/singcore)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/combustion_chamber)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/shield_zone)
 	possible_areas -= /area/sim/test_area
 
 	for (var/area/A in possible_areas)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the area used to designate shield generator coverage from spy bounty area possibilities.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Noticed this while debugging #12326, basically impossible to complete without area debug overlays.