### PR TITLE
Prevents flock sentinels from targeting incapacitated enemies

### DIFF
--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -94,7 +94,7 @@
 				if(src.flock?.isEnemy(A))
 					if (ismob(A))
 						var/mob/M = A
-						if (isdead(M))
+						if (isdead(M) || is_incapacitated(M))
 							continue
 					if (ON_COOLDOWN(A, "sentinel_shock", 2 SECONDS))
 						continue
@@ -115,7 +115,7 @@
 					if(src.flock?.isEnemy(A) && !(A in hit))
 						if (ismob(A))
 							var/mob/M = A
-							if (isdead(M))
+							if (isdead(M) || is_incapacitated(M))
 								continue
 						found_chain_target = TRUE
 						arcFlash(last_hit, A, wattage / 1.5, 1.1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just makes sentinels check `is_incapacitated` before targeting someone.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being chain stunned is not fun, and sentinels should be targeting upright humans instead.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Flock sentinels will no longer target incapacitated enemies.
```
