### PR TITLE
Quick fix for reactor suicide message

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -539,8 +539,8 @@
 					src.component_grid[chosen_slot[1]][chosen_slot[2]] = meat_rod //hehe
 				else
 					meat_rod.throw_at(get_ranged_target_turf(get_turf(src),pick(alldirs),rand(1,20)),rand(1,20),rand(1,20))
-				user.visible_message("<span class='alert'><b>The bits of [user] that didn't fit spray everywhere!</b></span>")
 				user.set_loc(get_turf(src))
+				user.visible_message("<span class='alert'><b>The bits of [user] that didn't fit spray everywhere!</b></span>")
 				user.gib()
 				_comp_grid_overlay_update = TRUE
 				UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`visible_message` relies on `loc`, and `loc` was inside the reactor at that point, meaning nobody saw the message. I just flip the ordering on the `set_loc()` and message.
