### PR TITLE
AIs Can Temporarily Override Intercom frequency

### DIFF
--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -94,6 +94,36 @@ TYPEINFO(/obj/item/device/radio/intercom)
 	var/maptext = generateMapText(msg, textLoc, style = "color:[color];", alpha = 255)
 	target.show_message(type = 2, just_maptext = TRUE, assoc_maptext = maptext)
 
+/obj/item/device/radio/intercom/receive_silicon_hotkey(var/mob/user)
+	..()
+
+	if (!isAI(user))
+		return
+
+	if (!isAIeye(user))
+		boutput("Deploy to an AI Eye first to override intercoms.")
+
+	var/original_src_frequency = src.frequency
+	var/original_src_broadcasting = src.broadcasting
+	var/original_src_listening = src.listening
+
+	if(user.client.check_key(KEY_BOLT))
+		if (src.locked_frequency)
+			return
+
+		src.locked_frequency = TRUE // lockdown; saves us from clickspam
+		set_frequency(R_FREQ_INTERCOM_AI)
+		src.broadcasting = TRUE
+		src.listening = TRUE
+
+		boutput(user, "<span class='alert'>Temporary override to AI Intercom frequency enabled on [src]!</span>")
+
+		SPAWN(1 MINUTE)
+			src.locked_frequency = FALSE // safe as long as we can't control locked frequencies in the first place
+			set_frequency(original_src_frequency)
+			src.broadcasting = original_src_broadcasting
+			src.listening = original_src_listening
+
 // -------------------- VR --------------------
 /obj/item/device/radio/intercom/virtual
 	desc = "Virtual radio for all your beeps and bops."

--- a/code/world.dm
+++ b/code/world.dm
@@ -481,7 +481,8 @@ var/f_color_selector_handler/F_Color_Selector
 		"[R_FREQ_COMMAND]" = "Command",
 		"[R_FREQ_SECURITY]" = "Security",
 		"[R_FREQ_CIVILIAN]" = "Civilian",
-		"[R_FREQ_DEFAULT]" = "General"
+		"[R_FREQ_DEFAULT]" = "General",
+		"[R_FREQ_INTERCOM_AI]" = "AI Intercom",
 		)
 
 	UPDATE_TITLE_STATUS("Starting processes")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an `receive_silicon_hotkey` implementation for AI Eyes only, that will:
* Change the frequency to the AI intercom frequency (144.7)
* Locks down the frequency
* Turns on speakers and microphones
  * These controls aren't locked out, so people can still turn them off
 
After a minute the changed intercom settings are restored to their pre-override state.

Also shows the default AI Intercom frequency of 144.7 to read as "AI Intercom" instead of "(Unknown)" in the radio list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
quickly speak to and listen in on a room

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*) AIs can override an intercom to the AI intercom frequency by holding the Bolting key and clicking on it.
(+) AI intercom override locks down the frequency for one minute and enables microphones and speakers.
```
