### PR TITLE
Adds the ability to pick a custom spawn location for antag spawn events

### DIFF
--- a/code/modules/admin/data_input.dm
+++ b/code/modules/admin/data_input.dm
@@ -119,12 +119,7 @@
 				return
 
 		if (DATA_INPUT_REFPICKER)
-			var/datum/promise/promise = new
-			var/datum/targetable/refpicker/abil = new
-			abil.promise = promise
-			src.mob.targeting_ability = abil
-			src.mob.update_cursor()
-			input = promise.wait_for_value()
+			input = pick_ref(src.mob)
 
 		if (DATA_INPUT_NEW_INSTANCE)
 			var/stub = input(custom_message  || "Enter part of type:", custom_title) as null|text
@@ -320,3 +315,12 @@
 
 	handleCast(var/atom/selected)
 		promise.fulfill(selected)
+
+///Gives the target mob a reference picker ability and returns the atom picked. Synchronous.
+/proc/pick_ref(mob/M)
+	var/datum/promise/promise = new
+	var/datum/targetable/refpicker/abil = new
+	abil.promise = promise
+	M.targeting_ability = abil
+	M.update_cursor()
+	return promise.wait_for_value()

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -4,7 +4,7 @@
 	var/turf/custom_spawn_turf = null
 	admin_call(var/source)
 		if (src.targetable)
-			var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom")
+			var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom") == "Custom"
 			if (custom_loc)
 				src.custom_spawn_turf = get_turf(pick_ref(usr))
 /datum/random_event/major/antag/antagonist

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -1,9 +1,12 @@
 /datum/random_event/major/antag
+	///Can this event be given a custom spawn location
+	var/targetable = FALSE
 	var/turf/custom_spawn_turf = null
 	admin_call(var/source)
-		var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom")
-		if (custom_loc)
-			src.custom_spawn_turf = get_turf(pick_ref(usr))
+		if (src.targetable)
+			var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom")
+			if (custom_loc)
+				src.custom_spawn_turf = get_turf(pick_ref(usr))
 /datum/random_event/major/antag/antagonist
 	name = "Antagonist Spawn"
 	required_elapsed_round_time = 26.6 MINUTES
@@ -12,6 +15,7 @@
 	centcom_headline = "Biogenic Outbreak"
 	centcom_message = "Aggressive macrocellular organism detected aboard the station. All personnel must contain the outbreak."
 	message_delay = 5 MINUTES // (+ ghost_confirmation_delay). Don't out them too early, blobs in particular need time to establish themselves.
+	targetable = TRUE
 	var/antagonist_type = "Blob"
 	var/ghost_confirmation_delay = 2 MINUTES // time to acknowledge or deny respawn offer.
 	var/respawn_lock = 0

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -1,3 +1,9 @@
+/datum/random_event/major/antag
+	var/turf/custom_spawn_turf = null
+	admin_call(var/source)
+		var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom")
+		if (custom_loc)
+			src.custom_spawn_turf = get_turf(pick_ref(usr))
 /datum/random_event/major/antag/antagonist
 	name = "Antagonist Spawn"
 	required_elapsed_round_time = 26.6 MINUTES
@@ -382,20 +388,23 @@
 				boutput(M3, "<b>Objective #[i]</b>: [Obj.explanation_text]")
 				i++
 
-			switch (send_to)
-				if (1)
-					if (map_settings?.arrivals_type == MAP_SPAWN_MISSILE)
-						latejoin_missile_spawn(M3)
-					else
+			if (src.custom_spawn_turf)
+				M3.set_loc(src.custom_spawn_turf)
+			else
+				switch (send_to)
+					if (1)
+						if (map_settings?.arrivals_type == MAP_SPAWN_MISSILE)
+							latejoin_missile_spawn(M3)
+						else
+							M3.set_loc(ASLoc)
+					if (2)
+						if (!job_start_locations["wizard"])
+							boutput(M3, "<B><span class='alert'>A starting location for you could not be found, please report this bug!</span></B>")
+							M3.set_loc(ASLoc)
+						else
+							M3.set_loc(pick(job_start_locations["wizard"]))
+					if (3)
 						M3.set_loc(ASLoc)
-				if (2)
-					if (!job_start_locations["wizard"])
-						boutput(M3, "<B><span class='alert'>A starting location for you could not be found, please report this bug!</span></B>")
-						M3.set_loc(ASLoc)
-					else
-						M3.set_loc(pick(job_start_locations["wizard"]))
-				if (3)
-					M3.set_loc(ASLoc)
 			//nah
 			/*
 			if (src.centcom_headline && src.centcom_message && random_events.announce_events)
@@ -420,5 +429,4 @@
 		src.message_delay = initial(src.message_delay)
 		src.admin_override = initial(src.admin_override)
 		src.antag_count = initial(src.antag_count)
-
-		return
+		src.custom_spawn_turf = null

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -58,6 +58,7 @@
 /datum/random_event/major/antag/antagonist_pest
 	name = "Antagonist Critter Spawn"
 	customization_available = 1
+	targetable = TRUE
 	var/num_critters = 0
 	var/critter_type = null
 #ifdef RP_MODE

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -219,6 +219,8 @@
 					var/obj/item/implant/access/infinite/assistant/O = new /obj/item/implant/access/infinite/assistant(M.current)
 					O.owner = M.current
 					O.implanted = 1
+					if (src.custom_spawn_turf)
+						M.current.set_loc(src.custom_spawn_turf)
 					antagify(M.current, null, 1)
 				candidates -= M
 
@@ -228,3 +230,4 @@
 	proc/cleanup_event()
 		src.critter_type = null
 		src.num_critters = 0
+		src.custom_spawn_turf = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN] [FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an option to antag spawn event setup to pick a custom spawn location.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lets you spawn antags at a location without doing the janky `get ghost -> make into critter -> give antag status` bit.