### PR TITLE
Thralls only get a blood penalty for draining rotten corpses

### DIFF
--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -82,9 +82,9 @@
 		boutput(M, "<span class='alert'>This human is completely void of blood... Wow!</span>")
 		return 0
 
-	if (HH.decomp_stage > DECOMP_STAGE_NO_ROT)
+	if (HH.decomp_stage > DECOMP_STAGE_NO_ROT && thrall || isdead(HH) && !thrall)
 		if (prob(20))
-			boutput(M, "<span class='alert'>The blood of the rotten provides little sustenance...</span>")
+			boutput(M, "<span class='alert'>The blood of the [thrall ? "rotten" : "dead"] provides little sustenance...</span>")
 
 		var/bitesize = 5 * mult
 		H.change_vampire_blood(bitesize, 1)

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -82,7 +82,7 @@
 		boutput(M, "<span class='alert'>This human is completely void of blood... Wow!</span>")
 		return 0
 
-	if (HH.decomp_stage > 0)
+	if (HH.decomp_stage > DECOMP_STAGE_NO_ROT)
 		if (prob(20))
 			boutput(M, "<span class='alert'>The blood of the rotten provides little sustenance...</span>")
 

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -82,9 +82,9 @@
 		boutput(M, "<span class='alert'>This human is completely void of blood... Wow!</span>")
 		return 0
 
-	if (isdead(HH))
+	if (HH.decomp_stage > 0)
 		if (prob(20))
-			boutput(M, "<span class='alert'>The blood of the dead provides little sustenance...</span>")
+			boutput(M, "<span class='alert'>The blood of the rotten provides little sustenance...</span>")
 
 		var/bitesize = 5 * mult
 		H.change_vampire_blood(bitesize, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the Thrall bite isDead check to a decomp stage check, does penalties if its started decomposing at all.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The recent change to thralls made them very good at killing things but killing things makes them get a trickle of blood. 
Makes it less punishing for killing prey as a thrall.
gives more incentive for proper corpse disposal.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheffie
(+)The penalty for draining a corpse as a thrall now only applies if it's rotting.
```
