### PR TITLE
moved the ghostdrone factory chair

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12786,11 +12786,9 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
 "aQi" = (
-/obj/decal/fakeobjects/pipe/heat{
-	dir = 4
-	},
+/obj/disposalpipe/segment/horizontal,
 /obj/stool/chair{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
@@ -69861,7 +69859,7 @@ aJX
 aJX
 aJX
 aPi
-aQi
+aUR
 aJX
 aSy
 aJX
@@ -70162,7 +70160,7 @@ aJX
 aMs
 aNx
 aOw
-aWc
+aQi
 aQj
 aMs
 aMs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/51260013/213174271-08675819-b1fa-40b2-81ed-af055f36178a.png)
This chair layers under the fake pipes.
I don't know how to make them layer over it, so I have simply moved it away from the pipes.
Maybe the decals are meant to look like they're in the ceiling..? I have no idea.
![image](https://user-images.githubusercontent.com/51260013/213174740-b9176660-adcd-4db3-b0e0-839452181cc9.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12711

## PS
this is on kondaru