### PR TITLE
Adds a crew respawn event

### DIFF
--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -225,61 +225,23 @@ var/datum/event_controller/random_events
 	Topic(href, href_list[])
 		//So we have not had any validation on the admin random events panel since its inception. Argh. /Spy
 		if(usr?.client && !usr.client.holder) {boutput(usr, "Only administrators may use this command."); return}
+		if (href_list["TriggerEvent"] || href_list["TriggerMEvent"] || href_list["TriggerSEvent"] || href_list["TriggerStartEvent"])
+			var/datum/random_event/RE
+			if(href_list["TriggerEvent"])
+				RE = locate(href_list["TriggerEvent"]) in events
+			else if(href_list["TriggerMEvent"])
+				RE = locate(href_list["TriggerMEvent"]) in minor_events
+			else if(href_list["TriggerSEvent"])
+				RE = locate(href_list["TriggerSEvent"]) in special_events
+			else if(href_list["TriggerStartEvent"])
+				RE = locate(href_list["TriggerStartEvent"]) in start_events
 
-		if(href_list["TriggerEvent"])
-			var/datum/random_event/RE = locate(href_list["TriggerEvent"]) in events
 			if (!istype(RE,/datum/random_event/))
 				return
 			var/choice = alert("Trigger a [RE.name] event?","Random Events","Yes","No")
 			if (choice == "Yes")
 				if (RE.customization_available)
-					var/choice2 = alert("Random or custom variables?","[RE.name]","Random","Custom")
-					if (choice2 == "Custom")
-						RE.admin_call(key_name(usr, 1))
-					else
-						RE.event_effect("Triggered by [key_name(usr)]")
-				else
-					RE.event_effect("Triggered by [key_name(usr)]")
-
-		else if(href_list["TriggerMEvent"])
-			var/datum/random_event/RE = locate(href_list["TriggerMEvent"]) in minor_events
-			if (!istype(RE,/datum/random_event/))
-				return
-			var/choice = alert("Trigger a [RE.name] event?","Random Events","Yes","No")
-			if (choice == "Yes")
-				if (RE.customization_available)
-					var/choice2 = alert("Random or custom variables?","[RE.name]","Random","Custom")
-					if (choice2 == "Custom")
-						RE.admin_call(key_name(usr, 1))
-					else
-						RE.event_effect("Triggered by [key_name(usr)]")
-				else
-					RE.event_effect("Triggered by [key_name(usr)]")
-
-		else if(href_list["TriggerSEvent"])
-			var/datum/random_event/RE = locate(href_list["TriggerSEvent"]) in special_events
-			if (!istype(RE,/datum/random_event/))
-				return
-			var/choice = alert("Trigger a [RE.name] event?","Random Events","Yes","No")
-			if (choice == "Yes")
-				if (RE.customization_available)
-					var/choice2 = alert("Random or custom variables?","[RE.name]","Random","Custom")
-					if (choice2 == "Custom")
-						RE.admin_call(key_name(usr, 1))
-					else
-						RE.event_effect("Triggered by [key_name(usr)]")
-				else
-					RE.event_effect("Triggered by [key_name(usr)]")
-
-		else if(href_list["TriggerStartEvent"])
-			var/datum/random_event/RE = locate(href_list["TriggerStartEvent"]) in start_events
-			if (!istype(RE,/datum/random_event/))
-				return
-			var/choice = alert("Trigger a [RE.name] event?","Random Events","Yes","No")
-			if (choice == "Yes")
-				if (RE.customization_available)
-					var/choice2 = alert("Random or custom variables?","[RE.name]","Random","Custom")
-					if (choice2 == "Custom")
+					if (RE.always_custom || alert("Random or custom variables?","[RE.name]","Random","Custom") == "Custom")
 						RE.admin_call(key_name(usr, 1))
 					else
 						RE.event_effect("Triggered by [key_name(usr)]")

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -72,6 +72,8 @@
 ABSTRACT_TYPE(/datum/objective/crew)
 /datum/objective/crew
 
+/datum/objective/crew/custom
+
 ABSTRACT_TYPE(/datum/objective/crew/captain)
 /datum/objective/crew/captain/hat
 	explanation_text = "Don't lose your hat!"

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2400,7 +2400,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 		M.traitHolder.addTrait("training_security")
-		M.show_text("<b>Hostile assault force incoming! Defend the crew from the attacking Syndicate Special Operatives!</b>", "blue")
+		// M.show_text("<b>Hostile assault force incoming! Defend the crew from the attacking Syndicate Special Operatives!</b>", "blue")
 
 
 // Use this one for late respawns to dael with existing antags. they are weaker cause they dont get a laser rifle or frags

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -1,4 +1,4 @@
-/datum/random_event/major/antag
+/datum/random_event/major/player_spawn
 	///Can this event be given a custom spawn location
 	var/targetable = FALSE
 	var/turf/custom_spawn_turf = null
@@ -7,7 +7,10 @@
 			var/custom_loc = alert("Custom spawn location?","[src.name]","Default","Custom") == "Custom"
 			if (custom_loc)
 				src.custom_spawn_turf = get_turf(pick_ref(usr))
-/datum/random_event/major/antag/antagonist
+
+	cleanup()
+		src.custom_spawn_turf = null
+/datum/random_event/major/player_spawn/antag/antagonist
 	name = "Antagonist Spawn"
 	required_elapsed_round_time = 26.6 MINUTES
 	customization_available = 1
@@ -94,7 +97,7 @@
 				..() // Report spawn().
 			else
 				message_admins("Couldn't spawn AI blob (no blobstart landmark found).")
-			src.post_event()
+			src.cleanup()
 			return
 
 		// Don't lock up the event controller.
@@ -110,7 +113,7 @@
 		return ..()
 
 	proc/do_event(var/source)
-		if (!src || !istype(src, /datum/random_event/major/antag/antagonist))
+		if (!src || !istype(src, /datum/random_event/major/player_spawn/antag/antagonist))
 			return
 
 		src.respawn_lock = 1
@@ -128,7 +131,7 @@
 		if (!islist(candidates) || !length(candidates))
 			message_admins("Couldn't set up Antagonist Spawn ([src.antagonist_type]); no ghosts responded. Source: [source ? "[source]" : "random"]")
 			logTheThing(LOG_ADMIN, null, "Couldn't set up Antagonist Spawn ([src.antagonist_type]); no ghosts responded. Source: [source ? "[source]" : "random"]")
-			src.post_event()
+			src.cleanup()
 			global.random_events.next_spawn_event = TIME + 1 MINUTE
 			return
 
@@ -169,7 +172,7 @@
 			if (!(lucky_dude && istype(lucky_dude) && lucky_dude.current))
 				message_admins("Couldn't set up Antagonist Spawn ([src.antagonist_type]); candidate selection failed (had [candidates.len] candidate(s)). Source: [source ? "[source]" : "random"]")
 				logTheThing(LOG_ADMIN, null, "Couldn't set up Antagonist Spawn ([src.antagonist_type]); candidate selection failed (had [candidates.len] candidate(s)). Source: [source ? "[source]" : "random"]")
-				src.post_event()
+				src.cleanup()
 				return
 
 			candidates -= lucky_dude
@@ -180,7 +183,7 @@
 				M3 = lucky_dude.current
 			else
 				if (src.respawn_lock != 1) // Respawn might be in progress still.
-					src.post_event()
+					src.cleanup()
 				return
 
 			// Shouldn't happen, will happen.
@@ -368,7 +371,7 @@
 			if (failed != 0)
 				message_admins("Couldn't set up Antagonist Spawn ([src.antagonist_type]); respawn failed. Source: [source ? "[source]" : "random"]")
 				logTheThing(LOG_ADMIN, null, "Couldn't set up Antagonist Spawn ([src.antagonist_type]); respawn failed. Source: [source ? "[source]" : "random"]")
-				src.post_event()
+				src.cleanup()
 				return
 
 			lucky_dude.assigned_role = "MODE"
@@ -420,17 +423,16 @@
 				lucky_dude.current.show_text("<h3>You have been respawned as a random event [src.antagonist_type].</h3>", "blue")
 			message_admins("[key_name(lucky_dude.key)] respawned as a random event [src.antagonist_type]. Source: [source ? "[source]" : "random"]")
 			logTheThing(LOG_ADMIN, lucky_dude.current, "respawned as a random event [src.antagonist_type]. Source: [source ? "[source]" : "random"]")
-		src.post_event()
+		src.cleanup()
 		return
 
 	// Restore defaults.
-	proc/post_event()
-		if (!src || !istype(src, /datum/random_event/major/antag/antagonist))
+	cleanup()
+		if (!src || !istype(src, /datum/random_event/major/player_spawn/antag/antagonist))
 			return
-
+		..()
 		src.antagonist_type = initial(src.antagonist_type)
 		src.respawn_lock = initial(src.respawn_lock)
 		src.message_delay = initial(src.message_delay)
 		src.admin_override = initial(src.admin_override)
 		src.antag_count = initial(src.antag_count)
-		src.custom_spawn_turf = null

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -55,7 +55,7 @@
 
 
 //very similar to playable_pests.dm :)
-/datum/random_event/major/antag/antagonist_pest
+/datum/random_event/major/player_spawn/antag/antagonist_pest
 	name = "Antagonist Critter Spawn"
 	customization_available = 1
 	targetable = TRUE
@@ -135,7 +135,7 @@
 
 		src.num_critters = input(usr, "How many critter antagonists to spawn? ([length(eligible_dead_player_list(allow_dead_antags = TRUE))] players eligible)", src.name, 0) as num|null
 		if (!src.num_critters || src.num_critters < 1)
-			cleanup_event()
+			cleanup()
 			return
 		else
 			src.num_critters = round(src.num_critters)
@@ -144,7 +144,7 @@
 		if (alert(usr, "You have chosen to spawn [src.num_critters] [src.critter_type ? src.critter_type : "random critters"]. Is this correct?", src.name, "Yes", "No") == "Yes")
 			event_effect(source)
 		else
-			cleanup_event()
+			cleanup()
 
 	event_effect(var/source)
 		..()
@@ -177,7 +177,7 @@
 
 
 			if (!length(candidates))
-				cleanup_event()
+				cleanup()
 				global.random_events.next_spawn_event = TIME + 1 MINUTE
 				return
 
@@ -192,7 +192,7 @@
 				EV += landmarks[LANDMARK_LATEJOIN]
 				if (!EV.len)
 					message_admins("Pests event couldn't find a pest landmark!")
-					cleanup_event()
+					cleanup()
 					return
 
 			var/atom/pestlandmark = pick(EV)
@@ -226,9 +226,9 @@
 				candidates -= M
 
 			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter", alert_origin = ALERT_GENERAL)
-			cleanup_event()
+			cleanup()
 
-	proc/cleanup_event()
+	cleanup()
+		..()
 		src.critter_type = null
 		src.num_critters = 0
-		src.custom_spawn_turf = null

--- a/code/modules/events/crew_spawn.dm
+++ b/code/modules/events/crew_spawn.dm
@@ -4,7 +4,7 @@
 	customization_available = TRUE
 	always_custom = TRUE
 	name = "Crew respawn"
-	var/ghost_confirmation_delay = 60 SECONDS // time to acknowledge or deny respawn offer.
+	var/ghost_confirmation_delay = 20 SECONDS // time to acknowledge or deny respawn offer.
 	var/datum/job/respawn_job = null
 	var/num_crew = 1
 	var/objective_text = ""

--- a/code/modules/events/crew_spawn.dm
+++ b/code/modules/events/crew_spawn.dm
@@ -1,0 +1,83 @@
+/datum/random_event/major/player_spawn/crew
+	disabled = TRUE
+	targetable = TRUE
+	customization_available = TRUE
+	always_custom = TRUE
+	name = "Crew respawn"
+	var/ghost_confirmation_delay = 60 SECONDS // time to acknowledge or deny respawn offer.
+	var/datum/job/respawn_job = null
+	var/num_crew = 1
+	var/objective_text = ""
+
+	admin_call(var/source)
+		if (..())
+			return
+		var/list/jobs = list()
+		for (var/datum/job/job in (job_controls.staple_jobs + job_controls.special_jobs + job_controls.hidden_jobs))
+			jobs[job.name] = job
+		src.respawn_job = tgui_input_list(usr, "Pick a job", src.name, jobs)
+		if (!src.respawn_job)
+			return
+		src.respawn_job = jobs[src.respawn_job]
+		src.num_crew = input(usr, "How many crew to spawn?", src.name, 0) as num|null
+		if (!src.num_crew || src.num_crew < 1)
+			src.cleanup()
+			return
+
+		src.objective_text = tgui_input_text(usr, "Custom objective text.", "Objectives", src.objective_text, multiline=TRUE, allowEmpty=TRUE)
+
+		//confirmation
+		if (alert(usr, "You have chosen to spawn [src.num_crew] [src.respawn_job.name]s. Is this correct?", src.name, "Yes", "No") == "Yes")
+			event_effect(source)
+		else
+			src.cleanup()
+
+	event_effect(var/source)
+		..()
+
+		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
+		var/list/text_messages = list()
+		text_messages.Add("Would you like to respawn as [src.num_crew > 1 ? "part of a group of" : "a"] [src.respawn_job.name][src.num_crew > 1 ? "s" : ""]?")
+		text_messages.Add("You are eligible to be respawned as a [src.respawn_job.name]. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
+		text_messages.Add("You have been added to the list of respawns. Please wait...")
+
+		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
+		message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
+		var/list/datum/mind/candidates = dead_player_list(TRUE, src.ghost_confirmation_delay, text_messages, allow_dead_antags = TRUE, require_client = TRUE)
+
+		for (var/i = 1 to src.num_crew)
+			if (!length(candidates))
+				return
+			var/datum/mind/mind = pick(candidates)
+			src.spawn_as_job(src.respawn_job, mind.current, src.custom_spawn_turf || pick_landmark(LANDMARK_LATEJOIN))
+			candidates -= mind
+			if (src.objective_text)
+				new /datum/objective/crew/custom(src.objective_text, mind)
+				boutput(mind.current, "<span style='font-size:24px'>You have respawned as a [src.respawn_job.name].</span>")
+				boutput(mind.current, "<span style='font-size:24px'>Your objective is: [src.objective_text]</span>")
+				SPAWN(0)
+					tgui_alert(mind.current, "You have respawned as a [src.respawn_job.name]. Your objective is: [src.objective_text]", "Respawned", list("Ok"))
+		SPAWN(1)
+			src.cleanup()
+
+	proc/spawn_as_job(datum/job/job, mob/player, turf/location)
+		var/mob/living/carbon/human/normal/M = new/mob/living/carbon/human/normal(location)
+		SPAWN(0)
+			M.JobEquipSpawned(job.name)
+
+		if(!player.mind)
+			player.mind = new (player)
+		player.mind.assigned_role = job.name
+		M.job = job.name
+		player.mind.transfer_to(M)
+		remove_antag(M, usr, 1, 1)
+		SPAWN(5 SECONDS)
+			if(player && !player:client)
+				qdel(player)
+
+	cleanup()
+		..()
+		src.ghost_confirmation_delay = initial(src.ghost_confirmation_delay)
+		src.respawn_job = null
+		src.objective_text = initial(src.objective_text)
+		src.num_crew = initial(src.num_crew)

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -31,7 +31,7 @@
 
 		src.num_pests = input(usr, "How many pests to spawn?", src.name, 0) as num|null
 		if (!src.num_pests || src.num_pests < 1)
-			cleanup_event()
+			cleanup()
 			return
 		else
 			src.num_pests = round(src.num_pests)
@@ -40,7 +40,7 @@
 		if (alert(usr, "You have chosen to spawn [src.num_pests] [src.pest_type ? src.pest_type : "random pests"]. Is this correct?", src.name, "Yes", "No") == "Yes")
 			event_effect(source)
 		else
-			cleanup_event()
+			cleanup()
 
 	event_effect(var/source)
 		..()
@@ -74,7 +74,7 @@
 				if (!EV.len)
 					message_admins("Pests event couldn't find any valid landmarks!")
 					logTheThing(LOG_DEBUG, null, "Failed to find any valid landmarks for a Pests event!")
-					cleanup_event()
+					src.cleanup()
 					return
 
 			var/atom/pestlandmark = pick(EV)
@@ -105,9 +105,9 @@
 
 			if (src.num_pests >= 5)
 				command_alert("A large number of pests have been detected onboard.", "Pest invasion", alert_origin = ALERT_STATION)
-		cleanup_event()
+		src.cleanup()
 
-	proc/cleanup_event()
+	cleanup()
 		src.num_pests = 0
 		src.pest_type = null
 

--- a/code/modules/events/random_event.dm
+++ b/code/modules/events/random_event.dm
@@ -9,6 +9,7 @@
 	var/disabled = 0                     // Event won't occur if this is true.
 	var/announce_to_admins = 1
 	var/customization_available = 0
+	var/always_custom = FALSE
 	var/weight = 100					//for weighted probability picker. 100 is base
 
 	proc/event_effect(var/source)
@@ -41,6 +42,9 @@
 			return 0
 
 		return 1
+
+	proc/cleanup()
+		return
 
 /datum/random_event/minor
 	announce_to_admins = 0

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -911,6 +911,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\events\battle_storm.dm"
 #include "code\modules\events\black_hole.dm"
 #include "code\modules\events\blowout.dm"
+#include "code\modules\events\crew_spawn.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\locker_entanglement.dm"
 #include "code\modules\events\magnetic.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an admin only random event that lets you respawn a number of ghosts as jobs with custom objectives.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current respawn as job system just yanks people out of the aether and dumps them at arrivals with no direction or warning, this should be much better. Also I may want to use this for flock at some point.