### PR TITLE
Make tomatoes' reagent react before transfering to the splat when thrown

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -106,8 +106,9 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 		playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 100, 1)
 		var/obj/decal/cleanable/tomatosplat/splat = new
 		if(src.reagents)
+			src.reagents.handle_reactions()
 			splat.reagents = new(10000)
-			src.reagents.trans_to(splat, src.reagents.total_volume) //could be deleted immediately
+			src.reagents.trans_to(splat, src.reagents.total_volume)
 		splat.set_loc(T)
 		splat.setup(T)
 		qdel(src)


### PR DESCRIPTION
[bug][hydroponics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR let's thrown tomatoes react before transfering their chemicals to the created splat

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Because a recent change made the tomato splat receive it's reagents before being moved to it's designated area, reactions happened on a splat without being in the area of impact, essentially disabling tomato splices which have immediate on-reaction effects. This essentially meant potassium+water tomatoes didn't worked.