### PR TITLE
fixes #12341

### DIFF
--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -14,7 +14,7 @@
 	w_class = W_CLASS_NORMAL
 	amount_per_transfer_from_this = 25
 	incompatible_with_chem_dispensers = 1
-	flags = FPRINT | TABLEPASS | OPENCONTAINER
+	flags = FPRINT | TABLEPASS | OPENCONTAINER | ACCEPTS_MOUSEDROP_REAGENTS
 	rc_flags = RC_SCALE
 	initial_volume = 400
 	can_recycle = FALSE


### PR DESCRIPTION
[LABEL][Bug][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the newly-ish added ACCEPT_MOUSEDROP_REAGENTS flag to handheld fuel tanks, making they behave as they used to before it's addition.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it so you can clickdrag reagents into fuel tanks again. As opposed to it's current state where you can only clickdrag reagents out, and have to add them in 10 unit increments. Reduces a lot of chatlog clutter and overall makes reagent transfer smoother, brings it to par with water coolers and beakers like it was before the behavior got accidentally changed.

