### PR TITLE
Fix stabilizing a gene applied to a player not reversing its stability effect

### DIFF
--- a/code/modules/medical/genetics/chromosomes.dm
+++ b/code/modules/medical/genetics/chromosomes.dm
@@ -17,6 +17,9 @@
 		if (.)
 			return
 
+		if(BE.holder && !BE.activated_from_pool)
+			BE.holder.genetic_stability = max(0, BE.holder.genetic_stability + BE.stability_loss)
+
 		BE.stability_loss = 0
 		BE.name = "Stabilized " + BE.name
 		BE.altered = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(Not tested yet)
Fixes bug where stabilizing a gene on a player doesn't reverse its stability effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easily get lots of stability by applying 'Deaf' gene, stabilizing it, removing it, then applying another 'Deaf', and repeat.


