### PR TITLE
Fix double encoding custom emotes

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -445,6 +445,8 @@
 				if (!param)
 					param = input("Choose an emote to display.")
 					if(!param) return
+				else //hack to fix double encoding of custom emotes when using hotkey, speech code is a knotted mess
+					param = html_decode(param)
 
 				param = copytext(sanitize(html_encode(param)), 1, MAX_MESSAGE_LEN)
 				phrase_log.log_phrase("emote", param)

--- a/code/procs/mobprocs/typing_indicator.dm
+++ b/code/procs/mobprocs/typing_indicator.dm
@@ -95,7 +95,7 @@ The say/whisper/me wrappers and cancel_typing remove the typing indicator.
 
 	remove_emote_typing_indicator()
 	if(message)
-		say_verb("*customv [message]")
+		emote("customv", TRUE, message)
 
 /mob/verb/me_wrapper(message as text)
 	set name = ".Me"

--- a/code/procs/mobprocs/typing_indicator.dm
+++ b/code/procs/mobprocs/typing_indicator.dm
@@ -95,7 +95,7 @@ The say/whisper/me wrappers and cancel_typing remove the typing indicator.
 
 	remove_emote_typing_indicator()
 	if(message)
-		emote("customv", TRUE, message)
+		say_verb("*customv [message]")
 
 /mob/verb/me_wrapper(message as text)
 	set name = ".Me"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* the custom hotkey emote now calls `emote` directly instead of `say_verb`
* allows players to emote special characters like quotes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* `say_verb` performs a `strip_html` which in turn `html_encode`s the emote. Then over in `emote` the `customv` emote `html_encode`s the emote text a second time