### PR TITLE
Nadir "Multi-Melty" Update (nuclear reactor, Mining dept. introduction)

### DIFF
--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -103,6 +103,9 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/engine/caution,
 /area/shuttle/sea_elevator)
 "dw" = (
@@ -199,6 +202,7 @@
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator)
 "fP" = (
@@ -246,6 +250,7 @@
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/south,
 /area/shuttle/sea_elevator)
 "gR" = (
@@ -533,6 +538,9 @@
 	dir = 4
 	},
 /obj/access_spawn/mining,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/caution/westeast,
 /area/shuttle/sea_elevator)
 "sF" = (
@@ -585,6 +593,7 @@
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
@@ -653,6 +662,7 @@
 	})
 "vs" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution,
 /area/shuttle/sea_elevator)
 "vX" = (

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -941,11 +941,14 @@
 /area/diner/kitchen)
 "Fi" = (
 /obj/table/reinforced/auto,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/cargo,
-/obj/item/shipcomponent/communications/mining,
+/obj/item/shipcomponent/sensor/mining{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/item/shipcomponent/secondary_system/orescoop{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator)
 "Fk" = (

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -48,14 +48,14 @@
 	},
 /area/noGenerate)
 "bx" = (
-/obj/overlay{
-	density = 1;
-	desc = "It probably has something to do with the elevator.";
-	icon = 'icons/obj/machines/nuclear.dmi';
-	icon_state = "neutinj";
-	name = "strange machine"
+/obj/rack,
+/obj/item/sea_ladder{
+	pixel_x = 4
 	},
-/turf/simulated/floor/plating,
+/obj/item/mining_tool/power_pick{
+	pixel_x = -7
+	},
+/turf/simulated/floor/black,
 /area/shuttle/sea_elevator)
 "bR" = (
 /turf/simulated/wall/void{
@@ -63,12 +63,10 @@
 	},
 /area/noGenerate)
 "cj" = (
-/obj/shrub{
-	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
 /area/shuttle/sea_elevator)
 "dd" = (
 /obj/landmark{
@@ -102,8 +100,10 @@
 	name = "The Recluse"
 	})
 "dt" = (
-/obj/machinery/computer/sea_elevator,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution,
 /area/shuttle/sea_elevator)
 "dw" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -116,8 +116,9 @@
 	})
 "dC" = (
 /obj/machinery/light/small/floor/netural,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
 /area/shuttle/sea_elevator)
 "dU" = (
 /turf/unsimulated/wall/setpieces/leadwall{
@@ -158,15 +159,11 @@
 	},
 /area/shuttle/sea_elevator)
 "ey" = (
-/turf/unsimulated/wall/setpieces/leadwall/junction{
-	dir = 4
-	},
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/black,
 /area/shuttle/sea_elevator)
 "eT" = (
-/obj/machinery/door/airlock/pyro,
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
-	},
+/turf/simulated/floor/engine/caution/north,
 /area/shuttle/sea_elevator)
 "fb" = (
 /obj/table/reinforced/auto,
@@ -184,11 +181,7 @@
 	},
 /area/bee_trader)
 "fv" = (
-/obj/landmark{
-	name = "seafall"
-	},
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
+/turf/simulated/floor/caution/north,
 /area/shuttle/sea_elevator)
 "fy" = (
 /turf/simulated/floor/stairs/wide{
@@ -201,7 +194,12 @@
 	},
 /area/shuttle/sea_elevator)
 "fG" = (
-/turf/simulated/floor/scorched2,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_minebot";
+	name = "Vehicle Bay Door"
+	},
+/turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator)
 "fP" = (
 /obj/grille/catwalk{
@@ -236,25 +234,19 @@
 	},
 /area/bee_trader)
 "gv" = (
-/obj/decal/poster/wallsign/biohazard{
-	desc = "A warning sign which reads 'ACID HAZARD'.";
-	name = "ACID HAZARD"
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
 	},
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 5
-	},
-/area/shuttle/sea_elevator)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "gL" = (
-/obj/storage/crate/packing,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor/scorched2,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_minebot";
+	name = "Vehicle Bay Door"
+	},
+/turf/simulated/floor/engine/caution/south,
 /area/shuttle/sea_elevator)
 "gR" = (
 /turf/simulated/floor/carpet/red/fancy/innercorner/west,
@@ -289,10 +281,10 @@
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
 "ii" = (
-/obj/stool/chair{
-	dir = 8
+/obj/machinery/door/airlock/pyro{
+	dir = 4
 	},
-/turf/simulated/floor/industrial,
+/turf/simulated/floor/caution/westeast,
 /area/shuttle/sea_elevator)
 "ji" = (
 /obj/table/reinforced/auto,
@@ -308,25 +300,48 @@
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
+"km" = (
+/obj/machinery/vehicle/pod_smooth/industrial,
+/turf/simulated/floor/engine,
+/area/shuttle/sea_elevator)
 "kv" = (
 /turf/unsimulated/wall/setpieces/leadwall{
 	dir = 10
 	},
 /area/shuttle/sea_elevator)
+"kx" = (
+/obj/lattice,
+/obj/warp_beacon{
+	name = "Subsurface Bay"
+	},
+/turf/space/fluid/trench,
+/area/noGenerate)
 "kD" = (
-/obj/machinery/door/airlock/pyro,
-/turf/simulated/floor/engine/caution/corner{
-	dir = 8
+/obj/item/crowbar,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 6
 	},
 /area/shuttle/sea_elevator)
+"lB" = (
+/obj/overlay{
+	density = 1;
+	desc = "It probably has something to do with the elevator.";
+	icon = 'icons/obj/machines/nuclear.dmi';
+	icon_state = "neutinj";
+	name = "strange machine"
+	},
+/turf/simulated/floor/industrial,
+/area/shuttle/sea_elevator)
 "lK" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/engine/caution/east,
-/area/shuttle/sea_elevator)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "lW" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/engine/caution/east,
-/area/shuttle/sea_elevator)
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space/fluid/trench,
+/area/noGenerate)
 "lZ" = (
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/black/grime,
@@ -360,6 +375,18 @@
 /obj/item/instrument/large/jukebox,
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
+"mG" = (
+/obj/storage/crate/packing,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor/industrial,
+/area/shuttle/sea_elevator)
 "mH" = (
 /obj/machinery/vending/air_vendor,
 /turf/simulated/floor/industrial,
@@ -372,21 +399,7 @@
 /turf/variableTurf/wall,
 /area/allowGenerate/trench)
 "nJ" = (
-/obj/rack,
-/obj/item/device/gps{
-	identifier = "NT-E";
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/device/gps{
-	identifier = "NT-E";
-	pixel_y = 3
-	},
-/obj/item/device/gps{
-	identifier = "NT-E";
-	pixel_x = -5
-	},
-/turf/simulated/floor/industrial,
+/turf/simulated/floor/caution/south,
 /area/shuttle/sea_elevator)
 "nO" = (
 /obj/table/reinforced/bar/auto,
@@ -446,6 +459,12 @@
 "oQ" = (
 /turf/simulated/floor/engine/caution/west,
 /area/shuttle/sea_elevator)
+"pk" = (
+/obj/machinery/computer/sea_elevator{
+	dir = 8
+	},
+/turf/simulated/floor/industrial,
+/area/shuttle/sea_elevator)
 "pO" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/shaker/pepper{
@@ -457,6 +476,10 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge,
 /area/diner/kitchen)
+"qc" = (
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator)
 "qe" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/machinery/vending/kitchen,
@@ -510,12 +533,15 @@
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
 "se" = (
-/obj/decal/poster/wallsign/biohazard{
-	desc = "A warning sign which reads 'ACID HAZARD'.";
-	name = "ACID HAZARD"
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4
 	},
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 9
+/obj/access_spawn/mining,
+/turf/simulated/floor/caution/westeast,
+/area/shuttle/sea_elevator)
+"sF" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
 	},
 /area/shuttle/sea_elevator)
 "sR" = (
@@ -536,8 +562,8 @@
 /turf/variableTurf/wall,
 /area/noGenerate)
 "tk" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/engine/caution/west,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/caution/north,
 /area/shuttle/sea_elevator)
 "tm" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/ne,
@@ -558,8 +584,14 @@
 /turf/simulated/floor/specialroom/bar/edge,
 /area/diner/kitchen)
 "tA" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/engine/caution/east,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_minebot";
+	name = "Vehicle Bay Door"
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 1
+	},
 /area/shuttle/sea_elevator)
 "tC" = (
 /obj/machinery/light/small/floor/netural,
@@ -624,19 +656,16 @@
 	name = "Space Diner Backhall"
 	})
 "vs" = (
-/obj/rack,
-/obj/item/sea_ladder{
-	pixel_x = 4
-	},
-/obj/item/mining_tool/power_pick{
-	pixel_x = -7
-	},
-/turf/simulated/floor/industrial,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/engine/caution,
 /area/shuttle/sea_elevator)
 "vX" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/engine/caution/west,
-/area/shuttle/sea_elevator)
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/trench,
+/area/noGenerate)
 "wk" = (
 /obj/item/cell/charged{
 	pixel_x = 8;
@@ -651,6 +680,34 @@
 /area/tech_outpost{
 	name = "The Recluse"
 	})
+"wr" = (
+/obj/table/reinforced/auto,
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator)
 "wX" = (
 /turf/unsimulated/wall/setpieces/leadwindow,
 /area/shuttle/sea_elevator)
@@ -680,13 +737,28 @@
 	},
 /area/shuttle/sea_elevator)
 "xK" = (
-/obj/decal/poster/wallsign/hazard_danger,
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 4
+/obj/rack,
+/obj/item/device/gps{
+	identifier = "NT-E";
+	pixel_x = -5;
+	pixel_y = 6
 	},
+/obj/item/device/gps{
+	identifier = "NT-E";
+	pixel_y = 3
+	},
+/obj/item/device/gps{
+	identifier = "NT-E";
+	pixel_x = 5
+	},
+/turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
 "xX" = (
-/turf/unsimulated/wall/setpieces/leadwall/junction_four,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/turf/simulated/floor/caution/north,
 /area/shuttle/sea_elevator)
 "yd" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
@@ -728,6 +800,11 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
+"zv" = (
+/turf/simulated/floor/caution/corner/misc{
+	dir = 10
+	},
+/area/shuttle/sea_elevator)
 "zF" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -752,11 +829,7 @@
 /turf/simulated/floor/black/grime,
 /area/skeleton_trader)
 "Af" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/engine/caution/corner{
-	dir = 1
-	},
+/turf/unsimulated/wall/setpieces/leadwall/junction,
 /area/shuttle/sea_elevator)
 "An" = (
 /obj/table/wood/auto,
@@ -772,11 +845,7 @@
 	name = "The Recluse"
 	})
 "Ap" = (
-/obj/decal/poster/wallsign/biohazard{
-	desc = "A warning sign which reads 'ACID HAZARD'.";
-	name = "ACID HAZARD"
-	},
-/turf/unsimulated/wall/setpieces/leadwall/cap,
+/turf/simulated/floor/engine/caution,
 /area/shuttle/sea_elevator)
 "Av" = (
 /obj/decal/cleanable/blood/tracks,
@@ -787,9 +856,18 @@
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "AG" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/engine/caution/corner,
+/obj/machinery/light/small/floor/netural,
+/obj/machinery/door_control{
+	id = "nadir_minebot";
+	name = "Bay Door Control";
+	pixel_y = 24
+	},
+/turf/simulated/floor/caution/north,
+/area/shuttle/sea_elevator)
+"Be" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
 /area/shuttle/sea_elevator)
 "BK" = (
 /obj/submachine/ATM{
@@ -822,6 +900,12 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
+"CG" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
+	},
+/area/shuttle/sea_elevator)
 "CS" = (
 /obj/machinery/light/incandescent/warm,
 /obj/table/wood/round/auto,
@@ -886,10 +970,22 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge,
 /area/diner/kitchen)
+"Fi" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/secondary_system/orescoop,
+/obj/item/shipcomponent/secondary_system/cargo,
+/obj/item/shipcomponent/communications/mining,
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator)
 "Fk" = (
 /obj/decal/cleanable/molten_item,
 /turf/simulated/floor/black/grime,
 /area/diner/kitchen)
+"Fp" = (
+/turf/simulated/floor/engine,
+/area/shuttle/sea_elevator)
 "Fs" = (
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -1027,6 +1123,11 @@
 "JT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/bathroom)
+"Kf" = (
+/turf/unsimulated/wall/setpieces/leadwall/cap{
+	dir = 4
+	},
+/area/shuttle/sea_elevator)
 "Kj" = (
 /obj/decal/poster/wallsign/biohazard{
 	desc = "A warning sign which reads 'ACID HAZARD'.";
@@ -1165,6 +1266,10 @@
 	},
 /turf/simulated/floor/grime,
 /area/diner/bathroom)
+"Ou" = (
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/caution/north,
+/area/shuttle/sea_elevator)
 "Ow" = (
 /turf/simulated/floor/scorched2,
 /area/diner/bathroom)
@@ -1178,6 +1283,16 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
+"ON" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/shuttle/sea_elevator)
+"OT" = (
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/engine/caution/west,
+/area/shuttle/sea_elevator)
 "Ql" = (
 /obj/machinery/door/airlock/pyro,
 /turf/simulated/floor/black/grime,
@@ -1310,6 +1425,11 @@
 /area/tech_outpost{
 	name = "The Recluse"
 	})
+"TC" = (
+/turf/unsimulated/wall/setpieces/leadwall/junction{
+	dir = 1
+	},
+/area/shuttle/sea_elevator)
 "TP" = (
 /obj/npc/trader/bee{
 	name = "Bambini"
@@ -1368,6 +1488,10 @@
 "Vf" = (
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
+"Vo" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/caution,
+/area/shuttle/sea_elevator)
 "Vq" = (
 /obj/stool/chair/wooden,
 /turf/simulated/floor/black/grime,
@@ -1385,6 +1509,14 @@
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
+"VJ" = (
+/obj/machinery/r_door_control{
+	id = "nadir_minebot"
+	},
+/turf/unsimulated/wall/setpieces/leadwall/junction{
+	dir = 1
+	},
+/area/shuttle/sea_elevator)
 "VR" = (
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/black/grime,
@@ -1451,6 +1583,10 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
+"Xr" = (
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor,
+/area/shuttle/sea_elevator)
 "Xs" = (
 /obj/decal/fakeobjects/teleport_pad,
 /obj/marker/supplymarker,
@@ -1551,15 +1687,11 @@
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "Zf" = (
-/obj/rack,
-/obj/item/sea_ladder{
-	pixel_x = -4
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/item/mining_tool/power_pick{
-	pixel_x = 7
-	},
-/turf/simulated/floor/industrial,
-/area/shuttle/sea_elevator)
+/turf/space/fluid/trench,
+/area/noGenerate)
 "Zp" = (
 /obj/table/auto,
 /obj/item/circuitboard/teleporter{
@@ -1605,8 +1737,14 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
+"ZZ" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/caution/south,
+/area/shuttle/sea_elevator)
 
 (1,1,1) = {"
+XP
+XP
 XP
 al
 bt
@@ -1630,9 +1768,13 @@ XP
 XP
 XP
 XP
-nw
-nw
-nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1650,6 +1792,8 @@ XP
 XP
 "}
 (2,1,1) = {"
+XP
+XP
 XP
 aL
 bR
@@ -1671,13 +1815,17 @@ XP
 XP
 XP
 XP
-nw
-nw
-nw
-nw
-nw
-nw
-nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1693,6 +1841,8 @@ XP
 XP
 "}
 (3,1,1) = {"
+XP
+XP
 XP
 aU
 bt
@@ -1711,18 +1861,22 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
+XP
+XP
+XP
 nw
 nw
 nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1753,20 +1907,26 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 nw
 nw
 nw
 nw
 nw
 nw
-WQ
-WQ
-WQ
-WQ
-WQ
 nw
-nw
-nw
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1779,6 +1939,107 @@ XP
 XP
 "}
 (5,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+"}
+(6,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+nw
+nw
+nw
+nw
+nw
+nw
+WQ
+WQ
+WQ
+WQ
+WQ
+nw
+nw
+nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+"}
+(7,1,1) = {"
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1820,8 +2081,14 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
 "}
-(6,1,1) = {"
+(8,1,1) = {"
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1863,8 +2130,14 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
 "}
-(7,1,1) = {"
+(9,1,1) = {"
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1906,8 +2179,14 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
 "}
-(8,1,1) = {"
+(10,1,1) = {"
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1949,8 +2228,14 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
 "}
-(9,1,1) = {"
+(11,1,1) = {"
+XP
+XP
+XP
 XP
 XP
 XP
@@ -1992,8 +2277,11 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
 "}
-(10,1,1) = {"
+(12,1,1) = {"
 XP
 XP
 XP
@@ -2002,6 +2290,9 @@ XP
 XP
 XP
 XP
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2035,89 +2326,6 @@ XP
 XP
 XP
 XP
-"}
-(11,1,1) = {"
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-nw
-nw
-nw
-WQ
-WQ
-WQ
-WQ
-WQ
-nw
-nw
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-"}
-(12,1,1) = {"
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
 XP
 XP
 XP
@@ -2127,12 +2335,13 @@ XP
 XP
 XP
 XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2148,9 +2357,14 @@ XP
 nw
 nw
 nw
+WQ
+WQ
+WQ
+WQ
+WQ
 nw
 nw
-nw
+XP
 XP
 XP
 XP
@@ -2168,6 +2382,16 @@ XP
 (14,1,1) = {"
 XP
 XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2180,19 +2404,15 @@ XP
 XP
 XP
 XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2211,6 +2431,17 @@ XP
 (15,1,1) = {"
 XP
 XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2223,17 +2454,12 @@ XP
 XP
 XP
 XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2253,12 +2479,18 @@ XP
 "}
 (16,1,1) = {"
 XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2295,13 +2527,19 @@ XP
 XP
 "}
 (17,1,1) = {"
-XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
+nw
 XP
 XP
 XP
@@ -2338,13 +2576,19 @@ XP
 XP
 "}
 (18,1,1) = {"
-XP
-XP
-XP
-XP
-XP
-XP
-XP
+nw
+nw
+nw
+nw
+nw
+nw
+aV
+qX
+qX
+qX
+kv
+nw
+nw
 XP
 XP
 XP
@@ -2381,16 +2625,22 @@ XP
 XP
 "}
 (19,1,1) = {"
-XP
-XP
-XP
-XP
-XP
-XP
 nw
 nw
 nw
 nw
+nw
+aV
+ma
+bx
+bx
+bx
+va
+kv
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -2425,21 +2675,27 @@ XP
 "}
 (20,1,1) = {"
 XP
+nw
+nw
+nw
+nw
+xI
+yJ
+oQ
+yJ
+oQ
+yJ
+xI
 XP
 XP
 XP
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
 XP
 XP
 XP
 XP
+XP
+Nl
+Nl
 Nl
 Nl
 XP
@@ -2467,21 +2723,27 @@ XP
 XP
 "}
 (21,1,1) = {"
-XP
-XP
-nw
-nw
-nw
 aV
 qX
-wX
-wX
 qX
-kv
-nw
-nw
+qX
+qX
+TC
+Ap
+Ap
+Ap
+Ap
+Ap
+bn
+XP
+Nl
+Nl
+Nl
 XP
 XP
+Nl
+Nl
+Nl
 Nl
 Nl
 Nl
@@ -2510,27 +2772,33 @@ XP
 XP
 "}
 (22,1,1) = {"
-XP
-nw
-nw
-nw
-nw
-bn
-ji
-ob
-ob
-ru
-va
-kv
-nw
-XP
-XP
+xI
+mH
+xh
+xK
+jy
+Kf
+fy
+gh
+aV
+dt
+dt
+TC
 Nl
 Nl
 Nl
 Nl
 Nl
-nw
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
 nw
 nw
 nw
@@ -2553,27 +2821,33 @@ XP
 XP
 "}
 (23,1,1) = {"
-nw
-nw
-nw
-nw
-nw
 bn
-jy
-ob
+ji
+tC
 ob
 tC
-vs
+ob
+tC
+ob
 xI
-nw
-nw
+Vo
+Ap
+vs
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
 Nl
 Nl
 Nl
 nw
 nw
-Nl
 nw
+Nl
+Nl
+Nl
 Nl
 Nl
 Nl
@@ -2596,23 +2870,29 @@ XP
 XP
 "}
 (24,1,1) = {"
-nw
-aV
-qX
-qX
-qX
-et
-kv
+xI
+fb
 ob
 ob
 ob
-nJ
-xK
+ob
+ob
+ob
+xI
+Vo
+Ap
+vs
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
+Nl
 nw
 nw
-Nl
-Nl
-Nl
+nw
 nw
 nw
 Nl
@@ -2639,23 +2919,29 @@ XP
 XP
 "}
 (25,1,1) = {"
-nw
-bn
-cj
-bx
-dC
-fG
-xI
-oG
-fE
-se
+Af
 wX
-xX
-Ap
+ii
+ii
+wX
+kv
+tC
+ob
+bn
+qu
+qu
+bn
 Nl
 Nl
 Nl
 Nl
+Nl
+Nl
+Nl
+Nl
+nw
+nw
+nw
 nw
 nw
 nw
@@ -2682,22 +2968,28 @@ XP
 XP
 "}
 (26,1,1) = {"
-nw
 bn
-dd
-dd
-fv
-fG
-kD
-oQ
-oQ
-tk
-vX
-yJ
-AG
+ru
+ob
+ob
+mG
+Af
+se
+se
+et
+qX
+qX
+VJ
+lK
+lK
+lK
+lK
+lK
+lK
 Nl
-Nl
-Nl
+XP
+nw
+nw
 nw
 nw
 nw
@@ -2725,22 +3017,28 @@ XP
 XP
 "}
 (27,1,1) = {"
-nw
 bn
-dd
-dd
-fv
+pk
+tC
+tC
+lB
+bn
+oG
+fE
+sF
+OT
+oQ
 fG
-eT
-qu
-qu
-tA
 lK
-lW
-Af
-Nl
-Nl
-Nl
+lK
+lK
+lK
+lK
+lK
+lK
+XP
+XP
+nw
 nw
 nw
 nw
@@ -2768,22 +3066,28 @@ XP
 XP
 "}
 (28,1,1) = {"
-nw
-bn
+va
+kv
+dd
+dd
+aV
+ma
+AG
+kD
 cj
-dt
+qu
 dC
 gL
-xI
-fy
-gh
+lK
+lK
+lK
 gv
-wX
-xX
-Ap
-Nl
-Nl
-Nl
+lK
+lK
+lK
+XP
+XP
+XP
 nw
 nw
 nw
@@ -2811,22 +3115,28 @@ XP
 XP
 "}
 (29,1,1) = {"
-nw
-va
-qX
-qX
-qX
-ey
-ma
-ob
-ob
-ob
-xh
-xK
-Nl
-Nl
-Nl
-Nl
+XP
+bn
+dd
+dd
+bn
+wr
+Ou
+nJ
+Fp
+km
+eT
+gL
+Zf
+Zf
+Zf
+kx
+vX
+lK
+lK
+XP
+XP
+XP
 nw
 nw
 nw
@@ -2854,21 +3164,27 @@ XP
 XP
 "}
 (30,1,1) = {"
-nw
-nw
-nw
-nw
-nw
-bn
-mH
-ob
-ob
-tC
-Zf
-xI
-Nl
-Nl
-Nl
+XP
+va
+qX
+qX
+TC
+Fi
+fv
+ZZ
+Fp
+Fp
+eT
+gL
+lK
+lK
+lK
+lW
+lK
+lK
+lK
+XP
+XP
 nw
 nw
 nw
@@ -2898,20 +3214,26 @@ XP
 "}
 (31,1,1) = {"
 XP
-nw
-nw
-nw
-nw
+XP
+XP
+XP
 bn
-fb
-ob
-ob
-ii
-aV
-ma
-Nl
-Nl
-Nl
+qc
+tk
+zv
+CG
+oQ
+ON
+gL
+lK
+lK
+lK
+lK
+lK
+lK
+lK
+XP
+XP
 nw
 nw
 nw
@@ -2941,19 +3263,25 @@ XP
 "}
 (32,1,1) = {"
 XP
-nw
-nw
-nw
-nw
-va
-qX
-wX
-wX
-qX
-ma
-Nl
-Nl
-Nl
+XP
+XP
+XP
+bn
+ey
+xX
+Xr
+Be
+qu
+qu
+tA
+lK
+lK
+lK
+lK
+lK
+lK
+XP
+XP
 nw
 nw
 nw
@@ -2985,18 +3313,24 @@ XP
 (33,1,1) = {"
 XP
 XP
-nw
-nw
-nw
-nw
-nw
-nw
-nw
-nw
+XP
+XP
+va
+wX
+qX
+wX
+qX
+qX
+qX
+ma
 Nl
 Nl
 Nl
-nw
+Nl
+Nl
+XP
+XP
+XP
 nw
 nw
 nw
@@ -3029,17 +3363,23 @@ XP
 XP
 XP
 XP
-nw
-nw
-nw
-nw
-nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 Nl
 Nl
 Nl
 Nl
 Nl
-nw
+XP
+XP
+XP
 nw
 nw
 nw
@@ -3075,12 +3415,18 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 Nl
 Nl
 Nl
 Nl
-Nl
-Nl
+XP
 XP
 XP
 nw
@@ -3117,12 +3463,18 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 Nl
 Nl
-Nl
-Nl
-Nl
-Nl
+XP
 XP
 XP
 XP
@@ -3159,13 +3511,19 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3202,17 +3560,23 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
 XP
 XP
 XP
-nw
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 nw
 nw
 nw
@@ -3245,12 +3609,18 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3289,11 +3659,17 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3332,10 +3708,16 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3376,9 +3758,15 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3419,9 +3807,15 @@ XP
 XP
 XP
 XP
-Nl
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3463,8 +3857,14 @@ XP
 XP
 XP
 XP
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3506,8 +3906,14 @@ XP
 XP
 XP
 XP
-Nl
-Nl
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP
@@ -3563,6 +3969,12 @@ XP
 XP
 XP
 XP
+XP
+XP
+XP
+XP
+XP
+XP
 nw
 nw
 nw
@@ -3585,6 +3997,12 @@ XP
 XP
 "}
 (47,1,1) = {"
+XP
+XP
+XP
+XP
+XP
+XP
 XP
 XP
 XP

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -62,12 +62,6 @@
 	desc = "The energies within ebb and flow, driven by the source beneath."
 	},
 /area/noGenerate)
-"cj" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
-	},
-/area/shuttle/sea_elevator)
 "dd" = (
 /obj/landmark{
 	name = "seafall"
@@ -197,12 +191,11 @@
 	},
 /area/shuttle/sea_elevator)
 "fG" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
-/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator)
 "fP" = (
@@ -242,15 +235,14 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench/nospawn,
 /area/noGenerate)
 "gL" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
-/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/south,
 /area/shuttle/sea_elevator)
 "gR" = (
@@ -289,6 +281,9 @@
 /obj/machinery/door/airlock/pyro{
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/caution/westeast,
 /area/shuttle/sea_elevator)
 "ji" = (
@@ -316,13 +311,15 @@
 /area/shuttle/sea_elevator)
 "kx" = (
 /obj/lattice,
+/obj/machinery/light/small/floor/greenish,
 /obj/warp_beacon{
 	name = "Subsurface Bay"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench/nospawn,
 /area/noGenerate)
 "kD" = (
 /obj/item/crowbar,
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
 	},
@@ -337,15 +334,12 @@
 	},
 /turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
-"lK" = (
-/turf/space/fluid/trench,
-/area/noGenerate)
 "lW" = (
 /obj/lattice{
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench/nospawn,
 /area/noGenerate)
 "lZ" = (
 /obj/decal/cleanable/dirt/dirt2,
@@ -565,10 +559,6 @@
 "ta" = (
 /turf/variableTurf/wall,
 /area/noGenerate)
-"tk" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/caution/north,
-/area/shuttle/sea_elevator)
 "tm" = (
 /turf/simulated/floor/carpet/red/fancy/narrow/ne,
 /area/tech_outpost{
@@ -588,12 +578,11 @@
 /turf/simulated/floor/specialroom/bar/edge,
 /area/diner/kitchen)
 "tA" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "nadir_minebot";
 	name = "Vehicle Bay Door"
 	},
-/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
@@ -670,7 +659,7 @@
 	dir = 1;
 	icon_state = "lattice-dir-b"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench/nospawn,
 /area/noGenerate)
 "wk" = (
 /obj/item/cell/charged{
@@ -780,6 +769,7 @@
 	name = "Space Diner Backhall"
 	})
 "zv" = (
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
@@ -835,7 +825,6 @@
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
 "AG" = (
-/obj/machinery/light/small/floor/netural,
 /obj/machinery/door_control{
 	id = "nadir_minebot";
 	name = "Bay Door Control";
@@ -879,12 +868,6 @@
 /area/diner/hallway{
 	name = "Space Diner Backhall"
 	})
-"CG" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/engine/caution/corner{
-	dir = 8
-	},
-/area/shuttle/sea_elevator)
 "CS" = (
 /obj/machinery/light/incandescent/warm,
 /obj/table/wood/round/auto,
@@ -1184,6 +1167,10 @@
 	},
 /obj/item/storage/pill_bottle/antirad{
 	pixel_x = 15
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator)
@@ -1668,6 +1655,9 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/diner/kitchen)
+"YD" = (
+/turf/space/fluid/trench/nospawn,
+/area/noGenerate)
 "YO" = (
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/engine,
@@ -1715,7 +1705,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/turf/space/fluid/trench,
+/turf/space/fluid/trench/nospawn,
 /area/noGenerate)
 "Zp" = (
 /obj/table/auto,
@@ -2707,7 +2697,7 @@ nw
 xI
 yJ
 oQ
-yJ
+oQ
 oQ
 yJ
 xI
@@ -2720,9 +2710,9 @@ XP
 XP
 XP
 Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
 XP
 XP
 XP
@@ -2766,13 +2756,13 @@ Nl
 Nl
 XP
 XP
+YD
 Nl
+YD
+YD
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
 XP
 XP
 nw
@@ -2810,20 +2800,20 @@ dt
 dt
 TC
 Nl
+YD
 Nl
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 nw
 nw
 nw
@@ -2852,32 +2842,32 @@ tC
 ob
 tC
 ob
-tC
+ob
 ob
 xI
-Vo
+Ap
 Ap
 vs
+YD
+YD
 Nl
+YD
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
 nw
 nw
 nw
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 Ol
 bd
 Sp
@@ -2901,32 +2891,32 @@ ob
 ob
 ob
 ob
-ob
+tC
 ob
 xI
 Vo
 Ap
 vs
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 nw
 nw
 nw
 nw
 nw
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
 yh
 Iw
 LT
@@ -2945,25 +2935,25 @@ XP
 "}
 (25,1,1) = {"
 Af
-wX
+qX
 ii
 ii
-wX
+qX
 kv
-tC
+ob
 ob
 bn
 qu
 qu
 bn
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 nw
 nw
 nw
@@ -3005,13 +2995,13 @@ et
 qX
 qX
 VJ
-lK
-lK
-lK
-lK
-lK
-lK
-Nl
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 XP
 nw
 nw
@@ -3044,7 +3034,7 @@ XP
 (27,1,1) = {"
 bn
 pk
-tC
+ob
 tC
 lB
 bn
@@ -3054,13 +3044,13 @@ sF
 OT
 oQ
 fG
-lK
-lK
-lK
-lK
-lK
-lK
-lK
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 XP
 XP
 nw
@@ -3099,17 +3089,17 @@ aV
 ma
 AG
 kD
-cj
+Be
 qu
 dC
 gL
-lK
-lK
-lK
+YD
+YD
+YD
 gv
-lK
-lK
-lK
+YD
+YD
+YD
 XP
 XP
 XP
@@ -3157,8 +3147,8 @@ Zf
 Zf
 kx
 vX
-lK
-lK
+YD
+YD
 XP
 XP
 XP
@@ -3201,13 +3191,13 @@ Fp
 Fp
 eT
 gL
-lK
-lK
-lK
+YD
+YD
+YD
 lW
-lK
-lK
-lK
+YD
+YD
+YD
 XP
 XP
 nw
@@ -3244,19 +3234,19 @@ XP
 XP
 bn
 Fi
-tk
+fv
 zv
-CG
+sF
 oQ
 ON
 gL
-lK
-lK
-lK
-lK
-lK
-lK
-lK
+YD
+YD
+YD
+YD
+YD
+YD
+YD
 XP
 XP
 nw
@@ -3299,12 +3289,12 @@ Be
 qu
 qu
 tA
-lK
-lK
-lK
-lK
-lK
-lK
+YD
+YD
+YD
+YD
+YD
+YD
 XP
 XP
 nw
@@ -3349,9 +3339,9 @@ qX
 qX
 ma
 Nl
-Nl
-Nl
-Nl
+YD
+YD
+YD
 Nl
 XP
 XP
@@ -3397,11 +3387,11 @@ XP
 XP
 XP
 XP
+YD
+YD
 Nl
-Nl
-Nl
-Nl
-Nl
+YD
+YD
 XP
 XP
 XP
@@ -3449,7 +3439,7 @@ XP
 XP
 Nl
 Nl
-Nl
+YD
 Nl
 XP
 XP

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -301,7 +301,7 @@
 /turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
 "km" = (
-/obj/machinery/vehicle/pod_smooth/industrial,
+/obj/machinery/vehicle/pod_smooth/industrial/nadir,
 /turf/simulated/floor/engine,
 /area/shuttle/sea_elevator)
 "kv" = (
@@ -946,8 +946,12 @@
 	pixel_x = -3
 	},
 /obj/item/shipcomponent/secondary_system/orescoop{
-	pixel_y = 4;
-	pixel_x = 5
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/item/shipcomponent/secondary_system/lock/pw_id{
+	pixel_y = 2;
+	pixel_x = 6
 	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator)

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -476,10 +476,6 @@
 	},
 /turf/simulated/floor/specialroom/bar/edge,
 /area/diner/kitchen)
-"qc" = (
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator)
 "qe" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/machinery/vending/kitchen,
@@ -681,31 +677,7 @@
 	name = "The Recluse"
 	})
 "wr" = (
-/obj/table/reinforced/auto,
-/obj/item/pinpointer/trench{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/pinpointer/trench{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/pinpointer/trench{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/trench_map{
-	pixel_x = 3
-	},
-/obj/item/trench_map{
-	pixel_x = 3
-	},
-/obj/item/trench_map{
-	pixel_x = 3
-	},
-/obj/item/trench_map{
-	pixel_x = 3
-	},
+/obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator)
 "wX" = (
@@ -754,10 +726,7 @@
 /turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
 "xX" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 3;
-	pixel_x = 4
-	},
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/caution/north,
 /area/shuttle/sea_elevator)
 "yd" = (
@@ -1166,6 +1135,41 @@
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/engine/caution/corner,
 /area/diner/dining)
+"Lv" = (
+/obj/table/reinforced/auto,
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/pinpointer/trench{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/trench_map{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/emergency_injector/anti_rad{
+	pixel_x = 16;
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/antirad{
+	pixel_x = 15
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator)
 "LG" = (
 /obj/decal/cleanable/dirt,
 /obj/submachine/ice_cream_dispenser,
@@ -1585,6 +1589,10 @@
 	})
 "Xr" = (
 /obj/decal/cleanable/dirt/jen,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 4
+	},
 /turf/simulated/floor,
 /area/shuttle/sea_elevator)
 "Xs" = (
@@ -3169,7 +3177,7 @@ va
 qX
 qX
 TC
-Fi
+Lv
 fv
 ZZ
 Fp
@@ -3218,7 +3226,7 @@ XP
 XP
 XP
 bn
-qc
+Fi
 tk
 zv
 CG

--- a/code/map.dm
+++ b/code/map.dm
@@ -953,9 +953,6 @@ var/global/list/mapNames = list(
 		"the derelict southeast 'Warrens'" = list(/area/station/hallway/secondary/construction))
 
 	job_limits_from_landmarks = TRUE
-	job_limits_override = list(
-		/datum/job/engineering/miner = 0 //eventually, assay technicians?
-	)
 
 /datum/map_settings/wrestlemap
 	name = "WRESTLEMAP"

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -407,7 +407,7 @@
 	generateLight = 0
 	allow_hole = 0
 #ifdef MAP_OVERRIDE_NADIR
-	spawningFlags = SPAWN_LOOT | SPAWN_HOSTILE | SPAWN_ACID_DOODADS
+	spawningFlags = SPAWN_LOOT | SPAWN_HOSTILE
 #else
 	spawningFlags = SPAWN_DECOR | SPAWN_PLANTS | SPAWN_FISH | SPAWN_LOOT | SPAWN_HALLU
 #endif

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -407,7 +407,7 @@
 	generateLight = 0
 	allow_hole = 0
 #ifdef MAP_OVERRIDE_NADIR
-	spawningFlags = SPAWN_LOOT | SPAWN_HOSTILE
+	spawningFlags = SPAWN_LOOT | SPAWN_HOSTILE | SPAWN_ACID_DOODADS
 #else
 	spawningFlags = SPAWN_DECOR | SPAWN_PLANTS | SPAWN_FISH | SPAWN_LOOT | SPAWN_HALLU
 #endif
@@ -424,6 +424,12 @@
 						src.linked_hole = hole
 						src.add_simple_light("trenchhole", list(120, 120, 120, 120))
 						break
+
+/turf/space/fluid/trench/nospawn
+	spawningFlags = null
+
+	generate_worldgen()
+		return
 
 /turf/space/fluid/nospawn
 	spawningFlags = null

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1007,10 +1007,16 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	capacity = 4
 
 /obj/machinery/vehicle/pod_smooth/industrial/nadir
-	//just adds a special name
+	//special name, pre-equipped with drilling hardware
 	New()
 		..()
 		name += "[pick(" (The Orca)"," (Sea Pig)"," (The Iso-Pod)")]"
+		src.m_w_system = new /obj/item/shipcomponent/mainweapon/rockdrills(src)
+		src.m_w_system.ship = src
+		src.components += src.m_w_system
+		myhud.update_systems()
+		myhud.update_states()
+		return
 
 //pod wars ones//
 /obj/machinery/vehicle/pod_smooth/nt_light

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1006,6 +1006,12 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	speed = 1.5
 	capacity = 4
 
+/obj/machinery/vehicle/pod_smooth/industrial/nadir
+	//just adds a special name
+	New()
+		..()
+		name += "[pick(" (The Orca)"," (Sea Pig)"," (The Iso-Pod)")]"
+
 //pod wars ones//
 /obj/machinery/vehicle/pod_smooth/nt_light
 	name = "Pod NTL-"

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -1016,6 +1016,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 		src.components += src.m_w_system
 		myhud.update_systems()
 		myhud.update_states()
+		src.overlays += image('icons/effects/64x64.dmi', "[src.m_w_system.appearanceString]")
 		return
 
 //pod wars ones//

--- a/code/modules/worldgen/prefab/mining.dm
+++ b/code/modules/worldgen/prefab/mining.dm
@@ -299,7 +299,7 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 		probability = 100
 		prefabPath = "assets/maps/prefabs/prefab_water_nadirelevator.dmm" //also sneakily contains diner and siphon shaft cover
 		prefabSizeX = 47
-		prefabSizeY = 41
+		prefabSizeY = 47
 
 	miracliumsurvey
 		underwater = 1

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -34677,7 +34677,6 @@
 /obj/cable{
 	icon_state = "5-8"
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/west)
 "pmV" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1911,6 +1911,9 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_east)
 "aUV" = (
@@ -4689,6 +4692,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "cdg" = (
@@ -7192,7 +7196,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
-/area/shuttle/sea_elevator_room)
+/area/shuttle/sea_elevator/upper)
 "dpb" = (
 /obj/rack,
 /obj/disposalpipe/segment/mineral,
@@ -8860,6 +8864,11 @@
 	pixel_y = -14;
 	pixel_x = 7
 	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "dYJ" = (
@@ -8977,6 +8986,7 @@
 "ebd" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
 "ebi" = (
@@ -23859,6 +23869,11 @@
 /obj/item/decoration/flower_vase{
 	pixel_y = 22
 	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "ktK" = (
@@ -28441,6 +28456,7 @@
 "mrW" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "msd" = (
@@ -30607,6 +30623,7 @@
 "nsO" = (
 /obj/table/reinforced/auto,
 /obj/item/game_kit,
+/obj/machinery/light,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -31287,7 +31304,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
-/area/shuttle/sea_elevator_room)
+/area/shuttle/sea_elevator/upper)
 "nGo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31583,6 +31600,10 @@
 /obj/item/clothing/head/that{
 	pixel_y = 6;
 	pixel_x = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/quarters_east)
@@ -35350,6 +35371,10 @@
 /obj/item/kitchen/food_box/donut_box{
 	pixel_y = 6
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "pFB" = (
@@ -35776,6 +35801,10 @@
 	},
 /obj/item/clothing/mask/balaclava{
 	pixel_x = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_east)
@@ -38693,6 +38722,10 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/quarters_east)
 "rpX" = (
@@ -39495,7 +39528,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
-/area/shuttle/sea_elevator_room)
+/area/shuttle/sea_elevator/upper)
 "rKK" = (
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -39629,7 +39662,7 @@
 /area/station/crew_quarters/catering)
 "rNu" = (
 /turf/simulated/floor/engine/caution/corner,
-/area/shuttle/sea_elevator_room)
+/area/shuttle/sea_elevator/upper)
 "rNU" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -42342,6 +42375,7 @@
 "sVw" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "sVB" = (
@@ -47349,6 +47383,11 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -587,14 +587,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "alM" = (
-/obj/cable/orange{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
 /obj/cable/orange{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
@@ -2375,7 +2372,6 @@
 /area/station/crew_quarters/quarters_east)
 "bel" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/obj/cable/orange,
 /obj/cable/orange{
 	icon_state = "0-8"
 	},
@@ -14270,6 +14266,22 @@
 	dir = 3
 	},
 /area/station/hallway/primary/southwest)
+"gsx" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid0";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
+	},
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "gsX" = (
 /obj/lattice{
 	dir = 9;
@@ -31845,6 +31857,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/cable/orange,
 /turf/simulated/floor/engine/caution/northsouth,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -37849,13 +37862,7 @@
 	density = 0;
 	opacity = 0
 	},
-/obj/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/simulated/floor/engine,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -49461,7 +49468,10 @@
 	dir = 4
 	},
 /obj/cable/orange{
-	icon_state = "4-9"
+	icon_state = "2-9"
+	},
+/obj/cable/orange{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
@@ -109162,7 +109172,7 @@ ygt
 ygt
 ygt
 wks
-dfm
+gsx
 nSj
 wqi
 bko

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -428,13 +428,6 @@
 /obj/rack,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
-"ait" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/cafeteria)
 "aiC" = (
 /obj/machinery/conveyor/EW{
 	id = "garbage";
@@ -510,6 +503,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"ajO" = (
+/obj/disposalpipe/segment/food{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ajV" = (
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
@@ -605,6 +605,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
+	},
+/obj/cable/orange{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
@@ -985,6 +988,14 @@
 	dir = 1
 	},
 /area/pasiphae/sys)
+"auj" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "aut" = (
 /obj/machinery/centrifuge_nuclear,
 /turf/simulated/floor/yellowblack,
@@ -1162,6 +1173,23 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"ayy" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
+"ayC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "ayE" = (
 /turf/simulated/wall/false_wall,
 /area/station/hallway/secondary/construction{
@@ -1689,6 +1717,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"aLf" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "aLz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1759,6 +1794,10 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"aOD" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "aOF" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grey,
@@ -2045,9 +2084,7 @@
 /area/station/hallway/primary/southeast)
 "aWy" = (
 /obj/machinery/vending/hydroponics,
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "aWz" = (
 /obj/machinery/camera{
@@ -2386,6 +2423,7 @@
 /obj/cable/orange{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/computer/power_monitor/smes{
 	dir = 8;
 	name = "Engine Output Monitoring"
@@ -2418,7 +2456,7 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -2529,6 +2567,15 @@
 	dir = 1
 	},
 /area/station/science/hall)
+"bhZ" = (
+/obj/decal/cleanable/dirt/dirt4,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bib" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -2627,7 +2674,10 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine/caution/westeast,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack,
 /area/space)
 "bks" = (
 /obj/table/auto,
@@ -3053,19 +3103,11 @@
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
 "bso" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/west)
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/station/crew_quarters/cafeteria)
 "bsp" = (
 /obj/indestructible/shuttle_corner{
 	dir = 1
@@ -3076,13 +3118,7 @@
 	},
 /area/shuttle/arrival/station)
 "bsw" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/machinery/disposal/mail/small/autoname/kitchen/west,
-/obj/disposalpipe/trunk/mail/south,
+/obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bsK" = (
@@ -3190,6 +3226,12 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
+"bus" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/yellowblack,
+/area/space)
 "buB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -3352,6 +3394,15 @@
 /obj/machinery/vending/standard,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
+"bxj" = (
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
+/obj/machinery/shieldgenerator/energy_shield{
+	power_level = 2
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "bxk" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -3581,12 +3632,13 @@
 	})
 "bCR" = (
 /obj/disposalpipe/segment/food,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "bCZ" = (
 /obj/machinery/computer/power_monitor{
 	name = "Station Power Grid Monitoring"
@@ -3645,14 +3697,12 @@
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
 "bER" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "1-10"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/black,
 /area/station/maintenance/west)
 "bEZ" = (
 /turf/simulated/floor/greenblack{
@@ -3836,6 +3886,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/west)
+"bJI" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "bJL" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "14"
@@ -4046,6 +4102,10 @@
 	dir = 6
 	},
 /area/station/crew_quarters/market)
+"bPQ" = (
+/obj/machinery/door/airlock/pyro/command/alt,
+/turf/simulated/floor/black,
+/area/space)
 "bQh" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Medical Bay"
@@ -4121,6 +4181,13 @@
 /obj/item/pen,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
+"bRJ" = (
+/obj/disposalpipe/segment/bent/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "bRY" = (
 /turf/simulated/floor/carpet/purple/fancy/narrow/T_north,
 /area/station/chapel/sanctuary)
@@ -4234,24 +4301,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"bTZ" = (
-/obj/machinery/light_switch/east,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "bUd" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
@@ -4348,6 +4397,13 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
+"bVY" = (
+/obj/machinery/plantpot,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "bWq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4574,10 +4630,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
-"cbe" = (
-/obj/disposalpipe/loafer/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "cbx" = (
 /obj/decal/tile_edge/line/green{
 	dir = 5;
@@ -4626,6 +4678,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northeast)
+"cdf" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/space)
 "cdg" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
@@ -4642,16 +4700,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
 /area/station/bridge)
-"cdv" = (
-/obj/disposalpipe/segment/food{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/shieldgenerator/energy_shield{
-	power_level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "cdL" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -4745,6 +4793,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"cfX" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cgt" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4844,6 +4901,13 @@
 	dir = 8
 	},
 /area/listeningpost)
+"cit" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "ciw" = (
 /turf/simulated/floor/black,
 /area/station/engine/storage)
@@ -4854,22 +4918,6 @@
 	dir = 1
 	},
 /area/pasiphae/crew)
-"ciR" = (
-/obj/disposalpipe/segment/food{
-	dir = 4
-	},
-/obj/storage/crate,
-/obj/item/reagent_containers/food/snacks/ingredient/flour,
-/obj/item/reagent_containers/food/snacks/ingredient/flour,
-/obj/item/reagent_containers/food/snacks/ingredient/sugar,
-/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
-/obj/item/reagent_containers/food/snacks/ingredient/oatmeal,
-/obj/decal/tile_edge/line/green{
-	dir = 5;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "cjf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -5134,6 +5182,11 @@
 	dir = 8
 	},
 /area/station/storage/emergency2)
+"cpC" = (
+/obj/disposalpipe/segment/food,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "cpV" = (
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
@@ -5149,12 +5202,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"cqv" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "cqw" = (
 /obj/item/storage/wall/emergency{
 	dir = 8
@@ -5230,6 +5277,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"crB" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/south,
+/area/space)
 "crF" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 8
@@ -5372,6 +5423,15 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"cvT" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "cwd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -5443,6 +5503,8 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "cyG" = (
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /obj/machinery/computer/power_monitor{
 	dir = 8
 	},
@@ -5676,6 +5738,10 @@
 /obj/machinery/vending/standard,
 /turf/simulated/floor/black/grime,
 /area/station/storage/warehouse)
+"cFx" = (
+/obj/disposalpipe/loafer/horizontal,
+/turf/simulated/floor/plating,
+/area/space)
 "cFB" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -5737,6 +5803,13 @@
 	dir = 4
 	},
 /area/station/quartermaster/cargooffice)
+"cGR" = (
+/obj/disposalpipe/segment/bent/south,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cGX" = (
 /obj/machinery/light/small/floor,
 /obj/machinery/light_switch/west,
@@ -5945,14 +6018,9 @@
 	})
 "cMH" = (
 /obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 5
-	},
-/obj/item/wrench,
-/obj/item/bee_egg_carton,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/item/bee_egg_carton{
+	pixel_y = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hydroponics{
@@ -6044,6 +6112,16 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
+"cOL" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/bent/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "cOM" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -6161,6 +6239,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"cQM" = (
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/space)
 "cRq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -6190,6 +6274,13 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
+	})
+"cSf" = (
+/obj/submachine/cargopad/hydroponic,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
 	})
 "cSg" = (
 /obj/cable{
@@ -6586,7 +6677,7 @@
 /obj/machinery/phone/wall{
 	pixel_y = 32
 	},
-/obj/submachine/chef_oven,
+/obj/submachine/foodprocessor,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "dau" = (
@@ -6796,6 +6887,7 @@
 	},
 /area/station/science/teleporter)
 "dhu" = (
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
@@ -6829,6 +6921,23 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
 /area/space)
+"dis" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "diA" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
@@ -7064,6 +7173,7 @@
 "drc" = (
 /obj/disposalpipe/segment/food,
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "drj" = (
@@ -7563,11 +7673,6 @@
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
 	})
-"dAP" = (
-/obj/storage/closet/wardrobe/green,
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "dAS" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/janitor/supply)
@@ -7710,6 +7815,13 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
+"dDa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction/left/west,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "dDg" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -7967,15 +8079,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"dHA" = (
-/obj/disposalpipe/segment/food{
-	dir = 4
-	},
-/obj/machinery/shieldgenerator/energy_shield{
-	power_level = 2
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "dHI" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -8253,9 +8356,18 @@
 	},
 /area/station/security/brig)
 "dOQ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/storage/secure/crate/eng{
+	name = "Fissile Materials Crate"
+	},
+/obj/access_spawn/engineering_engine,
+/obj/item/raw_material/cerenkite,
+/obj/item/raw_material/cerenkite,
+/obj/item/raw_material/cerenkite,
+/obj/item/raw_material/cerenkite,
+/obj/item/raw_material/cerenkite,
+/obj/item/raw_material/cerenkite,
 /turf/simulated/floor/engine/caution/misc{
-	dir = 4
+	dir = 6
 	},
 /area/space)
 "dPx" = (
@@ -8499,6 +8611,12 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
+"dWW" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "dXl" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/cable{
@@ -8567,13 +8685,6 @@
 	},
 /turf/simulated/floor/redblack,
 /area/listeningpost)
-"dZn" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "dZu" = (
 /obj/machinery/door_control{
 	id = "det_entry";
@@ -8639,9 +8750,7 @@
 	})
 "eaw" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "eaE" = (
 /obj/cable{
@@ -8665,6 +8774,10 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/bridge/captain)
+"ebd" = (
+/obj/machinery/door/airlock/pyro/alt,
+/turf/simulated/floor,
+/area/space)
 "ebi" = (
 /obj/landmark{
 	name = "blobstart"
@@ -8683,6 +8796,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
+"ebu" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/corner,
+/area/space)
 "eby" = (
 /turf/simulated/floor/redblack/corner,
 /area/station/security/equipment)
@@ -8734,15 +8851,6 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/exit)
-"ecO" = (
-/obj/machinery/disposal/ore/small/west{
-	name = "brig meal-line chute"
-	},
-/obj/disposalpipe/trunk/food{
-	dir = 8
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
 "ecQ" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/wood/two,
@@ -8905,6 +9013,10 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"egJ" = (
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "egQ" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -8913,6 +9025,19 @@
 /obj/machinery/fluid_canister,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"egS" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/reagent_dispensers/compostbin,
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "ehQ" = (
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/computer/power_monitor/smes{
@@ -8992,17 +9117,6 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"ejD" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "ejP" = (
 /obj/machinery/power/furnace,
 /obj/cable{
@@ -9029,9 +9143,6 @@
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 28
-	},
-/obj/item/device/radio/intercom{
-	dir = 4
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -9408,6 +9519,10 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/west)
+"esK" = (
+/obj/table/wood/round/auto,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/cafeteria)
 "esU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9434,9 +9549,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/greenblack{
-	dir = 10
-	},
+/turf/simulated/floor/greenblack,
 /area/station/hydroponics/bay)
 "etW" = (
 /obj/machinery/camera{
@@ -10375,7 +10488,7 @@
 /area/station/engine/elect)
 "ePt" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/engine/caution/misc{
+/turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
 /area/space)
@@ -10851,6 +10964,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
@@ -11507,11 +11621,6 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "fsg" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
@@ -11520,6 +11629,7 @@
 	dir = 10;
 	icon_state = "line1"
 	},
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "fsl" = (
@@ -11713,6 +11823,12 @@
 	},
 /turf/simulated/floor/carpet/purple/standard/narrow/sw,
 /area/station/chapel/sanctuary)
+"fuX" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "fvh" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2{
 	dir = 5
@@ -11759,9 +11875,10 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "fvZ" = (
-/obj/reagent_dispensers/still,
 /obj/machinery/light/small,
-/turf/simulated/floor/black/grime,
+/obj/machinery/plantpot,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/plating,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
@@ -11834,6 +11951,10 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"fxg" = (
+/obj/landmark/random_room/size3x3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "fxt" = (
 /obj/stool/chair/office/red{
 	dir = 8
@@ -11967,6 +12088,17 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"fBr" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/terminal/zeta{
+	dir = 4;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "fBR" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency{
@@ -12055,13 +12187,6 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
-"fDF" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "fDR" = (
 /obj/machinery/plantpot,
 /obj/machinery/light,
@@ -12165,6 +12290,9 @@
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/survey)
+"fHb" = (
+/turf/simulated/wall/auto/supernorn,
+/area/space)
 "fHf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12646,6 +12774,13 @@
 /obj/pool_springboard,
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
+"fTk" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "fTq" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -12785,13 +12920,6 @@
 /obj/machinery/phone/unlisted,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
-"fWc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "fWG" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -12940,6 +13068,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"fZP" = (
+/obj/reagent_dispensers/still,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "fZQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13087,6 +13222,7 @@
 /area/station/medical/medbay)
 "gcL" = (
 /obj/machinery/power/smes,
+/obj/cable,
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
 	},
@@ -14126,6 +14262,12 @@
 /obj/machinery/vending/jobclothing/security,
 /turf/simulated/floor/redblack/corner,
 /area/station/security/equipment)
+"gzG" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "gzN" = (
 /obj/stool/chair{
 	dir = 4
@@ -14273,6 +14415,7 @@
 	})
 "gDo" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/yellow,
 /area/space)
 "gDp" = (
@@ -14326,6 +14469,15 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"gEK" = (
+/obj/disposalpipe/segment/vertical,
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "gEL" = (
 /obj/machinery/light/small,
 /obj/machinery/shieldgenerator/energy_shield{
@@ -14559,6 +14711,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "gKd" = (
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/power/nuclear/reactor_control,
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -14732,6 +14888,22 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"gNa" = (
+/obj/table/reinforced/auto,
+/obj/item/extinguisher{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/turf/simulated/floor/yellowblack,
+/area/space)
 "gNo" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purpleblack/corner{
@@ -14757,7 +14929,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "gNU" = (
-/turf/space,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "gOm" = (
 /obj/machinery/vending/computer3,
@@ -14827,6 +15003,12 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/science/research_director)
+"gQb" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/west,
+/area/space)
 "gQh" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/electrical{
@@ -15627,6 +15809,15 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
+"hhO" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "hiE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16082,13 +16273,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/crew)
-"hrb" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "hrd" = (
 /obj/disposalpipe/junction/right/south,
 /turf/simulated/floor/grey/side,
@@ -16569,8 +16753,9 @@
 "hAe" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "hAs" = (
@@ -16712,16 +16897,6 @@
 	dir = 8
 	},
 /area/station/quartermaster/cargooffice)
-"hDf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/west)
 "hDr" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/space_law,
@@ -16751,6 +16926,10 @@
 "hEa" = (
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"hEe" = (
+/obj/storage/closet/wardrobe/green,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "hEf" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4
@@ -16938,10 +17117,18 @@
 	dir = 5
 	},
 /area/station/ai_monitored/armory)
-"hHm" = (
-/obj/submachine/cargopad/hydroponic,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+"hHq" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "nadir_diploshut";
+	name = "Diplomatic Quarters Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "hHx" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/gloves/latex,
@@ -17233,9 +17420,7 @@
 /area/station/bridge)
 "hQc" = (
 /obj/machinery/hydro_growlamp,
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "hQg" = (
 /obj/decal/poster/wallsign/keep_it_or_melt{
@@ -17414,6 +17599,14 @@
 	},
 /turf/simulated/floor,
 /area/pasiphae/hangar)
+"hTc" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 6
+	},
+/area/space)
 "hTu" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/brig{
@@ -17556,6 +17749,14 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"hWN" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "hWO" = (
 /obj/machinery/light{
 	dir = 8;
@@ -17603,6 +17804,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/southwest)
+"hXx" = (
+/obj/machinery/door/unpowered/wood/stall{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/space)
 "hXJ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -17686,9 +17893,7 @@
 /area/station/crew_quarters/quarters_east)
 "hYt" = (
 /obj/reagent_dispensers/compostbin,
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "hYv" = (
 /obj/machinery/door/airlock/pyro/mining{
@@ -18245,6 +18450,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/engine/caution/east,
 /area/space)
 "ikV" = (
@@ -18534,6 +18740,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"irk" = (
+/obj/machinery/door/unpowered/wood/stall,
+/turf/simulated/floor/sanitary,
+/area/space)
 "irE" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon19,
 /obj/disposalpipe/segment/horizontal,
@@ -18773,6 +18983,9 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 12
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -20044,6 +20257,12 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/west)
+"jbY" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/corner{
+	dir = 1
+	},
+/area/space)
 "jch" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/disposalpipe/segment/transport,
@@ -20364,6 +20583,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"jhN" = (
+/obj/machinery/light_switch/north,
+/obj/storage/closet/office,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "jhQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -20372,6 +20596,18 @@
 /obj/disposalpipe/trunk/mail/east,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"jiR" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/disposalpipe/trunk/south,
+/obj/machinery/disposal,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "jjb" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -20379,16 +20615,10 @@
 /obj/machinery/light/runway_light/delay2,
 /turf/space/fluid/acid/clear,
 /area/space)
-"jjd" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
+"jjg" = (
+/obj/item/device/radio/intercom/botany,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "jjs" = (
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Net Cafe";
@@ -20607,6 +20837,7 @@
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4
 	},
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/black,
 /area/space)
 "jpQ" = (
@@ -20635,13 +20866,6 @@
 /obj/access_spawn/telesci,
 /turf/simulated/floor/purpleblack,
 /area/station/science/teleporter)
-"jpZ" = (
-/obj/decal/tile_edge/line/green{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "jqj" = (
 /obj/shrub{
 	dir = 4;
@@ -20664,6 +20888,15 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/grey,
 /area/station/crewquarters/cryotron)
+"jqC" = (
+/obj/machinery/power/smes,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine/caution/misc{
+	dir = 8
+	},
+/area/space)
 "jqS" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -20710,13 +20943,6 @@
 	dir = 8
 	},
 /area/station/storage/emergencyinternals)
-"jrb" = (
-/obj/decal/tile_edge/line/green{
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "jrg" = (
 /obj/machinery/vending/pda,
 /turf/simulated/floor/grey/side{
@@ -20873,6 +21099,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/secondary/exit)
+"juz" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/machinery/disposal/mail/autoname/kitchen,
+/obj/disposalpipe/trunk/mail/west,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "juT" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone/unlisted,
@@ -21366,6 +21602,17 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"jGQ" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/horizontal,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "jHl" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -21812,13 +22059,6 @@
 /area/station/crew_quarters/market)
 "jRv" = (
 /obj/machinery/vending/hydroponics,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
@@ -22212,6 +22452,16 @@
 "jXY" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
+"jYJ" = (
+/obj/rack,
+/obj/item/extinguisher{
+	pixel_x = -5
+	},
+/obj/item/extinguisher{
+	pixel_x = 7
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "jYO" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -22561,7 +22811,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "kgy" = (
-/obj/submachine/foodprocessor,
+/obj/storage/crate,
+/obj/item/reagent_containers/food/snacks/ingredient/oatmeal,
+/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
+/obj/item/reagent_containers/food/snacks/ingredient/sugar,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "kgH" = (
@@ -22579,6 +22834,7 @@
 	dir = 4;
 	level = 2
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/engine/caution/east,
 /area/space)
 "khK" = (
@@ -23432,13 +23688,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"kxr" = (
-/obj/decal/tile_edge/line/green{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "kxz" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/beakerbox{
@@ -23592,7 +23841,9 @@
 /area/station/hallway/secondary/west)
 "kAr" = (
 /obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
 /area/station/hydroponics/bay)
 "kAS" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -24143,13 +24394,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"kOn" = (
-/obj/cable{
-	icon_state = "1-6"
-	},
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "kOC" = (
 /obj/cable{
 	d1 = 2;
@@ -24200,6 +24444,9 @@
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "kQl" = (
+/obj/cable/orange{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/engine/caution/corner2,
 /area/space)
 "kQn" = (
@@ -25194,12 +25441,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
-"llU" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/black,
-/area/station/science/lobby{
-	name = "Science Lounge"
-	})
 "llV" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/toxin{
@@ -25678,6 +25919,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/teleporter)
+"lwL" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/space)
 "lxm" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -25939,6 +26186,12 @@
 "lDT" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
+"lDX" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "lEn" = (
 /turf/simulated/floor/black,
 /area/station/science/lobby{
@@ -26240,6 +26493,11 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"lIN" = (
+/turf/simulated/floor/purpleblack{
+	dir = 4
+	},
+/area/space)
 "lIR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -26612,13 +26870,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"lQA" = (
-/obj/reagent_dispensers/compostbin,
-/turf/simulated/floor/black/grime,
-/area/station/hydroponics{
-	do_not_irradiate = 1;
-	name = "Hydroponics Storage"
-	})
 "lQK" = (
 /turf/unsimulated/wall/setpieces/leadwall{
 	dir = 4
@@ -26987,14 +27238,14 @@
 /area/station/chapel/sanctuary)
 "lZa" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "5-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/light_switch/east,
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/cafeteria)
 "lZl" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2{
 	dir = 9
@@ -27324,17 +27575,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"mfN" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/switch_junction/biofilter/left/west,
-/obj/decal/tile_edge/line/green{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "mfV" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -27507,7 +27747,6 @@
 /area/station/science/hall)
 "mjF" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/light_switch/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "mjW" = (
@@ -27750,6 +27989,10 @@
 	dir = 4
 	},
 /area/station/science/hall)
+"mpJ" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "mqj" = (
 /obj/machinery/light{
 	dir = 8;
@@ -27832,17 +28075,6 @@
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
 	})
-"mrH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "mrO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27976,17 +28208,14 @@
 	},
 /area/station/storage/emergency)
 "mvb" = (
-/obj/machinery/plantpot,
-/obj/item/device/radio/intercom/botany{
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/greenblack{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "mvp" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -28133,6 +28362,11 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"mxp" = (
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
+/area/space)
 "mxA" = (
 /obj/rack,
 /obj/item/reagent_containers/food/drinks/juicer,
@@ -29080,6 +29314,18 @@
 	},
 /turf/simulated/floor/redblack/corner,
 /area/station/hallway/secondary/exit)
+"mTZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/bent/north,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "mUh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29148,6 +29394,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/pasiphae/sys)
+"mXc" = (
+/obj/machinery/disposal/ore{
+	name = "brig meal-line chute"
+	},
+/obj/disposalpipe/trunk/food{
+	dir = 8
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "mXd" = (
 /turf/simulated/floor/purpleblack,
 /area/station/science/hall)
@@ -29164,6 +29419,18 @@
 /obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"mYy" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/nuclear_engineering{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/obj/item/paper/book/from_file/nuclear_engineering{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/turf/simulated/floor/yellowblack,
+/area/space)
 "mYF" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -29197,6 +29464,12 @@
 /obj/storage/secure/closet/animal,
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"mZi" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
+/turf/simulated/floor/black/side,
+/area/space)
 "mZj" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/beakerbox,
@@ -29235,6 +29508,17 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"naz" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "naN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30369,6 +30653,9 @@
 /area/station/hallway/secondary/exit)
 "nCb" = (
 /obj/machinery/atmospherics/binary/reactor_turbine,
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/engine,
 /area/space)
 "nCD" = (
@@ -30664,6 +30951,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
+"nHQ" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "nIj" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -31149,12 +31443,6 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
-"nTW" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/engine/caution/corner2{
-	dir = 5
-	},
-/area/space)
 "nUa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31361,6 +31649,15 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/arcade)
+"oad" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "oae" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31596,6 +31893,12 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
+"ogK" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "oha" = (
 /obj/machinery/drainage,
 /obj/item/storage/wall{
@@ -31639,10 +31942,6 @@
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/engine/caution/east,
 /area/station/ai_monitored/armory)
-"ojk" = (
-/obj/storage/closet/office,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "ojw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31921,13 +32220,14 @@
 	},
 /area/station/storage/eva)
 "opW" = (
-/obj/reagent_dispensers/watertank/big,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/table/reinforced/auto,
+/obj/item/wrench{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 8;
+	pixel_x = 5
 	},
 /turf/simulated/floor/greenblack{
 	dir = 4
@@ -32274,7 +32574,6 @@
 /area/station/crew_quarters/kitchen)
 "oxS" = (
 /obj/machinery/light/small,
-/obj/storage/closet/fire,
 /turf/simulated/floor/black,
 /area/station/science/lobby{
 	name = "Science Lounge"
@@ -32347,15 +32646,6 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"ozA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/hydroponics{
-	do_not_irradiate = 1;
-	name = "Hydroponics Storage"
-	})
 "ozD" = (
 /obj/stool/chair/office/blue{
 	dir = 4
@@ -32469,6 +32759,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
+"oCN" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "oDy" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -32686,6 +32988,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "oJh" = (
@@ -32794,6 +33097,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"oLJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "oLM" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1
@@ -32962,6 +33271,9 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"oPP" = (
+/turf/simulated/floor/sanitary,
+/area/space)
 "oPR" = (
 /obj/vehicle/segway,
 /obj/machinery/camera{
@@ -33231,6 +33543,19 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"oVg" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/bent/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "oVo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33362,6 +33687,17 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"oYs" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "nadir_diploshut";
+	name = "Diplomatic Quarters Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "oYt" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/black,
@@ -33417,6 +33753,14 @@
 "oZp" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
+"oZD" = (
+/obj/stool/chair/green{
+	dir = 4
+	},
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "oZQ" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 16
@@ -33856,6 +34200,14 @@
 	dir = 8
 	},
 /area/shuttle/arrival/station)
+"pmn" = (
+/obj/disposalpipe/segment/food,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/west)
 "pmV" = (
 /obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellowblack{
@@ -33877,20 +34229,12 @@
 "pnt" = (
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"pnx" = (
-/obj/cable{
-	icon_state = "4-8"
+"pnP" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
 	},
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/sanitary,
+/area/space)
 "poa" = (
 /obj/decal/poster/wallsign/warning1{
 	desc = "A sign warning you of a nearby acid hazard.";
@@ -34325,6 +34669,10 @@
 	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
+"pwy" = (
+/obj/machinery/nanofab/nuclear,
+/turf/simulated/floor/black,
+/area/space)
 "pwO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -34598,7 +34946,7 @@
 /area/station/chapel/office)
 "pDQ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/supernorn,
 /area/space)
 "pDS" = (
 /turf/simulated/floor/engine/caution/south,
@@ -34750,13 +35098,6 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor,
 /area/pasiphae/bridge)
-"pJd" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "pJf" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -35266,6 +35607,12 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/black,
 /area/pasiphae/survey)
+"pVr" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/floor/sanitary,
+/area/space)
 "pVR" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -35440,15 +35787,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
-"qaa" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/west)
 "qaO" = (
 /obj/cable,
 /obj/machinery/light/incandescent/netural{
@@ -36536,9 +36874,6 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "qBe" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour10;desc=The east crew quarters are your best place to catch up on sleep - most public beds are located here, with personal safes for your security. Also located here are the diplomatic quarters.";
 	freq = 1443;
@@ -36802,10 +37137,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"qJa" = (
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "qJo" = (
 /obj/machinery/vending/security_ammo,
 /obj/machinery/light{
@@ -36954,6 +37285,16 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"qNs" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "qNu" = (
 /obj/machinery/drainage/big,
 /turf/simulated/floor/industrial,
@@ -37963,6 +38304,13 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/southwest)
+"rnN" = (
+/obj/disposalpipe/segment/bent/north,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "rnQ" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -38144,6 +38492,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"rsE" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/sanitary,
+/area/space)
+"rsG" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/kitchen)
 "rsJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
@@ -38605,6 +38961,18 @@
 /obj/stool/chair,
 /turf/simulated/floor/plating,
 /area/space)
+"rED" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/yellowblack,
+/area/space)
 "rEP" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -38618,6 +38986,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
+"rGh" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/blind_switch/area/west,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "rGm" = (
 /obj/disposalpipe/trunk/north,
 /obj/machinery/disposal/transport{
@@ -38783,6 +39161,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"rKn" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "rKp" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -39458,7 +39842,9 @@
 "rYV" = (
 /obj/machinery/disposal/mail/small/autoname/hydroponics/west,
 /obj/disposalpipe/trunk/mail/south,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/greenblack{
+	dir = 9
+	},
 /area/station/hydroponics/bay)
 "rZb" = (
 /turf/simulated/floor/black,
@@ -39701,6 +40087,10 @@
 	dir = 6
 	},
 /area/station/medical/medbay/lobby)
+"sec" = (
+/obj/submachine/chef_oven,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/kitchen)
 "seK" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -40190,13 +40580,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/space)
-"srs" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "srx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40271,6 +40654,16 @@
 "ssc" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"ssd" = (
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/green{
+	dir = 5;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ssg" = (
 /obj/reagent_dispensers/fueltank,
 /obj/disposalpipe/segment/transport{
@@ -40456,6 +40849,12 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
+"svj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "svP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -40779,6 +41178,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
+"sDL" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "sDR" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/horizontal,
@@ -40832,6 +41237,15 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/engine/caution/corner,
 /area/station/science/chemistry)
+"sEK" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "sEL" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -40880,6 +41294,9 @@
 "sFC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
+	},
+/obj/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
@@ -41153,6 +41570,7 @@
 /area/listeningpost)
 "sKX" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 8
 	},
@@ -41432,9 +41850,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig/solitary)
-"sPZ" = (
-/turf/space,
-/area/station/hallway/primary/southeast)
 "sQj" = (
 /obj/disposalpipe/segment/transport,
 /obj/cable{
@@ -41456,6 +41871,7 @@
 	dir = 4;
 	name = "mobile camera - research 1"
 	},
+/obj/machinery/plantpot,
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
@@ -41509,6 +41925,16 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
+"sRi" = (
+/obj/disposalpipe/segment/food{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/shieldgenerator/energy_shield{
+	power_level = 2
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "sRr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42267,6 +42693,11 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
+"tgU" = (
+/turf/simulated/floor/greenblack{
+	dir = 10
+	},
+/area/station/hydroponics/bay)
 "thb" = (
 /obj/table/auto,
 /obj/item/hand_labeler{
@@ -42387,6 +42818,10 @@
 	dir = 4
 	},
 /area/station/medical/medbay/pharmacy)
+"tja" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/cafeteria)
 "tje" = (
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
@@ -42745,13 +43180,6 @@
 	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
-"tsp" = (
-/obj/decal/tile_edge/line/green{
-	dir = 5;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "tsG" = (
 /obj/machinery/light{
 	dir = 8;
@@ -43135,13 +43563,6 @@
 /obj/item/light/tube,
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
-"tBD" = (
-/obj/decal/tile_edge/line/green{
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "tBS" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -43565,6 +43986,12 @@
 	dir = 8
 	},
 /area/station/medical/morgue)
+"tLk" = (
+/obj/stool/chair/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/crew_quarters/cafeteria)
 "tLt" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -43713,14 +44140,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
-"tPd" = (
-/obj/machinery/light/small,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "tPe" = (
 /obj/landmark/halloween,
 /turf/simulated/floor/black,
@@ -44309,6 +44728,21 @@
 "uen" = (
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
+"ueo" = (
+/obj/machinery/light_switch/east,
+/obj/table/reinforced/auto,
+/obj/item/plate,
+/obj/item/kitchen/utensil/fork{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/kitchen/utensil/spoon{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/bowl,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/kitchen)
 "ufa" = (
 /obj/machinery/computer/riotgear{
 	dir = 8;
@@ -44369,6 +44803,13 @@
 	dir = 4
 	},
 /area/station/quartermaster/refinery)
+"uhD" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uhK" = (
 /obj/machinery/traymachine/locking/tanning,
 /obj/machinery/computer/tanning{
@@ -44692,6 +45133,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"uqt" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "uqB" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/health_upgrade_kit,
@@ -44863,16 +45308,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"utU" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "utW" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -45361,6 +45796,11 @@
 	dir = 1
 	},
 /area/station/crew_quarters/market)
+"uGM" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uHj" = (
 /obj/item/wrench,
 /obj/item/storage/toolbox/electrical{
@@ -45570,6 +46010,9 @@
 "uNg" = (
 /obj/stool/chair/office/yellow{
 	dir = 1
+	},
+/obj/cable/orange{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/space)
@@ -45867,6 +46310,13 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"uTx" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "uTB" = (
 /obj/machinery/light{
 	dir = 4;
@@ -45996,8 +46446,8 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/greenblack{
-	dir = 8
+/turf/simulated/floor/greenblack/corner{
+	dir = 1
 	},
 /area/station/hydroponics/bay)
 "uXm" = (
@@ -46421,7 +46871,6 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/tile_edge/line/black{
 	dir = 8;
 	icon_state = "line1"
@@ -46627,13 +47076,6 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"voE" = (
-/obj/disposalpipe/segment/food{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "vpe" = (
 /obj/surgery_tray,
 /obj/item/circular_saw{
@@ -46852,6 +47294,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northeast)
+"vtY" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/space)
 "vuc" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack,
@@ -46865,6 +47316,17 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
+"vuA" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/switch_junction/biofilter/left/west,
+/obj/decal/tile_edge/line/green{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "vuC" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -47020,6 +47482,15 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/southwest)
+"vwT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "vwU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47302,6 +47773,10 @@
 "vEu" = (
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
+"vEA" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/west)
 "vFk" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4;
@@ -47329,7 +47804,8 @@
 /turf/simulated/floor/black,
 /area/station/science/research_director)
 "vFq" = (
-/obj/machinery/computer3/terminal/zeta,
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -47477,7 +47953,7 @@
 /area/station/security/interrogation)
 "vJu" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/engine/caution/northsouth,
+/turf/simulated/floor/engine/caution/north,
 /area/space)
 "vJO" = (
 /obj/rack,
@@ -47590,6 +48066,10 @@
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/pasiphae/crew)
 "vMP" = (
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/power/nuclear/turbine_control,
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -47768,6 +48248,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "vRR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/yellowblack/corner,
 /area/space)
 "vSi" = (
@@ -48137,6 +48620,13 @@
 /obj/machinery/crusher,
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/disposal)
+"vZi" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "vZo" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/yellowblack,
@@ -48326,13 +48816,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/northwest)
-"wfN" = (
-/obj/decal/tile_edge/line/green{
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "wgH" = (
 /obj/stool/chair/office,
 /obj/cable{
@@ -48482,6 +48965,17 @@
 	},
 /turf/simulated/floor/yellowblack/corner,
 /area/station/hallway/primary/southeast)
+"wks" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "wkv" = (
 /obj/machinery/conveyor/SN{
 	id = "garbage";
@@ -48614,6 +49108,12 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"woE" = (
+/obj/reagent_dispensers/watertank/big,
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "woF" = (
 /obj/storage/crate{
 	name = "radioisotope fuel crate"
@@ -48659,6 +49159,15 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
+"wqi" = (
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "wqj" = (
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
@@ -49053,6 +49562,13 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"wBt" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/black/grime,
+/area/station/hydroponics{
+	do_not_irradiate = 1;
+	name = "Hydroponics Storage"
+	})
 "wBN" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -49452,9 +49968,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "wJT" = (
 /obj/machinery/door/airlock/pyro/glass/med{
@@ -49622,14 +50136,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
-"wQf" = (
-/obj/disposalpipe/segment/food,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hydroponics{
-	do_not_irradiate = 1;
-	name = "Hydroponics Storage"
-	})
 "wQo" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 4
@@ -49975,6 +50481,7 @@
 /area/station/maintenance/west)
 "wYE" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/space)
 "wYK" = (
@@ -50596,17 +51103,6 @@
 "xmL" = (
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"xmM" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "xmO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51049,12 +51545,14 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "xyJ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/black,
 /area/station/maintenance/west)
 "xyR" = (
 /obj/disposalpipe/segment/mail/bent/south,
@@ -51918,6 +52416,9 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
+"xQx" = (
+/turf/simulated/floor,
+/area/space)
 "xQD" = (
 /obj/table/reinforced/auto,
 /obj/item/remote/porter/port_a_medbay{
@@ -52103,18 +52604,11 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black,
 /area/station/security/equipment)
-"xTC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "xTI" = (
-/obj/disposalpipe/segment/mail/vertical,
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "xTJ" = (
@@ -52448,13 +52942,6 @@
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/science/teleporter)
-"ybp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/west)
 "ybB" = (
 /turf/unsimulated/wall/setpieces/leadwall/gray{
 	dir = 1;
@@ -52497,6 +52984,11 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"ycC" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/catering)
 "ycT" = (
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
@@ -84661,15 +85153,15 @@ ajs
 ajs
 ajs
 ajs
-pvZ
-pvZ
+oEZ
+oEZ
+fxg
+wqA
 osg
 uxX
 ctg
-voE
-cdv
-pvZ
-pvZ
+ajO
+sRi
 rvl
 gvL
 xsX
@@ -84962,16 +85454,16 @@ mNi
 uHm
 lLM
 trK
-ajs
-pvZ
-pvZ
+mbt
+oEZ
+oEZ
+oEZ
+uGM
 oEZ
 gbZ
 oEZ
-cbe
-dHA
-pvZ
-pvZ
+cFx
+bxj
 rvl
 dYJ
 obA
@@ -85262,18 +85754,18 @@ sti
 ajs
 joi
 fix
-qqc
-uUP
-plo
-pvZ
-pvZ
-utU
+bpN
+bVY
+mbt
+oEZ
+oEZ
+oEZ
+wqA
+nHQ
 ydp
 qGw
-mfN
-ciR
-pvZ
-pvZ
+vuA
+ssd
 rvl
 oaQ
 obA
@@ -85564,14 +86056,14 @@ kJK
 ajs
 oBi
 bpN
-ozA
+bpN
 fvZ
 mbt
-pvZ
-pvZ
+mbt
+mbt
+mbt
+wqA
 gbZ
-pvZ
-pvZ
 rvl
 rvl
 afy
@@ -85866,14 +86358,14 @@ ngq
 ajs
 jRv
 uXV
-ozA
-lQA
-mbt
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+qqc
+uUP
+uUP
+dis
+rGh
+plo
+cOL
+oVg
 rvl
 agr
 iaW
@@ -86169,13 +86661,13 @@ ajs
 euf
 uUP
 tQs
+wBt
+bpN
+bpN
 qHC
-wQf
-pvZ
-pvZ
 bCR
-pvZ
-pvZ
+cpC
+pmn
 drc
 noD
 hTF
@@ -86470,15 +86962,15 @@ kKs
 ajs
 kEt
 bpN
-bpN
+fZP
 cMH
-mbt
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
-rvl
+cSf
+bpN
+jiR
+gEK
+jGQ
+bRJ
+ycC
 iwQ
 aVQ
 xHl
@@ -86772,14 +87264,14 @@ kLn
 ajs
 ajs
 wpS
+mbt
+mbt
+mbt
 wpS
 mbt
 mbt
-pvZ
-pvZ
-tPd
-pvZ
-pvZ
+jVa
+vEA
 iHN
 iHN
 sOx
@@ -87074,14 +87566,14 @@ ewv
 ewv
 rXG
 cZD
-cZD
+oZD
 opW
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+woE
+cZD
+egS
+wqA
+vZi
+vyr
 iHN
 wPX
 kyY
@@ -87377,16 +87869,16 @@ fLE
 jdV
 jdV
 jdV
+jdV
+jdV
+jdV
 fLE
-oNg
-pvZ
-pvZ
-jVa
-pvZ
-pvZ
-iHN
+wqA
+vyr
+aLf
+rsG
 oJc
-kyY
+dDa
 iPX
 mJW
 eKa
@@ -87678,14 +88170,14 @@ bYZ
 kWV
 jdV
 jdV
+bJI
+bJI
+jdV
 jdV
 fDR
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+wqA
+vyr
+oLJ
 iHN
 myU
 xPz
@@ -87980,14 +88472,14 @@ bYZ
 fLE
 jdV
 jdV
+bJI
+egJ
+jdV
 jdV
 fLE
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+wqA
+naz
+oLJ
 iHN
 daa
 rCD
@@ -88280,16 +88772,16 @@ sdD
 kRd
 ewv
 ewv
+jjg
+jdV
+bJI
+bJI
 jdV
 jdV
-jdV
-jdV
-oNg
-pvZ
-pvZ
-pnx
-pvZ
-pvZ
+lDX
+wqA
+hWN
+oLJ
 iHN
 vAs
 bhF
@@ -88582,18 +89074,18 @@ sdD
 wKU
 bYZ
 fLE
-kxr
-jpZ
-tsp
+jdV
+jdV
+jdV
+jdV
+jdV
+jdV
 fLE
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+wqA
+vyr
+oLJ
 iHN
-nAa
+sec
 rCD
 tTz
 ssc
@@ -88884,18 +89376,18 @@ sdD
 wKU
 bYZ
 kWV
-cqv
-hHm
-fDF
+jdV
+jdV
+jdV
+jdV
+jdV
+jdV
 fDR
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+wqA
+auj
+vwT
 iHN
-cNa
+nAa
 rCD
 maE
 uti
@@ -89186,18 +89678,18 @@ sdD
 wKU
 bYZ
 fLE
-wfN
-jrb
-tBD
+jdV
+jdV
+bJI
+bJI
+jdV
+jdV
 fLE
-oNg
-pvZ
-pvZ
-gbZ
-pvZ
-pvZ
+wqA
+txT
+rnN
 iHN
-mDr
+cNa
 umB
 abu
 diQ
@@ -89490,16 +89982,16 @@ ewv
 ewv
 nrw
 jdV
-jdV
+bJI
 rUj
-oNg
-pvZ
-pvZ
-ejD
-pvZ
-pvZ
+jdV
+jdV
+oCN
+wqA
+wqA
+gbZ
 iHN
-ers
+mDr
 vnp
 vvS
 pYx
@@ -89792,22 +90284,22 @@ bYZ
 fLE
 jdV
 jdV
+bJI
+bJI
+jdV
 jdV
 fLE
-oNg
-pvZ
-pvZ
+wqA
+hEe
 gbZ
-pvZ
-pvZ
 iHN
-wdF
-ecO
+ers
+maE
 bsw
 mjF
 wWR
 xTI
-ait
+qtl
 qtl
 qli
 qli
@@ -90095,22 +90587,22 @@ kWV
 jdV
 jdV
 jdV
+jdV
+jdV
+jdV
 fDR
-oNg
-pvZ
-pvZ
-xmM
-pvZ
-pvZ
+wqA
+oEZ
+gbZ
 iHN
-iHN
-iHN
-iHN
-iHN
+wdF
+mXc
+juz
+ueo
 iHN
 fsg
 vjb
-bTZ
+mSd
 ftP
 ePP
 bpV
@@ -90396,23 +90888,23 @@ bYZ
 nmm
 rYV
 kAr
-jdV
+vnJ
 mvb
-oNg
-pvZ
-pvZ
-srs
-uOE
-uOE
-uOE
-kOn
-oEZ
-pvZ
-pvZ
-rsJ
-rsJ
+vnJ
+tgU
+fLE
+wqA
+ogK
+gbZ
+iHN
+iHN
+iHN
+iHN
+iHN
+iHN
+cvT
 bso
-rsJ
+tLk
 iWT
 iWT
 iWT
@@ -90700,21 +91192,21 @@ ewv
 pyq
 qlJ
 oNg
+llQ
+uTx
+qPX
 oNg
 oNg
-oNg
-oNg
-oNg
-pvZ
-pvZ
-txT
-hrb
+cGR
+uhD
 uOE
-pvZ
-pvZ
 vjq
-lZa
+sDL
 srJ
+rsJ
+tja
+lZa
+esK
 iWT
 jST
 nZW
@@ -91000,7 +91492,7 @@ kYt
 ewv
 uXb
 eaw
-vnJ
+ajV
 hYt
 aWy
 wJP
@@ -91010,13 +91502,13 @@ oNg
 oNg
 oNg
 oNg
-pvZ
-pvZ
-pvZ
-pvZ
-xyJ
-fWc
+vyr
+oLJ
 wqA
+rsJ
+xyJ
+rsJ
+rsJ
 iWT
 iWT
 iWT
@@ -91312,15 +91804,15 @@ irP
 jdK
 hot
 oNg
-pvZ
-pvZ
-pvZ
-pvZ
-vyr
-fWc
+hWN
+oLJ
 wqA
 cUx
-oVv
+cit
+wqA
+bhZ
+tjx
+par
 iWT
 jwP
 pCW
@@ -91614,15 +92106,15 @@ igl
 igl
 igl
 nVx
-pvZ
-pvZ
-pvZ
-pvZ
 wYC
+cfX
+qNs
+oad
+fTk
 bER
-mrH
-pJd
-qJa
+iLL
+eHE
+fQN
 iWT
 bGm
 pJi
@@ -91916,15 +92408,15 @@ ajV
 fpO
 lFq
 oNg
-pvZ
-pvZ
-pvZ
-pvZ
 txT
 nWF
 nWF
-xTC
+mTZ
 dwo
+wqA
+ctr
+kll
+gZm
 iWT
 bGm
 agu
@@ -92218,15 +92710,15 @@ jOy
 amO
 kQX
 oNg
-pvZ
-pvZ
-pvZ
-pvZ
-dAP
-ojk
+jhN
+oVv
 ahQ
 gbZ
 oRw
+wqA
+trb
+pqp
+jWG
 iWT
 jqS
 vAE
@@ -92520,15 +93012,15 @@ llQ
 qPX
 ewv
 ewv
-pvZ
-pvZ
-pvZ
-pvZ
 jmJ
 jmJ
 jmJ
 rsk
 fnY
+wqA
+wqA
+wqA
+wqA
 iWT
 lxp
 lxp
@@ -92815,8 +93307,8 @@ gNQ
 kAn
 esj
 esj
-pvZ
-pvZ
+mxp
+mxp
 esj
 esj
 sIa
@@ -92826,11 +93318,11 @@ esj
 gIt
 abg
 gNU
-gNU
-hAe
-hCf
-hDf
 iER
+hAe
+uqt
+uqt
+uqt
 jpG
 jli
 jli
@@ -93117,8 +93609,8 @@ gNQ
 gNQ
 gNQ
 gNQ
-pvZ
-pvZ
+cKX
+cKX
 gNQ
 gNQ
 gNQ
@@ -93127,12 +93619,12 @@ gNQ
 gNQ
 gNQ
 gNQ
-gNU
-gNU
-gNQ
-gNQ
-qaa
+gzG
 tal
+ayC
+hCf
+hCf
+hCf
 hCf
 hCf
 sxl
@@ -93419,8 +93911,8 @@ bJF
 bJF
 eRl
 bJF
-pvZ
-pvZ
+lIN
+lIN
 kOG
 bJF
 bJF
@@ -93429,12 +93921,12 @@ gjM
 cjv
 bJF
 jbQ
-gNQ
-gNQ
 uPZ
-uPZ
-ybp
 wAy
+uPZ
+uPZ
+uPZ
+uPZ
 uPZ
 uPZ
 lyT
@@ -93738,7 +94230,7 @@ lJi
 vRv
 vRv
 jUz
-jUz
+mUC
 jmJ
 jmJ
 eGA
@@ -98572,7 +99064,7 @@ fip
 bBa
 oxS
 lEn
-llU
+lEn
 lEn
 nKe
 buD
@@ -102799,7 +103291,7 @@ dxd
 dxd
 cAs
 lZB
-lZB
+aOD
 sOU
 sOU
 sOU
@@ -103101,7 +103593,7 @@ dxd
 dxd
 cAs
 lZB
-lZB
+mpJ
 sOU
 sOU
 sOU
@@ -104597,7 +105089,7 @@ gdf
 ybP
 gdf
 siL
-pvZ
+siL
 dDv
 siL
 siL
@@ -105508,7 +106000,7 @@ yjf
 siL
 siL
 dhu
-hkU
+jYJ
 hkU
 hkU
 hkU
@@ -106418,7 +106910,7 @@ ygt
 ygt
 ygt
 nCb
-ygt
+pKL
 kQl
 siL
 siL
@@ -106721,12 +107213,12 @@ ygt
 ygt
 ygt
 ygt
-ijc
+hTc
 dfm
 vFq
-cKX
-cKX
-sSm
+fBr
+fuX
+gNa
 siL
 bEm
 sVX
@@ -107023,11 +107515,11 @@ lDM
 gAA
 lFh
 ijc
-ijc
+hTc
 dfm
 vMP
 uNg
-cKX
+svj
 sSm
 gDo
 bEm
@@ -107325,12 +107817,12 @@ ffH
 nJZ
 cdg
 ffH
-nJZ
+gQb
 dfm
 gKd
-cKX
-cKX
-sSm
+hhO
+svj
+mYy
 siL
 bEm
 vEo
@@ -107627,10 +108119,10 @@ khh
 xNP
 ikE
 mKE
-hkU
+rKn
 siL
 siL
-cKX
+dWW
 vRR
 siL
 siL
@@ -107917,13 +108409,13 @@ uDe
 hTZ
 cHd
 yjf
-yjf
-yjf
-yjf
+fHb
+fHb
+fHb
+fHb
 siL
 siL
-siL
-qXv
+vtY
 cNc
 cNc
 fXU
@@ -107931,9 +108423,9 @@ hkl
 eZV
 sFC
 dfm
-gcL
-cKX
-sSm
+jqC
+sEK
+rED
 gcL
 siL
 bEm
@@ -108220,9 +108712,9 @@ kuV
 cHd
 qrh
 pDQ
+rsE
 pDQ
-pDQ
-oMR
+pVr
 oMR
 xYh
 olC
@@ -108231,10 +108723,10 @@ ygt
 ygt
 ygt
 ygt
-hkl
+wks
 dfm
 nSj
-bko
+wqi
 bko
 kNR
 siL
@@ -108521,10 +109013,10 @@ qxv
 xnE
 cHd
 eIK
-siL
-siL
-siL
-siL
+fHb
+hXx
+fHb
+hXx
 siL
 siL
 rAG
@@ -108537,7 +109029,7 @@ alM
 qPw
 bel
 eSW
-sSm
+bus
 cyG
 siL
 bEm
@@ -108823,10 +109315,10 @@ opJ
 cHd
 cHd
 eIK
-siL
-yjf
-yjf
-yjf
+fHb
+oPP
+oPP
+oPP
 siL
 siL
 tjk
@@ -108837,14 +109329,14 @@ pKL
 pKL
 fQt
 siL
-siL
+pwy
 tXe
 sSm
 siL
 siL
 sXH
 beT
-fdg
+rZb
 nqh
 sXH
 nWv
@@ -109125,10 +109617,10 @@ uqg
 xnE
 cHd
 eIK
-siL
-yjf
-yjf
-yjf
+pnP
+oPP
+oPP
+oPP
 siL
 siL
 dmq
@@ -109143,9 +109635,9 @@ nEw
 bgj
 sSm
 ePt
-siL
-bEm
-jjd
+ebu
+sXH
+vEo
 qBe
 rZb
 nlG
@@ -109427,10 +109919,10 @@ wLs
 hEL
 cHd
 eIK
-yjf
-yjf
-yjf
-yjf
+fHb
+oPP
+oPP
+oPP
 siL
 siL
 dmq
@@ -109445,9 +109937,9 @@ oPG
 rqB
 sSm
 vJu
-siL
-bEm
-dZn
+crB
+sXH
+vEo
 rZb
 rZb
 oHA
@@ -109729,14 +110221,14 @@ rtj
 sJR
 cHd
 eIK
-siL
-yjf
-yjf
-yjf
+fHb
+fHb
+fHb
+cQM
 siL
 siL
 lXA
-nTW
+lDM
 wuw
 xDg
 ijc
@@ -109746,9 +110238,9 @@ dfm
 jwy
 fHA
 sSm
-vJu
-siL
-bEm
+lwL
+jbY
+sXH
 vEo
 rZb
 rZb
@@ -110031,10 +110523,10 @@ fmc
 fmc
 fmc
 eIK
-siL
-yjf
-yjf
-yjf
+fHb
+oPP
+irk
+oPP
 siL
 siL
 siL
@@ -110333,6 +110825,11 @@ kdb
 uAs
 fmc
 eIK
+fHb
+fHb
+fHb
+oPP
+oPP
 siL
 siL
 siL
@@ -110347,12 +110844,7 @@ siL
 siL
 siL
 siL
-siL
-siL
-siL
-siL
-siL
-sPZ
+yiB
 vEo
 rZb
 rZb
@@ -110635,26 +111127,26 @@ fmc
 kfP
 fmc
 eIK
+fHb
+oPP
+irk
+oPP
+oPP
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
 siL
-sPZ
+yjf
+yjf
+yjf
+yjf
+siL
+yiB
 vEo
 rZb
 rZb
@@ -110937,26 +111429,26 @@ fmc
 fmc
 fmc
 eIK
-siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-siL
-sPZ
+fHb
+fHb
+fHb
+oPP
+oPP
+ebd
+xQx
+xQx
+xQx
+ebd
+xQx
+xQx
+xQx
+ayy
+yjf
+yjf
+yjf
+yjf
+mZi
+yiB
 vEo
 rZb
 rZb
@@ -111239,24 +111731,24 @@ chF
 fmc
 bcx
 eIK
+fHb
+oPP
+irk
+oPP
+oPP
+fHb
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
+siL
+siL
+siL
+siL
 siL
 sXH
 crt
@@ -111541,26 +112033,26 @@ hyM
 smu
 eNW
 eIK
+fHb
+fHb
+fHb
+fHb
+fHb
+fHb
+xQx
+xQx
+xQx
+fHb
+fHb
+fHb
+fHb
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-siL
-sPZ
+cKX
+cKX
+cKX
+cKX
+oYs
+yiB
 vEo
 xZJ
 rZb
@@ -111843,26 +112335,26 @@ hys
 fmc
 xWr
 eIK
+fHb
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-siL
-sPZ
+cKX
+cKX
+cKX
+cKX
+bPQ
+yiB
 vEo
 rZb
 rZb
@@ -112145,26 +112637,26 @@ ero
 fmc
 aXr
 eIK
+fHb
+xQx
+xQx
+xQx
+ebd
+xQx
+xQx
+xQx
+xQx
+ebd
+xQx
+xQx
+xQx
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-siL
-sPZ
+cKX
+cKX
+cKX
+cKX
+oYs
+yiB
 vEo
 oZk
 rZb
@@ -112447,23 +112939,23 @@ oOx
 fmc
 oDI
 eIK
+fHb
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
+xQx
+fHb
+xQx
+xQx
+xQx
 siL
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-pvZ
-siL
-siL
-siL
-siL
+hHq
+hHq
+hHq
 siL
 siL
 sXH
@@ -112755,9 +113247,9 @@ uSe
 uSe
 uSe
 siL
-siL
-siL
-siL
+ctT
+cdf
+ctT
 uSe
 uSe
 uSe

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -29413,7 +29413,7 @@
 "mKE" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
-	name = "cold loop gas supply valve"
+	name = "gas supply valve"
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/engine/core/nuclear)
@@ -33758,8 +33758,8 @@
 	dir = 8;
 	frequency = 1225;
 	icon_state = "intact_on";
-	id = "Cold Loop Gas Supply 1";
-	name = "cold loop gas supply pump";
+	id = "Reactor Gas Supply 1";
+	name = "reactor gas supply pump 1";
 	on = 1;
 	target_pressure = 1000
 	},
@@ -38898,8 +38898,8 @@
 	dir = 8;
 	frequency = 1225;
 	icon_state = "intact_on";
-	id = "Cold Loop Gas Supply 2";
-	name = "cold loop gas supply pump";
+	id = "Reactor Gas Supply 2";
+	name = "reactor gas supply pump 2";
 	on = 1;
 	target_pressure = 1000
 	},
@@ -52691,7 +52691,7 @@
 /area/station/maintenance/inner/east)
 "xNP" = (
 /obj/machinery/atmospherics/valve{
-	name = "cold loop freezer interface valve"
+	name = "freezer interface valve"
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/engine/core/nuclear)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1635,7 +1635,6 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aLH" = (
@@ -4227,7 +4226,6 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "bRJ" = (
-/obj/disposalpipe/segment/bent/north,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
@@ -5273,10 +5271,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
-"cqm" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/bay)
 "cqt" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
@@ -7960,13 +7954,6 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
-"dDa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/junction/left/west,
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
 "dDg" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -10051,6 +10038,10 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"ezU" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/black,
+/area/station/hydroponics/bay)
 "eAk" = (
 /obj/reagent_dispensers/still,
 /turf/simulated/floor/grime,
@@ -16568,11 +16559,6 @@
 	dir = 1
 	},
 /area/station/science/hall)
-"hlY" = (
-/obj/machinery/plantpot,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "hmy" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18697,6 +18683,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "igp" = (
@@ -22026,11 +22013,10 @@
 /obj/cable{
 	icon_state = "4-10"
 	},
-/obj/disposalpipe/segment/vertical,
-/obj/disposalpipe/segment/horizontal,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/west)
 "jHl" = (
@@ -24189,10 +24175,6 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
-"kyI" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "kyK" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/paper_bin,
@@ -25062,10 +25044,6 @@
 "kUs" = (
 /turf/simulated/floor/greenblack/corner,
 /area/station/storage/emergencyinternals)
-"kUx" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "kUI" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -29432,11 +29410,6 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
-"mKY" = (
-/obj/machinery/plantpot,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/grass,
-/area/station/hydroponics/bay)
 "mLB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32022,6 +31995,7 @@
 /obj/access_spawn/hydro,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "nVL" = (
@@ -33484,7 +33458,6 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "oJh" = (
@@ -38993,10 +38966,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"rsG" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/kitchen)
 "rsJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
@@ -43107,6 +43076,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "tgS" = (
@@ -43124,7 +43094,6 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "tgU" = (
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/greenblack{
 	dir = 10
 	},
@@ -46817,7 +46786,6 @@
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "uTB" = (
@@ -46904,11 +46872,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"uWr" = (
-/obj/disposalpipe/segment/vertical,
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "uWw" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/networked/storage/scanner{
@@ -48280,10 +48243,6 @@
 "vEu" = (
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
-"vEA" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/west)
 "vFk" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4;
@@ -50425,7 +50384,6 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "wJT" = (
@@ -50947,7 +50905,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/horizontal,
+/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "wYE" = (
@@ -53380,6 +53338,10 @@
 	dir = 8
 	},
 /area/station/engine/storage)
+"ycf" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/black,
+/area/station/hydroponics/bay)
 "ycq" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -87717,7 +87679,7 @@ wpS
 mbt
 mbt
 jVa
-vEA
+wqA
 iHN
 iHN
 sOx
@@ -88019,7 +87981,7 @@ cZD
 egS
 oNg
 vZi
-vyr
+oEZ
 iHN
 wPX
 kyY
@@ -88317,14 +88279,14 @@ jdV
 jdV
 jdV
 jdV
-kUx
-mKY
-cqm
-uWr
+jdV
+fLE
+oNg
+vyr
 aLf
-rsG
+iHN
 oJc
-dDa
+kyY
 iPX
 mJW
 eKa
@@ -88619,7 +88581,7 @@ jdV
 bJI
 bJI
 jdV
-kyI
+jdV
 fDR
 oNg
 vyr
@@ -88921,7 +88883,7 @@ jdV
 bJI
 egJ
 jdV
-kyI
+jdV
 fLE
 oNg
 naz
@@ -89223,7 +89185,7 @@ jdV
 bJI
 bJI
 jdV
-kyI
+jdV
 lDX
 oNg
 hWN
@@ -89525,7 +89487,7 @@ jdV
 jdV
 jdV
 jdV
-kyI
+jdV
 fLE
 oNg
 vyr
@@ -89827,7 +89789,7 @@ jdV
 nqD
 jdV
 jdV
-kyI
+jdV
 fDR
 oNg
 auj
@@ -90129,7 +90091,7 @@ jdV
 bJI
 bJI
 jdV
-kyI
+jdV
 fLE
 oNg
 txT
@@ -90431,7 +90393,7 @@ jdV
 bJI
 rUj
 jdV
-kyI
+jdV
 oCN
 oNg
 wqA
@@ -90733,7 +90695,7 @@ jdV
 bJI
 bJI
 jdV
-kyI
+jdV
 fLE
 oNg
 hEe
@@ -91035,7 +90997,7 @@ jdV
 jdV
 jdV
 jdV
-kyI
+jdV
 fDR
 oNg
 oEZ
@@ -92243,7 +92205,7 @@ hOK
 ajV
 ajV
 ajV
-hlY
+loU
 loU
 kry
 irP
@@ -92545,8 +92507,8 @@ ajV
 ajV
 ajV
 ajV
-omx
-ajV
+ezU
+ycf
 tgQ
 igl
 igl

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -31,12 +31,6 @@
 	dir = 8
 	},
 /area/station/quartermaster/refinery)
-"abg" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/west)
 "abh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -374,7 +368,6 @@
 	id = "nadir_minetop";
 	name = "Elevator Loading Door"
 	},
-/obj/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/staff_room)
@@ -539,6 +532,14 @@
 /obj/stool,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
+"alk" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "alm" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -1076,15 +1077,6 @@
 	dir = 1
 	},
 /area/station/security/main)
-"axJ" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "axP" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -1680,10 +1672,6 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
-	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
 "aNe" = (
@@ -2134,6 +2122,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"aYv" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "aYA" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
@@ -2545,7 +2543,7 @@
 	icon_state = "5-6"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "bib" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -2706,6 +2704,7 @@
 	},
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
+/obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
@@ -2974,6 +2973,9 @@
 /obj/decal/tile_edge/line/yellow{
 	dir = 10;
 	icon_state = "line1"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -3656,6 +3658,9 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bEm" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -3686,7 +3691,7 @@
 	icon_state = "1-10"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black,
+/turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bEZ" = (
 /turf/simulated/floor/greenblack{
@@ -5067,6 +5072,7 @@
 	},
 /obj/access_spawn/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "cmf" = (
@@ -5394,7 +5400,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "ctG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -6091,6 +6097,10 @@
 	pixel_y = 6;
 	pixel_x = -1
 	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/black/grime,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
@@ -6133,6 +6143,7 @@
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -6158,6 +6169,16 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"cNU" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour15;desc=This tool storage room is accessible to all Site personnel. In the unlikely event of mechanical failures, this is your one-stop shop.";
+	freq = 1443;
+	location = "tour14";
+	name = "tour 14 - east2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "cNY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/artifact)
@@ -8073,9 +8094,6 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
@@ -9295,6 +9313,17 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"ejj" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "ejw" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -9706,6 +9735,9 @@
 /area/station/hallway/secondary/west)
 "esK" = (
 /obj/table/wood/round/auto,
+/obj/item/decoration/flower_vase{
+	pixel_y = 10
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/cafeteria)
 "esU" = (
@@ -10188,6 +10220,17 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
+"eEA" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/station/engine/core/nuclear)
 "eFd" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
@@ -10334,7 +10377,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "eHX" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -12075,7 +12118,6 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "fvZ" = (
-/obj/machinery/light/small,
 /obj/machinery/plantpot,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/plating,
@@ -12768,6 +12810,10 @@
 /obj/decal/tile_edge/floorguide/engineering{
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
 "fMQ" = (
@@ -12955,7 +13001,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "fQQ" = (
 /obj/table/auto,
 /obj/item/peripheral/network/radio/locked{
@@ -13521,11 +13567,6 @@
 "gcL" = (
 /obj/machinery/power/smes,
 /obj/cable,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
 	},
@@ -13692,8 +13733,9 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "gfT" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -14593,6 +14635,7 @@
 /obj/item/pen/pencil{
 	pixel_x = -8
 	},
+/obj/machinery/light,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -14761,6 +14804,10 @@
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -15066,7 +15113,6 @@
 	location = "tour15";
 	name = "tour 15 - warehouse"
 	},
-/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "gKd" = (
@@ -15263,11 +15309,6 @@
 /obj/item/chem_grenade/firefighting{
 	pixel_y = -1;
 	pixel_x = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/monitoring{
@@ -15809,7 +15850,7 @@
 	},
 /obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "gZx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/storage/closet/fire,
@@ -15911,6 +15952,10 @@
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-6"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -16095,6 +16140,14 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
+"heN" = (
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_x = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "heV" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17000,6 +17053,11 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "hxc" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black/corner,
 /area/station/storage/tools)
 "hxe" = (
@@ -17172,11 +17230,10 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "hAe" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/disposalpipe/segment/vertical,
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "hAs" = (
@@ -18353,10 +18410,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour8;desc=There are three emergency storages on-site. These are public, with assorted supplies including nanolooms for suit repair.";
+	codes_txt = "tour;next_tour=tour9;desc=There are three emergency storages on-site. These are public, with assorted supplies including nanolooms for suit repair.";
 	freq = 1443;
-	location = "tour7";
-	name = "tour 7 - southeast"
+	location = "tour8";
+	name = "tour 8 - southeast"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -19972,7 +20029,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "iLM" = (
 /obj/machinery/computer/announcement{
 	dir = 8;
@@ -20008,6 +20065,13 @@
 "iMT" = (
 /turf/space/fluid/acid/clear,
 /area/shuttle/escape/station)
+"iMW" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "iNm" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -20180,18 +20244,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
-"iSq" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour15;desc=This is the Site's nuclear reactor section. Please do not linger here during operation. Tool storage is across the hall.";
-	freq = 1443;
-	location = "tour14";
-	name = "tour 14 - east2"
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 4
-	},
-/area/station/hallway/secondary/east)
 "iSv" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -20943,10 +20995,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "jiR" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/disposalpipe/trunk/south,
 /obj/machinery/disposal,
 /turf/simulated/floor/black/grime,
@@ -21061,11 +21109,6 @@
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
 	})
-"jlG" = (
-/obj/machinery/light/incandescent/netural,
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "jlW" = (
 /turf/simulated/wall/false_wall,
 /area/station/maintenance/storage{
@@ -21094,6 +21137,9 @@
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 28
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -21193,6 +21239,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -21899,9 +21946,6 @@
 /turf/simulated/wall/false_wall,
 /area/station/crew_quarters/arcade/dungeon)
 "jEz" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/yellowblack{
 	dir = 6
@@ -21935,11 +21979,6 @@
 /area/station/medical/robotics)
 "jGq" = (
 /obj/rack,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/item/storage/wall/random,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
@@ -22776,7 +22815,7 @@
 	pixel_y = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "jXe" = (
 /obj/machinery/portable_reclaimer,
 /obj/machinery/power/apc/autoname_north,
@@ -23356,7 +23395,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "klm" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2/junction{
 	dir = 8
@@ -23385,6 +23424,17 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
+"klz" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 12
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "klG" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/grass/leafy,
@@ -23603,6 +23653,14 @@
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"kqw" = (
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_x = -4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "kqL" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -23868,11 +23926,6 @@
 	},
 /obj/item/decoration/flower_vase{
 	pixel_y = 22
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
@@ -24892,6 +24945,10 @@
 /area/station/engine/engineering)
 "kRT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -24956,11 +25013,6 @@
 "kUc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},
@@ -25227,6 +25279,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/storage)
+"kYL" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "kZh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25425,6 +25482,15 @@
 "ldy" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
+"ldK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "lej" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26067,6 +26133,10 @@
 /obj/stool/chair{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -26127,11 +26197,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ltZ" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "lue" = (
@@ -26143,6 +26214,14 @@
 /obj/item/storage/pill_bottle/hairgrownium,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
+"lut" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "luK" = (
 /obj/stool/chair{
 	dir = 1
@@ -26976,6 +27055,10 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
 "lMr" = (
@@ -27551,11 +27634,6 @@
 "lYL" = (
 /obj/machinery/disposal/mail/autoname/research,
 /obj/disposalpipe/trunk/mail/east,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
@@ -27851,6 +27929,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/storage/tools)
@@ -29145,11 +29226,6 @@
 /obj/item/device/nanoloom{
 	pixel_x = 3;
 	pixel_y = -2
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
 	},
 /turf/simulated/floor/black/side,
 /area/station/storage/tools)
@@ -30623,7 +30699,6 @@
 "nsO" = (
 /obj/table/reinforced/auto,
 /obj/item/game_kit,
-/obj/machinery/light,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -32079,6 +32154,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"oas" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "oaD" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -32456,6 +32538,12 @@
 /obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
+"omX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tools)
 "ona" = (
 /obj/table/reinforced/auto,
 /obj/access_spawn/kitchen,
@@ -32676,6 +32764,11 @@
 /obj/reagent_dispensers/watertank/fountain,
 /obj/machinery/light_switch/north{
 	pixel_y = 22
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
@@ -33540,6 +33633,18 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core/nuclear)
+"oNe" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour8;desc=The east crew quarters are your best place to catch up on sleep - most public beds are located here, with personal safes for your security. Also located here are the diplomatic quarters.";
+	freq = 1443;
+	location = "tour7";
+	name = "tour 7 - crew quarters"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "oNg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
@@ -33666,8 +33771,9 @@
 "oPP" = (
 /obj/table/auto,
 /obj/item/paper_bin,
-/obj/machinery/light/incandescent/cool{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -34168,7 +34274,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "paN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/staff)
@@ -34527,10 +34633,10 @@
 	})
 "plq" = (
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour9;desc=The on-site radio station is a great source for entertainment and current events. Make sure to ask the DJ for your favorite song!";
+	codes_txt = "tour;next_tour=tour10;desc=The on-site radio station is a great source for entertainment and current events. Make sure to ask the DJ for your favorite song!";
 	freq = 1443;
-	location = "tour8";
-	name = "tour 8 - radio station"
+	location = "tour9";
+	name = "tour 9 - radio station"
 	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/southeast)
@@ -34746,7 +34852,7 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "pqr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35040,6 +35146,9 @@
 /area/station/storage/tech)
 "pwy" = (
 /obj/machinery/nanofab/nuclear,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/black,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -35527,10 +35636,6 @@
 /obj/cable{
 	icon_state = "2-9"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -35843,6 +35948,10 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
+"pSF" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/yellowblack,
+/area/station/hallway/primary/southeast)
 "pSL" = (
 /obj/cable{
 	d1 = 1;
@@ -36509,6 +36618,14 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"qif" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "qip" = (
 /obj/item/rods/steel{
 	amount = 50;
@@ -36731,6 +36848,10 @@
 /area/station/crew_quarters/fitness)
 "qoe" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -37111,6 +37232,10 @@
 /area/listeningpost)
 "qxM" = (
 /obj/machinery/vending/cola/red,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -37454,6 +37579,7 @@
 	desc = "A pneumatic delivery chute for ferrying produce across a distance.";
 	name = "produce chute"
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
@@ -39584,13 +39710,13 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_west)
-"rLM" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1
+"rLQ" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "rLX" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -40368,6 +40494,9 @@
 /area/station/hallway/primary/northwest)
 "sdK" = (
 /obj/machinery/vending/air_vendor,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "sdM" = (
@@ -40905,18 +41034,21 @@
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
-/obj/machinery/phone/wall{
-	pixel_y = 32;
-	pixel_x = 7
-	},
 /obj/item/paper,
 /obj/item/pen/fancy{
 	pixel_x = 3;
 	pixel_y = 5
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
 /obj/machinery/firealarm{
-	pixel_y = 28;
-	pixel_x = -7
+	pixel_x = 4;
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/heads{
@@ -41065,6 +41197,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"ssJ" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/purpleblack{
+	dir = 8
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "stc" = (
 /obj/stool/chair{
 	dir = 8
@@ -41662,12 +41802,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/crew)
 "sGN" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/storage/tools)
@@ -42227,6 +42363,18 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"sRM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "sRO" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -42407,10 +42555,10 @@
 "sVX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour11;desc=On my left, you'll see the public market - creatively-minded Site personnel, or the occasional trader bold enough to brave Magus' conditions, will set up shop here from time to time.";
+	codes_txt = "tour;next_tour=tour11;desc=On my left, you'll see the nuclear reactor responsible for s electrical generation for the Site. Please respect caution borders.";
 	freq = 1443;
 	location = "tour10";
-	name = "tour 10 - market"
+	name = "tour 10 - nuclear"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -43084,7 +43232,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "tjV" = (
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -43365,7 +43513,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "trx" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/blueblack,
@@ -45151,6 +45299,17 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
+"uiD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "uiQ" = (
 /obj/stool/chair/red{
 	dir = 4
@@ -45485,14 +45644,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "urL" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
+	},
+/obj/machinery/door_control{
+	id = "market";
+	pixel_y = 24
 	},
 /turf/simulated/floor/grey/side{
 	dir = 9
@@ -45658,7 +45816,21 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black/side,
+/area/station/storage/tools)
+"uuJ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black/corner,
 /area/station/storage/tools)
 "uvb" = (
 /obj/table/reinforced/bar/auto{
@@ -46966,9 +47138,10 @@
 /obj/machinery/photocopier{
 	pixel_x = 0
 	},
-/obj/machinery/door_control{
-	id = "market";
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -47383,11 +47556,6 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
@@ -47990,6 +48158,10 @@
 /obj/item/nanoloom_cartridge{
 	pixel_x = 2;
 	pixel_y = 11
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black/side,
 /area/station/storage/tools)
@@ -49440,6 +49612,9 @@
 "wpf" = (
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
+"wpF" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/secondary/west)
 "wpI" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -49935,7 +50110,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "wEh" = (
-/obj/stool/chair/yellow,
+/obj/stool/chair/yellow{
+	dir = 8
+	},
 /obj/landmark/start{
 	name = "Miner"
 	},
@@ -50431,9 +50608,6 @@
 	})
 "wRc" = (
 /obj/cable,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
 /obj/disposalpipe/segment/transport,
 /obj/cable{
 	icon_state = "0-6"
@@ -50753,6 +50927,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -51362,19 +51537,11 @@
 /obj/stool/chair/comfy{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
 /obj/cable{
 	icon_state = "6-8"
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/heads{
@@ -51713,10 +51880,6 @@
 /area/station/hallway/primary/northwest)
 "xwb" = (
 /obj/table/wood/auto,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/item/paper_bin{
 	pixel_y = -8;
 	pixel_x = 7
@@ -52247,10 +52410,10 @@
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
 	},
-/obj/machinery/power/apc/autoname_west,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -52528,6 +52691,10 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"xOd" = (
+/obj/decal/poster/wallsign/hazard_rad,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core/nuclear)
 "xOk" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -53457,10 +53624,9 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/machinery/light{
+/obj/machinery/firealarm{
 	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+	pixel_x = -24
 	},
 /turf/simulated/floor/black,
 /area/station/storage/tools)
@@ -85727,7 +85893,7 @@ lLM
 trK
 mbt
 oEZ
-oEZ
+iMW
 oEZ
 uGM
 oEZ
@@ -93288,10 +93454,10 @@ jmJ
 jmJ
 rsk
 fnY
-wqA
-wqA
-wqA
-wqA
+wpF
+wpF
+wpF
+wpF
 iWT
 lxp
 lxp
@@ -93581,17 +93747,17 @@ esj
 esj
 esj
 esj
-esj
 sIa
 esj
 esj
 esj
+sIa
 gIt
-abg
+gNQ
 gNU
 iER
 hAe
-uqt
+lut
 uqt
 uqt
 jpG
@@ -93892,8 +94058,8 @@ gNQ
 gNQ
 gzG
 tal
-ayC
 hCf
+ayC
 hCf
 hCf
 jwV
@@ -94196,8 +94362,8 @@ uPZ
 wAy
 uPZ
 uPZ
-cWX
 uPZ
+cWX
 tNV
 uPZ
 lyT
@@ -94501,7 +94667,7 @@ jHU
 vRv
 jmJ
 xVH
-jmJ
+aYv
 jmJ
 jmJ
 eGA
@@ -97213,7 +97379,7 @@ agE
 fNd
 lLZ
 czo
-mXd
+cfj
 fmO
 gEi
 mUC
@@ -97515,7 +97681,7 @@ agE
 fTC
 sDF
 czo
-cfj
+mXd
 fmO
 feY
 mUC
@@ -98126,7 +98292,7 @@ jfa
 pDb
 cvc
 cvc
-cvc
+rLQ
 cvc
 cvc
 kBB
@@ -99033,7 +99199,7 @@ xCK
 xCK
 fRN
 xCK
-xCK
+ssJ
 xCK
 tVG
 plQ
@@ -99334,9 +99500,9 @@ hbm
 lEn
 fip
 lEn
-fip
 lEn
-fip
+lEn
+lEn
 nKe
 buD
 fJg
@@ -102353,7 +102519,7 @@ vBq
 cAs
 cAs
 cAs
-xSt
+oLr
 lZB
 sOU
 sOU
@@ -102655,7 +102821,7 @@ sGN
 hKE
 bxi
 cAs
-oLr
+xSt
 lZB
 sOU
 sOU
@@ -102955,7 +103121,7 @@ yji
 xun
 mdV
 bQm
-lep
+dxd
 cAs
 xSt
 lZB
@@ -103253,11 +103419,11 @@ rnu
 vJU
 cAs
 uuD
-hxc
-ind
+uuJ
+omX
 hxc
 bQm
-dxd
+lep
 cAs
 xSt
 lZB
@@ -104171,14 +104337,14 @@ xKn
 sdK
 aLa
 qWs
+rZb
+rZb
 uCT
-rZb
-rZb
 cnx
 sFL
 vbq
 sFL
-sFL
+kYL
 vrj
 lBl
 jHD
@@ -104463,7 +104629,7 @@ cib
 iTi
 iTi
 iTi
-iTi
+cNU
 iTi
 iTi
 hQB
@@ -104481,7 +104647,7 @@ ezi
 drr
 hkH
 rZb
-vlO
+bBr
 iYt
 nes
 nes
@@ -105064,13 +105230,13 @@ hsY
 unW
 unW
 unW
-iSq
-cxr
-unW
-unW
 unW
 cxr
 unW
+unW
+unW
+unW
+cxr
 unW
 unW
 cYD
@@ -105381,7 +105547,7 @@ teP
 hoD
 bkl
 vEo
-oHA
+pSF
 skO
 bSP
 gyV
@@ -105620,7 +105786,7 @@ xes
 xes
 xes
 wBN
-wBN
+oas
 wBN
 mIG
 mIG
@@ -105652,7 +105818,7 @@ lsj
 euV
 dMT
 sDl
-gdf
+fNc
 nBc
 cBo
 dmC
@@ -106256,7 +106422,7 @@ dMT
 eeW
 lsj
 klL
-gdf
+fNc
 sqP
 cBo
 cBo
@@ -106283,7 +106449,7 @@ kYA
 qyC
 aut
 ajo
-axJ
+gIk
 vEo
 hrC
 vEo
@@ -107175,7 +107341,7 @@ pIJ
 jVj
 mio
 ibV
-ibV
+xOd
 tjk
 ygt
 ygt
@@ -107192,7 +107358,7 @@ ocD
 sXH
 vEo
 oWK
-jlG
+vEo
 sXH
 hWH
 tPJ
@@ -107478,7 +107644,7 @@ aXs
 rkh
 ibV
 ibV
-dmq
+eEA
 ygt
 ygt
 ygt
@@ -107490,8 +107656,8 @@ vFq
 fBr
 fuX
 gNa
-ocD
-bEm
+kqw
+klz
 sVX
 iPJ
 wlW
@@ -107790,12 +107956,12 @@ hTc
 dfm
 vMP
 uNg
-kYA
-sSm
+uiD
+qif
 gDo
-bEm
-vEo
-iPJ
+ldK
+iZl
+sRM
 uEI
 dOr
 uBt
@@ -108094,8 +108260,8 @@ gKd
 hhO
 kYA
 mYy
-ocD
-bEm
+heN
+ejj
 vEo
 iPJ
 rZb
@@ -108398,7 +108564,7 @@ vRR
 ocD
 ocD
 sXH
-rLM
+vEo
 iPJ
 wjM
 sXH
@@ -109591,7 +109757,7 @@ bLW
 oZp
 bLW
 ibV
-ibV
+xOd
 tjk
 ygt
 ygt
@@ -109894,7 +110060,7 @@ jXY
 kCV
 ibV
 ibV
-dmq
+eEA
 ygt
 ygt
 ygt
@@ -110210,7 +110376,7 @@ sSm
 vJu
 crB
 ocD
-vEo
+alk
 fdg
 rZb
 oHA
@@ -114124,7 +114290,7 @@ xbW
 rGn
 ifZ
 uql
-ifZ
+oNe
 ifZ
 gCS
 ifZ

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1616,9 +1616,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/decal/tile_edge/floorguide/mining{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "aKU" = (
@@ -1713,8 +1710,18 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"aOE" = (
+/obj/stool/chair,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "aOF" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/qm,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "aOL" = (
@@ -2137,6 +2144,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aYP" = (
+/obj/decal/tile_edge/floorguide/botany{
+	dir = 1
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
 "aZc" = (
@@ -2869,19 +2879,6 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"bpG" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/black,
-/area/space)
 "bpI" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -2917,12 +2914,40 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "bpY" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/storage/cart/mechcart{
+	desc = "A big rolling supply cart equipped for handling hull breaches.";
+	name = "breach repair cart";
+	req_access_txt = "40"
 	},
-/obj/storage/secure/crate/eng/interdictor,
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/chem_grenade/metalfoam{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/chem_grenade/metalfoam{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/item/chem_grenade/metalfoam{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 6
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -5
+	},
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
@@ -4115,6 +4140,13 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "nadir_diploshut";
+	name = "Diplomatic Quarters Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads{
@@ -5410,10 +5442,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"ctT" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/space)
 "ctW" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -6337,15 +6365,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
-"cQM" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "cRq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7013,10 +7032,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"din" = (
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
-/area/space)
 "dis" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7125,7 +7140,7 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
 "dmC" = (
-/obj/machinery/light/small/warm/very{
+/obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
@@ -7232,10 +7247,6 @@
 /obj/item/device/nanoloom{
 	pixel_y = -4;
 	pixel_x = 6
-	},
-/obj/item/tank/mini_oxygen{
-	pixel_x = -8;
-	pixel_y = -1
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/mining/staff_room)
@@ -7795,40 +7806,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "dAy" = (
-/obj/storage/cart/mechcart{
-	desc = "A big rolling supply cart equipped for handling hull breaches.";
-	name = "breach repair cart";
-	req_access_txt = "40"
-	},
-/obj/item/sheet/steel{
-	amount = 50
-	},
-/obj/item/chem_grenade/metalfoam{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/chem_grenade/metalfoam{
-	pixel_x = -1;
-	pixel_y = -4
-	},
-/obj/item/chem_grenade/metalfoam{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/food/drinks/fueltank{
-	pixel_x = 6
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -5
-	},
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
@@ -7895,10 +7872,10 @@
 	name = "Southeast Breach Hull"
 	})
 "dCr" = (
-/obj/decal/tile_edge/floorguide/qm,
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
 	},
+/obj/decal/tile_edge/floorguide/mining,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "dCt" = (
@@ -8099,7 +8076,9 @@
 	},
 /obj/access_spawn/maint,
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+	dir = 4;
+	can_rupture = 0;
+	level = 1
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
@@ -10808,6 +10787,7 @@
 /area/station/crew_quarters/baroffice)
 "eQG" = (
 /obj/disposalpipe/segment/transport,
+/obj/decal/tile_edge/floorguide/qm,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "eRb" = (
@@ -11260,13 +11240,13 @@
 	name = "Southwest Breach Hull"
 	})
 "fbu" = (
-/obj/decal/tile_edge/floorguide/qm,
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "hydroponics";
 	name = "hydroponics mail junction"
+	},
+/obj/decal/tile_edge/floorguide/mining,
+/obj/decal/tile_edge/floorguide/arrow_n{
+	dir = 4
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
@@ -14382,9 +14362,7 @@
 	},
 /area/pasiphae)
 "guF" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1
-	},
+/obj/machinery/door/unpowered/wood/stall,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "guH" = (
@@ -17345,7 +17323,9 @@
 /area/pasiphae)
 "hCz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+	dir = 4;
+	can_rupture = 0;
+	level = 1
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -18669,6 +18649,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"iga" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/qm,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/northwest)
 "igf" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -20337,6 +20322,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 4
 	},
+/obj/decal/tile_edge/floorguide/mining,
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
@@ -21453,10 +21439,6 @@
 /obj/item/device/nanoloom{
 	pixel_y = -4;
 	pixel_x = 6
-	},
-/obj/item/tank/mini_oxygen{
-	pixel_x = -8;
-	pixel_y = -1
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/mining/staff_room)
@@ -24284,12 +24266,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"kCn" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/space)
 "kCz" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -24699,6 +24675,13 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"kLT" = (
+/obj/disposalpipe/segment/transport,
+/obj/decal/tile_edge/floorguide/botany{
+	dir = 8
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/northeast)
 "kMu" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26783,8 +26766,8 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "lHq" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 8
+/obj/machinery/door/unpowered/wood/stall{
+	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
@@ -27625,12 +27608,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
-"lYm" = (
-/obj/decal/tile_edge/floorguide/mining{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/engine/storage)
 "lYL" = (
 /obj/machinery/disposal/mail/autoname/research,
 /obj/disposalpipe/trunk/mail/east,
@@ -30845,6 +30822,7 @@
 	})
 "nvD" = (
 /obj/disposalpipe/segment/mineral,
+/obj/landmark/gps_waypoint,
 /turf/simulated/floor/industrial,
 /area/station/mining/staff_room)
 "nvK" = (
@@ -33174,9 +33152,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/manufacturer/mining{
-	free_resources = list(/obj/item/material_piece/steel,/obj/item/material_piece/copper,/obj/item/material_piece/glass,/obj/item/material_piece/cloth/cottonfabric)
-	},
+/obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -33629,7 +33605,8 @@
 /area/space)
 "oMR" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
+	can_rupture = 0;
+	level = 1
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core/nuclear)
@@ -34680,7 +34657,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/west)
 "pmV" = (
-/obj/machinery/manufacturer/general,
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellowblack{
 	dir = 6
 	},
@@ -35416,7 +35393,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/office)
 "pDQ" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	level = 1
+	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
 "pDS" = (
@@ -36102,7 +36082,10 @@
 /turf/simulated/floor/black,
 /area/pasiphae/survey)
 "pVr" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	level = 1
+	},
 /obj/machinery/drainage,
 /obj/machinery/shower{
 	dir = 8;
@@ -38980,10 +38963,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
 "rsN" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
 /obj/machinery/vending/jobclothing/catering,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -39303,7 +39282,9 @@
 	},
 /obj/cable,
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+	dir = 4;
+	can_rupture = 0;
+	level = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -39697,10 +39678,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-8"
+	dir = 4;
+	can_rupture = 0;
+	level = 1
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -39737,7 +39717,6 @@
 	name = "Diplomatic Quarters"
 	})
 "rLY" = (
-/obj/decal/tile_edge/floorguide/qm,
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
 	},
@@ -39745,6 +39724,7 @@
 	mail_tag = "security";
 	name = "security mail junction"
 	},
+/obj/decal/tile_edge/floorguide/mining,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
 "rMD" = (
@@ -40264,7 +40244,9 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "rYl" = (
 /obj/storage/secure/closet/immersion/quartermasters,
 /obj/item/clothing/suit/space/diving/civilian{
@@ -40771,6 +40753,9 @@
 "skM" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/transport,
+/obj/decal/tile_edge/floorguide/botany{
+	dir = 8
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "skO" = (
@@ -41020,11 +41005,19 @@
 /turf/simulated/floor/engine,
 /area/listeningpost/power)
 "sqP" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/light/small/warm/very{
+/obj/machinery/recharger/wall/sticky{
 	dir = 1;
-	pixel_y = 21
+	pixel_y = 26
 	},
+/obj/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/tank/mini_oxygen{
+	pixel_x = -7
+	},
+/obj/item/tank/mini_oxygen{
+	pixel_x = 8
+	},
+/obj/item/clothing/mask/breath,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -41896,12 +41889,12 @@
 	},
 /area/station/storage/eva)
 "sJS" = (
-/obj/decal/tile_edge/floorguide/qm,
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
+/obj/decal/tile_edge/floorguide/arrow_n{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/mining,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "sJU" = (
@@ -43163,7 +43156,9 @@
 	},
 /obj/storage/closet/emergency,
 /turf/simulated/floor/black,
-/area/space)
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "tii" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44057,6 +44052,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/access_spawn/mining,
 /turf/simulated/floor/yellow,
 /area/station/mining/staff_room)
 "tFt" = (
@@ -45305,6 +45301,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -47407,6 +47404,10 @@
 "vkE" = (
 /turf/simulated/floor/black,
 /area/station/storage/emergencyinternals)
+"vkO" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "vkT" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -48955,8 +48956,8 @@
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "vVS" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 4
+/obj/machinery/door/unpowered/wood/stall{
+	dir = 8
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
@@ -49428,9 +49429,6 @@
 	})
 "wkp" = (
 /obj/disposalpipe/segment/vertical,
-/obj/decal/tile_edge/floorguide/arrow_w{
-	dir = 1
-	},
 /turf/simulated/floor/yellowblack/corner,
 /area/station/hallway/primary/southeast)
 "wks" = (
@@ -51167,19 +51165,11 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "xep" = (
-/obj/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/tank/mini_oxygen{
-	pixel_x = 8
-	},
-/obj/item/tank/mini_oxygen{
-	pixel_x = -7
-	},
-/obj/item/clothing/mask/breath,
-/obj/machinery/recharger/wall/sticky{
+/obj/machinery/light/small{
 	dir = 1;
-	pixel_y = 26
+	pixel_y = 21
 	},
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -51982,9 +51972,6 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/transport,
-/obj/decal/tile_edge/floorguide/arrow_e{
-	dir = 1
-	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "xyJ" = (
@@ -52792,10 +52779,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"xPJ" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black,
-/area/space)
 "xPY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53080,10 +53063,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/ranch)
-"xVo" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/industrial,
-/area/station/mining/staff_room)
 "xVu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53331,6 +53310,7 @@
 /area/station/science/bot_storage)
 "yaa" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/qm,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
 "yaH" = (
@@ -53610,9 +53590,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/pharmacy)
-"yjf" = (
-/turf/simulated/floor/plating,
-/area/space)
 "yji" = (
 /obj/table/auto,
 /obj/item/device/gps{
@@ -83489,8 +83466,8 @@ fDm
 dqY
 fDm
 fDm
-din
-siL
+fDm
+dqY
 fDm
 fDm
 fDm
@@ -83791,8 +83768,8 @@ gfS
 gbL
 gfS
 gfS
-yjf
-ctT
+gfS
+gbL
 gfS
 gfS
 gfS
@@ -84093,8 +84070,8 @@ gbL
 dqY
 gbL
 gbL
-ctT
-siL
+gbL
+dqY
 gbL
 gbL
 gbL
@@ -84391,11 +84368,11 @@ hWJ
 gkJ
 hWJ
 hLQ
+hWJ
+hWJ
 qga
 hWJ
 hWJ
-hWJ
-xPJ
 rYi
 nsh
 iZX
@@ -84697,8 +84674,8 @@ uTO
 uTO
 uTO
 uTO
-kCn
-bpG
+uTO
+joJ
 dnH
 uTO
 uTO
@@ -84993,14 +84970,14 @@ fsf
 lyE
 cbx
 dqY
-oWp
+aOE
 iaz
 pjU
 dCz
 iEo
 eap
 thP
-siL
+dqY
 bHq
 hWJ
 hWJ
@@ -85301,8 +85278,8 @@ vUa
 vUa
 vUa
 vUa
-siL
-siL
+vUa
+vUa
 uNk
 qBW
 kGA
@@ -94037,7 +94014,7 @@ cFR
 jrk
 ggq
 rKe
-ggq
+iga
 awO
 mYF
 rtm
@@ -104907,7 +104884,7 @@ rJy
 sUv
 snR
 buF
-eQG
+kLT
 nbX
 eQG
 bCg
@@ -106121,7 +106098,7 @@ izA
 tXW
 fNc
 xep
-cBo
+vkO
 cBo
 lVi
 rGH
@@ -106729,9 +106706,9 @@ woS
 gdf
 aXs
 pqb
-xVo
+dYV
 tYz
-xVo
+dYV
 ujK
 aXs
 rkh
@@ -110660,7 +110637,7 @@ eIK
 oZp
 oZp
 oZp
-cQM
+jXY
 ibV
 ibV
 lXA
@@ -111287,7 +111264,7 @@ rZb
 vWX
 mkh
 oAO
-lYm
+ciw
 ciw
 ciw
 eGD

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -9210,6 +9210,7 @@
 /area/station/maintenance/disposal)
 "egJ" = (
 /obj/machinery/hydro_growlamp,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "egQ" = (
@@ -9788,6 +9789,12 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"euD" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "euF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -14877,6 +14884,12 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
+"gEM" = (
+/obj/decal/cleanable/writing/infrared{
+	words = "they know. clean up shop"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/west)
 "gEQ" = (
 /obj/machinery/light/small/floor/netural,
 /obj/cable{
@@ -30609,6 +30622,10 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"nqD" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "nqF" = (
 /turf/simulated/floor/yellowblack{
 	dir = 4
@@ -32665,6 +32682,11 @@
 	pixel_y = 8;
 	pixel_x = 5
 	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -34231,6 +34253,9 @@
 "oZD" = (
 /obj/stool/chair/green{
 	dir = 4
+	},
+/obj/landmark/start{
+	name = "Botanist"
 	},
 /turf/simulated/floor/greenblack{
 	dir = 4
@@ -40080,6 +40105,7 @@
 /area/station/hallway/primary/southwest)
 "rUj" = (
 /obj/machinery/hydro_mister,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rUk" = (
@@ -46974,15 +47000,6 @@
 /area/station/maintenance/storage{
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
-	})
-"uXV" = (
-/obj/landmark/start{
-	name = "Botanist"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/hydroponics{
-	do_not_irradiate = 1;
-	name = "Hydroponics Storage"
 	})
 "uYq" = (
 /obj/warp_beacon{
@@ -86778,7 +86795,7 @@ akw
 ngq
 ajs
 jRv
-uXV
+bpN
 qqc
 uUP
 uUP
@@ -89799,7 +89816,7 @@ bYZ
 kWV
 jdV
 jdV
-jdV
+nqD
 jdV
 jdV
 kyI
@@ -91309,7 +91326,7 @@ bYZ
 nmm
 rYV
 kAr
-vnJ
+euD
 mvb
 vnJ
 tgU
@@ -92230,7 +92247,7 @@ oLJ
 wqA
 cUx
 cit
-wqA
+gEM
 bhZ
 tjx
 par

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -9706,7 +9706,8 @@
 "esK" = (
 /obj/table/wood/round/auto,
 /obj/item/decoration/flower_vase{
-	pixel_y = 10
+	pixel_y = 13;
+	pixel_x = 7
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/cafeteria)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -17,22 +17,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
-"aaH" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/east)
 "aaN" = (
 /obj/stool/chair/red{
 	dir = 4
@@ -169,13 +153,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/blackwhite,
 /area/station/medical/morgue)
-"adk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "adB" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -287,13 +264,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"afH" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "aga" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/pink,
@@ -305,7 +275,7 @@
 	},
 /obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/normal,
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "agr" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -401,6 +371,8 @@
 	id = "nadir_minetop";
 	name = "Elevator Loading Door"
 	},
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/staff_room)
 "ahQ" = (
@@ -429,15 +401,6 @@
 	dir = 4
 	},
 /area/station/medical/medbay/pharmacy)
-"aiq" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/rack,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "aiC" = (
 /obj/machinery/conveyor/EW{
 	id = "garbage";
@@ -490,7 +453,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "ajr" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -521,10 +486,16 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "ajV" = (
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
+"akq" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters_east)
 "akw" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/black,
@@ -624,7 +595,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "amr" = (
 /obj/stool/chair{
 	dir = 4
@@ -978,26 +949,6 @@
 	dir = 4
 	},
 /area/pasiphae)
-"atG" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "auc" = (
 /obj/table/nanotrasen/auto,
 /obj/machinery/cell_charger,
@@ -1020,7 +971,9 @@
 "aut" = (
 /obj/machinery/centrifuge_nuclear,
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "auw" = (
 /obj/submachine/chef_sink{
 	desc = "A common utility sink.";
@@ -1060,25 +1013,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"avl" = (
-/obj/table/auto,
-/obj/item/storage/belt/utility{
-	pixel_y = -2
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 3
-	},
-/obj/item/device/multitool{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/obj/item/device/t_scanner{
-	pixel_x = 9
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/storage/tools)
 "avt" = (
 /obj/machinery/door_control{
 	id = "nadir_bhull_ne";
@@ -1133,16 +1067,6 @@
 	},
 /turf/simulated/floor/industrial,
 /area/station/mining/staff_room)
-"axq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "axs" = (
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack/corner{
@@ -1153,6 +1077,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -1198,13 +1123,12 @@
 	},
 /area/station/medical/medbay/lobby)
 "ayy" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
+/obj/storage/crate,
+/obj/item/clothing/under/misc/vice,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/crew_quarters/quarters_east)
 "ayC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1484,18 +1408,6 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
 /area/station/crew_quarters/arcade/dungeon)
-"aDS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "aDT" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -1600,17 +1512,6 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
-"aHy" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_east)
 "aHI" = (
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -1748,12 +1649,6 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aLz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "aLH" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/cable{
@@ -1903,15 +1798,6 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/pasiphae/bridge)
-"aQS" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "aRh" = (
 /obj/machinery/chem_dispenser/chemical,
 /turf/simulated/floor/engine/caution/east,
@@ -1922,9 +1808,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"aRG" = (
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_east)
 "aRM" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 2
@@ -2003,7 +1886,7 @@
 	icon_state = "5-8"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "aTK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2020,19 +1903,13 @@
 	},
 /area/listeningpost/power)
 "aUS" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/station/crew_quarters/quarters_east)
 "aUV" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2166,11 +2043,18 @@
 "aWX" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/machinery/light/small,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = 26
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "aWY" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/redblack,
@@ -2292,8 +2176,13 @@
 	},
 /obj/machinery/drainage,
 /obj/stool/bench/yellow/auto,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "aZR" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack{
@@ -2318,7 +2207,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "baa" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor,
@@ -2327,22 +2216,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner{
 	name = "Transception Array Control"
-	})
-"baq" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
 	})
 "bat" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -2362,12 +2235,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/science/artifact)
-"baS" = (
-/obj/submachine/GTM{
-	pixel_y = 32
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "baU" = (
 /obj/decal/cleanable/oil{
 	icon_state = "streak1"
@@ -2403,11 +2270,6 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"bbK" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 8
-	},
-/area/space)
 "bck" = (
 /obj/stool/bench/wooden/auto,
 /obj/disposalpipe/segment/vertical,
@@ -2467,20 +2329,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/detectives_office)
-"bdz" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/space)
 "bdB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2507,9 +2355,10 @@
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
 /area/station/medical/head)
 "beh" = (
-/obj/machinery/door/airlock/pyro/alt,
-/turf/simulated/floor/black,
-/area/space)
+/turf/simulated/floor/black/corner{
+	dir = 8
+	},
+/area/station/crew_quarters/quarters_east)
 "bel" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/cable/orange,
@@ -2524,7 +2373,9 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "beq" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4;
@@ -2585,12 +2436,12 @@
 	dir = 4
 	},
 /area/station/security/interrogation)
-"bfG" = (
-/obj/storage/closet/office,
-/turf/simulated/floor/black/side,
-/area/station/storage/tools)
 "bfW" = (
 /obj/machinery/manufacturer/mining,
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
@@ -2601,7 +2452,9 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine/caution/corner,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "bgw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby{
@@ -2627,6 +2480,18 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment)
+"bgX" = (
+/obj/item/storage/toilet,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bhB" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -2783,7 +2648,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "bks" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -2800,7 +2667,12 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "bkJ" = (
-/obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "bkQ" = (
@@ -2820,14 +2692,18 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
-"blR" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
+"blv" = (
+/obj/machinery/door_control{
+	id = "nadir_diploshut";
+	name = "Quarters Shutters";
+	pixel_x = 22
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/black,
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "blV" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
@@ -2936,7 +2812,10 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
 /obj/firedoor_spawn,
-/obj/disposalpipe/segment/ejection,
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "boT" = (
@@ -3093,7 +2972,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "brA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3341,7 +3222,9 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "buB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -3379,11 +3262,6 @@
 	dir = 4
 	},
 /area/station/science/hall)
-"buR" = (
-/obj/machinery/light/small,
-/obj/disposalpipe/segment/ejection,
-/turf/simulated/floor/plating,
-/area/space)
 "buS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3449,7 +3327,13 @@
 	},
 /area/station/crew_quarters/courtroom)
 "bwx" = (
-/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "bwA" = (
@@ -3516,7 +3400,7 @@
 	power_level = 2
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "bxk" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -3795,6 +3679,7 @@
 /obj/cable{
 	icon_state = "1-10"
 	},
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "bEZ" = (
@@ -4058,6 +3943,12 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
+"bLW" = (
+/obj/machinery/door/unpowered/wood/stall{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "bLX" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2{
@@ -4105,7 +3996,9 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "bNm" = (
 /obj/shrub,
 /obj/machinery/camera{
@@ -4196,15 +4089,26 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
 "bPO" = (
-/obj/storage/secure/closet/personal,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/storage/secure/closet/personal/empty,
 /turf/simulated/floor/grey/side{
 	dir = 6
 	},
 /area/station/crew_quarters/market)
 "bPQ" = (
 /obj/machinery/door/airlock/pyro/command/alt,
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "bQh" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Medical Bay"
@@ -4214,6 +4118,9 @@
 	icon_state = "floor3"
 	},
 /area/listeningpost)
+"bQm" = (
+/turf/simulated/floor/black/side,
+/area/station/storage/tools)
 "bQn" = (
 /obj/decal/fakeobjects/catalytic_doodad,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -4292,6 +4199,9 @@
 /area/station/chapel/sanctuary)
 "bSc" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "bSg" = (
@@ -4604,18 +4514,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"bXN" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "bYb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -4632,13 +4530,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
-"bYd" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "bYs" = (
 /obj/rack,
 /obj/item/reagent_containers/glass/bucket,
@@ -4786,18 +4677,24 @@
 	},
 /area/station/hallway/primary/northeast)
 "cdf" = (
-/obj/machinery/door/airlock/pyro/glass{
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/machinery/door/airlock/pyro/alt{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
+/area/station/crew_quarters/quarters_east)
 "cdg" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
 	level = 2
 	},
 /turf/simulated/floor/engine/caution/west,
-/area/space)
+/area/station/engine/core/nuclear)
 "cdp" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -4816,15 +4713,6 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
-"cdO" = (
-/obj/table/reinforced/auto,
-/obj/item/decoration/flower_vase{
-	pixel_y = 14
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "cdT" = (
 /obj/stool/chair{
 	dir = 4
@@ -4925,11 +4813,20 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "cgu" = (
+/obj/storage/cart,
+/obj/item/instrument/vuvuzela,
+/obj/item/storage/box/mousetraps,
+/obj/item/device/radio{
+	pixel_x = -3
+	},
+/obj/item/device/multitool{
+	pixel_x = 5
+	},
 /obj/cable{
 	icon_state = "1-10"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "cgS" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
@@ -5162,8 +5059,9 @@
 	name = "Secondary Core Access"
 	},
 /obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "cmf" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -5413,7 +5311,9 @@
 "crB" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/engine/caution/south,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "crF" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 8
@@ -5425,6 +5325,24 @@
 /turf/simulated/floor/caution/west,
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
+	})
+"csu" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
+"csz" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
 	})
 "csA" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -5483,6 +5401,20 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/space)
+"ctW" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "nadir_diploshut";
+	name = "Diplomatic Quarters Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "cuw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/drainage,
@@ -5653,7 +5585,9 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "cyJ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -5687,14 +5621,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
-"czt" = (
-/obj/shrub{
-	dir = 1
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "czE" = (
 /obj/machinery/door/poddoor{
 	id = "ai_core";
@@ -5848,14 +5774,6 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/engine/caution/east,
 /area/station/crew_quarters/cafeteria)
-"cEk" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/storage/tools)
 "cEr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -5883,7 +5801,7 @@
 "cFx" = (
 /obj/disposalpipe/loafer/horizontal,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "cFB" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -6079,14 +5997,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"cKb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "cKo" = (
 /obj/storage/crate,
 /obj/decal/cleanable/dirt,
@@ -6100,8 +6010,12 @@
 	name = "The Warrens"
 	})
 "cKX" = (
-/turf/simulated/floor/black,
-/area/space)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/black,
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "cLn" = (
 /obj/machinery/light,
 /obj/machinery/disposal/mail/autoname/qm,
@@ -6197,7 +6111,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "cNf" = (
 /obj/machinery/disposal/cart_port,
 /obj/storage/cart/trash,
@@ -6208,6 +6122,14 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/southwest)
+"cNs" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/engine,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "cNA" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right,
@@ -6272,7 +6194,6 @@
 /area/station/maintenance/west)
 "cOM" = (
 /obj/machinery/space_heater,
-/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "cPh" = (
@@ -6392,8 +6313,11 @@
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "cRq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -6610,18 +6534,6 @@
 /obj/machinery/networked/telepad,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
-"cVL" = (
-/obj/rack,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/head/helmet/firefighter,
-/obj/item/tank/air,
-/obj/item/extinguisher,
-/obj/item/crowbar,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor/plating,
-/area/space)
 "cVU" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
@@ -6670,6 +6582,13 @@
 	dir = 8
 	},
 /area/station/storage/tools)
+"cWX" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "cXb" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2{
 	dir = 6
@@ -6920,20 +6839,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"dcD" = (
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/space)
 "dcH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
@@ -6968,7 +6873,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "dft" = (
 /obj/disposalpipe/segment/vertical,
 /obj/disposalpipe/segment/transport{
@@ -6985,6 +6892,9 @@
 "dfC" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
@@ -7049,7 +6959,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "dhw" = (
 /obj/disposalpipe/block_sensing_outlet/west,
 /turf/unsimulated/wall/setpieces/leadwall/cap,
@@ -7063,10 +6973,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/elect)
-"dhS" = (
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/space)
 "dif" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7180,7 +7086,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "dmr" = (
 /obj/decal/tile_edge/floorguide/security{
 	dir = 8
@@ -7209,6 +7115,18 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"dnh" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "dni" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8
@@ -7246,9 +7164,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"dnY" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market)
 "doa" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right{
@@ -7327,18 +7242,6 @@
 /obj/reagent_dispensers/beerkeg,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
-"dqr" = (
-/obj/machinery/door/airlock/pyro/engineering/alt{
-	dir = 4
-	},
-/obj/access_spawn/engineering_engine,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/space)
 "dqs" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -7478,23 +7381,19 @@
 	name = "Extraction Nexus"
 	})
 "dtq" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
-/obj/machinery/light/small,
-/obj/table/reinforced/auto,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/space)
-"dtx" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/ejection,
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/station/crew_quarters/quarters_east)
 "dtz" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7540,6 +7439,12 @@
 	icon_state = "2"
 	},
 /area/station/hallway/secondary/exit)
+"dva" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "dvb" = (
 /obj/stool,
 /obj/cable{
@@ -7547,9 +7452,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"dvi" = (
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/crew_quarters/quarters_east)
 "dvC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7648,9 +7550,22 @@
 	},
 /area/station/medical/medbay/treatment2)
 "dxd" = (
-/turf/simulated/floor/black/corner{
-	dir = 1
+/obj/table/auto,
+/obj/item/storage/belt/utility{
+	pixel_y = -2
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3
+	},
+/obj/item/device/multitool{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 9
+	},
+/obj/machinery/light,
+/turf/simulated/floor/black,
 /area/station/storage/tools)
 "dxw" = (
 /obj/cable{
@@ -7760,16 +7675,13 @@
 	name = "Bridge Reception"
 	})
 "dzn" = (
-/obj/storage/crate,
-/obj/item/clothing/under/misc/vice,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/table/reinforced/auto,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
 	},
+/obj/bedsheetbin,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "dzt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour1;desc=Hey, everyone. I'm Mariana, your personal guide to the Nadir Extraction Site, Nanotrasen's most advanced facility cleared for general personnel. Let's get going!";
@@ -8075,7 +7987,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/maintenance/east)
 "dDw" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "15"
@@ -8101,14 +8013,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"dEG" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 4
-	},
-/obj/table/auto,
-/obj/item/paper_bin,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "dEI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8252,7 +8156,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "dFR" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -8377,6 +8281,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"dIW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "dJj" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1
@@ -8483,13 +8395,6 @@
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
-"dLj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_east)
 "dLt" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/emergency2)
@@ -8595,7 +8500,9 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 6
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "dPx" = (
 /obj/submachine/laundry_machine,
 /turf/simulated/floor/sanitary,
@@ -8729,6 +8636,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"dSY" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "dTk" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8853,7 +8774,9 @@
 	name = "Reactor Core Shielding"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "dXl" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/cable{
@@ -8903,10 +8826,33 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
 "dYx" = (
-/turf/simulated/floor/black/side{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/item/storage/box/cutlery{
+	pixel_x = 4;
+	pixel_y = 14
 	},
-/area/space)
+/obj/item/storage/box/glassbox{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/cereal_box/roach{
+	pixel_y = -3;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/cereal_box/roach{
+	pixel_y = -5;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/drinks/bowl{
+	pixel_y = -14;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/bowl{
+	pixel_y = -14;
+	pixel_x = 7
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "dYJ" = (
 /obj/kitchenspike,
 /turf/simulated/floor/specialroom/freezer,
@@ -9021,8 +8967,9 @@
 /area/station/bridge/captain)
 "ebd" = (
 /obj/machinery/door/airlock/pyro/alt,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "ebi" = (
 /obj/landmark{
 	name = "blobstart"
@@ -9044,7 +8991,9 @@
 "ebu" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/engine/caution/corner,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "eby" = (
 /turf/simulated/floor/redblack/corner,
 /area/station/security/equipment)
@@ -9063,6 +9012,16 @@
 	dir = 8
 	},
 /area/station/medical/medbay/cloner)
+"ecc" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "ecd" = (
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -9209,38 +9168,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_west)
-"efI" = (
-/obj/decal/cleanable/dirt/dirt4,
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"efM" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/nanoloom_cartridge{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/nanoloom_cartridge{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/turf/simulated/floor/black,
-/area/station/storage/tools)
-"efZ" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "egg" = (
 /obj/stool/chair{
 	dir = 4
@@ -9283,12 +9210,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"egW" = (
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/space)
 "ehQ" = (
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/computer/power_monitor/smes{
@@ -9369,7 +9290,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ejz" = (
-/obj/disposalpipe/segment/ejection,
+/obj/item/device/radio/beacon,
+/obj/cable{
+	icon_state = "2-5"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "ejP" = (
@@ -9389,20 +9313,6 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
-"ejY" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 28
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
 "ekF" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -9763,13 +9673,6 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
-"esc" = (
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "esh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9911,24 +9814,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
-"ewo" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "ewv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hydroponics/bay)
@@ -10083,6 +9968,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "ezI" = (
@@ -10174,12 +10062,6 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
-"eBr" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "eBt" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -10287,6 +10169,15 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
+"eFd" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	icon_state = "5-10"
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/station/engine/core/nuclear)
 "eFf" = (
 /obj/machinery/light_switch/north,
 /obj/machinery/recharge_station,
@@ -10319,7 +10210,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "eGi" = (
 /obj/table/auto,
 /obj/item/weldingtool,
@@ -10471,6 +10362,26 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/northeast)
+"eIo" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/machinery/light_switch/west,
+/obj/machinery/computer3/generic/personal{
+	desc = "This workstation appears to be outfitted with non-standard equipment.";
+	name = "modified computer";
+	setup_starting_peripheral2 = /datum/computer/file/terminal_program/communications;
+	setup_starting_program = null
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "eIz" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/machinery/camera{
@@ -10489,7 +10400,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "eIP" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -10510,17 +10421,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"eJa" = (
-/obj/stool/bed,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/station/crew_quarters/quarters_east)
 "eJW" = (
 /obj/item/sea_ladder,
 /turf/simulated/floor/plating,
@@ -10767,7 +10667,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "ePD" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/standard/edge{
@@ -10846,12 +10748,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
-"eQO" = (
-/obj/item/storage/wall/random,
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "eRb" = (
 /obj/landmark/random_room/size5x3,
 /turf/simulated/floor/plating,
@@ -10871,15 +10767,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/west)
-"eRs" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/space)
 "eRu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10925,6 +10812,16 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/southwest)
+"eSf" = (
+/obj/item/sheet/steel/reinforced/fullstack{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/storage/tools)
 "eSo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10961,10 +10858,15 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "eSP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "eSU" = (
 /obj/machinery/turretid{
 	pixel_x = 24;
@@ -10978,7 +10880,9 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "eTi" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11082,10 +10986,9 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
-"eVh" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
-/area/space)
+"eVi" = (
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "eVv" = (
 /obj/stool/chair/pew/fancy/left{
 	dir = 1
@@ -11238,7 +11141,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "eZZ" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -11392,9 +11295,12 @@
 	},
 /area/shuttle/arrival/station)
 "feY" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 3;
+	dir = 6;
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
@@ -11413,7 +11319,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/engine/caution/west,
-/area/space)
+/area/station/engine/core/nuclear)
 "ffN" = (
 /obj/reagent_dispensers/watertank/big,
 /obj/disposalpipe/segment/transport{
@@ -11484,20 +11390,6 @@
 /obj/item/circuitboard/transception,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
-"fhJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/submachine/ATM{
-	pixel_y = 32
-	},
-/turf/simulated/floor/black/corner{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "fip" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
@@ -11543,12 +11435,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
-"fjq" = (
-/obj/stool/chair/comfy{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/red,
-/area/space)
 "fjA" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/black,
@@ -11765,20 +11651,6 @@
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
 	})
-"fpC" = (
-/obj/rack,
-/obj/item/storage/belt/utility,
-/obj/item/extinguisher{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/oilcan{
-	pixel_x = 7
-	},
-/obj/machinery/light,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/storage/tools)
 "fpO" = (
 /obj/stool/chair/office/green{
 	dir = 4
@@ -11788,12 +11660,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
-"fpR" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "fpW" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -11808,8 +11674,7 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/ejection{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 2
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -11819,6 +11684,20 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
+"fqg" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/det_hat{
+	desc = "Ugh, gross.";
+	name = "fedora";
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/quarters_east)
 "fqi" = (
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/industrial,
@@ -11847,6 +11726,14 @@
 /obj/access_spawn/chemistry,
 /turf/simulated/floor/engine/caution/west,
 /area/station/science/chemistry)
+"fqO" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "frb" = (
 /obj/decal/fakeobjects/catalytic_doodad{
 	dir = 4
@@ -11883,14 +11770,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
-"frT" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/fanny,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
 "fse" = (
 /obj/machinery/bathtub{
 	anchored = 1;
@@ -11996,10 +11875,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"ftI" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "ftP" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12089,6 +11964,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"fuD" = (
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "fuI" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/storage/scanner{
@@ -12121,8 +12003,13 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "fvh" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2{
 	dir = 5
@@ -12344,11 +12231,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/cloner)
-"fAv" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
-	},
-/area/space)
 "fAy" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -12365,6 +12247,15 @@
 /area/station/crew_quarters/lounge/starboard{
 	name = "Book Nook"
 	})
+"fAH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "fAX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12375,6 +12266,13 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"fAZ" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "fBi" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12397,7 +12295,9 @@
 	setup_os_string = "ZETA_MAINFRAME"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "fBR" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency{
@@ -12512,6 +12412,19 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/artifact)
+"fER" = (
+/obj/rack,
+/obj/item/storage/belt/utility,
+/obj/item/extinguisher{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 7
+	},
+/turf/simulated/floor/black/corner{
+	dir = 1
+	},
+/area/station/storage/tools)
 "fES" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12590,8 +12503,17 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/survey)
 "fHb" = (
-/turf/simulated/wall/auto/supernorn,
-/area/space)
+/obj/storage/secure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/meatloaf{
+	desc = "A loaf of meat. Age unknown.";
+	name = "old meatloaf";
+	quality = -20
+	},
+/obj/item/reagent_containers/food/drinks/milk{
+	pixel_x = 5
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "fHf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12622,7 +12544,9 @@
 	name = "cold loop gas supply valve"
 	},
 /turf/simulated/floor/engine/caution/south,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "fHL" = (
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -12645,6 +12569,14 @@
 	dir = 4
 	},
 /area/station/crew_quarters/pool)
+"fIM" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_east)
 "fJg" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/science/lobby{
@@ -12786,7 +12718,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "fMs" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/brain,
@@ -12867,6 +12799,12 @@
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Miner"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 5
@@ -12974,7 +12912,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine/caution/corner2,
-/area/space)
+/area/station/engine/core/nuclear)
 "fQu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12987,6 +12925,11 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
+"fQF" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/station/engine/core/nuclear)
 "fQN" = (
 /obj/decal/cleanable/dirt,
 /obj/cable{
@@ -13022,6 +12965,21 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
+"fRi" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/machinery/drainage,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "fRy" = (
 /obj/machinery/computer/card{
 	dir = 8
@@ -13288,25 +13246,13 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "fYi" = (
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
 /area/pasiphae/bridge)
-"fYj" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/firedoor_spawn,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/market)
 "fYu" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light/emergency{
@@ -13340,11 +13286,6 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
-"fYT" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 1
-	},
-/area/space)
 "fZb" = (
 /turf/simulated/floor/shuttlebay,
 /area/pasiphae/hangar)
@@ -13481,14 +13422,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
-"gbA" = (
-/obj/item/clothing/head/plunger{
-	pixel_x = 13;
-	pixel_y = -2
-	},
-/obj/submachine/laundry_machine,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "gbC" = (
 /obj/machinery/light{
 	dir = 1;
@@ -13560,6 +13493,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"gcG" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/station/engine/core/nuclear)
 "gcL" = (
 /obj/machinery/power/smes,
 /obj/cable,
@@ -13571,7 +13510,9 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "gdf" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -13611,15 +13552,6 @@
 	},
 /turf/space/fluid/acid,
 /area/space)
-"gdY" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "ged" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13690,6 +13622,14 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"gfu" = (
+/obj/machinery/door/airlock/pyro/alt{
+	name = "Decontamination"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "gfw" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 9
@@ -13732,6 +13672,12 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"gfT" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "ggq" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grey,
@@ -13963,6 +13909,12 @@
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
+"gkY" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "glb" = (
 /obj/decal/boxingrope,
 /turf/simulated/floor/specialroom/gym,
@@ -14187,13 +14139,6 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"gqq" = (
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "gqO" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -14483,6 +14428,12 @@
 	dir = 5
 	},
 /area/station/hallway/primary/northeast)
+"gwB" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "gwG" = (
 /obj/machinery/vending/alcohol,
 /turf/simulated/floor/redblack{
@@ -14545,6 +14496,15 @@
 "gyD" = (
 /turf/simulated/floor/purpleblack/corner,
 /area/station/hallway/primary/northwest)
+"gyI" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters_east)
 "gyV" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -14564,7 +14524,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "gzl" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -14605,6 +14565,19 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"gzB" = (
+/obj/table/reinforced/auto,
+/obj/item/item_box/medical_patches/mini_silver_sulf{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/pen/pencil{
+	pixel_x = -8
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_east)
 "gzE" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14657,7 +14630,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "gAF" = (
 /obj/machinery/door/airlock/pyro/glass/toxins{
 	dir = 4
@@ -14770,7 +14743,9 @@
 /obj/access_spawn/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/yellow,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "gDp" = (
 /obj/stool/chair/office/red{
 	dir = 1
@@ -14809,6 +14784,16 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
+"gEi" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "gEl" = (
 /obj/disposalpipe/switch_junction/biofilter/left/north,
 /obj/cable{
@@ -15074,7 +15059,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "gKe" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
@@ -15264,7 +15251,9 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "gNo" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purpleblack/corner{
@@ -15369,7 +15358,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/west,
-/area/space)
+/area/station/engine/core/nuclear)
 "gQh" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/electrical{
@@ -15802,16 +15791,6 @@
 /obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"gZs" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_east)
 "gZx" = (
 /obj/disposalpipe/segment/vertical,
 /obj/storage/closet/fire,
@@ -15870,23 +15849,6 @@
 	dir = 10
 	},
 /area/station/mining/staff_room)
-"had" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "haf" = (
 /obj/machinery/door/unpowered/wood/pyro,
 /turf/simulated/floor/carpet/red/standard/narrow/north,
@@ -15932,7 +15894,7 @@
 	icon_state = "1-6"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "haF" = (
 /turf/simulated/floor/blackwhite{
 	dir = 8
@@ -15980,10 +15942,10 @@
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
 "hbm" = (
-/obj/machinery/light/small/floor/netural,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
 /area/station/science/lobby{
 	name = "Science Lounge"
@@ -16092,12 +16054,6 @@
 	},
 /turf/simulated/floor/carpet/green/standard/narrow/se,
 /area/station/crew_quarters/cafeteria)
-"hdN" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "heh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16242,7 +16198,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "hiE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16258,6 +16216,17 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
+"hiN" = (
+/obj/storage/closet/office,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/storage/tools)
 "hiO" = (
 /obj/decal/tile_edge/line/black,
 /obj/decal/tile_edge{
@@ -16351,7 +16320,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "hkp" = (
 /obj/lattice{
 	dir = 9;
@@ -16406,7 +16375,7 @@
 /area/pasiphae/maint)
 "hkU" = (
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "hkW" = (
 /obj/cable{
 	icon_state = "5-10"
@@ -16947,16 +16916,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"hvX" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "hwd" = (
 /obj/table/wood/auto,
 /obj/displaycase{
@@ -16985,17 +16944,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"hwo" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "hwr" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -17014,6 +16962,11 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"hwM" = (
+/turf/simulated/floor/black/side{
+	dir = 6
+	},
+/area/station/storage/tools)
 "hwO" = (
 /turf/simulated/floor/black,
 /area/station/medical/head)
@@ -17220,13 +17173,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"hAF" = (
-/obj/table/wood/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "hAU" = (
 /obj/item/sheet/glass{
 	amount = 10;
@@ -17300,6 +17246,14 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"hBS" = (
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/crew_quarters/market)
 "hCf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17368,10 +17322,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blue,
 /area/pasiphae/bridge)
-"hDL" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/space)
 "hEa" = (
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -17413,15 +17363,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"hED" = (
-/obj/stool/bench/blue/auto,
-/obj/machinery/shower{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "hEL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/incandescent/netural,
@@ -17442,17 +17383,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"hEW" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "hFf" = (
 /turf/simulated/floor/yellowblack{
 	dir = 4
@@ -17567,7 +17497,15 @@
 	},
 /area/station/ai_monitored/armory)
 "hHq" = (
-/obj/wingrille_spawn/auto/crystal,
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -17576,8 +17514,12 @@
 	name = "Diplomatic Quarters Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "hHx" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/gloves/latex,
@@ -17663,6 +17605,16 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
+"hJQ" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "hJR" = (
 /obj/machinery/light_switch/north{
 	pixel_x = -8
@@ -17706,6 +17658,10 @@
 	dir = 10
 	},
 /area/station/medical/morgue)
+"hKE" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/black/side,
+/area/station/storage/tools)
 "hLa" = (
 /obj/machinery/door/airlock/pyro/glass/toxins,
 /obj/access_spawn/research,
@@ -17841,12 +17797,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/circuit/white,
 /area/station/turret_protected/ai_upload)
-"hPh" = (
-/obj/item/device/radio/intercom{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "hPM" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/greenblack{
@@ -17970,14 +17920,6 @@
 /obj/stool/bed/moveable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"hRD" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "hRH" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -18048,7 +17990,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 6
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "hTu" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/brig{
@@ -18126,6 +18068,17 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/baroffice)
+"hVz" = (
+/obj/table/reinforced/auto,
+/obj/item/matchbook{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/decoration/ashtray{
+	pixel_x = 6
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/station/crew_quarters/quarters_east)
 "hVC" = (
 /obj/submachine/laundry_machine,
 /obj/machinery/light{
@@ -18147,21 +18100,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"hVR" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "hWb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -18247,11 +18185,14 @@
 	},
 /area/station/hallway/primary/southwest)
 "hXx" = (
-/obj/machinery/door/unpowered/wood/stall{
-	dir = 4
+/obj/item/storage/wall{
+	name = "bath cabinet";
+	pixel_y = 32;
+	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
+/obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "hXJ" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -18450,6 +18391,15 @@
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
 	})
+"iaS" = (
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	name = "Decontamination"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "iaW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -18474,24 +18424,6 @@
 /obj/item/device/microphone,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"ibt" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/bot_storage)
-"ibI" = (
-/obj/storage/crate,
-/obj/item/clothing/under/misc/vice,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
 "ibN" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -18499,6 +18431,9 @@
 /obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"ibV" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core/nuclear)
 "icc" = (
 /obj/table/wood/auto/desk,
 /obj/item/storage/box/record/radio/host{
@@ -18625,17 +18560,6 @@
 "idM" = (
 /turf/simulated/floor/redblack/corner,
 /area/station/crew_quarters/courtroom)
-"idW" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "ieD" = (
 /obj/storage/closet/medicalclothes,
 /obj/machinery/firealarm{
@@ -18650,15 +18574,6 @@
 	dir = 10
 	},
 /area/station/medical/medbay/treatment)
-"ieN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "ifl" = (
 /obj/machinery/drainage,
 /obj/machinery/light/small{
@@ -18841,7 +18756,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 6
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "ijx" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -18893,14 +18808,14 @@
 "iky" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "ikE" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "ikV" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1
@@ -19191,16 +19106,12 @@
 "irk" = (
 /obj/machinery/door/unpowered/wood/stall,
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "irE" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon19,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
-"irG" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "irP" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -19491,24 +19402,6 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon20_to_1_end,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
-"ixQ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_east)
-"ixW" = (
-/obj/stool/chair,
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/crew_quarters/quarters_east)
 "iya" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -19523,18 +19416,6 @@
 /obj/towelbin,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
-"iyt" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/space)
 "iyG" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -19585,7 +19466,10 @@
 	},
 /area/station/medical/head)
 "iyZ" = (
-/obj/machinery/photocopier,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grey/side{
 	dir = 5
 	},
@@ -19793,20 +19677,6 @@
 /obj/lattice,
 /turf/space/fluid/acid/clear,
 /area/space)
-"iDs" = (
-/obj/machinery/computer/sea_elevator{
-	dir = 8
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/black,
-/area/space)
 "iDO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -19961,17 +19831,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"iIr" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
 "iIC" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 8
@@ -20019,17 +19878,6 @@
 	dir = 1
 	},
 /area/station/science/hall)
-"iKc" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "iKJ" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /obj/machinery/recharger/wall/sticky,
@@ -20117,6 +19965,11 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/pasiphae/bridge)
+"iLR" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "iLV" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -20141,23 +19994,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"iNo" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"iNG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "iNN" = (
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "RD";
@@ -20216,15 +20052,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"iPM" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/mask/balaclava,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
 "iPR" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/blueblack{
@@ -20458,6 +20285,20 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
+"iWH" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
+"iWS" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "iWT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/arcade)
@@ -20584,28 +20425,13 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
-"iZs" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = 5;
-	pixel_y = 4
+"iZl" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/space)
-"iZE" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "iZO" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sanitary/white,
@@ -20775,7 +20601,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jch" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/disposalpipe/segment/transport,
@@ -20965,15 +20793,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
-"jfd" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "jfm" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/blood,
@@ -21246,13 +21065,16 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
-"jmz" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
+"jmx" = (
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/ai_status_display{
+	pixel_y = 28
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "jmJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/west)
@@ -21346,8 +21168,13 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jpQ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small,
@@ -21404,7 +21231,9 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jqS" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -21492,10 +21321,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/storage/emergencyinternals)
-"jrJ" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "jrU" = (
 /obj/stool/chair{
 	dir = 8
@@ -21572,11 +21397,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
-"jsQ" = (
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "jsU" = (
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -21585,6 +21405,18 @@
 "jtq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/northwest)
+"jtr" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jtz" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/stool/chair{
@@ -21740,7 +21572,9 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jwF" = (
 /obj/stool/chair{
 	dir = 1
@@ -21758,6 +21592,15 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"jwV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "jxl" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -21807,10 +21650,6 @@
 /obj/storage/crate/rcd/CE,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
-"jyD" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/space)
 "jyP" = (
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/grey,
@@ -21853,13 +21692,6 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
-"jAu" = (
-/obj/storage/crate,
-/obj/item/clothing/under/gimmick/princess,
-/obj/item/clothing/mask/horse_mask,
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/station/crew_quarters/quarters_east)
 "jAx" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
@@ -21922,14 +21754,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
-"jBr" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_east)
 "jBz" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -21969,10 +21793,6 @@
 "jCw" = (
 /turf/simulated/floor/black,
 /area/station/security/detectives_office)
-"jCy" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_east)
 "jCJ" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -22000,12 +21820,6 @@
 	dir = 1
 	},
 /area/listeningpost)
-"jCY" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "jDb" = (
 /obj/stool/bench/red/auto,
 /turf/simulated/floor/redblack{
@@ -22097,23 +21911,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"jGl" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/machinery/light/small,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_east)
 "jGq" = (
-/obj/table/reinforced/auto,
+/obj/rack,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/item/storage/wall/random,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "jGr" = (
@@ -22177,6 +21982,24 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"jHU" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "market";
+	name = "Public Market";
+	opacity = 0;
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "jIg" = (
 /obj/stool/chair{
 	dir = 4
@@ -22218,11 +22041,6 @@
 	dir = 8
 	},
 /area/station/storage/emergency2)
-"jIw" = (
-/obj/machinery/light/small,
-/obj/table/reinforced/auto,
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/space)
 "jJk" = (
 /obj/lattice{
 	dir = 5;
@@ -22242,13 +22060,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
-"jJH" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "jJW" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -22293,7 +22104,9 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "jKH" = (
-/obj/disposalpipe/segment/ejection,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/market)
 "jKJ" = (
@@ -22415,10 +22228,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/ejection{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -22482,10 +22291,13 @@
 	},
 /area/station/hallway/primary/northwest)
 "jOW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "jPg" = (
 /obj/stool/chair{
 	dir = 8
@@ -22553,11 +22365,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"jQj" = (
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_east)
 "jQk" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/redblack/corner{
@@ -22571,7 +22378,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "jQy" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/evidence{
@@ -22601,10 +22410,6 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
-"jRu" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
 "jRv" = (
 /obj/machinery/vending/hydroponics,
 /turf/simulated/floor/plating,
@@ -22776,17 +22581,6 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"jUf" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "jUq" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/machinery/power/apc/autoname_west,
@@ -22851,7 +22645,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "jVa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22877,6 +22671,10 @@
 "jVj" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/mining,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -22896,6 +22694,10 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"jVM" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "jVR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22945,25 +22747,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"jWW" = (
-/obj/table/wood/auto,
-/obj/item/clothing/head/det_hat{
-	desc = "Ugh, gross.";
-	name = "fedora";
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 11;
-	pixel_y = -1
-	},
-/obj/blind_switch/area/west,
-/obj/machinery/light/lamp/green{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
 "jXe" = (
 /obj/machinery/portable_reclaimer,
 /obj/machinery/power/apc/autoname_north,
@@ -23031,24 +22814,6 @@
 	dir = 10
 	},
 /area/station/bridge)
-"jYT" = (
-/obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_y = 6;
-	pixel_x = 6
-	},
-/obj/machinery/light/lamp/black{
-	pixel_y = 10;
-	pixel_x = 1
-	},
-/obj/item/pen{
-	pixel_y = -2;
-	pixel_x = -5
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "jYY" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -23113,20 +22878,6 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
-"kaN" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "kba" = (
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/redblack{
@@ -23370,11 +23121,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
-"khg" = (
-/obj/rack,
-/obj/item/sponge,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "khh" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
@@ -23382,7 +23128,7 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "khK" = (
 /turf/simulated/floor/grey/side{
 	dir = 10
@@ -23412,10 +23158,16 @@
 	},
 /area/station/engine/elect)
 "kiz" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "kiY" = (
 /obj/decal/tile_edge/floorguide/evac,
 /obj/decal/tile_edge/floorguide/evac{
@@ -23890,6 +23642,12 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"krx" = (
+/obj/storage/secure/closet/personal,
+/turf/simulated/floor/black/corner{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_east)
 "kry" = (
 /obj/machinery/plantpot,
 /obj/cable{
@@ -24045,18 +23803,6 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
-"ktv" = (
-/obj/machinery/light/small,
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/device/radio/intercom{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
 "ktw" = (
 /obj/disposalpipe/segment/food,
 /obj/cable{
@@ -24082,6 +23828,19 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"ktH" = (
+/obj/table/reinforced/auto,
+/obj/item/gobowl/b{
+	pixel_x = -7
+	},
+/obj/item/gobowl/w{
+	pixel_x = 8
+	},
+/obj/item/decoration/flower_vase{
+	pixel_y = 22
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "ktK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24152,21 +23911,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"kuP" = (
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/space)
 "kuV" = (
 /obj/rack,
 /obj/machinery/light/incandescent/netural,
@@ -24727,15 +24471,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"kHr" = (
-/obj/machinery/door_control{
-	id = "market";
-	pixel_y = 24
-	},
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "kHD" = (
 /obj/stool/chair{
 	dir = 4
@@ -24868,13 +24603,6 @@
 	dir = 6
 	},
 /area/station/hallway/primary/northwest)
-"kLs" = (
-/obj/machinery/light/small,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "kLJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24941,7 +24669,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine/caution/northsouth,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "kOd" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -25002,22 +24732,13 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine/caution/corner2,
-/area/space)
+/area/station/engine/core/nuclear)
 "kQn" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/bridge)
-"kQr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
 "kQw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -25134,11 +24855,6 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
-"kRP" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black,
-/area/space)
 "kRT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/yellowblack{
@@ -25154,6 +24870,14 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
+	})
+"kSK" = (
+/obj/item/storage/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
 	})
 "kST" = (
 /turf/simulated/floor/plating,
@@ -25455,6 +25179,14 @@
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/black,
 /area/station/science/hall)
+"kYA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "kYJ" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light,
@@ -25584,22 +25316,14 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/northwest)
-"lcr" = (
-/obj/storage/secure/closet/personal,
-/obj/item/storage/wall{
-	dir = 4;
-	name = "libation cellar";
-	pixel_x = -32;
-	spawn_contents = list(/obj/item/reagent_containers/food/drinks/bottle/wine,/obj/item/reagent_containers/food/drinks/bottle/tequila,/obj/item/reagent_containers/food/drinks/bottle/mead,/obj/item/reagent_containers/food/drinks/bottle/rum)
+"lcd" = (
+/obj/submachine/laundry_machine,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "lcu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -26082,10 +25806,6 @@
 	dir = 4
 	},
 /area/abandonedmedicalship/robot_trader)
-"lmN" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating,
-/area/space)
 "lmY" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm,
@@ -26129,6 +25849,12 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
+"lnD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "lnM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26381,18 +26107,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
-"lve" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/item/storage/toilet,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "lvq" = (
 /obj/decal/poster/wallsign/keep_it_or_melt{
 	pixel_y = 28
@@ -26491,7 +26205,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "lxm" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -26509,8 +26225,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "lxv" = (
-/turf/simulated/floor/carpet/red,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/station/crew_quarters/quarters_east)
 "lxA" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/door/airlock/pyro/alt,
@@ -26660,6 +26376,9 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"lAS" = (
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters_east)
 "lAU" = (
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
@@ -26735,10 +26454,6 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
-"lDu" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/space)
 "lDC" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/light,
@@ -26752,7 +26467,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "lDT" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -26822,7 +26537,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 6
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "lFq" = (
 /obj/submachine/chem_extractor{
 	dir = 8
@@ -26918,7 +26633,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "lGN" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -27007,19 +26724,6 @@
 	dir = 9
 	},
 /area/station/quartermaster/cargooffice)
-"lIl" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/storage/tools)
 "lIr" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -27216,17 +26920,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
-"lMa" = (
-/obj/storage/crate,
-/obj/item/plate,
-/obj/item/reagent_containers/food/snacks/spaghetti/meatball{
-	pixel_x = -1
-	},
-/obj/item/toy/gooncode{
-	pixel_x = 3
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "lMn" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	dir = 1
@@ -27564,25 +27257,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"lTQ" = (
-/obj/table/auto,
-/obj/item/sheet/steel/fullstack{
-	pixel_x = -10;
-	pixel_y = 6
-	},
-/obj/item/sheet/glass/reinforced/fullstack{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/black/side,
-/area/station/storage/tools)
 "lUE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -27615,6 +27289,8 @@
 "lVi" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/mining,
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/staff_room)
 "lVy" = (
@@ -27690,7 +27366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "lWM" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 2
@@ -27746,7 +27422,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "lXG" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/black,
@@ -27824,10 +27500,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
-"lYD" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
-/area/space)
 "lYL" = (
 /obj/machinery/disposal/mail/autoname/research,
 /obj/disposalpipe/trunk/mail/east,
@@ -27915,6 +27587,17 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
+"mai" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "mav" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28112,13 +27795,17 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/communications/centre)
-"mdY" = (
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
+"mdV" = (
+/obj/stool/chair{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/space)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tools)
 "mer" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -28312,6 +27999,16 @@
 /obj/item/clothing/suit/bedsheet/orange,
 /turf/simulated/floor/black/side,
 /area/pasiphae/crew)
+"mio" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "mip" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -28708,11 +28405,6 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine/glow/blue,
 /area/station/communications/centre)
-"mrT" = (
-/turf/simulated/floor/black/corner{
-	dir = 4
-	},
-/area/station/storage/tools)
 "mrW" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -28850,7 +28542,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "mvy" = (
 /obj/chicken_nesting_box,
 /obj/machinery/light{
@@ -28948,13 +28642,6 @@
 	dir = 4
 	},
 /area/station/ranch)
-"mwn" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "mwv" = (
 /turf/simulated/floor/greenblack/corner{
 	dir = 8
@@ -29086,6 +28773,13 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"mzL" = (
+/obj/table/reinforced/auto,
+/obj/item/goboard{
+	pixel_y = 9
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters_east)
 "mzS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29385,6 +29079,31 @@
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
 	})
+"mGC" = (
+/obj/table/auto,
+/obj/item/storage/box/cablesbox{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/storage/box/cablesbox{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/device/nanoloom{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/item/device/nanoloom{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black/side,
+/area/station/storage/tools)
 "mGH" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/sec_foyer{
@@ -29455,13 +29174,6 @@
 "mIG" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
-"mIR" = (
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/black,
-/area/space)
 "mJj" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -29572,7 +29284,7 @@
 	name = "cold loop gas supply valve"
 	},
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "mKK" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -29625,16 +29337,21 @@
 /obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"mMT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "mMV" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/standard/edge{
 	dir = 6
 	},
 /area/station/crew_quarters/cafeteria)
-"mNh" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/space)
 "mNi" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/syringes,
@@ -29813,10 +29530,6 @@
 	dir = 4
 	},
 /area/pasiphae)
-"mQb" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/space)
 "mQd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30054,6 +29767,15 @@
 "mXv" = (
 /turf/simulated/floor/engine/caution/north,
 /area/listeningpost)
+"mYa" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "mYj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30072,7 +29794,9 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "mYF" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -30106,12 +29830,6 @@
 /obj/storage/secure/closet/animal,
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
-"mZi" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
-	},
-/turf/simulated/floor/black/side,
-/area/space)
 "mZj" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/beakerbox,
@@ -30138,6 +29856,26 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
+"mZZ" = (
+/obj/item/storage/toilet,
+/obj/landmark/spawner{
+	name = "monkeyspawn_tanhony"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
+"nab" = (
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 6
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "nal" = (
 /obj/stool/chair/couch{
 	desc = "It's comfortable, but has an aura of unease about it, like somebody's watching you the moment you sit down.";
@@ -30161,32 +29899,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"naN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"nbk" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "nbp" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/cable{
@@ -30214,19 +29926,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/storage/eva)
-"nbP" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/stool/bench/blue/auto,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "nbQ" = (
 /obj/machinery/processor,
 /turf/simulated/floor/grey/side{
@@ -30260,12 +29959,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
-"ncu" = (
-/obj/decal/cleanable/writing/infrared{
-	words = "use gloves, dust it after"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
 "ncz" = (
 /turf/simulated/floor/blueblack/corner{
 	dir = 8
@@ -30517,8 +30210,11 @@
 /turf/space/fluid/acid/clear,
 /area/shuttle/arrival/station)
 "nkd" = (
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/space)
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/crew_quarters/quarters_east)
 "nkk" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2/junction{
 	dir = 1
@@ -30633,17 +30329,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/bridge/captain)
-"nmg" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/east)
 "nmi" = (
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
@@ -30876,6 +30561,13 @@
 "nsK" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/science/research_director)
+"nsO" = (
+/obj/table/reinforced/auto,
+/obj/item/game_kit,
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters_east)
 "nsS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31016,10 +30708,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"nvB" = (
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "nvD" = (
 /obj/disposalpipe/segment/mineral,
 /turf/simulated/floor/industrial,
@@ -31078,19 +30766,6 @@
 	},
 /turf/simulated/floor/stairs/dark,
 /area/pasiphae/crew)
-"nwR" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "nwS" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/black,
@@ -31252,20 +30927,17 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"nAF" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/rack,
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/crew_quarters/quarters_east)
 "nAH" = (
 /obj/stool/chair/red{
 	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
+"nAJ" = (
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/storage/tools)
 "nAP" = (
 /obj/reagent_dispensers/foamtank,
 /obj/machinery/light_switch/west,
@@ -31296,12 +30968,6 @@
 	dir = 1
 	},
 /area/shuttle/sea_elevator_room)
-"nBp" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/hall)
 "nBu" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -31347,7 +31013,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "nCD" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -31391,7 +31057,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
+/area/station/hallway/secondary/east)
 "nEm" = (
 /obj/storage/secure/closet/immersion/security,
 /obj/item/clothing/suit/space/diving/security{
@@ -31445,7 +31111,9 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "nEz" = (
 /obj/storage/closet/wardrobe/pink,
 /turf/simulated/floor/grey/side{
@@ -31711,7 +31379,7 @@
 "nJZ" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine/caution/west,
-/area/space)
+/area/station/engine/core/nuclear)
 "nKe" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -31782,10 +31450,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/nw,
 /area/station/bridge)
-"nLd" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/space)
 "nLe" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
@@ -31821,20 +31485,6 @@
 	dir = 4
 	},
 /area/pasiphae)
-"nLQ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/item/kitchen/utensil/spoon{
-	pixel_x = 13;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "nLT" = (
 /obj/disposalpipe/trunk{
 	dir = 8;
@@ -31875,23 +31525,24 @@
 	dir = 8
 	},
 /area/station/security/interrogation)
-"nNu" = (
-/obj/storage/crate,
-/obj/item/clothing/mask/moustache,
-/obj/item/clothing/suit/wcoat,
-/obj/item/clothing/head/that,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/space)
 "nNI" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"nOk" = (
+/obj/table/reinforced/auto,
+/obj/item/clothing/mask/moustache,
+/obj/item/clothing/suit/wcoat{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/that{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/crew_quarters/quarters_east)
 "nOs" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
@@ -31968,17 +31619,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"nPZ" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/space)
 "nQa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32009,11 +31649,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_west)
-"nRv" = (
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "nRJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32070,7 +31705,9 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/engine/caution/northsouth,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "nSu" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -32423,18 +32060,6 @@
 /obj/decal/cleanable/generic,
 /turf/simulated/floor/black,
 /area/pasiphae)
-"obm" = (
-/obj/storage/cart,
-/obj/item/instrument/vuvuzela,
-/obj/item/storage/box/mousetraps,
-/obj/item/device/radio{
-	pixel_x = -3
-	},
-/obj/item/device/multitool{
-	pixel_x = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "obA" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
@@ -32477,6 +32102,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/listeningpost/power)
+"ocD" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "ocE" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -32620,15 +32250,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
-"ohk" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "oht" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -32642,15 +32263,10 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner/east)
-"ohK" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
+"ohY" = (
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/black,
-/area/space)
+/area/station/storage/tools)
 "oil" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32662,16 +32278,6 @@
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/engine/caution/east,
 /area/station/ai_monitored/armory)
-"ojw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "ojD" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/decal/tile_edge/stripe/big,
@@ -32692,14 +32298,6 @@
 /turf/simulated/floor/redblack,
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
-	})
-"okc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
 	})
 "okh" = (
 /obj/cable{
@@ -32769,7 +32367,7 @@
 	level = 2
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "omd" = (
 /obj/item/furniture_parts/table/nanotrasen,
 /obj/item/raw_material/shard/glass,
@@ -32890,15 +32488,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"ooW" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/clothingbooth,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "opl" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -33020,8 +32609,12 @@
 	name = "Drop Capsule"
 	})
 "osB" = (
-/turf/simulated/floor/black/side,
-/area/space)
+/obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/light_switch/north{
+	pixel_y = 22
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "osX" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -33252,6 +32845,19 @@
 	dir = 1
 	},
 /area/station/storage/emergency2)
+"oxz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/purpleblack{
+	dir = 4
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "oxA" = (
 /obj/machinery/light/small/warm/very{
 	dir = 8;
@@ -33290,12 +32896,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
-"oxS" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/science/lobby{
-	name = "Science Lounge"
-	})
 "oyi" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -33413,15 +33013,6 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
-"oAx" = (
-/obj/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/tank/mini_oxygen{
-	pixel_x = 8
-	},
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/black,
-/area/space)
 "oAO" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -33540,8 +33131,11 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "1-6"
+	},
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "oDX" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -33636,19 +33230,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
-"oGn" = (
-/obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "oGv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
@@ -33769,19 +33350,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/west)
-"oJO" = (
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal{
-	dir = 6
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/storage/tools)
 "oJR" = (
 /obj/shrub{
 	dir = 1
@@ -33797,7 +33365,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "oKe" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro/security/alt{
@@ -33841,6 +33411,16 @@
 	dir = 4
 	},
 /area/listeningpost)
+"oLr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "oLu" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -33895,7 +33475,7 @@
 	can_rupture = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
+/area/station/engine/core/nuclear)
 "oNg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
@@ -33910,21 +33490,6 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
-"oNJ" = (
-/obj/table/reinforced/auto,
-/obj/item/dice{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/coin{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/food/drinks/cola{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
 "oNO" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/carpet/purple/fancy/innercorner/ne_sw,
@@ -33978,6 +33543,11 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/crew)
+"oOV" = (
+/turf/simulated/floor/carpet/blue/fancy/innercorner/west,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "oPc" = (
 /obj/stool/chair/office/blue{
 	dir = 4
@@ -34019,7 +33589,9 @@
 	target_pressure = 1000
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "oPO" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/drainage,
@@ -34028,8 +33600,13 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "oPP" = (
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "oPR" = (
 /obj/vehicle/segway,
 /obj/machinery/camera{
@@ -34129,13 +33706,6 @@
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black/grime,
 /area/station/storage/warehouse)
-"oRR" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "oSi" = (
 /obj/stool/chair{
 	dir = 8
@@ -34169,7 +33739,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "oSF" = (
 /obj/rack,
 /obj/item/extinguisher,
@@ -34213,6 +33783,15 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"oTv" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "oTz" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/cable{
@@ -34246,15 +33825,6 @@
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
-"oUg" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "oUh" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -34299,10 +33869,6 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"oVd" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/space)
 "oVg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34451,7 +34017,9 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "oYC" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -34566,13 +34134,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blue,
 /area/pasiphae/bridge)
-"pbY" = (
-/obj/machinery/recharge_station,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black/side,
-/area/station/storage/tools)
 "pci" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
@@ -34674,14 +34235,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
-"peS" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/space)
 "peU" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/industrial,
@@ -34957,10 +34510,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/west)
-"pmw" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/black,
-/area/space)
 "pmV" = (
 /obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellowblack{
@@ -34986,10 +34535,11 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
 	},
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/blackwhite{
 	dir = 1
 	},
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "poa" = (
 /obj/decal/poster/wallsign/warning1{
 	desc = "A sign warning you of a nearby acid hazard.";
@@ -35232,14 +34782,6 @@
 	dir = 8
 	},
 /area/abandonedmedicalship/robot_trader)
-"psJ" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "psN" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey/side{
@@ -35411,9 +34953,6 @@
 	dir = 8
 	},
 /area/station/medical/morgue)
-"pvZ" = (
-/turf/space,
-/area/space)
 "pwa" = (
 /obj/stool/chair/office/syndie{
 	dir = 4
@@ -35438,7 +34977,9 @@
 "pwy" = (
 /obj/machinery/nanofab/nuclear,
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "pwO" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -35466,15 +35007,6 @@
 /obj/item/chem_grenade/cleaner,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
-"pxp" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "pxr" = (
 /obj/stool/chair{
 	dir = 8
@@ -35714,7 +35246,7 @@
 "pDQ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/supernorn,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "pDS" = (
 /turf/simulated/floor/engine/caution/south,
 /area/station/science/chemistry)
@@ -35723,6 +35255,13 @@
 /obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/radio/lab)
+"pEp" = (
+/obj/machinery/light/small,
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/station/crew_quarters/quarters_east)
 "pED" = (
 /turf/simulated/floor/engine/caution/corner,
 /area/listeningpost)
@@ -35763,6 +35302,13 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
+"pFw" = (
+/obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_y = 6
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "pFB" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -35778,10 +35324,6 @@
 	dir = 4
 	},
 /area/ghostdrone_factory)
-"pFX" = (
-/obj/machinery/door/airlock/pyro/alt,
-/turf/simulated/floor/sanitary,
-/area/space)
 "pFY" = (
 /obj/table/nanotrasen/auto,
 /obj/machinery/networked/printer{
@@ -35866,6 +35408,9 @@
 	},
 /area/station/crew_quarters/lounge)
 "pIJ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/mining/staff_room)
 "pIU" = (
@@ -35914,8 +35459,15 @@
 /obj/cable{
 	icon_state = "2-9"
 	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "pJt" = (
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
@@ -35961,6 +35513,14 @@
 	dir = 4
 	},
 /area/pasiphae/bridge)
+"pKq" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/carpet/blue/fancy/innercorner/east,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "pKF" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -35979,7 +35539,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "pKY" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency{
@@ -36035,20 +35595,6 @@
 /obj/item/clothing/under/gimmick/dolan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"pMD" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "pMV" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -36081,18 +35627,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"pOI" = (
-/obj/table/reinforced/auto,
-/obj/item/gobowl/b{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/item_box/assorted/stickers/stickers_limited{
-	pixel_x = 12;
-	pixel_y = 3
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "pOW" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -36187,24 +35721,21 @@
 	name = "Cargo Primary Endpoint"
 	})
 "pRS" = (
-/obj/table/wood/auto,
-/obj/item/clothing/head/det_hat{
-	desc = "Ugh, gross.";
-	name = "fedora";
-	pixel_x = -5;
-	pixel_y = -9
+/obj/table/reinforced/auto,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
 	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 11;
-	pixel_y = -1
+/obj/item/storage/fanny{
+	pixel_y = 1
 	},
-/obj/blind_switch/area/west,
-/obj/machinery/light/lamp/green{
-	pixel_x = -1;
-	pixel_y = 11
+/obj/item/clothing/gloves/fingerless{
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/balaclava{
+	pixel_x = 6
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "pRY" = (
 /obj/mopbucket,
 /turf/simulated/floor/darkblue,
@@ -36340,13 +35871,6 @@
 	dir = 4
 	},
 /area/station/medical/morgue)
-"pUJ" = (
-/obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 3
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "pUQ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -36366,15 +35890,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
-"pUS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "pUW" = (
 /obj/machinery/computer/power_monitor{
 	dir = 4;
@@ -36407,11 +35922,19 @@
 /turf/simulated/floor/black,
 /area/pasiphae/survey)
 "pVr" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "pVR" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -36806,19 +36329,6 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
-"qfy" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "market";
-	name = "Public Market";
-	opacity = 0
-	},
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "qfE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
@@ -36911,6 +36421,16 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/black,
 /area/station/security/beepsky)
+"qhG" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/submachine/laundry_machine,
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "qhL" = (
 /obj/machinery/portableowl/attached{
 	name = "Owlderich"
@@ -36927,32 +36447,10 @@
 "qiE" = (
 /turf/simulated/floor/grey/side,
 /area/station/quartermaster/refinery)
-"qiM" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "qiP" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
-"qjh" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
 "qjj" = (
 /obj/machinery/lrteleporter,
 /turf/simulated/floor/purpleblack{
@@ -37022,6 +36520,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"qlL" = (
+/obj/item/clothing/head/plunger{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "qlS" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -37072,17 +36577,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"qmS" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/head/blue{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_east)
 "qmT" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -37100,6 +36594,18 @@
 	},
 /turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
+"qmV" = (
+/obj/stool/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "qmY" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/blueblack{
@@ -37237,7 +36743,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "qrn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37392,12 +36898,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"qvy" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "qvP" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -37530,11 +37030,19 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "qxC" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/black,
 /area/listeningpost)
+"qxM" = (
+/obj/machinery/vending/cola/red,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "qxR" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -37568,6 +37076,11 @@
 	dir = 8
 	},
 /area/station/security/main)
+"qyC" = (
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "qyK" = (
 /obj/machinery/light{
 	dir = 4;
@@ -37653,12 +37166,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"qAS" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/space)
 "qAT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37675,12 +37182,6 @@
 	},
 /area/station/bridge)
 "qAW" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -37768,13 +37269,6 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
-"qDf" = (
-/obj/table/reinforced/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "qDG" = (
 /obj/storage/secure/closet/command/medical_director,
 /turf/simulated/floor/blueblack{
@@ -37831,20 +37325,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
-"qFM" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
-"qGa" = (
-/obj/table/reinforced/auto,
-/obj/item/goboard{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "qGh" = (
 /obj/machinery/door/airlock/pyro/engineering/alt{
 	dir = 4
@@ -37907,14 +37387,6 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
-"qHD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "qHP" = (
 /obj/machinery/light{
 	dir = 8;
@@ -37932,7 +37404,7 @@
 	id = "nadirflush";
 	name = "manual loading chute"
 	},
-/obj/disposalpipe/trunk/west,
+/obj/disposalpipe/trunk/south,
 /turf/simulated/floor/purpleblack{
 	dir = 10
 	},
@@ -38057,12 +37529,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
-"qLl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black/corner,
-/area/station/crew_quarters/quarters_east)
 "qLm" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/cable{
@@ -38144,13 +37610,6 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/artifact)
-"qNM" = (
-/obj/table/reinforced/auto,
-/obj/item/gobowl/w{
-	pixel_x = -4
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "qNO" = (
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/southwest)
@@ -38168,20 +37627,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"qOW" = (
-/obj/table/wood/auto,
-/obj/item/device/radio/intercom{
-	dir = 4
-	},
-/obj/item/camera{
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = -12
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/space)
 "qPw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
@@ -38199,7 +37644,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "qPQ" = (
 /obj/rack,
 /obj/item/clothing/mask/breath{
@@ -38363,7 +37810,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -38417,10 +37863,6 @@
 /obj/machinery/light/runway_light,
 /turf/space/fluid/acid/clear,
 /area/space)
-"qTS" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "qUb" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/yellowblack{
@@ -38491,24 +37933,6 @@
 "qVJ" = (
 /turf/simulated/floor/engine/caution/east,
 /area/station/medical/head)
-"qVZ" = (
-/obj/decal/tile_edge/line/orange{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 4
-	},
-/area/station/science/bot_storage)
 "qWs" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -38579,10 +38003,14 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-10"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "qXF" = (
 /turf/simulated/floor/greenblack/corner,
 /area/station/turret_protected/Zeta)
@@ -38681,15 +38109,6 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
-"rbE" = (
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
-/turf/simulated/floor/black/side{
-	dir = 8
-	},
-/area/station/crew_quarters/quarters_east)
 "rbF" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -38747,8 +38166,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
 "rcN" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/emergency,
+/obj/stool/chair,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -38765,19 +38183,9 @@
 	name = "Cargo Primary Endpoint"
 	})
 "rdj" = (
-/obj/table/reinforced/auto,
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
+/obj/rack,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
-"rdq" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/ejection,
-/turf/simulated/floor/plating,
-/area/space)
 "rdL" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine,
@@ -38852,10 +38260,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"rfO" = (
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "rfZ" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/sw{
@@ -38887,6 +38291,16 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"rha" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/submachine/GTM{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "rhe" = (
 /turf/simulated/floor/carpet/green/standard/edge{
 	dir = 5
@@ -39042,12 +38456,18 @@
 	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/disposalpipe/segment/ejection,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -39058,7 +38478,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "rkv" = (
 /obj/storage/crate/clown,
 /turf/simulated/floor/carpet/arcade,
@@ -39150,20 +38570,6 @@
 /obj/disposalpipe/segment/mineral,
 /turf/simulated/floor/grey/side,
 /area/station/quartermaster/refinery)
-"rnJ" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/station/crew_quarters/quarters_east)
 "rnL" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/redblack,
@@ -39183,13 +38589,6 @@
 /obj/submachine/claw_machine,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"roO" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "rpq" = (
 /obj/storage/secure/closet/immersion{
 	name = "Janitorial Immersion Suit Vault";
@@ -39222,6 +38621,9 @@
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
 "rpz" = (
+/obj/stool/chair/blue{
+	dir = 8
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -39239,6 +38641,14 @@
 	dir = 1
 	},
 /area/station/science/hall)
+"rpT" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/station/crew_quarters/quarters_east)
 "rpX" = (
 /obj/rack,
 /obj/item/clothing/suit/chemsuit,
@@ -39274,7 +38684,9 @@
 	target_pressure = 1000
 	},
 /turf/simulated/floor/engine/caution/south,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "rqE" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -39356,10 +38768,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"rsE" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/sanitary,
-/area/space)
 "rsG" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/supernorn,
@@ -39379,25 +38787,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
-"rsT" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "rte" = (
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
@@ -39514,24 +38903,6 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"rwN" = (
-/obj/storage/crate,
-/obj/item/clothing/mask/moustache,
-/obj/item/clothing/suit/wcoat,
-/obj/item/clothing/head/that,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/crew_quarters/quarters_east)
-"rxi" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/red/fancy/edge/south,
-/area/station/crew_quarters/quarters_east)
 "rxw" = (
 /obj/machinery/conveyor/WE{
 	id = "nadir_qmio"
@@ -39673,7 +39044,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "rAP" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency{
@@ -39690,18 +39061,12 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "rAX" = (
-/obj/machinery/light/small,
-/obj/table/reinforced/auto,
-/obj/item/storage/secure/ssafe{
-	pixel_x = -28
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/item/storage/fanny,
-/obj/item/clothing/gloves/fingerless{
-	pixel_y = 5
-	},
-/obj/item/clothing/mask/balaclava,
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/station/crew_quarters/quarters_east)
 "rBd" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -39717,30 +39082,16 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"rBC" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+"rBl" = (
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/hall)
+"rBp" = (
+/obj/machinery/vending/pda,
+/turf/simulated/floor/yellowblack{
+	dir = 1
 	},
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "blue";
-	icon_state = "bedsheet-blue"
-	},
-/obj/machinery/light_switch/north{
-	pixel_y = 22
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/hallway/primary/southeast)
 "rBV" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -39839,10 +39190,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
-"rEB" = (
-/obj/stool/chair,
-/turf/simulated/floor/plating,
-/area/space)
 "rED" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39854,7 +39201,9 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "rEP" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -39869,16 +39218,23 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "rFZ" = (
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
 /obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/station/crew_quarters/quarters_east)
 "rGh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39898,6 +39254,14 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"rGn" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "rGp" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39958,11 +39322,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blueblack,
 /area/pasiphae/bridge)
-"rIw" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_east)
 "rIF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40064,7 +39423,7 @@
 	icon_state = "5-8"
 	},
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "rKp" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -40153,20 +39512,26 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"rLR" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/cutlery{
-	pixel_x = 4;
-	pixel_y = 14
+"rLX" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/item/storage/box/glassbox{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/storage/secure/closet/personal/empty,
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = -3
 	},
-/turf/simulated/floor/black/side{
-	dir = 4
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = 5
 	},
-/area/station/crew_quarters/quarters_east)
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "rLY" = (
 /obj/decal/tile_edge/floorguide/qm,
 /obj/decal/tile_edge/floorguide/arrow_s{
@@ -40216,12 +39581,6 @@
 /obj/machinery/vending/pizza,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
-"rNt" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "rNu" = (
 /turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator_room)
@@ -40270,17 +39629,6 @@
 	dir = 9
 	},
 /area/station/medical/medbay)
-"rOZ" = (
-/obj/storage/secure/closet/fridge,
-/obj/item/reagent_containers/food/snacks/meatloaf{
-	desc = "A loaf of meat. Age unknown.";
-	name = "old meatloaf";
-	quality = -20
-	},
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "rPt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40294,6 +39642,12 @@
 "rPF" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"rQs" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "rQt" = (
 /obj/machinery/light{
 	dir = 8;
@@ -40314,11 +39668,6 @@
 	icon_state = "respect4"
 	},
 /area/station/security/brig)
-"rRa" = (
-/obj/table/reinforced/auto,
-/obj/item/game_kit,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "rRb" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -40404,27 +39753,6 @@
 /turf/simulated/floor/black,
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
-	})
-"rSi" = (
-/obj/table/wood/auto,
-/obj/machinery/door_control{
-	id = "nadir_diploshut";
-	name = "Quarters Shutters";
-	pixel_y = 26
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/computer3/generic/personal{
-	desc = "This workstation appears to be outfitted with non-standard equipment.";
-	name = "modified computer";
-	setup_starting_peripheral2 = /datum/computer/file/terminal_program/communications;
-	setup_starting_program = null
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
 	})
 "rSm" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -40542,6 +39870,13 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"rTU" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "rTX" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -40850,12 +40185,6 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
-"sbs" = (
-/obj/shrub,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/space)
 "sbw" = (
 /obj/storage/closet/wardrobe/pride,
 /obj/cable{
@@ -40904,7 +40233,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/east)
 "scm" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/decoration/ashtray{
@@ -40925,7 +40254,7 @@
 "scP" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "scW" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -41247,14 +40576,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
-"skQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "sla" = (
 /obj/stool/bench/red/auto,
 /turf/simulated/floor/wood,
@@ -41501,6 +40822,27 @@
 	dir = 1
 	},
 /area/shuttle/sea_elevator_room)
+"sqZ" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32;
+	pixel_x = 7
+	},
+/obj/item/paper,
+/obj/item/pen/fancy{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28;
+	pixel_x = -7
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "srd" = (
 /obj/stool/chair/red{
 	dir = 1
@@ -41509,19 +40851,6 @@
 	dir = 4
 	},
 /area/listeningpost)
-"srr" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/space)
 "srx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41605,7 +40934,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "ssg" = (
 /obj/reagent_dispensers/fueltank,
 /obj/disposalpipe/segment/transport{
@@ -41791,12 +41120,6 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
-"svj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/space)
 "svP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -41859,17 +41182,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"sxk" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters_east)
 "sxl" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -41877,23 +41189,6 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
-"sxq" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "market";
-	name = "Public Market";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment/transport,
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/market)
 "sxE" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -42041,12 +41336,6 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
-"sCD" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
 "sCH" = (
 /obj/machinery/siphon_lever,
 /obj/item/paper/siphon_guide{
@@ -42126,6 +41415,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"sDO" = (
+/obj/grille/catwalk{
+	dir = 1
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/crew_quarters/quarters_east)
 "sDR" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/horizontal,
@@ -42187,7 +41482,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "sEL" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -42233,7 +41530,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "sFH" = (
 /obj/lattice,
 /obj/machinery/launcher_loader/south,
@@ -42285,21 +41582,16 @@
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/crew)
-"sGO" = (
-/obj/reagent_dispensers/watertank/fountain,
-/obj/machinery/phone/wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters_east)
-"sHI" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/access_spawn/maint,
+"sGN" = (
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/maintenance/east)
+/area/station/storage/tools)
 "sHW" = (
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/science/lobby{
@@ -42325,18 +41617,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/ce)
-"sId" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/machinery/light/small,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/station/crew_quarters/quarters_east)
 "sIe" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellowblack/corner,
@@ -42479,13 +41759,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"sKN" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/bot_storage)
 "sKR" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -42502,7 +41775,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 8
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "sLf" = (
 /obj/monkeyplant,
 /obj/machinery/firealarm{
@@ -42602,18 +41875,6 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
-"sNl" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor/black,
-/area/space)
 "sNm" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -42670,17 +41931,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
-"sOe" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/space)
 "sOh" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -42705,11 +41955,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"sOF" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/lamp/black,
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
 "sOI" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -42759,6 +42004,10 @@
 	dir = 4
 	},
 /obj/access_spawn/mining,
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/mining/staff_room)
 "sPN" = (
@@ -42839,12 +42088,6 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
 /area/station/bridge)
-"sQI" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_east)
 "sQU" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/navbeacon{
@@ -42884,7 +42127,7 @@
 	power_level = 2
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "sRr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42928,7 +42171,9 @@
 /area/station/security/brig)
 "sSm" = (
 /turf/simulated/floor/yellowblack,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "sSA" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -43154,14 +42399,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
-"sXv" = (
-/obj/table/reinforced/auto,
-/obj/bedsheetbin,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
 "sXC" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -43199,7 +42436,9 @@
 "sYj" = (
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "sYs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -43246,6 +42485,12 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
+"sZF" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "sZL" = (
 /obj/table/glass/reinforced/auto,
 /obj/machinery/camera{
@@ -43328,13 +42573,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"taV" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "tba" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -43427,15 +42665,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"tdd" = (
-/obj/item/sheet/steel/reinforced/fullstack{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/storage/tools)
 "tdf" = (
 /obj/shrub{
 	dir = 4;
@@ -43595,21 +42824,6 @@
 /obj/item/device/radio/intercom/medical,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay)
-"tfx" = (
-/obj/table/wood/auto,
-/obj/item/camera{
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = -12
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/carpet/red/fancy/edge/west,
-/area/station/crew_quarters/quarters_east)
 "tgc" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/drinks/bottle/soda/bottledwater{
@@ -43740,17 +42954,6 @@
 /obj/machinery/light/runway_light,
 /turf/space/fluid/acid/clear,
 /area/space)
-"tiw" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/item/storage/toilet,
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "tiN" = (
 /obj/cable{
 	d1 = 1;
@@ -43790,18 +42993,10 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "tjr" = (
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"tjw" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "tjx" = (
 /obj/decal/cleanable/dirt/dirt4,
 /obj/item/spacecash/fifty{
@@ -43810,12 +43005,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"tjF" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "tjV" = (
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -43827,6 +43016,10 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"tkd" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "tkf" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -43906,6 +43099,20 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/staff)
+"tlQ" = (
+/obj/stool/chair/office/blue{
+	dir = 4
+	},
+/obj/item/storage/wall{
+	dir = 4;
+	name = "libation cellar";
+	pixel_x = -32;
+	spawn_contents = list(/obj/item/reagent_containers/food/drinks/bottle/wine,/obj/item/reagent_containers/food/drinks/bottle/tequila,/obj/item/reagent_containers/food/drinks/bottle/mead,/obj/item/reagent_containers/food/drinks/bottle/rum)
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "tmd" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/ai_upload,
@@ -43921,15 +43128,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"tms" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 6
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/space)
 "tmw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44022,9 +43220,6 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/pasiphae/hangar)
-"toN" = (
-/turf/simulated/floor/engine/caution/corner,
-/area/space)
 "toT" = (
 /obj/indestructible/shuttle_corner{
 	dir = 0
@@ -44039,6 +43234,10 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
 "tpv" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -44188,7 +43387,7 @@
 "ttQ" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer,
 /turf/simulated/floor/engine/caution/west,
-/area/space)
+/area/station/engine/core/nuclear)
 "ttW" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4
@@ -44247,11 +43446,6 @@
 "tvO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/maint)
-"tvR" = (
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/desk_stuff,
-/turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/station/crew_quarters/quarters_east)
 "tvS" = (
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
@@ -44456,20 +43650,6 @@
 	dir = 1
 	},
 /area/pasiphae)
-"tAd" = (
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/space)
 "tAx" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
@@ -44640,14 +43820,14 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"tEU" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "tFf" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
 /turf/simulated/floor/yellow,
@@ -44810,7 +43990,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "tIi" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
@@ -45100,6 +44280,13 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"tNV" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "tOe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45150,16 +44337,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"tPR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "tQs" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -45281,10 +44458,13 @@
 	can_rupture = 0;
 	dir = 5
 	},
+/obj/cable{
+	icon_state = "2-9"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "tSY" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -45347,22 +44527,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "tUl" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
 /obj/firedoor_spawn,
-/obj/disposalpipe/segment/transport,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "market";
-	name = "Public Market";
-	opacity = 0;
-	dir = 4
-	},
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/machinery/cashreg,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "tUn" = (
@@ -45453,7 +44626,9 @@
 	transfer_rate = 1000
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "tXk" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
@@ -45867,15 +45042,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
-"uik" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "uiy" = (
 /obj/table/reinforced/auto,
 /obj/machinery/coffeemaker/research,
@@ -45934,11 +45100,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/space)
-"ujo" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
-/area/station/storage/tools)
+/area/station/maintenance/east)
 "ujv" = (
 /obj/item/sheet/steel/fullstack{
 	pixel_x = -6
@@ -46169,12 +45331,14 @@
 	},
 /area/station/storage/eva)
 "uql" = (
-/obj/cable,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -46241,6 +45405,15 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "urL" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
 /turf/simulated/floor/grey/side{
 	dir = 9
 	},
@@ -46395,6 +45568,18 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"uuD" = (
+/obj/table/auto,
+/obj/item/sheet/steel/fullstack{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/obj/item/sheet/glass/reinforced/fullstack{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/black/side,
+/area/station/storage/tools)
 "uvb" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -46567,6 +45752,12 @@
 "uzl" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"uzq" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/bot_storage)
 "uzu" = (
 /obj/lattice,
 /obj/warp_beacon{
@@ -46716,13 +45907,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"uDa" = (
-/obj/machinery/light,
-/obj/stool/chair/office/blue{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "uDe" = (
 /obj/item/sheet/steel/fullstack{
 	pixel_x = -8
@@ -46754,16 +45938,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
-"uEm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "uEI" = (
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/black,
@@ -46820,6 +45994,15 @@
 	dir = 1
 	},
 /area/pasiphae/crew)
+"uFZ" = (
+/obj/table/reinforced/auto,
+/obj/machinery/computer3/generic/personal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "uGt" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -46828,26 +46011,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"uGB" = (
-/obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
-"uGK" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/space)
 "uGM" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
@@ -46892,14 +46055,6 @@
 "uHS" = (
 /turf/simulated/floor/yellowblack,
 /area/station/engine/elect)
-"uIr" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "uIs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47077,7 +46232,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "uNk" = (
 /obj/stool/chair{
 	dir = 8
@@ -47352,10 +46509,6 @@
 "uSe" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
-"uSr" = (
-/obj/rack,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
 "uSB" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47457,9 +46610,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/yellowblack,
 /area/pasiphae/sys)
-"uVp" = (
-/turf/simulated/wall/false_wall,
-/area/space)
 "uWf" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -47578,16 +46728,6 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
-"uYg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "uYq" = (
 /obj/warp_beacon{
 	name = "Arrivals Wing"
@@ -47632,10 +46772,12 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig/genpop)
-"uZi" = (
-/obj/reagent_dispensers/beerkeg,
+"uZj" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/inner/east)
 "uZq" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -47694,17 +46836,10 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
-"vaR" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
+"vaE" = (
+/turf/simulated/floor/black/side{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_east)
 "vbd" = (
 /obj/machinery/light{
@@ -47747,21 +46882,14 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"vcF" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/space)
 "vcJ" = (
+/obj/machinery/photocopier{
+	pixel_x = 0
+	},
+/obj/machinery/door_control{
+	id = "market";
+	pixel_y = 24
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -47851,7 +46979,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "vfp" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/emergency_injector/atropine{
@@ -47897,17 +47025,6 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
-"vgz" = (
-/obj/stool/chair/office/blue{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "vgL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48105,17 +47222,6 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"vns" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/stool/chair,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/crew_quarters/quarters_east)
 "vnv" = (
 /obj/lattice{
 	dir = 10;
@@ -48131,20 +47237,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"vnF" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
 "vnJ" = (
 /turf/simulated/floor/greenblack{
 	dir = 8
@@ -48205,6 +47297,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/southwest)
+"vpJ" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "vpL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -48339,6 +47440,10 @@
 /obj/disposalpipe/trunk/mineral{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
@@ -48405,7 +47510,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "vuc" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack,
@@ -48425,7 +47530,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/west)
 "vuC" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -48524,7 +47629,9 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/sanitary,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vwg" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -48544,6 +47651,14 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
+"vwl" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "vwq" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 4;
@@ -48778,6 +47893,21 @@
 /obj/access_spawn/research_foyer,
 /turf/simulated/floor/black,
 /area/station/science/hall)
+"vCh" = (
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/nanoloom_cartridge{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/nanoloom_cartridge{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/turf/simulated/floor/black/side,
+/area/station/storage/tools)
 "vCk" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/grime,
@@ -48899,7 +48029,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vFY" = (
 /obj/landmark/random_room/size3x5,
 /turf/simulated/floor/plating,
@@ -49044,7 +48176,9 @@
 "vJu" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/engine/caution/north,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vJO" = (
 /obj/rack,
 /obj/item/crowbar/red{
@@ -49084,6 +48218,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
+"vJR" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vJU" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 8;
@@ -49143,6 +48288,14 @@
 	icon_state = "12"
 	},
 /area/shuttle/arrival/station)
+"vLW" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "vMt" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/access_spawn/bar,
@@ -49162,6 +48315,15 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/pasiphae/crew)
+"vMN" = (
+/obj/table/reinforced/auto,
+/obj/machinery/microwave,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quarters_east)
 "vMP" = (
 /obj/cable/orange{
 	icon_state = "0-2"
@@ -49176,13 +48338,9 @@
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
-"vMQ" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 1
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vMU" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black/side,
@@ -49360,12 +48518,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellowblack/corner,
-/area/space)
-"vSi" = (
-/obj/table/wood/auto,
-/obj/machinery/computer3/luggable,
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/station/crew_quarters/quarters_east)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "vSy" = (
 /obj/rack,
 /obj/item/clothing/suit/bedsheet/cape/black,
@@ -49469,6 +48624,9 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
+"vTZ" = (
+/turf/simulated/wall/false_wall/reinforced,
+/area/station/hallway/primary/southeast)
 "vUa" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/catering)
@@ -49484,11 +48642,6 @@
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
 	})
-"vUm" = (
-/obj/table/wood/auto,
-/obj/machinery/computer3/luggable,
-/turf/simulated/floor/carpet/red/fancy/edge/north,
-/area/space)
 "vUR" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/heads,
@@ -49572,10 +48725,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/lounge)
-"vWr" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/space)
 "vWA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -49785,11 +48934,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"wbW" = (
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/storage/tools)
 "wci" = (
 /obj/rack,
 /obj/item/mop,
@@ -49799,12 +48943,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
-"wcU" = (
-/obj/machinery/vending/pda,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "wcV" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -49864,26 +49002,6 @@
 	dir = 4
 	},
 /area/station/security/interrogation)
-"weg" = (
-/obj/machinery/light/small/warm/very,
-/obj/storage/secure/closet/immersion{
-	name = "Maintenance Immersion Suit Vault";
-	req_access = list(12)
-	},
-/obj/item/clothing/suit/space/diving/civilian{
-	pixel_x = -4
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/air{
-	pixel_x = 5
-	},
-/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
-	pixel_x = -4
-	},
-/turf/simulated/floor/black,
-/area/space)
 "wer" = (
 /obj/machinery/light/small,
 /obj/stool/chair{
@@ -49927,27 +49045,6 @@
 "wfh" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"wfq" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/table/wood/round/auto,
-/obj/item/decoration/flower_vase{
-	pixel_x = -8;
-	pixel_y = 14
-	},
-/obj/item/paper{
-	pixel_x = 4
-	},
-/obj/item/pen/fancy{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "wfL" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 8
@@ -50042,28 +49139,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/southwest)
-"wjg" = (
-/obj/table/auto,
-/obj/item/decoration/ashtray,
-/obj/item/dice{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/coin{
-	pixel_x = -2;
-	pixel_y = 16
-	},
-/obj/machinery/light/small,
-/obj/item/dice{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/beer{
-	pixel_x = -14;
-	pixel_y = 6
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "wjl" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -50112,7 +49187,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "wkv" = (
 /obj/machinery/conveyor/SN{
 	id = "garbage";
@@ -50261,6 +49336,9 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/caution/westeast,
 /area/shuttle/sea_elevator_room)
 "wpc" = (
@@ -50310,7 +49388,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "wqj" = (
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
@@ -50318,16 +49398,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/pasiphae/hangar)
-"wqx" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
 "wqA" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
@@ -50387,21 +49457,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
-"wsv" = (
-/obj/table/auto,
-/obj/item/device/gps{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/sheet/glass/fullstack{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/storage/tools)
 "wsM" = (
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/white,
@@ -50440,13 +49495,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
-"wuh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/space)
 "wuw" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -50455,7 +49503,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "wuF" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -50555,6 +49603,12 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
+"wwM" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters_east)
 "wwY" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -50647,6 +49701,10 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"wye" = (
+/obj/machinery/vending/cards,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "wzx" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -50696,9 +49754,6 @@
 	mail_tag = "kitchen";
 	name = "kitchen mail junction"
 	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "wAB" = (
@@ -50707,8 +49762,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "wAW" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -50792,8 +49847,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "wEh" = (
-/obj/stool/chair/yellow{
-	dir = 8
+/obj/stool/chair/yellow,
+/obj/landmark/start{
+	name = "Miner"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
@@ -50816,20 +49872,6 @@
 	},
 /turf/space/fluid/acid/clear,
 /area/space)
-"wEC" = (
-/obj/table/reinforced/auto,
-/obj/item/matchbook{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/decoration/ashtray{
-	pixel_x = 6
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/ne,
-/area/station/crew_quarters/quarters_east)
 "wEH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50844,31 +49886,6 @@
 /obj/machinery/light/small/warm/very,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"wFc" = (
-/obj/table/auto,
-/obj/item/storage/box/cablesbox{
-	pixel_x = 5;
-	pixel_y = 13
-	},
-/obj/item/storage/box/cablesbox{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/item/device/nanoloom{
-	pixel_x = -10;
-	pixel_y = -2
-	},
-/obj/item/device/nanoloom{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/turf/simulated/floor/black/side,
-/area/station/storage/tools)
 "wFd" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -51035,16 +50052,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"wIh" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "wIo" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51116,13 +50123,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
-"wJL" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
-/obj/storage/closet/wardrobe/mixed,
-/turf/simulated/floor/plating,
-/area/space)
 "wJP" = (
 /obj/machinery/plantpot,
 /obj/machinery/light{
@@ -51633,10 +50633,11 @@
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
 "wYn" = (
-/turf/simulated/floor/black/corner{
-	dir = 1
+/obj/machinery/clothingbooth,
+/turf/simulated/floor/black/side{
+	dir = 8
 	},
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "wYs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51661,8 +50662,13 @@
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "wYK" = (
 /obj/storage/secure/closet/immersion/engineering,
 /obj/item/clothing/suit/space/diving/engineering{
@@ -51727,15 +50733,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
-"wZn" = (
-/obj/table/wood/round/auto,
-/obj/item/paper_bin{
-	pixel_y = 2
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/space)
 "wZv" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
@@ -51748,16 +50745,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"wZT" = (
-/obj/stool/bench/blue/auto,
-/obj/item/storage/wall{
-	dir = 4;
-	name = "bath cabinet";
-	pixel_x = -32;
-	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "wZU" = (
 /obj/machinery/networked/test_apparatus/impact_pad,
 /obj/cable{
@@ -51777,17 +50764,6 @@
 	dir = 1
 	},
 /area/listeningpost)
-"xap" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/item/storage/toilet,
-/obj/landmark/spawner{
-	name = "monkeyspawn_tanhony"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "xaW" = (
 /obj/machinery/networked/secdetector{
 	area_access = 37;
@@ -51829,16 +50805,6 @@
 	},
 /turf/space/fluid/acid/clear,
 /area/space)
-"xbx" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/quarters_east)
 "xbE" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -51856,12 +50822,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
-"xbV" = (
-/obj/item/device/radio/intercom,
-/turf/simulated/floor/grey/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "xbW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51893,25 +50853,6 @@
 "xcu" = (
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
-"xcC" = (
-/obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east)
-"xcF" = (
-/obj/stool/chair/comfy{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/carpet/red,
-/area/station/crew_quarters/quarters_east)
 "xcR" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -52089,13 +51030,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
-"xhy" = (
-/obj/item/storage/secure/ssafe{
-	pixel_x = 28
-	},
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_east)
 "xhL" = (
 /turf/unsimulated/wall/trench,
 /area/pasiphae/bridge)
@@ -52197,6 +51131,11 @@
 "xjY" = (
 /turf/simulated/floor/black,
 /area/station/science/artifact)
+"xka" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "xke" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52331,6 +51270,28 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"xna" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/station/crew_quarters/heads{
+	name = "Diplomatic Quarters"
+	})
 "xnq" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
@@ -52545,20 +51506,39 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
+"xun" = (
+/obj/table/auto,
+/obj/machinery/computer3/generic/personal{
+	dir = 6
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tools)
 "xup" = (
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
 /obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/space)
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/quarters_east)
 "xuD" = (
 /obj/stool/chair/wooden{
 	dir = 1
@@ -52644,30 +51624,28 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
 "xwb" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/table/wood/auto,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
+/obj/item/paper_bin{
+	pixel_y = -8;
+	pixel_x = 7
 	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/space)
-"xwd" = (
-/obj/stool/chair/comfy{
-	dir = 8
+/obj/item/pen{
+	pixel_y = -5;
+	pixel_x = -3
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = -11;
+	pixel_x = -7
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/item/camera{
+	pixel_y = 11
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/station/crew_quarters/quarters_east)
 "xwS" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -52687,22 +51665,6 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/arrival/station)
-"xwV" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "xxc" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -52829,6 +51791,9 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "xzL" = (
@@ -52882,6 +51847,10 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
+"xAq" = (
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "xAt" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -53074,7 +52043,7 @@
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 4
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "xDz" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -53190,10 +52159,16 @@
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
 	},
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
-/area/space)
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "xHG" = (
 /obj/machinery/door/airlock/pyro/reinforced/syndicate{
 	desc = "Seems to be a pretty sturdy door.";
@@ -53457,7 +52432,7 @@
 	name = "cold loop freezer interface valve"
 	},
 /turf/simulated/floor/engine/caution/east,
-/area/space)
+/area/station/engine/core/nuclear)
 "xOa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
@@ -53515,30 +52490,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"xOG" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "nadir_diploshut";
-	name = "Diplomatic Quarters Shutters";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/heads,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
 "xOU" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -53642,8 +52593,11 @@
 	name = "Northwest Breach Hull"
 	})
 "xQx" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
-/area/space)
+/area/station/crew_quarters/quarters_east)
 "xQD" = (
 /obj/table/reinforced/auto,
 /obj/item/remote/porter/port_a_medbay{
@@ -53694,18 +52648,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
-"xRN" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/bowl{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/cereal_box/roach{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "xRP" = (
 /obj/machinery/computer3/generic/med_data{
 	dir = 4
@@ -53910,6 +52852,19 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"xVH" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/west)
 "xVL" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	name = "Auxiliary Compartment"
@@ -54060,7 +53015,7 @@
 /turf/simulated/floor/engine/caution/misc{
 	dir = 6
 	},
-/area/space)
+/area/station/engine/core/nuclear)
 "xYr" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -54113,6 +53068,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/ejection{
+	dir = 2
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -54135,12 +53093,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/surgery)
-"yaN" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/storage/tools)
 "ybk" = (
 /obj/item/device/radio/intercom/science{
 	dir = 8
@@ -54200,6 +53152,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"ydi" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "ydp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54242,10 +53201,10 @@
 	name = "South Catalytic Substation"
 	})
 "yem" = (
-/obj/machinery/light/small,
-/obj/table/reinforced/auto,
-/turf/simulated/floor/carpet/red/fancy/edge/se,
-/area/space)
+/obj/table/wood/auto,
+/obj/machinery/computer3/luggable,
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/station/crew_quarters/quarters_east)
 "yex" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 1;
@@ -54299,7 +53258,7 @@
 /area/station/crew_quarters/quarters_east)
 "ygt" = (
 /turf/simulated/floor/engine,
-/area/space)
+/area/station/engine/core/nuclear)
 "yhH" = (
 /obj/cable,
 /obj/cable{
@@ -54360,7 +53319,13 @@
 	name = "Transception Array Control"
 	})
 "yiB" = (
-/turf/simulated/floor/black/side{
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/simulated/floor/greenblack{
 	dir = 1
 	},
 /area/station/hallway/primary/southeast)
@@ -54394,6 +53359,23 @@
 "yjf" = (
 /turf/simulated/floor/plating,
 /area/space)
+"yji" = (
+/obj/table/auto,
+/obj/item/device/gps{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/sheet/glass/fullstack{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tools)
 "yjq" = (
 /obj/deployable_turret/riot{
 	active = 1;
@@ -86059,8 +85041,8 @@ dqY
 dqY
 sUF
 dqY
-siL
-siL
+dqY
+dqY
 vUa
 vUa
 vUa
@@ -94826,7 +93808,7 @@ ayC
 hCf
 hCf
 hCf
-hCf
+jwV
 hCf
 sxl
 mYF
@@ -95126,9 +94108,9 @@ uPZ
 wAy
 uPZ
 uPZ
+cWX
 uPZ
-uPZ
-uPZ
+tNV
 uPZ
 lyT
 ozw
@@ -95425,12 +94407,12 @@ gfR
 gfR
 cNY
 tUl
-jRu
-fYj
 lJi
+lJi
+jHU
 vRv
 jmJ
-jUz
+xVH
 jmJ
 jmJ
 jmJ
@@ -95727,12 +94709,12 @@ pHo
 gCI
 cNY
 urL
-itK
+hBS
 itK
 khK
 vRv
 hBh
-cvc
+hgF
 cvc
 dMn
 pqn
@@ -96029,15 +95011,15 @@ qNE
 fFJ
 cNY
 vcJ
-bYd
+qVd
 ejz
 jKH
 boK
+lnD
 bkJ
-bkJ
-bkJ
+cvc
 cOM
-ibt
+pqn
 fgd
 vcK
 jCM
@@ -96336,10 +95318,10 @@ tpv
 bPO
 vRv
 mUC
-cvc
+hgF
 ppA
 mUC
-sKN
+pqn
 rjL
 qSj
 qSj
@@ -96638,11 +95620,11 @@ vRv
 vRv
 vRv
 aTs
-cvc
-cvc
+hgF
+rTU
 bSc
-pqn
-qVZ
+uzq
+xZW
 xZW
 xZW
 fpX
@@ -96935,13 +95917,13 @@ gfR
 gfR
 cNY
 fmO
-nBp
 fmO
-cvc
-pDb
-cvc
-cvc
-cvc
+fmO
+iWH
+dnh
+fAH
+mYa
+fAZ
 vne
 pqn
 aVa
@@ -97238,7 +96220,7 @@ crg
 lYL
 ocX
 qHV
-fmO
+rBl
 bwx
 mUC
 mUC
@@ -97843,7 +96825,7 @@ tRU
 czo
 bfp
 fmO
-cvc
+hgF
 pDb
 cvc
 cvc
@@ -98145,7 +97127,7 @@ lLZ
 czo
 mXd
 fmO
-cvc
+gEi
 mUC
 cvc
 cvc
@@ -100261,12 +99243,12 @@ cUZ
 bwa
 pjY
 hbm
+lEn
 fip
 lEn
-oxS
+fip
 lEn
-lEn
-lEn
+fip
 nKe
 buD
 fJg
@@ -100566,7 +99548,7 @@ fLp
 jdX
 jdX
 jdX
-jdX
+oxz
 jdX
 jdX
 eQi
@@ -100868,8 +99850,8 @@ oht
 bgw
 bgw
 bgw
-rpz
-rpz
+dSY
+vLW
 rpz
 bgw
 uiy
@@ -101168,10 +100150,10 @@ fmO
 lZB
 xSt
 bgw
-pfN
+hJQ
 bgw
 bgw
-pfN
+iaS
 bgw
 bgw
 bgw
@@ -101470,11 +100452,11 @@ fmO
 lEU
 aOo
 bgw
+ecc
+gfu
+oTv
 pfN
-pfN
-pfN
-pfN
-pfN
+qhG
 sOU
 sgu
 ycq
@@ -101769,13 +100751,13 @@ juT
 czo
 mXd
 fmO
-lZB
+csu
 xSt
 bgw
-pfN
+kSK
 bgw
-pfN
-pfN
+fRi
+csz
 sOU
 sOU
 sOU
@@ -102377,8 +101359,8 @@ lZB
 xSt
 wPw
 cAH
-lZB
-lZB
+tkd
+iWS
 sOU
 fqt
 qXF
@@ -102680,7 +101662,7 @@ xSt
 wPw
 wPw
 wPw
-lZB
+tkd
 sOU
 pMc
 qXF
@@ -102977,12 +101959,12 @@ haT
 bAq
 bPo
 fmO
-lZB
+uZj
 ezG
 lVG
 xNH
 tIK
-lZB
+jVM
 sOU
 gXd
 nCO
@@ -103279,7 +102261,7 @@ qKT
 qmt
 klu
 fmO
-cAs
+vBq
 cAs
 cAs
 cAs
@@ -103581,11 +102563,11 @@ fmO
 fmO
 fmO
 fmO
-dxd
-dxd
-dxd
+sGN
+hKE
+bxi
 cAs
-xSt
+oLr
 lZB
 sOU
 sOU
@@ -103879,13 +102861,13 @@ aaY
 sEd
 dkT
 mPS
-xZH
-dxd
-dxd
-dxd
-dxd
-dxd
-dxd
+cAs
+vCh
+yji
+xun
+mdV
+bQm
+lep
 cAs
 xSt
 lZB
@@ -104181,12 +103163,12 @@ qiE
 vkv
 rnu
 vJU
-xZH
-dxd
-dxd
-dxd
-dxd
-dxd
+cAs
+uuD
+hxc
+ind
+hxc
+bQm
 dxd
 cAs
 xSt
@@ -104483,13 +103465,13 @@ iBT
 oyF
 hrd
 ner
-xZH
-dxd
-dxd
-dxd
-dxd
-dxd
-dxd
+cAs
+mGC
+cWV
+ind
+ind
+hwM
+lep
 cAs
 xSt
 aOD
@@ -104785,13 +103767,13 @@ fte
 uhy
 aVI
 xmz
-xZH
-dxd
-dxd
-dxd
-dxd
-dxd
-dxd
+cAs
+fjA
+eSf
+nAJ
+hiN
+fER
+ohY
 cAs
 xSt
 mpJ
@@ -105087,13 +104069,13 @@ xZH
 asK
 hJl
 xZH
-xZH
 cAs
+cie
 cAs
+mCe
 cAs
-cAs
-cAs
-cAs
+cie
+cie
 cAs
 qEl
 xKn
@@ -106293,19 +105275,19 @@ aXs
 aXs
 dDv
 nDS
-siL
+ibV
 fLQ
 cmb
 fLQ
-siL
+ibV
 fLQ
 fLQ
 fLQ
-siL
-siL
-siL
-siL
-siL
+ocD
+ocD
+ocD
+ocD
+ocD
 nyR
 teP
 hoD
@@ -106595,7 +105577,7 @@ haa
 aXs
 rkh
 lWL
-siL
+ibV
 aZV
 aZV
 aZV
@@ -106603,12 +105585,12 @@ fLQ
 aZV
 aZV
 aZV
-siL
+ocD
 xHz
 aZM
 vwd
-siL
-siL
+ocD
+ocD
 bEm
 vEo
 tZU
@@ -106897,20 +105879,20 @@ dpb
 pZd
 uiV
 sce
-siL
+ibV
 fLQ
 cmb
 fLQ
-siL
+ibV
 fLQ
 fLQ
 fLQ
-siL
+ocD
 bre
-qxz
+jtr
 qxz
 bMH
-siL
+ocD
 sXH
 qwN
 fnx
@@ -107198,19 +106180,19 @@ dYV
 jsE
 aXs
 rkh
-siL
-siL
+ibV
+ibV
 dhu
 hkU
-hkU
+gcG
 oDS
 hkU
 hkU
 hkU
 dfm
 lGL
-cKX
-cKX
+kYA
+qyC
 aut
 ajo
 axJ
@@ -107500,10 +106482,10 @@ xVo
 ujK
 aXs
 rkh
-siL
-siL
+ibV
+ibV
 tHH
-gzh
+eFd
 gzh
 sKX
 tSU
@@ -107511,11 +106493,11 @@ jOW
 jOW
 wYE
 eSP
-cKX
-cKX
+vJR
+fqO
 aut
 ajo
-bEm
+qoe
 vEo
 iPJ
 vEo
@@ -107802,22 +106784,22 @@ dYV
 ujK
 aXs
 rkh
-siL
-siL
+ibV
+ibV
 qXv
 ygt
 ygt
 ygt
 ygt
 ygt
-jOW
+fQF
 dfm
 oJY
 sYj
-cKX
+kYA
 aut
 ajo
-bEm
+gIk
 vEo
 iPJ
 vEo
@@ -108100,12 +107082,12 @@ ahN
 rGH
 dYV
 dYV
-dYV
+gkY
 pIJ
 jVj
-rkh
-siL
-siL
+mio
+ibV
+ibV
 tjk
 ygt
 ygt
@@ -108113,12 +107095,12 @@ ygt
 nCb
 pKL
 kQl
-siL
-siL
-ctT
+ocD
+ocD
+dva
 jpM
-siL
-siL
+ocD
+ocD
 sXH
 vEo
 oWK
@@ -108406,8 +107388,8 @@ bfW
 qpA
 aXs
 rkh
-siL
-siL
+ibV
+ibV
 dmq
 ygt
 ygt
@@ -108420,7 +107402,7 @@ vFq
 fBr
 fuX
 gNa
-siL
+ocD
 bEm
 sVX
 iPJ
@@ -108708,8 +107690,8 @@ aXs
 aXs
 aXs
 rkh
-siL
-siL
+ibV
+ibV
 dFE
 vfd
 lDM
@@ -108720,7 +107702,7 @@ hTc
 dfm
 vMP
 uNg
-svj
+kYA
 sSm
 gDo
 bEm
@@ -109006,12 +107988,12 @@ iIi
 iIi
 iIi
 haC
-vWr
-vWr
-vWr
+aTP
+aTP
+aTP
 aTy
-siL
-siL
+ibV
+ibV
 oSB
 ttQ
 ffH
@@ -109022,9 +108004,9 @@ gQb
 dfm
 gKd
 hhO
-svj
+kYA
 mYy
-siL
+ocD
 bEm
 vEo
 iPJ
@@ -109307,13 +108289,13 @@ nbH
 cHd
 cHd
 cHd
-yjf
+gwB
 pJo
 eGf
 cgu
 iky
-siL
-siL
+ibV
+ibV
 jUT
 scP
 khh
@@ -109321,12 +108303,12 @@ xNP
 ikE
 mKE
 rKn
-siL
-siL
+ocD
+ocD
 dWW
 vRR
-siL
-siL
+ocD
+ocD
 sXH
 rLM
 iPJ
@@ -109609,13 +108591,13 @@ gKW
 uDe
 hTZ
 cHd
-yjf
-fHb
-fHb
-fHb
-fHb
-siL
-siL
+ydi
+oZp
+oZp
+oZp
+oZp
+ibV
+ibV
 vtY
 cNc
 cNc
@@ -109628,8 +108610,8 @@ jqC
 sEK
 rED
 gcL
-siL
-gIk
+ocD
+sZF
 vEo
 iPJ
 rZb
@@ -109913,7 +108895,7 @@ kuV
 cHd
 qrh
 pDQ
-rsE
+pVr
 pDQ
 pVr
 oMR
@@ -109930,8 +108912,8 @@ nSj
 wqi
 bko
 kNR
-siL
-qoe
+ocD
+qxM
 vEo
 vWA
 tdq
@@ -110214,12 +109196,12 @@ qxv
 xnE
 cHd
 eIK
-fHb
+oZp
 hXx
-fHb
+oZp
 hXx
-siL
-siL
+ibV
+ibV
 rAG
 ygt
 ygt
@@ -110232,8 +109214,8 @@ bel
 eSW
 bus
 cyG
-siL
-gIk
+ocD
+rBp
 vEo
 fdg
 rZb
@@ -110516,12 +109498,12 @@ opJ
 cHd
 cHd
 eIK
-fHb
-oPP
-oPP
-oPP
-siL
-siL
+oZp
+bLW
+oZp
+bLW
+ibV
+ibV
 tjk
 ygt
 ygt
@@ -110529,13 +109511,13 @@ agh
 pKL
 pKL
 fQt
-siL
+ocD
 pwy
 tXe
 sSm
-siL
-siL
-sXH
+ocD
+ocD
+ocD
 beT
 mAW
 nqh
@@ -110819,11 +109801,11 @@ xnE
 cHd
 eIK
 pnP
-oPP
-oPP
-oPP
-siL
-siL
+jXY
+jXY
+kCV
+ibV
+ibV
 dmq
 ygt
 ygt
@@ -110837,7 +109819,7 @@ bgj
 sSm
 ePt
 ebu
-sXH
+ocD
 vEo
 qBe
 rZb
@@ -111120,12 +110102,12 @@ wLs
 hEL
 cHd
 eIK
-fHb
-oPP
-oPP
-oPP
-siL
-siL
+oZp
+lcd
+xAq
+jXY
+ibV
+ibV
 dmq
 ygt
 ygt
@@ -111133,13 +110115,13 @@ ygt
 ygt
 ygt
 ijc
-wYE
+cNs
 oPG
 rqB
 sSm
 vJu
 crB
-sXH
+ocD
 vEo
 fdg
 rZb
@@ -111422,12 +110404,12 @@ rtj
 sJR
 cHd
 eIK
-fHb
-fHb
-fHb
+oZp
+oZp
+oZp
 cQM
-siL
-siL
+ibV
+ibV
 lXA
 lDM
 wuw
@@ -111441,7 +110423,7 @@ fHA
 sSm
 lwL
 jbY
-sXH
+ocD
 vEo
 fdg
 rZb
@@ -111724,27 +110706,27 @@ fmc
 fmc
 fmc
 eIK
-fHb
-oPP
+oZp
+bgX
 irk
-oPP
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
+jXY
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ocD
 mvp
 jQr
 sSm
 dOQ
-siL
-sXH
-rLM
+ocD
+ocD
+vEo
 fdg
 rZb
 sXH
@@ -112026,25 +111008,25 @@ kdb
 uAs
 fmc
 eIK
-fHb
-fHb
-fHb
+oZp
+oZp
+oZp
+jXY
 oPP
-oPP
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-siL
-dqr
-siL
-siL
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ibV
+ocD
+ocD
+ocD
+ocD
+ocD
+ocD
 yiB
 vEo
 fdg
@@ -112328,26 +111310,26 @@ fmc
 kfP
 fmc
 eIK
-fHb
-oPP
+oZp
+mZZ
 irk
-oPP
-oPP
-siL
+xPc
+qlL
+wMJ
+vMN
 dYx
-dYx
-cKX
+pFw
 fHb
-bdz
+oZp
 aUS
 rAX
-siL
-oVd
-yjf
-yjf
-yjf
-siL
-yiB
+rpT
+iXV
+sDO
+sDO
+sDO
+vTZ
+mai
 vEo
 fdg
 rZb
@@ -112630,26 +111612,26 @@ fmc
 fmc
 fmc
 eIK
-fHb
-fHb
-fHb
-oPP
-oPP
-pFX
+oZp
+oZp
+oZp
+jXY
+kHl
+sVw
+wwM
 xQx
-xQx
-jsQ
+usM
 beh
-mQb
+mrW
 lxv
 nkd
 ayy
-yjf
-yjf
-taV
-yjf
-mZi
-yiB
+vuv
+vuv
+vuv
+vuv
+vuv
+nab
 vEo
 fdg
 rZb
@@ -112905,7 +111887,7 @@ xeY
 xeY
 jPN
 pYH
-ktD
+rha
 uha
 nIv
 bEB
@@ -112932,25 +111914,25 @@ chF
 fmc
 bcx
 eIK
-fHb
-oPP
+oZp
+mZZ
 irk
-oPP
-oPP
-fHb
-xQx
-xQx
-jsQ
-fHb
-vcF
+gfT
+oZp
+oZp
+gyI
+nRJ
+usM
+fIM
+oZp
 xwb
 yem
-siL
-siL
-siL
-siL
-siL
-siL
+fqg
+vuv
+eIo
+tlQ
+rLX
+vuv
 sXH
 crt
 fdg
@@ -113234,26 +112216,26 @@ hyM
 smu
 gie
 eIK
-fHb
-fHb
-fHb
-fHb
-fHb
-fHb
-xQx
-nNu
-jsQ
-fHb
-fHb
-fHb
-fHb
-siL
-cKX
-cKX
-cKX
+oZp
+oZp
+oZp
+oZp
+oZp
+ktH
+mzL
+nRJ
+ctd
+nsO
+oZp
+oZp
+oZp
+oZp
+vuv
+xna
+oOV
 cKX
 oYs
-yiB
+vwl
 vEo
 sRc
 rZb
@@ -113536,28 +112518,28 @@ hys
 fmc
 xWr
 eIK
-fHb
+oZp
 pRS
-qOW
-iyt
-fHb
+xAt
+hYo
+oZp
 osB
-xQx
-xQx
-jsQ
-fHb
-dcD
+akq
+nRJ
+ctd
+gzB
+oZp
 rFZ
-jIw
-siL
-cKX
-cKX
-cKX
-cKX
+jOu
+nOk
+vuv
+sqZ
+pKq
+dIW
 bPQ
-yiB
-vEo
-fdg
+rQs
+iZl
+mMT
 rZb
 oFp
 fXB
@@ -113838,26 +112820,26 @@ ero
 fmc
 aXr
 eIK
-fHb
-vUm
-fjq
-nkd
+oZp
+fKD
+gkC
+ygn
 ebd
-osB
-xQx
-xQx
-jsQ
-beh
-mQb
+eVi
+lAS
+nRJ
+usM
+vaE
+mrW
 lxv
-qAS
-siL
-cKX
-cKX
-cKX
-cKX
+gkC
+pEp
+vuv
+qmV
+iLR
+blv
 oYs
-yiB
+vwl
 vEo
 oZk
 rZb
@@ -114140,25 +113122,25 @@ oOx
 fmc
 oDI
 eIK
-uVp
+oZp
 dzn
-egW
+dtq
 aWX
-fHb
-cKX
-kiz
+oZp
+uFZ
+vpJ
 kiz
 wYn
-fHb
-tAd
+krx
+oZp
 xup
 dtq
-siL
+hVz
+vuv
+ctW
 hHq
-hHq
-hHq
-siL
-siL
+vuv
+vuv
 sXH
 qwN
 pOW
@@ -114442,21 +113424,21 @@ lsA
 uSe
 uSe
 dFf
-uSe
-uSe
-uSe
-uSe
-uSe
-uSe
-nxE
+wMJ
+wMJ
+wMJ
+wMJ
+wMJ
+wMJ
+wMJ
 cdf
-nxE
-uSe
-uSe
-uSe
-uSe
-uSe
-ejY
+wMJ
+wMJ
+wMJ
+wMJ
+wMJ
+wMJ
+vuv
 rcN
 qAW
 uSe
@@ -114748,17 +113730,17 @@ xfb
 lEM
 lXG
 sTv
-pnk
+wye
 uSe
-pnk
-pnk
-pnk
+jmx
+fiR
+fuD
 xfb
 oys
 xfb
 jhQ
 uSe
-pnk
+xka
 pnk
 pnk
 rBd
@@ -115049,9 +114031,9 @@ rLr
 oqn
 ifZ
 ifZ
-uql
+oqn
 xbW
-ifZ
+rGn
 ifZ
 uql
 ifZ
@@ -115353,7 +114335,7 @@ qlS
 pnk
 npg
 pnk
-pnk
+rBd
 pnk
 fiR
 pnk
@@ -125644,7 +124626,7 @@ bzS
 bzS
 bzS
 bzS
-czt
+bzS
 bzS
 bzS
 bzS
@@ -125946,7 +124928,7 @@ bzS
 bzS
 bzS
 bzS
-skQ
+bzS
 bzS
 bzS
 bzS
@@ -126248,7 +125230,7 @@ bzS
 bzS
 bzS
 bzS
-hVR
+bzS
 bzS
 bzS
 bzS
@@ -126550,7 +125532,7 @@ bzS
 bzS
 bzS
 bzS
-siL
+bzS
 bzS
 bzS
 bzS
@@ -126852,7 +125834,7 @@ bzS
 bzS
 bzS
 bzS
-fpR
+bzS
 bzS
 bzS
 bzS
@@ -127154,7 +126136,7 @@ bzS
 bzS
 bzS
 bzS
-qvy
+bzS
 bzS
 bzS
 bzS
@@ -127456,7 +126438,7 @@ bzS
 bzS
 bzS
 bzS
-wcU
+bzS
 bzS
 bzS
 bzS
@@ -127749,16 +126731,16 @@ bzS
 bzS
 bzS
 bzS
-yjf
-siL
-iZE
-eVh
 bzS
 bzS
 bzS
 bzS
 bzS
-siL
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -128041,26 +127023,26 @@ bzS
 bzS
 bzS
 bzS
-jYT
-bzS
-bzS
-kuP
-bzS
-bzS
-jCY
-yjf
-pvZ
-bzS
-yjf
-siL
-yjf
-yjf
 bzS
 bzS
 bzS
 bzS
 bzS
-psJ
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -128343,26 +127325,26 @@ bzS
 bzS
 bzS
 bzS
-vgz
-bzS
-bzS
-sOe
-bzS
-bzS
-nLQ
-tjF
-pvZ
-bzS
-uYg
-dtx
-rdq
-buR
 bzS
 bzS
 bzS
 bzS
 bzS
-cdO
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -128645,26 +127627,26 @@ bzS
 bzS
 bzS
 bzS
-wZn
-bzS
-bzS
-tms
-bzS
-bzS
-uZi
-jCY
-pvZ
-bzS
-wJL
-siL
-jCY
-aQS
 bzS
 bzS
 bzS
 bzS
 bzS
-qiM
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -128957,12 +127939,12 @@ bzS
 bzS
 bzS
 bzS
-pvZ
-pvZ
-pvZ
-pvZ
-rEB
-xRN
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -129259,12 +128241,12 @@ bzS
 bzS
 bzS
 bzS
-pvZ
-cVL
-pvZ
-pvZ
-rEB
-wjg
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -129561,12 +128543,12 @@ bzS
 bzS
 bzS
 bzS
-pvZ
-pvZ
-pvZ
-pvZ
-yjf
-ohk
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -129833,16 +128815,16 @@ bzS
 bzS
 bzS
 bzS
-siL
-sbs
-iZs
-peS
-peS
-siL
-ctT
-ohK
-ctT
-siL
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -130135,16 +129117,6 @@ bzS
 bzS
 bzS
 bzS
-siL
-siL
-siL
-ctT
-ctT
-siL
-dhS
-cKX
-oAx
-siL
 bzS
 bzS
 bzS
@@ -130159,17 +129131,27 @@ bzS
 bzS
 bzS
 bzS
-cVL
-hDL
-siL
-yjf
-jCY
 bzS
 bzS
 bzS
 bzS
 bzS
-lMa
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -130437,16 +129419,6 @@ bzS
 bzS
 bzS
 bzS
-siL
-lmN
-siL
-esc
-yjf
-ctT
-mIR
-lYD
-oAx
-siL
 bzS
 bzS
 bzS
@@ -130461,11 +129433,21 @@ bzS
 bzS
 bzS
 bzS
-wIh
-eGf
-eRs
-eGf
-kLs
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -130739,16 +129721,6 @@ bzS
 bzS
 bzS
 bzS
-siL
-siL
-siL
-ctT
-ctT
-siL
-ctT
-uGK
-ctT
-siL
 bzS
 bzS
 bzS
@@ -130763,11 +129735,21 @@ bzS
 bzS
 bzS
 bzS
-wuh
-mNh
-siL
-yjf
-ieN
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -131041,16 +130023,6 @@ bzS
 bzS
 bzS
 bzS
-ctT
-mdY
-ctT
-bbK
-toN
-kRP
-cKX
-cKX
-weg
-siL
 bzS
 bzS
 bzS
@@ -131065,11 +130037,21 @@ bzS
 bzS
 bzS
 bzS
-jCY
-nLd
-siL
-lDu
-jyD
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -131343,16 +130325,6 @@ bzS
 bzS
 bzS
 bzS
-ctT
-gqq
-ctT
-fAv
-fYT
-kRP
-cKX
-cKX
-pmw
-siL
 bzS
 bzS
 bzS
@@ -131367,11 +130339,21 @@ bzS
 bzS
 bzS
 bzS
-srr
-nPZ
-siL
-siL
-siL
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -131645,16 +130627,16 @@ bzS
 bzS
 bzS
 bzS
-siL
-siL
-siL
-ctT
-ctT
-siL
-iDs
-fuX
-sNl
-siL
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -131947,16 +130929,16 @@ bzS
 bzS
 bzS
 bzS
-siL
-lmN
-siL
-esc
-yjf
-siL
-siL
-srr
-siL
-siL
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -132249,16 +131231,16 @@ bzS
 bzS
 bzS
 bzS
-siL
-siL
-siL
-ctT
-ctT
-siL
-yjf
-yjf
-yjf
-yjf
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -134021,20 +133003,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-cie
-cAs
-mCe
-cAs
-cie
-cAs
-aaH
-nmg
-vRv
-kQr
-blR
-vRv
-pvZ
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -134323,20 +133305,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-efM
-wsv
-wbW
-tdd
-lep
-cAs
-naN
-qTS
-dnY
-xbV
-uDa
-jRu
-jRu
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -134625,20 +133607,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-lTQ
-dxd
-ujo
-mrT
-avl
-cAs
-tPR
-qTS
-dnY
-kHr
-qVd
-oGn
-vRv
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -134927,20 +133909,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-wFc
-mrT
-ind
-dxd
-avl
-cAs
-naN
-qTS
-dnY
-eQO
-irG
-ftI
-jRu
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -135229,20 +134211,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-pbY
-hxc
-ind
-cWV
-fpC
-cAs
-xwV
-qHD
-sxq
-uik
-tEU
-tEU
-qfy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -135531,20 +134513,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-bfG
-cWV
-ind
-hxc
-yaN
-cAs
-aLz
-qTS
-dnY
-uGB
-aiq
-uSr
-jRu
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -135833,20 +134815,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-bxi
-oJO
-lIl
-cEk
-fjA
-cAs
-aLz
-qTS
-dnY
-dnY
-dnY
-dnY
-vRv
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -136135,20 +135117,20 @@ oeA
 oeA
 oeA
 oeA
-cAs
-cAs
-cAs
-cAs
-vBq
-cAs
-cAs
-jfd
-oRR
-sHI
-efI
-tjx
-par
-sXH
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -136435,22 +135417,22 @@ oeA
 oeA
 oeA
 oeA
-oUg
-iKc
-iIi
-iIi
-iIi
-uEm
-axq
-iIi
-iIi
-iNo
-rfO
-ncu
-iLL
-eHE
-fQN
-sXH
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -136737,22 +135719,22 @@ oeA
 oeA
 oeA
 oeA
-hvX
-rfO
-gie
-oZp
-oZp
-sxk
-oZp
-oZp
-oZp
-iXV
-oZp
-oZp
-ctr
-kll
-gZm
-sXH
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -137039,22 +136021,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-jmz
-gie
-oZp
-jWW
-tfx
-ktv
-oZp
-tvR
-ixW
-oNJ
-oZp
-trb
-pqp
-jWG
-sXH
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -137341,22 +136323,22 @@ oeA
 oeA
 oeA
 oeA
-pMD
-gie
-gie
-rIw
-vSi
-xcF
-eJa
-oZp
-rwN
-gkC
-rxi
-oZp
-oZp
-oZp
-oZp
-wMJ
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -137643,22 +136625,22 @@ oeA
 oeA
 oeA
 oeA
-iNG
-uIr
-obm
-oZp
-ibI
-xhy
-dLj
-oZp
-vnF
-aRG
-rnJ
-oZp
-qDf
-rLR
-rOZ
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -137945,22 +136927,22 @@ oeA
 oeA
 oeA
 oeA
-kaN
-oZp
-oZp
-oZp
-oZp
-oZp
-nwR
-oZp
-oZp
-pxp
-oZp
-oZp
-qFM
-usM
-usM
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -138247,22 +137229,22 @@ oeA
 oeA
 oeA
 oeA
-hwo
-oZp
-iPM
-xAt
-hYo
-oZp
-bXN
-xcC
-afH
-nRv
-vns
-pOI
-qGa
-rNt
-nvB
-wMJ
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -138549,22 +137531,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-fKD
-gkC
-ygn
-mrW
-qLl
-usM
-usM
-usM
-ctd
-pUJ
-qNM
-rNt
-usM
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -138851,22 +137833,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-frT
-aHy
-vaR
-oZp
-fhJ
-eBr
-adk
-eBr
-eBr
-pUS
-pUS
-efZ
-eBr
-gdY
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -139153,22 +138135,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-oZp
-oZp
-oZp
-oZp
-jJH
-hPh
-gZs
-jQj
-jQj
-usM
-usM
-nRJ
-qFM
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -139455,22 +138437,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-sXv
-jOu
-sId
-oZp
-hEW
-oZp
-oZp
-pxp
-oZp
-oZp
-sGO
-nRJ
-rRa
-wMJ
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -139757,22 +138739,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-fKD
-gkC
-ygn
-mrW
-jrJ
-oZp
-qjh
-dvi
-iIr
-oZp
-ooW
-nRJ
-sCD
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -140059,22 +139041,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-wEC
-ixQ
-jGl
-oZp
-baS
-oZp
-nAF
-gkC
-jAu
-oZp
-rbE
-jBr
-rbE
-jCy
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -140361,22 +139343,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-oZp
-oZp
-oZp
-oZp
-wqx
-oZp
-sOF
-sQI
-qmS
-vuv
-vuv
-xOG
-vuv
-vuv
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -140663,22 +139645,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-tiw
-vMQ
-roO
-hdN
-jXY
-oZp
-oZp
-oZp
-oZp
-vuv
-lcr
-idW
-wfq
-vuv
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -140965,22 +139947,22 @@ oeA
 oeA
 oeA
 oeA
-ojw
-oZp
-oZp
-oZp
-xbx
-jXY
-jXY
-oZp
-nbP
-wZT
-khg
-vuv
-rBC
-aDS
-jUf
-had
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -141267,22 +140249,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-xap
-vMQ
-jXY
-xPc
-jXY
-sVw
-jXY
-xPc
-kCV
-vuv
-hRD
-okc
-hAF
-rsT
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -141569,22 +140551,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-oZp
-oZp
-jXY
-jXY
-gbA
-oZp
-jXY
-jXY
-tjw
-vuv
-rSi
-xwd
-atG
-baq
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA
@@ -141871,22 +140853,22 @@ oeA
 oeA
 oeA
 oeA
-mwn
-oZp
-lve
-vMQ
-kHl
-jXY
-dEG
-oZp
-hED
-cKb
-wMJ
-vuv
-nbk
-ewo
-vuv
-vuv
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
 oeA
 oeA
 oeA

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -125,6 +125,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
@@ -7434,6 +7437,12 @@
 "dun" = (
 /turf/simulated/floor/black,
 /area/station/engine/elect)
+"duN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
 "duZ" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "2"
@@ -19206,6 +19215,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
@@ -22125,6 +22137,14 @@
 /turf/simulated/floor/black,
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
+	})
+"jLv" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/outer/sw{
+	name = "Southwest Breach Hull"
 	})
 "jLL" = (
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -25444,6 +25464,16 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/elect)
+"leS" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/space/fluid/acid/clear,
+/area/station/ai_monitored/armory)
 "leU" = (
 /obj/cable,
 /obj/machinery/computer/power_monitor{
@@ -27091,6 +27121,9 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish,
 /obj/lattice,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/space/fluid/acid/clear,
 /area/station/ai_monitored/armory)
 "lPy" = (
@@ -29152,6 +29185,16 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
+"mIj" = (
+/obj/grille/steel,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/ai_monitored/armory)
 "mIv" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer{
@@ -38432,6 +38475,9 @@
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 9
@@ -49361,6 +49407,9 @@
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/sw{
@@ -89612,7 +89661,7 @@ llS
 tkp
 tzj
 qLh
-rhC
+leS
 rhC
 jjE
 aUV
@@ -89914,7 +89963,7 @@ iCA
 acA
 qJo
 qLh
-qLh
+duN
 jjE
 jjE
 jjE
@@ -90216,8 +90265,8 @@ qLh
 qLh
 qLh
 qLh
-rnQ
-jjE
+mIj
+jLv
 acI
 nyP
 vcl

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -20797,7 +20797,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/hydroponics/bay)
+/area/station/science/teleporter)
 "jdK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -41169,7 +41169,9 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/table/reinforced/auto,
+/obj/table/reinforced/chemistry/auto{
+	name = "prep counter"
+	},
 /obj/machinery/espresso_machine{
 	pixel_y = 7
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5052,6 +5052,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"ckM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters_east)
 "ckR" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -35669,6 +35676,7 @@
 /obj/cable{
 	icon_state = "2-9"
 	},
+/obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/east,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
@@ -113057,7 +113065,7 @@ ygn
 ebd
 eVi
 lAS
-nRJ
+ckM
 usM
 vaE
 mrW

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -388,6 +388,13 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"ahx" = (
+/obj/disposalpipe/segment/transport,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "ahN" = (
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
@@ -1721,7 +1728,7 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/obj/disposalpipe/segment/bent/south,
+/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aLz" = (
@@ -1948,7 +1955,7 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/area/station/maintenance/inner/west)
 "aTt" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/landmark/gps_waypoint,
@@ -2670,6 +2677,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
+"bkl" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "bko" = (
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -3338,6 +3351,10 @@
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
+"bwx" = (
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "bwA" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -3610,6 +3627,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
 "bCq" = (
@@ -5198,6 +5216,10 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
+"cqm" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/west)
 "cqt" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
@@ -5458,6 +5480,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"cxr" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "cxw" = (
 /obj/table/nanotrasen/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -6602,7 +6635,7 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black/side{
+/turf/simulated/floor/yellowblack{
 	dir = 4
 	},
 /area/station/hallway/secondary/east)
@@ -7132,6 +7165,18 @@
 /obj/reagent_dispensers/beerkeg,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"dqr" = (
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4
+	},
+/obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/space)
 "dqs" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -7163,13 +7208,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"dqZ" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "drc" = (
 /obj/disposalpipe/segment/food,
 /obj/wingrille_spawn/auto,
@@ -7733,7 +7771,6 @@
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "dCt" = (
@@ -10567,6 +10604,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/baroffice)
 "eQG" = (
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "eQO" = (
@@ -10733,10 +10771,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"eTy" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "eTI" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10965,6 +10999,9 @@
 	dir = 10
 	},
 /obj/machinery/meter,
+/obj/cable/orange{
+	icon_state = "6-10"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
@@ -11121,6 +11158,16 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/arrival/station)
+"feY" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "ffx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -11390,9 +11437,16 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"fnk" = (
+"fnx" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/area/station/hallway/primary/southeast)
 "fnA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12975,6 +13029,9 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "fYu" = (
@@ -12989,9 +13046,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "fYI" = (
@@ -14122,9 +14177,6 @@
 	name = "Cargo Primary Endpoint"
 	})
 "gwx" = (
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
@@ -14416,6 +14468,7 @@
 "gDo" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/yellow,
 /area/space)
 "gDp" = (
@@ -14567,11 +14620,6 @@
 /obj/item/wrench,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/storage)
-"gGG" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
 "gGH" = (
 /obj/table/round/auto,
 /obj/item/storage/toolbox/emergency,
@@ -15717,8 +15765,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "hft" = (
-/obj/disposalpipe/segment/bent/south,
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -16094,6 +16142,11 @@
 	dir = 1
 	},
 /area/station/science/hall)
+"hlY" = (
+/obj/machinery/plantpot,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/black,
+/area/station/hydroponics/bay)
 "hmy" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16274,7 +16327,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/crew)
 "hrd" = (
-/obj/disposalpipe/junction/right/south,
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/grey/side,
 /area/station/quartermaster/refinery)
 "hri" = (
@@ -16315,6 +16368,9 @@
 	},
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -16571,7 +16627,6 @@
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon6,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
@@ -16800,7 +16855,7 @@
 "hBh" = (
 /obj/storage/closet/wardrobe/mixed,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/area/station/maintenance/inner/west)
 "hBo" = (
 /obj/stool/chair{
 	dir = 4
@@ -18242,7 +18297,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "igp" = (
@@ -20416,7 +20470,7 @@
 	})
 "jej" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black/corner{
+/turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/southeast)
@@ -20492,7 +20546,6 @@
 /obj/decal/tile_edge/floorguide/arrow_n{
 	dir = 1
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "jfT" = (
@@ -20838,6 +20891,9 @@
 	dir = 4
 	},
 /obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/space)
 "jpQ" = (
@@ -22358,6 +22414,7 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "jWw" = (
@@ -22877,6 +22934,10 @@
 	dir = 8
 	},
 /obj/landmark/halloween,
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "kjb" = (
@@ -23390,13 +23451,13 @@
 	name = "The Warrens"
 	})
 "kse" = (
-/obj/disposalpipe/segment/transport,
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour15;desc=On your right is the Tool Storage, equipped with maintenance and repair supplies - further ahead is an elevator with access to the Site sub-level and natural trenches.";
 	freq = 1443;
 	location = "tour14";
 	name = "tour 14 - east2"
 	},
+/obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "ksh" = (
@@ -23791,6 +23852,10 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
+"kyI" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "kyK" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/paper_bin,
@@ -24661,6 +24726,10 @@
 "kUs" = (
 /turf/simulated/floor/greenblack/corner,
 /area/station/storage/emergencyinternals)
+"kUx" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "kUI" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -26523,6 +26592,9 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "lJs" = (
@@ -27046,6 +27118,7 @@
 "lVG" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "lVO" = (
@@ -28938,10 +29011,14 @@
 /area/space)
 "mKK" = (
 /obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/transport,
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
+"mKY" = (
+/obj/machinery/plantpot,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/grass,
+/area/station/hydroponics/bay)
 "mLB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29609,6 +29686,7 @@
 	dir = 8
 	},
 /obj/landmark/halloween,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northeast)
 "ncu" = (
@@ -30482,7 +30560,7 @@
 	dir = 1;
 	pixel_y = 16
 	},
-/turf/simulated/floor/black/side{
+/turf/simulated/floor/yellowblack{
 	dir = 5
 	},
 /area/station/hallway/primary/southeast)
@@ -30986,13 +31064,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
-"nIK" = (
-/obj/disposalpipe/segment/transport,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/northeast)
 "nIO" = (
 /obj/machinery/computer/power_monitor{
 	dir = 4;
@@ -31517,7 +31588,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/vertical,
 /obj/machinery/door/airlock/pyro/alt,
 /obj/access_spawn/hydro,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -32044,12 +32114,6 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
-"olA" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/hallway/secondary/east)
 "olC" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -32210,10 +32274,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/engine/glow,
 /area/station/ai_monitored/armory)
-"opC" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/refinery)
 "opJ" = (
 /turf/simulated/floor/blackwhite{
 	dir = 1
@@ -32265,6 +32325,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
+"oqO" = (
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "orS" = (
 /obj/table/reinforced/auto,
 /obj/item/shaker/salt{
@@ -33580,6 +33645,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "oVX" = (
@@ -33648,6 +33714,9 @@
 /obj/machinery/drainage,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -33952,16 +34021,6 @@
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
 	})
-"pfn" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "pfr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34926,6 +34985,7 @@
 "pDb" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "pDy" = (
@@ -36023,10 +36083,6 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon4,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
-"qfI" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "qfP" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -36441,8 +36497,8 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/black,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/yellowblack/corner,
 /area/space)
 "qrL" = (
 /obj/machinery/floorflusher/solitary,
@@ -38263,6 +38319,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/east)
 "rne" = (
@@ -39163,7 +39220,7 @@
 /area/station/medical/dome)
 "rKn" = (
 /obj/cable/orange{
-	icon_state = "4-8"
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/space)
@@ -40303,6 +40360,11 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"skM" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/southeast)
 "skO" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -40366,7 +40428,6 @@
 	},
 /area/station/science/hall)
 "smp" = (
-/obj/disposalpipe/segment/transport,
 /obj/decal/tile_edge/floorguide/arrow_w{
 	dir = 4
 	},
@@ -40475,7 +40536,7 @@
 /area/station/security/hos)
 "snR" = (
 /obj/disposalpipe/segment/transport{
-	dir = 4
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black/corner{
 	dir = 8
@@ -41295,9 +41356,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
-/obj/cable/orange{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
@@ -42032,6 +42090,7 @@
 /area/station/hallway/primary/northeast)
 "sUB" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "sUF" = (
@@ -42565,7 +42624,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "teP" = (
-/turf/simulated/floor/black/corner{
+/turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/southeast)
@@ -42676,7 +42735,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "tgS" = (
@@ -42694,6 +42752,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "tgU" = (
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/greenblack{
 	dir = 10
 	},
@@ -44363,6 +44422,9 @@
 	opacity = 0;
 	dir = 4
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "tUn" = (
@@ -44475,7 +44537,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/northeast)
 "tYe" = (
-/turf/space,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "tYl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -44573,6 +44640,15 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"tZU" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "uar" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -45046,6 +45122,12 @@
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"unW" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "unY" = (
 /turf/simulated/floor/redblack/corner{
 	dir = 1
@@ -45599,6 +45681,7 @@
 	})
 "uBb" = (
 /obj/cable,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "uBf" = (
@@ -45799,6 +45882,7 @@
 "uGM" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "uHj" = (
@@ -46315,6 +46399,7 @@
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "uTB" = (
@@ -46401,6 +46486,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"uWr" = (
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uWw" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/networked/storage/scanner{
@@ -46912,13 +47002,6 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
-"vkn" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "vkq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47307,10 +47390,6 @@
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack,
 /area/station/security/equipment)
-"vui" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black/corner,
-/area/station/hallway/secondary/east)
 "vuv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads{
@@ -48143,6 +48222,10 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"vOt" = (
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "vOG" = (
 /obj/machinery/sleeper/compact,
 /obj/machinery/light/incandescent/netural{
@@ -48970,7 +49053,7 @@
 	dir = 4
 	},
 /obj/cable/orange{
-	icon_state = "4-8"
+	icon_state = "4-9"
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
@@ -49968,6 +50051,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "wJT" = (
@@ -49986,6 +50070,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"wJW" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "wKF" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/engine/caution/south,
@@ -50177,6 +50267,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "wRi" = (
@@ -50476,12 +50567,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction/left/west,
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "wYE" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_engine,
+/obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/engine,
 /area/space)
 "wYK" = (
@@ -50848,6 +50940,9 @@
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon9,
 /obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "xhg" = (
@@ -51079,6 +51174,16 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"xmt" = (
+/obj/disposalpipe/segment/transport,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "xmz" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/matsci_guide,
@@ -51552,6 +51657,9 @@
 /obj/cable{
 	icon_state = "4-10"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "xyR" = (
@@ -51767,15 +51875,6 @@
 	dir = 1
 	},
 /area/station/security/main)
-"xCs" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "xCu" = (
 /obj/machinery/door_control{
 	id = "nadir_disposalock";
@@ -52039,7 +52138,6 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "xII" = (
@@ -52078,12 +52176,6 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
-"xJA" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "xJE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -79412,7 +79504,7 @@ dqY
 dqY
 dqY
 pDy
-mWE
+pDy
 pDy
 mWE
 cVU
@@ -79432,7 +79524,7 @@ teB
 cVU
 bQV
 pDy
-bQV
+pDy
 pDy
 dqY
 dqY
@@ -80620,7 +80712,7 @@ dqY
 gbL
 dqY
 pDy
-mWE
+pDy
 pDy
 mWE
 cVU
@@ -80640,7 +80732,7 @@ umD
 cVU
 bQV
 pDy
-bQV
+pDy
 pDy
 dqY
 gbL
@@ -87871,10 +87963,10 @@ jdV
 jdV
 jdV
 jdV
-jdV
-fLE
-wqA
-vyr
+kUx
+mKY
+cqm
+uWr
 aLf
 rsG
 oJc
@@ -88173,7 +88265,7 @@ jdV
 bJI
 bJI
 jdV
-jdV
+kyI
 fDR
 wqA
 vyr
@@ -88475,7 +88567,7 @@ jdV
 bJI
 egJ
 jdV
-jdV
+kyI
 fLE
 wqA
 naz
@@ -88777,7 +88869,7 @@ jdV
 bJI
 bJI
 jdV
-jdV
+kyI
 lDX
 wqA
 hWN
@@ -89079,7 +89171,7 @@ jdV
 jdV
 jdV
 jdV
-jdV
+kyI
 fLE
 wqA
 vyr
@@ -89381,7 +89473,7 @@ jdV
 jdV
 jdV
 jdV
-jdV
+kyI
 fDR
 wqA
 auj
@@ -89683,7 +89775,7 @@ jdV
 bJI
 bJI
 jdV
-jdV
+kyI
 fLE
 wqA
 txT
@@ -89985,7 +90077,7 @@ jdV
 bJI
 rUj
 jdV
-jdV
+kyI
 oCN
 wqA
 wqA
@@ -90287,7 +90379,7 @@ jdV
 bJI
 bJI
 jdV
-jdV
+kyI
 fLE
 wqA
 hEe
@@ -90589,7 +90681,7 @@ jdV
 jdV
 jdV
 jdV
-jdV
+kyI
 fDR
 wqA
 oEZ
@@ -91797,7 +91889,7 @@ hOK
 ajV
 ajV
 ajV
-loU
+hlY
 loU
 kry
 irP
@@ -92099,8 +92191,8 @@ ajV
 ajV
 ajV
 ajV
-eTy
-qfI
+omx
+ajV
 tgQ
 igl
 igl
@@ -94228,9 +94320,9 @@ jRu
 fYj
 lJi
 vRv
-vRv
+jmJ
 jUz
-mUC
+jmJ
 jmJ
 jmJ
 eGA
@@ -94832,7 +94924,7 @@ qVd
 qVd
 jKH
 boK
-fnk
+cvc
 cvc
 cvc
 cOM
@@ -95134,7 +95226,7 @@ tpv
 tpv
 bPO
 vRv
-vRv
+mUC
 cvc
 ppA
 mUC
@@ -95736,11 +95828,11 @@ cNY
 fmO
 nBp
 fmO
-fnk
-gGG
-fnk
 cvc
-pfn
+pDb
+cvc
+cvc
+cvc
 vne
 pqn
 aVa
@@ -96038,12 +96130,12 @@ lYL
 ocX
 qHV
 fmO
-cvc
+bwx
 mUC
 mUC
 mUC
 mUC
-mUC
+kBB
 kBB
 kBB
 kBB
@@ -96345,7 +96437,7 @@ mUC
 cvc
 cvc
 ooq
-mUC
+kBB
 dzR
 bks
 kBB
@@ -96647,7 +96739,7 @@ pDb
 cvc
 cvc
 cvc
-mUC
+kBB
 acs
 fGD
 pXV
@@ -96949,7 +97041,7 @@ mUC
 cvc
 cvc
 cvc
-mUC
+kBB
 uyD
 pyi
 kBB
@@ -97246,14 +97338,14 @@ sDF
 czo
 cfj
 fmO
-cvc
+feY
 mUC
 mUC
 mUC
 mUC
-mUC
-mUC
-mUC
+kBB
+kBB
+kBB
 kBB
 jTO
 vHa
@@ -103281,8 +103373,8 @@ hft
 iBT
 iBT
 hrd
-iBT
-opC
+qiE
+xZH
 dxd
 dxd
 dxd
@@ -103579,7 +103671,7 @@ xZH
 qeJ
 oxO
 pFf
-qeJ
+wJW
 fte
 uhy
 aVI
@@ -104183,21 +104275,21 @@ kFd
 pzd
 xpP
 lxX
-iTi
+hQs
 vGu
 sQU
 qyt
 xpP
 cib
 hQp
-hQs
-xCs
+iTi
+iTi
+iTi
+iTi
+iTi
 hQB
+iTi
 vGW
-tYe
-tYe
-tYe
-tYe
 qnF
 ezi
 ezi
@@ -104470,40 +104562,40 @@ sUv
 rJy
 sUv
 snR
-lsj
+buF
 eQG
 nbX
 eQG
 bCg
 rmX
 uBb
-mDQ
-mDQ
-mDQ
-mDQ
-mDQ
-mDQ
-mDQ
+qwj
+qwj
+qwj
+qwj
+qwj
+qwj
+qwj
 sUB
-mDQ
-mDQ
-cKX
-cKX
-mDQ
-mDQ
+oqO
+qwj
+aXE
+aXE
+qwj
+qwj
 oVJ
-dqZ
-xJA
 fYG
-vkn
-tYe
-tYe
-tYe
+fYG
+fYG
+ahx
+ahx
+xmt
+ahx
 tYe
 rmX
 wRc
-rZb
-aOF
+tdq
+skM
 kiY
 aOF
 rZb
@@ -104776,32 +104868,32 @@ smp
 jfB
 hwY
 dCr
-nIK
+jdT
 mKK
-qwj
-qwj
-qwj
-qwj
-qwj
-qwj
-qwj
+mDQ
+mDQ
+mDQ
+mDQ
+mDQ
+mDQ
+mDQ
 xIE
-qwj
-qwj
+mDQ
+vOt
 kse
-aXE
+xPJ
 qrF
-qwj
-qwj
-mDQ
-mDQ
-vui
-olA
-olA
-tYe
-tYe
-tYe
-tYe
+unW
+unW
+unW
+cxr
+unW
+unW
+unW
+cxr
+unW
+unW
+unW
 cYD
 jej
 sFL
@@ -105108,7 +105200,7 @@ siL
 nyR
 teP
 vEo
-rZb
+bkl
 vEo
 oHA
 skO
@@ -105408,9 +105500,9 @@ aZM
 vwd
 siL
 siL
-yiB
+bEm
 vEo
-oZk
+tZU
 vEo
 vyU
 dfH
@@ -105712,7 +105804,7 @@ bMH
 siL
 sXH
 qwN
-pOW
+fnx
 qwN
 sXH
 hWH
@@ -106316,7 +106408,7 @@ aut
 ajo
 bEm
 vEo
-fdg
+iPJ
 vEo
 krn
 hWH
@@ -106618,7 +106710,7 @@ aut
 ajo
 bEm
 vEo
-fdg
+iPJ
 vEo
 vIQ
 hWH
@@ -107222,7 +107314,7 @@ gNa
 siL
 bEm
 sVX
-fdg
+iPJ
 wlW
 fMN
 qbA
@@ -107524,7 +107616,7 @@ sSm
 gDo
 bEm
 vEo
-fdg
+iPJ
 uEI
 dOr
 uBt
@@ -110841,7 +110933,7 @@ siL
 siL
 siL
 siL
-siL
+dqr
 siL
 siL
 yiB

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -396,10 +396,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "ahN" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 1
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_minetop";
+	name = "Elevator Loading Door"
 	},
-/area/shuttle/sea_elevator/upper)
+/turf/simulated/floor/caution/northsouth,
+/area/station/mining/staff_room)
 "ahQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
@@ -934,6 +937,13 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
+"asK" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
 "asM" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -1117,9 +1127,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "axd" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/obj/disposalpipe/segment/mineral{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "axq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1766,10 +1779,15 @@
 	},
 /area/station/security/main)
 "aMA" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
 	},
-/area/shuttle/sea_elevator/upper)
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "aNe" = (
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/hallway/secondary/construction{
@@ -1979,6 +1997,13 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"aTy" = (
+/obj/disposalpipe/segment/bent/west,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "aTK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1994,6 +2019,20 @@
 	dir = 9
 	},
 /area/listeningpost/power)
+"aUS" = (
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = -28
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/space)
 "aUV" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2124,6 +2163,14 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"aWX" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/space)
 "aWY" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/redblack,
@@ -2144,6 +2191,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"aXs" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/mining/staff_room)
 "aXu" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
 	dir = 4
@@ -2157,8 +2207,14 @@
 /area/station/medical/robotics)
 "aXE" = (
 /obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/hallway/secondary/east)
 "aXK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2333,6 +2389,7 @@
 	})
 "bbm" = (
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "bbq" = (
@@ -2346,6 +2403,11 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
+"bbK" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
+	},
+/area/space)
 "bck" = (
 /obj/stool/bench/wooden/auto,
 /obj/disposalpipe/segment/vertical,
@@ -2405,6 +2467,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/detectives_office)
+"bdz" = (
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/space)
 "bdB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2430,6 +2506,10 @@
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
 /area/station/medical/head)
+"beh" = (
+/obj/machinery/door/airlock/pyro/alt,
+/turf/simulated/floor/black,
+/area/space)
 "bel" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/cable/orange,
@@ -2509,6 +2589,12 @@
 /obj/storage/closet/office,
 /turf/simulated/floor/black/side,
 /area/station/storage/tools)
+"bfW" = (
+/obj/machinery/manufacturer/mining,
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/mining/staff_room)
 "bgj" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -2656,6 +2742,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "bjQ" = (
@@ -2666,12 +2753,11 @@
 	name = "Genetic Research"
 	})
 "bjU" = (
-/obj/machinery/disposal/mail/autoname/qm,
-/obj/disposalpipe/trunk/mail/west,
 /obj/noticeboard/persistent{
 	name = "Cargo persistent notice board";
 	persistent_id = "cargo"
 	},
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -2713,6 +2799,10 @@
 /obj/shrub,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"bkJ" = (
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "bkQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/treatment1)
@@ -2846,6 +2936,7 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "boT" = (
@@ -3455,18 +3546,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"byw" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "byA" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
@@ -3567,16 +3646,6 @@
 	dir = 1
 	},
 /area/station/storage/emergencyinternals)
-"bBa" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lobby{
-	name = "Science Lounge"
-	})
 "bBd" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black/corner{
@@ -4127,6 +4196,7 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
 "bPO" = (
+/obj/storage/secure/closet/personal,
 /turf/simulated/floor/grey/side{
 	dir = 6
 	},
@@ -4562,6 +4632,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
+"bYd" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "bYs" = (
 /obj/rack,
 /obj/item/reagent_containers/glass/bucket,
@@ -4657,6 +4734,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "cbx" = (
@@ -4712,7 +4790,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/hallway/secondary/exit)
 "cdg" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
@@ -4846,6 +4924,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"cgu" = (
+/obj/cable{
+	icon_state = "1-10"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "cgS" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
@@ -5246,7 +5330,7 @@
 "cqm" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/west)
+/area/station/hydroponics/bay)
 "cqt" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
@@ -5885,18 +5969,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "cHo" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
+/obj/machinery/portable_reclaimer,
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/simulated/floor/yellowblack{
 	dir = 4
 	},
+/area/station/mining/staff_room)
+"cHQ" = (
+/obj/disposalpipe/segment/transport,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/access_spawn/maint,
 /turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/area/station/hallway/secondary/east)
 "cHV" = (
 /obj/stool/chair/couch{
 	desc = "It's comfortable, but has an aura of unease about it, like somebody's watching you the moment you sit down.";
@@ -6012,10 +6103,9 @@
 /turf/simulated/floor/black,
 /area/space)
 "cLn" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
 /obj/machinery/light,
+/obj/machinery/disposal/mail/autoname/qm,
+/obj/disposalpipe/trunk/mail/north,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
@@ -6182,6 +6272,7 @@
 /area/station/maintenance/west)
 "cOM" = (
 /obj/machinery/space_heater,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "cPh" = (
@@ -6829,6 +6920,20 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
+"dcD" = (
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/space)
 "dcH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
@@ -6878,23 +6983,11 @@
 	},
 /area/station/medical/medbay/cloner)
 "dfC" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black/side{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/area/station/hallway/secondary/east)
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "dfH" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -6970,6 +7063,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/elect)
+"dhS" = (
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/space)
 "dif" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7047,10 +7144,10 @@
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
 "dkT" = (
-/obj/machinery/processor,
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
+/obj/machinery/arc_electroplater,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -7093,6 +7190,13 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southwest)
+"dmC" = (
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "dmE" = (
 /turf/unsimulated/wall/setpieces/leadwall/gray{
 	dir = 8;
@@ -7166,6 +7270,32 @@
 /obj/machinery/turret,
 /turf/simulated/floor/circuit/white,
 /area/station/turret_protected/ai_upload)
+"doE" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
+	},
+/area/shuttle/sea_elevator_room)
+"dpb" = (
+/obj/rack,
+/obj/disposalpipe/segment/mineral,
+/obj/item/clothing/suit/space/diving/engineering,
+/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
+/obj/item/clothing/mask/breath{
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/device/nanoloom{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/tank/mini_oxygen{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/mining/staff_room)
 "dpk" = (
 /obj/machinery/vending/standard,
 /turf/simulated/floor/industrial,
@@ -7347,6 +7477,14 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"dtq" = (
+/obj/item/storage/secure/ssafe{
+	pixel_x = 26
+	},
+/obj/machinery/light/small,
+/obj/table/reinforced/auto,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/space)
 "dtx" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/cable{
@@ -7487,6 +7625,7 @@
 	location = "tour6";
 	name = "tour 6 - escape"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/blackwhite{
 	dir = 5
 	},
@@ -7620,6 +7759,17 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"dzn" = (
+/obj/storage/crate,
+/obj/item/clothing/under/misc/vice,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/space)
 "dzt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour1;desc=Hey, everyone. I'm Mariana, your personal guide to the Nadir Extraction Site, Nanotrasen's most advanced facility cleared for general personnel. Let's get going!";
@@ -7921,6 +8071,9 @@
 	dir = 8
 	},
 /obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/space)
 "dDw" = (
@@ -8006,7 +8159,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
@@ -8491,6 +8643,12 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"dRA" = (
+/obj/cable{
+	icon_state = "6-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "dRD" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -8744,6 +8902,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
+"dYx" = (
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/space)
 "dYJ" = (
 /obj/kitchenspike,
 /turf/simulated/floor/specialroom/freezer,
@@ -8755,6 +8918,9 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/bridge)
+"dYV" = (
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "dZk" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9117,6 +9283,12 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"egW" = (
+/obj/item/storage/secure/ssafe{
+	pixel_x = 28
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/space)
 "ehQ" = (
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/computer/power_monitor/smes{
@@ -9196,6 +9368,10 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"ejz" = (
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "ejP" = (
 /obj/machinery/power/furnace,
 /obj/cable{
@@ -9449,6 +9625,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/redblack/corner,
 /area/station/hallway/secondary/exit)
 "epj" = (
@@ -9586,6 +9763,13 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
+"esc" = (
+/obj/machinery/light/small/warm/very{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "esh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9895,6 +10079,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
+"ezG" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "ezI" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -10010,6 +10200,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "eCR" = (
@@ -10275,6 +10466,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/northeast)
 "eIz" = (
@@ -10352,6 +10546,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"eKf" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "eKw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/emergencyinternals)
@@ -10510,12 +10708,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"eNW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "eOn" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -10931,12 +11123,6 @@
 	dir = 4
 	},
 /area/station/storage/emergency)
-"eWn" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "eWr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -11357,6 +11543,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
+"fjq" = (
+/obj/stool/chair/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/space)
 "fjA" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/black,
@@ -11772,6 +11964,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/redblack/corner{
 	dir = 8
 	},
@@ -12151,6 +12344,11 @@
 	dir = 8
 	},
 /area/station/medical/medbay/cloner)
+"fAv" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/space)
 "fAy" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -12494,6 +12692,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "fKD" = (
@@ -12663,6 +12862,16 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/greenblack,
 /area/station/ranch)
+"fNE" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 5
+	},
+/area/station/mining/staff_room)
 "fNH" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_mrsmuggles"
@@ -12847,6 +13056,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/artifact)
+"fRN" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/purpleblack{
+	dir = 8
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "fRP" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -13117,6 +13340,11 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
+"fYT" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 1
+	},
+/area/space)
 "fZb" = (
 /turf/simulated/floor/shuttlebay,
 /area/pasiphae/hangar)
@@ -13138,6 +13366,13 @@
 	},
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
+"fZj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "fZD" = (
 /obj/machinery/recharger/wall/sticky{
 	dir = 1;
@@ -13749,7 +13984,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "glC" = (
 /obj/machinery/light/small,
 /obj/cable{
@@ -13950,6 +14187,13 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"gqq" = (
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "gqO" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -14286,6 +14530,7 @@
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
 "gxC" = (
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
 "gxH" = (
@@ -14556,6 +14801,7 @@
 	icon_state = "1-2"
 	},
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "gEe" = (
@@ -14772,6 +15018,12 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
+"gIk" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "gIl" = (
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
@@ -14928,6 +15180,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "gMh" = (
@@ -15280,6 +15533,12 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"gUh" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "gUi" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/medical_surgery_guide{
@@ -15576,6 +15835,41 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/redblack,
 /area/station/security/main)
+"haa" = (
+/obj/table/reinforced/auto,
+/obj/item/device/gps{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/device/gps{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/gps{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/item/nanoloom_cartridge{
+	pixel_y = -2;
+	pixel_x = 10
+	},
+/obj/item/nanoloom_cartridge{
+	pixel_y = -4;
+	pixel_x = 7
+	},
+/obj/item/storage/pill_bottle/antirad{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 10
+	},
+/area/station/mining/staff_room)
 "had" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -15632,6 +15926,13 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
+"haC" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "haF" = (
 /turf/simulated/floor/blackwhite{
 	dir = 8
@@ -15761,6 +16062,16 @@
 	dir = 4
 	},
 /area/station/storage/emergency)
+"hdl" = (
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = 23
+	},
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/mining/staff_room)
 "hdG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -15885,6 +16196,12 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"hgF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "hgG" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -16222,11 +16539,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/escape)
-"hmE" = (
-/turf/simulated/floor/engine/caution/corner{
-	dir = 8
-	},
-/area/shuttle/sea_elevator/upper)
 "hmF" = (
 /obj/machinery/door/unpowered/wood/pyro,
 /turf/simulated/floor/carpet/green/standard/narrow/north,
@@ -16306,6 +16618,19 @@
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
+"hoD" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
+"hoO" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
 "hoR" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light_switch/north,
@@ -16478,6 +16803,18 @@
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/crew_quarters/courtroom)
+"hsY" = (
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "htX" = (
 /obj/machinery/disposal/mail/autoname/public/medbay_lobby,
 /obj/disposalpipe/trunk/mail/north,
@@ -16806,10 +17143,7 @@
 	})
 "hyM" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/checkpoint/escape)
@@ -17568,13 +17902,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"hQp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "hQq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18147,6 +18474,13 @@
 /obj/item/device/microphone,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"ibt" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/bot_storage)
 "ibI" = (
 /obj/storage/crate,
 /obj/item/clothing/under/misc/vice,
@@ -19189,6 +19523,18 @@
 /obj/towelbin,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
+"iyt" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/space)
 "iyG" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -19239,6 +19585,7 @@
 	},
 /area/station/medical/head)
 "iyZ" = (
+/obj/machinery/photocopier,
 /turf/simulated/floor/grey/side{
 	dir = 5
 	},
@@ -19445,6 +19792,20 @@
 	},
 /obj/lattice,
 /turf/space/fluid/acid/clear,
+/area/space)
+"iDs" = (
+/obj/machinery/computer/sea_elevator{
+	dir = 8
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small/warm/very{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
 /area/space)
 "iDO" = (
 /obj/disposalpipe/segment/brig{
@@ -19970,6 +20331,18 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"iSq" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour15;desc=This is the Site's nuclear reactor section. Please do not linger here during operation. Tool storage is across the hall.";
+	freq = 1443;
+	location = "tour14";
+	name = "tour 14 - east2"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "iSv" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -20059,6 +20432,14 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/grey,
 /area/pasiphae/sys)
+"iVK" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "iVP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/morgue)
@@ -20203,6 +20584,24 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
+"iZs" = (
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/food/snacks/popcorn{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/popcorn{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/space)
 "iZE" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -20396,11 +20795,6 @@
 	dir = 1
 	},
 /area/station/storage/emergency2)
-"jcz" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black,
-/area/space)
 "jcF" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
@@ -20498,7 +20892,7 @@
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
-/area/station/science/teleporter)
+/area/station/hydroponics/bay)
 "jdK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20565,6 +20959,12 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"jfa" = (
+/obj/cable{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "jfd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20631,14 +21031,6 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"jgk" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black,
-/area/space)
 "jgK" = (
 /obj/cable{
 	icon_state = "5-10"
@@ -21154,12 +21546,37 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"jsE" = (
+/obj/rack,
+/obj/item/clothing/suit/space/diving/engineering,
+/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
+/obj/item/clothing/mask/breath{
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/device/nanoloom{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/tank/mini_oxygen{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/mining/staff_room)
 "jsJ" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
+"jsQ" = (
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "jsU" = (
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -21695,6 +22112,10 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_east)
+"jGq" = (
+/obj/table/reinforced/auto,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "jGr" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -21797,6 +22218,11 @@
 	dir = 8
 	},
 /area/station/storage/emergency2)
+"jIw" = (
+/obj/machinery/light/small,
+/obj/table/reinforced/auto,
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/space)
 "jJk" = (
 /obj/lattice{
 	dir = 5;
@@ -21867,6 +22293,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "jKH" = (
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/market)
 "jKJ" = (
@@ -22447,6 +22874,13 @@
 	dir = 4
 	},
 /area/listeningpost)
+"jVj" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/mining,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "jVB" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -22977,6 +23411,11 @@
 	dir = 5
 	},
 /area/station/engine/elect)
+"kiz" = (
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/space)
 "kiY" = (
 /obj/decal/tile_edge/floorguide/evac,
 /obj/decal/tile_edge/floorguide/evac{
@@ -23506,14 +23945,13 @@
 	name = "The Warrens"
 	})
 "kse" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour15;desc=On your right is the Tool Storage, equipped with maintenance and repair supplies - further ahead is an elevator with access to the Site sub-level and natural trenches.";
-	freq = 1443;
-	location = "tour14";
-	name = "tour 14 - east2"
-	},
 /obj/disposalpipe/junction/middle/east,
-/turf/simulated/floor/black,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
 /area/station/hallway/secondary/east)
 "ksh" = (
 /obj/cable{
@@ -24278,10 +24716,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"kGN" = (
-/obj/stool/chair,
-/turf/simulated/floor/black,
-/area/space)
 "kGW" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
@@ -24700,6 +25134,17 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
+"kRP" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/black,
+/area/space)
+"kRT" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "kSp" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -24749,6 +25194,18 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
+"kUc" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 9
+	},
+/area/station/mining/staff_room)
 "kUe" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/specialroom/gym/alt,
@@ -25252,12 +25709,6 @@
 /obj/random_item_spawner/tools/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"lev" = (
-/obj/shrub,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/hallway/secondary/east)
 "leK" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -25411,14 +25862,10 @@
 /turf/simulated/floor/grey,
 /area/pasiphae/crew)
 "liA" = (
-/obj/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/tank/mini_oxygen{
-	pixel_x = 8
+/turf/simulated/floor/yellowblack{
+	dir = 8
 	},
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/area/station/mining/staff_room)
 "liC" = (
 /obj/machinery/sleeper/compact,
 /obj/machinery/camera{
@@ -25635,6 +26082,10 @@
 	dir = 4
 	},
 /area/abandonedmedicalship/robot_trader)
+"lmN" = (
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/space)
 "lmY" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm,
@@ -25811,14 +26262,6 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
-"lsa" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
-/area/station/hallway/secondary/east)
 "lsj" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
@@ -25917,7 +26360,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk/south,
+/obj/disposalpipe/trunk/east,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "lue" = (
@@ -26065,6 +26508,9 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
+"lxv" = (
+/turf/simulated/floor/carpet/red,
+/area/space)
 "lxA" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/door/airlock/pyro/alt,
@@ -26622,11 +27068,6 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"lIN" = (
-/turf/simulated/floor/purpleblack{
-	dir = 4
-	},
-/area/space)
 "lIR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -26677,6 +27118,13 @@
 /area/station/engine/substation/north{
 	name = "North Catalytic Substation"
 	})
+"lKL" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "lKN" = (
 /turf/simulated/floor/carpet/purple/standard/narrow/ne,
 /area/station/chapel/sanctuary)
@@ -26792,6 +27240,13 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
+"lMr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
 "lMz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27158,8 +27613,10 @@
 	},
 /area/station/science/hall)
 "lVi" = (
-/turf/simulated/floor/plating,
-/area/shuttle/sea_elevator_room)
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/mining,
+/turf/simulated/floor/caution/northsouth,
+/area/station/mining/staff_room)
 "lVy" = (
 /obj/reagent_dispensers/foamtank,
 /obj/machinery/power/apc/autoname_north,
@@ -27179,6 +27636,9 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "lVO" = (
@@ -27225,6 +27685,12 @@
 /obj/machinery/chemicompiler_stationary,
 /turf/simulated/floor/engine/caution/east,
 /area/station/science/chemistry)
+"lWL" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "lWM" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 2
@@ -27358,6 +27824,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
+"lYD" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/black,
+/area/space)
 "lYL" = (
 /obj/machinery/disposal/mail/autoname/research,
 /obj/disposalpipe/trunk/mail/east,
@@ -27642,6 +28112,13 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/communications/centre)
+"mdY" = (
+/obj/machinery/light/small/warm/very{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "mer" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -27844,6 +28321,13 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"miB" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "miC" = (
 /obj/stool/chair{
 	dir = 4
@@ -28504,11 +28988,6 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
-"mxp" = (
-/turf/simulated/floor/greenblack{
-	dir = 8
-	},
-/area/space)
 "mxA" = (
 /obj/rack,
 /obj/item/reagent_containers/food/drinks/juicer,
@@ -28672,6 +29151,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"mAW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "mCe" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -28967,6 +29455,13 @@
 "mIG" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
+"mIR" = (
+/obj/machinery/light/small/warm/very{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/space)
 "mJj" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/pyro{
@@ -29295,7 +29790,13 @@
 	name = "Extraction Nexus"
 	})
 "mPS" = (
-/obj/machinery/arc_electroplater,
+/obj/disposaloutlet{
+	name = "ore chute outlet";
+	dir = 4
+	},
+/obj/disposalpipe/trunk/mineral{
+	dir = 4
+	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -29312,11 +29813,15 @@
 	dir = 4
 	},
 /area/pasiphae)
+"mQb" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/space)
 "mQd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/bent/north,
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
 "mQl" = (
@@ -29458,6 +29963,7 @@
 /obj/landmark/gps_waypoint{
 	name = "Escape Wing - North"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/redblack/corner,
 /area/station/hallway/secondary/exit)
 "mTZ" = (
@@ -29511,16 +30017,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"mVF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/bent/west,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
 "mWj" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -29731,6 +30227,12 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
+"nbQ" = (
+/obj/machinery/processor,
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/quartermaster/refinery)
 "nbS" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm{
@@ -29847,6 +30349,13 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
+"ner" = (
+/obj/storage/cart/mechcart{
+	desc = "A big rolling supply cart for utility things.";
+	name = "utility cart"
+	},
+/turf/simulated/floor/grey/side,
+/area/station/quartermaster/refinery)
 "nes" = (
 /turf/simulated/floor/black/grime,
 /area/station/storage/warehouse)
@@ -30007,6 +30516,9 @@
 	},
 /turf/space/fluid/acid/clear,
 /area/shuttle/arrival/station)
+"nkd" = (
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/space)
 "nkk" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2/junction{
 	dir = 1
@@ -30047,6 +30559,7 @@
 	name = "South Catalytic Substation"
 	})
 "nlq" = (
+/obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
@@ -30292,6 +30805,11 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"nqF" = (
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "nqG" = (
 /obj/machinery/bot/medbot/no_camera,
 /turf/simulated/floor/shuttle{
@@ -30502,6 +31020,10 @@
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
+"nvD" = (
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "nvK" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -30753,6 +31275,27 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/station/security/hos)
+"nBc" = (
+/obj/storage/secure/closet/immersion{
+	name = "Maintenance Immersion Suit Vault";
+	req_access = list(12)
+	},
+/obj/item/clothing/suit/space/diving/civilian{
+	pixel_x = -4
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/tank/air{
+	pixel_x = 5
+	},
+/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
+	pixel_x = -4
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/shuttle/sea_elevator_room)
 "nBp" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -30843,6 +31386,12 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"nDS" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "nEm" = (
 /obj/storage/secure/closet/immersion/security,
 /obj/item/clothing/suit/space/diving/security{
@@ -31023,6 +31572,11 @@
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
 	})
+"nGn" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 1
+	},
+/area/shuttle/sea_elevator_room)
 "nGo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31321,6 +31875,17 @@
 	dir = 8
 	},
 /area/station/security/interrogation)
+"nNu" = (
+/obj/storage/crate,
+/obj/item/clothing/mask/moustache,
+/obj/item/clothing/suit/wcoat,
+/obj/item/clothing/head/that,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/space)
 "nNI" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/greenblack{
@@ -32077,6 +32642,15 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/inner/east)
+"ohK" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/space)
 "oil" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32445,6 +33019,9 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
+"osB" = (
+/turf/simulated/floor/black/side,
+/area/space)
 "osX" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -32734,6 +33311,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"oyF" = (
+/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
+/turf/simulated/floor/grey/side,
+/area/station/quartermaster/refinery)
 "ozc" = (
 /obj/item/device/light/flashlight{
 	pixel_y = -12;
@@ -32829,6 +33413,15 @@
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
 	})
+"oAx" = (
+/obj/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/tank/mini_oxygen{
+	pixel_x = 8
+	},
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/black,
+/area/space)
 "oAO" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -33338,6 +33931,10 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
+"oNV" = (
+/obj/disposalpipe/segment/bent/west,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "oOu" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/food/drinks/cola/random{
@@ -33702,6 +34299,10 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"oVd" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/space)
 "oVg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33732,16 +34333,6 @@
 /obj/machinery/light_switch/east,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"oVJ" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "oVX" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/wood/two,
@@ -33861,10 +34452,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
-"oYt" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "oYC" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -33910,6 +34497,9 @@
 "oZk" = (
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -34084,6 +34674,14 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
+"peS" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/space)
 "peU" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/industrial,
@@ -34123,9 +34721,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"pft" = (
-/turf/simulated/floor/engine/caution/corner,
-/area/shuttle/sea_elevator/upper)
 "pfN" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/science/lobby{
@@ -34171,6 +34766,7 @@
 /obj/access_spawn/cargo,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
@@ -34361,6 +34957,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/west)
+"pmw" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/black,
+/area/space)
 "pmV" = (
 /obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellowblack{
@@ -34386,7 +34986,9 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
 	},
-/turf/simulated/floor/sanitary,
+/turf/simulated/floor/blackwhite{
+	dir = 1
+	},
 /area/space)
 "poa" = (
 /obj/decal/poster/wallsign/warning1{
@@ -34504,10 +35106,18 @@
 	name = "The Warrens"
 	})
 "pqb" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/obj/table/reinforced/auto,
+/obj/machinery/recharger,
+/obj/item/cargotele,
+/obj/machinery/door_control{
+	id = "nadir_minetop";
+	name = "Loading Door Control";
+	pixel_y = 24
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "pqn" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/bot_storage)
@@ -34584,13 +35194,16 @@
 	},
 /area/station/medical/head)
 "pro" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -35165,6 +35778,10 @@
 	dir = 4
 	},
 /area/ghostdrone_factory)
+"pFX" = (
+/obj/machinery/door/airlock/pyro/alt,
+/turf/simulated/floor/sanitary,
+/area/space)
 "pFY" = (
 /obj/table/nanotrasen/auto,
 /obj/machinery/networked/printer{
@@ -35248,6 +35865,9 @@
 	dir = 4
 	},
 /area/station/crew_quarters/lounge)
+"pIJ" = (
+/turf/simulated/floor/yellowblack,
+/area/station/mining/staff_room)
 "pIU" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor,
@@ -35290,6 +35910,12 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"pJo" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "pJt" = (
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
@@ -35560,6 +36186,25 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"pRS" = (
+/obj/table/wood/auto,
+/obj/item/clothing/head/det_hat{
+	desc = "Ugh, gross.";
+	name = "fedora";
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/blind_switch/area/west,
+/obj/machinery/light/lamp/green{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/nw,
+/area/space)
 "pRY" = (
 /obj/mopbucket,
 /turf/simulated/floor/darkblue,
@@ -35800,6 +36445,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
 "pWY" = (
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -35887,6 +36536,10 @@
 "pYH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
+"pZd" = (
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/mining/staff_room)
 "pZq" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -36431,11 +37084,21 @@
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_east)
 "qmT" = (
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/light/small/warm/very{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
 /area/shuttle/sea_elevator_room)
 "qmY" = (
 /obj/reagent_dispensers/watertank/fountain,
@@ -36488,6 +37151,12 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"qoe" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/hallway/primary/southeast)
 "qog" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36533,6 +37202,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
+"qpA" = (
+/obj/machinery/dispenser,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 6
+	},
+/area/station/mining/staff_room)
 "qqc" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -36585,13 +37265,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
-"qrF" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/space)
 "qrL" = (
 /obj/machinery/floorflusher/solitary,
 /obj/disposalpipe/trunk/brig{
@@ -36616,12 +37289,6 @@
 	dir = 9
 	},
 /area/station/engine/engineering)
-"qsI" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "qsZ" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -36882,12 +37549,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
-"qyt" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/purpleblack{
-	dir = 8
-	},
-/area/space)
 "qyu" = (
 /obj/stool/bed,
 /obj/machinery/light/small,
@@ -36992,6 +37653,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"qAS" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/south,
+/area/space)
 "qAT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37027,6 +37694,9 @@
 	freq = 1443;
 	location = "tour9";
 	name = "tour 9 - east crew"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -37126,6 +37796,19 @@
 "qEj" = (
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"qEl" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/east)
 "qEo" = (
 /obj/machinery/ghostdrone_factory,
 /obj/machinery/conveyor/EW{
@@ -37485,6 +38168,20 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"qOW" = (
+/obj/table/wood/auto,
+/obj/item/device/radio/intercom{
+	dir = 4
+	},
+/obj/item/camera{
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = -12
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/space)
 "qPw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
@@ -38060,6 +38757,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae/bridge)
 "rdb" = (
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -38067,6 +38765,10 @@
 	name = "Cargo Primary Endpoint"
 	})
 "rdj" = (
+/obj/table/reinforced/auto,
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/market)
 "rdq" = (
@@ -38350,6 +39052,13 @@
 	dir = 8
 	},
 /area/station/science/bot_storage)
+"rkh" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "rkv" = (
 /obj/storage/crate/clown,
 /turf/simulated/floor/carpet/arcade,
@@ -38437,6 +39146,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
+"rnu" = (
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/floor/grey/side,
+/area/station/quartermaster/refinery)
 "rnJ" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -38976,6 +39689,19 @@
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
+"rAX" = (
+/obj/machinery/light/small,
+/obj/table/reinforced/auto,
+/obj/item/storage/secure/ssafe{
+	pixel_x = -28
+	},
+/obj/item/storage/fanny,
+/obj/item/clothing/gloves/fingerless{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/balaclava,
+/turf/simulated/floor/carpet/red/fancy/edge/sw,
+/area/space)
 "rBd" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -39142,6 +39868,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
+"rFZ" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/west,
+/area/space)
 "rGh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39173,6 +39910,11 @@
 	dir = 8
 	},
 /area/station/security/main)
+"rGH" = (
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/mining/staff_room)
 "rGY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39344,6 +40086,11 @@
 "rKH" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
+"rKI" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/shuttle/sea_elevator_room)
 "rKK" = (
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -39386,11 +40133,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
@@ -39475,6 +40222,9 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_east)
+"rNu" = (
+/turf/simulated/floor/engine/caution/corner,
+/area/shuttle/sea_elevator_room)
 "rNU" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -39675,6 +40425,16 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
+	})
+"rSm" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay{
+	name = "Cargo Primary Endpoint"
 	})
 "rSo" = (
 /obj/cable{
@@ -40090,6 +40850,12 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"sbs" = (
+/obj/shrub,
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/space)
 "sbw" = (
 /obj/storage/closet/wardrobe/pride,
 /obj/cable{
@@ -40132,6 +40898,13 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay)
+"sce" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "scm" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/decoration/ashtray{
@@ -40536,9 +41309,6 @@
 /area/station/hallway/primary/northeast)
 "smu" = (
 /obj/machinery/door/airlock/pyro/security/alt,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/access_spawn/security,
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/redblack{
@@ -40721,6 +41491,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/listeningpost/power)
+"sqP" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/light/small/warm/very{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/shuttle/sea_elevator_room)
 "srd" = (
 /obj/stool/chair/red{
 	dir = 1
@@ -41419,13 +42199,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
-"sFa" = (
-/turf/simulated/floor/purpleblack{
-	dir = 4
-	},
-/area/station/science/lobby{
-	name = "Science Lounge"
-	})
 "sFb" = (
 /obj/table/wood/auto,
 /obj/item/paper/book/from_file/monster_manual,
@@ -41568,13 +42341,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/yellowblack/corner,
 /area/station/hallway/primary/southeast)
-"sIJ" = (
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "sIP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -41714,7 +42480,10 @@
 	name = "Southwest Breach Hull"
 	})
 "sKN" = (
-/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment/ejection{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/bot_storage)
 "sKR" = (
@@ -41833,6 +42602,18 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"sNl" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/recharger,
+/turf/simulated/floor/black,
+/area/space)
 "sNm" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -41973,6 +42754,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"sPB" = (
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4
+	},
+/obj/access_spawn/mining,
+/turf/simulated/floor/caution/westeast,
+/area/station/mining/staff_room)
 "sPN" = (
 /obj/surgery_tray,
 /obj/item/clothing/gloves/latex,
@@ -42065,10 +42853,13 @@
 	location = "tour13";
 	name = "tour 13 - east1"
 	},
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
-/area/space)
+/area/station/hallway/secondary/east)
 "sRc" = (
 /obj/landmark/halloween,
 /obj/cable{
@@ -42537,6 +43328,13 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"taV" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "tba" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -43224,6 +44022,9 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/pasiphae/hangar)
+"toN" = (
+/turf/simulated/floor/engine/caution/corner,
+/area/space)
 "toT" = (
 /obj/indestructible/shuttle_corner{
 	dir = 0
@@ -43326,20 +44127,6 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"trR" = (
-/obj/machinery/computer/sea_elevator{
-	dir = 8
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small/warm/very{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "tsG" = (
 /obj/machinery/light{
 	dir = 8;
@@ -43669,6 +44456,20 @@
 	dir = 1
 	},
 /area/pasiphae)
+"tAd" = (
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/space)
 "tAx" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
@@ -43843,6 +44644,14 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
+"tFf" = (
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/turf/simulated/floor/yellow,
+/area/station/mining/staff_room)
 "tFt" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black/side{
@@ -44028,6 +44837,12 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/southwest)
+"tIK" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "tIW" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -44206,6 +45021,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "tMp" = (
@@ -44358,6 +45174,16 @@
 	dir = 4
 	},
 /area/listeningpost)
+"tQS" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "tQZ" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular{
@@ -44440,6 +45266,13 @@
 "tSt" = (
 /turf/simulated/floor/blueblack/corner,
 /area/station/crew_quarters/courtroom)
+"tSK" = (
+/obj/landmark/halloween,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/northeast)
 "tSO" = (
 /turf/simulated/floor/redblack,
 /area/listeningpost)
@@ -44652,6 +45485,12 @@
 "tYl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/robotics)
+"tYz" = (
+/obj/submachine/cargopad{
+	name = "Mining Gear Room Pad"
+	},
+/turf/simulated/floor/black,
+/area/station/mining/staff_room)
 "tYE" = (
 /obj/table/reinforced/auto,
 /obj/item/sheet/steel{
@@ -44752,6 +45591,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-9"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "uar" = (
@@ -44818,6 +45660,7 @@
 /obj/access_spawn/janitor,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
 "ubl" = (
@@ -44980,6 +45823,9 @@
 /area/station/turret_protected/ai_upload)
 "uhy" = (
 /obj/machinery/manufacturer/general,
+/obj/disposalpipe/segment/mineral{
+	dir = 8
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -45081,6 +45927,14 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"uiV" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/disposalpipe/segment/mineral,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ujo" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
@@ -45103,6 +45957,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"ujK" = (
+/obj/storage/secure/closet/engineering/mining,
+/turf/simulated/floor/yellowblack,
+/area/station/mining/staff_room)
 "ukd" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/belt/utility{
@@ -45984,12 +46842,27 @@
 	dir = 1
 	},
 /area/station/crew_quarters/market)
+"uGK" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/space)
 "uGM" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/maint,
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"uHh" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "uHj" = (
 /obj/item/wrench,
 /obj/item/storage/toolbox/electrical{
@@ -46584,6 +47457,9 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/yellowblack,
 /area/pasiphae/sys)
+"uVp" = (
+/turf/simulated/wall/false_wall,
+/area/space)
 "uWf" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -46797,11 +47673,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "uZN" = (
-/obj/machinery/light/small/warm/very{
-	dir = 4;
-	pixel_x = 12
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/computer/sea_elevator,
+/obj/machinery/light/small/warm/very{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
 /area/shuttle/sea_elevator_room)
 "vay" = (
 /obj/decal/tile_edge/floorguide/command{
@@ -46865,6 +47747,20 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"vcF" = (
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 26
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/ne,
+/area/space)
 "vcJ" = (
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -47122,6 +48018,13 @@
 /obj/machinery/chem_heater,
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
+"vkv" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grey/side,
+/area/station/quartermaster/refinery)
 "vkx" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -47175,6 +48078,9 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/secondary/exit)
+"vmx" = (
+/turf/simulated/floor/yellowblack/corner,
+/area/station/hallway/secondary/east)
 "vmT" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -47428,6 +48334,15 @@
 	dir = 5
 	},
 /area/station/engine/storage)
+"vsv" = (
+/obj/machinery/disposal/ore,
+/obj/disposalpipe/trunk/mineral{
+	dir = 4
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/mining/staff_room)
 "vsB" = (
 /obj/machinery/computer/chem_requester/science{
 	dir = 4
@@ -47869,15 +48784,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"vCH" = (
-/obj/storage/cart/mechcart{
-	desc = "A big rolling supply cart for utility things.";
-	name = "utility cart"
-	},
-/turf/simulated/floor/grey/side{
-	dir = 8
-	},
-/area/station/quartermaster/refinery)
 "vCS" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8
@@ -48178,6 +49084,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
+"vJU" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grey/side,
+/area/station/quartermaster/refinery)
 "vKn" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -48334,7 +49247,9 @@
 /area/station/hallway/primary/southwest)
 "vOt" = (
 /obj/disposalpipe/segment/bent/south,
-/turf/simulated/floor/black,
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
 /area/station/hallway/secondary/east)
 "vOG" = (
 /obj/machinery/sleeper/compact,
@@ -48569,6 +49484,11 @@
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
 	})
+"vUm" = (
+/obj/table/wood/auto,
+/obj/machinery/computer3/luggable,
+/turf/simulated/floor/carpet/red/fancy/edge/north,
+/area/space)
 "vUR" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/heads,
@@ -48652,6 +49572,10 @@
 	dir = 8
 	},
 /area/station/crew_quarters/lounge)
+"vWr" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/space)
 "vWA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48940,6 +49864,26 @@
 	dir = 4
 	},
 /area/station/security/interrogation)
+"weg" = (
+/obj/machinery/light/small/warm/very,
+/obj/storage/secure/closet/immersion{
+	name = "Maintenance Immersion Suit Vault";
+	req_access = list(12)
+	},
+/obj/item/clothing/suit/space/diving/civilian{
+	pixel_x = -4
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/item/tank/air{
+	pixel_x = 5
+	},
+/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
+	pixel_x = -4
+	},
+/turf/simulated/floor/black,
+/area/space)
 "wer" = (
 /obj/machinery/light/small,
 /obj/stool/chair{
@@ -49313,6 +50257,12 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/pasiphae/sys)
+"woS" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/shuttle/sea_elevator_room)
 "wpc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49627,6 +50577,7 @@
 	},
 /area/listeningpost)
 "wxe" = (
+/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
@@ -49755,6 +50706,14 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"wAW" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/station/crew_quarters/market)
 "wBt" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/black/grime,
@@ -49833,9 +50792,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
 "wEh" = (
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/mining/staff_room)
 "wEt" = (
 /obj/machinery/computer/ordercomp{
 	dir = 8
@@ -49993,6 +50956,12 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
+"wGJ" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/shuttle/sea_elevator_room)
 "wGL" = (
 /obj/stool/chair/yellow{
 	dir = 4
@@ -50378,6 +51347,9 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/transport,
+/obj/cable{
+	icon_state = "0-6"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "wRi" = (
@@ -50514,6 +51486,13 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
+"wTZ" = (
+/obj/disposalpipe/segment/transport,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "wUf" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -50553,13 +51532,6 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
-"wVU" = (
-/obj/machinery/light/small/warm/very{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/sea_elevator_room)
 "wWe" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -50660,6 +51632,11 @@
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
+"wYn" = (
+/turf/simulated/floor/black/corner{
+	dir = 1
+	},
+/area/space)
 "wYs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50987,8 +51964,22 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "xep" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating,
+/obj/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/tank/mini_oxygen{
+	pixel_x = 8
+	},
+/obj/item/tank/mini_oxygen{
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/breath,
+/obj/machinery/recharger/wall/sticky{
+	dir = 1;
+	pixel_y = 26
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
 /area/shuttle/sea_elevator_room)
 "xes" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -51145,7 +52136,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail/bent/north,
+/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -51554,6 +52545,20 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
+"xup" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = 26
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/space)
 "xuD" = (
 /obj/stool/chair/wooden{
 	dir = 1
@@ -51638,6 +52643,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"xwb" = (
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "black";
+	icon_state = "bedsheet-black"
+	},
+/turf/simulated/floor/carpet/red/fancy/edge/east,
+/area/space)
 "xwd" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -52232,6 +53248,9 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/access_spawn/security,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "xIC" = (
@@ -52247,14 +53266,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"xIE" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "xII" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/food_box/donut_box{
@@ -52295,6 +53306,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
 "xJK" = (
@@ -52434,6 +53446,12 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
+"xNH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "xNP" = (
 /obj/machinery/atmospherics/valve{
 	name = "cold loop freezer interface valve"
@@ -52867,25 +53885,9 @@
 /turf/simulated/floor/black,
 /area/station/ranch)
 "xVo" = (
-/obj/machinery/light/small/warm/very,
-/obj/storage/secure/closet/immersion{
-	name = "Maintenance Immersion Suit Vault";
-	req_access = list(12)
-	},
-/obj/item/clothing/suit/space/diving/civilian{
-	pixel_x = -4
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/air{
-	pixel_x = 5
-	},
-/obj/item/clothing/head/helmet/space/engineer/diving/civilian{
-	pixel_x = -4
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/industrial,
+/area/station/mining/staff_room)
 "xVu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53103,10 +54105,6 @@
 "xZH" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/refinery)
-"xZJ" = (
-/obj/landmark/halloween,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "xZW" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 4;
@@ -53155,15 +54153,6 @@
 	icon_state = "leadjunction_gray"
 	},
 /area/listeningpost/power)
-"ybP" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/shuttle/sea_elevator_room)
 "ycd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -53252,6 +54241,11 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"yem" = (
+/obj/machinery/light/small,
+/obj/table/reinforced/auto,
+/turf/simulated/floor/carpet/red/fancy/edge/se,
+/area/space)
 "yex" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 1;
@@ -83246,8 +84240,8 @@ fDm
 fDm
 fDm
 dqY
-din
-din
+fDm
+fDm
 fDm
 dqY
 fDm
@@ -83548,8 +84542,8 @@ gfS
 gfS
 gfS
 gbL
-yjf
-yjf
+gfS
+gfS
 gfS
 gbL
 gfS
@@ -83850,8 +84844,8 @@ gbL
 gbL
 gbL
 dqY
-ctT
-ctT
+gbL
+gbL
 gbL
 dqY
 gbL
@@ -84152,10 +85146,10 @@ hQg
 lNt
 krr
 shv
-cKX
-cKX
-diT
-diT
+hWJ
+hWJ
+hWJ
+hWJ
 qga
 iuy
 hWJ
@@ -84454,10 +85448,10 @@ uTO
 uTO
 dnH
 joJ
-cKX
-cKX
-diT
-diT
+uTO
+uTO
+uTO
+uTO
 uTO
 hzB
 uTO
@@ -84757,7 +85751,7 @@ hWJ
 aRF
 dqY
 glx
-kGN
+oWp
 wvv
 dCz
 fsf
@@ -85058,10 +86052,10 @@ kGA
 lkN
 kGA
 dqY
-siL
-siL
 dqY
-ahQ
+dqY
+dqY
+dqY
 dqY
 sUF
 dqY
@@ -87778,7 +88772,7 @@ opW
 woE
 cZD
 egS
-wqA
+oNg
 vZi
 vyr
 iHN
@@ -88382,7 +89376,7 @@ bJI
 jdV
 kyI
 fDR
-wqA
+oNg
 vyr
 oLJ
 iHN
@@ -88684,7 +89678,7 @@ egJ
 jdV
 kyI
 fLE
-wqA
+oNg
 naz
 oLJ
 iHN
@@ -88986,7 +89980,7 @@ bJI
 jdV
 kyI
 lDX
-wqA
+oNg
 hWN
 oLJ
 iHN
@@ -89288,7 +90282,7 @@ jdV
 jdV
 kyI
 fLE
-wqA
+oNg
 vyr
 oLJ
 iHN
@@ -89590,7 +90584,7 @@ jdV
 jdV
 kyI
 fDR
-wqA
+oNg
 auj
 vwT
 iHN
@@ -89892,7 +90886,7 @@ bJI
 jdV
 kyI
 fLE
-wqA
+oNg
 txT
 rnN
 iHN
@@ -90194,7 +91188,7 @@ rUj
 jdV
 kyI
 oCN
-wqA
+oNg
 wqA
 gbZ
 iHN
@@ -90496,7 +91490,7 @@ bJI
 jdV
 kyI
 fLE
-wqA
+oNg
 hEe
 gbZ
 iHN
@@ -90798,7 +91792,7 @@ jdV
 jdV
 kyI
 fDR
-wqA
+oNg
 oEZ
 gbZ
 iHN
@@ -91100,7 +92094,7 @@ mvb
 vnJ
 tgU
 fLE
-wqA
+oNg
 ogK
 gbZ
 iHN
@@ -93514,8 +94508,8 @@ gNQ
 kAn
 esj
 esj
-mxp
-mxp
+esj
+esj
 esj
 esj
 sIa
@@ -93816,8 +94810,8 @@ gNQ
 gNQ
 gNQ
 gNQ
-cKX
-cKX
+gNQ
+gNQ
 gNQ
 gNQ
 gNQ
@@ -94118,8 +95112,8 @@ bJF
 bJF
 eRl
 bJF
-lIN
-lIN
+bJF
+bJF
 kOG
 bJF
 bJF
@@ -95035,15 +96029,15 @@ qNE
 fFJ
 cNY
 vcJ
-qVd
-qVd
+bYd
+ejz
 jKH
 boK
-cvc
-cvc
-cvc
+bkJ
+bkJ
+bkJ
 cOM
-pqn
+ibt
 fgd
 vcK
 jCM
@@ -95337,7 +96331,7 @@ fEJ
 fEJ
 cNY
 iyZ
-tpv
+wAW
 tpv
 bPO
 vRv
@@ -95638,7 +96632,7 @@ uBU
 dJE
 wZU
 cNY
-rdj
+jGq
 rdj
 vRv
 vRv
@@ -97755,7 +98749,7 @@ hyG
 czo
 mXd
 fmO
-cvc
+dRA
 cvc
 mUC
 cvc
@@ -98058,7 +99052,7 @@ czo
 mXd
 fmO
 cvc
-cvc
+jfa
 pDb
 cvc
 cvc
@@ -98360,7 +99354,7 @@ czo
 teX
 fmO
 cvc
-cvc
+hgF
 mUC
 cvc
 cvc
@@ -98967,7 +99961,7 @@ xCK
 cQo
 xCK
 xCK
-xCK
+fRN
 xCK
 xCK
 xCK
@@ -99268,7 +100262,7 @@ bwa
 pjY
 hbm
 fip
-bBa
+lEn
 oxS
 lEn
 lEn
@@ -99571,10 +100565,10 @@ jdX
 fLp
 jdX
 jdX
-sFa
-sFa
-sFa
-sFa
+jdX
+jdX
+jdX
+jdX
 eQi
 lrN
 jRl
@@ -101078,7 +102072,7 @@ uun
 cfj
 fmO
 qzW
-lZB
+xSt
 bgw
 bgw
 bgw
@@ -101098,14 +102092,14 @@ nkB
 gHd
 xio
 tMa
-vEu
-vEu
-jsJ
+hoO
+hoO
+lMr
 bbm
 gxC
 pia
 rdb
-tIW
+rSm
 nlq
 pWY
 gAM
@@ -101380,7 +102374,7 @@ czo
 mXd
 fmO
 lZB
-lZB
+xSt
 wPw
 cAH
 lZB
@@ -101682,7 +102676,7 @@ czo
 bfp
 fmO
 lZB
-lZB
+xSt
 wPw
 wPw
 wPw
@@ -101984,10 +102978,10 @@ bAq
 bPo
 fmO
 lZB
-lZB
+ezG
 lVG
-lZB
-lZB
+xNH
+tIK
 lZB
 sOU
 gXd
@@ -102289,7 +103283,7 @@ cAs
 cAs
 cAs
 cAs
-lZB
+xSt
 lZB
 sOU
 sOU
@@ -102591,7 +103585,7 @@ dxd
 dxd
 dxd
 cAs
-lZB
+xSt
 lZB
 sOU
 sOU
@@ -102877,12 +103871,12 @@ los
 sEG
 wRi
 xZH
-sEd
+nbQ
 nAo
 fvu
 bZA
-vCH
 aaY
+sEd
 dkT
 mPS
 xZH
@@ -102893,7 +103887,7 @@ dxd
 dxd
 dxd
 cAs
-lZB
+xSt
 lZB
 sOU
 sOU
@@ -103184,9 +104178,9 @@ fKP
 kWo
 psN
 qiE
-qiE
-qiE
-qiE
+vkv
+rnu
+vJU
 xZH
 dxd
 dxd
@@ -103195,7 +104189,7 @@ dxd
 dxd
 dxd
 cAs
-lZB
+xSt
 lZB
 sOU
 sOU
@@ -103486,9 +104480,9 @@ kWo
 kWo
 hft
 iBT
-iBT
+oyF
 hrd
-qiE
+ner
 xZH
 dxd
 dxd
@@ -103497,7 +104491,7 @@ dxd
 dxd
 dxd
 cAs
-lZB
+xSt
 aOD
 sOU
 sOU
@@ -103799,7 +104793,7 @@ dxd
 dxd
 dxd
 cAs
-lZB
+xSt
 mpJ
 sOU
 sOU
@@ -104090,7 +105084,7 @@ hJl
 xZH
 jWj
 xZH
-hJl
+asK
 hJl
 xZH
 xZH
@@ -104101,7 +105095,7 @@ cAs
 cAs
 cAs
 cAs
-vHw
+qEl
 xKn
 xKn
 sdK
@@ -104393,17 +105387,17 @@ lxX
 hQs
 vGu
 sQU
-qyt
+pzd
 xpP
 cib
-hQp
+iTi
 iTi
 iTi
 iTi
 iTi
 iTi
 hQB
-iTi
+lKL
 vGW
 qnF
 ezi
@@ -104693,19 +105687,19 @@ qwj
 qwj
 sUB
 oqO
-qwj
+wTZ
 aXE
-aXE
-qwj
-qwj
-oVJ
+ahx
+ahx
+ahx
+ahx
 fYG
 fYG
 fYG
 ahx
 ahx
 xmt
-ahx
+cHQ
 tYe
 rmX
 wRc
@@ -104988,19 +105982,19 @@ mKK
 mDQ
 mDQ
 mDQ
-mDQ
-mDQ
-mDQ
-mDQ
-xIE
-mDQ
+vmx
+nqF
+nqF
+iVK
+nqF
+nqF
 vOt
 kse
-xPJ
-qrF
+hsY
 unW
 unW
 unW
+iSq
 cxr
 unW
 unW
@@ -105011,7 +106005,7 @@ unW
 unW
 cYD
 jej
-sFL
+uHh
 mmO
 xhb
 sJS
@@ -105286,19 +106280,19 @@ lsj
 lsj
 lsj
 wmf
-xKn
-lev
-dfC
-lsa
-lsa
 fNc
 gdf
-ybP
+dfC
 gdf
-siL
-siL
+aXs
+aXs
+tFf
+aXs
+sPB
+aXs
+aXs
 dDv
-siL
+nDS
 siL
 fLQ
 cmb
@@ -105314,7 +106308,7 @@ siL
 siL
 nyR
 teP
-vEo
+hoD
 bkl
 vEo
 oHA
@@ -105588,19 +106582,19 @@ lsj
 euV
 dMT
 sDl
-fNc
-fNc
-fNc
 gdf
-gdf
-fNc
-wEh
+nBc
 cBo
+dmC
+eKf
+kUc
+wEh
+vsv
 liA
-siL
-yjf
-yjf
-yjf
+haa
+aXs
+rkh
+lWL
 siL
 aZV
 aZV
@@ -105892,17 +106886,17 @@ izA
 tXW
 fNc
 xep
-fNc
-qmT
+cBo
+cBo
 lVi
-gdf
-sIJ
+rGH
+dYV
 axd
-liA
-siL
-yjf
-yjf
-yjf
+nvD
+dpb
+pZd
+uiV
+sce
 siL
 fLQ
 cmb
@@ -106192,18 +107186,18 @@ dMT
 eeW
 lsj
 klL
-fNc
-fNc
-fNc
 gdf
-gdf
-fNc
-gdf
-qsI
-gdf
-siL
-yjf
-yjf
+sqP
+cBo
+cBo
+eKf
+kRT
+dYV
+dYV
+dYV
+jsE
+aXs
+rkh
 siL
 siL
 dhu
@@ -106494,18 +107488,18 @@ lsj
 jdT
 lsj
 kZS
+fNc
 gdf
-wVU
+woS
 gdf
-hmE
-pft
+aXs
 pqb
-cBo
-cBo
 xVo
-siL
-yjf
-yjf
+tYz
+xVo
+ujK
+aXs
+rkh
 siL
 siL
 tHH
@@ -106798,16 +107792,16 @@ lsj
 kqm
 gdf
 uZN
-gdf
+gUh
 aMA
 ahN
-pqb
-cBo
-cBo
-oYt
-siL
-yjf
-yjf
+rGH
+dYV
+dYV
+dYV
+ujK
+aXs
+rkh
 siL
 siL
 qXv
@@ -107099,17 +108093,17 @@ bzJ
 lsj
 tXW
 fNc
-fNc
-fNc
-gdf
-gdf
-fNc
-trR
-eWn
-byw
-siL
-yjf
-yjf
+doE
+rNu
+wGJ
+ahN
+rGH
+dYV
+dYV
+dYV
+pIJ
+jVj
+rkh
 siL
 siL
 tjk
@@ -107400,18 +108394,18 @@ lsj
 jdT
 lsj
 car
-fNc
-xep
-fNc
+gdf
+rKI
+nGn
 qmT
-lVi
-fNc
-fNc
+ahN
+fNE
+hdl
 cHo
-fNc
-siL
-yjf
-yjf
+bfW
+qpA
+aXs
+rkh
 siL
 siL
 dmq
@@ -107705,15 +108699,15 @@ car
 fNc
 fNc
 fNc
-gdf
-gdf
 fNc
-gie
-yjf
-yjf
-yjf
-yjf
-yjf
+aXs
+aXs
+aXs
+aXs
+aXs
+aXs
+aXs
+rkh
 siL
 siL
 dFE
@@ -108011,11 +109005,11 @@ gYH
 iIi
 iIi
 iIi
-yjf
-yjf
-yjf
-yjf
-yjf
+haC
+vWr
+vWr
+vWr
+aTy
 siL
 siL
 oSB
@@ -108314,9 +109308,9 @@ cHd
 cHd
 cHd
 yjf
-yjf
-yjf
-yjf
+pJo
+eGf
+cgu
 iky
 siL
 siL
@@ -108635,7 +109629,7 @@ sEK
 rED
 gcL
 siL
-bEm
+gIk
 vEo
 iPJ
 rZb
@@ -108937,7 +109931,7 @@ wqi
 bko
 kNR
 siL
-bEm
+qoe
 vEo
 vWA
 tdq
@@ -109239,7 +110233,7 @@ eSW
 bus
 cyG
 siL
-bEm
+gIk
 vEo
 fdg
 rZb
@@ -109543,7 +110537,7 @@ siL
 siL
 sXH
 beT
-rZb
+mAW
 nqh
 sXH
 nWv
@@ -110147,7 +111141,7 @@ vJu
 crB
 sXH
 vEo
-rZb
+fdg
 rZb
 oHA
 bZm
@@ -110449,7 +111443,7 @@ lwL
 jbY
 sXH
 vEo
-rZb
+fdg
 rZb
 oHA
 lhe
@@ -110751,7 +111745,7 @@ dOQ
 siL
 sXH
 rLM
-rZb
+fdg
 rZb
 sXH
 nWv
@@ -111053,7 +112047,7 @@ siL
 siL
 yiB
 vEo
-rZb
+fdg
 rZb
 vWX
 mkh
@@ -111340,22 +112334,22 @@ irk
 oPP
 oPP
 siL
-xQx
-xQx
-xQx
+dYx
+dYx
+cKX
 fHb
-xQx
-xQx
-xQx
+bdz
+aUS
+rAX
 siL
-yjf
+oVd
 yjf
 yjf
 yjf
 siL
 yiB
 vEo
-rZb
+fdg
 rZb
 vXS
 syh
@@ -111641,23 +112635,23 @@ fHb
 fHb
 oPP
 oPP
-ebd
+pFX
 xQx
 xQx
-xQx
-ebd
-xQx
-xQx
-xQx
+jsQ
+beh
+mQb
+lxv
+nkd
 ayy
 yjf
 yjf
-yjf
+taV
 yjf
 mZi
 yiB
 vEo
-rZb
+fdg
 rZb
 vZo
 bti
@@ -111946,11 +112940,11 @@ oPP
 fHb
 xQx
 xQx
-xQx
+jsQ
 fHb
-xQx
-xQx
-xQx
+vcF
+xwb
+yem
 siL
 siL
 siL
@@ -111959,7 +112953,7 @@ siL
 siL
 sXH
 crt
-rZb
+fdg
 nqh
 sXH
 nWv
@@ -112228,9 +113222,9 @@ jaN
 jjs
 kUl
 iEn
-jdT
-fgH
-lsj
+bsR
+tSK
+dMT
 eIn
 xIy
 pro
@@ -112238,7 +113232,7 @@ gKX
 hmz
 hyM
 smu
-eNW
+gie
 eIK
 fHb
 fHb
@@ -112247,8 +113241,8 @@ fHb
 fHb
 fHb
 xQx
-xQx
-xQx
+nNu
+jsQ
 fHb
 fHb
 fHb
@@ -112261,7 +113255,7 @@ cKX
 oYs
 yiB
 vEo
-xZJ
+sRc
 rZb
 plq
 pEc
@@ -112543,18 +113537,18 @@ fmc
 xWr
 eIK
 fHb
-xQx
-xQx
-xQx
+pRS
+qOW
+iyt
 fHb
+osB
 xQx
 xQx
-xQx
-xQx
+jsQ
 fHb
-xQx
-xQx
-xQx
+dcD
+rFZ
+jIw
 siL
 cKX
 cKX
@@ -112563,7 +113557,7 @@ cKX
 bPQ
 yiB
 vEo
-rZb
+fdg
 rZb
 oFp
 fXB
@@ -112845,18 +113839,18 @@ fmc
 aXr
 eIK
 fHb
-xQx
-xQx
-xQx
+vUm
+fjq
+nkd
 ebd
+osB
 xQx
 xQx
-xQx
-xQx
-ebd
-xQx
-xQx
-xQx
+jsQ
+beh
+mQb
+lxv
+qAS
 siL
 cKX
 cKX
@@ -113146,19 +114140,19 @@ oOx
 fmc
 oDI
 eIK
+uVp
+dzn
+egW
+aWX
 fHb
-xQx
-xQx
-xQx
+cKX
+kiz
+kiz
+wYn
 fHb
-xQx
-xQx
-xQx
-xQx
-fHb
-xQx
-xQx
-xQx
+tAd
+xup
+dtq
 siL
 hHq
 hHq
@@ -113453,10 +114447,10 @@ uSe
 uSe
 uSe
 uSe
-siL
-ctT
+uSe
+nxE
 cdf
-ctT
+nxE
 uSe
 uSe
 uSe
@@ -113749,16 +114743,16 @@ pnk
 pnk
 uSe
 ltZ
-mVF
+hCz
 xfb
 lEM
 lXG
 sTv
 pnk
-siL
-cKX
-cKX
-cKX
+uSe
+pnk
+pnk
+pnk
 xfb
 oys
 xfb
@@ -114043,24 +115037,24 @@ dyX
 fmU
 evo
 epi
-ifZ
-oqn
+fZj
+tQS
 gEa
-ifZ
-ifZ
-oqn
+fZj
+fZj
+tQS
 gMg
-ifZ
+miB
 rLr
 oqn
 ifZ
 ifZ
 uql
 xbW
-jgk
-cKX
-cKX
-cKX
+ifZ
+ifZ
+uql
+ifZ
 ifZ
 gCS
 ifZ
@@ -114359,10 +115353,10 @@ qlS
 pnk
 npg
 pnk
-jcz
-cKX
-cKX
-cKX
+pnk
+pnk
+fiR
+pnk
 qlS
 fiR
 pnk
@@ -114643,10 +115637,10 @@ fKl
 eCi
 xJE
 bjx
-ifZ
+fZj
 ftn
 mTN
-pnk
+oNV
 gmw
 pJG
 uSe
@@ -128839,16 +129833,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+sbs
+iZs
+peS
+peS
+siL
+ctT
+ohK
+ctT
+siL
 bzS
 bzS
 bzS
@@ -129141,16 +130135,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+siL
+siL
+ctT
+ctT
+siL
+dhS
+cKX
+oAx
+siL
 bzS
 bzS
 bzS
@@ -129443,16 +130437,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+lmN
+siL
+esc
+yjf
+ctT
+mIR
+lYD
+oAx
+siL
 bzS
 bzS
 bzS
@@ -129745,16 +130739,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+siL
+siL
+ctT
+ctT
+siL
+ctT
+uGK
+ctT
+siL
 bzS
 bzS
 bzS
@@ -130047,16 +131041,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+ctT
+mdY
+ctT
+bbK
+toN
+kRP
+cKX
+cKX
+weg
+siL
 bzS
 bzS
 bzS
@@ -130349,16 +131343,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+ctT
+gqq
+ctT
+fAv
+fYT
+kRP
+cKX
+cKX
+pmw
+siL
 bzS
 bzS
 bzS
@@ -130651,16 +131645,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+siL
+siL
+ctT
+ctT
+siL
+iDs
+fuX
+sNl
+siL
 bzS
 bzS
 bzS
@@ -130953,16 +131947,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+lmN
+siL
+esc
+yjf
+siL
+siL
+srr
+siL
+siL
 bzS
 bzS
 bzS
@@ -131255,16 +132249,16 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+siL
+siL
+siL
+ctT
+ctT
+siL
+yjf
+yjf
+yjf
+yjf
 bzS
 bzS
 bzS

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -13673,9 +13673,7 @@
 	name = "Genetic Research"
 	})
 "gfu" = (
-/obj/machinery/door/airlock/pyro/alt{
-	name = "Decontamination"
-	},
+/obj/machinery/door/unpowered/wood/stall,
 /turf/simulated/floor/sanitary/white,
 /area/station/science/lobby{
 	name = "Science Lounge"

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -41,10 +41,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"aaX" = (
-/obj/reagent_dispensers/beerkeg,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "aaY" = (
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor/grey/side{
@@ -247,6 +243,19 @@
 /obj/decal/poster/wallsign/barber,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
+"afk" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/west)
 "afl" = (
 /obj/storage/closet/medicalclothes,
 /turf/simulated/floor/blueblack{
@@ -290,6 +299,13 @@
 /obj/item/clothing/suit/bedsheet/pink,
 /turf/simulated/floor/carpet/red/fancy/junction/ne_w,
 /area/pasiphae/crew)
+"agh" = (
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/normal,
+/turf/simulated/floor/engine,
+/area/space)
 "agr" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -461,6 +477,15 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"ajo" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ajr" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -574,6 +599,17 @@
 /obj/decal/tile_edge/floorguide/arrow_s,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"alM" = (
+/obj/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 10
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "amr" = (
 /obj/stool/chair{
 	dir = 4
@@ -771,11 +807,6 @@
 /obj/landmark/random_room/size3x3,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"apR" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "aqa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -954,6 +985,10 @@
 	dir = 1
 	},
 /area/pasiphae/sys)
+"aut" = (
+/obj/machinery/centrifuge_nuclear,
+/turf/simulated/floor/yellowblack,
+/area/space)
 "auw" = (
 /obj/submachine/chef_sink{
 	desc = "A common utility sink.";
@@ -1083,7 +1118,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
-/turf/simulated/floor/black/side{
+/turf/simulated/floor/yellowblack{
 	dir = 1
 	},
 /area/station/hallway/primary/southeast)
@@ -1711,6 +1746,15 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"aOo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "aOt" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grass/leafy,
@@ -1791,6 +1835,15 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/pasiphae/bridge)
+"aQS" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "aRh" = (
 /obj/machinery/chem_dispenser/chemical,
 /turf/simulated/floor/engine/caution/east,
@@ -1847,12 +1900,16 @@
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
 "aTs" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
+/obj/storage/crate,
+/obj/item/plate,
+/obj/item/reagent_containers/food/snacks/spaghetti/meatball{
+	pixel_x = -1
 	},
-/obj/storage/closet/wardrobe/mixed,
+/obj/item/toy/gooncode{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/crew_quarters/market)
 "aTt" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/landmark/gps_waypoint,
@@ -2050,6 +2107,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"aXE" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/black,
+/area/space)
 "aXK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2119,6 +2180,16 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
+"aZM" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/machinery/drainage,
+/obj/stool/bench/yellow/auto,
+/turf/simulated/floor/sanitary,
+/area/space)
 "aZR" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack{
@@ -2133,6 +2204,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack/corner,
 /area/pasiphae)
+"aZV" = (
+/obj/machinery/door/poddoor/blast/pyro{
+	dir = 4;
+	icon_state = "bdoormid1";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding"
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "baa" = (
 /obj/structure/girder/reinforced,
 /turf/simulated/floor,
@@ -2300,6 +2380,20 @@
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
 /area/station/medical/head)
+"bel" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/cable/orange,
+/obj/cable/orange{
+	icon_state = "0-8"
+	},
+/obj/machinery/computer/power_monitor/smes{
+	dir = 8;
+	name = "Engine Output Monitoring"
+	},
+/turf/simulated/floor/engine/caution/misc{
+	dir = 4
+	},
+/area/space)
 "beq" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4;
@@ -2364,6 +2458,13 @@
 /obj/storage/closet/office,
 /turf/simulated/floor/black/side,
 /area/station/storage/tools)
+"bgj" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine/caution/corner,
+/area/space)
 "bgw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lobby{
@@ -2522,6 +2623,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
+"bko" = (
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine/caution/westeast,
+/area/space)
 "bks" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -2540,6 +2647,13 @@
 "bkQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/treatment1)
+"bld" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "blp" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -2652,6 +2766,19 @@
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering/ce)
+"boK" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "market";
+	name = "Public Market";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "boT" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -2698,6 +2825,19 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
+"bpG" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/space)
 "bpI" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -2784,6 +2924,16 @@
 /obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
+"bre" = (
+/obj/storage/closet/radiation,
+/obj/decal/tile_edge/line/yellow{
+	dir = 10;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "brA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3077,6 +3227,11 @@
 	dir = 4
 	},
 /area/station/science/hall)
+"buR" = (
+/obj/machinery/light/small,
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/plating,
+/area/space)
 "buS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3103,20 +3258,6 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_east,
 /area/station/crew_quarters/arcade/dungeon)
-"buW" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/item/kitchen/utensil/spoon{
-	pixel_x = 13;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "bvt" = (
 /obj/machinery/computer/siphon_db,
 /obj/machinery/light/small{
@@ -3480,8 +3621,7 @@
 /turf/simulated/floor/red,
 /area/station/security/brig)
 "bEm" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/black/side{
+/turf/simulated/floor/yellowblack{
 	dir = 1
 	},
 /area/station/hallway/primary/southeast)
@@ -3529,9 +3669,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"bFl" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/inner/south)
 "bFz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3807,6 +3944,14 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
+"bMH" = (
+/obj/machinery/centrifuge_nuclear,
+/obj/decal/tile_edge/line/yellow{
+	dir = 9;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/yellowblack,
+/area/space)
 "bNm" = (
 /obj/shrub,
 /obj/machinery/camera{
@@ -3896,6 +4041,11 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
+"bPO" = (
+/turf/simulated/floor/grey/side{
+	dir = 6
+	},
+/area/station/crew_quarters/market)
 "bQh" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Medical Bay"
@@ -3975,14 +4125,9 @@
 /turf/simulated/floor/carpet/purple/fancy/narrow/T_north,
 /area/station/chapel/sanctuary)
 "bSc" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "bSg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4429,13 +4574,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
-"caO" = (
-/obj/ladder{
-	id = "recluse";
-	layer = 2
-	},
-/turf/simulated/floor/carpet/red/standard/narrow/solo,
-/area/station/maintenance/inner/south)
 "cbe" = (
 /obj/disposalpipe/loafer/horizontal,
 /turf/simulated/floor/plating,
@@ -4444,6 +4582,11 @@
 /obj/decal/tile_edge/line/green{
 	dir = 5;
 	icon_state = "line1"
+	},
+/obj/shrub{
+	dir = 1;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
@@ -4467,14 +4610,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
-"ccc" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/blackwhite{
-	dir = 5
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
 "ccf" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purpleblack/corner{
@@ -4491,6 +4626,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northeast)
+"cdg" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/engine/caution/west,
+/area/space)
 "cdp" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -4519,6 +4661,15 @@
 	},
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
+"cdO" = (
+/obj/table/reinforced/auto,
+/obj/item/decoration/flower_vase{
+	pixel_y = 14
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "cdT" = (
 /obj/stool/chair{
 	dir = 4
@@ -4550,15 +4701,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/ranch)
-"ceK" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
 "ceO" = (
 /obj/machinery/siphon/resonator,
 /turf/simulated/floor/engine/caution/misc{
@@ -5153,6 +5295,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"ctT" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/space)
 "cuw" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/drainage,
@@ -5206,27 +5352,8 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/disposal)
 "cvc" = (
-/obj/table/auto,
-/obj/item/decoration/ashtray,
-/obj/item/dice{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/coin{
-	pixel_x = -2;
-	pixel_y = 16
-	},
-/obj/machinery/light/small,
-/obj/item/dice{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/beer{
-	pixel_x = -14;
-	pixel_y = 6
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "cvg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -5315,6 +5442,14 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"cyG" = (
+/obj/machinery/computer/power_monitor{
+	dir = 8
+	},
+/turf/simulated/floor/engine/caution/misc{
+	dir = 4
+	},
+/area/space)
 "cyJ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -5348,6 +5483,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
+"czt" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "czE" = (
 /obj/machinery/door/poddoor{
 	id = "ai_core";
@@ -5389,6 +5532,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
+"cAH" = (
+/obj/ladder{
+	id = "recluse";
+	layer = 2
+	},
+/turf/simulated/floor/carpet/red/standard/narrow/solo,
+/area/station/maintenance/inner/east)
 "cAO" = (
 /obj/landmark/map{
 	name = "NADIR"
@@ -5421,13 +5571,6 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"cBO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
 "cBP" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/cleanable/dirt/jen,
@@ -5671,13 +5814,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
-"cJe" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/west)
 "cJf" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera{
@@ -5741,6 +5877,9 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"cKX" = (
+/turf/simulated/floor/black,
+/area/space)
 "cLn" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
@@ -5838,6 +5977,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"cNc" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/space)
 "cNf" = (
 /obj/machinery/disposal/cart_port,
 /obj/storage/cart/trash,
@@ -5901,8 +6045,9 @@
 	},
 /area/station/chapel/sanctuary)
 "cOM" = (
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "cPh" = (
 /obj/storage/secure/closet/immersion/research,
 /obj/item/clothing/suit/space/diving/civilian{
@@ -6225,6 +6370,18 @@
 /obj/machinery/networked/telepad,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
+"cVL" = (
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/head/helmet/firefighter,
+/obj/item/tank/air,
+/obj/item/extinguisher,
+/obj/item/crowbar,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
+/turf/simulated/floor/plating,
+/area/space)
 "cVU" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
@@ -6547,6 +6704,15 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/ce)
+"dfm" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding"
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "dft" = (
 /obj/disposalpipe/segment/vertical,
 /obj/disposalpipe/segment/transport{
@@ -6629,6 +6795,11 @@
 	dir = 1
 	},
 /area/station/science/teleporter)
+"dhu" = (
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/space)
 "dhw" = (
 /obj/disposalpipe/block_sensing_outlet/west,
 /turf/unsimulated/wall/setpieces/leadwall/cap,
@@ -6654,6 +6825,10 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"din" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating,
+/area/space)
 "diA" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
@@ -6727,6 +6902,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
+"dmq" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "dmr" = (
 /obj/decal/tile_edge/floorguide/security{
 	dir = 8
@@ -6984,6 +7167,16 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"dtx" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/ejection,
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/space)
 "dtz" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7008,15 +7201,6 @@
 	dir = 8
 	},
 /area/pasiphae/survey)
-"dtV" = (
-/obj/table/wood/round/auto,
-/obj/item/paper_bin{
-	pixel_y = 2
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "dul" = (
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
@@ -7548,6 +7732,16 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"dDv" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/space)
 "dDw" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "15"
@@ -7624,6 +7818,23 @@
 /obj/item/cell/supercell/charged,
 /turf/simulated/floor/grey,
 /area/station/science/bot_storage)
+"dFf" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/east)
 "dFs" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7695,6 +7906,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"dFE" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "dFR" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -7960,9 +8180,17 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
 "dMn" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/head/helmet/firefighter,
+/obj/item/tank/air,
+/obj/item/extinguisher,
+/obj/item/crowbar,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "dMT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8024,6 +8252,12 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"dOQ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/misc{
+	dir = 4
+	},
+/area/space)
 "dPx" = (
 /obj/submachine/laundry_machine,
 /turf/simulated/floor/sanitary,
@@ -8333,10 +8567,6 @@
 	},
 /turf/simulated/floor/redblack,
 /area/listeningpost)
-"dZl" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "dZn" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -8407,9 +8637,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"eas" = (
-/turf/simulated/floor/redblack/corner,
-/area/station/hallway/secondary/exit)
 "eaw" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/greenblack{
@@ -8876,13 +9103,6 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space/fluid/acid/clear,
 /area/space)
-"emc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "emm" = (
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
@@ -9543,6 +9763,16 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"eAL" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space/fluid/acid/clear,
+/area/space)
 "eAM" = (
 /obj/storage/secure/closet/command,
 /obj/item/clothing/under/rank/captain/blue,
@@ -9649,9 +9879,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "eDS" = (
 /obj/cable{
@@ -9703,6 +9931,12 @@
 	dir = 8
 	},
 /area/station/science/hall)
+"eGf" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "eGi" = (
 /obj/table/auto,
 /obj/item/weldingtool,
@@ -9864,6 +10098,12 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"eIK" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "eIP" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -9956,15 +10196,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/bridge/captain)
-"eLY" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "eMc" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -10142,6 +10373,12 @@
 	dir = 1
 	},
 /area/station/engine/elect)
+"ePt" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/misc{
+	dir = 8
+	},
+/area/space)
 "ePD" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/standard/edge{
@@ -10244,6 +10481,15 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/west)
+"eRs" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/space)
 "eRu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10324,6 +10570,11 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/barber_shop)
+"eSP" = (
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "eSU" = (
 /obj/machinery/turretid{
 	pixel_x = 24;
@@ -10331,6 +10582,13 @@
 	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
+"eSW" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/black,
+/area/space)
 "eTi" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -10438,6 +10696,10 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
+"eVh" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/space)
 "eVv" = (
 /obj/stool/chair/pew/fancy/left{
 	dir = 1
@@ -10585,6 +10847,14 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"eZV" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 10
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "eZZ" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -10744,6 +11014,12 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"ffH" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/turf/simulated/floor/engine/caution/west,
+/area/space)
 "ffN" = (
 /obj/reagent_dispensers/watertank/big,
 /obj/disposalpipe/segment/transport{
@@ -10861,26 +11137,12 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
-"fiK" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "fiR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
-"fiT" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
 "fjb" = (
 /obj/stool/chair/blue{
 	dir = 8
@@ -11014,6 +11276,9 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"fnk" = (
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/market)
 "fnA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -11116,6 +11381,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
+"fpR" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "fpW" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -11227,10 +11498,6 @@
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/ce)
 "fsf" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/storage/closet/fire,
 /obj/decal/tile_edge/line/green{
 	dir = 6;
 	icon_state = "line1"
@@ -11881,10 +12148,6 @@
 "fGI" = (
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
-"fGK" = (
-/obj/disposalpipe/junction/left/east,
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "fGO" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 6;
@@ -11926,6 +12189,13 @@
 	dir = 8
 	},
 /area/station/engine/elect)
+"fHA" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "cold loop gas supply valve"
+	},
+/turf/simulated/floor/engine/caution/south,
+/area/space)
 "fHL" = (
 /obj/cable,
 /turf/simulated/floor/plating,
@@ -12077,6 +12347,16 @@
 	dir = 1
 	},
 /area/station/medical/medbay/cloner)
+"fLQ" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	dir = 4;
+	icon_state = "bdoormid1";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding"
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "fMs" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/brain,
@@ -12193,16 +12473,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"fOH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "fPl" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -12259,6 +12529,12 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/storage/warehouse)
+"fQt" = (
+/obj/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine/caution/corner2,
+/area/space)
 "fQu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12504,10 +12780,6 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
-"fUZ" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "fVU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone/unlisted,
@@ -12557,12 +12829,26 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"fXU" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 8
+	},
+/area/space)
 "fYi" = (
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
 /area/pasiphae/bridge)
+"fYj" = (
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "fYu" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light/emergency{
@@ -12799,6 +13085,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"gcL" = (
+/obj/machinery/power/smes,
+/turf/simulated/floor/engine/caution/misc{
+	dir = 8
+	},
+/area/space)
 "gdf" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -13205,6 +13497,13 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_west)
+"glx" = (
+/obj/storage/closet/fire,
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/space)
 "glC" = (
 /obj/machinery/light/small,
 /obj/cable{
@@ -13772,6 +14071,12 @@
 	dir = 9
 	},
 /area/station/engine/elect)
+"gzh" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/space)
 "gzl" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13851,6 +14156,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
+"gAA" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 4
+	},
+/area/space)
 "gAF" = (
 /obj/machinery/door/airlock/pyro/glass/toxins{
 	dir = 4
@@ -13958,6 +14271,10 @@
 /area/station/crew_quarters/lounge/starboard{
 	name = "Book Nook"
 	})
+"gDo" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/turf/simulated/floor/yellow,
+/area/space)
 "gDp" = (
 /obj/stool/chair/office/red{
 	dir = 1
@@ -14098,6 +14415,11 @@
 /obj/item/wrench,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/storage)
+"gGG" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/market)
 "gGH" = (
 /obj/table/round/auto,
 /obj/item/storage/toolbox/emergency,
@@ -14236,6 +14558,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"gKd" = (
+/obj/machinery/power/nuclear/reactor_control,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "gKe" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
@@ -14428,10 +14756,9 @@
 "gNQ" = (
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
-"gOc" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+"gNU" = (
+/turf/space,
+/area/station/hallway/secondary/west)
 "gOm" = (
 /obj/machinery/vending/computer3,
 /obj/machinery/light/small{
@@ -15251,21 +15578,6 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/brig)
-"hgk" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "hgq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15416,6 +15728,14 @@
 /obj/item/coin,
 /turf/simulated/floor/carpet/red/fancy/innercorner/nw_se,
 /area/station/crew_quarters/arcade/dungeon)
+"hkl" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "hkp" = (
 /obj/lattice{
 	dir = 9;
@@ -15468,12 +15788,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/pasiphae/maint)
-"hkS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+"hkU" = (
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "hkW" = (
 /obj/cable{
 	icon_state = "5-10"
@@ -16063,15 +16380,6 @@
 "hwO" = (
 /turf/simulated/floor/black,
 /area/station/medical/head)
-"hwS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
 "hwY" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	dir = 1
@@ -16304,6 +16612,10 @@
 /obj/item/device/radio/intercom/security,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"hBh" = (
+/obj/storage/closet/wardrobe/mixed,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/market)
 "hBo" = (
 /obj/stool/chair{
 	dir = 4
@@ -16367,15 +16679,12 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/pasiphae)
-"hCB" = (
-/obj/stool/chair{
-	dir = 8
+"hCz" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
 	},
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "hCT" = (
 /obj/machinery/computer/barcode/qm/no_belthell{
 	dir = 8
@@ -16435,6 +16744,10 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/blue,
 /area/pasiphae/bridge)
+"hDL" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/space)
 "hEa" = (
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -17199,6 +17512,21 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"hVR" = (
+/obj/shrub{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "hWb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -17668,6 +17996,15 @@
 	dir = 10
 	},
 /area/station/medical/medbay/treatment)
+"ieN" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ifl" = (
 /obj/machinery/drainage,
 /obj/machinery/light/small{
@@ -17803,16 +18140,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
-"ihI" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/ejection,
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "ihU" = (
 /obj/table/reinforced/auto,
 /obj/item/old_grenade/oxygen{
@@ -17857,6 +18184,11 @@
 	dir = 4
 	},
 /area/station/science/teleporter)
+"ijc" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 6
+	},
+/area/space)
 "ijx" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -17905,6 +18237,16 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/teleporter)
+"iky" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/space)
+"ikE" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "ikV" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1
@@ -18299,6 +18641,11 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"itK" = (
+/turf/simulated/floor/grey/side{
+	dir = 8
+	},
+/area/station/crew_quarters/market)
 "iub" = (
 /obj/machinery/light_switch/west,
 /obj/disposalpipe/segment/brig{
@@ -18338,9 +18685,7 @@
 /area/pasiphae/sys)
 "iuy" = (
 /obj/disposalpipe/junction/left/north,
-/turf/simulated/floor/blueblack/corner{
-	dir = 4
-	},
+/turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
@@ -18566,6 +18911,11 @@
 	dir = 4
 	},
 /area/station/medical/head)
+"iyZ" = (
+/turf/simulated/floor/grey/side{
+	dir = 5
+	},
+/area/station/crew_quarters/market)
 "izk" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -18791,6 +19141,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northeast)
+"iEo" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "iEw" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
@@ -19520,10 +19876,20 @@
 /area/station/security/checkpoint{
 	name = "Security Overwatch"
 	})
+"iZE" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/space)
 "iZO" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
+"iZS" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "iZX" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -19697,6 +20063,11 @@
 	dir = 1
 	},
 /area/station/storage/emergency2)
+"jcz" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/black,
+/area/space)
 "jcF" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
@@ -19928,6 +20299,14 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"jgk" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/black,
+/area/space)
 "jgK" = (
 /obj/cable{
 	icon_state = "5-10"
@@ -20224,6 +20603,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/west)
+"jpM" = (
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/space)
 "jpQ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small,
@@ -20575,6 +20960,13 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"jwy" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "cold loop gas supply valve"
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/space)
 "jwF" = (
 /obj/stool/chair{
 	dir = 1
@@ -20641,6 +21033,10 @@
 /obj/storage/crate/rcd/CE,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"jyD" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/space)
 "jyP" = (
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/grey,
@@ -20830,6 +21226,12 @@
 	dir = 1
 	},
 /area/listeningpost)
+"jCY" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "jDb" = (
 /obj/stool/bench/red/auto,
 /turf/simulated/floor/redblack{
@@ -21096,6 +21498,9 @@
 /obj/stool/chair,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"jKH" = (
+/turf/simulated/floor/grey/side,
+/area/station/crew_quarters/market)
 "jKJ" = (
 /obj/cryotron{
 	layer = 3.9
@@ -21281,6 +21686,11 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"jOW" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "jPg" = (
 /obj/stool/chair{
 	dir = 8
@@ -21359,6 +21769,14 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
+"jQr" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 1
+	},
+/area/space)
 "jQy" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/evidence{
@@ -21610,6 +22028,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"jUz" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/west)
 "jUB" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -21628,6 +22056,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/equipment)
+"jUT" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/space)
 "jVa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21799,6 +22235,24 @@
 	dir = 10
 	},
 /area/station/bridge)
+"jYT" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/machinery/light/lamp/black{
+	pixel_y = 10;
+	pixel_x = 1
+	},
+/obj/item/pen{
+	pixel_y = -2;
+	pixel_x = -5
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "jYY" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -22120,6 +22574,18 @@
 /obj/item/sponge,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
+"khh" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
+"khK" = (
+/turf/simulated/floor/grey/side{
+	dir = 10
+	},
+/area/station/crew_quarters/market)
 "khL" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/light/small,
@@ -22876,6 +23342,21 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"kuP" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/space)
 "kuV" = (
 /obj/rack,
 /obj/machinery/light/incandescent/netural,
@@ -23162,6 +23643,12 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"kCn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "kCz" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -23420,6 +23907,10 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"kGN" = (
+/obj/stool/chair,
+/turf/simulated/floor/black,
+/area/space)
 "kGW" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
@@ -23507,10 +23998,6 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/hallway/primary/northwest)
-"kJO" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "kJT" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -23576,6 +24063,13 @@
 	dir = 6
 	},
 /area/station/hallway/primary/northwest)
+"kLs" = (
+/obj/machinery/light/small,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "kLJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23633,6 +24127,16 @@
 	dir = 1
 	},
 /area/pasiphae/crew)
+"kNR" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/cable/orange,
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/northsouth,
+/area/space)
 "kOd" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -23695,6 +24199,9 @@
 /obj/item/paper/book/from_file/space_law,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"kQl" = (
+/turf/simulated/floor/engine/caution/corner2,
+/area/space)
 "kQn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24032,10 +24539,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"kXG" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "kXK" = (
 /obj/decal/tile_edge/floorguide/science{
 	dir = 1
@@ -24607,11 +25110,6 @@
 	},
 /turf/space/fluid/acid/clear,
 /area/space)
-"ljM" = (
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
 "ljS" = (
 /turf/space/fluid/warp_z5/edge,
 /area/space)
@@ -24696,6 +25194,12 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"llU" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/black,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "llV" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/toxin{
@@ -25081,15 +25585,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"lvk" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
 "lvq" = (
 /obj/decal/poster/wallsign/keep_it_or_melt{
 	pixel_y = 28
@@ -25423,6 +25918,10 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"lDu" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/space)
 "lDC" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/light,
@@ -25430,6 +25929,13 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
+"lDM" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "lDT" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -25461,16 +25967,6 @@
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"lEz" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/inner/south)
 "lEA" = (
 /obj/machinery/drainage,
 /obj/submachine/chef_sink/chem_sink{
@@ -25483,12 +25979,27 @@
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"lEU" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "lEV" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/grey,
 /area/pasiphae/crew)
+"lFh" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 6
+	},
+/area/space)
 "lFq" = (
 /obj/submachine/chem_extractor{
 	dir = 8
@@ -25574,6 +26085,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"lGL" = (
+/obj/storage/closet/radiation,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "lGN" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -25742,6 +26259,14 @@
 	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/secondary/exit)
+"lJi" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "lJs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25853,6 +26378,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
+"lMa" = (
+/obj/storage/crate,
+/obj/item/plate,
+/obj/item/reagent_containers/food/snacks/spaghetti/meatball{
+	pixel_x = -1
+	},
+/obj/item/toy/gooncode{
+	pixel_x = 3
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "lMn" = (
 /obj/decal/tile_edge/floorguide/engineering{
 	dir = 1
@@ -26221,16 +26757,6 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
-"lUQ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "lUT" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/blueblack/corner{
@@ -26266,6 +26792,11 @@
 	dir = 6
 	},
 /area/station/security/brig)
+"lVG" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "lVO" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -26349,6 +26880,14 @@
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/ai_monitored/armory)
+"lXA" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "lXG" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/black,
@@ -26479,14 +27018,8 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "lZB" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/east)
 "lZF" = (
 /turf/unsimulated/wall/trench/side,
 /area/space)
@@ -26756,12 +27289,6 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/maintenance/northwest)
-"mfr" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/space/fluid/acid,
-/area/shuttle/arrival/station)
 "mfB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -26983,17 +27510,6 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
-"mjJ" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "mjW" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -27472,6 +27988,14 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"mvp" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/space)
 "mvy" = (
 /obj/chicken_nesting_box,
 /obj/machinery/light{
@@ -28171,6 +28695,13 @@
 	icon_state = "leadjunction_gray"
 	},
 /area/listeningpost/power)
+"mKE" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "cold loop gas supply valve"
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "mKK" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/transport,
@@ -28225,6 +28756,10 @@
 	dir = 6
 	},
 /area/station/crew_quarters/cafeteria)
+"mNh" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/plating,
+/area/space)
 "mNi" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/syringes,
@@ -28563,6 +29098,9 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"mUC" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/inner/west)
 "mVk" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo{
 	dir = 2
@@ -28581,6 +29119,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"mVF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/bent/west,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "mWj" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -29022,6 +29570,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
+"njT" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/space/fluid/acid/clear,
+/area/shuttle/arrival/station)
 "nkk" = (
 /turf/unsimulated/wall/setpieces/leadwall/white_2/junction{
 	dir = 1
@@ -29813,24 +30367,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
+"nCb" = (
+/obj/machinery/atmospherics/binary/reactor_turbine,
+/turf/simulated/floor/engine,
+/area/space)
 "nCD" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"nCG" = (
-/obj/rack,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/head/helmet/firefighter,
-/obj/item/tank/air,
-/obj/item/extinguisher,
-/obj/item/crowbar,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "nCM" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -29908,6 +30454,14 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black/side,
 /area/station/crew_quarters/courtroom)
+"nEw" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
+	},
+/area/space)
 "nEz" = (
 /obj/storage/closet/wardrobe/pink,
 /turf/simulated/floor/grey/side{
@@ -30122,17 +30676,6 @@
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
 	})
-"nIo" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/inner/south)
 "nIv" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -30176,6 +30719,9 @@
 "nJn" = (
 /turf/simulated/floor/stairs/wide,
 /area/listeningpost)
+"nJZ" = (
+/turf/simulated/floor/engine/caution/west,
+/area/space)
 "nKe" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -30246,6 +30792,10 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/nw,
 /area/station/bridge)
+"nLd" = (
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/plating,
+/area/space)
 "nLe" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
@@ -30281,6 +30831,20 @@
 	dir = 4
 	},
 /area/pasiphae)
+"nLQ" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/item/kitchen/utensil/spoon{
+	pixel_x = 13;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "nLT" = (
 /obj/disposalpipe/trunk{
 	dir = 8;
@@ -30403,6 +30967,17 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"nPZ" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/space)
 "nQa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30475,6 +31050,21 @@
 	dir = 10
 	},
 /area/station/crew_quarters/cafeteria)
+"nSj" = (
+/obj/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine/caution/northsouth,
+/area/space)
 "nSu" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -30559,6 +31149,12 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"nTW" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "nUa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31010,6 +31606,28 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
+"ohk" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark{
+	name = "shitty_bill_respawn"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"oht" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/east)
 "oil" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31133,6 +31751,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/east)
+"olC" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "omd" = (
 /obj/item/furniture_parts/table/nanotrasen,
 /obj/item/raw_material/shard/glass,
@@ -31221,6 +31845,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"ooq" = (
+/obj/landmark/random_room/size3x3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "ooK" = (
 /obj/machinery/light,
 /turf/simulated/floor/redblack{
@@ -31644,6 +32272,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"oxS" = (
+/obj/machinery/light/small,
+/obj/storage/closet/fire,
+/turf/simulated/floor/black,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "oyi" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -31812,16 +32447,6 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
-"oBy" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/east)
 "oBG" = (
 /obj/table/wood/round/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
@@ -32204,6 +32829,12 @@
 /obj/disposalpipe/trunk/north,
 /turf/space/fluid/acid/clear,
 /area/space)
+"oMR" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "oNg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
@@ -32312,6 +32943,18 @@
 	dir = 9
 	},
 /area/station/hallway/primary/southwest)
+"oPG" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Cold Loop Gas Supply 1";
+	name = "cold loop gas supply pump";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/engine/caution/north,
+/area/space)
 "oPO" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/drainage,
@@ -32451,6 +33094,14 @@
 /obj/machinery/door/airlock/pyro/classic,
 /turf/simulated/floor/industrial,
 /area/abandonedmedicalship/robot_trader)
+"oSB" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 8
+	},
+/area/space)
 "oSF" = (
 /obj/rack,
 /obj/item/extinguisher,
@@ -32672,9 +33323,6 @@
 /obj/machinery/drainage,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
@@ -32961,12 +33609,15 @@
 	name = "Head of Personnel's Quarters"
 	})
 "pfn" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "pfr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32979,10 +33630,10 @@
 /turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator/upper)
 "pfN" = (
-/obj/machinery/light/small,
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/turf/simulated/floor/sanitary/white,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "pgy" = (
 /obj/table/wood/auto{
 	pixel_w = -1
@@ -33339,12 +33990,9 @@
 	},
 /area/station/medical/head)
 "ppA" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/ejection,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "ppQ" = (
 /obj/machinery/plantpot{
 	anchored = 1
@@ -33474,6 +34122,14 @@
 	dir = 8
 	},
 /area/abandonedmedicalship/robot_trader)
+"psJ" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "psN" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey/side{
@@ -33645,6 +34301,9 @@
 	dir = 8
 	},
 /area/station/medical/morgue)
+"pvZ" = (
+/turf/space,
+/area/space)
 "pwa" = (
 /obj/stool/chair/office/syndie{
 	dir = 4
@@ -33916,6 +34575,11 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"pDb" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "pDy" = (
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "3"
@@ -33932,6 +34596,10 @@
 "pDB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/office)
+"pDQ" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/plating,
+/area/space)
 "pDS" = (
 /turf/simulated/floor/engine/caution/south,
 /area/station/science/chemistry)
@@ -34185,6 +34853,12 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/barber_shop)
+"pKL" = (
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "pKY" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency{
@@ -34254,10 +34928,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"pMS" = (
-/obj/stool/chair,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "pMV" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35038,6 +35708,15 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
+"qga" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "qgg" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/access_spawn/teleporter,
@@ -35107,6 +35786,17 @@
 "qiE" = (
 /turf/simulated/floor/grey/side,
 /area/station/quartermaster/refinery)
+"qiM" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "qiP" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -35191,6 +35881,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"qlS" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "qmk" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
@@ -35368,6 +36064,12 @@
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pasiphae)
+"qrh" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "qrn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35395,6 +36097,15 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
+"qrF" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/black,
+/area/space)
 "qrL" = (
 /obj/machinery/floorflusher/solitary,
 /obj/disposalpipe/trunk/brig{
@@ -35528,6 +36239,12 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
+"qvy" = (
+/obj/machinery/vending/cards,
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "qvP" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -35654,6 +36371,13 @@
 	dir = 6
 	},
 /area/station/storage/eva)
+"qxz" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black,
+/area/space)
 "qxC" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/black,
@@ -35672,6 +36396,12 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"qyt" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/purpleblack{
+	dir = 8
+	},
+/area/space)
 "qyu" = (
 /obj/stool/bed,
 /obj/machinery/light/small,
@@ -35738,6 +36468,16 @@
 "qzF" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/cloner)
+"qzW" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "qAa" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -35925,13 +36665,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
-"qFg" = (
-/obj/machinery/light/small,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "qFM" = (
 /obj/stool/chair{
 	dir = 4
@@ -35997,11 +36730,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"qGL" = (
-/obj/machinery/light/small,
-/obj/disposalpipe/segment/ejection,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "qHC" = (
 /obj/disposalpipe/trunk/food,
 /obj/machinery/disposal/ore{
@@ -36268,6 +36996,22 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"qPw" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	icon_state = "bdoormid1";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding"
+	},
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "qPQ" = (
 /obj/rack,
 /obj/item/clothing/mask/breath{
@@ -36587,17 +37331,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"qWH" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "qWP" = (
 /turf/unsimulated/wall/setpieces/leadwall/gray{
 	icon_state = "leadjunction_gray"
@@ -36654,6 +37387,14 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northwest)
+"qXv" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/space)
 "qXF" = (
 /turf/simulated/floor/greenblack/corner,
 /area/station/turret_protected/Zeta)
@@ -36834,6 +37575,16 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
+"rdj" = (
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
+"rdq" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/plating,
+/area/space)
 "rdL" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine,
@@ -36917,10 +37668,6 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
-"rgb" = (
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "rgd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37262,6 +38009,13 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
+"rpz" = (
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "rpK" = (
 /obj/stool/chair{
 	dir = 8
@@ -37297,6 +38051,18 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/pasiphae)
+"rqB" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Cold Loop Gas Supply 2";
+	name = "cold loop gas supply pump";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/engine/caution/south,
+/area/space)
 "rqE" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -37546,18 +38312,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
-"rxk" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour14;desc=On your left is the Site refinery - Engineers access the Siphon through its far door, and its nano-fabricator is often used for catalytic rod fabrication.";
-	freq = 1443;
-	location = "tour13";
-	name = "tour 13 - east1"
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/station/hallway/secondary/east)
 "rxw" = (
 /obj/machinery/conveyor/WE{
 	id = "nadir_qmio"
@@ -37689,6 +38443,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
+"rAG" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/space)
 "rAP" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency{
@@ -37743,6 +38503,17 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
+"rBV" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "rCd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37830,6 +38601,10 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
+"rEB" = (
+/obj/stool/chair,
+/turf/simulated/floor/plating,
+/area/space)
 "rEP" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -38067,6 +38842,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"rLr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "rLG" = (
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -38473,10 +39260,6 @@
 	dir = 8
 	},
 /area/listeningpost)
-"rUr" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "rUx" = (
 /obj/machinery/disposal/mail/autoname/mechanics,
 /obj/machinery/light{
@@ -38641,12 +39424,8 @@
 	dir = 8;
 	pixel_x = -10
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
+/turf/simulated/floor/black,
+/area/space)
 "rYl" = (
 /obj/storage/secure/closet/immersion/quartermasters,
 /obj/item/clothing/suit/space/diving/civilian{
@@ -38828,6 +39607,10 @@
 	},
 /turf/simulated/floor/black,
 /area/pasiphae)
+"scP" = (
+/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "scW" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -38995,25 +39778,6 @@
 	dir = 8
 	},
 /area/station/bridge)
-"shc" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/inner/south)
-"shh" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/space/fluid/acid,
-/area/shuttle/arrival/station)
 "shv" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/light/emergency{
@@ -39159,6 +39923,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"skQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "sla" = (
 /obj/stool/bench/red/auto,
 /turf/simulated/floor/wood,
@@ -39405,6 +40177,19 @@
 	dir = 4
 	},
 /area/listeningpost)
+"srr" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/space)
 "srs" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -39706,21 +40491,6 @@
 	dir = 4
 	},
 /area/station/science/chemistry)
-"swA" = (
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "swN" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -39839,13 +40609,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
-"sAl" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/redblack/corner,
-/area/station/hallway/secondary/exit)
 "sBk" = (
 /obj/machinery/computer/operating{
 	id = "OR1";
@@ -40080,6 +40843,13 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
+"sFa" = (
+/turf/simulated/floor/purpleblack{
+	dir = 4
+	},
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "sFb" = (
 /obj/table/wood/auto,
 /obj/item/paper/book/from_file/monster_manual,
@@ -40107,6 +40877,14 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"sFC" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "sFH" = (
 /obj/lattice,
 /obj/machinery/launcher_loader/south,
@@ -40174,11 +40952,10 @@
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "sHW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/turf/simulated/wall/false_wall/reinforced,
+/area/station/science/lobby{
+	name = "Science Lounge"
+	})
 "sHZ" = (
 /obj/machinery/light,
 /obj/decal/tile_edge/line/black{
@@ -40253,15 +41030,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"sJl" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 6
-	},
-/turf/simulated/floor/greenblack{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "sJw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40383,6 +41151,12 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/listeningpost)
+"sKX" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 8
+	},
+/area/space)
 "sLf" = (
 /obj/monkeyplant,
 /obj/machinery/firealarm{
@@ -40520,14 +41294,6 @@
 	dir = 8
 	},
 /area/station/turret_protected/Zeta)
-"sNR" = (
-/obj/shrub{
-	dir = 1
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "sNW" = (
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/northeast)
@@ -40546,6 +41312,17 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"sOe" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/space)
 "sOh" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -40656,10 +41433,7 @@
 /turf/simulated/floor/red,
 /area/station/security/brig/solitary)
 "sPZ" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
+/turf/space,
 /area/station/hallway/primary/southeast)
 "sQj" = (
 /obj/disposalpipe/segment/transport,
@@ -40702,18 +41476,24 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
 /area/station/bridge)
-"sQx" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "sQI" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_east)
+"sQU" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour14;desc=On your left is the Site refinery - Engineers access the Siphon through its far door, and its nano-fabricator is often used for catalytic rod fabrication.";
+	freq = 1443;
+	location = "tour13";
+	name = "tour 13 - east1"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/space)
 "sRc" = (
 /obj/landmark/halloween,
 /obj/cable{
@@ -40770,6 +41550,9 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"sSm" = (
+/turf/simulated/floor/yellowblack,
+/area/space)
 "sSA" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -40840,13 +41623,9 @@
 /obj/access_spawn/bar,
 /obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
-/area/station/maintenance/west)
-"sUG" = (
-/obj/machinery/vending/pda,
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
+/area/station/hallway/secondary/entry{
+	name = "Arrival Shuttle Hallway"
+	})
 "sUK" = (
 /obj/stool/chair{
 	dir = 4
@@ -41040,6 +41819,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
+"sYj" = (
+/obj/stool/bench/yellow/auto,
+/turf/simulated/floor/black,
+/area/space)
 "sYs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41550,9 +42333,7 @@
 	},
 /obj/storage/closet/emergency,
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
+/area/space)
 "tii" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -41609,6 +42390,14 @@
 "tje" = (
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
+"tjk" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 1
+	},
+/area/space)
 "tjr" = (
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
@@ -41628,6 +42417,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"tjF" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "tjV" = (
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -41687,14 +42482,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"tkM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "tly" = (
 /obj/storage/crate,
 /obj/item/wirecutters,
@@ -41741,6 +42528,15 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
+"tms" = (
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 6
+	},
+/turf/simulated/floor/greenblack{
+	dir = 1
+	},
+/area/space)
 "tmw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41786,16 +42582,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"tnm" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "tnC" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/lightbox/tubes,
@@ -41856,6 +42642,11 @@
 /obj/item/cargotele,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
+"tpv" = (
+/turf/simulated/floor/grey/side{
+	dir = 4
+	},
+/area/station/crew_quarters/market)
 "tpy" = (
 /obj/machinery/light,
 /obj/cable{
@@ -41878,15 +42669,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
-"tqj" = (
-/obj/table/reinforced/auto,
-/obj/item/decoration/flower_vase{
-	pixel_y = 14
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "tqL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/hos{
@@ -42028,6 +42810,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"ttQ" = (
+/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/turf/simulated/floor/engine/caution/west,
+/area/space)
 "ttW" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4
@@ -42170,6 +42956,12 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"txv" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/space/fluid/acid/clear,
+/area/shuttle/arrival/station)
 "txC" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/access_spawn/chapel_office,
@@ -42617,6 +43409,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
+"tHH" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 9
+	},
+/area/space)
 "tIi" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
@@ -42797,10 +43597,6 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
-"tLK" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "tLV" = (
 /obj/machinery/light{
 	dir = 1;
@@ -42996,13 +43792,6 @@
 	},
 /turf/simulated/floor/greenblack/corner,
 /area/station/storage/emergency)
-"tRa" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "tRj" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 4
@@ -43043,14 +43832,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"tRH" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "tRU" = (
 /turf/simulated/floor/black,
 /area/station/science/hall)
@@ -43079,6 +43860,15 @@
 "tSO" = (
 /turf/simulated/floor/redblack,
 /area/listeningpost)
+"tSU" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 5
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/space)
 "tSY" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -43140,6 +43930,22 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"tUl" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/transport,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "market";
+	name = "Public Market";
+	opacity = 0;
+	dir = 4
+	},
+/turf/simulated/floor/grey,
+/area/station/crew_quarters/market)
 "tUn" = (
 /obj/disposalpipe/segment/vertical,
 /obj/landmark/gps_waypoint,
@@ -43221,6 +44027,14 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"tXe" = (
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8;
+	on = 1;
+	transfer_rate = 1000
+	},
+/turf/simulated/floor/black,
+/area/space)
 "tXk" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/engine,
@@ -43241,6 +44055,9 @@
 "tXW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/northeast)
+"tYe" = (
+/turf/space,
+/area/station/hallway/secondary/east)
 "tYl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/robotics)
@@ -43263,13 +44080,6 @@
 	dir = 6
 	},
 /area/station/engine/storage)
-"tYH" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "tYQ" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/stma_kit,
@@ -43344,17 +44154,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
-"tZS" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/blueblack/corner{
-	dir = 4
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
 "uar" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -43951,6 +44750,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
+"urL" = (
+/turf/simulated/floor/grey/side{
+	dir = 9
+	},
+/area/station/crew_quarters/market)
 "usf" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -44583,10 +45387,6 @@
 "uHL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
-"uHR" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "uHS" = (
 /turf/simulated/floor/yellowblack,
 /area/station/engine/elect)
@@ -44767,6 +45567,12 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
+"uNg" = (
+/obj/stool/chair/office/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/space)
 "uNk" = (
 /obj/stool/chair{
 	dir = 8
@@ -45251,6 +46057,16 @@
 	do_not_irradiate = 1;
 	name = "Hydroponics Storage"
 	})
+"uYg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "uYq" = (
 /obj/warp_beacon{
 	name = "Arrivals Wing"
@@ -45295,6 +46111,10 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig/genpop)
+"uZi" = (
+/obj/reagent_dispensers/beerkeg,
+/turf/simulated/floor/plating,
+/area/space)
 "uZq" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -45400,6 +46220,11 @@
 /area/station/maintenance/outer/sw{
 	name = "Southwest Breach Hull"
 	})
+"vcJ" = (
+/turf/simulated/floor/grey/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market)
 "vcK" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -45478,6 +46303,14 @@
 	dir = 8
 	},
 /area/station/security/main)
+"vfd" = (
+/obj/machinery/atmospherics/valve{
+	name = "bleed valve"
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "vfp" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/emergency_injector/atropine{
@@ -45523,6 +46356,17 @@
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
 	})
+"vgz" = (
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "vgL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45707,6 +46551,10 @@
 	dir = 6
 	},
 /area/station/science/chemistry)
+"vne" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "vnp" = (
 /obj/disposalpipe/segment/food{
 	dir = 4;
@@ -46107,6 +46955,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"vwd" = (
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/sanitary,
+/area/space)
 "vwg" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -46321,24 +47178,6 @@
 	dir = 4
 	},
 /area/station/security/main)
-"vBk" = (
-/obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_y = 6;
-	pixel_x = 6
-	},
-/obj/machinery/light/lamp/black{
-	pixel_y = 10;
-	pixel_x = 1
-	},
-/obj/item/pen{
-	pixel_y = -2;
-	pixel_x = -5
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "vBq" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -46375,17 +47214,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"vCz" = (
-/obj/storage/crate,
-/obj/item/plate,
-/obj/item/reagent_containers/food/snacks/spaghetti/meatball{
-	pixel_x = -1
-	},
-/obj/item/toy/gooncode{
-	pixel_x = 3
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "vCH" = (
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart for utility things.";
@@ -46500,18 +47328,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
+"vFq" = (
+/obj/machinery/computer3/terminal/zeta,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "vFY" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/drinks/bowl{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/cereal_box/roach{
-	pixel_x = -5;
-	pixel_y = 4
-	},
+/obj/landmark/random_room/size3x5,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
+/area/station/maintenance/inner/west)
 "vGn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46583,6 +47409,16 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"vHw" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	dir = 8
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/inner/east)
 "vHX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46639,6 +47475,10 @@
 "vJk" = (
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"vJu" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/engine/caution/northsouth,
+/area/space)
 "vJO" = (
 /obj/rack,
 /obj/item/crowbar/red{
@@ -46749,6 +47589,12 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/pasiphae/crew)
+"vMP" = (
+/obj/machinery/power/nuclear/turbine_control,
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "vMQ" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1
@@ -46921,6 +47767,9 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
+"vRR" = (
+/turf/simulated/floor/yellowblack/corner,
+/area/space)
 "vSi" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/luggable,
@@ -47343,6 +48192,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
+"wcU" = (
+/obj/machinery/vending/pda,
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "wcV" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -47567,6 +48422,28 @@
 	dir = 8
 	},
 /area/station/hallway/primary/southwest)
+"wjg" = (
+/obj/table/auto,
+/obj/item/decoration/ashtray,
+/obj/item/dice{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/coin{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/obj/machinery/light/small,
+/obj/item/dice{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/beer{
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "wjl" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -47911,6 +48788,22 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
+"wuh" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/plating,
+/area/space)
+"wuw" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 9
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 5
+	},
+/area/space)
 "wuF" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -48149,6 +49042,9 @@
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "kitchen";
 	name = "kitchen mail junction"
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
@@ -48461,6 +49357,16 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"wIh" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "wIo" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -48532,6 +49438,13 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
+"wJL" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
+/obj/storage/closet/wardrobe/mixed,
+/turf/simulated/floor/plating,
+/area/space)
 "wJP" = (
 /obj/machinery/plantpot,
 /obj/machinery/light{
@@ -48690,6 +49603,9 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"wPw" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/inner/east)
 "wPO" = (
 /turf/unsimulated/floor/shuttle{
 	dir = 8;
@@ -48891,17 +49807,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
-"wUa" = (
-/obj/stool/chair/office/blue{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/black/side{
-	dir = 1
-	},
-/area/station/hallway/primary/southeast)
 "wUf" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -49068,6 +49973,10 @@
 /obj/disposalpipe/junction/left/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"wYE" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/turf/simulated/floor/engine,
+/area/space)
 "wYK" = (
 /obj/storage/secure/closet/immersion/engineering,
 /obj/item/clothing/suit/space/diving/engineering{
@@ -49132,6 +50041,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
+"wZn" = (
+/obj/table/wood/round/auto,
+/obj/item/paper_bin{
+	pixel_y = 2
+	},
+/turf/simulated/floor/black/side{
+	dir = 1
+	},
+/area/space)
 "wZv" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
@@ -50075,16 +50993,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/pasiphae/hangar)
-"xxz" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "xxE" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/black,
@@ -50184,6 +51092,13 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"xzv" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "xzL" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
@@ -50427,6 +51342,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/disposal)
+"xDg" = (
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 4
+	},
+/area/space)
 "xDz" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -50518,6 +51438,33 @@
 	icon_state = "gib6"
 	},
 /turf/space/fluid/acid/clear,
+/area/space)
+"xHz" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/item/storage/pill_bottle/antirad{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/emergency_injector/anti_rad{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/emergency_injector/anti_rad{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
 /area/space)
 "xHG" = (
 /obj/machinery/door/airlock/pyro/reinforced/syndicate{
@@ -50782,6 +51729,12 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/northwest)
+"xNP" = (
+/obj/machinery/atmospherics/valve{
+	name = "cold loop freezer interface valve"
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "xOa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
@@ -50913,12 +51866,8 @@
 	})
 "xPJ" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/blackwhite{
-	dir = 6
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
+/turf/simulated/floor/black,
+/area/space)
 "xPY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51019,6 +51968,18 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
+"xRN" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/bowl{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/cereal_box/roach{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "xRP" = (
 /obj/machinery/computer3/generic/med_data{
 	dir = 4
@@ -51086,6 +52047,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
+"xSt" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "xSx" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency,
@@ -51383,6 +52350,14 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/storage/emergency2)
+"xYh" = (
+/obj/machinery/atmospherics/valve{
+	name = "purge valve"
+	},
+/turf/simulated/floor/engine/caution/misc{
+	dir = 6
+	},
+/area/space)
 "xYr" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -51629,6 +52604,9 @@
 "ygn" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
+"ygt" = (
+/turf/simulated/floor/engine,
+/area/space)
 "yhH" = (
 /obj/cable,
 /obj/cable{
@@ -51671,15 +52649,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
-"yib" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/south)
 "yik" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/terminal/zeta{
@@ -51729,6 +52698,9 @@
 	dir = 8
 	},
 /area/station/medical/medbay/pharmacy)
+"yjf" = (
+/turf/simulated/floor/plating,
+/area/space)
 "yjq" = (
 /obj/deployable_turret/riot{
 	active = 1;
@@ -51747,20 +52719,6 @@
 	dir = 8
 	},
 /area/shuttle/arrival/station)
-"ykh" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/forcefield/energyshield/perma/doorlink{
-	dir = 8
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/black,
-/area/station/maintenance/east)
 "ykm" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay{
@@ -64062,11 +65020,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -64359,11 +65317,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -64660,11 +65618,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -64961,11 +65919,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -65261,11 +66219,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -65561,11 +66519,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -65858,11 +66816,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -66157,11 +67115,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -66458,11 +67416,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -66759,11 +67717,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -67060,11 +68018,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -67362,11 +68320,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -67664,11 +68622,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -67966,11 +68924,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -68268,11 +69226,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -68570,11 +69528,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -68871,11 +69829,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -69173,11 +70131,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -69475,11 +70433,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -69777,11 +70735,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -70079,11 +71037,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -70380,11 +71338,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -70682,11 +71640,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -70983,11 +71941,11 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -71285,10 +72243,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -71328,11 +72282,15 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -71586,11 +72544,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -71636,6 +72592,8 @@ nkR
 wEz
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -71888,11 +72846,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -71938,6 +72894,8 @@ hnw
 rJg
 hkp
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72188,11 +73146,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72240,6 +73196,8 @@ uYq
 iXj
 wTj
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72488,11 +73446,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72542,6 +73498,8 @@ hnw
 rJg
 emb
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72789,11 +73747,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -72844,6 +73800,8 @@ kmB
 wEz
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -73090,10 +74048,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -73140,11 +74094,15 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -73389,10 +74347,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -73443,9 +74397,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -73686,10 +74644,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -73745,9 +74699,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -73986,10 +74944,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -74047,9 +75001,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -74287,10 +75245,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -74349,9 +75303,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -74586,10 +75544,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -74651,9 +75605,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -74884,10 +75842,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -74953,9 +75907,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -75183,10 +76141,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -75254,11 +76208,15 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -75482,10 +76440,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -75552,6 +76506,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
@@ -75565,6 +76521,8 @@ rJg
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -75783,10 +76741,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -75856,6 +76810,8 @@ rJg
 rJg
 rJg
 rJg
+rJg
+rJg
 rXj
 rXj
 rXj
@@ -75865,6 +76821,8 @@ rJg
 rXj
 rXj
 rXj
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -76084,10 +77042,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -76155,6 +77109,8 @@ bzS
 bzS
 rJg
 rJg
+rJg
+rJg
 rXj
 toT
 mRK
@@ -76170,6 +77126,8 @@ qUn
 hrF
 dOJ
 rXj
+rJg
+rJg
 rJg
 rJg
 bzS
@@ -76386,10 +77344,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -76457,6 +77411,8 @@ bzS
 rJg
 rJg
 rJg
+rJg
+rJg
 bJL
 uJL
 bIB
@@ -76472,6 +77428,8 @@ rvz
 rvz
 bsp
 cMR
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -76687,10 +77645,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -76759,6 +77713,8 @@ rJg
 rJg
 rJg
 rJg
+rJg
+rJg
 wQv
 feM
 tJl
@@ -76774,6 +77730,8 @@ aDq
 wPO
 nBu
 wQv
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -76989,10 +77947,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -77061,6 +78015,8 @@ rJg
 rJg
 rJg
 rJg
+rJg
+rJg
 vLf
 guf
 xwU
@@ -77076,6 +78032,8 @@ wPO
 wPO
 nBu
 vLf
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -77290,10 +78248,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -77363,6 +78317,8 @@ dqY
 rJg
 rJg
 rJg
+rJg
+rJg
 bJL
 gey
 lrG
@@ -77378,6 +78334,8 @@ lrG
 lrG
 gey
 cMR
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -77590,10 +78548,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -77665,6 +78619,8 @@ dqY
 dqY
 rJg
 rJg
+rJg
+rJg
 xYB
 wMS
 teB
@@ -77680,6 +78636,8 @@ teB
 teB
 wMS
 xYB
+rJg
+rJg
 rJg
 rJg
 dqY
@@ -77891,10 +78849,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -77967,6 +78921,8 @@ dqY
 dqY
 pDy
 mWE
+pDy
+mWE
 cVU
 teB
 teB
@@ -77982,6 +78938,8 @@ teB
 teB
 teB
 cVU
+bQV
+pDy
 bQV
 pDy
 dqY
@@ -78193,10 +79151,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -78269,6 +79223,8 @@ diT
 wMp
 tEn
 tEn
+tEn
+tEn
 lzf
 saJ
 saJ
@@ -78284,6 +79240,8 @@ saJ
 saJ
 saJ
 lzf
+tEn
+tEn
 tEn
 tEn
 wMp
@@ -78494,10 +79452,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -78571,6 +79525,8 @@ fzq
 fDm
 tEn
 tEn
+tEn
+tEn
 xYB
 plY
 saJ
@@ -78586,6 +79542,8 @@ saJ
 saJ
 plY
 xYB
+tEn
+tEn
 tEn
 tEn
 fDm
@@ -78796,10 +79754,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -78873,6 +79827,8 @@ diT
 wMp
 tEn
 tEn
+tEn
+tEn
 lzf
 saJ
 saJ
@@ -78888,6 +79844,8 @@ saJ
 saJ
 saJ
 lzf
+tEn
+tEn
 tEn
 tEn
 wMp
@@ -79098,10 +80056,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -79175,6 +80129,8 @@ gbL
 dqY
 pDy
 mWE
+pDy
+mWE
 cVU
 umD
 umD
@@ -79190,6 +80146,8 @@ umD
 umD
 umD
 cVU
+bQV
+pDy
 bQV
 pDy
 dqY
@@ -79400,10 +80358,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -79477,6 +80431,8 @@ gfS
 fDm
 rJg
 rJg
+rJg
+rJg
 xYB
 umD
 umD
@@ -79492,6 +80448,8 @@ umD
 umD
 umD
 xYB
+rJg
+rJg
 rJg
 rJg
 fDm
@@ -79702,10 +80660,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 aUi
 lgj
 lgj
@@ -79779,6 +80733,8 @@ gfS
 fDm
 rJg
 rJg
+rJg
+rJg
 bJL
 pwP
 umD
@@ -79794,6 +80750,8 @@ umD
 umD
 mDc
 cMR
+rJg
+rJg
 rJg
 rJg
 fDm
@@ -80003,10 +80961,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 aUi
 csW
 hqD
@@ -80081,7 +81035,9 @@ gfS
 fDm
 rJg
 rJg
-shh
+rJg
+rJg
+njT
 dDw
 pwP
 hbN
@@ -80095,7 +81051,9 @@ umD
 hbN
 mDc
 dDw
-mfr
+txv
+rJg
+rJg
 rJg
 rJg
 fDm
@@ -80305,10 +81263,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 eNp
 sdY
 ouF
@@ -80384,7 +81338,9 @@ dqY
 rJg
 rJg
 rJg
-shh
+rJg
+rJg
+njT
 pjd
 gey
 yka
@@ -80396,7 +81352,9 @@ yka
 yka
 gey
 pjd
-mfr
+txv
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -80607,10 +81565,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 eNp
 xEP
 aLS
@@ -80683,6 +81637,10 @@ jQa
 gbL
 gfS
 fDm
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -80908,10 +81866,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 aUi
 dmE
 lgj
@@ -80985,6 +81939,10 @@ mSi
 gbL
 gfS
 fDm
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -81210,10 +82168,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 pki
 vfQ
 vVy
@@ -81287,6 +82241,10 @@ jQa
 gbL
 gfS
 fDm
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -81512,10 +82470,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 pki
 rUk
 mQV
@@ -81593,18 +82547,22 @@ fDm
 fDm
 fDm
 dqY
-fDm
-fDm
-fDm
-dqY
-fDm
-fDm
+din
+din
 fDm
 dqY
 fDm
 fDm
 fDm
 dqY
+fDm
+fDm
+fDm
+dqY
+fDm
+fDm
+din
+siL
 fDm
 fDm
 fDm
@@ -81812,10 +82770,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 pki
@@ -81895,18 +82849,22 @@ gfS
 gfS
 gfS
 gbL
-gfS
-gfS
-gfS
-gbL
-gfS
-gfS
+yjf
+yjf
 gfS
 gbL
 gfS
 gfS
 gfS
 gbL
+gfS
+gfS
+gfS
+gbL
+gfS
+gfS
+yjf
+ctT
 gfS
 gfS
 gfS
@@ -82113,10 +83071,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -82197,18 +83151,22 @@ gbL
 gbL
 gbL
 dqY
-gbL
-gbL
-gbL
-dqY
-gbL
-gbL
+ctT
+ctT
 gbL
 dqY
 gbL
 gbL
 gbL
 dqY
+gbL
+gbL
+gbL
+dqY
+gbL
+gbL
+ctT
+siL
 gbL
 gbL
 gbL
@@ -82414,10 +83372,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -82499,16 +83453,20 @@ hQg
 lNt
 krr
 shv
-ccc
+cKX
+cKX
+diT
+diT
+qga
 iuy
-ccc
-tZS
-ccc
+hWJ
+gkJ
+hWJ
 hLQ
-xPJ
-ceK
-xPJ
-fiT
+qga
+hWJ
+hWJ
+hWJ
 xPJ
 rYi
 nsh
@@ -82716,10 +83674,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -82801,18 +83755,22 @@ uTO
 uTO
 dnH
 joJ
+cKX
+cKX
+diT
+diT
 uTO
 hzB
 uTO
+sqb
 uTO
 uTO
 uTO
 uTO
 uTO
 uTO
-uTO
-uTO
-joJ
+kCn
+bpG
 dnH
 uTO
 uTO
@@ -83017,10 +83975,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -83103,18 +84057,22 @@ hWJ
 hWJ
 aRF
 dqY
+glx
+kGN
+wvv
+dCz
 fsf
 lyE
 cbx
+dqY
 oWp
 iaz
 pjU
 dCz
+iEo
 eap
-oWp
-wvv
 thP
-dqY
+siL
 bHq
 hWJ
 hWJ
@@ -83319,10 +84277,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -83405,18 +84359,22 @@ kGA
 lkN
 kGA
 dqY
+siL
+siL
+dqY
+ahQ
 dqY
 sUF
 dqY
-dqY
-dqY
+siL
+siL
 vUa
 vUa
 vUa
 vUa
 vUa
-vUa
-vUa
+siL
+siL
 uNk
 qBW
 kGA
@@ -83621,10 +84579,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -83707,11 +84661,15 @@ ajs
 ajs
 ajs
 ajs
+pvZ
+pvZ
 osg
 uxX
 ctg
 voE
 cdv
+pvZ
+pvZ
 rvl
 gvL
 xsX
@@ -83922,10 +84880,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -84009,11 +84963,15 @@ uHm
 lLM
 trK
 ajs
+pvZ
+pvZ
 oEZ
 gbZ
 oEZ
 cbe
 dHA
+pvZ
+pvZ
 rvl
 dYJ
 obA
@@ -84223,10 +85181,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -84311,11 +85265,15 @@ fix
 qqc
 uUP
 plo
+pvZ
+pvZ
 utU
 ydp
 qGw
 mfN
 ciR
+pvZ
+pvZ
 rvl
 oaQ
 obA
@@ -84521,10 +85479,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -84613,7 +85567,11 @@ bpN
 ozA
 fvZ
 mbt
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 rvl
 rvl
 afy
@@ -84819,10 +85777,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -84915,7 +85869,11 @@ uXV
 ozA
 lQA
 mbt
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 rvl
 agr
 iaW
@@ -85120,10 +86078,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -85217,7 +86171,11 @@ uUP
 tQs
 qHC
 wQf
+pvZ
+pvZ
 bCR
+pvZ
+pvZ
 drc
 noD
 hTF
@@ -85421,10 +86379,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -85519,7 +86473,11 @@ bpN
 bpN
 cMH
 mbt
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 rvl
 iwQ
 aVQ
@@ -85723,10 +86681,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -85821,7 +86775,11 @@ wpS
 wpS
 mbt
 mbt
+pvZ
+pvZ
 tPd
+pvZ
+pvZ
 iHN
 iHN
 sOx
@@ -86024,10 +86982,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -86123,7 +87077,11 @@ cZD
 cZD
 opW
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 wPX
 kyY
@@ -86325,10 +87283,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -86425,7 +87379,11 @@ jdV
 jdV
 fLE
 oNg
+pvZ
+pvZ
 jVa
+pvZ
+pvZ
 iHN
 oJc
 kyY
@@ -86626,10 +87584,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -86727,7 +87681,11 @@ jdV
 jdV
 fDR
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 myU
 xPz
@@ -86928,10 +87886,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -87029,7 +87983,11 @@ jdV
 jdV
 fLE
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 daa
 rCD
@@ -87230,10 +88188,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -87331,7 +88285,11 @@ jdV
 jdV
 jdV
 oNg
+pvZ
+pvZ
 pnx
+pvZ
+pvZ
 iHN
 vAs
 bhF
@@ -87531,10 +88489,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -87633,7 +88587,11 @@ jpZ
 tsp
 fLE
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 nAa
 rCD
@@ -87833,10 +88791,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -87935,7 +88889,11 @@ hHm
 fDF
 fDR
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 cNa
 rCD
@@ -88135,10 +89093,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -88237,7 +89191,11 @@ jrb
 tBD
 fLE
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 mDr
 umB
@@ -88437,10 +89395,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -88539,7 +89493,11 @@ jdV
 jdV
 rUj
 oNg
+pvZ
+pvZ
 ejD
+pvZ
+pvZ
 iHN
 ers
 vnp
@@ -88739,10 +89697,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -88841,7 +89795,11 @@ jdV
 jdV
 fLE
 oNg
+pvZ
+pvZ
 gbZ
+pvZ
+pvZ
 iHN
 wdF
 ecO
@@ -89041,10 +89999,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -89143,7 +90097,11 @@ jdV
 jdV
 fDR
 oNg
+pvZ
+pvZ
 xmM
+pvZ
+pvZ
 iHN
 iHN
 iHN
@@ -89343,10 +90301,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -89445,12 +90399,16 @@ kAr
 jdV
 mvb
 oNg
+pvZ
+pvZ
 srs
 uOE
 uOE
 uOE
 kOn
 oEZ
+pvZ
+pvZ
 rsJ
 rsJ
 bso
@@ -89645,10 +90603,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -89751,9 +90705,13 @@ oNg
 oNg
 oNg
 oNg
+pvZ
+pvZ
 txT
 hrb
 uOE
+pvZ
+pvZ
 vjq
 lZa
 srJ
@@ -89947,10 +90905,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -90056,6 +91010,10 @@ oNg
 oNg
 oNg
 oNg
+pvZ
+pvZ
+pvZ
+pvZ
 xyJ
 fWc
 wqA
@@ -90249,10 +91207,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -90358,6 +91312,10 @@ irP
 jdK
 hot
 oNg
+pvZ
+pvZ
+pvZ
+pvZ
 vyr
 fWc
 wqA
@@ -90550,10 +91508,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -90660,6 +91614,10 @@ igl
 igl
 igl
 nVx
+pvZ
+pvZ
+pvZ
+pvZ
 wYC
 bER
 mrH
@@ -90852,10 +91810,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -90962,6 +91916,10 @@ ajV
 fpO
 lFq
 oNg
+pvZ
+pvZ
+pvZ
+pvZ
 txT
 nWF
 nWF
@@ -91154,10 +92112,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -91264,6 +92218,10 @@ jOy
 amO
 kQX
 oNg
+pvZ
+pvZ
+pvZ
+pvZ
 dAP
 ojk
 ahQ
@@ -91456,10 +92414,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -91566,6 +92520,10 @@ llQ
 qPX
 ewv
 ewv
+pvZ
+pvZ
+pvZ
+pvZ
 jmJ
 jmJ
 jmJ
@@ -91758,10 +92716,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -91861,6 +92815,8 @@ gNQ
 kAn
 esj
 esj
+pvZ
+pvZ
 esj
 esj
 sIa
@@ -91869,6 +92825,8 @@ esj
 esj
 gIt
 abg
+gNU
+gNU
 hAe
 hCf
 hDf
@@ -92060,10 +93018,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -92163,6 +93117,8 @@ gNQ
 gNQ
 gNQ
 gNQ
+pvZ
+pvZ
 gNQ
 gNQ
 gNQ
@@ -92171,6 +93127,8 @@ gNQ
 gNQ
 gNQ
 gNQ
+gNU
+gNU
 gNQ
 gNQ
 qaa
@@ -92362,10 +93320,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -92465,6 +93419,8 @@ bJF
 bJF
 eRl
 bJF
+pvZ
+pvZ
 kOG
 bJF
 bJF
@@ -92472,12 +93428,14 @@ oJM
 gjM
 cjv
 bJF
-bJF
-bJF
 jbQ
+gNQ
+gNQ
+uPZ
+uPZ
 ybp
 wAy
-cJe
+uPZ
 uPZ
 lyT
 ozw
@@ -92664,10 +93622,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -92777,10 +93731,14 @@ gfR
 gfR
 gfR
 cNY
-shc
-lEz
-jmJ
-jmJ
+tUl
+jRu
+fYj
+lJi
+vRv
+vRv
+jUz
+jUz
 jmJ
 jmJ
 eGA
@@ -92966,10 +93924,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -93079,10 +94033,14 @@ nWL
 pHo
 gCI
 cNY
-sHW
-cOM
-bFl
-rUr
+urL
+itK
+itK
+khK
+vRv
+hBh
+cvc
+cvc
 dMn
 pqn
 bIi
@@ -93268,10 +94226,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -93381,10 +94335,14 @@ fRH
 qNE
 fFJ
 cNY
-sHW
-cOM
-bFl
-cOM
+vcJ
+qVd
+qVd
+jKH
+boK
+fnk
+cvc
+cvc
 cOM
 pqn
 fgd
@@ -93569,10 +94527,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -93683,11 +94637,15 @@ xjY
 fEJ
 fEJ
 cNY
-tnm
-fOH
-ihI
+iyZ
+tpv
+tpv
+bPO
+vRv
+vRv
+cvc
 ppA
-qGL
+mUC
 sKN
 rjL
 qSj
@@ -93871,10 +94829,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -93985,10 +94939,14 @@ uBU
 dJE
 wZU
 cNY
-nCG
+rdj
+rdj
+vRv
+vRv
+vRv
 aTs
-bFl
-sHW
+cvc
+cvc
 bSc
 pqn
 qVZ
@@ -94173,10 +95131,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -94290,8 +95244,12 @@ cNY
 fmO
 nBp
 fmO
+fnk
+gGG
+fnk
+cvc
 pfn
-cOM
+vne
 pqn
 aVa
 lLN
@@ -94475,10 +95433,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -94592,8 +95546,12 @@ lYL
 ocX
 qHV
 fmO
-sHW
-kBB
+cvc
+mUC
+mUC
+mUC
+mUC
+mUC
 kBB
 kBB
 kBB
@@ -94777,10 +95735,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -94894,8 +95848,12 @@ dGx
 kEe
 mXd
 fmO
-sHW
-kBB
+xzv
+mUC
+cvc
+cvc
+ooq
+mUC
 dzR
 bks
 kBB
@@ -95079,10 +96037,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -95196,8 +96150,12 @@ tRU
 czo
 bfp
 fmO
-sHW
-kBB
+cvc
+pDb
+cvc
+cvc
+cvc
+mUC
 acs
 fGD
 pXV
@@ -95381,10 +96339,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -95498,8 +96452,12 @@ lLZ
 czo
 mXd
 fmO
-sHW
-kBB
+cvc
+mUC
+cvc
+cvc
+cvc
+mUC
 uyD
 pyi
 kBB
@@ -95683,10 +96641,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -95800,10 +96754,14 @@ sDF
 czo
 cfj
 fmO
-sHW
-kBB
-kBB
-kBB
+cvc
+mUC
+mUC
+mUC
+mUC
+mUC
+mUC
+mUC
 kBB
 jTO
 vHa
@@ -95985,10 +96943,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -96102,9 +97056,13 @@ hyG
 czo
 mXd
 fmO
-sHW
-cOM
-pMS
+cvc
+cvc
+mUC
+cvc
+cvc
+cvc
+cvc
 vFY
 kBB
 dHz
@@ -96287,10 +97245,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -96404,9 +97358,13 @@ rpK
 czo
 mXd
 fmO
-buW
-fiK
-pMS
+cvc
+cvc
+pDb
+cvc
+cvc
+cvc
+cvc
 cvc
 kBB
 kBB
@@ -96589,10 +97547,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -96706,10 +97660,14 @@ lUZ
 czo
 teX
 fmO
-aaX
-sHW
-cOM
-hCB
+cvc
+cvc
+mUC
+cvc
+cvc
+cvc
+cvc
+cvc
 bgw
 tcx
 lEn
@@ -96891,10 +97849,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -97008,9 +97962,13 @@ aAe
 czo
 mXd
 fmO
+jUz
+afk
 bgw
-shc
-lEz
+bgw
+bgw
+bgw
+bgw
 bgw
 bgw
 fGg
@@ -97193,10 +98151,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -97312,6 +98266,10 @@ buP
 hHW
 xCK
 cQo
+xCK
+xCK
+xCK
+xCK
 xCK
 xCK
 tVG
@@ -97495,10 +98453,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -97616,6 +98570,10 @@ pjY
 hbm
 fip
 bBa
+oxS
+lEn
+llU
+lEn
 nKe
 buD
 fJg
@@ -97797,10 +98755,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -97918,6 +98872,10 @@ jdX
 fLp
 jdX
 jdX
+sFa
+sFa
+sFa
+sFa
 eQi
 lrN
 jRl
@@ -98099,10 +99057,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -98216,10 +99170,14 @@ lLA
 czo
 mXd
 fmO
+vHw
+oht
 bgw
-shc
-lEz
 bgw
+bgw
+rpz
+rpz
+rpz
 bgw
 uiy
 xII
@@ -98401,10 +99359,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -98518,10 +99472,14 @@ mqx
 uun
 mpx
 fmO
-vCz
-sHW
-cOM
-dZl
+lZB
+xSt
+bgw
+pfN
+bgw
+bgw
+pfN
+bgw
 bgw
 bgw
 bgw
@@ -98703,10 +99661,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -98820,9 +99774,13 @@ bhY
 uun
 mXd
 fmO
-tYH
-sHW
-cOM
+lEU
+aOo
+bgw
+pfN
+pfN
+pfN
+pfN
 pfN
 sOU
 sgu
@@ -99005,10 +99963,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -99122,9 +100076,13 @@ juT
 czo
 mXd
 fmO
-cOM
-sHW
-caO
+lZB
+xSt
+bgw
+pfN
+bgw
+pfN
+pfN
 sOU
 sOU
 sOU
@@ -99307,10 +100265,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -99424,7 +100378,11 @@ hOz
 uun
 cfj
 fmO
-cOM
+qzW
+lZB
+bgw
+bgw
+bgw
 sHW
 sOU
 sOU
@@ -99609,10 +100567,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -99726,7 +100680,11 @@ tRU
 czo
 mXd
 fmO
-tRa
+lZB
+lZB
+wPw
+cAH
+lZB
 lZB
 sOU
 fqt
@@ -99911,10 +100869,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -100028,8 +100982,12 @@ tRU
 czo
 bfp
 fmO
-cOM
-sHW
+lZB
+lZB
+wPw
+wPw
+wPw
+lZB
 sOU
 pMc
 qXF
@@ -100213,10 +101171,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -100330,8 +101284,12 @@ haT
 bAq
 bPo
 fmO
-cOM
-sHW
+lZB
+lZB
+lVG
+lZB
+lZB
+lZB
 sOU
 gXd
 nCO
@@ -100515,10 +101473,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -100632,8 +101586,12 @@ qKT
 qmt
 klu
 fmO
-cOM
-sHW
+cAs
+cAs
+cAs
+cAs
+lZB
+lZB
 sOU
 sOU
 iLV
@@ -100817,10 +101775,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -100934,8 +101888,12 @@ fmO
 fmO
 fmO
 fmO
-rgb
-sHW
+dxd
+dxd
+dxd
+cAs
+lZB
+lZB
 sOU
 sOU
 lPy
@@ -101119,10 +102077,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -101233,11 +102187,15 @@ aaY
 dkT
 mPS
 xZH
-nCG
-fUZ
-bFl
-cOM
-sHW
+dxd
+dxd
+dxd
+dxd
+dxd
+dxd
+cAs
+lZB
+lZB
 sOU
 sOU
 iJU
@@ -101420,10 +102378,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -101535,11 +102489,15 @@ qiE
 qiE
 qiE
 xZH
-xxz
-hkS
-eLY
-hkS
-qFg
+dxd
+dxd
+dxd
+dxd
+dxd
+dxd
+cAs
+lZB
+lZB
 sOU
 sOU
 nej
@@ -101722,10 +102680,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -101837,11 +102791,15 @@ iBT
 hrd
 iBT
 opC
-emc
-kXG
-bFl
-cOM
-yib
+dxd
+dxd
+dxd
+dxd
+dxd
+dxd
+cAs
+lZB
+lZB
 sOU
 sOU
 sOU
@@ -102024,10 +102982,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -102139,11 +103093,15 @@ uhy
 aVI
 xmz
 xZH
-sHW
-gOc
-bFl
-uHR
-tLK
+dxd
+dxd
+dxd
+dxd
+dxd
+dxd
+cAs
+lZB
+lZB
 sOU
 sOU
 sOU
@@ -102326,10 +103284,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -102441,10 +103395,14 @@ hJl
 hJl
 xZH
 xZH
-shc
-nIo
-xKn
-xKn
+cAs
+cAs
+cAs
+cAs
+cAs
+cAs
+cAs
+vHw
 xKn
 xKn
 sdK
@@ -102628,10 +103586,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -102739,8 +103693,8 @@ xpP
 lxX
 iTi
 vGu
-rxk
-pzd
+sQU
+qyt
 xpP
 cib
 hQp
@@ -102748,6 +103702,10 @@ hQs
 xCs
 hQB
 vGW
+tYe
+tYe
+tYe
+tYe
 qnF
 ezi
 ezi
@@ -102930,10 +103888,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -103041,8 +103995,8 @@ mDQ
 sUB
 mDQ
 mDQ
-mDQ
-mDQ
+cKX
+cKX
 mDQ
 mDQ
 oVJ
@@ -103050,6 +104004,10 @@ dqZ
 xJA
 fYG
 vkn
+tYe
+tYe
+tYe
+tYe
 rmX
 wRc
 rZb
@@ -103232,10 +104190,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -103343,15 +104297,19 @@ xIE
 qwj
 qwj
 kse
+aXE
+qrF
 qwj
-xIE
 qwj
-qwj
-oBy
-fGK
+mDQ
+mDQ
 vui
 olA
 olA
+tYe
+tYe
+tYe
+tYe
 cYD
 jej
 sFL
@@ -103534,10 +104492,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -103642,19 +104596,23 @@ fNc
 gdf
 ybP
 gdf
-cAs
-cie
-cAs
-mCe
-cAs
-cie
-cAs
-aaH
-nmg
-vRv
-kQr
-blR
-vRv
+siL
+pvZ
+dDv
+siL
+siL
+fLQ
+fLQ
+fLQ
+siL
+fLQ
+fLQ
+fLQ
+siL
+siL
+siL
+siL
+siL
 nyR
 teP
 vEo
@@ -103836,10 +104794,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -103944,20 +104898,24 @@ fNc
 wEh
 cBo
 liA
-cAs
-efM
-wsv
-wbW
-tdd
-lep
-cAs
-naN
-qTS
-dnY
-xbV
-uDa
-jRu
-jRu
+siL
+yjf
+yjf
+yjf
+siL
+aZV
+aZV
+aZV
+aZV
+aZV
+aZV
+aZV
+siL
+xHz
+aZM
+vwd
+siL
+siL
 yiB
 vEo
 oZk
@@ -104138,10 +105096,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -104246,20 +105200,24 @@ gdf
 sIJ
 axd
 liA
-cAs
-lTQ
-dxd
-ujo
-mrT
-avl
-cAs
-tPR
-qTS
-dnY
-kHr
-qVd
-oGn
-vRv
+siL
+yjf
+yjf
+yjf
+siL
+fLQ
+fLQ
+fLQ
+siL
+fLQ
+fLQ
+fLQ
+siL
+bre
+qxz
+qxz
+bMH
+siL
 sXH
 qwN
 pOW
@@ -104440,10 +105398,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -104548,20 +105502,24 @@ fNc
 gdf
 qsI
 gdf
-cAs
-wFc
-mrT
-ind
-dxd
-avl
-cAs
-naN
-qTS
-dnY
-eQO
-irG
-ftI
-jRu
+siL
+yjf
+yjf
+siL
+siL
+dhu
+hkU
+hkU
+hkU
+hkU
+hkU
+hkU
+dfm
+lGL
+cKX
+cKX
+aut
+ajo
 axJ
 vEo
 hrC
@@ -104741,10 +105699,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -104850,23 +105804,27 @@ pqb
 cBo
 cBo
 xVo
-cAs
-pbY
-hxc
-ind
-cWV
-fpC
-cAs
-xwV
-qHD
-sxq
-uik
-tEU
-tEU
-qfy
+siL
+yjf
+yjf
+siL
+siL
+tHH
+gzh
+gzh
+sKX
+tSU
+jOW
+jOW
+wYE
+eSP
+cKX
+cKX
+aut
+ajo
 bEm
-apR
-lUQ
+vEo
+fdg
 vEo
 krn
 hWH
@@ -105043,10 +106001,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -105152,23 +106106,27 @@ pqb
 cBo
 cBo
 oYt
-cAs
-bfG
-cWV
-ind
-hxc
-yaN
-cAs
-aLz
-qTS
-dnY
-uGB
-aiq
-uSr
-jRu
-yiB
+siL
+yjf
+yjf
+siL
+siL
+qXv
+ygt
+ygt
+ygt
+ygt
+ygt
+jOW
+dfm
+lGL
+sYj
+cKX
+aut
+ajo
+bEm
 vEo
-iPJ
+fdg
 vEo
 vIQ
 hWH
@@ -105345,10 +106303,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -105454,20 +106408,24 @@ fNc
 trR
 eWn
 byw
-cAs
-bxi
-oJO
-lIl
-cEk
-fjA
-cAs
-aLz
-qTS
-dnY
-dnY
-dnY
-dnY
-vRv
+siL
+yjf
+yjf
+siL
+siL
+tjk
+ygt
+ygt
+ygt
+nCb
+ygt
+kQl
+siL
+siL
+ctT
+jpM
+siL
+siL
 sXH
 vEo
 oWK
@@ -105647,10 +106605,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -105756,23 +106710,27 @@ fNc
 fNc
 cHo
 fNc
-cAs
-cAs
-cAs
-cAs
-vBq
-cAs
-cAs
-jfd
-oRR
-sHI
-efI
-tjx
-par
-sXH
-vBk
+siL
+yjf
+yjf
+siL
+siL
+dmq
+ygt
+ygt
+ygt
+ygt
+ygt
+ijc
+dfm
+vFq
+cKX
+cKX
+sSm
+siL
+bEm
 sVX
-iPJ
+fdg
 wlW
 fMN
 qbA
@@ -105949,10 +106907,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -106055,26 +107009,30 @@ fNc
 gdf
 gdf
 fNc
-kJO
-oUg
-iKc
-iIi
-iIi
-iIi
-uEm
-axq
-iIi
-iIi
-iNo
-rfO
-ncu
-iLL
-eHE
-fQN
-sXH
-wUa
+gie
+yjf
+yjf
+yjf
+yjf
+yjf
+siL
+siL
+dFE
+vfd
+lDM
+gAA
+lFh
+ijc
+ijc
+dfm
+vMP
+uNg
+cKX
+sSm
+gDo
+bEm
 vEo
-iPJ
+fdg
 uEI
 dOr
 uBt
@@ -106251,10 +107209,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -106358,23 +107312,27 @@ gYH
 iIi
 iIi
 iIi
-hvX
-rfO
-gie
-oZp
-oZp
-sxk
-oZp
-oZp
-oZp
-iXV
-oZp
-oZp
-ctr
-kll
-gZm
-sXH
-dtV
+yjf
+yjf
+yjf
+yjf
+yjf
+siL
+siL
+oSB
+ttQ
+ffH
+nJZ
+cdg
+ffH
+nJZ
+dfm
+gKd
+cKX
+cKX
+sSm
+siL
+bEm
 vEo
 iPJ
 rZb
@@ -106553,10 +107511,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -106660,22 +107614,26 @@ nbH
 cHd
 cHd
 cHd
-mwn
-jmz
-gie
-oZp
-jWW
-tfx
-ktv
-oZp
-tvR
-ixW
-oNJ
-oZp
-trb
-pqp
-jWG
-sXH
+yjf
+yjf
+yjf
+yjf
+iky
+siL
+siL
+jUT
+scP
+khh
+xNP
+ikE
+mKE
+hkU
+siL
+siL
+cKX
+vRR
+siL
+siL
 sXH
 rLM
 iPJ
@@ -106855,10 +107813,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -106962,23 +107916,27 @@ gKW
 uDe
 hTZ
 cHd
-pMD
-gie
-gie
-rIw
-vSi
-xcF
-eJa
-oZp
-rwN
-gkC
-rxi
-oZp
-oZp
-oZp
-oZp
-wMJ
-swA
+yjf
+yjf
+yjf
+yjf
+siL
+siL
+siL
+qXv
+cNc
+cNc
+fXU
+hkl
+eZV
+sFC
+dfm
+gcL
+cKX
+sSm
+gcL
+siL
+bEm
 vEo
 iPJ
 rZb
@@ -107157,10 +108115,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -107264,23 +108218,27 @@ hlO
 wLs
 kuV
 cHd
-iNG
-uIr
-obm
-oZp
-ibI
-xhy
-dLj
-oZp
-vnF
-aRG
-rnJ
-oZp
-qDf
-rLR
-rOZ
-jCy
-qWH
+qrh
+pDQ
+pDQ
+pDQ
+oMR
+oMR
+xYh
+olC
+ygt
+ygt
+ygt
+ygt
+ygt
+hkl
+dfm
+nSj
+bko
+bko
+kNR
+siL
+bEm
 vEo
 vWA
 tdq
@@ -107459,10 +108417,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -107566,23 +108520,27 @@ iww
 qxv
 xnE
 cHd
-kaN
-oZp
-oZp
-oZp
-oZp
-oZp
-nwR
-oZp
-oZp
-pxp
-oZp
-oZp
-qFM
-usM
-usM
-jCy
-sJl
+eIK
+siL
+siL
+siL
+siL
+siL
+siL
+rAG
+ygt
+ygt
+ygt
+ygt
+ygt
+alM
+qPw
+bel
+eSW
+sSm
+cyG
+siL
+bEm
 vEo
 fdg
 rZb
@@ -107761,10 +108719,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -107868,22 +108822,26 @@ iww
 opJ
 cHd
 cHd
-hwo
-oZp
-iPM
-xAt
-hYo
-oZp
-bXN
-xcC
-afH
-nRv
-vns
-pOI
-qGa
-rNt
-nvB
-wMJ
+eIK
+siL
+yjf
+yjf
+yjf
+siL
+siL
+tjk
+ygt
+ygt
+agh
+pKL
+pKL
+fQt
+siL
+siL
+tXe
+sSm
+siL
+siL
 sXH
 beT
 fdg
@@ -108063,10 +109021,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -108170,23 +109124,27 @@ wLs
 uqg
 xnE
 cHd
-mwn
-oZp
-fKD
-gkC
-ygn
-mrW
-qLl
-usM
-usM
-usM
-ctd
-pUJ
-qNM
-rNt
-usM
-jCy
-sNR
+eIK
+siL
+yjf
+yjf
+yjf
+siL
+siL
+dmq
+ygt
+ygt
+ygt
+ygt
+ygt
+ijc
+dfm
+nEw
+bgj
+sSm
+ePt
+siL
+bEm
 jjd
 qBe
 rZb
@@ -108365,10 +109323,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -108472,23 +109426,27 @@ vNd
 wLs
 hEL
 cHd
-mwn
-oZp
-frT
-aHy
-vaR
-oZp
-fhJ
-eBr
-adk
-eBr
-eBr
-pUS
-pUS
-efZ
-eBr
-gdY
-tkM
+eIK
+yjf
+yjf
+yjf
+yjf
+siL
+siL
+dmq
+ygt
+ygt
+ygt
+ygt
+ygt
+ijc
+wYE
+oPG
+rqB
+sSm
+vJu
+siL
+bEm
 dZn
 rZb
 rZb
@@ -108667,10 +109625,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -108774,23 +109728,27 @@ ukd
 rtj
 sJR
 cHd
-mwn
-oZp
-oZp
-oZp
-oZp
-oZp
-jJH
-hPh
-gZs
-jQj
-jQj
-usM
-usM
-nRJ
-qFM
-jCy
-hgk
+eIK
+siL
+yjf
+yjf
+yjf
+siL
+siL
+lXA
+nTW
+wuw
+xDg
+ijc
+ijc
+ijc
+dfm
+jwy
+fHA
+sSm
+vJu
+siL
+bEm
 vEo
 rZb
 rZb
@@ -108969,10 +109927,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 rJg
 bzS
@@ -109076,22 +110030,26 @@ fmc
 fmc
 fmc
 fmc
-mwn
-oZp
-sXv
-jOu
-sId
-oZp
-hEW
-oZp
-oZp
-pxp
-oZp
-oZp
-sGO
-nRJ
-rRa
-wMJ
+eIK
+siL
+yjf
+yjf
+yjf
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+mvp
+jQr
+sSm
+dOQ
+siL
 sXH
 rLM
 rZb
@@ -109271,10 +110229,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 rJg
 rJg
@@ -109378,22 +110332,26 @@ kzz
 kdb
 uAs
 fmc
-mwn
-oZp
-fKD
-gkC
-ygn
-mrW
-jrJ
-oZp
-qjh
-dvi
-iIr
-oZp
-ooW
-nRJ
-sCD
-jCy
+eIK
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
+siL
 sPZ
 vEo
 rZb
@@ -109573,10 +110531,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 rJg
 bzS
@@ -109680,23 +110634,27 @@ oYT
 fmc
 kfP
 fmc
-mwn
-oZp
-wEC
-ixQ
-jGl
-oZp
-baS
-oZp
-nAF
-gkC
-jAu
-oZp
-rbE
-jBr
-rbE
-jCy
-sQx
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+sPZ
 vEo
 rZb
 rZb
@@ -109875,10 +110833,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -109982,23 +110936,27 @@ tmq
 fmc
 fmc
 fmc
-mwn
-oZp
-oZp
-oZp
-oZp
-oZp
-wqx
-oZp
-sOF
-sQI
-qmS
-vuv
-vuv
-xOG
-vuv
-vuv
-sUG
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+sPZ
 vEo
 rZb
 rZb
@@ -110177,10 +111135,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -110284,22 +111238,26 @@ tHt
 chF
 fmc
 bcx
-mwn
-oZp
-tiw
-vMQ
-roO
-hdN
-jXY
-oZp
-oZp
-oZp
-oZp
-vuv
-lcr
-idW
-wfq
-vuv
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
 sXH
 crt
 rZb
@@ -110479,10 +111437,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -110586,23 +111540,27 @@ hmz
 hyM
 smu
 eNW
-ojw
-oZp
-oZp
-oZp
-xbx
-jXY
-jXY
-oZp
-nbP
-wZT
-khg
-vuv
-rBC
-aDS
-jUf
-had
-tRH
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+sPZ
 vEo
 xZJ
 rZb
@@ -110781,10 +111739,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -110888,23 +111842,27 @@ kzz
 hys
 fmc
 xWr
-mwn
-oZp
-xap
-vMQ
-jXY
-xPc
-jXY
-sVw
-jXY
-xPc
-kCV
-vuv
-hRD
-okc
-hAF
-rsT
-tqj
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+sPZ
 vEo
 rZb
 rZb
@@ -111083,10 +112041,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -111190,23 +112144,27 @@ bXc
 ero
 fmc
 aXr
-mwn
-oZp
-oZp
-oZp
-jXY
-jXY
-gbA
-oZp
-jXY
-jXY
-tjw
-vuv
-rSi
-xwd
-atG
-baq
-mjJ
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+sPZ
 vEo
 oZk
 rZb
@@ -111385,10 +112343,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -111492,22 +112446,26 @@ hqP
 oOx
 fmc
 oDI
-mwn
-oZp
-lve
-vMQ
-kHl
-jXY
-dEG
-oZp
-hED
-cKb
-wMJ
-vuv
-nbk
-ewo
-vuv
-vuv
+eIK
+siL
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+pvZ
+siL
+siL
+siL
+siL
+siL
+siL
 sXH
 qwN
 pOW
@@ -111687,10 +112645,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -111794,12 +112748,16 @@ fob
 lsA
 uSe
 uSe
-ykh
+dFf
 uSe
 uSe
 uSe
 uSe
-lvk
+uSe
+siL
+siL
+siL
+siL
 uSe
 uSe
 uSe
@@ -111989,10 +112947,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -112096,12 +113050,16 @@ pnk
 pnk
 uSe
 ltZ
-cBO
+mVF
 xfb
 lEM
 lXG
 sTv
 pnk
+siL
+cKX
+cKX
+cKX
 xfb
 oys
 xfb
@@ -112291,10 +113249,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -112398,12 +113352,16 @@ ifZ
 oqn
 gMg
 ifZ
-hwS
+rLr
 oqn
 ifZ
 ifZ
 uql
 xbW
+jgk
+cKX
+cKX
+cKX
 ifZ
 gCS
 ifZ
@@ -112593,10 +113551,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -112698,18 +113652,22 @@ jHl
 ecA
 qLL
 hfn
-sAl
-ecA
-eas
-hfn
-qLL
-ecA
+eDQ
+pnk
+hCz
+fiR
+qlS
+pnk
 npg
-iwj
-ajr
-rsn
-ljM
-iwj
+pnk
+jcz
+cKX
+cKX
+cKX
+qlS
+fiR
+pnk
+pnk
 eDQ
 rsn
 ajr
@@ -112895,10 +113853,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -113002,8 +113956,12 @@ oLu
 qAO
 uSe
 wwY
-oLu
+rBV
 qAO
+uSe
+wwY
+uQc
+hVr
 uSe
 wwY
 uQc
@@ -113198,10 +114156,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -113301,6 +114255,10 @@ eVF
 nxE
 wXk
 wXk
+wXk
+nxE
+wXk
+iZS
 wXk
 nxE
 wXk
@@ -113500,10 +114458,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -113603,6 +114557,10 @@ ndB
 uSe
 lxn
 lxn
+lxn
+uSe
+lxn
+bld
 lxn
 uSe
 lxn
@@ -113802,10 +114760,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -113908,6 +114862,8 @@ rJg
 rJg
 rJg
 rJg
+eAL
+rJg
 iMT
 iMT
 iMT
@@ -113917,6 +114873,8 @@ rJg
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -114104,10 +115062,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -114207,6 +115161,8 @@ wXk
 lxn
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -114222,6 +115178,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 lxn
@@ -114406,10 +115364,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -114509,6 +115463,8 @@ wXk
 lxn
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -114524,6 +115480,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 lxn
@@ -114708,10 +115666,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -114811,6 +115765,8 @@ nxE
 uSe
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -114826,6 +115782,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 uSe
@@ -115011,10 +115969,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -115113,6 +116067,8 @@ wXk
 lxn
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -115128,6 +116084,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 lxn
@@ -115313,10 +116271,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -115415,6 +116369,8 @@ wXk
 lxn
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -115430,6 +116386,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 lxn
@@ -115615,10 +116573,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -115648,8 +116602,8 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
+rJg
+rJg
 bzS
 bzS
 bzS
@@ -115717,6 +116671,8 @@ wXk
 lxn
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -115732,6 +116688,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 lxn
@@ -115918,10 +116876,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -115949,10 +116903,10 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
+rJg
+rJg
+rJg
+rJg
 bzS
 bzS
 bzS
@@ -116018,6 +116972,8 @@ evX
 nxE
 uSe
 cGm
+cGm
+cGm
 pqN
 iMT
 iMT
@@ -116035,6 +116991,8 @@ iMT
 iMT
 iMT
 duZ
+cGm
+cGm
 cGm
 uSe
 nxE
@@ -116220,10 +117178,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -116251,10 +117205,10 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
+nVV
+pBI
+emm
+llB
 bzS
 bzS
 bzS
@@ -116320,6 +117274,8 @@ taA
 fbB
 lsH
 uvq
+uvq
+uvq
 hpk
 iMT
 iMT
@@ -116337,6 +117293,8 @@ iMT
 iMT
 iMT
 hpk
+uvq
+uvq
 uvq
 lsH
 fbB
@@ -116522,10 +117480,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -116553,10 +117507,10 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
+lQK
+tNt
+wZG
+lQK
 bzS
 bzS
 bzS
@@ -116622,6 +117576,8 @@ nxE
 kUk
 lxn
 uvq
+uvq
+uvq
 hpk
 iMT
 iMT
@@ -116639,6 +117595,8 @@ iMT
 iMT
 iMT
 hpk
+uvq
+uvq
 uvq
 lxn
 rSA
@@ -116824,10 +117782,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -116853,20 +117807,20 @@ bzS
 bzS
 bzS
 bzS
+nVV
+pBI
+kjy
+pBI
+sLI
+kjy
+pBI
+llB
 bzS
 bzS
 bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-rJg
-rJg
 bzS
 bzS
 bzS
@@ -116924,6 +117878,8 @@ taA
 fbB
 lsH
 uvq
+uvq
+uvq
 hpk
 iMT
 iMT
@@ -116941,6 +117897,8 @@ iMT
 iMT
 iMT
 hpk
+uvq
+uvq
 uvq
 lsH
 fbB
@@ -117127,10 +118085,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -117155,6 +118109,14 @@ bzS
 bzS
 bzS
 bzS
+oSS
+sEa
+sEa
+sEa
+sEa
+iXS
+mno
+lQK
 bzS
 bzS
 bzS
@@ -117162,14 +118124,6 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-rJg
-rJg
-rJg
-rJg
 bzS
 bzS
 bzS
@@ -117226,6 +118180,8 @@ uSe
 uSe
 uSe
 cGm
+cGm
+cGm
 pqN
 iMT
 iMT
@@ -117243,6 +118199,8 @@ iMT
 iMT
 iMT
 duZ
+cGm
+cGm
 cGm
 uSe
 uSe
@@ -117429,10 +118387,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -117457,6 +118411,14 @@ bzS
 bzS
 bzS
 bzS
+pFW
+tNt
+rvR
+otU
+rvR
+nLT
+cqi
+lQK
 bzS
 bzS
 bzS
@@ -117464,14 +118426,6 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-nVV
-pBI
-emm
-llB
 bzS
 bzS
 bzS
@@ -117529,6 +118483,8 @@ uSe
 uSe
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -117544,6 +118500,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 uSe
@@ -117731,10 +118689,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -117759,21 +118713,21 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+tKr
+tbC
+mno
+rvR
+rvR
+abS
+mNG
 lQK
-tNt
-wZG
-lQK
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -117831,6 +118785,8 @@ uSe
 rJg
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -117846,6 +118802,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -118033,10 +118991,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -118061,6 +119015,14 @@ bzS
 bzS
 bzS
 bzS
+lQK
+uDi
+mNG
+tBz
+rvR
+oSm
+mNG
+lQK
 bzS
 bzS
 bzS
@@ -118070,14 +119032,6 @@ bzS
 bzS
 bzS
 bzS
-nVV
-pBI
-kjy
-pBI
-sLI
-kjy
-pBI
-llB
 bzS
 bzS
 bzS
@@ -118133,6 +119087,8 @@ rJg
 rJg
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -118148,6 +119104,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -118335,10 +119293,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -118363,23 +119317,23 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oSS
-sEa
-sEa
-sEa
-sEa
-iXS
-mno
+knz
+dhw
+bui
+rvR
+rvR
+abS
+mNG
 lQK
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -118436,6 +119390,8 @@ rJg
 rJg
 rJg
 rJg
+rJg
+rJg
 iMT
 iMT
 iMT
@@ -118449,6 +119405,8 @@ iMT
 iMT
 iMT
 iMT
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -118637,10 +119595,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -118665,22 +119619,13 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 pFW
-tNt
+uDi
 rvR
-otU
+tRj
 rvR
-nLT
-cqi
+aTq
+mhv
 lQK
 bzS
 bzS
@@ -118727,6 +119672,19 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -118939,10 +119897,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -118967,23 +119921,14 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 tKr
-tbC
+dhw
 mno
-rvR
-rvR
-abS
-mNG
-lQK
+nVV
+eYd
+uPS
+mug
+ril
 bzS
 bzS
 bzS
@@ -119029,6 +119974,19 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -119241,20 +120199,7 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 bzS
 bzS
 bzS
@@ -119281,10 +120226,10 @@ bzS
 lQK
 uDi
 mNG
-tBz
-rvR
-oSm
-mNG
+sXO
+ekO
+qEo
+nGL
 lQK
 bzS
 bzS
@@ -119331,6 +120276,19 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+rJg
+rJg
+rJg
+rJg
 rJg
 rJg
 rJg
@@ -119544,20 +120502,7 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 bzS
 bzS
 bzS
@@ -119583,10 +120528,10 @@ bzS
 knz
 dhw
 bui
-rvR
-rvR
-abS
-mNG
+eiA
+ekO
+wvw
+rrd
 lQK
 bzS
 bzS
@@ -119634,22 +120579,18 @@ bzS
 bzS
 bzS
 bzS
-rJg
-rJg
-bzS
-rJg
-rJg
-rJg
-rJg
-rJg
 bzS
 bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
 rJg
 rJg
-rJg
+bzS
 rJg
 rJg
 rJg
@@ -119659,7 +120600,24 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
 rJg
+rJg
+rJg
+rJg
+rJg
+rJg
+rJg
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 rJg
 rJg
 rJg
@@ -119846,10 +120804,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -119873,22 +120827,13 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-pFW
-uDi
-rvR
-tRj
-rvR
-aTq
-mhv
+lKP
+sEa
+kTN
+jDU
+rzn
+rzn
+oyi
 lQK
 bzS
 bzS
@@ -119936,6 +120881,15 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 rJg
 rJg
 bzS
@@ -119950,11 +120904,15 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -120149,10 +121107,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -120175,24 +121129,14 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-tKr
-dhw
-mno
-nVV
-eYd
-uPS
-mug
-ril
-bzS
+qef
+cQD
+sLI
+kjy
+pBI
+pBI
+cQD
+cjY
 bzS
 bzS
 bzS
@@ -120226,6 +121170,33 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+rJg
+bzS
+bzS
+bzS
+rJg
 bzS
 bzS
 bzS
@@ -120240,22 +121211,9 @@ bzS
 bzS
 rJg
 rJg
-bzS
-rJg
 rJg
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-rJg
-rJg
-rJg
 bzS
 bzS
 bzS
@@ -120451,10 +121409,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -120477,6 +121431,14 @@ bzS
 bzS
 bzS
 bzS
+rJg
+rVj
+rvR
+rvR
+waH
+rVl
+rVj
+rJg
 bzS
 bzS
 bzS
@@ -120486,14 +121448,6 @@ bzS
 bzS
 bzS
 bzS
-lQK
-uDi
-mNG
-sXO
-ekO
-qEo
-nGL
-lQK
 bzS
 bzS
 bzS
@@ -120555,9 +121509,13 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -120753,10 +121711,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -120779,6 +121733,14 @@ bzS
 bzS
 bzS
 bzS
+rJg
+rVj
+rvR
+rvR
+rvR
+rVl
+rVj
+rJg
 bzS
 bzS
 bzS
@@ -120788,14 +121750,8 @@ bzS
 bzS
 bzS
 bzS
-knz
-dhw
-bui
-eiA
-ekO
-wvw
-rrd
-lQK
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -120860,6 +121816,8 @@ bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121055,10 +122013,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -121082,6 +122036,12 @@ bzS
 bzS
 bzS
 bzS
+qef
+llB
+moO
+byS
+nVV
+cjY
 bzS
 bzS
 bzS
@@ -121090,14 +122050,10 @@ bzS
 bzS
 bzS
 bzS
-lKP
-sEa
-kTN
-jDU
-rzn
-rzn
-oyi
-lQK
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121162,6 +122118,8 @@ bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121357,10 +122315,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -121385,20 +122339,9 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 qef
-cQD
-sLI
-kjy
-pBI
-pBI
-cQD
+ioo
+ioo
 cjY
 bzS
 bzS
@@ -121461,9 +122404,24 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 rJg
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121660,10 +122618,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -121688,6 +122642,77 @@ bzS
 bzS
 bzS
 bzS
+rJg
+rJg
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121695,77 +122720,10 @@ bzS
 bzS
 bzS
 rJg
-rVj
-rvR
-rvR
-waH
-rVl
-rVj
-rJg
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 rJg
 rJg
-rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -121962,10 +122920,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -121996,79 +122950,83 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 rJg
-rVj
-rvR
-rvR
-rvR
-rVl
-rVj
-rJg
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
 rJg
 rJg
 rJg
 rJg
-rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122264,10 +123222,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -122299,12 +123253,14 @@ bzS
 bzS
 bzS
 bzS
-qef
-llB
-moO
-byS
-nVV
-cjY
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122372,6 +123328,8 @@ nkR
 wEz
 rJg
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122566,10 +123524,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -122602,10 +123556,12 @@ bzS
 bzS
 bzS
 bzS
-qef
-ioo
-ioo
-cjY
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122674,6 +123630,8 @@ hnw
 rJg
 mTM
 rJg
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122868,10 +123826,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -122905,8 +123859,10 @@ bzS
 bzS
 bzS
 bzS
-rJg
-rJg
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -122994,6 +123950,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+czt
 bzS
 bzS
 bzS
@@ -123170,11 +124128,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -123296,6 +124252,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+skQ
 bzS
 bzS
 bzS
@@ -123471,11 +124429,9 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -123598,6 +124554,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+hVR
 bzS
 bzS
 bzS
@@ -123773,10 +124731,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -123876,6 +124830,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
 rJg
 rJg
 rJg
@@ -123900,6 +124856,8 @@ bzS
 bzS
 bzS
 bzS
+bzS
+siL
 bzS
 bzS
 bzS
@@ -124074,11 +125032,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -124202,6 +125155,11 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+fpR
 bzS
 bzS
 bzS
@@ -124375,61 +125333,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -124481,6 +125384,11 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -124504,6 +125412,56 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+qvy
 bzS
 bzS
 bzS
@@ -124677,63 +125635,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -124783,6 +125684,15 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -124806,6 +125716,54 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+wcU
 bzS
 bzS
 bzS
@@ -124979,65 +125937,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -125085,6 +125984,19 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -125108,6 +126020,52 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+yjf
+siL
+iZE
+eVh
+bzS
+bzS
+bzS
+bzS
+bzS
+siL
 bzS
 bzS
 bzS
@@ -125282,66 +126240,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -125387,6 +126285,22 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -125410,6 +126324,50 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+jYT
+bzS
+bzS
+kuP
+bzS
+bzS
+jCY
+yjf
+pvZ
+bzS
+yjf
+siL
+yjf
+yjf
+bzS
+bzS
+bzS
+bzS
+bzS
+psJ
 bzS
 bzS
 bzS
@@ -125585,69 +126543,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -125691,6 +126586,27 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -125712,6 +126628,48 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+vgz
+bzS
+bzS
+sOe
+bzS
+bzS
+nLQ
+tjF
+pvZ
+bzS
+uYg
+dtx
+rdq
+buR
+bzS
+bzS
+bzS
+bzS
+bzS
+cdO
 bzS
 bzS
 bzS
@@ -125888,70 +126846,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -125993,6 +126887,30 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -126014,6 +126932,46 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+wZn
+bzS
+bzS
+tms
+bzS
+bzS
+uZi
+jCY
+pvZ
+bzS
+wJL
+siL
+jCY
+aQS
+bzS
+bzS
+bzS
+bzS
+bzS
+qiM
 bzS
 bzS
 bzS
@@ -126191,71 +127149,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -126296,6 +127189,32 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -126312,6 +127231,45 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+pvZ
+pvZ
+pvZ
+pvZ
+rEB
+xRN
 bzS
 bzS
 bzS
@@ -126495,71 +127453,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -126597,6 +127490,35 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -126614,6 +127536,42 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+pvZ
+cVL
+pvZ
+pvZ
+rEB
+wjg
 bzS
 bzS
 bzS
@@ -126800,69 +127758,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -126896,6 +127791,37 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -126916,6 +127842,38 @@ bzS
 bzS
 bzS
 bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+bzS
+pvZ
+pvZ
+pvZ
+pvZ
+yjf
+ohk
 bzS
 bzS
 bzS
@@ -127109,12 +128067,12 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
+bzS
+bzS
+bzS
+bzS
+bzS
 bzS
 bzS
 bzS
@@ -127420,56 +128378,6 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-lZF
-bzS
-bzS
-bzS
-bzS
-bzS
-bzS
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
 lZF
 bzS
 bzS
@@ -127482,6 +128390,45 @@ bzS
 bzS
 bzS
 bzS
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+oeA
+lZF
 bzS
 bzS
 bzS
@@ -127519,6 +128466,17 @@ bzS
 bzS
 bzS
 bzS
+cVL
+hDL
+siL
+yjf
+jCY
+bzS
+bzS
+bzS
+bzS
+bzS
+lMa
 bzS
 bzS
 bzS
@@ -127810,11 +128768,11 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+wIh
+eGf
+eRs
+eGf
+kLs
 bzS
 bzS
 bzS
@@ -128112,11 +129070,11 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+wuh
+mNh
+siL
+yjf
+ieN
 bzS
 bzS
 bzS
@@ -128414,11 +129372,11 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+jCY
+nLd
+siL
+lDu
+jyD
 bzS
 bzS
 bzS
@@ -128716,11 +129674,11 @@ bzS
 bzS
 bzS
 bzS
-bzS
-bzS
-bzS
-bzS
-bzS
+srr
+nPZ
+siL
+siL
+siL
 bzS
 bzS
 bzS
@@ -131370,20 +132328,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+cie
+cAs
+mCe
+cAs
+cie
+cAs
+aaH
+nmg
+vRv
+kQr
+blR
+vRv
+pvZ
 oeA
 oeA
 oeA
@@ -131672,20 +132630,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+efM
+wsv
+wbW
+tdd
+lep
+cAs
+naN
+qTS
+dnY
+xbV
+uDa
+jRu
+jRu
 oeA
 oeA
 oeA
@@ -131974,20 +132932,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+lTQ
+dxd
+ujo
+mrT
+avl
+cAs
+tPR
+qTS
+dnY
+kHr
+qVd
+oGn
+vRv
 oeA
 oeA
 oeA
@@ -132276,20 +133234,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+wFc
+mrT
+ind
+dxd
+avl
+cAs
+naN
+qTS
+dnY
+eQO
+irG
+ftI
+jRu
 oeA
 oeA
 oeA
@@ -132578,20 +133536,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+pbY
+hxc
+ind
+cWV
+fpC
+cAs
+xwV
+qHD
+sxq
+uik
+tEU
+tEU
+qfy
 oeA
 oeA
 oeA
@@ -132880,20 +133838,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+bfG
+cWV
+ind
+hxc
+yaN
+cAs
+aLz
+qTS
+dnY
+uGB
+aiq
+uSr
+jRu
 oeA
 oeA
 oeA
@@ -133182,20 +134140,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+bxi
+oJO
+lIl
+cEk
+fjA
+cAs
+aLz
+qTS
+dnY
+dnY
+dnY
+dnY
+vRv
 oeA
 oeA
 oeA
@@ -133484,20 +134442,20 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+cAs
+cAs
+cAs
+cAs
+vBq
+cAs
+cAs
+jfd
+oRR
+sHI
+efI
+tjx
+par
+sXH
 oeA
 oeA
 oeA
@@ -133784,22 +134742,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+oUg
+iKc
+iIi
+iIi
+iIi
+uEm
+axq
+iIi
+iIi
+iNo
+rfO
+ncu
+iLL
+eHE
+fQN
+sXH
 oeA
 oeA
 oeA
@@ -134086,22 +135044,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+hvX
+rfO
+gie
+oZp
+oZp
+sxk
+oZp
+oZp
+oZp
+iXV
+oZp
+oZp
+ctr
+kll
+gZm
+sXH
 oeA
 oeA
 oeA
@@ -134388,22 +135346,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+jmz
+gie
+oZp
+jWW
+tfx
+ktv
+oZp
+tvR
+ixW
+oNJ
+oZp
+trb
+pqp
+jWG
+sXH
 oeA
 oeA
 oeA
@@ -134690,22 +135648,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+pMD
+gie
+gie
+rIw
+vSi
+xcF
+eJa
+oZp
+rwN
+gkC
+rxi
+oZp
+oZp
+oZp
+oZp
+wMJ
 oeA
 oeA
 oeA
@@ -134992,22 +135950,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+iNG
+uIr
+obm
+oZp
+ibI
+xhy
+dLj
+oZp
+vnF
+aRG
+rnJ
+oZp
+qDf
+rLR
+rOZ
+jCy
 oeA
 oeA
 oeA
@@ -135294,22 +136252,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+kaN
+oZp
+oZp
+oZp
+oZp
+oZp
+nwR
+oZp
+oZp
+pxp
+oZp
+oZp
+qFM
+usM
+usM
+jCy
 oeA
 oeA
 oeA
@@ -135596,22 +136554,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+hwo
+oZp
+iPM
+xAt
+hYo
+oZp
+bXN
+xcC
+afH
+nRv
+vns
+pOI
+qGa
+rNt
+nvB
+wMJ
 oeA
 oeA
 oeA
@@ -135898,22 +136856,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+fKD
+gkC
+ygn
+mrW
+qLl
+usM
+usM
+usM
+ctd
+pUJ
+qNM
+rNt
+usM
+jCy
 oeA
 oeA
 oeA
@@ -136200,22 +137158,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+frT
+aHy
+vaR
+oZp
+fhJ
+eBr
+adk
+eBr
+eBr
+pUS
+pUS
+efZ
+eBr
+gdY
 oeA
 oeA
 oeA
@@ -136502,22 +137460,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+oZp
+oZp
+oZp
+oZp
+jJH
+hPh
+gZs
+jQj
+jQj
+usM
+usM
+nRJ
+qFM
+jCy
 oeA
 oeA
 oeA
@@ -136804,22 +137762,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+sXv
+jOu
+sId
+oZp
+hEW
+oZp
+oZp
+pxp
+oZp
+oZp
+sGO
+nRJ
+rRa
+wMJ
 oeA
 oeA
 oeA
@@ -137106,22 +138064,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+fKD
+gkC
+ygn
+mrW
+jrJ
+oZp
+qjh
+dvi
+iIr
+oZp
+ooW
+nRJ
+sCD
+jCy
 oeA
 oeA
 oeA
@@ -137408,22 +138366,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+wEC
+ixQ
+jGl
+oZp
+baS
+oZp
+nAF
+gkC
+jAu
+oZp
+rbE
+jBr
+rbE
+jCy
 oeA
 oeA
 oeA
@@ -137710,22 +138668,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+oZp
+oZp
+oZp
+oZp
+wqx
+oZp
+sOF
+sQI
+qmS
+vuv
+vuv
+xOG
+vuv
+vuv
 oeA
 oeA
 oeA
@@ -138012,22 +138970,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+tiw
+vMQ
+roO
+hdN
+jXY
+oZp
+oZp
+oZp
+oZp
+vuv
+lcr
+idW
+wfq
+vuv
 oeA
 oeA
 oeA
@@ -138314,22 +139272,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+ojw
+oZp
+oZp
+oZp
+xbx
+jXY
+jXY
+oZp
+nbP
+wZT
+khg
+vuv
+rBC
+aDS
+jUf
+had
 oeA
 oeA
 oeA
@@ -138616,22 +139574,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+xap
+vMQ
+jXY
+xPc
+jXY
+sVw
+jXY
+xPc
+kCV
+vuv
+hRD
+okc
+hAF
+rsT
 oeA
 oeA
 oeA
@@ -138918,22 +139876,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+oZp
+oZp
+jXY
+jXY
+gbA
+oZp
+jXY
+jXY
+tjw
+vuv
+rSi
+xwd
+atG
+baq
 oeA
 oeA
 oeA
@@ -139220,22 +140178,22 @@ oeA
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
-oeA
+mwn
+oZp
+lve
+vMQ
+kHl
+jXY
+dEG
+oZp
+hED
+cKb
+wMJ
+vuv
+nbk
+ewo
+vuv
+vuv
 oeA
 oeA
 oeA

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -480,9 +480,11 @@
 "ajo" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_nukecore";
-	name = "Reactor Core Shielding"
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -726,9 +728,11 @@
 /area/pasiphae)
 "aoa" = (
 /obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_exnex";
-	name = "Extraction Nexus Shielding"
+	name = "Extraction Nexus Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/science/construction{
@@ -2251,9 +2255,11 @@
 "aZV" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	dir = 4;
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_nukecore";
-	name = "Reactor Core Shielding"
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/space)
@@ -4024,6 +4030,11 @@
 	dir = 9;
 	icon_state = "line1"
 	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/yellowblack,
 /area/space)
 "bNm" = (
@@ -5053,6 +5064,22 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
+"cmb" = (
+/obj/machinery/door/poddoor/blast/pyro{
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
+	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Secondary Core Access"
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine,
+/area/space)
 "cmf" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -5482,10 +5509,8 @@
 /area/station/maintenance/southeast)
 "cxr" = (
 /obj/disposalpipe/segment/vertical,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/machinery/light/incandescent/netural{
+	dir = 4
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
@@ -6831,9 +6856,11 @@
 "dfm" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_nukecore";
-	name = "Reactor Core Shielding"
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/space)
@@ -6921,6 +6948,11 @@
 /area/station/science/teleporter)
 "dhu" = (
 /obj/reagent_dispensers/foamtank,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
@@ -8060,6 +8092,11 @@
 	dir = 1;
 	level = 2
 	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
@@ -8651,6 +8688,11 @@
 "dWW" = (
 /obj/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/machinery/door_control{
+	id = "nadir_nukecore";
+	pixel_y = 24;
+	name = "Reactor Core Shielding"
 	},
 /turf/simulated/floor/black,
 /area/space)
@@ -10525,6 +10567,11 @@
 /area/station/engine/elect)
 "ePt" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
@@ -12533,9 +12580,11 @@
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
 	dir = 4;
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_nukecore";
-	name = "Reactor Core Shielding"
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/engine,
 /area/space)
@@ -13012,6 +13061,7 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "fXU" = (
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 8
 	},
@@ -13278,6 +13328,11 @@
 "gcL" = (
 /obj/machinery/power/smes,
 /obj/cable,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
 	},
@@ -14949,6 +15004,11 @@
 /obj/item/chem_grenade/firefighting{
 	pixel_y = -1;
 	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
 /turf/simulated/floor/yellowblack,
 /area/space)
@@ -21257,6 +21317,11 @@
 	dir = 4;
 	name = "cold loop gas supply valve"
 	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/engine/caution/north,
 /area/space)
 "jwF" = (
@@ -22509,16 +22574,6 @@
 "jXY" = (
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
-"jYJ" = (
-/obj/rack,
-/obj/item/extinguisher{
-	pixel_x = -5
-	},
-/obj/item/extinguisher{
-	pixel_x = 7
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/space)
 "jYO" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -26409,6 +26464,11 @@
 /area/station/hallway/primary/northwest)
 "lGL" = (
 /obj/storage/closet/radiation,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -27207,6 +27267,15 @@
 "lXA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
+	},
+/obj/item/storage/wall/fire{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
@@ -30823,6 +30892,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
+/obj/machinery/portable_reclaimer,
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
@@ -31085,6 +31155,7 @@
 /turf/simulated/floor/stairs/wide,
 /area/listeningpost)
 "nJZ" = (
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/engine/caution/west,
 /area/space)
 "nKe" = (
@@ -31427,6 +31498,11 @@
 	},
 /obj/cable/orange{
 	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/engine/caution/northsouth,
 /area/space)
@@ -32865,6 +32941,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"oDS" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/engine/caution/east,
+/area/space)
 "oDX" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -33111,6 +33195,16 @@
 	},
 /turf/simulated/floor/greenblack/corner,
 /area/station/hallway/primary/northwest)
+"oJY" = (
+/obj/storage/closet/radiation,
+/obj/item/storage/wall/fire{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/space)
 "oKe" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro/security/alt{
@@ -36492,12 +36586,10 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "qrF" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/disposalpipe/segment/vertical,
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
 /turf/simulated/floor/yellowblack/corner,
 /area/space)
 "qrL" = (
@@ -37396,9 +37488,11 @@
 "qPw" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/door/poddoor/blast/pyro{
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_nukecore";
-	name = "Reactor Core Shielding"
+	name = "Reactor Core Shielding";
+	density = 0;
+	opacity = 0
 	},
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -38859,6 +38953,11 @@
 "rAG" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/engine,
 /area/space)
@@ -40586,9 +40685,11 @@
 "spn" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	dir = 4;
-	icon_state = "bdoormid1";
+	icon_state = "bdoormid0";
 	id = "nadir_exnex";
-	name = "Extraction Nexus Shielding"
+	name = "Extraction Nexus Shielding";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/science/construction{
@@ -43892,6 +43993,10 @@
 "tHH" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
+	},
+/obj/item/extinguisher{
+	pixel_y = 17;
+	pixel_x = -9
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
@@ -48150,6 +48255,11 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/power/nuclear/turbine_control,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -51940,6 +52050,11 @@
 /turf/simulated/floor/black,
 /area/station/maintenance/disposal)
 "xDg" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 4
 	},
@@ -105186,7 +105301,7 @@ dDv
 siL
 siL
 fLQ
-fLQ
+cmb
 fLQ
 siL
 fLQ
@@ -105490,7 +105605,7 @@ siL
 aZV
 aZV
 aZV
-aZV
+fLQ
 aZV
 aZV
 aZV
@@ -105790,7 +105905,7 @@ yjf
 yjf
 siL
 fLQ
-fLQ
+cmb
 fLQ
 siL
 fLQ
@@ -106092,9 +106207,9 @@ yjf
 siL
 siL
 dhu
-jYJ
 hkU
 hkU
+oDS
 hkU
 hkU
 hkU
@@ -106703,7 +106818,7 @@ ygt
 ygt
 jOW
 dfm
-lGL
+oJY
 sYj
 cKX
 aut

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7987,6 +7987,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "dDw" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Significant Nadir update introducing a nuclear reactor and mining department; the station was vertically stretched by four tiles to achieve this. The list below isn't exhaustive, but covers a significant majority of changes.

**Nuclear Reactor Complex**

![image](https://user-images.githubusercontent.com/12454065/211176680-e121b3ae-5413-41c6-b5ca-c7e065e546da.png)

Added north of Engineering. This has displaced several other rooms previously located in this space, which will be enumerated below.

- East crew quarters has been squished even more eastward. It's no longer as extensive as it was, but still serves as a nice crew retreat, and is now more secluded (potentially crime-friendly). Diplomatic quarters is its own separate partition now, and has been restructured to accommodate two individuals and one visitor.
- The public market and crew quarters have been shifted into the newly-larger space below the Research sector's left and right sides, respectively. Layouts have shifted a bit, but contents remain largely identical.
- The "Crime Room" has moved into maintenance east of the Cafeteria.

**Mining Department**

![image](https://user-images.githubusercontent.com/12454065/211177137-6ef489ec-b29d-412f-805c-43d3146f9ba0.png)

![image](https://user-images.githubusercontent.com/12454065/211177148-60447b30-9ee3-435e-b613-1e970148ccfa.png)

The sea elevator complex, both on station and trench levels, has received a considerable overhaul, with the Mining department split between both levels. The elevator remains publicly-accessible.

The surface-level Mining-locked area contains primary supplies and fabricators, while the vehicle bay at the trench level contains Mining's heavy-duty exploration pod (pre-equipped with a rock drilling rig) and a RockBox for offloading minerals.

#12638 provides support for machinery vehicles taking acid damage during excursions, and should be merged before this (barring that, as soon after this as possible); it's not necessary for this PR to function, but if it's not present, excursions can be effectively indefinite.

**Hydroponics and Kitchen Extension**

![image](https://user-images.githubusercontent.com/12454065/211177446-baa51df2-99f8-4ed4-8ec2-61c34182de98.png)

Newly-freed space was utilized to extend these departments.

Hydroponics received the bulk of this increase, improving the available space and number of plant pots to be more suitable for the five botanists allowed on staff; the Kitchen also received a shift-around, bringing the large food processor to the front of house, allowing supplies previously shoved out into Maintenance to be brought back into catering storage.

**Miscellaneous**

- Adjusted other elements of the elevator prefab to ensure they align with their station-level counterparts.
- Research's connecting hall down to the lobby section now has a small decontamination bathroom, with a laundry machine, showers, and one toilet.
- Two new 3x3 random room spawns and one 3x5 random room spawn were added.
- Updated navigation flowers, tour guide beacons and GPS waypoints to respect newly introduced / relocated departments.
- The northwest crew quarters and security quarters restrooms now use stall doors, in parity with the new east crew quarters.
- The quartermasters' front office now has a ship component fabricator.
- Engineering no longer has a mining fabricator, since there's a mining department now. Gotta talk to QM if you wanna join the fun.
- The counter under the espresso machine in the bar is now a prep counter with drawers.

**Codeside Changes**

- Removes enforced zero-miner limit on Nadir (map landmarks now define the limit, currently two as of this PR).
- Introduces a "nospawn" trench turf, used in the Nadir subsurface prefab to keep specific areas clear of lithoflora.
- Adds a pod subvariant for the Miners' special trench exploration vessel, with a cute nickname picked from a small pool and a preinstalled rock drilling rig.
- Updates data on Nadir trench prefab to match its actual current state.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Gives a cool new engine an additional (and mechanically synergistic) home, and enables benefits from Mining both as something for people to do and as a source of "gumball" materials when the Siphon's occupied by more targeted extraction.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Nadir has received a nuclear engine and a mining department.
(+)The mining department is fairly small, and two miners are on staff. Their cherished reinforced exploratory pod lives in a hangar below surface.
(+)Other things changed in Nadir include a larger Hydroponics Bay, a slightly wider Kitchen, several new random room spots, and a small Crime Conduit.
```
