### PR TITLE
No rude flocks

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -448,6 +448,9 @@ var/flock_signal_unleashed = FALSE
 				name_found = TRUE
 				src.active_names[name] = TRUE
 		tries++
+		if(phrase_log.is_uncool(jointext(splittext(name,"."),"")))
+			name_found = FALSE
+
 	if (!name_found && tries == max_tries)
 		logTheThing(LOG_DEBUG, null, "Too many tries were reached in trying to name a flock or one of its units.")
 		return "error"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just adds a quick check for uncool words in the flock name generation. Literally just strips out the `.`s and checks against the list. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/3855802/211896081-04e671a9-04cd-4130-a91a-3476335af0d8.png)
![image](https://user-images.githubusercontent.com/3855802/211896228-b4212bc7-77d9-4e0e-8546-3c6deed84567.png)

