### PR TITLE
Adds a Cleaner Manudrive to Atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12677,6 +12677,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/item/disk/data/floppy/manudrive/cleaner_grenade,
 /turf/simulated/floor/purple,
 /area/station/janitor/office)
 "Fa" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a cleaner grenade manudrive to the atlus jani closet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Originally didn't add it due to atlas's size, I now think it's fine if the jani's had 1 manudrive.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Added a cleaner grenade manudrive to the atlas jani closet.
```
