### PR TITLE
Blunts now inherit transforms from herbs

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -60,6 +60,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 			if(B.flavor)
 				doink.flavor = B.flavor
 			doink.name = "[reagent_id_to_name(doink.flavor)]-flavored [src.name] [pick("doink","'Rillo","cigarillo","brumbpo")]"
+			doink.transform = src.transform
 			doink.reagents.clear_reagents()
 			doink.reagents.maximum_volume = (src.reagents.total_volume + 50)
 			W.reagents.trans_to(doink, W.reagents.total_volume)

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -43,6 +43,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 				P.litstate = "ciglit-[W.icon_state]"
 				P.buttstate = "cigbutt-[W.icon_state]"
 			P.name = build_name(W)
+			P.transform = src.transform
 			P.reagents.maximum_volume = src.reagents.total_volume
 			src.reagents.trans_to(P, src.reagents.total_volume)
 			W.force_drop(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes rolled joints inherit the transform from the herb used, meaning that any massive cannabis leaves that botany grows will make similarly massive blunts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![image](https://user-images.githubusercontent.com/58530985/213876055-fc5eeee8-86fc-40a4-9291-39fe3b638498.png)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Rolled blunts inherit any size modifiers from the plant used to make them.
```
