### PR TITLE
Make turfs below the nuclear reactor and turbine immune to explosions

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -64,6 +64,10 @@
 			for(var/y=1 to REACTOR_GRID_HEIGHT)
 				src.flux_grid[x][y] = list()
 
+		//Prevents unreachable turfs from being damaged, so as not to ruin engineer rounds
+		for(var/turf/simulated/floor/F in src.locs)
+			F.explosion_immune = TRUE
+
 		AddComponent(/datum/component/mechanics_holder)
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Control Rods", .proc/_set_controlrods_mechchomp)
 		src._light_turf = get_turf(src)
@@ -73,6 +77,8 @@
 
 	disposing()
 		src._light_turf?.remove_medium_light("reactor_light")
+		for(var/turf/simulated/floor/F in src.locs) //restore the explosion immune state of the original turf
+			F.explosion_immune = initial(F.explosion_immune)
 		. = ..()
 
 	update_icon()

--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -64,6 +64,9 @@
 		terminal.master = src
 		src._light_turf = get_turf(src)
 		src._light_turf.add_medium_light("turbine_light", list(255,255,255,255))
+		//Prevents unreachable turfs from being damaged, so as not to ruin engineer rounds
+		for(var/turf/simulated/floor/F in src.locs)
+			F.explosion_immune = TRUE
 		AddComponent(/datum/component/mechanics_holder)
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Stator Load", .proc/_set_statorload_mechchomp)
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Flow Rate", .proc/_set_flowrate_mechchomp)
@@ -71,6 +74,8 @@
 
 	disposing()
 		src._light_turf?.remove_medium_light("turbine_light")
+		for(var/turf/simulated/floor/F in src.locs) //restore the explosion immune state of the original turf
+			F.explosion_immune = initial(F.explosion_immune)
 		. = ..()
 
 	proc/_set_statorload_mechchomp(var/datum/mechanicsMessage/inp)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -22,6 +22,8 @@
 	//Stuff for the floor & wall planner undo mode that initial() doesn't resolve.
 	var/tmp/roundstart_icon_state
 	var/tmp/roundstart_dir
+	/// if this turf is immune to explosion (explosion immune turfs immediately return on ex_act())
+	var/explosion_immune = FALSE
 
 	New()
 		..()
@@ -1652,6 +1654,8 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 		src.ex_act(1)
 
 /turf/simulated/floor/ex_act(severity)
+	if(src.explosion_immune)
+		return
 	switch(severity)
 		if(1)
 			src.ReplaceWithSpace()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets a flag on simulated turfs that makes them early return in `ex_act()`. Unsets the flag on disposal of the reactor/turbine. Fun fact, explosions which destroy the reactor make the turf destructible in time to not leave random squares of untouched floor, so that's neat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Floors beneath the reactor aren't accessible, and so can't be repaired. This is bad.

