### PR TITLE
Flockdrones take slightly longer to cage

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -574,7 +574,7 @@
 /datum/action/bar/flock_entomb
 	id = "flock_entomb"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
-	duration = 4 SECONDS
+	duration = 5 SECONDS
 	resumable = FALSE
 
 	var/atom/target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flock cage time 4 -> 5 seconds.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives the crew just a little more time to save each other.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Flockdrones now take 5 seconds to cage someone, up from 4.
```
