### PR TITLE
Fixes dippable foods annihilating bowls

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -541,7 +541,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 
 			src.bites_left--
 			if (!bites_left)
-				new/obj/item/reagent_containers/food/drinks/bowl(src.loc)
+				new src.dropped_item(src.loc)
 				qdel(src)
 		else
 			..()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -541,6 +541,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 
 			src.bites_left--
 			if (!bites_left)
+				new/obj/item/reagent_containers/food/drinks/bowl(src.loc)
 				qdel(src)
 		else
 			..()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -541,7 +541,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 
 			src.bites_left--
 			if (!bites_left)
-				new src.dropped_item(src.loc)
+				new src.dropped_item(get_turf(src))
 				qdel(src)
 		else
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spawns an empty bowl when a soup food item has been emptied by a dippable food.
fixes https://github.com/goonstation/goonstation/issues/12396

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bowls are expensive. Lets not send them into the aether.

