### PR TITLE
Fix drone factory timings, mult adjust chargers

### DIFF
--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -26,12 +26,12 @@ TYPEINFO(/obj/machinery/drone_recharger)
 			occupant = null
 		..()
 
-	process()
+	process(mult)
 		if(!(status & BROKEN))
 			if (occupant)
-				power_usage = 500
+				power_usage = 500 * mult
 			else
-				power_usage = 50
+				power_usage = 50 * mult
 			..()
 		if(status & (NOPOWER|BROKEN) || !anchored)
 			if (src.occupant)
@@ -49,9 +49,9 @@ TYPEINFO(/obj/machinery/drone_recharger)
 				src.turnOff("fullcharge")
 				return
 			else if (occupant.cell.charge < occupant.cell.maxcharge)
-				occupant.cell.charge += src.chargerate
+				occupant.cell.charge += src.chargerate * mult
 				occupant.cell.charge = min(occupant.cell.maxcharge, occupant.cell.charge)
-				use_power(50)
+				use_power(50 * mult)
 				return
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][game objects][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates some things about the ghost drone factory to current conventions (like TIME and SECONDS), adds in an auto-restart if the current ghostdrone frame goes missing (it's an item) and also fixing the timings involved:

Each factory piece was counting process calls up to 20, probably from whenever machinery processing happened every second (so 20s per part)
Because at the default processing tier the interval is 3,2 seconds now, each part of the factory would actually take ~64 seconds
The global interval between drones is supposed 100 seconds, but since making them took 3x as long as intended the factory would never finish before that time expires. 

Now it counts to 20 seconds passing again. The result is that the factory would previously immediately start on the next drone the moment the previous one hit a charger, but now it lays dormant for a bit between cycles.

Also mult adjusts the chargers cause neither used mult (the factories still don't but)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slightly less charging downtime. I like it when stuff works as intended. Also the drones come out significantly faster post-fix
