### PR TITLE
wrestlemap ai status display pass 2

### DIFF
--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -25953,10 +25953,6 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/maintenance/west)
-"kWp" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/data)
 "kWF" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -33139,6 +33135,9 @@
 	icon_state = "4-8"
 	},
 /obj/decal/stripe_delivery,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/data)
 "nXf" = (
@@ -90653,7 +90652,7 @@ iOM
 rtE
 wfW
 nRz
-kWp
+vyu
 drO
 rke
 sSa


### PR DESCRIPTION
[bug]

## About the PR 
moves an ai status display on wrestlemap; checks on the others for correctness

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12737