### PR TITLE
Makes bigshot destroy airlocks.

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -675,6 +675,8 @@ toxic - poisons
 
 		on_hit(atom/hit)
 			explosion_new(null, get_turf(hit), 4)
+			if(istype(hit, /obj/machinery/door))
+				hit.ex_act(1)
 
 		on_max_range_die(obj/projectile/O)
 			explosion_new(null, get_turf(O), 4)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes the high-explosive shots the Lawbringer fires destroy airlocks on hit, giving the mode some utility as a breaching tool while keeping in-theme as a one-weapon armory.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I noticed some people on Discord expressing confusion/annoyance that bigshot was almost useless for breaching (as well as nearly every other situation). This change should turn it from a joke mode that's really only good for showing off into something that situationally has an actual serious use.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The Lawbringer's bigshot mode now destroys airlocks on a direct hit.
```
