### PR TITLE
Fixes yet more conversion chamber jank

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -163,7 +163,8 @@ TYPEINFO(/obj/machinery/recharge_station)
 	if (!src.anchored)
 		boutput(user, "<span class='alert'>You must attach [src]'s floor bolts before the machine will work.</span>")
 		return FALSE
-
+	if (src.occupant)
+		boutput(user, "<span class='alert'>There's already someone in there.</span>")
 	var/mob/living/carbon/human/H = victim
 	logTheThing(LOG_COMBAT, user, "puts [constructTarget(H,"combat")] into a conversion chamber at [log_loc(src)]")
 	user.visible_message("<span class='notice>[user] stuffs [H] into \the [src].")

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -165,6 +165,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 		return FALSE
 	if (src.occupant)
 		boutput(user, "<span class='alert'>There's already someone in there.</span>")
+		return FALSE
 	var/mob/living/carbon/human/H = victim
 	logTheThing(LOG_COMBAT, user, "puts [constructTarget(H,"combat")] into a conversion chamber at [log_loc(src)]")
 	user.visible_message("<span class='notice>[user] stuffs [H] into \the [src].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES] [GAME OBJECT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes being able to put multiple people in the conversion chamber at once.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently you can put multiple people in the chamber but only the last one put in ever actually gets converted, leaving the others stuck there for eternity or until a nice admin saves them.