### PR TITLE
`grody` general manufacturer subtype

### DIFF
--- a/assets/maps/prefabs/prefab_silverglass.dmm
+++ b/assets/maps/prefabs/prefab_silverglass.dmm
@@ -931,15 +931,7 @@
 /turf/space,
 /area/prefab/silverglass/research)
 "FH" = (
-/obj/machinery/manufacturer/general{
-	desc = "There are bits and pieces of the internal mechanisms poking out the side. It's seen better days.";
-	free_resource_amt = 0;
-	free_resources = null;
-	malfunction = 1;
-	name = "grody manufacturer";
-	supplemental_desc = null;
-	wires = 11
-	},
+/obj/machinery/manufacturer/general/grody,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/plating,
 /area/prefab/silverglass)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2271,14 +2271,18 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/bagpipe,
 		/datum/manufacture/whistle)
 
+#define MALFUNCTION_WIRE_CUT 15 & ~(1<<WIRE_MALF)
+
 /obj/machinery/manufacturer/general/grody
 	name = "grody manufacturer"
 	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?"
 	supplemental_desc = "This one has seen better days. There are bits and pieces of the internal mechanisms poking out the side."
 	free_resource_amt = 0
 	free_resources = list()
-	malfunction = 1
-	wires = 11
+	malfunction = TRUE
+	wires = MALFUNCTION_WIRE_CUT
+
+#undef MALFUNCTION_WIRE_CUT
 
 /obj/machinery/manufacturer/robotics
 	name = "robotics fabricator"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2271,6 +2271,15 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/bagpipe,
 		/datum/manufacture/whistle)
 
+/obj/machinery/manufacturer/general/grody
+	name = "grody manufacturer"
+	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?"
+	supplemental_desc = "This one has seen better days. There are bits and pieces of the internal mechanisms poking out the side."
+	free_resource_amt = 0
+	free_resources = list()
+	malfunction = 1
+	wires = 11
+
 /obj/machinery/manufacturer/robotics
 	name = "robotics fabricator"
 	supplemental_desc = "This one produces robot parts, cybernetic organs, and other robotics-related equipment."

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1554,14 +1554,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "aet" = (
-/obj/machinery/manufacturer/general{
-	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?";
-	free_resource_amt = 0;
-	free_resources = null;
-	malfunction = 1;
-	name = "grody manufacturer";
-	wires = 11
-	},
+/obj/machinery/manufacturer/general/grody,
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -8503,14 +8503,7 @@
 	name = "Book Nook"
 	})
 "ecx" = (
-/obj/machinery/manufacturer/general{
-	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?";
-	free_resource_amt = 0;
-	free_resources = null;
-	malfunction = 1;
-	name = "grody manufacturer";
-	wires = 11
-	},
+/obj/machinery/manufacturer/general/grody,
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -67101,12 +67101,8 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "rnd" = (
-/obj/machinery/manufacturer/general{
-	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?";
+/obj/machinery/manufacturer/general/grody{
 	free_resource_amt = 2;
-	malfunction = 1;
-	name = "grody manufacturer";
-	wires = 11
 	},
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -2839,15 +2839,7 @@
 /area/dank_trench)
 "hB" = (
 /obj/decal/cleanable/dirt,
-/obj/machinery/manufacturer/general{
-	desc = "It's covered top to bottom in a thin layer of sticky gunk. You are absolutely certain it has never been cleaned.";
-	free_resource_amt = 0;
-	free_resources = null;
-	malfunction = 1;
-	name = "grody manufacturer";
-	supplemental_desc = null;
-	wires = 11
-	},
+/obj/machinery/manufacturer/general/grody,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12


### PR DESCRIPTION
[MAPPING][CODE QUALITY]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace several map-edited manufacturers with a new `grody` subtype.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce number of map-edited objects.
This is atomized from the wire panel component, as adding this in as a type makes it easier to unify manufacturer wire behavior there.