### PR TITLE
Replaces airless tiles on radio station.

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1294,7 +1294,7 @@
 /obj/machinery/light_switch/north{
 	pixel_y = 30
 	},
-/turf/simulated/floor/plating/airless/shuttlebay,
+/turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aea" = (
 /obj/item/wirecutters,
@@ -1392,7 +1392,7 @@
 /obj/machinery/light_switch/north{
 	pixel_y = 30
 	},
-/turf/simulated/floor/plating/airless/shuttlebay,
+/turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aet" = (
 /obj/item/shipcomponent/secondary_system/cargo/small,
@@ -1434,9 +1434,6 @@
 	name = "Radio Ship Dock"
 	},
 /turf/simulated/floor/shuttlebay,
-/area/radiostation/podbay)
-"aeA" = (
-/turf/simulated/floor/plating/airless/shuttlebay,
 /area/radiostation/podbay)
 "aeB" = (
 /turf/simulated/floor/caution/west,
@@ -1512,7 +1509,7 @@
 /area/radiostation/podbay)
 "aeS" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating/airless/shuttlebay,
+/turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aeT" = (
 /obj/decal/cleanable/oil/streak,
@@ -1538,7 +1535,7 @@
 /area/radiostation/podbay)
 "aeW" = (
 /obj/machinery/light,
-/turf/simulated/floor/plating/airless/shuttlebay,
+/turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aeX" = (
 /obj/rack,
@@ -1622,7 +1619,7 @@
 /obj/item/reagent_containers/glass/oilcan,
 /obj/machinery/light,
 /obj/decal/cleanable/oil/streak,
-/turf/simulated/floor/plating/airless/shuttlebay,
+/turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "afj" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
@@ -3504,8 +3501,8 @@
 	desc = "How long has this cat been here?";
 	icon_state = "cat6";
 	name = "jons the catte";
-	randomize_name = 0;
-	randomize_look = 0
+	randomize_look = 0;
+	randomize_name = 0
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
@@ -20357,8 +20354,8 @@
 "lJu" = (
 /obj/stool/chair/comfy/shuttle/brown,
 /obj/machinery/computer/transit_shuttle/mining{
-	icon_state = "shuttle-embed";
 	embed = 1;
+	icon_state = "shuttle-embed";
 	pixel_y = -25
 	},
 /turf/unsimulated/floor/shuttle{
@@ -106127,7 +106124,7 @@ aaa
 adJ
 adO
 adZ
-aeA
+adY
 aeW
 adO
 akS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces a few airless tiles in the radio station pod bays with air ones.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12745 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


