### PR TITLE
add perlin noise visualizer

### DIFF
--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -1253,7 +1253,7 @@ proc/debug_map_apc_count(delim,zlim)
 
 		GetInfo(turf/theTurf, image/debugoverlay/img)
 			. = ..()
-			if (!(length(noise_cache))) return
+			if (!length(noise_cache)) return
 			var/val = noise_cache[theTurf.x][theTurf.y]
 			img.app.color = rgb((val*255), 0, (255-val*255))
 			if(!isnull(val))

--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -1227,6 +1227,38 @@ proc/debug_map_apc_count(delim,zlim)
 			else
 				img.app.color = "#aa5555"
 
+	perlin_noise_visualizer
+		name = "perlin noise visualizer"
+		help = "Visualize a given perlin noise seed and zoom"
+		var/seed = 42069
+		var/perlin_zoom = 65
+		var/square_drift = 2
+		var/drift_x
+		var/drift_y
+		var/list/noise_cache
+		OnEnabled(client/C)
+			. = ..()
+			var/turf/user_turf = get_turf(C.mob)
+			seed = tgui_input_number(C.mob, "Enter a seed value", "Seed Selection", seed, 50000,0)
+			if (isnull(seed)) seed = initial(seed)
+			perlin_zoom = tgui_input_number(C.mob, "Enter a zoom value, higher numbers mean slower transitions", "Zoom Selection", perlin_zoom, 500, 2)
+			if (isnull(perlin_zoom)) perlin_zoom = initial(perlin_zoom)
+			square_drift = tgui_input_number(C.mob, "Enter a drift value, controls intensity of randomized intermingling of biomes", "Drift Selection", square_drift, 10, 0)
+			if (isnull(square_drift)) square_drift = initial(square_drift)
+			noise_cache = new/list(world.maxx, world.maxy)
+			for (var/turf/T as anything in block(locate(1, 1, user_turf.z), locate(world.maxx, world.maxy, user_turf.z)))
+				drift_x = (T.x + rand(-square_drift, square_drift)) / perlin_zoom
+				drift_y = (T.y + rand(-square_drift, square_drift)) / perlin_zoom
+				noise_cache[T.x][T.y] = text2num(rustg_noise_get_at_coordinates("[seed]", "[drift_x]", "[drift_y]"))
+
+		GetInfo(turf/theTurf, image/debugoverlay/img)
+			. = ..()
+			if (!(length(noise_cache))) return
+			var/val = noise_cache[theTurf.x][theTurf.y]
+			img.app.color = rgb((val*255), 0, (255-val*255))
+			if(!isnull(val))
+				img.app.overlays = list(src.makeText(round(val*100)/100, RESET_ALPHA))
+
 /client/var/list/infoOverlayImages
 /client/var/datum/infooverlay/activeOverlay
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds a perlin noise visualizer to help devs better understand how the different settings affect the resulting noise to the info overlays verb
* Features a simple blue to red gradient and rounds all values to 2 significant figures
* Pictured below, noise with a low perlin zoom setting
![image](https://user-images.githubusercontent.com/33204415/213994900-d716af56-34ab-4b5c-a0bc-116a6aba84e5.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* understanding how the various noise parameters interact can be difficult for people to understand, a configurable visualize aid makes it quick and easy to learn
