### PR TITLE
adds an arg to `...human/get_id()` that prevents getting worn ids

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3098,7 +3098,7 @@
 		souladjust(1)
 	return 1
 
-/mob/proc/get_id()
+/mob/proc/get_id(var/not_worn = FALSE)
 	RETURN_TYPE(/obj/item/card/id)
 	if(istype(src.equipped(), /obj/item/card/id))
 		return src.equipped()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3098,7 +3098,7 @@
 		souladjust(1)
 	return 1
 
-/mob/proc/get_id(var/not_worn = FALSE)
+/mob/proc/get_id(not_worn = FALSE)
 	RETURN_TYPE(/obj/item/card/id)
 	if(istype(src.equipped(), /obj/item/card/id))
 		return src.equipped()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3251,9 +3251,9 @@
 		abilityHolder.set_loc_callback(newloc)
 	..()
 
-/mob/living/carbon/human/get_id()
+/mob/living/carbon/human/get_id(var/not_worn = FALSE)
 	. = ..()
-	if(.)
+	if(. || not_worn)
 		return
 	if(istype(src.wear_id, /obj/item/card/id))
 		return src.wear_id

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3251,7 +3251,7 @@
 		abilityHolder.set_loc_callback(newloc)
 	..()
 
-/mob/living/carbon/human/get_id(var/not_worn = FALSE)
+/mob/living/carbon/human/get_id(not_worn = FALSE)
 	. = ..()
 	if(. || not_worn)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds an arg, false by default, to the `/mob/living/carbon/human/get_id`
 proc that returns early if true. specifically prevents fetching a human's worn ID card if true.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
pali tolb me to