### PR TITLE
Stop Flock gnesis turret trying to fire through windows

### DIFF
--- a/code/obj/flock/structure/gnesisturret.dm
+++ b/code/obj/flock/structure/gnesisturret.dm
@@ -185,6 +185,7 @@
 		//fun fact, we can abuse jpsTurfPassable for this and use path caching!
 		var/test_turf = get_step(src, get_dir(src, C))
 		var/obj/projectile/test_proj = new()
+		test_proj.proj_data = src.current_projectile
 		while(GET_DIST(test_turf, C) > 0)
 			var/next_turf = get_step(test_turf, get_dir(test_turf, C))
 			if(!jpsTurfPassable(test_turf, next_turf, test_proj))

--- a/code/obj/flock/structure/gnesisturret.dm
+++ b/code/obj/flock/structure/gnesisturret.dm
@@ -181,6 +181,15 @@
 				return FALSE
 		if (isflockmob(C))
 			return FALSE
+		//final check, as it's the most expensive: do we have an unobstructed line of sight to the target?
+		//fun fact, we can abuse jpsTurfPassable for this and use path caching!
+		var/test_turf = get_step(src, get_dir(src, C))
+		var/obj/projectile/test_proj = new()
+		while(GET_DIST(test_turf, C) > 0)
+			var/next_turf = get_step(test_turf, get_dir(test_turf, C))
+			if(!jpsTurfPassable(test_turf, next_turf, test_proj))
+				return FALSE
+			test_turf = next_turf
 
 		return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Basically adds "can a projectile path directly from the turret to the target" as a final check on the valid target checking. Uses `jpsTurfPassable` to take advantage of path caching, which will likely be heavily in use around flock structures.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Gnesis turrets kept wasting their ammo trying to shoot through windows, which made them nearly useless.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Flock gnesis turrets will now only shoot at targets they can hit, instead of trying to shoot through obstructions.
```
