### PR TITLE
Turbine Control Computer Bugfix

### DIFF
--- a/code/obj/nuclearreactor/reactorcontrol.dm
+++ b/code/obj/nuclearreactor/reactorcontrol.dm
@@ -84,7 +84,10 @@
 
 	ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 		. = ..()
-		if(. || QDELETED(src.turbine_handle))
+		if(.)
+			return
+
+		if(QDELETED(src.turbine_handle))
 			src.turbine_handle = null
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It was possible for ghosts to cause the turbine control computer to lose the handle to the turbine, causing the graphs to spit out zeros whenever a ghost observing the TGUI interface clicked on one of the input boxes.