### PR TITLE
Fixed intial() call in uplinks.dm

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1233,10 +1233,10 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 
 							B.run_on_spawn(A, usr, FALSE, src)
 							logTheThing(LOG_STATION, usr, "bought a [initial(B.item.name)] from a [src] at [log_loc(usr)].")
-							var/loadnum = world.load_intra_round_value("Nuclear-Commander-[initial(B)]-Purchased")
+							var/loadnum = world.load_intra_round_value("Nuclear-Commander-[initial(B.item.name)]-Purchased")
 							if(isnull(loadnum))
 								loadnum = 0
-							world.save_intra_round_value("NuclearCommander-[initial(B)]-Purchased", loadnum + 1)
+							world.save_intra_round_value("NuclearCommander-[initial(B.item.name)]-Purchased", loadnum + 1)
 							. = TRUE
 							break
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Apparently lines 1236 and 1239 had faulty parameters in their `initial()` procs. This replaces the `B` with the `B.item.name` that's used in line 1235 which seems to work fine.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12732