### PR TITLE
Adds 1 (one) cargo locker to Clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -32033,6 +32033,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "hyV" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I shoved it here.
![Screenshot_20230107_044011](https://user-images.githubusercontent.com/117641137/211144261-1d42de28-584e-4654-b05a-02650e8078c9.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There are ZERO cargo lockers on Clarion.
Fixes #12657

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)goonstation-enjoyer
(+)Adds a single cargo locker to Clarion
```
