### PR TITLE
Purchaseable interdictor manudrive crate

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -294,6 +294,13 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Station Pressurization Crate"
 
+/datum/supply_packs/interdictor_supply
+	name = "Interdictor Crate"
+	desc = "One (1) officially licensed Spatial Interdictor manufacture data disk. Includes complementary materials (x3 cable coil, x1 steel ingot, x1 glass block)."
+	category = "Engineering Department"
+	cost = 5000
+	containertype = /obj/storage/secure/crate/eng/itdr_supply
+
 /datum/supply_packs/disposal_pipe_cart
 	name = "Disposal Pipe Dispenser Cart"
 	desc = "Has a pesky staff assistant stolen your cart?"

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -177,12 +177,15 @@
 				B3.pixel_x = -6
 				B3.pixel_y = -4
 
-				var/obj/item/material_piece/glass/B4 = new(src)
+				var/obj/item/material_piece/steel/B4 = new(src)
 				B4.pixel_x = -6
-				B4.pixel_y = 4
 
-				var/obj/item/disk/data/floppy/manudrive/interdictor_parts/B5 = new(src)
-				B5.pixel_x = 6
+				var/obj/item/material_piece/glass/B5 = new(src)
+				B5.pixel_x = -6
+				B5.pixel_y = 4
+
+				var/obj/item/disk/data/floppy/manudrive/interdictor_parts/B6 = new(src)
+				B6.pixel_x = 6
 				return 1
 
 

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -155,6 +155,37 @@
 				B5.pixel_y = 1
 				return 1
 
+	itdr_supply
+		name = "interdictor supply crate"
+		desc = "Contains a drive with spatial interdictor manufacture data and several resources useful for interdictor production."
+		req_access = list(access_engineering)
+
+		make_my_stuff()
+			if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
+				var/obj/item/cable_coil/B0 = new(src)
+				B0.pixel_x = 5
+				B0.pixel_y = -4
+
+				var/obj/item/cable_coil/B1 = new(src)
+				B1.pixel_x = 5
+
+				var/obj/item/cable_coil/B2 = new(src)
+				B2.pixel_x = 5
+				B2.pixel_y = 4
+
+				var/obj/item/material_piece/steel/B3 = new(src)
+				B3.pixel_x = -6
+				B3.pixel_y = -4
+
+				var/obj/item/material_piece/glass/B4 = new(src)
+				B4.pixel_x = -6
+				B4.pixel_y = 4
+
+				var/obj/item/disk/data/floppy/manudrive/interdictor_parts/B5 = new(src)
+				B5.pixel_x = 6
+				return 1
+
+
 /obj/storage/secure/crate/medical
 	desc = "A secure medical crate."
 	name = "medical crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an interdictor crate for purchase in Cargo. It contains one interdictor component ManuDrive as well as some complementary materials (three cable coils, two steel ingots and a glass block) sufficient for manufacturing one batch of interdictor parts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Provides a way to reacquire interdictor schematics in the event somebody cares enough about interdictors to run off with the disk (or the fabricator with the disk gets wrecked).