### PR TITLE
Update CE locker and PDA contents

### DIFF
--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -276,30 +276,38 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 			src.root.add_file( new /datum/computer/file/pda_program/power_controller(src))
 			src.root.add_file( new /datum/computer/file/pda_program/atmos_alerts(src))
 			src.root.add_file( new /datum/computer/file/pda_program/signaler(src))
-			src.root.add_file( new /datum/computer/file/pda_program/pingtool(src) )
-			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src) )
-			src.root.add_file( new /datum/computer/file/pda_program/packet_sender(src) )
+			src.root.add_file( new /datum/computer/file/pda_program/pingtool(src))
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src))
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sender(src))
 			src.root.add_file( new /datum/computer/file/text/diagnostic_readme(src))
 			src.read_only = 1
 
 	chiefengineer
 		name = "\improper EngineDaemon Ultimate cartridge"
-		desc = "A limited edition cartridge for high-class engineers. The warranty label is missing."
+		desc = "A limited edition cartridge for high-class engineers. The warranty label is missing and it looks like it has been modified."
 		icon_state = "cart-engine"
-		file_amount = 64
+		file_amount = 256 //it has indeed been modified. not technically necessary (ce programs use 114 size) but seemed thematically appropriate
 
 		New()
 			..()
+			//Command stuff
 			src.root.add_file( new /datum/computer/file/pda_program/manifest(src))
+			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
+			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))
+			//Engineer stuff
+			src.root.add_file( new /datum/computer/file/pda_program/scan/electronics(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/health_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/power_checker(src))
 			src.root.add_file( new /datum/computer/file/pda_program/power_controller(src))
 			src.root.add_file( new /datum/computer/file/pda_program/atmos_alerts(src))
 			src.root.add_file( new /datum/computer/file/pda_program/signaler(src))
-			src.root.add_file( new /datum/computer/file/pda_program/scan/health_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/pingtool(src))
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src))
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sender(src))
+			//QM stuff
 			src.root.add_file( new /datum/computer/file/pda_program/qm_records(src))
-			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
-			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/mulebot(src))
+			//Miner stuff (lol)
 			src.read_only = 1
 
 	clown

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -267,6 +267,7 @@
 		name = "Engineer PDA"
 		icon_state = "pda-e"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/engineer
+		setup_default_module = /obj/item/device/pda_module/tray //mechanics used to have these
 		mailgroups = list(MGO_ENGINEER,MGD_STATIONREPAIR,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_RKIT, MGA_CRISIS)
 
@@ -274,6 +275,7 @@
 		name = "Technical Assistant PDA"
 		icon_state = "pda-e" //tech ass is too broad to have a set cartridge but should get alerts
 		mailgroups = list(MGD_STATIONREPAIR,MGD_PARTY)
+		setup_default_module = /obj/item/device/pda_module/tray
 		alertgroups = list(MGA_MAIL,MGA_RADIO)
 
 	mining
@@ -284,6 +286,7 @@
 	chiefengineer
 		icon_state = "pda-ce"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/chiefengineer
+		setup_default_module = /obj/item/device/pda_module/tray
 		mailgroups = list(MGO_ENGINEER,MGD_MINING,MGD_STATIONREPAIR,MGD_CARGO,MGD_COMMAND,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_CRISIS, MGA_SALES, MGA_CARGOREQUEST, MGA_SHIPPING, MGA_RKIT)
 

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -303,32 +303,36 @@
 /obj/storage/secure/closet/command/chief_engineer
 	name = "\improper Chief Engineer's locker"
 	req_access = list(access_engineering_chief)
-	spawn_contents = list(/obj/item/disk/data/floppy/manudrive/law_rack,
-	/obj/item/storage/toolbox/mechanical/yellow_tools,
-	/obj/item/storage/backpack/engineering,
-	/obj/item/storage/box/clothing/chief_engineer,
-	/obj/item/clothing/gloves/yellow,
-	/obj/item/clothing/shoes/brown,
-	/obj/item/clothing/shoes/magnetic,
-	/obj/item/clothing/ears/earmuffs,
-	/obj/item/clothing/glasses/meson,
-	/obj/item/clothing/suit/fire,
-	/obj/item/clothing/mask/gas,
-	/obj/item/storage/belt/utility/prepared/ceshielded,
-	/obj/item/clothing/head/helmet/welding,
-	/obj/item/clothing/head/helmet/hardhat,
-	/obj/item/device/multitool,
-	/obj/item/device/flash,
-	/obj/item/stamp/ce,
-	/obj/item/clothing/suit/hi_vis,
-#ifdef UNDERWATER_MAP
-	/obj/item/clothing/suit/space/diving/engineering,
-	/obj/item/clothing/head/helmet/space/engineer/diving,
-#else
-	/obj/item/clothing/suit/space/engineer,
-	/obj/item/clothing/head/helmet/space/engineer,
-#endif
-	/obj/item/device/radio/headset/command/ce)
+	spawn_contents = list(
+		/obj/item/storage/belt/utility/prepared/ceshielded,
+		/obj/item/disk/data/floppy/manudrive/law_rack,
+		/obj/item/storage/box/clothing/chief_engineer,
+		/obj/item/device/radio/headset/command/ce,
+		/obj/item/stamp/ce,
+		/obj/item/device/flash,
+		/obj/item/clothing/shoes/magnetic,
+		/obj/item/clothing/gloves/yellow,
+		/obj/item/clothing/suit/fire/heavy, //now theres at least one on every map
+		/obj/item/clothing/head/helmet/firefighter,
+		/obj/item/clothing/suit/rad, //mostly relevant for singulo and nuke maps
+		/obj/item/clothing/head/rad_hood,
+		/obj/item/storage/toolbox/mechanical/yellow_tools,
+		/obj/item/cargotele,
+		/obj/item/electronics/soldering,
+		/obj/item/electronics/scanner,
+		/obj/item/lamp_manufacturer/organic,
+		/obj/item/extinguisher,
+		/obj/item/pinpointer/category/apcs/station,
+	#ifdef UNDERWATER_MAP
+		/obj/item/clothing/suit/space/diving/engineering,
+		/obj/item/clothing/head/helmet/space/engineer/diving
+		/obj/item/clothing/shoes/flippers,
+		/obj/item/clothing/shoes/stomp_boots
+	#else
+		/obj/item/clothing/suit/space/engineer,
+		/obj/item/clothing/head/helmet/space/engineer,
+	#endif
+	)
 
 /* ==================== */
 /* ----- Security ----- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the contents of the CE locker to have more of the tools you're expected to carry and less of things you already spawn with anyways. It now contains:

- CE belt
- Law rack manudrive
- CE clothes box
- CE headset
- CE stamp
- Flash
- Magboots
- Insuls
- Heavy firesuit
- Fire helmet
- Radsuit
- Radsuit hood
- Toolbox with spare yellow tools
- Cargo transporter
- Soldering tool
- Mechscanner
- Lamp manufacturer
- Fire extinguisher
- APC pinpointer
IF Oshan:
- Stomper boots
IF underwater (Oshan & Nadir):
- Engineering dive suit
- Engineering dive helmet
- Flippers
OTHERWISE
- Engineering spacesuit
- Engineering space helmet

Changes the CE PDA cart to have all of the programs that jobs under their command have. This adds the mechanic stuff to their PDA cart that engineers got.

Gives the CE, Engineers, and Technical Assistants the T-Ray PDA module instead of the flashlight. Originally mechanics had it and after the merge nobody had it. Since engineers have mesons and hard hats, the flashlight seems like an acceptable loss.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The CE was missing a decent amount of tools, meaning that their start-of-round routine usually involved raiding all the lockers of their departments for the stuff they might need. Adding the mechscanner and t-ray to their PDA should hopefully somewhat address the CE's overstuffed inventory too.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+)Gave the CE more useful tools in their locker and PDA.
```
