### PR TITLE
Stops flockless flockbits from dormanting

### DIFF
--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -45,7 +45,7 @@
 /mob/living/critter/flock/bit/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
-	if (!src.dormant && src.flock && !src.flock?.z_level_check(src) && src.z != Z_LEVEL_NULL)
+	if (!src.dormant && src.flock && !src.flock.z_level_check(src) && src.z != Z_LEVEL_NULL)
 		src.dormantize()
 
 /mob/living/critter/flock/bit/MouseDrop_T(mob/living/target, mob/user)

--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -45,7 +45,7 @@
 /mob/living/critter/flock/bit/Life(datum/controller/process/mobs/parent)
 	if (..(parent))
 		return TRUE
-	if (!src.dormant && !src.flock?.z_level_check(src) && src.z != Z_LEVEL_NULL)
+	if (!src.dormant && src.flock && !src.flock?.z_level_check(src) && src.z != Z_LEVEL_NULL)
 		src.dormantize()
 
 /mob/living/critter/flock/bit/MouseDrop_T(mob/living/target, mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug introduced in the tutorial PR that made all flockbits without a flock dormant.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockbits can be made using gnesis, so should function without a flock.