### PR TITLE
Allows ghosts to automatically open TGUI windows

### DIFF
--- a/_std/defines/component_defines/component_defines_datum.dm
+++ b/_std/defines/component_defines/component_defines_datum.dm
@@ -23,4 +23,6 @@
 	/// area's active var set to false (when all clients leave)
 	#define COMSIG_AREA_DEACTIVATED "area_deactivated"
 
-
+// ---- TGUI signals ----
+	/// A TGUI window was opened by a user (receives tgui datum)
+	#define COMSIG_TGUI_WINDOW_OPEN "tgui_window_open"

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -230,7 +230,7 @@
 	src.see_invisible = INVIS_SPOOKY
 	src.see_in_dark = SEE_DARK_FULL
 	animate_bumble(src) // floaty ghosts  c:
-
+	src.verbs += /mob/dead/observer/proc/toggle_tgui_auto_open
 	if (ismob(corpse))
 		src.corpse = corpse
 		src.set_loc(get_turf(corpse))
@@ -520,6 +520,16 @@
 
 /mob/dead/observer/can_use_hands()	return 0
 /mob/dead/observer/is_active()		return 0
+
+/mob/dead/observer/proc/toggle_tgui_auto_open()
+	set category = "Ghost"
+	set name = "Toggle TGUI auto-observing"
+	if(src.auto_tgui_open)
+		boutput(src, "No longer auto-opening TGUI windows of observed mobs.")
+		src.auto_tgui_open = FALSE
+	else
+		boutput(src, "Observed mob's TGUI windows will now auto-open")
+		src.auto_tgui_open = TRUE
 
 /mob/dead/observer/proc/reenter_corpse()
 	set category = null

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -18,6 +18,7 @@
 	var/obj/item/clothing/head/wig/wig = null
 	var/in_point_mode = 0
 	var/datum/hud/ghost_observer/hud
+	var/auto_tgui_open = TRUE
 
 	mob_flags = MOB_HEARS_ALL
 
@@ -786,11 +787,11 @@ mob/dead/observer/proc/insert_observer(var/atom/target)
 	var/mob/dead/target_observer/newobs = new /mob/dead/target_observer
 	src.set_loc(newobs)
 	newobs.attach_hud(hud)
-	newobs.set_observe_target(target)
 	newobs.name = src.name
 	newobs.real_name = src.real_name
 	newobs.corpse = src.corpse
 	newobs.ghost = src
+	newobs.set_observe_target(target)
 	delete_on_logout_reset = delete_on_logout
 	delete_on_logout = 0
 	if (target?.invisibility)

--- a/code/mob/dead/target_observer.dm
+++ b/code/mob/dead/target_observer.dm
@@ -16,6 +16,7 @@
 		var/mob/living/M = src.target
 		if(istype(M))
 			M.observers -= src
+			src.UnregisterSignal(M, list(COMSIG_TGUI_WINDOW_OPEN))
 
 		if (isobj(target))
 			src.UnregisterSignal(target, list(COMSIG_PARENT_PRE_DISPOSING))
@@ -91,7 +92,8 @@
 		//Let's have a proc so as to make it easier to reassign an observer.
 		src.target = target
 		src.set_loc(target)
-
+		if(src.ghost?.auto_tgui_open)
+			RegisterSignal(target, COMSIG_TGUI_WINDOW_OPEN, .proc/open_tgui_if_interactive)
 		set_eye(target)
 
 		var/mob/living/M = target
@@ -114,6 +116,12 @@
 						return target.ui_interact(src)
 		return ..()
 
+	/// Checks if the tgui window being created is from an object with TGUI_INTERACTIVE, and opens the window for the observer if true
+	proc/open_tgui_if_interactive(mob/sender, datum/tgui/observe_window)
+		if(istype(observe_window.src_object, /atom))
+			var/atom/atom_object = observe_window.src_object
+			if(atom_object.flags & TGUI_INTERACTIVE)
+				return observe_window.src_object.ui_interact(src)
 
 	verb
 		stop_observing()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -93,6 +93,7 @@
 		with_data = TRUE,
 		with_static_data = TRUE))
 	tgui_process.on_open(src)
+	SEND_SIGNAL(user, COMSIG_TGUI_WINDOW_OPEN, src)
 
 /**
  * public


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The sequel to #10818 which now auto-opens windows the observed mob opens, so you don't have to guess at what they're clicking and hope you click it in time to see what they're doing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was pretty annoying having a delay between what the observed was seeing and what I was seeing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(*)As a ghost, observing a mob will now auto-open TGUI windows as they view them. This behaviour can be toggled in the Ghost tab.
```
