### PR TITLE
Removes the fuckable girder

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2002,7 +2002,6 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 				"readster's very own girder",
 				"just a girder",
 				"a gourder",//60
-				"a fuckable girder",
 				"a herd of girders",
 				"an A.D.G.S",
 				"the... thing",

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2012,7 +2012,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 				"nice",
 				"the girder egg")
 				msg = insert_girder[min(count+1, insert_girder.len)]
-				if(count >= 70)
+				if(count >= 69) //nice
 					girder_egg = 1
 					actions.start(new /datum/action/bar/icon/build(S, /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/townguard/passive, 2, null, 1, 'icons/obj/structures.dmi', "girder egg", msg, null), user)
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[REMOVAL][OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the ability for the player to construct a, and I quote, "fuckable girder". This one might be tagged incorrectly, please feel free to fix.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/66253095/208808119-35ae20f2-16b0-4f14-bed7-87262158b49e.png)
