### PR TITLE
Makes refilling cyborg docking stations a bit less jank

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -24,6 +24,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 
 /obj/machinery/recharge_station/New()
 	..()
+	src.flags |= NOSPLASH
 	src.create_reagents(500)
 	src.reagents.add_reagent("fuel", 250)
 	src.build_icon()
@@ -121,21 +122,22 @@ TYPEINFO(/obj/machinery/recharge_station)
 			user.drop_item()
 		qdel(W)
 
-	else if (istype(W, /obj/item/reagent_containers/glass))
-		var/obj/item/reagent_containers/glass/G = W
-		if (!G.reagents.total_volume)
-			boutput(user, "<span class='alert'>There is nothing in [G] to pour!</span>")
+	//this is defined here instead of just using OPENCONTAINER because we want to be able to dump large amounts of reagents at once
+	else if (istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
+		if (!W.reagents.total_volume)
+			boutput(user, "<span class='alert'>There is nothing in [W] to pour!</span>")
 			return
-		if (!G.reagents.has_reagent("fuel"))
-			boutput(user, "<span class='alert'>There's no fuel in [G]. It would be pointless to pour it in.</span>")
+		if (!W.reagents.has_reagent("fuel"))
+			boutput(user, "<span class='alert'>There's no fuel in [W]. It would be pointless to pour it in.</span>")
 			return
-		else
-			user.visible_message("<span class='notice'>[user] pours [G.amount_per_transfer_from_this] units of [G]'s contents into [src].</span>")
-			playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
-			W.reagents.trans_to(src, G.amount_per_transfer_from_this)
-			if (!G.reagents.total_volume)
-				boutput(user, "<span class='alert'><b>[G] is now empty.</b></span>")
-			src.reagents.isolate_reagent("fuel")
+		if (src.reagents.total_volume >= src.reagents.maximum_volume)
+			boutput(user, "<span class='alert'>[src] is full.</span>")
+			return
+		var/amount = min(W.reagents.total_volume, src.reagents.maximum_volume - src.reagents.total_volume, 50)
+		user.visible_message("<span class='notice'>[user] pours [amount] units of [W]'s contents into [src].</span>")
+		playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
+		W.reagents.trans_to(src, amount)
+		src.reagents.isolate_reagent("fuel")
 
 	else if (istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you pour fuel tanks into docking stations, changes the transfer amount to maximum 50u (up from 10), and cleans up some misc jank related to it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently although robotics starts with fuel tanks, they can't actually use them to refill their docking stations after they inevitably explode.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Cyborg docking stations are now easier to refill.
```
