### PR TITLE
Adds the Mining Combat Helmet to hacked mining fabricators

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1925,6 +1925,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/miningcombathelmet
+	name = "Mining Combat Helmet"
+	item_paths = list("MET-3","CON-2","CRY-2")
+	item_amounts = list(5,3,3)
+	item_outputs = list(/obj/item/clothing/head/helmet/space/mining_combat)
+	time = 30 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/industrialboots
 	name = "Mechanised Boots"
 	item_outputs = list(/obj/item/clothing/shoes/industrial)

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1927,8 +1927,8 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/miningcombathelmet
 	name = "Mining Combat Helmet"
-	item_paths = list("MET-3","CON-2","CRY-2")
-	item_amounts = list(5,3,3)
+	item_paths = list("MET-3","CON-2","erebite")
+	item_amounts = list(4,3,5)
 	item_outputs = list(/obj/item/clothing/head/helmet/space/mining_combat)
 	time = 30 SECONDS
 	create = 1

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -971,9 +971,6 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/industrial)
 		..()
 		setProperty("meleeprot_head", 7)
 
-TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
-	mats = 10
-
 /obj/item/clothing/head/helmet/space/mining_combat
 	name = "mining combat helmet"
 	desc = "The sweet strawberry-scented visor goes great with Mining Combat Armor! Too bad the blueprints never got sent over."

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -973,16 +973,17 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/industrial)
 
 /obj/item/clothing/head/helmet/space/mining_combat
 	name = "mining combat helmet"
-	desc = "The sweet strawberry-scented visor goes great with Mining Combat Armor! Too bad the blueprints never got sent over."
+	desc = "Goes with Mining Combat Armor... if the blueprints for it ever got sent over. Now with a sweet strawberry-scented visor!"
 	icon_state = "mining_combat"
 	item_state = "mining_combat"
 
 	setupProperties()
 		..()
-		setProperty("radprot", 25)
-		setProperty("meleeprot_head", 2)
+		setProperty("radprot", 5)
+		setProperty("meleeprot_head", 5)
 		setProperty("disorient_resist_eye", 25)
-		setProperty("disorient_resist_ear", 10)
+		setProperty("disorient_resist_ear", 25)
+		setProperty("exploprot", 15)
 		setProperty("space_movespeed", 0)
 
 /obj/item/clothing/head/helmet/bucket

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -979,7 +979,6 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/industrial)
 
 	setupProperties()
 		..()
-		setProperty("radprot", 5)
 		setProperty("meleeprot_head", 5)
 		setProperty("disorient_resist_eye", 25)
 		setProperty("disorient_resist_ear", 25)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -976,7 +976,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
 
 /obj/item/clothing/head/helmet/space/mining_combat
 	name = "mining combat helmet"
-	desc = "Goes with Mining Combat Armor. Now with sweet strawberry-scented visor!"
+	desc = "Goes great with Mining Combat Armor! Too bad the blueprints never got sent over."
 	icon_state = "mining_combat"
 	item_state = "mining_combat"
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -976,7 +976,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
 
 /obj/item/clothing/head/helmet/space/mining_combat
 	name = "mining combat helmet"
-	desc = "Goes great with Mining Combat Armor! Too bad the blueprints never got sent over."
+	desc = "The sweet strawberry-scented visor goes great with Mining Combat Armor! Too bad the blueprints never got sent over."
 	icon_state = "mining_combat"
 	item_state = "mining_combat"
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2558,7 +2558,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 	hidden = list(/datum/manufacture/RCD,
 		/datum/manufacture/RCDammo,
 		/datum/manufacture/RCDammomedium,
-		/datum/manufacture/RCDammolarge)
+		/datum/manufacture/RCDammolarge,
+		/datum/manufacture/miningcombathelmet)
 
 /obj/machinery/manufacturer/hangar
 	name = "ship component fabricator"


### PR DESCRIPTION
[CLOTHING] [BALANCE]

## About the PR
Adds the Mining Combat Helmet (previously only obtainable via the hat trait, iirc) to hacked mining fabricators, and it changes the description to make it clear the armor isn't obtainable. It has the same material requirements as the industrial armor, but lowered significantly on account of it only being the helmet.

## Why's this needed?
The helmet is pretty good looking, and it could be used as an alternative "evil" industrial helmet other than the syndicate command helmet, which is limited to syndies. The mining fabricator is also really lacking items when hacked, only having the RCD and the ammo for it.

## Changelog

```changelog
(u)Idiot
(*)Added the Mining Combat Helmet to hacked mining fabricators.
```
