### PR TITLE
Enables to pull out items from satchels in your pocket or belt/backpack via grab-click

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -58,8 +58,8 @@
 		// but to be honest this is one of those funny bugs that can be fixed later
 
 		if (GET_DIST(user, src) <= 0 && length(src.contents))
+			var/obj/item/getItem = null
 			if (user.l_hand == src || user.r_hand == src)
-				var/obj/item/getItem = null
 
 				if (src.contents.len > 1)
 					if (user.a_intent == INTENT_GRAB)
@@ -73,13 +73,38 @@
 
 				else if (src.contents.len == 1)
 					getItem = src.contents[1]
+			else
+				if (user.a_intent == INTENT_GRAB)
+					var/is_on_user = FALSE
+					//I'm amazed and terrified that i'm unable to find a proc that looks if an item is someone on a person
+					//theoretically you are able quick-access satchels implanted in your chest... if you would be able to click on chest items, which you shouldn't be
+					for(var/obj/item/searching in user)
+						if (searching == src)
+							is_on_user = TRUE
 
-				if (getItem)
-					user.visible_message("<span class='notice'><b>[user]</b> takes \a [getItem.name] out of \the [src].</span>",\
-					"<span class='notice'>You take \a [getItem.name] from [src].</span>")
-					user.put_in_hand_or_drop(getItem)
-					src.UpdateIcon()
+						else
+							if (istype(searching, /obj/item/storage/))
+								for(var/obj/item/searching_2 in searching)
+									if (searching_2 == src)
+										is_on_user = TRUE
+										//i could make a proc that iterates through each container in someone and loops itself on new containers it encounters
+										//but honestly dunno if that would make the storage option too strong
+
+					if (is_on_user)
+						if (src.contents.len > 1)
+							user.visible_message("<span class='notice'><b>[user]</b> rummages through \the [src].</span>",\
+							"<span class='notice'>You rummage through \the [src].</span>")
+
+							getItem = pick(src.contents)
+						else
+							getItem = src.contents[1]
 			tooltip_rebuild = 1
+			if (getItem)
+				user.visible_message("<span class='notice'><b>[user]</b> takes \a [getItem.name] out of \the [src].</span>",\
+				"<span class='notice'>You take \a [getItem.name] from [src].</span>")
+				user.put_in_hand_or_drop(getItem)
+				src.UpdateIcon()
+				return 1
 		return ..(user)
 
 	proc/search_through(mob/user as mob)


### PR DESCRIPTION
[Feature][[Game-Objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR gives the ability to pull out objects directly from satchels that are not in your hand by clicking on them while being on grab-intent. This enables to still pick up satchels from pocket/storage containers but gives a special case when you need quick access to your satchels, 

The ability to selectively choose items in a satchel by grab-clicking them while in hand is untouched.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This gives miners, botanists and chefs a way to quick access food/erebite chunks in stressfull situations (eg. bulk cooking, combat). Also this provides a shortcut to improve the handling of various ores/produce/food items by reducing the amount of clicks needed.

The current iteration only checks the first layer on storage containers (e.g. backpacks, stealth storages in pockets, belts). I can expand this to all places inside someones inventory but i wasn't sure if this would make sense (eg. grabbing inside your backpack, in a box and then rummage through a satchel).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)You can click on ore/produce satchels in your belt/backpack/pockets while being on grab-intent to retreive items directly out of them.
```
