### PR TITLE
Fixes seeds able to mutate through infusions being able to infused beyond 99% damage

### DIFF
--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -229,9 +229,8 @@ ABSTRACT_TYPE(/datum/plant)
 					DNA.endurance++
 
 		if (damage_amt)
-			if (prob(damage_prob)) S.seeddamage += damage_amt
-		if (S.seeddamage > 99)
-			return 99 // destroy the seed
+			if (prob(damage_prob))
+				S.seeddamage += damage_amt
 
 /datum/plantgenes/
 	var/growtime = 0 // These vars are pretty much bonuses/penalties applied on top of the

--- a/code/obj/item/seeds.dm
+++ b/code/obj/item/seeds.dm
@@ -92,7 +92,7 @@
 		// The proc for when the manipulator is infusing seeds with a reagent. This is sort of a
 		// framing proc simply to check if the seed is in good enough condition to withstand the
 		// infusion or not - the actual gameplay effects are handled in a different proc:
-		// proc/HYPinfusionP, /datums/plants.dm, line 115
+		// proc/HYPinfusionP, /datums/plants.dm, line 111
 		// Note that this continues down the chain and checks the proc for individual plant
 		// datums after it's finished executing the base plant datum infusion proc.
 
@@ -107,10 +107,10 @@
 			// Whoops, you did it too often and now the seed broke. Good job doofus!!
 
 		var/datum/plant/P = src.planttype
-		if (P.HYPinfusionP(src,reagent) == 99)
-			// The proc call both executes the infusion on the species AND performs a check -
-			// The check is for a return value of 99, basically an error code for "Whoops you
-			// destroyed the seed you dumbass".
+		//this proc handles all statistics changes of the plant that depends on the chemical used, like phlogs 80-100 damage.
+		P.HYPinfusionP(src,reagent)
+		if (src.seeddamage > 99)
+			// "Whoops you destroyed the seed you dumbass".
 			M.seeds -= src
 			qdel(src)
 			return 1 // We'll want to tell the manipulator that so it can inform the user, too.


### PR DESCRIPTION
[hydroponics][bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the check for seed damage out of `proc/HYPInfusionP` into `proc/HYPInfusionS`. All plants that override `proc/HYPInfusionP` were able to be damaged over 100% by the used chem (most notable encountered when making seethers with phlogiston, which often generated seeds with 106% or up to 190% damage when the first infusion hit like 90%). Instead of changing all children of `proc/HYPInfusionP`, the parent was changed to accomodate to how the proc was used to prevent further incidents of that kind. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Seeds shouldn't be damaged by over 99% and survive that. This should fix issue #9768.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(*)Fixes seeds being able to be damaged by over 100%. Prepare to have your phlog infusions to fail more often!
```
