### PR TITLE
Auto-unequip cigarettes when doing CPR

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -945,10 +945,12 @@
 		if (bandana.is_pulled_down)
 			boutput(H, "<span class='notice'>You pull down [bandana].</span>")
 			bandana.see_face = TRUE
+			bandana.c_flags ^= COVERSMOUTH
 			src.icon_state = "bandana_up"
 		else
 			boutput(H, "<span class='notice'>You pull up [bandana].</span>")
 			bandana.see_face = FALSE
+			bandana.c_flags |= COVERSMOUTH
 			src.icon_state = "bandana_down"
 		bandana.icon_state = "[initial(bandana.icon_state)][bandana.is_pulled_down ? "_down" : ""]"
 		if (H.wear_mask == bandana)

--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -146,6 +146,7 @@
 	name = "bubblegum"
 	desc = "Some chewable gum. You can blow bubbles with it!"
 	icon_state = "anime"	// todo: decent sprites
+	c_flags = null
 	var/mob/chewer = null
 	var/chew_size = 0.2		// unit amount transferred when gum is chewed
 	var/spam_flag = 0		// counts down from spam_timer after each time the chew message is shown

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1714,8 +1714,13 @@ var/datum/action_controller/actions
 				return FALSE
 
 			if (human_owner.wear_mask)
-				boutput(human_owner, "<span class='alert'>You need to take off your facemask before you can give CPR!</span>")
-				return FALSE
+				if (!istype(human_owner.wear_mask, /obj/item/clothing/mask/cigarette))
+					boutput(human_owner, "<span class='alert'>You need to take off your facemask before you can give CPR!</span>")
+					return FALSE
+				var/obj/item/clothing/mask/cigarette/C = human_owner.wear_mask
+				human_owner.u_equip(C)
+				C.set_loc(human_owner.loc)
+				boutput(human_owner, "<span class='alert'>You spit out your cigarette in preparation to give CPR!</span>")
 
 		if (ishuman(target))
 			var/mob/living/carbon/human/human_target = target
@@ -1724,8 +1729,13 @@ var/datum/action_controller/actions
 				return FALSE
 
 			if (human_target.wear_mask)
-				boutput(owner, "<span class='alert'>You need to take off [human_target]'s facemask before you can give CPR!</span>")
-				return FALSE
+				if (!istype(human_target.wear_mask, /obj/item/clothing/mask/cigarette))
+					boutput(owner, "<span class='alert'>You need to take off [human_target]'s facemask before you can give CPR!</span>")
+					return FALSE
+				var/obj/item/clothing/mask/cigarette/C = human_target.wear_mask
+				human_target.u_equip(C)
+				C.set_loc(human_target.loc)
+				boutput(owner, "<span class='alert'>You knock the cigarette out of [human_target]'s mouth in preparation to give CPR!</span>")
 
 		if (isdead(target))
 			owner.visible_message("<span class='alert'><B>[owner] tries to perform CPR, but it's too late for [target]!</B></span>")

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1714,13 +1714,14 @@ var/datum/action_controller/actions
 				return FALSE
 
 			if (human_owner.wear_mask)
-				if (!istype(human_owner.wear_mask, /obj/item/clothing/mask/cigarette))
+				if (human_owner.wear_mask.c_flags & COVERSMOUTH)
 					boutput(human_owner, "<span class='alert'>You need to take off your facemask before you can give CPR!</span>")
 					return FALSE
-				var/obj/item/clothing/mask/cigarette/C = human_owner.wear_mask
-				human_owner.u_equip(C)
-				C.set_loc(human_owner.loc)
-				boutput(human_owner, "<span class='alert'>You spit out your cigarette in preparation to give CPR!</span>")
+				if (istype(human_owner.wear_mask, /obj/item/clothing/mask/cigarette))
+					var/obj/item/clothing/mask/cigarette/C = human_owner.wear_mask
+					human_owner.u_equip(C)
+					C.set_loc(human_owner.loc)
+					boutput(human_owner, "<span class='alert'>You spit out your cigarette in preparation to give CPR!</span>")
 
 		if (ishuman(target))
 			var/mob/living/carbon/human/human_target = target
@@ -1729,13 +1730,14 @@ var/datum/action_controller/actions
 				return FALSE
 
 			if (human_target.wear_mask)
-				if (!istype(human_target.wear_mask, /obj/item/clothing/mask/cigarette))
+				if(human_target.wear_mask.c_flags & COVERSMOUTH)
 					boutput(owner, "<span class='alert'>You need to take off [human_target]'s facemask before you can give CPR!</span>")
 					return FALSE
-				var/obj/item/clothing/mask/cigarette/C = human_target.wear_mask
-				human_target.u_equip(C)
-				C.set_loc(human_target.loc)
-				boutput(owner, "<span class='alert'>You knock the cigarette out of [human_target]'s mouth in preparation to give CPR!</span>")
+				if (istype(human_target.wear_mask, /obj/item/clothing/mask/cigarette))
+					var/obj/item/clothing/mask/cigarette/C = human_target.wear_mask
+					human_target.u_equip(C)
+					C.set_loc(human_target.loc)
+					boutput(owner, "<span class='alert'>You knock the cigarette out of [human_target]'s mouth in preparation to give CPR!</span>")
 
 		if (isdead(target))
 			owner.visible_message("<span class='alert'><B>[owner] tries to perform CPR, but it's too late for [target]!</B></span>")

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -2041,6 +2041,7 @@
 	name = "bee beard"
 	desc = "A beard. From a bee."
 	icon_state = "beard"
+	c_flags = null
 
 /obj/item/reagent_containers/food/snacks/beefood
 	name = "bee kibble"

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -7,6 +7,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	var/obj/item/voice_changer/vchange = 0
 	body_parts_covered = HEAD
+	c_flags = COVERSMOUTH
 	compatible_species = list("human", "cow", "werewolf")
 	wear_layer = MOB_HEAD_LAYER1
 	var/is_muzzle = 0
@@ -139,6 +140,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 	item_state = "moustache"
 	see_face = 0
 	w_class = W_CLASS_TINY
+	c_flags = null
 	is_syndicate = 1
 
 	setupProperties()
@@ -627,6 +629,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	icon_state = "cherryblossom"
 	item_state = "cherryblossom"
 	see_face = 0
+	c_flags = null
 
 /obj/item/clothing/mask/peacockmask
 	name = "peacock mask"
@@ -634,6 +637,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	icon_state = "peacock"
 	item_state = "peacock"
 	see_face = 0
+	c_flags = null
 
 ABSTRACT_TYPE(/obj/item/clothing/mask/bandana)
 /obj/item/clothing/mask/bandana


### PR DESCRIPTION
[Game Objects][Player Actions][Feature]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets all masks to cover the mouth by default - this enables more masks to be used with the `force_mask` grab option

Adds a few exceptions  that seemed reasonable to me.

When attempting CPR, if the owner or the target have a cigarette in their mask slot, unequip and put it on the ground with a short message.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11595
