### PR TITLE
Datumises Nuclear Operatives

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -1,6 +1,7 @@
 #define ROLE_TRAITOR "traitor"
 #define ROLE_SPY_THIEF "spy_thief"
 #define ROLE_NUKEOP "nukeop"
+#define ROLE_NUKEOP_COMMANDER "nukeop_commander"
 #define ROLE_VAMPIRE "vampire"
 #define ROLE_GANG_LEADER "gang_leader"
 #define ROLE_WIZARD "wizard"

--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -4,7 +4,7 @@
 #define isconspirator(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:special_role == ROLE_CONSPIRATOR)
 #define ischangeling(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/changeling) != null)
 #define isabomination(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/abomination))
-#define isnukeop(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:special_role == ROLE_NUKEOP)
+#define isnukeop(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:special_role == ROLE_NUKEOP || x:mind:special_role == ROLE_NUKEOP_COMMANDER))
 #define isvampire(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && x:get_ability_holder(/datum/abilityHolder/vampire) != null)
 #define isvampiricthrall(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/vampiric_thrall) != null)
 #define iswizard(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && x:get_ability_holder(/datum/abilityHolder/wizard) != null)

--- a/browserassets/js/tooltip.js
+++ b/browserassets/js/tooltip.js
@@ -65,8 +65,6 @@ var tooltip = {
 	showDelay: 100,
 	showDelayInt: 0,
 	interrupt: false,
-	waitingTooltip: null,
-	uidCounter: 0,
 
 	init: function(screen, tileSize, interface, map) {
 		tooltip.screenProperties = screen;
@@ -353,13 +351,9 @@ var tooltip = {
 		}
 
 		//Images affect sizing, so we have to wait until they all load first
-		var ourUid = tooltip.uidCounter++;
-		tooltip.waitingTooltip = ourUid;
-		tooltip.$content.waitForImages(function() {
+		tooltip.showDelayInt = tooltip.$content.waitForImages(function() {
 			tooltip.showDelayInt = setTimeout(function() {
-				if (tooltip.waitingTooltip === ourUid) {
-					tooltip.position();
-				}
+				tooltip.position();
 			}, tooltip.showDelay);
 		});
 	},

--- a/browserassets/js/tooltip.js
+++ b/browserassets/js/tooltip.js
@@ -10,8 +10,8 @@ var escaper = encodeURIComponent || escape;
 var decoder = decodeURIComponent || unescape;
 
 function getParameterByName(name, params) {
-	name = name.replace(/[\[\]]/g, "\\$&");
-	var regex = new RegExp(name + "(=([^&;#]*)|&|#|$)");
+	name = name.replace(/[\[\]]/g, '\\$&');
+	var regex = new RegExp(name + '(=([^&;#]*)|&|#|$)');
 	var results = regex.exec(params);
 	if (!results) {
 		return null;
@@ -19,7 +19,7 @@ function getParameterByName(name, params) {
 	if (!results[2]) {
 		return '';
 	}
-	return decoder(results[2].replace(/\+/g, " "));
+	return decoder(results[2].replace(/\+/g, ' '));
 }
 
 function htmlEntities(str) {
@@ -65,6 +65,8 @@ var tooltip = {
 	showDelay: 100,
 	showDelayInt: 0,
 	interrupt: false,
+	waitingTooltip: null,
+	uidCounter: 0,
 
 	init: function(screen, tileSize, interface, map) {
 		tooltip.screenProperties = screen;
@@ -221,9 +223,9 @@ var tooltip = {
 		if (tooltip.options.hasOwnProperty('special')) {
 			if (tooltip.options.special === 'pod') {
 				top--; //Pods do some weird funky shit with view and well just trust me that this is needed
-			} 
+			}
 		}
-		
+
 		var yloc = top;
 
 		//Handle manually set offsets (whether to adjust the tooltip along an axis by a pixel amount)
@@ -351,9 +353,13 @@ var tooltip = {
 		}
 
 		//Images affect sizing, so we have to wait until they all load first
+		var ourUid = tooltip.uidCounter++;
+		tooltip.waitingTooltip = ourUid;
 		tooltip.$content.waitForImages(function() {
 			tooltip.showDelayInt = setTimeout(function() {
-				tooltip.position();
+				if (tooltip.waitingTooltip === ourUid) {
+					tooltip.position();
+				}
 			}, tooltip.showDelay);
 		});
 	},

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -170,7 +170,6 @@
 	syndicates |= chosen_syndicates
 	for (var/datum/mind/syndicate in syndicates)
 		syndicate.assigned_role = "MODE" //So they aren't chosen for other jobs.
-		syndicate.special_role = ROLE_NUKEOP
 		possible_syndicates.Remove(syndicate)
 
 	agent_radiofreq = random_radio_frequency()
@@ -188,12 +187,6 @@
 	return pick(syndicates)
 
 /datum/game_mode/nuclear/post_setup()
-	var/leader_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord", "General", "Warlord", "Commissar")
-
-	var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors", "birds", "mammals", "moons", "arthurian")
-	//Alphabetical agent callsign lists are delcared here, seperated in to catagories.
-	var/list/callsign_list = strings("agent_callsigns.txt", pick(callsign_pool_keys))
-
 	var/datum/mind/leader_mind = src.pick_leader()
 
 	//Building the plant location strings
@@ -217,8 +210,6 @@
 			to_output = "We have identified several major structural weaknesses in the [station_or_ship()]'s rickety excuse of a design. To obliterate [station_name(1)], arm the bomb in one of the following: <B>[concatenated_location_names]</B>."
 
 	for(var/datum/mind/synd_mind in syndicates)
-		bestow_objective(synd_mind, /datum/objective/specialist/nuclear)
-
 		var/obj_count = 1
 		boutput(synd_mind.current, "<span class='notice'>You are a [syndicate_name()] agent!</span>")
 		for(var/datum/objective/objective in synd_mind.objectives)
@@ -229,23 +220,10 @@
 		boutput(synd_mind.current, to_output)
 
 		if(synd_mind == leader_mind)
-			synd_mind.current.set_loc(pick_landmark(LANDMARK_SYNDICATE_BOSS))
-			if(!synd_mind.current.loc)
-				synd_mind.current.set_loc(pick_landmark(LANDMARK_SYNDICATE))
-			synd_mind.current.real_name = "[syndicate_name()] [leader_title]"
-			equip_syndicate(synd_mind.current, 1)
+			synd_mind.add_antagonist(ROLE_NUKEOP_COMMANDER)
 			new /obj/item/device/audio_log/nuke_briefing(synd_mind.current.loc, concatenated_location_names)
-			synd_mind.current.show_antag_popup("nukeop-commander")
 		else
-			synd_mind.current.set_loc(pick_landmark(LANDMARK_SYNDICATE))
-			var/callsign = pick(callsign_list)
-			synd_mind.current.real_name = "[syndicate_name()] Operative [callsign]" //new naming scheme
-			callsign_list -= callsign
-			equip_syndicate(synd_mind.current, 0)
-			var/obj/item/device/radio/headset/syndicate/headset = synd_mind.current.ears
-			headset.icon_override = "syndie_letters/[copytext(callsign, 1, 2)]"
-			synd_mind.current.show_antag_popup("nukeop")
-		boutput(synd_mind.current, "<span class='alert'>Your headset allows you to communicate on the syndicate radio channel by prefacing messages with :h, as (say \":h Agent reporting in!\").</span>")
+			synd_mind.add_antagonist(ROLE_NUKEOP)
 
 		synd_mind.current.antagonist_overlay_refresh(1, 0)
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2264,14 +2264,12 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
-			M.real_name = "[syndicate_name()] Operative #[ticker.mode:agent_number]"
-			ticker.mode:agent_number++
-		else
-			M.real_name = "Syndicate Operative [M.real_name]"
 
-		antagify(M, ROLE_NUKEOP, do_objectives = FALSE)
-		equip_syndicate(M, leader)
+		if (src.leader)
+			M.mind.add_antagonist(ROLE_NUKEOP_COMMANDER, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
+		else
+			M.mind.add_antagonist(ROLE_NUKEOP, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
+
 		return
 
 /datum/job/special/syndicate_operative/leader

--- a/code/datums/special_r.dm
+++ b/code/datums/special_r.dm
@@ -180,10 +180,6 @@ datum/special_respawn
 	proc/eq_mob(var/type, var/mob/living/carbon/human/user)
 		if(!type) return
 		switch(type)
-
-			if("syndie")
-				equip_syndicate(user)
-				return
 			if("commando")
 				user.equip_new_if_possible(/obj/item/clothing/under/color/red, user.slot_w_uniform)
 				user.equip_new_if_possible(/obj/item/clothing/suit/armor/vest, user.slot_wear_suit)

--- a/code/global.dm
+++ b/code/global.dm
@@ -433,6 +433,7 @@ var/global
 	antag_rev = image('icons/mob/antag_overlays.dmi', icon_state = "rev")
 	antag_revhead = image('icons/mob/antag_overlays.dmi', icon_state = "rev_head")
 	antag_syndicate = image('icons/mob/antag_overlays.dmi', icon_state = "syndicate")
+	antag_syndicate_comm = image('icons/mob/antag_overlays.dmi', icon_state = "syndcomm")
 	antag_spyleader = image('icons/mob/antag_overlays.dmi', icon_state = "spy")
 	antag_spyminion = image('icons/mob/antag_overlays.dmi', icon_state = "spyminion")
 	antag_gang = image('icons/mob/antag_overlays.dmi', icon_state = "gang")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2262,7 +2262,7 @@ var/global/noir = 0
 									evilize(M, ROLE_TRAITOR)
 							if(ROLE_NUKEOP)
 								if (tgui_alert(usr,"Commander?","Hierarchy",list("Yes", "No")) == "Yes")
-									evilize(M, ROLE_NUKEOP, "commander", do_objectives = FALSE)
+									evilize(M, ROLE_NUKEOP_COMMANDER, do_objectives = FALSE)
 								else
 									evilize(M, ROLE_NUKEOP, do_objectives = FALSE)
 							else
@@ -4810,14 +4810,11 @@ var/global/noir = 0
 				new objective_set_path(M.mind)
 				equip_spy_theft(tmob)
 			if(ROLE_NUKEOP)
-				M.show_text("<h1><font color=red><B>You have been chosen as a nuclear operative! And you have accepted! Because you would be silly not to!</B></font></h1>", "red")
-				var/mob/living/carbon/human/H = M
-				var/rank = (special == "commander" ? "Syndicate Operative Commander" : "Syndicate Operative")
-				H.unequip_all(delete_stuff = TRUE)
-				H.JobEquipSpawned(rank)
-				var/datum/game_mode/nuclear/nukemode = ticker.mode
-				nukemode.syndicates += H.mind
-				nukemode.bestow_objective(H.mind, /datum/objective/specialist/nuclear)
+				M.show_text("<h1><font color=red><B>You have been chosen as a Nuclear Operative! And you have accepted! Because you would be silly not to!</B></font></h1>", "red")
+				M.mind.add_antagonist(ROLE_NUKEOP, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
+			if(ROLE_NUKEOP_COMMANDER)
+				M.show_text("<h1><font color=red><B>You have been chosen as a Nuclear Operative Commander! And you have accepted! Because you would be silly not to!</B></font></h1>", "red")
+				M.mind.add_antagonist(ROLE_NUKEOP_COMMANDER, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
 
 	else
 		M.show_text("<h2><font color=red><B>You have become evil and are now an antagonist!</B></font></h2>", "red")

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -1,0 +1,114 @@
+/datum/antagonist/nuclear_operative
+	id = ROLE_NUKEOP
+	display_name = "\improper Syndicate Operative"
+
+	var/static/commander_title
+	var/static/available_callsigns
+
+	New()
+		if (!src.commander_title)
+			src.commander_title = pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord", "General", "Warlord", "Commissar")
+
+		if (!src.available_callsigns)
+			var/list/callsign_pool_keys = list("nato", "melee_weapons", "colors", "birds", "mammals", "moons", "arthurian")
+			src.available_callsigns = strings("agent_callsigns.txt", pick(callsign_pool_keys))
+
+		if (istype(ticker.mode, /datum/game_mode/nuclear))
+			var/datum/game_mode/nuclear/gamemode = ticker.mode
+			if (!(src.owner in gamemode.syndicates))
+				gamemode.syndicates += src.owner
+
+		. = ..()
+
+	give_equipment()
+		if (!ishuman(src.owner.current))
+			boutput(src.owner.current, "<span class='alert'>Due to your lack of opposable thumbs, the Syndicate was unable to provide you with an uplink. That's biology for you.</span>")
+			return FALSE
+
+		var/mob/living/carbon/human/H = src.owner.current
+		H.unequip_all(TRUE)
+
+		H.equip_if_possible(new /obj/item/clothing/under/misc/syndicate(H), H.slot_w_uniform)
+		H.equip_if_possible(new /obj/item/clothing/shoes/swat/noslip(H), H.slot_shoes)
+		H.equip_if_possible(new /obj/item/clothing/gloves/swat(H), H.slot_gloves)
+		H.equip_if_possible(new /obj/item/storage/backpack/syndie/tactical(H), H.slot_back)
+		H.equip_if_possible(new /obj/item/clothing/mask/gas/swat/syndicate(H), H.slot_wear_mask)
+		H.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(H), H.slot_glasses)
+		H.equip_if_possible(new /obj/item/requisition_token/syndicate(H), H.slot_r_store)
+		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), H.slot_l_store)
+
+		if(src.id == ROLE_NUKEOP_COMMANDER)
+			H.equip_if_possible(new /obj/item/clothing/head/helmet/space/syndicate/commissar_cap(H), H.slot_head)
+			H.equip_if_possible(new /obj/item/clothing/suit/space/syndicate/commissar_greatcoat(H), H.slot_wear_suit)
+			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate/leader(H), H.slot_ears)
+			H.equip_if_possible(new /obj/item/swords_sheaths/nukeop(H), H.slot_belt)
+			H.equip_if_possible(new /obj/item/device/nukeop_commander_uplink(H), H.slot_l_hand)
+		else
+			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate(H), H.slot_ears)
+
+		H.equip_sensory_items()
+
+		var/obj/item/card/id/syndicate/ID
+		if(src.id == ROLE_NUKEOP_COMMANDER)
+			ID = new /obj/item/card/id/syndicate/commander(H)
+		else
+			ID = new /obj/item/card/id/syndicate(H)
+
+		ID.icon_state = "id"
+		ID.icon = 'icons/obj/items/card.dmi'
+		H.equip_if_possible(ID, H.slot_wear_id)
+
+		var/obj/item/implant/revenge/microbomb/M = new /obj/item/implant/revenge/microbomb(H)
+		M.implanted = TRUE
+		H.implant.Add(M)
+		M.implanted(H)
+
+		boutput(H, "<span class='alert'>Your headset allows you to communicate on the Syndicate radio channel by prefacing messages with :h, as (say \":h Agent reporting in!\").</span>")
+		src.assign_name()
+
+	relocate()
+		var/mob/M = src.owner.current
+		if (src.id == ROLE_NUKEOP_COMMANDER)
+			M.set_loc(pick_landmark(LANDMARK_SYNDICATE_BOSS))
+		else
+			M.set_loc(pick_landmark(LANDMARK_SYNDICATE))
+
+	assign_objectives()
+		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/nuclear)
+
+	do_popup(override)
+		if (!override && src.id == ROLE_NUKEOP_COMMANDER)
+			override = "nukeop-commander"
+
+		..(override)
+
+	remove_self()
+		if (istype(ticker.mode, /datum/game_mode/nuclear))
+			var/datum/game_mode/nuclear/gamemode = ticker.mode
+			if (src.owner in gamemode.syndicates)
+				gamemode.syndicates -= src.owner
+
+		. = ..()
+
+	proc/assign_name()
+		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
+			if (src.id == ROLE_NUKEOP_COMMANDER)
+				src.owner.current.real_name = "[syndicate_name()] [src.commander_title]"
+			else
+				var/callsign = pick(src.available_callsigns)
+				src.available_callsigns -= callsign
+				src.owner.current.real_name = "[syndicate_name()] Operative [callsign]"
+
+				// Assign a headset icon to the Operative matching the first letter of their callsign.
+				var/obj/item/device/radio/headset/syndicate/headset = src.owner.current.ears
+				headset.icon_override = "syndie_letters/[copytext(callsign, 1, 2)]"
+
+		else
+			if (src.id == ROLE_NUKEOP_COMMANDER)
+				src.owner.current.real_name = "Syndicate Commander [src.owner.current.real_name]"
+			else
+				src.owner.current.real_name = "Syndicate Operative [src.owner.current.real_name]"
+
+/datum/antagonist/nuclear_operative/commander
+		id = ROLE_NUKEOP_COMMANDER
+		display_name = "\improper Syndicate Operative Commander"

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -22,7 +22,7 @@
 
 	give_equipment()
 		if (!ishuman(src.owner.current))
-			boutput(src.owner.current, "<span class='alert'>Due to your lack of opposable thumbs, the Syndicate was unable to provide you with an uplink. That's biology for you.</span>")
+			boutput(src.owner.current, "<span class='alert'>Due to your lack of opposable thumbs, the Syndicate was unable to provide you with your equipment. That's biology for you.</span>")
 			return FALSE
 
 		var/mob/living/carbon/human/H = src.owner.current

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -54,8 +54,6 @@
 		else
 			ID = new /obj/item/card/id/syndicate(H)
 
-		ID.icon_state = "id"
-		ID.icon = 'icons/obj/items/card.dmi'
 		H.equip_if_possible(ID, H.slot_wear_id)
 
 		var/obj/item/implant/revenge/microbomb/M = new /obj/item/implant/revenge/microbomb(H)
@@ -75,12 +73,6 @@
 
 	assign_objectives()
 		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/nuclear)
-
-	do_popup(override)
-		if (!override && src.id == ROLE_NUKEOP_COMMANDER)
-			override = "nukeop-commander"
-
-		..(override)
 
 	remove_self()
 		if (istype(ticker.mode, /datum/game_mode/nuclear))
@@ -110,5 +102,11 @@
 				src.owner.current.real_name = "Syndicate Operative [src.owner.current.real_name]"
 
 /datum/antagonist/nuclear_operative/commander
-		id = ROLE_NUKEOP_COMMANDER
-		display_name = "\improper Syndicate Operative Commander"
+	id = ROLE_NUKEOP_COMMANDER
+	display_name = "\improper Syndicate Operative Commander"
+
+	do_popup(override)
+		if (!override)
+			override = "nukeop-commander"
+
+		..(override)

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -144,7 +144,7 @@
 		var/list/goods_for_purchase = goods_sell.Copy()
 		// Illegal goods for syndicate traitors
 		if (illegal)
-			if(usr.mind && (usr.mind.special_role == ROLE_TRAITOR || usr.mind.special_role == ROLE_SPY_THIEF || usr.mind.special_role == ROLE_NUKEOP ||	usr.mind.special_role == ROLE_SLEEPER_AGENT || usr.mind.special_role == ROLE_HARDMODE_TRAITOR ||	usr.mind.special_role == ROLE_OMNITRAITOR))
+			if(usr.mind && (istraitor(usr) || isspythief(usr) || isnukeop(usr) || usr.mind.special_role == ROLE_SLEEPER_AGENT || usr.mind.special_role == ROLE_OMNITRAITOR))
 				goods_for_purchase += goods_illegal
 		if (href_list["purchase"])
 			src.temp =buy_dialogue + "<HR><BR>"

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -101,7 +101,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 						src.items_general.Add(S)
 
 				if (ownermind || istype(ownermind))
-					if (ownermind.special_role != ROLE_NUKEOP && istype(S, /datum/syndicate_buylist/traitor))
+					if (!isnukeop(ownermind.current) && istype(S, /datum/syndicate_buylist/traitor))
 						if (!S.objective && !S.job && !src.items_general.Find(S))
 							src.items_general.Add(S)
 

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -356,7 +356,7 @@ var/list/roles_to_prefs = list(
 			added_text = "spy"
 		if(ROLE_HEAD_REV)
 			added_text = "rev"
-		if((ROLE_NUKEOP || ROLE_NUKEOP_COMMANDER))
+		if(ROLE_NUKEOP, ROLE_NUKEOP_COMMANDER)
 			added_text = "nukeop"
 		if(ROLE_OMNITRAITOR)
 			added_text = "omni"

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -259,43 +259,6 @@
 	else
 		boutput(traitor_mob, "Something is BUGGED and we couldn't find you a PDA. Tell a coder.")
 
-
-/proc/equip_syndicate(mob/living/carbon/human/synd_mob, var/leader = 0)
-	if (!ishuman(synd_mob))
-		return
-
-	if(leader == 1)
-		synd_mob.equip_if_possible(new /obj/item/clothing/head/helmet/space/syndicate/commissar_cap(synd_mob), synd_mob.slot_head)
-		synd_mob.equip_if_possible(new /obj/item/clothing/suit/space/syndicate/commissar_greatcoat(synd_mob), synd_mob.slot_wear_suit)
-		synd_mob.equip_if_possible(new /obj/item/device/radio/headset/syndicate/leader(synd_mob), synd_mob.slot_ears)
-		synd_mob.equip_if_possible(new /obj/item/swords_sheaths/nukeop(synd_mob), synd_mob.slot_r_hand)
-		synd_mob.equip_if_possible(new /obj/item/device/nukeop_commander_uplink(synd_mob), synd_mob.slot_l_hand)
-	else
-		synd_mob.equip_if_possible(new /obj/item/device/radio/headset/syndicate(synd_mob), synd_mob.slot_ears)
-
-	synd_mob.equip_if_possible(new /obj/item/clothing/under/misc/syndicate(synd_mob), synd_mob.slot_w_uniform)
-	synd_mob.equip_if_possible(new /obj/item/clothing/shoes/swat/noslip(synd_mob), synd_mob.slot_shoes)
-	synd_mob.equip_if_possible(new /obj/item/clothing/gloves/swat(synd_mob), synd_mob.slot_gloves)
-	synd_mob.equip_if_possible(new /obj/item/storage/backpack/syndie/tactical(synd_mob), synd_mob.slot_back)
-	synd_mob.equip_if_possible(new /obj/item/clothing/mask/gas/swat/syndicate(synd_mob), synd_mob.slot_wear_mask)
-	synd_mob.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(synd_mob), synd_mob.slot_glasses)
-	synd_mob.equip_if_possible(new /obj/item/requisition_token/syndicate(synd_mob), synd_mob.slot_r_store)
-	synd_mob.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(synd_mob), synd_mob.slot_l_store)
-
-	synd_mob.equip_sensory_items()
-
-	var/obj/item/card/id/syndicate/I = new /obj/item/card/id/syndicate(synd_mob) // for whatever reason, this is neccessary
-	if(leader)
-		I = new /obj/item/card/id/syndicate/commander(synd_mob)
-	I.icon_state = "id"
-	I.icon = 'icons/obj/items/card.dmi'
-	synd_mob.equip_if_possible(I, synd_mob.slot_wear_id)
-
-	var/obj/item/implant/revenge/microbomb/M = new /obj/item/implant/revenge/microbomb(synd_mob)
-	M.implanted = 1
-	synd_mob.implant.Add(M)
-	M.implanted(synd_mob)
-
 /proc/alive_player_count()
 	. = 0
 	for(var/client/C)
@@ -393,7 +356,7 @@ var/list/roles_to_prefs = list(
 			added_text = "spy"
 		if(ROLE_HEAD_REV)
 			added_text = "rev"
-		if(ROLE_NUKEOP)
+		if((ROLE_NUKEOP || ROLE_NUKEOP_COMMANDER))
 			added_text = "nukeop"
 		if(ROLE_OMNITRAITOR)
 			added_text = "omni"

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -865,6 +865,14 @@
 					if (see_everything || see_traitors)
 						var/I = image(antag_traitor, loc = M.current)
 						can_see.Add(I)
+				if (ROLE_NUKEOP_COMMANDER)
+					if (see_everything || see_nukeops)
+						var/I = image(antag_syndicate_comm, loc = M.current)
+						can_see.Add(I)
+				if (ROLE_NUKEOP)
+					if (see_everything || see_nukeops)
+						var/I = image(antag_syndicate, loc = M.current)
+						can_see.Add(I)
 				if (ROLE_CHANGELING)
 					if (see_everything)
 						var/I = image(antag_changeling, loc = M.current)
@@ -955,16 +963,6 @@
 			for (var/datum/mind/M in heads)
 				if (M.current)
 					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
-					can_see.Add(I)
-
-	else if (istype(ticker.mode, /datum/game_mode/nuclear))
-		var/datum/game_mode/nuclear/N = ticker.mode
-		var/list/datum/mind/syndicates = N.syndicates
-		if (see_nukeops || see_everything)
-			for (var/datum/mind/M in syndicates)
-				if (M.current)
-					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_syndicate, loc = M.current)
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/spy))

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -163,7 +163,7 @@
 				if (M.master)
 					var/mob/mymaster = ckey_to_mob(M.master)
 					if (mymaster) special = mymaster.real_name
-			if (ROLE_NUKEOP)
+			if ((ROLE_NUKEOP || ROLE_NUKEOP_COMMANDER))
 				if (istype(ticker.mode, /datum/game_mode/nuclear))
 					special = syndicate_name()
 					if (ticker.mode:nuke_detonated)

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -163,7 +163,7 @@
 				if (M.master)
 					var/mob/mymaster = ckey_to_mob(M.master)
 					if (mymaster) special = mymaster.real_name
-			if ((ROLE_NUKEOP || ROLE_NUKEOP_COMMANDER))
+			if (ROLE_NUKEOP, ROLE_NUKEOP_COMMANDER)
 				if (istype(ticker.mode, /datum/game_mode/nuclear))
 					special = syndicate_name()
 					if (ticker.mode:nuke_detonated)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -765,6 +765,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\antagonists\hunter\abilities\hunter_gearspawn.dm"
 #include "code\modules\antagonists\hunter\abilities\hunter_summongear.dm"
 #include "code\modules\antagonists\hunter\abilities\hunter_taketrophy.dm"
+#include "code\modules\antagonists\nuclear_operative\nuclear_operative.dm"
 #include "code\modules\antagonists\salvager\salvager.dm"
 #include "code\modules\antagonists\traitor\licensed_traitor.dm"
 #include "code\modules\antagonists\traitor\sleeper_agent.dm"


### PR DESCRIPTION
[Gamemodes] [Internal] [Code Quality]


## About the PR:
Migrates Nuclear Operative antagonists onto the new antagonist datum system; a relatively simple move compared to other antagonists.

* Syndicate Operatives have been fully migrated onto the new datum system, provided I have not missed an area of code.
* Syndicate Operative Commanders now receive a unique antagonist role, permitting them to be easily distinguished from other Operatives in code.
* Syndicate Operatives now receive antagonist overlays outside of the Nuclear Emergency gamemode, as they seem to be popular antagonists for special events and gimmicks.
* Syndicate Operative Commanders now receive the star antagonist overlay, previously only reserved for Syndicate Commanders in the Pod Wars gamemode. This should further aid recognisability, and allow for greater consistency between the two implementations of Commanders.
* Naming code for Syndicate Operatives has been moved to the new datum, allowing for greater consistency when spawning Operatives during the Nuclear Emergency gamemode, with all names drawing from the same callsign pool. Event Operatives, Syndicate Operatives spawned outside of the Nuclear Emergency gamemode, still retain their naming scheme, with the minor correction that Commanders will no longer be mislabled as Operatives.
* Admin-spawned Operatives now count towards the total number of living Operatives for the purpose of determining when a Nuclear Emergency round should end.



## Why's this needed?
Same rationale as #9366.
