### PR TITLE
Changes dirtype manifolds on clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -33874,7 +33874,9 @@
 	},
 /area/station/science/lobby)
 "jiM" = (
-/obj/machinery/atmospherics/pipe/manifold/overfloor/north,
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 1
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "jiP" = (
@@ -37742,7 +37744,9 @@
 /area/station/mining/refinery)
 "mSt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/overfloor/west,
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -10
@@ -37797,7 +37801,9 @@
 	},
 /area/station/solar/west)
 "mVy" = (
-/obj/machinery/atmospherics/pipe/manifold/overfloor/south,
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 2
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "mVD" = (
@@ -38255,7 +38261,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/overfloor/north,
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 1
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "nAi" = (
@@ -40230,7 +40238,9 @@
 "pwH" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/overfloor/south,
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 2
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "pxJ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING][CLEAN]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes dirtype manifolds into using varedits.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's conflicting with my pr and also dirtype bad and should be removed.