### PR TITLE
Genebooth info PDA App for Geneticists

### DIFF
--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -90,6 +90,7 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portabrig(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/secbot(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/mulebot(src))
+			src.root.add_file( new /datum/computer/file/pda_program/genebooth_tracker(src))
 			src.root.add_file( new /datum/computer/file/pda_program/pingtool(src) )
 			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src) )
 			src.root.add_file( new /datum/computer/file/pda_program/packet_sender(src) )
@@ -153,6 +154,7 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portananomed(src))
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portamedbay(src))
+			src.root.add_file( new /datum/computer/file/pda_program/genebooth_tracker(src))
 			src.read_only = 1
 
 

--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -248,6 +248,7 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 			src.root.add_file( new /datum/computer/file/pda_program/scan/medrecord_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/reagent_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/medical(src))
+			src.root.add_file( new /datum/computer/file/pda_program/genebooth_tracker(src))
 			src.read_only = 1
 
 	quartermaster

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1633,14 +1633,14 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 		. = src.return_text_header()
 
 		var/booth_counter = 0
-		for_by_tcl(GB, /obj/machinery/genetics_booth)
+		for_by_tcl(booth, /obj/machinery/genetics_booth)
 			booth_counter += 1
 			. += "<hr><h4>GeneBooth [booth_counter]</h4>"
-			for (var/datum/geneboothproduct/P as anything in GB.offered_genes)
-				. += "<b>[P.name]</b> [P.cost][CREDIT_SIGN] | [P.uses] uses left"
-				if(P.locked)
+			for (var/datum/geneboothproduct/product as anything in booth.offered_genes)
+				. += "<b>[product.name]</b> [product.cost][CREDIT_SIGN] | [product.uses] uses left"
+				if(product.locked)
 					. += " (locked)"
 				. += "<br>"
-				if(P.desc)
-					. += P.desc
+				if(product.desc)
+					. += product.desc
 					. += "<br>"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1620,3 +1620,27 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 		signal.data["sender"] = src.master.net_id
 
 		SEND_SIGNAL(src.master, COMSIG_MOVABLE_POST_RADIO_PACKET, signal, null, "power_control")
+
+//Genebooth Tracker
+/datum/computer/file/pda_program/genebooth_tracker
+	name = "Genebooth Tracker"
+	size = 6
+
+	return_text()
+		if(..())
+			return
+
+		. = src.return_text_header()
+
+		var/booth_counter = 0
+		for_by_tcl(GB, /obj/machinery/genetics_booth)
+			booth_counter += 1
+			. += "<hr><h4>GeneBooth [booth_counter]</h4>"
+			for (var/datum/geneboothproduct/P as anything in GB.offered_genes)
+				. += "<b>[P.name]</b> [P.cost][CREDIT_SIGN] | [P.uses] uses left"
+				if(P.locked)
+					. += " (locked)"
+				. += "<br>"
+				if(P.desc)
+					. += P.desc
+					. += "<br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
PDA program for Geneticists only which shows what is in the genebooths.
~~Only present in Geneticists PDA, AI nor Medical Director have it.~~ Added to the Medical Director and AI too.
May be harder to make hidden gene booths if someone steals a Geneticists PDA to check the booths.

![image](https://user-images.githubusercontent.com/47158232/214164860-2d58cd5e-81b2-4540-b3b4-dd2bd8254ada.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So Geneticists can more easily keep track of whats is in the Genebooth and how much there is left.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Genebooth Info program for Geneticists!
```
