### PR TITLE
Makes AI intercom override use the frequency of your second radio instead of using 144.7

### DIFF
--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -125,13 +125,14 @@ TYPEINFO(/obj/item/device/radio/intercom)
 			M.show_message(msg=message,assoc_maptext=maptext)
 
 		src.locked_frequency = TRUE // lockdown; saves us from clickspam
-		set_frequency(R_FREQ_INTERCOM_AI)
+		var/mob/living/intangible/aieye/eye = user
+		src.set_frequency(eye.mainframe.radio2.frequency)
 		src.broadcasting = TRUE
 		src.listening = TRUE
 
 		SPAWN(1 MINUTE)
 			src.locked_frequency = FALSE // safe as long as we can't control locked frequencies in the first place
-			set_frequency(original_src_frequency)
+			src.set_frequency(original_src_frequency)
 			src.broadcasting = original_src_broadcasting
 			src.listening = original_src_listening
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes AI intercom override use the frequency of your second radio instead of using 144.7


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
[QOL] for AIs that don't want to use 144.7


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)AI intercom override now uses the frequency of your second radio
```
