### PR TITLE
Items can be thrown from some vehicles

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -163,7 +163,7 @@ TYPEINFO(/obj/vehicle/tug)
 	health = 80
 	health_max = 80
 	var/obj/tug_cart/cart = null
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 	ability_buttons_to_initialize = list(/obj/ability_button/vehicle_speed)
 	var/start_with_cart = 1
 	delay = 4

--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -95,6 +95,11 @@
 			var/mob/M = src
 			M.force_laydown_standup()
 
+	if (istype(src.loc, /obj/vehicle))
+		var/obj/vehicle/V = src.loc
+		if (V.can_eject_items == 1)
+			src.set_loc(get_turf(V))
+
 	src.last_throw_x = src.x
 	src.last_throw_y = src.y
 	src.throw_begin(target, thrown_from, thrown_by)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1274,7 +1274,7 @@
 		if (W && !W.qdeled)
 			if (istype(src.loc, /obj/vehicle))
 				var/obj/vehicle/V = src.loc
-				if (V.throw_dropped_items_overboard == 1)
+				if (V.can_eject_items == 1)
 					W.set_loc(get_turf(V))
 				else
 					W.set_loc(src.loc)

--- a/code/modules/transport/skateboard.dm
+++ b/code/modules/transport/skateboard.dm
@@ -67,7 +67,7 @@
 	icon_state = "skateboard0"
 	layer = MOB_LAYER + 1
 	soundproofing = 0
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 	var/sickness = 0
 	var/speed_delay = 5
 	var/datum/action/bar/skateboard/runningAction = null

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -25,7 +25,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 	var/rider_visible =	1 //can we see the driver from outside of the vehicle? (used for overlays)
 	var/list/ability_buttons = null //storage for the ability buttons after initialization
 	var/list/ability_buttons_to_initialize = null //list of types of ability buttons to be initialized
-	var/throw_dropped_items_overboard = 0 // See /mob/proc/drop_item() in mob.dm.
+	var/can_eject_items = 0 // See /mob/proc/drop_item() in mob.dm and /atom/movable/proc/throw_at in throwing.dm
 	var/attacks_fast_eject = 1 //whether any attack with an item that has a force vallue will immediately eject the rider (only works if rider_visible is true)
 	layer = MOB_LAYER
 	var/delay = 2 //speed, lower is faster, minimum of MINIMUM_EFFECTIVE_DELAY
@@ -282,7 +282,7 @@ TYPEINFO(/obj/vehicle/segway)
 	var/weeoo_in_progress = 0
 	var/icon_weeoo_state = 2
 	soundproofing = 0
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 	var/datum/light/light
 	ability_buttons_to_initialize = list(/obj/ability_button/weeoo)
 	var/obj/item/joustingTool = null // When jousting will be reference to lance being used
@@ -674,7 +674,7 @@ TYPEINFO(/obj/vehicle/floorbuffer)
 	delay = 4
 	ability_buttons_to_initialize = list(/obj/ability_button/fbuffer_toggle, /obj/ability_button/fbuffer_status)
 	soundproofing = 0
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 
 	New()
 		..()
@@ -1401,7 +1401,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 	icon_state = "segwaycat"
 	layer = MOB_LAYER + 1
 	soundproofing = 0
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 
 // Might as well make use of the Garfield sprites (Convair880).
 
@@ -2203,7 +2203,7 @@ TYPEINFO(/obj/vehicle/forklift)
 	var/broken = 0				//1 when the forklift is broken
 	var/light = 0				//1 when the yellow light is on
 	soundproofing = 5
-	throw_dropped_items_overboard = 1
+	can_eject_items = 1
 	var/image/image_light = null
 	var/image/image_panel = null
 	var/image/image_crate = null


### PR DESCRIPTION
[BUG][GAME OBJECTS]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Renames `throw_dropped_items_overboard` to `can_eject_items`
* Adds a check when throwing, that if `can_eject_items` is true, to set the location of the item to the turf the vehicle is on
  * This allows the throw to work as expected from "open cab" vehicles

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12346

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)You can throw items from certain rideables, like segways and skateboards.
```
