### PR TITLE
Check the user before tapping playing cards

### DIFF
--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -86,7 +86,7 @@
 
 	mouse_drop(var/atom/target as obj|mob) //r o t a t e
 		if(!istype(target,/obj/item/card_group))
-			if (is_incapacitated(user) || !user.can_use_hands() || !can_reach(user, src) || user.sleeping || (target && target.event_handler_flags & NO_MOUSEDROP_QOL))
+			if (is_incapacitated(usr) || !usr.can_use_hands() || !can_reach(usr, src) || usr.sleeping || (target && target.event_handler_flags & NO_MOUSEDROP_QOL))
 				return
 			tap_or_reverse(usr)
 		else

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -86,6 +86,8 @@
 
 	mouse_drop(var/atom/target as obj|mob) //r o t a t e
 		if(!istype(target,/obj/item/card_group))
+			if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isghostcritter(usr) || (target && target.event_handler_flags & NO_MOUSEDROP_QOL) || isintangible(usr))
+				return
 			tap_or_reverse(usr)
 		else
 			..()

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -86,7 +86,7 @@
 
 	mouse_drop(var/atom/target as obj|mob) //r o t a t e
 		if(!istype(target,/obj/item/card_group))
-			if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isghostcritter(usr) || (target && target.event_handler_flags & NO_MOUSEDROP_QOL) || isintangible(usr))
+			if (is_incapacitated(user) || !user.can_use_hands() || !can_reach(user, src) || user.sleeping || (target && target.event_handler_flags & NO_MOUSEDROP_QOL))
 				return
 			tap_or_reverse(usr)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a litany of checks yanked from the parent `mouse_drop` before tapping cards. Still allows robots to tap cards :)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12492

