### PR TITLE
Moves flock Life dead check to parent

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -530,7 +530,7 @@
 	return ..()
 
 /mob/living/critter/flock/drone/Life(datum/controller/process/mobs/parent)
-	if (..(parent) || isdead(src))
+	if (..(parent))
 		return TRUE
 	if (src.floorrunning && src.resources >= 1)
 		src.pay_resources(1)

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -186,7 +186,7 @@
 	return FALSE
 
 /mob/living/critter/flock/Life(datum/controller/process/mobs/parent)
-	if (..(parent))
+	if (..(parent) || isdead(src))
 		return TRUE
 
 	// automatic extinguisher! after some time, anyway


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the check to see if the flockcritter is alive from flockdrone `Life` to flockcritter `Life`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes flockdrone fire suppression going off after death.
I probably should have just done this last time.