### PR TITLE
reduce delay between stacking items on ground in hands

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -69,7 +69,7 @@
 				user.put_in_hand(src)
 			boutput(user, "<span class='notice'>You add the material to the stack. It now has [src.amount] pieces.</span>")
 
-	mouse_drop(over_object, src_location, over_location) //src dragged onto over_object
+	mouse_drop(atom/over_object, src_location, over_location) //src dragged onto over_object
 		if (isobserver(usr))
 			boutput(usr, "<span class='alert'>Quit that! You're dead!</span>")
 			return
@@ -85,7 +85,7 @@
 				boutput(usr, "<span class='alert'>You're too far away from it to do that.</span>")
 				return
 
-		if (istype(over_object,/obj/item/material_piece)) //piece to piece, doesnt matter if in hand or not.
+		if (istype(over_object,/obj/item/material_piece) && isturf(over_object.loc)) //piece to piece only if on ground
 			var/obj/item/targetObject = over_object
 			if(targetObject.stack_item(src))
 				usr.visible_message("<span class='notice'>[usr.name] stacks \the [src]!</span>")

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -603,7 +603,7 @@
 			if (!stack_result)
 				continue
 			else
-				sleep(0.3 SECONDS)
+				sleep(0.5)
 				added += stack_result
 				if (user.loc != staystill) break
 				if (src.amount >= max_stack)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -603,7 +603,7 @@
 			if (!stack_result)
 				continue
 			else
-				sleep(0.5)
+				sleep(0.5 DECI SECONDS)
 				added += stack_result
 				if (user.loc != staystill) break
 				if (src.amount >= max_stack)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -91,7 +91,7 @@
 		else
 			return
 
-	mouse_drop(over_object, src_location, over_location) //src dragged onto over_object
+	mouse_drop(atom/over_object, src_location, over_location) //src dragged onto over_object
 		if (isobserver(usr))
 			boutput(usr, "<span class='alert'>Quit that! You're dead!</span>")
 			return
@@ -110,7 +110,7 @@
 		if(istype(over_object, /obj/afterlife_donations))
 			return ..()
 
-		if (istype(over_object,/obj/item/raw_material)) //piece to piece, doesnt matter if in hand or not.
+		if (istype(over_object,/obj/item/material_piece) && isturf(over_object.loc)) //piece to piece only if on ground
 			var/obj/item/targetObject = over_object
 			if(targetObject.stack_item(src))
 				usr.visible_message("<span class='notice'>[usr.name] stacks \the [src]!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
reduces the stacking time for items on the ground into your hand from `0.3 SECONDS` to `0.5`. 

uses default item stacking behavior for stacks of ore on ground

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This reduces the chance that people will click money onto a stack queued for pickup, leading to the resulting stack ending up qdel'd.

Relates to #5836
