### PR TITLE
Fixing custom small power cells not being able to self-charge

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1332,7 +1332,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 
 		charge = max_charge
 
-		AddComponent(/datum/component/power_cell, max_charge, charge, recharge_delay, recharge_rate)
+		AddComponent(/datum/component/power_cell, max_charge, charge, recharge_rate, recharge_delay)
 		return
 
 
@@ -1347,7 +1347,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 			recharge_rate = (coreMat.getProperty("radioactive") / 2 + coreMat.getProperty("n_radioactive") \
 			+ genMat.getProperty("radioactive")  + genMat.getProperty("n_radioactive") * 2) / 6 //weight this too
 
-			AddComponent(/datum/component/power_cell, max_charge, max_charge, recharge_delay, recharge_rate)
+			AddComponent(/datum/component/power_cell, max_charge, max_charge, recharge_rate, recharge_delay)
 
 /obj/item/ammo/power_cell/self_charging/slowcharge
 	name = "Power Cell - Atomic Slowcharge"


### PR DESCRIPTION
[bug][Materials]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This enables custom power cells to be able to be self-charging using radioactive material. This fixes #12778

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

One of custom power cells main point is them being rechargeable. The bug this PR is fixing does prevent that.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

