### PR TITLE
Fix area for one tile in cogmap maints by EVA

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -23101,7 +23101,7 @@
 "bjJ" = (
 /obj/storage/closet/office,
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/storage/eva)
+/area/station/maintenance/central)
 "bjK" = (
 /obj/cable{
 	icon_state = "1-4"


### PR DESCRIPTION
[BUG][MAPPING]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
 Change area to the relevant maint area from EVA to match the geography of the map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Radstorms mostly

## Screenshots
Before / HEAD
![image](https://user-images.githubusercontent.com/91498627/209616956-c753801b-e2f0-41e6-9c6b-4dedf2b51a29.png)

After / This PR
![image](https://user-images.githubusercontent.com/91498627/209617003-de6bcdfc-f86f-4a18-a143-c549015829b8.png)

