### PR TITLE
Destructible stones

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -119,12 +119,33 @@
 	anchored = 1
 
 /obj/stone
-	name = "Stone"
+	name = "stone"
 	desc = "Rock and stone, son. Rock and stone."
 	icon = 'icons/misc/worlds.dmi'
 	icon_state = "stone"
-	anchored = 1
-	density=1
+	anchored = TRUE
+	density = TRUE
+
+	_max_health = 25
+	_health = 25
+
+	attackby(obj/item/I, mob/user)
+		if ((istype(I, /obj/item/mining_tool) || istype(I, /obj/item/mining_tools)) && !isrestrictedz(src.z))
+			playsound(src, 'sound/impact_sounds/Stone_Cut_1.ogg', 50)
+			//bleh
+			if (istype(I, /obj/item/mining_tool))
+				src._health -= I.force
+			else
+				var/obj/item/mining_tools/tool = I
+				src._health -= tool.power * 2
+			if (src._health <= 0)
+				src.visible_message("<span class='alert'>\The [src] breaks apart.</span>", "<span class='alert'>You hear rock shattering.</span>")
+				for (var/i in 1 to 3)
+					var/obj/item/raw_material/rock/rock = new(src.loc)
+					rock.pixel_x = rand(-16,16)
+					rock.pixel_y = rand(-16,16)
+				qdel(src)
+		. = ..()
 
 	random
 		New()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -141,9 +141,7 @@
 			if (src._health <= 0)
 				src.visible_message("<span class='alert'>\The [src] breaks apart.</span>", "<span class='alert'>You hear rock shattering.</span>")
 				for (var/i in 1 to 3)
-					var/obj/item/raw_material/rock/rock = new(src.loc)
-					rock.pixel_x = rand(-16,16)
-					rock.pixel_y = rand(-16,16)
+					new /obj/item/raw_material/rock{rand_pos = TRUE}(src.loc)
 				qdel(src)
 		. = ..()
 

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -147,6 +147,14 @@
 				qdel(src)
 		. = ..()
 
+	attack_hand(mob/user)
+		if(ishuman(user))
+			var/mob/living/carbon/human/human = user
+			if (istype(human.gloves, /obj/item/clothing/gloves/concussive))
+				var/obj/item/clothing/gloves/concussive/gauntlets = human.gloves
+				return src.Attackby(gauntlets.tool, user)
+		. = ..()
+
 	random
 		New()
 			. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets mining tools break stones on non-restricted z levels.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Annoying invincible stones from terrainify.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)More types of stones can now be broken with mining tools.
```
