### PR TITLE
Contents of unopened soda can be poured out of the container fix.

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -662,10 +662,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(user, "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>")
 
 		else if (target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
-			if (is_sealed)
-				boutput(user, "<span class='alert'>[src] is sealed.</span>")
-				return
-
 			if (!reagents.total_volume)
 				boutput(user, "<span class='alert'>[src] is empty.</span>")
 				return

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -675,10 +675,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
 
 		else if (istype(target, /obj/item/sponge)) // dump contents onto it
-			if (is_sealed)
-				boutput(user, "<span class='alert'>[src] is sealed.</span>")
-				return
-
 			if (!reagents.total_volume)
 				boutput(user, "<span class='alert'>[src] is empty.</span>")
 				return

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -649,10 +649,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				boutput(user, "<span class='notice'>You transfer [trans] units of the solution to [T].</span>")
 
 		else if (is_reagent_dispenser(target)|| (target.is_open_container() == -1 && target.reagents) || (istype(target, /obj/fluid) && !istype(target, /obj/fluid/airborne) && !src.reagents.total_volume)) //A dispenser. Transfer FROM it TO us.
-			if (is_sealed)
-				boutput(user, "<span class='alert'>[src] is sealed.</span>")
-				return
-
 			if (!target.reagents.total_volume && target.reagents)
 				boutput(user, "<span class='alert'>[target] is empty.</span>")
 				return

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -618,6 +618,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	//bleck, i dont like this at all. (Copied from chemistry-tools reagent_containers/glass/ definition w minor adjustments)
 	// still copy paste btw
 	afterattack(obj/target, mob/user , flag)
+		if (is_sealed)
+			boutput(user, "<span class='alert'>[src] is sealed.</span>")
+			return
 		user.lastattacked = target
 		if (istype(target, /obj/fluid) && !istype(target, /obj/fluid/airborne)) // fluid handling : If src is empty, fill from fluid. otherwise add to the fluid.
 			var/obj/fluid/F = target
@@ -637,10 +640,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				var/amt = min(F.group.amt_per_tile, reagents.maximum_volume - reagents.total_volume)
 				boutput(user, "<span class='notice'>You fill [src] with [amt] units of [target].</span>")
 				F.group.drain(F, amt / F.group.amt_per_tile, src) // drain uses weird units
-
-			if (is_sealed)
-				boutput(user, "<span class='alert'>[src] is sealed.</span>")
-				return
 
 			else //trans_to to the FLOOR of the liquid, not the liquid itself. will call trans_to() for turf which has a little bit that handles turf application -> fluids
 				var/turf/T = get_turf(F)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -691,9 +691,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 
 			if (ismob(target) || (isobj(target) && target:flags & NOSPLASH))
 				return
-			if (is_sealed)
-				boutput(user, "<span class='alert'>[src] is sealed.</span>")
-				return
 			boutput(user, "<span class='notice'>You [src.splash_all_contents ? "pour all of" : "apply [amount_per_transfer_from_this] units of"] the solution onto [target].</span>")
 			logTheThing(LOG_CHEMISTRY, user, "pours [src] onto [constructTarget(target,"combat")] [log_reagents(src)] at [log_loc(user)].") // Added location (Convair880).
 			reagents.physical_shock(14)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -483,6 +483,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	throw_speed = 1
 	var/can_recycle = 1
 	var/can_chug = 1
+	var/is_sealed = 0
 
 	New()
 		..()
@@ -637,6 +638,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				boutput(user, "<span class='notice'>You fill [src] with [amt] units of [target].</span>")
 				F.group.drain(F, amt / F.group.amt_per_tile, src) // drain uses weird units
 
+			if (is_sealed)
+				boutput(user, "<span class='alert'>[src] is sealed.</span>")
+				return
+
 			else //trans_to to the FLOOR of the liquid, not the liquid itself. will call trans_to() for turf which has a little bit that handles turf application -> fluids
 				var/turf/T = get_turf(F)
 
@@ -645,6 +650,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				boutput(user, "<span class='notice'>You transfer [trans] units of the solution to [T].</span>")
 
 		else if (is_reagent_dispenser(target)|| (target.is_open_container() == -1 && target.reagents) || (istype(target, /obj/fluid) && !istype(target, /obj/fluid/airborne) && !src.reagents.total_volume)) //A dispenser. Transfer FROM it TO us.
+			if (is_sealed)
+				boutput(user, "<span class='alert'>[src] is sealed.</span>")
+				return
+
 			if (!target.reagents.total_volume && target.reagents)
 				boutput(user, "<span class='alert'>[target] is empty.</span>")
 				return
@@ -658,6 +667,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(user, "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>")
 
 		else if (target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
+			if (is_sealed)
+				boutput(user, "<span class='alert'>[src] is sealed.</span>")
+				return
+
 			if (!reagents.total_volume)
 				boutput(user, "<span class='alert'>[src] is empty.</span>")
 				return
@@ -671,6 +684,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
 
 		else if (istype(target, /obj/item/sponge)) // dump contents onto it
+			if (is_sealed)
+				boutput(user, "<span class='alert'>[src] is sealed.</span>")
+				return
+
 			if (!reagents.total_volume)
 				boutput(user, "<span class='alert'>[src] is empty.</span>")
 				return
@@ -687,10 +704,12 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 
 			if (ismob(target) || (isobj(target) && target:flags & NOSPLASH))
 				return
+			if (is_sealed)
+				boutput(user, "<span class='alert'>[src] is sealed.</span>")
+				return
 			boutput(user, "<span class='notice'>You [src.splash_all_contents ? "pour all of" : "apply [amount_per_transfer_from_this] units of"] the solution onto [target].</span>")
 			logTheThing(LOG_CHEMISTRY, user, "pours [src] onto [constructTarget(target,"combat")] [log_reagents(src)] at [log_loc(user)].") // Added location (Convair880).
 			reagents.physical_shock(14)
-
 			var/splash_volume
 			if (src.splash_all_contents)
 				splash_volume = src.reagents.maximum_volume

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -483,7 +483,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	throw_speed = 1
 	var/can_recycle = 1
 	var/can_chug = 1
-	var/is_sealed = 0
+	var/is_sealed = FALSE
 
 	New()
 		..()

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -334,8 +334,8 @@
 		if (src.is_sealed)
 			is_sealed = 0
 			can_chug = 1
-			splash_all_contents = 1
-			incompatible_with_chem_dispensers = 0
+			splash_all_contents = TRUE
+			incompatible_with_chem_dispensers = FALSE
 			amount_per_transfer_from_this = 5
 			playsound(src.loc, 'sound/items/can_open.ogg', 50, 1)
 			if (src.shaken)

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -311,8 +311,8 @@
 	rc_flags = RC_FULLNESS
 	initial_volume = 50
 	can_chug = 0
-	splash_all_contents = 0
-	incompatible_with_chem_dispensers = 1
+	splash_all_contents = FALSE
+	incompatible_with_chem_dispensers = TRUE
 	amount_per_transfer_from_this = 0
 	initial_reagents = list("cola"=20,"VHFCS"=10)
 	is_sealed = 1

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -311,8 +311,11 @@
 	rc_flags = RC_FULLNESS
 	initial_volume = 50
 	can_chug = 0
+	splash_all_contents = 0
+	incompatible_with_chem_dispensers = 1
+	amount_per_transfer_from_this = 0
 	initial_reagents = list("cola"=20,"VHFCS"=10)
-	var/is_sealed = 1 //can you drink out of it?
+	is_sealed = 1
 	var/standard_override //is this a random cola or a standard cola (for crushed icons)
 	var/shaken = FALSE //sets to TRUE on *twirl emote
 
@@ -329,8 +332,12 @@
 	attack_self(mob/user as mob)
 		var/drop_this_shit = 0 //i promise this is useful
 		if (src.is_sealed)
+			IN
 			is_sealed = 0
 			can_chug = 1
+			splash_all_contents = 1
+			incompatible_with_chem_dispensers = 0
+			amount_per_transfer_from_this = 5
 			playsound(src.loc, 'sound/items/can_open.ogg', 50, 1)
 			if (src.shaken)
 				src.reagents.reaction(user)

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -315,7 +315,7 @@
 	incompatible_with_chem_dispensers = TRUE
 	amount_per_transfer_from_this = 0
 	initial_reagents = list("cola"=20,"VHFCS"=10)
-	is_sealed = 1
+	is_sealed = TRUE
 	var/standard_override //is this a random cola or a standard cola (for crushed icons)
 	var/shaken = FALSE //sets to TRUE on *twirl emote
 

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -332,7 +332,6 @@
 	attack_self(mob/user as mob)
 		var/drop_this_shit = 0 //i promise this is useful
 		if (src.is_sealed)
-			IN
 			is_sealed = 0
 			can_chug = 1
 			splash_all_contents = 1


### PR DESCRIPTION
Fixes #8658
Fixes #12652

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Catering] [Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes unopened cans of soda/cola unpourable into the floor and containers and instead says "Space Cola is sealed" 



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It fixes a behavior that shouldn't be possible (pouring things out of a can even though its sealed) and it would be irittating when you spill your soda even though its unopened.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Buyrcsp2
(+)Unopened cans of soda now can't be poured, unless popped open.
```
