### PR TITLE
Nadir post-multi-melty camera coverage fix/adjust

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4026,6 +4026,12 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -9022,6 +9028,17 @@
 	dir = 8
 	},
 /area/station/medical/medbay/cloner)
+"ebU" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/west)
 "ecc" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -14490,6 +14507,13 @@
 "gwB" = (
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -28011,6 +28035,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
+"mfN" = (
+/obj/storage/secure/closet/engineering/mining,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/mining/staff_room)
 "mfV" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -30699,6 +30733,12 @@
 "nsO" = (
 /obj/table/reinforced/auto,
 /obj/item/game_kit,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -40798,19 +40838,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"slG" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/cafeteria)
 "slV" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -45666,6 +45693,13 @@
 	id = "market";
 	pixel_y = 24
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
 /turf/simulated/floor/grey/side{
 	dir = 9
 	},
@@ -47454,6 +47488,15 @@
 "vmx" = (
 /turf/simulated/floor/yellowblack/corner,
 /area/station/hallway/secondary/east)
+"vmA" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/quarters_east)
 "vmT" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -47763,6 +47806,13 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
 	},
@@ -50280,6 +50330,17 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"wHy" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellowblack,
+/area/station/engine/monitoring{
+	name = "Nuclear Control Room"
+	})
 "wHU" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib5"
@@ -90422,7 +90483,7 @@ chV
 bYc
 nea
 jwF
-slG
+jBz
 nKx
 idy
 bts
@@ -93739,7 +93800,7 @@ gNU
 iER
 hAe
 lut
-uqt
+ebU
 uqt
 jpG
 jli
@@ -106714,7 +106775,7 @@ pqb
 dYV
 tYz
 dYV
-ujK
+mfN
 aXs
 rkh
 ibV
@@ -109749,7 +109810,7 @@ fQt
 ocD
 pwy
 tXe
-sSm
+wHy
 ocD
 ocD
 ocD
@@ -110642,7 +110703,7 @@ eIK
 oZp
 oZp
 oZp
-jXY
+vmA
 ibV
 ibV
 lXA

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -49285,6 +49285,13 @@
 	pixel_x = -14;
 	pixel_y = 4
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "wdR" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts Nadir camera coverage a bit more to (mainly) fix some gaps after the Multi-Melty nuclear/mining update.

Camera coverage in Mining and the nuclear core has been fixed and should now cover all vital hardware. Also added two cameras to east crew quarters (inside of quarters themselves deliberately omitted) and improved coverage in the west hallway by (and in) the public market, as well as the kitchen.

Removed a camera from the south side of the bar; this causes the new little "back corner table" with the comfy chairs to be outside the AI's camera coverage, making it a sneaky spot to meet in public without the prying eyes of Big Computer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Corrects camera coverage majorly lacking in some spots, and being slightly excessive in one.

Fixes #12757 