### PR TITLE
Fix butchering

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -312,7 +312,7 @@ ABSTRACT_TYPE(/mob/living/critter)
 					src.skinresult = null
 					M.visible_message("<span class='alert'>[M] skins [src].</span>","You skin [src].")
 					return
-			if (issawingtool(I) || iscuttingtool(I))
+			if (src.butcherable && (issawingtool(I) || iscuttingtool(I)))
 				actions.start(new/datum/action/bar/icon/butcher_living_critter(src,src.butcher_time), M)
 				return
 

--- a/code/mob/living/critter/capybara.dm
+++ b/code/mob/living/critter/capybara.dm
@@ -6,4 +6,4 @@
 	is_npc = TRUE
 	ai_type = /datum/aiHolder/capybara
 	can_lie = FALSE
-
+	butcherable = 2 //2 makes butchering this creature an abominable act. Which it is. You monsters.

--- a/code/mob/living/critter/sawfly.dm
+++ b/code/mob/living/critter/sawfly.dm
@@ -128,7 +128,7 @@ This file is the critter itself, and all the custom procs it needs in order to f
 	proc/do_retaliate(mob/living/user)
 		if(!(issawflybuddy(user) || (user in src.friends) || (user.health < 40)))//are you an eligible target: nonantag or healthy enough?
 			if(prob(50) && !ON_COOLDOWN(src, "sawfly_retaliate_cd", 5 SECONDS) && !isdead(src))//now that you're eligible, are WE eligible?
-				if((ai.target != user))
+				if(ai && (ai.target != user))
 					src.lastattacker = user
 					src.retaliate = TRUE
 					src.visible_message("<span class='alert'><b>[src]'s targeting subsystems identify [user] as a high priority threat!</b></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A minor oversight meant all critters could be butchered, even when `butcherable` was `FALSE`.

Also I fixed a tiny runtime I found on sawflys with no AI

Also capybara butchering is now considered monstrous. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Some critters were butcherable when they shouldn't have been. If you find a critter that isn't butcherable but should be, report it as a bug.
```
