### PR TITLE
Fixes airless ranch random room

### DIFF
--- a/assets/maps/random_rooms/3x5/ranchroom_75.dmm
+++ b/assets/maps/random_rooms/3x5/ranchroom_75.dmm
@@ -2,41 +2,41 @@
 "a" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg,
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "f" = (
 /obj/railing/reinforced,
-/turf/simulated/floor/airless/green/corner{
+/turf/simulated/floor/green/corner{
 	dir = 8
 	},
 /area/dmm_suite/clear_area)
 "g" = (
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "h" = (
 /obj/chicken_nesting_box,
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "o" = (
-/turf/simulated/floor/airless/green/side{
+/turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/dmm_suite/clear_area)
 "q" = (
-/turf/simulated/floor/airless/green,
+/turf/simulated/floor/green,
 /area/dmm_suite/clear_area)
 "s" = (
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/simulated/floor/airless/green/corner{
+/turf/simulated/floor/green/corner{
 	dir = 1
 	},
 /area/dmm_suite/clear_area)
 "v" = (
 /obj/railing/reinforced,
-/turf/simulated/floor/airless/green/corner,
+/turf/simulated/floor/green/corner,
 /area/dmm_suite/clear_area)
 "x" = (
 /obj/shrub{
@@ -51,13 +51,13 @@
 	nostick = 1;
 	pixel_x = -11
 	},
-/turf/simulated/floor/airless/green/corner{
+/turf/simulated/floor/green/corner{
 	dir = 4
 	},
 /area/dmm_suite/clear_area)
 "M" = (
 /obj/railing/reinforced,
-/turf/simulated/floor/airless/green/side,
+/turf/simulated/floor/green/side,
 /area/dmm_suite/clear_area)
 "N" = (
 /obj/table/reinforced/auto,
@@ -67,11 +67,11 @@
 	nostick = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "Q" = (
 /obj/item/reagent_containers/food/snacks/ranch_feed_bag,
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "R" = (
 /obj/submachine/ranch_feed_grinder,
@@ -81,13 +81,13 @@
 	nostick = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 "Z" = (
 /obj/stool/chair/green{
 	dir = 1
 	},
-/turf/simulated/floor/airless/damaged1,
+/turf/simulated/floor/damaged1,
 /area/dmm_suite/clear_area)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Un-airlesses the ranch random room


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm not sure if this was intentional, but I'm pretty sure it shouldn't be airless.
Fixes #12640


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)Ranch random room is no longer airless
```
