### PR TITLE
Adds operating computers to all operating rooms

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4931,12 +4931,17 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
 "mK" = (
-/obj/table/auto,
+/obj/surgery_tray,
+/obj/item/scissors/surgical_scissors,
+/obj/item/scalpel,
+/obj/item/circular_saw{
+	pixel_y = 8
+	},
 /obj/item/surgical_spoon{
 	pixel_y = 4
 	},
-/obj/item/suture,
 /obj/item/staple_gun,
+/obj/item/suture,
 /obj/item/hemostat,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
@@ -10441,7 +10446,9 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zh" = (
-/obj/machinery/optable,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "delivery2"
 	},
@@ -10465,16 +10472,13 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zi" = (
-/obj/surgery_tray,
-/obj/item/circular_saw{
-	pixel_y = 8
-	},
-/obj/item/scalpel,
 /obj/decal/tile_edge/line/blue{
 	dir = 4;
 	icon_state = "line2"
 	},
-/obj/item/scissors/surgical_scissors,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zj" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -24748,8 +24748,10 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/computer/operating,
 /obj/decal/stripe_caution,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "bcx" = (
@@ -28439,12 +28441,14 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bmC" = (
-/obj/machinery/optable,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/item/paper/book/from_file/medical_surgery_guide,
 /obj/decal/stripe_caution,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "bmE" = (
@@ -29160,10 +29164,12 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bok" = (
-/obj/machinery/computer/operating,
 /obj/decal/tile_edge/line/white,
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/computer/operating{
+	id = "robotics"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -42367,7 +42373,6 @@
 /turf/simulated/floor/wood,
 /area/station/engine/engineering/ce/private)
 "fFW" = (
-/obj/machinery/optable,
 /obj/decal/tile_edge/stripe{
 	dir = 10;
 	tag = ""
@@ -42377,6 +42382,9 @@
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 5
+	},
+/obj/machinery/optable{
+	id = "robotics"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/robotics)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45958,18 +45958,21 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/machinery/drainage,
-/obj/iv_stand,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cul" = (
-/obj/machinery/optable,
 /obj/machinery/light/small/floor,
 /obj/decal/stripe_caution,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cuo" = (
@@ -46486,17 +46489,20 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/machinery/drainage,
-/obj/iv_stand,
 /obj/disposalpipe/segment,
+/obj/machinery/computer/operating{
+	id = "OR2"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwd" = (
-/obj/machinery/optable,
 /obj/item/robodefibrillator,
 /obj/item/paper/book/from_file/medical_surgery_guide,
 /obj/machinery/light/small/floor,
 /obj/decal/stripe_caution,
+/obj/machinery/optable{
+	id = "OR2"
+	},
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwe" = (
@@ -55399,6 +55405,16 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
+"lef" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/morgue,
+/obj/machinery/drainage,
+/obj/iv_stand,
+/turf/simulated/floor,
+/area/station/medical/medbay/surgery)
 "lel" = (
 /obj/item/device/radio/intercom/catering{
 	dir = 1
@@ -104961,10 +104977,10 @@ cwF
 crM
 csB
 ctA
-cwe
+lef
 cDm
 cwe
-cwe
+lef
 ilc
 aKZ
 cxq

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -18984,6 +18984,12 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/quartersA)
+"aTi" = (
+/obj/machinery/computer/operating{
+	id = "OR2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "aTj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/arrivals)
@@ -68252,12 +68258,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cXN" = (
-/obj/machinery/optable,
 /obj/item/paper/book/from_file/pharmacopia,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4
 	},
 /obj/decal/stripe_caution,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cXO" = (
@@ -68265,8 +68273,9 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
-/obj/table/auto,
-/obj/machinery/defib_mount,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cXP" = (
@@ -71743,10 +71752,12 @@
 	},
 /area/station/medical/dome)
 "dfY" = (
-/obj/machinery/optable,
 /obj/disposalpipe/segment/morgue,
 /obj/item/paper/book/from_file/medical_surgery_guide,
 /obj/decal/stripe_caution,
+/obj/machinery/optable{
+	id = "OR2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "dfZ" = (
@@ -78343,6 +78354,12 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/podbay)
+"leN" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/table/auto,
+/obj/machinery/defib_mount,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "lhJ" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment{
@@ -81900,6 +81917,12 @@
 	icon_state = "fgreen4"
 	},
 /area/station/hydroponics/bay)
+"xWy" = (
+/obj/machinery/computer/operating{
+	id = "robotics"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/robotics)
 "xWJ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 10
@@ -116042,7 +116065,7 @@ cQJ
 cSw
 cTM
 dfr
-cVq
+leN
 cXO
 cVq
 dfr
@@ -116344,8 +116367,8 @@ cQI
 cSv
 cTN
 cVp
-cVp
 dfM
+aTi
 cVp
 cVp
 daP
@@ -118741,7 +118764,7 @@ tLy
 cqq
 cAK
 daZ
-daZ
+xWy
 daZ
 qEw
 nSx

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11972,9 +11972,11 @@
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "aPN" = (
-/obj/machinery/optable,
 /obj/item/paper/book/from_file/medical_surgery_guide,
 /obj/machinery/drainage,
+/obj/machinery/optable{
+	id = "robotics"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aPO" = (
@@ -13074,9 +13076,11 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "aTr" = (
-/obj/machinery/optable,
 /obj/machinery/drainage,
 /obj/item/paper/book/from_file/medical_surgery_guide,
+/obj/machinery/optable{
+	id = "OR2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "aTt" = (
@@ -15808,9 +15812,10 @@
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "bbj" = (
-/obj/table/auto,
 /obj/item_dispenser/latex_gloves,
-/obj/machinery/defib_mount,
+/obj/machinery/computer/operating{
+	id = "OR2"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -26240,6 +26245,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/research)
+"cKc" = (
+/obj/machinery/computer/operating{
+	id = "robotics"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "cKd" = (
 /obj/table/reinforced/bar/auto,
 /obj/item_dispenser/icedispenser{
@@ -29812,8 +29823,8 @@
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/obj/machinery/disposal/small/west,
 /obj/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -34521,10 +34532,12 @@
 	},
 /area/station/crew_quarters/pool)
 "jIf" = (
-/obj/machinery/optable,
 /obj/machinery/drainage,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/optable{
+	id = "OR1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -42942,9 +42955,10 @@
 	},
 /area/station/hangar/arrivals)
 "qIb" = (
-/obj/table/auto,
-/obj/machinery/defib_mount,
 /obj/machinery/light/incandescent,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "qIt" = (
@@ -46861,6 +46875,8 @@
 	},
 /obj/machinery/light_switch/east,
 /obj/disposalpipe/segment,
+/obj/table/auto,
+/obj/machinery/defib_mount,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -70420,7 +70436,7 @@ mGU
 arO
 aKL
 gpn
-aNb
+cKc
 aNb
 aOx
 aPj

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -18602,7 +18602,9 @@
 /area/station/maintenance/inner/east)
 "bjH" = (
 /obj/machinery/drainage,
-/obj/machinery/optable,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "bjI" = (
@@ -32568,6 +32570,9 @@
 /area/station/medical/medbay)
 "ceJ" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -42076,7 +42081,9 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "gCb" = (
-/obj/machinery/computer/operating,
+/obj/machinery/computer/operating{
+	id = "robotics"
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "gCA" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -693,6 +693,13 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"aox" = (
+/obj/machinery/computer/operating{
+	id = "OR2";
+	dir = 4
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/medbay/surgery)
 "aoA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -11200,6 +11207,13 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/pasiphae)
+"fsR" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/medical/medbay/surgery)
 "fsX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23497,6 +23511,8 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -37976,7 +37992,10 @@
 	name = "Extraction Nexus"
 	})
 "rNn" = (
-/obj/machinery/optable,
+/obj/machinery/drainage,
+/obj/machinery/optable{
+	id = "OR1"
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "rNq" = (
@@ -38211,20 +38230,14 @@
 "rSz" = (
 /obj/table/reinforced/auto,
 /obj/item/scalpel,
-/obj/item/scalpel,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
 	},
 /obj/item/suture,
-/obj/item/suture,
-/obj/item/scissors/surgical_scissors,
 /obj/item/scissors/surgical_scissors,
 /obj/machinery/light/small/floor,
+/obj/machinery/defib_mount,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "rSA" = (
@@ -39694,9 +39707,10 @@
 /turf/simulated/floor/redblack/corner,
 /area/station/hallway/secondary/exit)
 "sBk" = (
-/obj/machinery/drainage,
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/saline,
+/obj/machinery/computer/operating{
+	id = "OR1";
+	dir = 8
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "sBn" = (
@@ -41176,6 +41190,13 @@
 "teC" = (
 /obj/table/reinforced/auto,
 /obj/machinery/defib_mount,
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/scalpel,
+/obj/item/scissors/surgical_scissors,
+/obj/item/suture,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "teP" = (
@@ -41951,15 +41972,16 @@
 /turf/simulated/floor/red,
 /area/listeningpost)
 "twS" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	pixel_x = -10;
 	tag = ""
+	},
+/obj/machinery/computer/operating{
+	id = "robotics";
+	dir = 4
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
@@ -47398,6 +47420,13 @@
 	dir = 1
 	},
 /area/station/science/hall)
+"wkT" = (
+/obj/machinery/drainage,
+/obj/machinery/optable{
+	id = "OR2"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/medbay/surgery)
 "wlJ" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/rkit,
@@ -95203,7 +95232,7 @@ bEp
 iqo
 eej
 hkz
-eej
+fsR
 sPN
 xlx
 tyd
@@ -96411,8 +96440,8 @@ bEp
 mvT
 aqa
 iZO
-sBk
-rNn
+aox
+wkT
 xnq
 xnq
 tZC

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -5333,11 +5333,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "amq" = (
-/obj/item/clothing/suit/cardboard_box/head_surgeon,
+/obj/machinery/computer/operating{
+	id = "OR1"
+	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "amr" = (
-/obj/machinery/optable,
 /obj/machinery/drainage/big,
 /obj/item/paper/book/from_file/medical_surgery_guide{
 	pixel_x = 9
@@ -5345,6 +5346,9 @@
 /obj/machinery/defib_mount{
 	pixel_x = -7;
 	pixel_y = 4
+	},
+/obj/machinery/optable{
+	id = "OR1"
 	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
@@ -5968,6 +5972,7 @@
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1"
 	},
+/obj/item/clothing/suit/cardboard_box/head_surgeon,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "anY" = (
@@ -7426,8 +7431,8 @@
 	d2 = 4;
 	icon_state = "5-10"
 	},
-/obj/landmark/start{
-	name = "Roboticist"
+/obj/machinery/computer/operating{
+	id = "robotics"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)


### PR DESCRIPTION
[QOL] [MAPPING] 
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds operating computers from #12208 to ORs  (and robotics where it was missing) on all in rotation maps.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cool computers must be used.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(+)New operating computers have been shipped to all operating rooms on NT stations. 
```
