### PR TITLE
Makes the senior botanist jumpsuit a job reward for botanists

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -244,6 +244,21 @@ mob/verb/checkrewards()
 	required_levels = list("Botanist"=10)
 	path_to_spawn = /obj/item/reagent_containers/glass/wateringcan/rainbow
 
+/datum/jobXpReward/botanist/jumpsuit
+	name = "Senior Botanist Jumpsuit"
+	desc = "An old jumpsuit with an earthy smell to it."
+	required_levels = list("Botanist"=15)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		boutput(C, "The jumpsuit pops into existance!")
+		var/obj/item/I = new/obj/item/clothing/under/misc/hydroponics()
+		I.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand(I)
+		return
+
 /datum/jobXpReward/botanist/wateringcan/old
 	name = "Antique Watering Can"
 	desc = "A Watering can that looks like it's made of rainbows... sorta. Seems the same as normal otherwise..."

--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -254,7 +254,7 @@ mob/verb/checkrewards()
 
 	activate(var/client/C)
 		boutput(C, "<span class='hint'>The jumpsuit pops into existance!</span>")
-		var/obj/item/I = new/obj/item/clothing/under/misc/hydroponics(get_turf(C.mob))
+		var/obj/item/I = new /obj/item/clothing/under/misc/hydroponics(get_turf(C.mob))
 		C.mob.put_in_hand(I)
 
 /datum/jobXpReward/botanist/wateringcan/old

--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -253,11 +253,9 @@ mob/verb/checkrewards()
 	claimPerRound = 1
 
 	activate(var/client/C)
-		boutput(C, "The jumpsuit pops into existance!")
-		var/obj/item/I = new/obj/item/clothing/under/misc/hydroponics()
-		I.set_loc(get_turf(C.mob))
+		boutput(C, "<span class='hint'>The jumpsuit pops into existance!</span>")
+		var/obj/item/I = new/obj/item/clothing/under/misc/hydroponics(get_turf(C.mob))
 		C.mob.put_in_hand(I)
-		return
 
 /datum/jobXpReward/botanist/wateringcan/old
 	name = "Antique Watering Can"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so botanists can claim the senior botanist jumpsuit at botanist level 15. Maybe the reward description could be changed, I'm not creative enough to make something good.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The suit already exists and it seemed pretty fitting for being a job reward.