### PR TITLE
Fix health scanner recipe

### DIFF
--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -1,6 +1,6 @@
 
 TYPEINFO(/obj/health_scanner)
-	mats = list("CON-1" = 5, "CRY" = 2)
+	mats = list("CON-1" = 5, "CRY-1" = 2)
 
 /obj/health_scanner
 	icon = 'icons/obj/items/device.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes health scanners use crystal 1 instead of CRY

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Crafting recipes should use materials that exist