### PR TITLE
Fixes being able to see into the Donut 2 AI Upload using cameras

### DIFF
--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -106,7 +106,11 @@
 	..()
 	var/area/area = get_area(src)
 	//if only these had a common parent...
-	if (istype(area, /area/station/turret_protected/ai) || istype(area, /area/station/turret_protected/ai_upload) || istype(area, /area/station/turret_protected/AIsat))
+	var/list/aiareas = list(/area/station/turret_protected/ai,
+							/area/station/turret_protected/ai_upload,
+							/area/station/turret_protected/AIsat,
+							/area/station/turret_protected/AIbasecore1)
+	if (locate(area) in aiareas)
 		src.ai_only = TRUE
 
 	AddComponent(/datum/component/camera_coverage_emitter)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes being able to see into the AI Upload using cameras


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency, can't see into the AI upload on any other station.
Fixes #12641