### PR TITLE
Gave closedoff.dmm air

### DIFF
--- a/assets/maps/random_rooms/5x3/closedoff.dmm
+++ b/assets/maps/random_rooms/5x3/closedoff.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/woodwall,
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "i" = (
 /obj/stool/chair/moveable{
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "j" = (
 /obj/item/broken_egun,
@@ -16,26 +16,26 @@
 	pixel_x = 11;
 	pixel_y = -9
 	},
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "k" = (
 /obj/decal/cleanable/dirt,
 /obj/ladder/broken{
 	pixel_y = 22
 	},
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "l" = (
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "t" = (
 /obj/burning_barrel,
 /obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "C" = (
 /obj/decal/cleanable/dirt/dirt4,
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "F" = (
 /obj/table/round,
@@ -44,7 +44,7 @@
 	pixel_y = 9;
 	pixel_x = -4
 	},
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "J" = (
 /obj/stool/bench{
@@ -52,13 +52,13 @@
 	pixel_x = 8
 	},
 /obj/decal/cleanable/dirt/dirt2,
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "K" = (
 /obj/storage/crate/trench_loot/drug,
 /obj/item/clothing/suit/bedsheet,
 /obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "X" = (
 /obj/machinery/computer/security/wooden_tv,
@@ -66,7 +66,7 @@
 	dir = 1;
 	pixel_y = 17
 	},
-/turf/simulated/floor/airless/plating/damaged1,
+/turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The 5x3 random room `closedoff.dmm` used airless damaged plating 1 instead of the simulated kind. This replaces that.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12741