### PR TITLE
In-hand omnitools auto-switch when a deconstruction tool contextAction is selected

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -75,6 +75,15 @@
 #define TOOL_WRENCHING 512
 #define TOOL_CHOPPING 1024 // for firaxes, does additional damage to doors.
 
+//omnitool flags
+#define OMNI_MODE_PRYING 1
+#define OMNI_MODE_SNIPPING 2
+#define OMNI_MODE_WRENCHING 3
+#define OMNI_MODE_SCREWING 4
+#define OMNI_MODE_PULSING 5
+#define OMNI_MODE_CUTTING 6
+#define OMNI_MODE_WELDING 7
+
 //tooltip flags for rebuilding
 
 /// rebuild tooltip every single time without exception

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1755,6 +1755,9 @@
 		else
 			hud.set_active_tool(null)
 
+	equipped_list(var/check_for_magtractor=1)
+		. = src.module_states
+
 	click(atom/target, params)
 		if (istype(target, /obj/item/roboupgrade) && (target in src.upgrades)) // ugh
 			src.activate_upgrade(target)

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -442,14 +442,6 @@
 		else
 			. = ..()
 
-// bodge to support omnitools
-#define OMNI_MODE_PRYING 1
-#define OMNI_MODE_SNIPPING 2
-#define OMNI_MODE_WRENCHING 3
-#define OMNI_MODE_SCREWING 4
-#define OMNI_MODE_PULSING 5
-#define OMNI_MODE_CUTTING 6
-#define OMNI_MODE_WELDING 7
 #define OMNI_TOOL_WAIT_TIME 0.5 SECONDS
 
 /datum/contextAction/deconstruction
@@ -610,15 +602,6 @@
 					user.show_text("...then pulse [target]. In a general sense.", "blue")
 					playsound(target, 'sound/items/penclick.ogg', 50, 1)
 					return ..()
-
-#undef OMNI_MODE_PRYING
-#undef OMNI_MODE_SNIPPING
-#undef OMNI_MODE_WRENCHING
-#undef OMNI_MODE_SCREWING
-#undef OMNI_MODE_PULSING
-#undef OMNI_MODE_CUTTING
-#undef OMNI_MODE_WELDING
-#undef OMNI_TOOL_WAIT_TIME
 
 /datum/contextAction/vehicle
 	icon = 'icons/ui/context16x16.dmi'

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -489,7 +489,7 @@
 					user.show_text("You flip [omni] to wrenching mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then wrench [target]'s bolts.", "blue")
-					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
+					playsound(target, 'sound/items/Ratchet.ogg', 50, 1)
 					return ..()
 
 	cut
@@ -511,7 +511,7 @@
 					user.show_text("You flip [omni] to cutting mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then cut some vestigial wires from [target].", "blue")
-					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
+					playsound(target, 'sound/items/Wirecutter.ogg', 50, 1)
 					return ..()
 	weld
 		name = "Weld"

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -528,7 +528,7 @@
 		omni_mode = OMNI_MODE_WELDING
 		omni_path = /obj/item/weldingtool
 		success_text = "You weld %target% carefully."
-		success_sound = null
+		success_sound = null // sound handled in try_weld
 
 		execute(atom/target, mob/user)
 			for (var/obj/item/I in user.equipped_list())

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -442,7 +442,14 @@
 		else
 			. = ..()
 
-
+// bodge to support omnitools
+#define OMNI_MODE_PRYING 1
+#define OMNI_MODE_SNIPPING 2
+#define OMNI_MODE_WRENCHING 3
+#define OMNI_MODE_SCREWING 4
+#define OMNI_MODE_PULSING 5
+#define OMNI_MODE_CUTTING 6
+#define OMNI_MODE_WELDING 7
 /datum/contextAction/deconstruction
 	icon = 'icons/ui/context16x16.dmi'
 	name = "Deconstruct with Tool"
@@ -480,6 +487,14 @@
 					user.show_text("You wrench [target]'s bolts.", "blue")
 					playsound(target, 'sound/items/Ratchet.ogg', 50, 1)
 					return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_WRENCHING in omni.modes))
+						return
+					omni.change_mode(OMNI_MODE_WRENCHING, user, /obj/item/wrench)
+					user.show_text("You flip the [omni] to wrenching mode, then wrench [target]'s bolts.", "blue")
+					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
+					return ..()
 
 	cut
 		name = "Cut"
@@ -492,6 +507,14 @@
 					user.show_text("You cut some vestigial wires from [target].", "blue")
 					playsound(target, 'sound/items/Wirecutter.ogg', 50, 1)
 					return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_SNIPPING in omni.modes))
+						return
+					omni.change_mode(OMNI_MODE_SNIPPING, user, /obj/item/wirecutters)
+					user.show_text("You flip [omni] to cutting mode, then cut some vestigial wires from [target].", "blue")
+					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
+					return ..()
 	weld
 		name = "Weld"
 		desc = "Welding required to deconstruct."
@@ -503,6 +526,17 @@
 					if (I:try_weld(user, 2))
 						user.show_text("You weld [target] carefully.", "blue")
 						return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_WELDING in omni.modes))
+						continue
+					omni.change_mode(OMNI_MODE_WELDING, user, /obj/item/weldingtool)
+					user.show_text("You flip [omni] to welding mode...", "blue")
+					if (omni:try_weld(user, 2))
+						user.show_text("...then weld [target] carefully.", "blue")
+						return ..()
+					else
+						user.show_text("...but it failed!.", "red")
 
 	pry
 		name = "Pry"
@@ -513,6 +547,14 @@
 			for (var/obj/item/I in user.equipped_list())
 				if (ispryingtool(I))
 					user.show_text("You pry on [target] without remorse.", "blue")
+					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
+					return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_PRYING in omni.modes))
+						return
+					omni.change_mode(OMNI_MODE_PRYING, user, /obj/item/crowbar)
+					user.show_text("You flip [omni] to prying mode, then pry on [target] without remorse.", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
 					return ..()
 
@@ -527,6 +569,14 @@
 					user.show_text("You unscrew some of the screws on [target].", "blue")
 					playsound(target, 'sound/items/Screwdriver.ogg', 50, 1)
 					return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_SCREWING in omni.modes))
+						return
+					omni.change_mode(OMNI_MODE_SCREWING, user, /obj/item/screwdriver)
+					user.show_text("You flip [omni] to screwdriving mode, then unscrew some of the screws on [target].", "blue")
+					playsound(target, 'sound/items/Screwdriver.ogg', 50, 1)
+					return ..()
 
 	pulse
 		name = "Pulse"
@@ -539,6 +589,22 @@
 					user.show_text("You pulse [target]. In a general sense.", "blue")
 					playsound(target, 'sound/items/penclick.ogg', 50, 1)
 					return ..()
+				if(istype(I, /obj/item/tool/omnitool))
+					var/obj/item/tool/omnitool/omni = I
+					if (!(OMNI_MODE_PULSING in omni.modes))
+						return
+					omni.change_mode(OMNI_MODE_PULSING, user, /obj/item/device/multitool)
+					user.show_text("You flip [omni] to pulsing mode, then pulse [target]. In a general sense.", "blue")
+					playsound(target, 'sound/items/penclick.ogg', 50, 1)
+					return ..()
+
+#undef OMNI_MODE_PRYING
+#undef OMNI_MODE_SNIPPING
+#undef OMNI_MODE_WRENCHING
+#undef OMNI_MODE_SCREWING
+#undef OMNI_MODE_PULSING
+#undef OMNI_MODE_CUTTING
+#undef OMNI_MODE_WELDING
 
 /datum/contextAction/vehicle
 	icon = 'icons/ui/context16x16.dmi'

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -450,6 +450,8 @@
 #define OMNI_MODE_PULSING 5
 #define OMNI_MODE_CUTTING 6
 #define OMNI_MODE_WELDING 7
+#define OMNI_TOOL_WAIT_TIME 0.5 SECONDS
+
 /datum/contextAction/deconstruction
 	icon = 'icons/ui/context16x16.dmi'
 	name = "Deconstruct with Tool"
@@ -490,9 +492,11 @@
 				if(istype(I, /obj/item/tool/omnitool))
 					var/obj/item/tool/omnitool/omni = I
 					if (!(OMNI_MODE_WRENCHING in omni.modes))
-						return
+						continue
 					omni.change_mode(OMNI_MODE_WRENCHING, user, /obj/item/wrench)
-					user.show_text("You flip the [omni] to wrenching mode, then wrench [target]'s bolts.", "blue")
+					user.show_text("You flip [omni] to wrenching mode...")
+					sleep(OMNI_TOOL_WAIT_TIME)
+					user.show_text("...then wrench [target]'s bolts.", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
 					return ..()
 
@@ -510,9 +514,11 @@
 				if(istype(I, /obj/item/tool/omnitool))
 					var/obj/item/tool/omnitool/omni = I
 					if (!(OMNI_MODE_SNIPPING in omni.modes))
-						return
+						continue
 					omni.change_mode(OMNI_MODE_SNIPPING, user, /obj/item/wirecutters)
-					user.show_text("You flip [omni] to cutting mode, then cut some vestigial wires from [target].", "blue")
+					user.show_text("You flip [omni] to cutting mode...")
+					sleep(OMNI_TOOL_WAIT_TIME)
+					user.show_text("...then cut some vestigial wires from [target].", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
 					return ..()
 	weld
@@ -532,6 +538,7 @@
 						continue
 					omni.change_mode(OMNI_MODE_WELDING, user, /obj/item/weldingtool)
 					user.show_text("You flip [omni] to welding mode...", "blue")
+					sleep(OMNI_TOOL_WAIT_TIME)
 					if (omni:try_weld(user, 2))
 						user.show_text("...then weld [target] carefully.", "blue")
 						return ..()
@@ -552,9 +559,11 @@
 				if(istype(I, /obj/item/tool/omnitool))
 					var/obj/item/tool/omnitool/omni = I
 					if (!(OMNI_MODE_PRYING in omni.modes))
-						return
+						continue
 					omni.change_mode(OMNI_MODE_PRYING, user, /obj/item/crowbar)
-					user.show_text("You flip [omni] to prying mode, then pry on [target] without remorse.", "blue")
+					user.show_text("You flip [omni] to prying mode...")
+					sleep(OMNI_TOOL_WAIT_TIME)
+					user.show_text("...then pry on [target] without remorse.", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
 					return ..()
 
@@ -572,9 +581,11 @@
 				if(istype(I, /obj/item/tool/omnitool))
 					var/obj/item/tool/omnitool/omni = I
 					if (!(OMNI_MODE_SCREWING in omni.modes))
-						return
+						continue
 					omni.change_mode(OMNI_MODE_SCREWING, user, /obj/item/screwdriver)
-					user.show_text("You flip [omni] to screwdriving mode, then unscrew some of the screws on [target].", "blue")
+					user.show_text("You flip [omni] to screwdriving mode...")
+					sleep(OMNI_TOOL_WAIT_TIME)
+					user.show_text("...then unscrew some of the screws on [target].", "blue")
 					playsound(target, 'sound/items/Screwdriver.ogg', 50, 1)
 					return ..()
 
@@ -592,9 +603,11 @@
 				if(istype(I, /obj/item/tool/omnitool))
 					var/obj/item/tool/omnitool/omni = I
 					if (!(OMNI_MODE_PULSING in omni.modes))
-						return
+						continue
 					omni.change_mode(OMNI_MODE_PULSING, user, /obj/item/device/multitool)
-					user.show_text("You flip [omni] to pulsing mode, then pulse [target]. In a general sense.", "blue")
+					user.show_text("You flip [omni] to pulsing mode...", "blue")
+					sleep(OMNI_TOOL_WAIT_TIME)
+					user.show_text("...then pulse [target]. In a general sense.", "blue")
 					playsound(target, 'sound/items/penclick.ogg', 50, 1)
 					return ..()
 
@@ -605,6 +618,7 @@
 #undef OMNI_MODE_PULSING
 #undef OMNI_MODE_CUTTING
 #undef OMNI_MODE_WELDING
+#undef OMNI_TOOL_WAIT_TIME
 
 /datum/contextAction/vehicle
 	icon = 'icons/ui/context16x16.dmi'

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -494,7 +494,7 @@
 					if (!(OMNI_MODE_WRENCHING in omni.modes))
 						continue
 					omni.change_mode(OMNI_MODE_WRENCHING, user, /obj/item/wrench)
-					user.show_text("You flip [omni] to wrenching mode...")
+					user.show_text("You flip [omni] to wrenching mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then wrench [target]'s bolts.", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
@@ -516,7 +516,7 @@
 					if (!(OMNI_MODE_SNIPPING in omni.modes))
 						continue
 					omni.change_mode(OMNI_MODE_SNIPPING, user, /obj/item/wirecutters)
-					user.show_text("You flip [omni] to cutting mode...")
+					user.show_text("You flip [omni] to cutting mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then cut some vestigial wires from [target].", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
@@ -561,7 +561,7 @@
 					if (!(OMNI_MODE_PRYING in omni.modes))
 						continue
 					omni.change_mode(OMNI_MODE_PRYING, user, /obj/item/crowbar)
-					user.show_text("You flip [omni] to prying mode...")
+					user.show_text("You flip [omni] to prying mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then pry on [target] without remorse.", "blue")
 					playsound(target, 'sound/items/Crowbar.ogg', 50, 1)
@@ -583,7 +583,7 @@
 					if (!(OMNI_MODE_SCREWING in omni.modes))
 						continue
 					omni.change_mode(OMNI_MODE_SCREWING, user, /obj/item/screwdriver)
-					user.show_text("You flip [omni] to screwdriving mode...")
+					user.show_text("You flip [omni] to screwdriving mode...", "blue")
 					sleep(OMNI_TOOL_WAIT_TIME)
 					user.show_text("...then unscrew some of the screws on [target].", "blue")
 					playsound(target, 'sound/items/Screwdriver.ogg', 50, 1)

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -590,6 +590,9 @@
 						return ..()
 				if (ispulsingtool(I))
 					return ..()
+
+#undef OMNI_TOOL_WAIT_TIME
+
 /datum/contextAction/vehicle
 	icon = 'icons/ui/context16x16.dmi'
 	name = "Vehicle action"

--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -10,14 +10,6 @@
 
 	custom_suicide = 1
 
-	#define OMNI_MODE_PRYING 1
-	#define OMNI_MODE_SNIPPING 2
-	#define OMNI_MODE_WRENCHING 3
-	#define OMNI_MODE_SCREWING 4
-	#define OMNI_MODE_PULSING 5
-	#define OMNI_MODE_CUTTING 6
-	#define OMNI_MODE_WELDING 7
-
 	///List of tool settings
 	var/list/modes = list(OMNI_MODE_PRYING, OMNI_MODE_SCREWING, OMNI_MODE_PULSING, OMNI_MODE_WRENCHING, OMNI_MODE_SNIPPING)
 	///The current setting
@@ -307,11 +299,3 @@
 		icon_state = "weld"
 		mode = OMNI_MODE_WELDING
 		typepath = /obj/item/weldingtool
-
-#undef OMNI_MODE_PRYING
-#undef OMNI_MODE_SNIPPING
-#undef OMNI_MODE_WRENCHING
-#undef OMNI_MODE_SCREWING
-#undef OMNI_MODE_PULSING
-#undef OMNI_MODE_CUTTING
-#undef OMNI_MODE_WELDING


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When holding an omnitool and a deconstruction device, the omnitool will automatically switch to the matching required tool (if the omnitool has it), then automatically apply the tool after 0.5 seconds.

* Adds robot-specific handling for checking if an item is equipped
  * Cursory review showed nothing that would break with this change
* Moves omnitool mode defines into globals
* Restructures the deconstruction context menu code
  * Subclasses define omnitool mode/path and success text/sound
 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for graceful use of omnitools with deconstruction devices
Fixes #12305

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Omnitools auto-swap to the needed tool when using the deconstruction tool context menu.
```
