### PR TITLE
Nadir Multi-Melty mini degoof batch

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -16955,6 +16955,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
+"hvm" = (
+/obj/item/storage/toilet,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/landmark{
+	name = "shitty_bill_respawn"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "hvw" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -111528,7 +111539,7 @@ kfP
 fmc
 eIK
 oZp
-mZZ
+hvm
 irk
 xPc
 qlL

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -37387,18 +37387,6 @@
 "qAZ" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
-"qBe" = (
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour10;desc=The east crew quarters are your best place to catch up on sleep - most public beds are located here, with personal safes for your security. Also located here are the diplomatic quarters.";
-	freq = 1443;
-	location = "tour9";
-	name = "tour 9 - east crew"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
 "qBw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42310,7 +42298,7 @@
 "sQU" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour14;desc=On your left is the Site refinery - Engineers access the Siphon through its far door, and its nano-fabricator is often used for catalytic rod fabrication.";
+	codes_txt = "tour;next_tour=tour14;desc=On your left is the Site refinery - Engineers access the Harmonic Siphon, Nadir's primary prototype device, through its far door.";
 	freq = 1443;
 	location = "tour13";
 	name = "tour 13 - east1"
@@ -42559,7 +42547,7 @@
 "sVX" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour11;desc=On my left, you'll see the nuclear reactor responsible for s electrical generation for the Site. Please respect caution borders.";
+	codes_txt = "tour;next_tour=tour11;desc=On my left, you'll see the nuclear reactor responsible for primary electrical generation for the Site. Please respect caution borders.";
 	freq = 1443;
 	location = "tour10";
 	name = "tour 10 - nuclear"
@@ -84368,8 +84356,8 @@ gkJ
 hWJ
 hLQ
 hWJ
-hWJ
 qga
+hWJ
 hWJ
 hWJ
 rYi
@@ -110050,7 +110038,7 @@ ePt
 ebu
 ocD
 vEo
-qBe
+fdg
 rZb
 nlG
 hXJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small fixes for Nadir Multi-Melty (nuclear and mining) update.

- Corrected some tour beacons. A beacon from the previous route managed to elude deletion (causing occasional wrong behavior) and has now correctly been removed; also updated one beacon to fix a typo and another to adjust focus of attention.
- Adjusted a misplaced light in the arrivals secondary hallway.
- Swapped a shitty_bill_respawn landmark in for an accidental second Tanhony landmark (returning to pre-update east crew quarters bathroom stall spawns, overall).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Realized some minor goofs that ought to be corrected.