### PR TITLE
removes rp-4 phaser on oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -36868,10 +36868,6 @@
 	dir = 4
 	},
 /obj/machinery/bot/secbot/beepsky,
-/obj/item/gun/energy/phaser_gun{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/machinery/light_switch/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)


### PR DESCRIPTION
[removal][balance]

## About the PR 
removes the roundstart rp-4 phaser on oshan in beepsky's room

## Why's this needed? 
i keep thinking about this and:
1. no other map has a roundstart gun like this, and i think general design has trended away from easy-grab guns?
2. i just don't understand why it's there!