### PR TITLE
Fix Round-start Clone Disk Generation Runtime

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -594,7 +594,7 @@
 					var/datum/abilityHolder/A = src.abilityHolder.deepCopy()
 					R.fields["abilities"] = A
 
-				R["defects"] = src.cloner_defects.copy()
+				R.fields["defects"] = src.cloner_defects.copy()
 
 				SPAWN(0)
 					if(!isnull(src.traitHolder))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
disks use the `fields` map instead of writing properties directly

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtime
stops officers from getting trinkets/badges
Fixes #12352 
Fixes #12345