### PR TITLE
AI mainframe and law rack interdict teleports

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -139,6 +139,8 @@ var/global/list/ai_emotions = list("Happy" = "ai_happy", \
 	var/datum/ai_hologram_data/holoHolder = new
 	var/list/hologramContextActions
 
+	var/teleblock_range = 4
+
 	proc/set_hat(obj/item/clothing/head/hat, var/mob/user as mob)
 		if( src.hat )
 			src.hat.wear_image.pixel_y = 0
@@ -202,6 +204,7 @@ var/global/list/ai_emotions = list("Happy" = "ai_happy", \
 	START_TRACKING
 
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES, src)
+	APPLY_ATOM_PROPERTY(src, PROP_ATOM_TELEPORT_JAMMER, src, src.teleblock_range)
 
 	ai_station_map = new /obj/minimap/ai
 	AddComponent(/datum/component/minimap_marker, MAP_AI | MAP_SYNDICATE, "ai")

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -25,12 +25,15 @@
 	var/list/holo_expansions = list()
 	/// list of ability expansions
 	var/list/datum/targetable/ai_abilities = list()
+	///range that the law rack interdicts incoming teleports
+	var/teleblock_range = 1 //law rack and adjacent tiles, prevents avoiding the turrets by teleporting inside the law rack or a wall
 
 	New(loc)
 		START_TRACKING
 		. = ..()
 		//if the ticker isn't initialised yet, it'll grab this rack when it is (see /datum/ai_rack_manager)
 		ticker?.ai_law_rack_manager.register_new_rack(src)
+		APPLY_ATOM_PROPERTY(src, PROP_ATOM_TELEPORT_JAMMER, src, src.teleblock_range)
 
 		src.light = new/datum/light/point
 		src.light.set_brightness(0.4)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the ai mainframe block teleports within 4 tiles of itself and the ai law rack block teleports within 1 tile of itself.

I would have liked to make it so that AI mainframes only block teleports when they are linked to a connected player client, to prevent the hopefully unlikely situation of using dormant AI mainframes as teleblockers. However, I'm not aware of any existing mob procs that are called when a player client gains or loses control of a mob (which would be further comlpicated by the AI being a couple of mobs controlled by one client). If you know a reasonable way to implement this let me know and I can include it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The AI's relatively fixed position renders them extremely vulnerable to teleportation, as anyone who wished them dead could simply teleport on top of them and beat them to death, or teleport bombs or hostile critters on top of them.

The law rack teleblocking is meant to address the problem of being able to teleport inside of the law rack (or an adjacent wall) in order to access it in a way that neither the turrets or any players could reach you.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(*)The AI and AI law rack now prevent nearby teleportations.
```
