### PR TITLE
removes tech outpost recharger on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -41136,7 +41136,6 @@
 /area/tech_outpost)
 "cdE" = (
 /obj/table/auto,
-/obj/machinery/recharger,
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/grime,
 /area/tech_outpost)


### PR DESCRIPTION
[removal][balance]

## About the PR 
removes the recharger at the oshan tech outpost

## Why's this needed? 
parity with space maps' tech outpost