### PR TITLE
Interdictor crate for Donut 2 engineering

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -21122,6 +21122,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellow/corner,
 /area/station/engine/engineering)
 "bvP" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an interdictor crate to Donut 2 engineering in a convenient open space. One line!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There should be an interdictor crate on each map.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Donut 2 is now equipped with an interdictor crate for all your spatial phenomena needs.
```
