### PR TITLE
minor clarion patches

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -455,7 +455,6 @@ var/global/list/mapNames = list(
 		"the central research sector hub" = list(/area/station/science/lobby),
 		"the quartermaster's office" = list(/area/station/quartermaster/office),
 		"the thermo-electric generator room" = list(/area/station/engine/core),
-		"the courtroom" = list(/area/station/crew_quarters/courtroom),
 		"the medbay" = list(/area/station/medical/medbay, /area/station/medical/medbay/lobby),
 		"the bar" = list(/area/station/crew_quarters/bar),
 		//"the EVA storage" = list(/area/station/ai_monitored/storage/eva),

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -4705,6 +4705,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},


### PR DESCRIPTION
[bug]

## About the PR 
adds a ship component fab to the public podbay
removes "courtroom" from the available nuke plant sites


## Why's this needed? 
wasn't a ship fab on that half of the ship, closest was in sec podbay
clarion courtroom isn't real
fixes #12707
fixes #12700