### PR TITLE
Patch engivac to work on pick-up

### DIFF
--- a/code/obj/item/tool/engivac.dm
+++ b/code/obj/item/tool/engivac.dm
@@ -15,7 +15,7 @@ obj/item/engivac
 	icon_state = "engivac"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "engivac_"
-	c_flags = ONBELT | ONBACK //engis & mechs will want to keep their toolbelts on with this, most other crew their backpacks. Hope this doesn't break stuff.
+	c_flags = ONBELT | ONBACK | EQUIPPED_WHILE_HELD //engis & mechs will want to keep their toolbelts on with this, most other crew their backpacks. Hope this doesn't break stuff.
 	w_class = W_CLASS_BULKY
 
 	//Stuff relating to the particular toolbox we have installed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds EQUIPPED_WHEN_HELD to the engivac's flags.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Engivacs didn't function in-hand unless you equipped it on back/belt first, which is wrong behaviour. Nice if it's not jank.