### PR TITLE
Set material admin verb

### DIFF
--- a/code/modules/admin/admin_holder.dm
+++ b/code/modules/admin/admin_holder.dm
@@ -74,7 +74,8 @@
 			"Possess",\
 			"Create Poster",\
 			"Copy Here",\
-			"Ship to Cargo"\
+			"Ship to Cargo",\
+			"Set Material",\
 			)
 			admin_interact_verbs["mob"] = list(\
 			"Player Options",\
@@ -105,7 +106,8 @@
 			"Transfer Client To",\
 			"Shamecube",\
 			"Create Poster",\
-			"Ship to Cargo"\
+			"Ship to Cargo",\
+			"Set Material",\
 			)
 			admin_interact_verbs["turf"] = list(\
 			"Jump To Turf",\
@@ -119,7 +121,8 @@
 			"View Variables",\
 			"View Fingerprints",\
 			"Delete",\
-			"Create Poster"\
+			"Create Poster",\
+			"Set Material",\
 			)
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2236,6 +2236,8 @@ var/list/fun_images = list()
 			C.cmd_scale_target(A)
 		if ("Emag")
 			C.cmd_emag_target(A)
+		if ("Set Material")
+			C.cmd_set_material(A)
 
 	src.update_cursor()
 

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1523,6 +1523,22 @@
 	if (ismob(A))
 		message_admins("[key_name(src)] added [amount] units of [reagent.id] to [A] (Key: [key_name(A) || "NULL"]) at [log_loc(A)].")
 
+
+/client/proc/cmd_set_material(var/atom/A in world)
+	SET_ADMIN_CAT(ADMIN_CAT_NONE)
+	set name = "Set Material"
+	set desc = "Sets the material of an atom using its matid"
+	set popup_menu = 0
+
+	ADMIN_ONLY
+	var/matid = tgui_input_list(src, "Select material to transmute to:", "Set Material", material_cache)
+	var/material_selected = getMaterial(matid)
+	if(!material_selected)
+		alert(src, "Invalid material selected: [matid]", "Invalid Material", "Ok")
+		return
+	A.setMaterial(material_selected)
+	boutput(src, "Set material of [A] to [material_selected]")
+
 /client/proc/cmd_cat_county()
 	SET_ADMIN_CAT(ADMIN_CAT_FUN)
 	set name = "Cat County"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a "Set Material" option to the admin interact menu.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Inconvenient to have to go into build mode to do one offs
