### PR TITLE
Turrets target people in `/obj/vehicle` vehicles

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -126,9 +126,9 @@
 			continue
 		if (isdead(C) || isghostcritter(C))
 			continue
-		if (!istype(C.loc,/turf))
+		if (!(istype(C.loc,/turf) || istype(C.loc, /obj/vehicle)))
 			continue
-		if (!istype(C.loc.loc,A))
+		if (!(istype(C.loc.loc,A) || istype(C.loc.loc.loc, A)))
 			continue
 		if ((src.req_access || src.req_access_txt) && src.allowed(C))
 			continue //optional access whitelist

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -128,7 +128,7 @@
 			continue
 		if (!(istype(C.loc,/turf) || istype(C.loc, /obj/vehicle)))
 			continue
-		if (!(istype(C.loc.loc,A) || istype(C.loc.loc.loc, A)))
+		if (!(get_area(C) == A))
 			continue
 		if ((src.req_access || src.req_access_txt) && src.allowed(C))
 			continue //optional access whitelist


### PR DESCRIPTION
[GameObjects][Balance][Bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check in turret targeting for mobs in `/obj/vehicle`s , with a matching increased loc depth check.

This does make turret target checks more expensive, but the number of people riding `/obj/vehicle/*` at any one time has never risen to double-digits based on past experience.

This does not cause pods to be targeted, as they are `/obj/machinery/vehicle`s. Using lockers to circumvent turret targeting works the same as it does on live.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12465