### PR TITLE
Make koshmarite a weak source of neutron radiation

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1067,7 +1067,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 		material_flags |= MATERIAL_CRYSTAL
 		setProperty("hard", 3)
 		setProperty("reflective", 6)
-		setProperty("radioactive", 2)
+		setProperty("n_radioactive", 1)
 		setProperty("density", 5)
 
 

--- a/code/modules/materials/Mat_Properties.dm
+++ b/code/modules/materials/Mat_Properties.dm
@@ -197,6 +197,7 @@ ABSTRACT_TYPE(/datum/material_property)
 	prefix_high_min = 1
 	prefix_low_max = 9
 	default_value = 0
+	min_value = 0
 
 	getAdjective(var/datum/material/M)
 		switch(M.getProperty(id))
@@ -230,6 +231,7 @@ ABSTRACT_TYPE(/datum/material_property)
 	prefix_high_min = 1
 	prefix_low_max = 9
 	default_value = 0
+	min_value = 0
 
 
 	getAdjective(var/datum/material/M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes koshmarite from being 20% normal radiation to 10% neutron radiation. 
Fixes the min value of radiation and neutron radiation material properties so that decay can go all the way.
Note: there's a comment saying that min_value < 1 will break everything, but I tested it and nothing broke. @ZeWaka may know more - probably don't merge this until they've weighed in.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Koshmarite is a weird eldritch material, but its radiation is just normal and weak? Now it can be weird and blue instead!

This *slightly* buffs the radioactive danger of koshmarite, though it's still weaker than cerenkite. 10% neutron radiation is equivalent to 40% normal radiation.

Mostly this enables koshmarite to actually be useful in the nuclear reactor, rather than being literally the worst fuel. It's still not a great fuel on its own, but it works well in concert with other normally radioactive materials.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Koshmarite becomes even spookier, as it is now a weak source of neutron radiation.
```
