### PR TITLE
Showers log when trying to access a missing `reagent_id`

### DIFF
--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -62,6 +62,8 @@
 			// "blood - 2.7867e-018" because remove_any() uses ratios (Convair880).
 			for (var/current_id in src.reagents.reagent_list)
 				var/datum/reagent/current_reagent = src.reagents.reagent_list[current_id]
+				if (isnull(current_reagent))
+					continue
 				if (current_reagent.id == "water" || current_reagent.id == "cleaner")
 					continue
 				if (current_reagent.volume < 0.5)

--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -62,7 +62,7 @@
 			// "blood - 2.7867e-018" because remove_any() uses ratios (Convair880).
 			for (var/current_id in src.reagents.reagent_list)
 				if (isnull(src.reagents.reagent_list[current_id]))
-					logTheThing(LOG_CHEMISTRY, src, "got a null refernece when accessing reagent `[current_id]` in its list of reagents [log_reagents(src)] at [log_loc(src)].")
+					stack_trace("[identify_object(src)] had `[current_id]` in its reagent list, but the value was null")
 					continue
 				var/datum/reagent/current_reagent = src.reagents.reagent_list[current_id]
 				if (current_reagent.id == "water" || current_reagent.id == "cleaner")

--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -61,9 +61,10 @@
 
 			// "blood - 2.7867e-018" because remove_any() uses ratios (Convair880).
 			for (var/current_id in src.reagents.reagent_list)
-				var/datum/reagent/current_reagent = src.reagents.reagent_list[current_id]
-				if (isnull(current_reagent))
+				if (isnull(src.reagents.reagent_list[current_id]))
+					logTheThing(LOG_CHEMISTRY, src, "got a null refernece when accessing [current_id] in its list of reagents [log_reagents(src)] at [log_loc(src)].")
 					continue
+				var/datum/reagent/current_reagent = src.reagents.reagent_list[current_id]
 				if (current_reagent.id == "water" || current_reagent.id == "cleaner")
 					continue
 				if (current_reagent.volume < 0.5)

--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -62,7 +62,7 @@
 			// "blood - 2.7867e-018" because remove_any() uses ratios (Convair880).
 			for (var/current_id in src.reagents.reagent_list)
 				if (isnull(src.reagents.reagent_list[current_id]))
-					logTheThing(LOG_CHEMISTRY, src, "got a null refernece when accessing [current_id] in its list of reagents [log_reagents(src)] at [log_loc(src)].")
+					logTheThing(LOG_CHEMISTRY, src, "got a null refernece when accessing reagent `[current_id]` in its list of reagents [log_reagents(src)] at [log_loc(src)].")
 					continue
 				var/datum/reagent/current_reagent = src.reagents.reagent_list[current_id]
 				if (current_reagent.id == "water" || current_reagent.id == "cleaner")


### PR DESCRIPTION
[Game-Objects][Bug][runtime]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Do an explicit null check on the reagent datum we just formed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes :(
Fixes #12439
