### PR TITLE
Clarion Cargo Conveyor Control Correction

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -31996,7 +31996,7 @@
 	dir = 4
 	},
 /obj/machinery/conveyor_switch{
-	id = "mining2qm"
+	id = "qm2hall"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
@@ -32009,7 +32009,7 @@
 	pixel_y = 21
 	},
 /obj/machinery/door_control{
-	id = "mining2qm_sec_door";
+	id = "qm2hall_door";
 	name = "QM - Mining Security Doors";
 	pixel_y = 24
 	},
@@ -34820,6 +34820,14 @@
 /area/station/quartermaster/office)
 "bzu" = (
 /obj/machinery/light,
+/obj/machinery/conveyor_switch{
+	id = "mining2qm"
+	},
+/obj/machinery/door_control{
+	id = "mining2qm_sec_door";
+	name = "QM - Mining Transfer Shutters";
+	pixel_y = -22
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster/office)
 "bzv" = (
@@ -41611,7 +41619,8 @@
 	},
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";
-	operating = 1
+	operating = 1;
+	id = "qm2hall"
 	},
 /turf/simulated/floor/caution/misc,
 /area/station/quartermaster/office)
@@ -41651,7 +41660,7 @@
 /area/station/security/hos)
 "eeM" = (
 /obj/machinery/conveyor/NS{
-	id = "cargo_out"
+	id = "mining2qm"
 	},
 /obj/plasticflaps,
 /obj/machinery/door/poddoor/blast/single{
@@ -46320,12 +46329,13 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";
-	operating = 1
+	operating = 1;
+	id = "qm2hall"
 	},
 /obj/machinery/door/poddoor/blast/single{
 	doordir = "noblasts";
 	icon_state = "bdoornoblasts1";
-	id = "mining2qm_sec_door";
+	id = "qm2hall_door";
 	layer = 4;
 	name = "QM Security Door"
 	},
@@ -47685,7 +47695,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/conveyor/NS{
-	id = "cargo_out"
+	id = "mining2qm"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/storage)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Changes the front desk lever & belt IDs to be `qm2hall`
2. Changes the front desk button and door to be `qm2hall_door`
3. Adds new lever and button for the south `mining2qm` belt/door

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The lever next to the front desk in cargo should control the belt next to it.

## Visual conveyor control reference
![image](https://user-images.githubusercontent.com/91498627/207450937-cae0d681-e838-4e33-844e-231e0f19a55b.png)
