### PR TITLE
Vortex interdiction

### DIFF
--- a/code/obj/vortex.dm
+++ b/code/obj/vortex.dm
@@ -30,10 +30,25 @@
 					*/
 
 				if(4)
-					src.visible_message("<span class='alert'><b>[src] explodes in a burst of intense light!</b></span>")
-					for (var/mob/living/C in view(3,src))
-						C.apply_flash(30, 1, 0, 0, 0, rand(0, 2))
-					qdel(src)
+					//spatial interdictor: suppress intense particle discharge
+					//consumes 150 units of charge per flash interdicted
+					var/interdicted = FALSE
+					for_by_tcl(IX, /obj/machinery/interdictor)
+						if (IX.expend_interdict(150,src))
+							interdicted = TRUE
+							break
+					if(!interdicted)
+						src.visible_message("<span class='alert'><b>[src] explodes in a burst of intense light!</b></span>")
+						playsound(src.loc, 'sound/weapons/flashbang.ogg', 40, 1)
+						for (var/mob/living/C in view(3,src))
+							C.apply_flash(30, 1, 0, 0, 0, rand(0, 2))
+						qdel(src)
+					else
+						icon = 'icons/effects/effects.dmi'
+						icon_state = "sparks_attack"
+						playsound(src.loc, "sparks", 30, 1)
+						SPAWN(rand(10,20))
+							qdel(src)
 					return
 
 				/*if(5)
@@ -52,45 +67,58 @@
 
 	proc/spawn_horror()
 		var/horror_path = null
-		if(derelict_mode)
-			horror_path = pick(/obj/critter/shade,
-			/obj/critter/shade,
-			/obj/critter/shade,
-			/obj/critter/shade,
-			/obj/critter/shade,
-			/obj/critter/crunched,
-			/obj/critter/crunched,
-			/obj/critter/crunched,
-			/obj/critter/bloodling,
-			/obj/critter/ancient_thing,
-			/obj/critter/ancient_thing,
-			/obj/critter/ancient_repairbot/grumpy,
-			/obj/critter/ancient_repairbot/grumpy,
-			/obj/critter/ancient_repairbot/security,
-			/obj/critter/ancient_repairbot/security,
-			/obj/critter/gunbot/heavy,
-			/obj/machinery/bot/medbot/terrifying,
-			/obj/machinery/bot/medbot/terrifying)
-			if(prob(3))
-				horror_path = pick(/obj/critter/gunbot/drone/buzzdrone,/obj/critter/gunbot/drone/buzzdrone, /obj/critter/aberration)
-			if (was_eaten && prob(15))
-				horror_path = /obj/critter/blobman/meaty_martha
+		//spatial interdictor: when something would exit a vortex, it doesn't
+		//consumes 500 units of charge per inbound thing interdicted
+		var/interdicted = FALSE
+		for_by_tcl(IX, /obj/machinery/interdictor)
+			if (IX.expend_interdict(500,src))
+				interdicted = TRUE
+				break
+		if(!interdicted)
+			if(derelict_mode)
+				horror_path = pick(/obj/critter/shade,
+				/obj/critter/shade,
+				/obj/critter/shade,
+				/obj/critter/shade,
+				/obj/critter/shade,
+				/obj/critter/crunched,
+				/obj/critter/crunched,
+				/obj/critter/crunched,
+				/obj/critter/bloodling,
+				/obj/critter/ancient_thing,
+				/obj/critter/ancient_thing,
+				/obj/critter/ancient_repairbot/grumpy,
+				/obj/critter/ancient_repairbot/grumpy,
+				/obj/critter/ancient_repairbot/security,
+				/obj/critter/ancient_repairbot/security,
+				/obj/critter/gunbot/heavy,
+				/obj/machinery/bot/medbot/terrifying,
+				/obj/machinery/bot/medbot/terrifying)
+				if(prob(3))
+					horror_path = pick(/obj/critter/gunbot/drone/buzzdrone,/obj/critter/gunbot/drone/buzzdrone, /obj/critter/aberration)
+				if (was_eaten && prob(15))
+					horror_path = /obj/critter/blobman/meaty_martha
+			else
+				horror_path = pick(/obj/critter/killertomato,
+				/obj/critter/spore,
+				/obj/critter/spacerattlesnake,
+				/obj/critter/martian/warrior,
+				/obj/machinery/bot/firebot/emagged,
+				/obj/machinery/bot/secbot/emagged,
+				/obj/machinery/bot/medbot/mysterious/emagged,
+				/obj/machinery/bot/cleanbot/emagged,
+				/obj/critter/wasp/angry,
+				/obj/critter/spacescorpion,
+				/obj/critter/mimic,
+				/obj/critter/fermid,
+				/obj/critter/bear)
+			var/obj/horror = new horror_path(src.loc)
+			src.visible_message("<span class='alert'><b>[horror] emerges from the [src]!</b></span>","<span class='alert'>You hear a sharp buzzing noise.</span>")
 		else
-			horror_path = pick(/obj/critter/killertomato,
-			/obj/critter/spore,
-			/obj/critter/spacerattlesnake,
-			/obj/critter/martian/warrior,
-			/obj/machinery/bot/firebot/emagged,
-			/obj/machinery/bot/secbot/emagged,
-			/obj/machinery/bot/medbot/mysterious/emagged,
-			/obj/machinery/bot/cleanbot/emagged,
-			/obj/critter/wasp/angry,
-			/obj/critter/spacescorpion,
-			/obj/critter/mimic,
-			/obj/critter/fermid,
-			/obj/critter/bear)
-		var/obj/horror = new horror_path(src.loc)
-		src.visible_message("<span class='alert'><b>[horror] emerges from the [src]!</b></span>","<span class='alert'>You hear a sharp buzzing noise.</span>")
+			SPAWN(rand(2,20)) //desynchronize the visual/audible indication of interdiction in case of large batches of simultaneous vortexes
+				src.icon = 'icons/effects/effects.dmi'
+				src.icon_state = "portswirl_error"
+				playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
 		SPAWN(20 SECONDS)
 			qdel(src)
 

--- a/code/obj/vortex.dm
+++ b/code/obj/vortex.dm
@@ -47,7 +47,7 @@
 						icon = 'icons/effects/effects.dmi'
 						icon_state = "sparks_attack"
 						playsound(src.loc, "sparks", 30, 1)
-						SPAWN(rand(10,20))
+						SPAWN(rand(1 SECOND, 2 SECONDS))
 							qdel(src)
 					return
 

--- a/code/obj/vortex.dm
+++ b/code/obj/vortex.dm
@@ -115,7 +115,7 @@
 			var/obj/horror = new horror_path(src.loc)
 			src.visible_message("<span class='alert'><b>[horror] emerges from the [src]!</b></span>","<span class='alert'>You hear a sharp buzzing noise.</span>")
 		else
-			SPAWN(rand(2,20)) //desynchronize the visual/audible indication of interdiction in case of large batches of simultaneous vortexes
+			SPAWN(rand(0.2 SECONDS, 2 SECONDS)) //desynchronize the visual/audible indication of interdiction in case of large batches of simultaneous vortexes
 				src.icon = 'icons/effects/effects.dmi'
 				src.icon_state = "portswirl_error"
 				playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)


### PR DESCRIPTION
<!-- Sord pls-->
[EVENTS][OBJECTS][BUG][MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the mob-spawning vortexes able to be blocked with a spatial interdictor. Blocking a mob has a larger, flashier effect and higher cost, while blocking the "flashbang" effect has a smaller effect and lower cost.

Also gives the flashbang effect an actual bang noise.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These vortexes are a random event now, and interdictor protection from them seems to have been missed. If I'm incorrect and the lack of protection against vortexes is a deliberate omission, feel free to close this.