### PR TITLE
disables hostile critter vortex event chance on rp servers

### DIFF
--- a/code/modules/events/vortexes.dm
+++ b/code/modules/events/vortexes.dm
@@ -3,7 +3,7 @@
 	customization_available = 1
 	var/derelictchoice = null
 #ifdef RP_MODE
-	disabled = 1
+	disabled = TRUE
 #else
 	required_elapsed_round_time = 45 MINUTES
 #endif

--- a/code/modules/events/vortexes.dm
+++ b/code/modules/events/vortexes.dm
@@ -3,7 +3,7 @@
 	customization_available = 1
 	var/derelictchoice = null
 #ifdef RP_MODE
-	required_elapsed_round_time = 60 MINUTES
+	disabled = 1
 #else
 	required_elapsed_round_time = 45 MINUTES
 #endif


### PR DESCRIPTION
[removal][events]

## About the PR 
sets disabled to 1/TRUE for #ifdef RP_MODE

## Why's this needed? 
players think it's a little over-tuned; my experiences are the same. i will say that my particular experiences were more that there weren't enough resources in medbay to handle all the poison critters for how many there are spawned.

don't really know what to do to apply weighting to each critter at this time, so i've just opted for a removal until someone else can do a more granular pass on weights for critters.

## Changelog
```changelog
(u)
(+)disabled the hostile critter vortexes random event on rp servers
```
