### PR TITLE
Fix suiciding set to 1 despite not choosing to suicide

### DIFF
--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -53,8 +53,8 @@
 			boutput(H, "Your cannot bring yourself to commit suicide!")
 			return
 
-	src.suiciding = TRUE
 	if (src.do_suicide()) //                           <------ put mob unique behaviour here in an override!!!!
+		src.suiciding = TRUE
 		logTheThing(LOG_COMBAT, src, "commits suicide")
 		src.unlock_medal("Damned", 1) //You don't get the medal if you tried to wuss out!
 		if (src.suiciding)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#12347

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Maybe Fixes: #12347
Testing soon

