### PR TITLE
adds klepto block prop to board games and gameclocks

### DIFF
--- a/code/obj/item/boardgame/boardgame.dm
+++ b/code/obj/item/boardgame/boardgame.dm
@@ -134,6 +134,8 @@
 		// Store old styling if there is any reason to reset the board
 		src.styling[STYLING_OLDTILECOLOR1] = src.styling[STYLING_TILECOLOR1]
 		src.styling[STYLING_OLDTILECOLOR2] = src.styling[STYLING_TILECOLOR2]
+		// Klepto block
+		APPLY_ATOM_PROPERTY(src, PROP_MOVABLE_KLEPTO_IGNORE, src)
 
 	/**
 	 * Reset the board to its color scheme, in case it has been changed

--- a/code/obj/item/boardgame/gameclock.dm
+++ b/code/obj/item/boardgame/gameclock.dm
@@ -60,6 +60,8 @@
 		. = ..()
 		src.whiteTime = src.defaultTime
 		src.blackTime = src.defaultTime
+		// Klepto block
+		APPLY_ATOM_PROPERTY(src, PROP_MOVABLE_KLEPTO_IGNORE, src)
 
 	examine()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
chess boards and board game clocks can no longer be interacted with or picked up randomly with the klepto trait


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
spam popups bad when unintentional, herb is lazy and needs to thank stonepillar