### PR TITLE
Removes signaler implant from surplus crates

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -164,6 +164,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	cost = 1
 	desc = "An implant that can send configurable signals. Can be used while stunned or handcuffed."
 	not_in_crates = 1
+	can_buy = UPLINK_TRAITOR
 
 /datum/syndicate_buylist/generic/spen
 	name = "Sleepy Pen"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -163,6 +163,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/implanter/signaler
 	cost = 1
 	desc = "An implant that can send configurable signals. Can be used while stunned or handcuffed."
+	not_in_crates = 1
 
 /datum/syndicate_buylist/generic/spen
 	name = "Sleepy Pen"


### PR DESCRIPTION
[OBJECTS] [BALANCE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Restricts signaller implants from spawning in surplus crates.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While the signaller implant has good potential, it remains an item with a very specific use, not exactly suitable for surplus crates.
Relevant thread: https://forum.ss13.co/showthread.php?tid=20396&pid=189538#pid189538


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatausours
(+)Signaler implants will no longer appear in surplus crates.
```
