### PR TITLE
Fix the new plantoverlay not being transferred by garden trowels

### DIFF
--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -25,7 +25,9 @@ TYPEINFO(/obj/decorative_pot)
 						if(!t.plantyboi)
 								return
 						src.UpdateOverlays(t.plantyboi,"plant")
+						src.UpdateOverlays(t.plantyboi_plantoverlay, "plantoverlay")
 						t.plantyboi = null
+						t.plantyboi_plantoverlay = null
 						t.icon_state = "trowel"
 						return
 				if(istype(weapon,/obj/item/seed))

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -476,8 +476,8 @@ TYPEINFO(/obj/item/plantanalyzer)
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
 
 	rand_pos = 1
-	var/image/plantyboi /// The "plant" overlay of the plant
-	var/image/plantyboi_plantoverlay /// The "plantoverlay" of the plant
+	var/image/plantyboi //! The "plant" overlay of the plant
+	var/image/plantyboi_plantoverlay //! The "plantoverlay" of the plant
 
 	New()
 		..()

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -476,7 +476,8 @@ TYPEINFO(/obj/item/plantanalyzer)
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
 
 	rand_pos = 1
-	var/image/plantyboi
+	var/image/plantyboi /// The "plant" overlay of the plant
+	var/image/plantyboi_plantoverlay /// The "plantoverlay" of the plant
 
 	New()
 		..()
@@ -494,6 +495,11 @@ TYPEINFO(/obj/item/plantanalyzer)
 					plantyboi = pot.GetOverlayImage("plant")
 					plantyboi.pixel_x = 2
 					src.icon_state = "trowel_full"
+					if(pot.GetOverlayImage("plantoverlay"))
+						plantyboi_plantoverlay = pot.GetOverlayImage("plantoverlay")
+						plantyboi_plantoverlay.pixel_x = 2
+					else
+						plantyboi_plantoverlay = null
 				else
 					return
 				pot.HYPdestroyplant()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -871,6 +871,7 @@ TYPEINFO(/obj/machinery/plantpot)
 			UpdateOverlays(null, "health_display")
 			UpdateOverlays(null, "plant")
 			UpdateOverlays(null, "plantdeath")
+			UpdateOverlays(null, "plantoverlay")
 			if(status & (NOPOWER|BROKEN))
 				UpdateOverlays(null, "water_meter")
 			return


### PR DESCRIPTION
[Bug][Hydroponics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes the new overlay `"plantoverlay"`, used by Hydrangeas, be able to be transferred by the garden trowel. Alsothis PR makes that particular overlay be removed properly if a plant gets removed instantly from the plantpot. 

This fixes #12826 and its duplicate #12859 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I want to see some happy little flowers together with their respectable plant in plantpots :)
