### PR TITLE
stop observer/aieye mousedrops categorically

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -849,6 +849,8 @@
 		return
 	if (isalive(usr) && !isintangible(usr) && isghostdrone(usr) && ismob(src) && src != usr)
 		return // Stops ghost drones from MouseDropping mobs
+	if (isAIeye(usr) || (isobserver(usr) && src != usr))
+		return // Stops AI eyes from click-dragging anything, and observers from click-dragging anything that isn't themselves (ugh)
 	over_object._MouseDrop_T(src, usr, src_location, over_location, src_control, over_control, params)
 	if (SEND_SIGNAL(src, COMSIG_ATOM_MOUSEDROP, usr, over_object, src_location, over_location, src_control, over_control, params))
 		return


### PR DESCRIPTION
[BUG]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
stop aieye click-drags, and observer click-drags UNLESS they are click-dragging themselves to move (to preserve an existing feature)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should (hopefully) resolve a class of bug where ghosts/aieyes can click-drag stuff

Fixes #12532
Fixes #12509
Fixes #12433