### PR TITLE
Spicy Dead Hen Meat no longer makes Spicy Chicken Sandwiches Fix

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -495,6 +495,7 @@ table#cooktime a#start {
 			src.recipes += new /datum/cookingrecipe/monkeyburger(src)
 			src.recipes += new /datum/cookingrecipe/synthburger(src)
 			src.recipes += new /datum/cookingrecipe/baconburger(src)
+			src.recipes += new /datum/cookingrecipe/spicychickensandwich_2(src)
 			src.recipes += new /datum/cookingrecipe/spicychickensandwich(src)
 			src.recipes += new /datum/cookingrecipe/chickensandwich(src)
 			src.recipes += new /datum/cookingrecipe/mysteryburger(src)


### PR DESCRIPTION
Fixes #12681

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Catering][C-Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It adds src.recipes += new /datum/cookingrecipe/spicychickensandwich_2(src) above the
src.recipes += new /datum/cookingrecipe/spicychickensandwich(src) which allows you to make spicy chicken sandwich with a dough and spicy nugget (as per wiki)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because it's fixes a bug, someone probably forgot to add the second recipe to the cooking.dm,  and it also makes the wiki accurate again.