### PR TITLE
Stops you from activating sawflies in sanctuary zones

### DIFF
--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -35,6 +35,13 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	//used in dictating behavior when deployed from grenade
 	var/mob/living/critter/robotic/sawfly/heldfly = null
 
+	attack_self(mob/user)
+		var/turf/T =  get_turf(src)
+		var/area/A = T.loc
+		if (A.sanctuary == TRUE && !istype(T.loc,/area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
+			boutput(user, "<span class='notice'>You can't prime it here!</span>")
+			return
+		..()
 
 	prime()
 		var/turf/T =  get_turf(src)
@@ -103,6 +110,9 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 				S.foldself()
 
 		for(var/obj/item/old_grenade/S in range(get_turf(src), 4)) // unfolds passive sawflies
+			var/area/A = S.loc.loc // the best way i know (get turf doesnt work)
+			if (A.sanctuary == TRUE && !istype(A, /area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
+				continue
 			if (S.issawfly == TRUE) //check if we're allowed to prime the grenade
 				if (istype(S, /obj/item/old_grenade/sawfly))
 					S.visible_message("<span class='alert'>[S] suddenly springs open as its engine purrs to a start!</span>")

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -36,9 +36,8 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	var/mob/living/critter/robotic/sawfly/heldfly = null
 
 	attack_self(mob/user)
-		var/turf/T =  get_turf(src)
-		var/area/A = T.loc
-		if (A.sanctuary == TRUE && !istype(T.loc,/area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
+		var/area/A = get_area(src)
+		if (A.sanctuary == TRUE && !istype(A, /area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
 			boutput(user, "<span class='notice'>You can't prime it here!</span>")
 			return
 		..()
@@ -110,7 +109,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 				S.foldself()
 
 		for(var/obj/item/old_grenade/S in range(get_turf(src), 4)) // unfolds passive sawflies
-			var/area/A = S.loc.loc // the best way i know (get turf doesnt work)
+			var/area/A = get_area(S)
 			if (A.sanctuary == TRUE && !istype(A, /area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
 				continue
 			if (S.issawfly == TRUE) //check if we're allowed to prime the grenade

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -38,7 +38,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	attack_self(mob/user)
 		var/area/A = get_area(src)
 		if (A.sanctuary == TRUE && !istype(A, /area/syndicate_station/battlecruiser)) // salvager vessel, vr, THE SHAMECUBE, but not the battlecruiser
-			boutput(user, "<span class='notice'>You can't prime it here!</span>")
+			boutput(user, "<span class='notice'>You can't prime [src] here!</span>")
 			return
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. You can still use them in the nukie ship.

I'm not sure if I should use 'notice' for the span class or something else

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You probably shouldn't be able to activate them in sanctuary zones. You can't even fight back. :(
Fixes #12488