### PR TITLE
Fix satchels spawning with internals

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -211,14 +211,14 @@ ABSTRACT_TYPE(/datum/job/command)
 
 #ifdef SUBMARINE_MAP
 	slot_suit = list(/obj/item/clothing/suit/armor/hopcoat)
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/heads)
 	slot_jump = list(/obj/item/clothing/under/suit/hop)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_ears = list(/obj/item/device/radio/headset/command/hop)
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash,/obj/item/storage/box/accessimp_kit)
 #else
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/heads)
 	slot_jump = list(/obj/item/clothing/under/suit/hop)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
@@ -361,7 +361,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/research_director)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_jump = list(/obj/item/clothing/under/rank/research_director)
@@ -394,7 +394,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_glov = list(/obj/item/clothing/gloves/latex)
 	slot_belt = list(/obj/item/storage/belt/medical/prepared)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
@@ -537,7 +537,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	receives_badge = 1
 	cant_spawn_as_rev = 1
 	allow_antag_fallthrough = FALSE
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/storage/belt/security/shoulder_holster)
 	slot_poc1 = list(/obj/item/device/pda2/forensic)
 	slot_jump = list(/obj/item/clothing/under/rank/det)
@@ -1452,7 +1452,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	receives_miranda = 1
 	cant_spawn_as_rev = 1
 	receives_badge = 1
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/heads)
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer/black) // so they can slam tables
 	slot_foot = list(/obj/item/clothing/shoes/brown)
@@ -1488,7 +1488,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	cant_spawn_as_rev = 1
 	wages = PAY_EXECUTIVE
 
-	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/heads)
 	slot_jump = list(/obj/item/clothing/under/misc/NT)
 	slot_foot = list(/obj/item/clothing/shoes/brown)

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2157,7 +2157,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Red Backpack"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/red)
+	item_outputs = list(/obj/item/storage/backpack/empty/red)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2166,7 +2166,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Green Backpack"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/green)
+	item_outputs = list(/obj/item/storage/backpack/empty/green)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2175,7 +2175,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Blue Backpack"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/blue)
+	item_outputs = list(/obj/item/storage/backpack/empty/blue)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2184,7 +2184,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Satchel"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/satchel)
+	item_outputs = list(/obj/item/storage/backpack/satchel/empty)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2193,7 +2193,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Red Satchel"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/satchel/red)
+	item_outputs = list(/obj/item/storage/backpack/satchel/empty/red)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2202,7 +2202,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Green Satchel"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/satchel/green)
+	item_outputs = list(/obj/item/storage/backpack/satchel/empty/green)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2211,7 +2211,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Blue Satchel"
 	item_paths = list("FAB-1")
 	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/satchel/blue)
+	item_outputs = list(/obj/item/storage/backpack/satchel/empty/blue)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -13,7 +13,7 @@
 	max_wclass = W_CLASS_NORMAL
 	wear_image_icon = 'icons/mob/clothing/back.dmi'
 	does_not_open_in_pocket = 0
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 	duration_remove = 3 SECONDS
 	duration_put = 3 SECONDS
 
@@ -45,29 +45,69 @@
 /obj/item/storage/backpack/empty
 	spawn_contents = list()
 
+	blue
+		icon_state = "backpackb"
+		item_state = "backpackb"
+		desc = "A thick, wearable container made of synthetic fibers. The blue variation is similar in shade to Abzu's ocean."
+
+	red
+		icon_state = "backpackr"
+		item_state = "backpackr"
+		desc = "A thick, wearable container made of synthetic fibers. The red variation is striking and slightly suspicious."
+
+	brown
+		icon_state = "backpackbr"
+		item_state = "backpackbr"
+		desc = "A thick, wearable container made of synthetic fibers. The brown variation is both rustic and adventurous!"
+
+	green
+		icon_state = "backpackg"
+		item_state = "backpackg"
+		desc = "A thick, wearable container made of synthetic fibers. The green variation reminds you of a botanist's garden..."
+
 /obj/item/storage/backpack/withO2
 	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+
+	blue
+		icon_state = "backpackb"
+		item_state = "backpackb"
+		desc = "A thick, wearable container made of synthetic fibers. The blue variation is similar in shade to Abzu's ocean."
+
+	red
+		icon_state = "backpackr"
+		item_state = "backpackr"
+		desc = "A thick, wearable container made of synthetic fibers. The red variation is striking and slightly suspicious."
+
+	brown
+		icon_state = "backpackbr"
+		item_state = "backpackbr"
+		desc = "A thick, wearable container made of synthetic fibers. The brown variation is both rustic and adventurous!"
+
+	green
+		icon_state = "backpackg"
+		item_state = "backpackg"
+		desc = "A thick, wearable container made of synthetic fibers. The green variation reminds you of a botanist's garden..."
 
 /obj/item/storage/backpack/NT
 	name = "\improper NT backpack"
 	desc = "A stylish blue, thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's back."
 	icon_state = "NTbackpack"
 	item_state = "NTbackpack"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/syndie
 	name = "\improper Syndicate backpack"
 	desc = "A stylish red, evil, thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on an operative's back."
 	icon_state = "Syndiebackpack"
 	item_state = "Syndiebackpack"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/captain
 	name = "Captain's Backpack"
 	desc = "A fancy designer bag made out of space snake leather and encrusted with plastic expertly made to look like gold."
 	icon_state = "capbackpack"
 	item_state = "capbackpack"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 	blue
 		desc = "A fancy designer bag made out of rare blue space snake leather and encrusted with plastic expertly made to look like gold."
@@ -83,7 +123,7 @@
 	name = "tactical assault rucksack"
 	desc = "A military backpack made of high density fabric, designed to fit a wide array of tools for comprehensive storage support."
 	icon_state = "tactical_backpack"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 	slots = 10
 
 /obj/item/storage/backpack/medic
@@ -91,35 +131,35 @@
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a Medical Doctor's back."
 	icon_state = "bp_medic" //im doing inhands, im not getting baited into refactoring every icon state to use hyphens instead of underscores right now
 	item_state = "bp-medic"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/security
 	name = "security backpack"
 	desc = "A sturdy, wearable container made of synthetic fibers, able to carry a number of objects adequately on the back of security personnel."
 	icon_state = "bp_security"
 	item_state = "bp_security"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/robotics
 	name = "robotics backpack"
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects monochromaticly on the back of roboticists."
 	icon_state = "bp_robotics"
 	item_state = "bp_robotics"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/genetics
 	name = "genetics backpack"
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects safely on the back of geneticists."
 	icon_state = "bp_genetics"
 	item_state = "bp_genetics"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/engineering
 	name = "engineering backpack"
 	desc = "A sturdy, wearable container made of synthetic fibers, able to carry a number of objects effectively on the back of engineering personnel."
 	icon_state = "bp_engineering"
 	item_state = "bp_engineering"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/research
 	name = "research backpack"
@@ -239,12 +279,50 @@
 		icon_state = "satchelg"
 		item_state = "satchelg"
 
+/obj/item/storage/backpack/satchel/empty
+	spawn_contents = list()
+
+	blue
+		icon_state = "satchelb"
+		item_state = "satchelb"
+
+	red
+		icon_state = "satchelr"
+		item_state = "satchelr"
+
+	brown
+		icon_state = "satchelbr"
+		item_state = "satchelbr"
+
+	green
+		icon_state = "satchelg"
+		item_state = "satchelg"
+
+/obj/item/storage/backpack/satchel/withO2
+	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+
+	blue
+		icon_state = "satchelb"
+		item_state = "satchelb"
+
+	red
+		icon_state = "satchelr"
+		item_state = "satchelr"
+
+	brown
+		icon_state = "satchelbr"
+		item_state = "satchelbr"
+
+	green
+		icon_state = "satchelg"
+		item_state = "satchelg"
+
 /obj/item/storage/backpack/satchel/syndie
 	name = "\improper Syndicate Satchel"
 	desc = "A stylish red, evil, thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on an operative's shoulder."
 	icon_state = "Syndiesatchel"
 	item_state = "Syndiesatchel"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 	New()
 		..()
@@ -259,7 +337,7 @@
 	desc = "A stylish blue, thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's shoulder."
 	icon_state = "NTsatchel"
 	item_state = "NTsatchel"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/satchel/captain
 	name = "Captain's Satchel"
@@ -284,28 +362,28 @@
 	desc = "A sturdy, wearable container made of synthetic fibers, able to carry a number of objects stylishly on the shoulder of security personnel."
 	icon_state = "satchel_security"
 	item_state = "satchel_security"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/satchel/robotics
 	name = "robotics satchel"
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects monochromaticly on the shoulder of roboticists."
 	icon_state = "satchel_robotics"
 	item_state = "satchel_robotics"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/satchel/genetics
 	name = "genetics satchel"
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects safely on the shoulder of geneticists."
 	icon_state = "satchel_genetics"
 	item_state = "satchel_genetics"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/satchel/engineering
 	name = "engineering satchel"
 	desc = "A sturdy, wearable container made of synthetic fibers, able to carry a number of objects effectively on the shoulder of engineering personnel."
 	icon_state = "satchel_engineering"
 	item_state = "satchel_engineering"
-	spawn_contents = list(/obj/item/storage/box/starter/withO2)
+	spawn_contents = list(/obj/item/storage/box/starter)
 
 /obj/item/storage/backpack/satchel/research
 	name = "research satchel"

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -357,12 +357,12 @@
 
 /obj/item/storage/box/starter // the one you get in your backpack
 	icon_state = "emergbox"
-	spawn_contents = list(/obj/item/clothing/mask/breath)
-	make_my_stuff()
+	spawn_contents = list(/obj/item/clothing/mask/breath, /obj/item/tank/emergency_oxygen)
+	make_my_stuff(onlyMaskAndOxygen)
 		..()
-		if (prob(15) || ticker?.round_elapsed_ticks > 20 MINUTES) //aaaaaa
+		if (prob(15) || ticker?.round_elapsed_ticks > 20 MINUTES && !onlyMaskAndOxygen) //aaaaaa
 			new /obj/item/tank/emergency_oxygen(src)
-		if (ticker?.round_elapsed_ticks > 20 MINUTES)
+		if (ticker?.round_elapsed_ticks > 20 MINUTES && !onlyMaskAndOxygen)
 			new /obj/item/crowbar/red(src)
 #ifdef MAP_OVERRIDE_NADIR //guarantee protective gear
 		new /obj/item/clothing/suit/space/emerg(src)
@@ -373,8 +373,11 @@
 			new /obj/item/clothing/head/emerg(src)
 #endif
 
-/obj/item/storage/box/starter/withO2
+
+/obj/item/storage/box/starter/withO2 //use this if the box should not get additional items after the round has passed 20 min
 	spawn_contents = list(/obj/item/clothing/mask/breath, /obj/item/tank/emergency_oxygen)
+	make_my_stuff()
+		..(TRUE)
 
 /obj/item/storage/pill_bottle
 	name = "pill bottle"

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -170,9 +170,9 @@
 	make_my_stuff() //Let's spawn the backpack/satchel in random colours!
 		. = ..()
 		if (. == 1 && length(spawn_contents)) //if we've not spawned stuff before (also empty lockers get no backpack)
-			var/backwear = pick(/obj/item/storage/backpack,/obj/item/storage/backpack/blue,/obj/item/storage/backpack/red,/obj/item/storage/backpack/green)
+			var/backwear = pick(/obj/item/storage/backpack/withO2,/obj/item/storage/backpack/withO2/blue,/obj/item/storage/backpack/withO2/red,/obj/item/storage/backpack/withO2/green)
 			new backwear(src)
-			backwear = pick(/obj/item/storage/backpack/satchel,/obj/item/storage/backpack/satchel/blue,/obj/item/storage/backpack/satchel/red,/obj/item/storage/backpack/satchel/green)
+			backwear = pick(/obj/item/storage/backpack/satchel/withO2,/obj/item/storage/backpack/satchel/withO2/blue,/obj/item/storage/backpack/satchel/withO2/red,/obj/item/storage/backpack/satchel/withO2/green)
 			new backwear(src)
 
 /obj/storage/secure/closet/personal/empty


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[BUG]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #6127 where you could use
the uniform fabricator to get a free mask and oxygen.
Also the Satchels/backpacks in lockers will also now only
contain an emergency box that has a mask and O2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It fixes getting free O2 from the manufacturer and also
keeps contents of backpacks inside personal lockers consistent,
so that they don't change after the 20 min mark
