### PR TITLE
Makes the dethat more saurian-friendly

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -325,7 +325,7 @@ proc/filter_trait_hats(var/type)
 									"audiolog" = /obj/item/device/audio_log ,
 									"flashlight" = /obj/item/device/light/flashlight,
 									"glasses" = /obj/item/clothing/glasses,
-									"goggles"= /obj/item/clothing/glasses) //For the lizard mutatrance that say glassssssses
+									"goggles" = /obj/item/clothing/glasses) //For the lizard mutatrance that say glassssssses
 		cigs = list()
 	examine()
 		. = ..()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -324,7 +324,8 @@ proc/filter_trait_hats(var/type)
 									"camera" = /obj/item/camera,
 									"audiolog" = /obj/item/device/audio_log ,
 									"flashlight" = /obj/item/device/light/flashlight,
-									"glasses" = /obj/item/clothing/glasses)
+									"glasses" = /obj/item/clothing/glasses,
+									"goggles"= /obj/item/clothing/glasses) //For the lizard mutatrance that say glassssssses
 		cigs = list()
 	examine()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets the saurians summon glasses with the dethat by asking for "goggles", as the dethat isn't picking up the "glasssssssses".
The glasses command still remains for the people used to it.
Closes #12682 
Closes #7361

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes dets happy.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
None needed.
