### PR TITLE
Makes flock incapacitors recharge at half speed while not on a feathertile

### DIFF
--- a/code/datums/components/power_cell.dm
+++ b/code/datums/components/power_cell.dm
@@ -109,3 +109,17 @@ TYPEINFO(/datum/component/power_cell)
 		src.charge(null, recharge_rate)
 	SEND_SIGNAL(parent, COMSIG_UPDATE_ICON)
 	return
+
+/datum/component/power_cell/flockdrone
+	var/original_rate
+
+/datum/component/power_cell/flockdrone/Initialize(max, start_charge, recharge, delay, rechargable)
+	. = ..()
+	src.original_rate = src.recharge_rate
+
+/datum/component/power_cell/flockdrone/process()
+	if (isfeathertile(get_turf(src.parent)))
+		src.recharge_rate = src.original_rate
+	else
+		src.recharge_rate = src.original_rate/2
+	..()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -492,7 +492,7 @@
 	HH.can_hold_items = FALSE
 
 	HH = hands[3]
-	HH.limb = new /datum/limb/gun/flock_stunner
+	HH.limb = new /datum/limb/gun/flock_stunner(hands[3])
 	HH.name = "incapacitor"
 	HH.icon = 'icons/mob/flock_ui.dmi'
 	HH.icon_state = "incapacitor"
@@ -1175,6 +1175,7 @@
 
 /datum/limb/gun/flock_stunner/New()
 	..()
+	src.cell.set_loc(src.holder.holder)
 	RegisterSignal(src.cell, COMSIG_UPDATE_ICON, .proc/update_overlay)
 
 /datum/limb/gun/flock_stunner/proc/update_overlay()

--- a/code/obj/flock/goods.dm
+++ b/code/obj/flock/goods.dm
@@ -63,7 +63,7 @@
 	force = 1
 	rechargeable = 0 // yeah this is weird alien technology good fucking luck charging it
 	can_swap_cell = 0 // No
-	cell_type = /obj/item/ammo/power_cell/self_charging
+	cell_type = /obj/item/ammo/power_cell/self_charging/flockdrone
 	projectiles = null
 	is_syndicate = 1 // it's less that this is a syndicate weapon and more that replicating it isn't trivial
 	custom_cell_max_capacity = 100

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1197,10 +1197,11 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	var/sound_load = 'sound/weapons/gunload_click.ogg'
 	var/unusualCell = 0
 	var/rechargable = TRUE
+	var/component_type = /datum/component/power_cell
 
 	New()
 		..()
-		AddComponent(/datum/component/power_cell, max_charge, charge, recharge_rate, recharge_delay, rechargable)
+		AddComponent(src.component_type, max_charge, charge, recharge_rate, recharge_delay, rechargable)
 		RegisterSignal(src, COMSIG_UPDATE_ICON, /atom/proc/UpdateIcon)
 		desc = "A power cell that holds a max of [src.max_charge]PU. Can be inserted into any energy gun, even tasers!"
 		UpdateIcon()
@@ -1441,6 +1442,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "You should not be seeing this!"
 	max_charge = 40
 	recharge_rate = 5
+	component_type = /datum/component/power_cell/flockdrone
 
 /datum/action/bar/icon/powercellswap
 	duration = 1 SECOND


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES] [WIKI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
^


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Incapacitors are really really good, flock have a tendency to steamroll, flock also don't have much incentive to convert large areas. This should help with all of that.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Flockdrone incapacitors now recharge at half speed while not on a flock tile.
```
