### PR TITLE
Removes a single tile of east solar array area on cog2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -72277,13 +72277,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market)
-"dhk" = (
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/solar/east)
 "dhl" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'COLLISION HAZARD'";
@@ -115170,7 +115163,7 @@ cLH
 cqE
 aaI
 aaa
-dhk
+aam
 jQd
 dic
 dic


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/20713227/210114280-02575bf1-cbd0-44c6-ab68-c33f9be4dd59.png)
Removes this single tile of area that caused almost impossible to complete spy-thief bounties.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad, do not ask me to deliver to a single tile area.
