### PR TITLE
Fix set_density cache invalidation

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -992,8 +992,9 @@
 
 //reason for having this proc is explained below
 /atom/proc/set_density(var/newdensity)
+	var/old_density = src.density
 	src.density = HAS_ATOM_PROPERTY(src, PROP_ATOM_NEVER_DENSE) ? 0 : newdensity
-	if(src.density != newdensity)
+	if(old_density != src.density && isturf(src.loc))
 		var/turf/loc = src.loc // invalidate JPS cache on density changes
 		loc.passability_cache = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][internal]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the density change detection to _actually work_ and check for turf type because lockers exist.

(I have no idea how it worked during testing (thinking back now, I think the interaction hand was invalidating the cache, not the locker closing))

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #12351 