### PR TITLE
Items contain corresponding reagents of the materials they are made of

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -686,6 +686,9 @@
 
 /obj/item/stamp/New()
 	..()
+	src.create_reagents(1)
+	src.reagents.add_reagent("rubber", 1)
+
 	if(special_mode)
 		available_modes += special_mode
 		current_mode = special_mode

--- a/code/modules/writing/pens_writing_etc.dm
+++ b/code/modules/writing/pens_writing_etc.dm
@@ -242,6 +242,11 @@
 
 	New()
 		..()
+		src.create_reagents(6)
+		src.reagents.add_reagent("rubber", 1)
+		src.reagents.add_reagent("carbon", 2)
+		src.reagents.add_reagent("wood", 3)
+
 		if (prob(25))
 			src.icon_state = pick("pencil-b", "pencil-g")
 

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -38,6 +38,9 @@ TYPEINFO(/obj/item/camera/large)
 
 	New()
 		..()
+		src.create_reagents(5)
+		src.reagents.add_reagent("silicon", 4)
+		src.reagents.add_reagent("copper", 1)
 		src.setItemSpecial(null)
 
 	large

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -38,6 +38,13 @@ TYPEINFO(/obj/item/card/emag)
 	is_syndicate = 1
 	contraband = 6
 
+	New()
+		..()
+		src.create_reagents(10)
+		src.reagents.add_reagent("copper", 2)
+		src.reagents.add_reagent("iron", 3)
+		src.reagents.add_reagent("crime", 5)
+
 	afterattack(var/atom/A, var/mob/user)
 		if(!A || !user)
 			return

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -213,6 +213,11 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		setProperty("heatprot", 5)
 		setProperty("chemprot", 15)
 
+	New()
+		..()
+		src.create_reagents(3)
+		src.reagents.add_reagent("rubber", 3)
+
 /obj/item/clothing/gloves/fingerless
 	desc = "These gloves lack fingers. Good for a space biker look, but not so good for concealing your fingerprints."
 	name = "fingerless gloves"

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1233,6 +1233,11 @@ proc/filter_trait_hats(var/type)
 		setProperty("disorient_resist_eye", 6)
 		setProperty("disorient_resist_ear", 5)
 
+	New()
+		..()
+		src.create_reagents(5)
+		src.reagents.add_reagent("rubber", 5)
+
 /obj/item/clothing/head/jester
 	name = "jester's hat"
 	desc = "The hat of not-so-funny-clown."

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -262,6 +262,10 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 	setupProperties()
 		..()
 		setProperty("chemprot", 7)
+	New()
+		..()
+		src.create_reagents(6)
+		src.reagents.add_reagent("rubber", 6)
 
 	torn
 		desc = "Rubber boots that would prevent slipping on wet surfaces, were they not all torn up. Like these are. Damn."
@@ -270,6 +274,10 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 		setupProperties()
 			..()
 			delProperty("chemprot")
+		New()
+			..()
+			src.create_reagents(8)
+			src.reagents.add_reagent("rubber", 8)
 
 /obj/item/clothing/shoes/clown_shoes
 	name = "clown shoes"
@@ -336,6 +344,8 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 		..()
 		setProperty("chemprot", 7)
 		setProperty("negate_fluid_speed_penalty",0.6)
+		src.create_reagents(5)
+		src.reagents.add_reagent("rubber", 5)
 
 TYPEINFO(/obj/item/clothing/shoes/moon)
 	mats = 2

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1739,6 +1739,8 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	setupProperties()
 		..()
 		setProperty("chemprot", 70)
+		src.create_reagents(12)
+		src.reagents.add_reagent("rubber", 12)
 
 /obj/item/clothing/suit/security_badge
 	name = "Security Badge"

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -534,6 +534,11 @@
 	ammo_type = new/datum/projectile/bullet/nine_mm_NATO
 	ammo_cat = AMMO_PISTOL_9MM
 
+	New()
+		..()
+		src.create_reagents(1)
+		src.reagents.add_reagent("rubber", 1)
+
 /obj/item/ammo/bullets/nine_mm_NATO/boomerang //empty clip for the clock_188/boomerang
 	amount_left = 0
 
@@ -808,6 +813,11 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	icon_dynamic = 0
 	icon_empty = "bg-0"
 	sound_load = 'sound/weapons/gunload_click.ogg'
+
+	New()
+		..()
+		src.create_reagents(1)
+		src.reagents.add_reagent("rubber", 1)
 
 /obj/item/ammo/bullets/abg/two //spawns in the break action
 	amount_left = 2

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -864,6 +864,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		icon_state = "rubberball"
 		desc = "A rubber ball from a stinger grenade. Ouch."
 
+		New()
+			..()
+			src.create_reagents(1)
+			src.reagents.add_reagent("rubber", 1)
+
 	grenade_fragment
 		name = "grenade fragment"
 		icon_state = "grenadefragment"

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -161,6 +161,11 @@ TYPEINFO(/obj/item/disk)
 	stamina_cost = 5
 	stamina_crit_chance = 3
 
+	New()
+		..()
+		src.create_reagents(3)
+		src.reagents.add_reagent("rubber", 3)
+
 /obj/item/module
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_module"
@@ -260,6 +265,8 @@ TYPEINFO(/obj/item/disk)
 	New()
 		..()
 		BLOCK_SETUP(BLOCK_ALL)
+		src.create_reagents(6)
+		src.reagents.add_reagent("rubber", 6)
 
 	attack(mob/M, mob/user)
 		src.add_fingerprint(user)

--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -25,6 +25,8 @@
 
 	New(loc, datum/organHolder/nholder)
 		..()
+		src.create_reagents(10)
+		src.reagents.add_reagent("calcium", 10)
 		SPAWN(0)
 			if (istype(nholder) && nholder.donor)
 				src.holder = nholder

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -18,6 +18,8 @@
 
 	New()
 		..()
+		src.create_reagents(1)
+		src.reagents.add_reagent("spaceglue", 2)
 		if (islist(src.random_icons) && length(src.random_icons))
 			src.icon_state = pick(src.random_icons)
 		pixel_y = rand(-8, 8)

--- a/code/obj/item/tool/crowbar.dm
+++ b/code/obj/item/tool/crowbar.dm
@@ -25,6 +25,8 @@
 
 	New()
 		..()
+		src.create_reagents(10)
+		src.reagents.add_reagent("iron", 10)
 		src.setItemSpecial(/datum/item_special/tile_fling)
 		BLOCK_SETUP(BLOCK_ROD)
 

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -31,6 +31,9 @@
 	icon_state = "batt1"
 
 /obj/item/electronics/battery/New()
+	src.create_reagents(5)
+	src.reagents.add_reagent("carbon", 2)
+	src.reagents.add_reagent("lithium", 3)
 	src.icon_state = pick("batt1", "batt2", "batt3")
 	randompix()
 	..()
@@ -41,6 +44,9 @@
 
 /obj/item/electronics/board/New()
 	src.icon_state = pick("board1", "board2", "board3")
+	src.create_reagents(5)
+	src.reagents.add_reagent("silicon", 4)
+	src.reagents.add_reagent("copper", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -50,6 +56,8 @@
 
 /obj/item/electronics/fuse/New()
 	src.icon_state = pick("fuse1", "fuse2", "fuse3")
+	src.create_reagents(4)
+	src.reagents.add_reagent("copper", 4)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -59,6 +67,9 @@
 
 /obj/item/electronics/switc/New()
 	src.icon_state = pick("switch1", "switch2", "switch3")
+	src.create_reagents(4)
+	src.reagents.add_reagent("copper", 3)
+	src.reagents.add_reagent("aluminum", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////up
@@ -67,6 +78,10 @@
 	icon_state = "keypad1"
 /obj/item/electronics/keypad/New()
 	src.icon_state = pick("keypad1", "keypad2", "keypad3")
+	src.create_reagents(4)
+	src.reagents.add_reagent("silicon", 2)
+	src.reagents.add_reagent("copper", 2)
+	src.reagents.add_reagent("aluminum", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////up
@@ -75,6 +90,9 @@
 	icon_state = "screen1"
 /obj/item/electronics/screen/New()
 	src.icon_state = pick("screen1", "screen2", "screen3")
+	src.create_reagents(10)
+	src.reagents.add_reagent("silicon", 8)
+	src.reagents.add_reagent("copper", 2)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -83,6 +101,9 @@
 	icon_state = "capacitor1"
 /obj/item/electronics/capacitor/New()
 	src.icon_state = pick("capacitor1", "capacitor2", "capacitor3")
+	src.create_reagents(4)
+	src.reagents.add_reagent("silicon", 3)
+	src.reagents.add_reagent("copper", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////up
@@ -90,6 +111,10 @@
 	name = "buzzer"
 	icon_state = "buzzer"
 /obj/item/electronics/buzzer/New()
+	src.create_reagents(3)
+	src.reagents.add_reagent("silicon", 1)
+	src.reagents.add_reagent("copper", 1)
+	src.reagents.add_reagent("aluminum", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -98,6 +123,8 @@
 	icon_state = "resistor1"
 /obj/item/electronics/resistor/New()
 	src.icon_state = pick("resistor1", "resistor2")
+	src.create_reagents(3)
+	src.reagents.add_reagent("copper", 3)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -106,6 +133,9 @@
 	icon_state = "bulb1"
 /obj/item/electronics/bulb/New()
 	src.icon_state = pick("bulb1", "bulb2")
+	src.create_reagents(4)
+	src.reagents.add_reagent("silicon", 3)
+	src.reagents.add_reagent("aluminum", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////
@@ -114,6 +144,9 @@
 	icon_state = "relay1"
 /obj/item/electronics/bulb/New()
 	src.icon_state = pick("relay1", "relay2")
+	src.create_reagents(2)
+	src.reagents.add_reagent("silicon", 1)
+	src.reagents.add_reagent("copper", 1)
 	randompix()
 	..()
 ////////////////////////////////////////////////////////////////no
@@ -129,6 +162,11 @@
 	var/list/needed_parts = new/list()
 	var/obj/deconstructed_thing = null
 
+	New()
+		src.create_reagents(5)
+		src.reagents.add_reagent("silicon", 3)
+		src.reagents.add_reagent("copper", 2)
+		..()
 
 	disposing()
 		if(deconstructed_thing)

--- a/code/obj/item/tool/multitool.dm
+++ b/code/obj/item/tool/multitool.dm
@@ -21,6 +21,12 @@ TYPEINFO(/obj/item/device/multitool)
 	m_amt = 50
 	g_amt = 20
 
+	New()
+		..()
+		src.create_reagents(6)
+		src.reagents.add_reagent("copper", 4)
+		src.reagents.add_reagent("silicon", 2)
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))

--- a/code/obj/item/tool/screwdriver.dm
+++ b/code/obj/item/tool/screwdriver.dm
@@ -26,6 +26,8 @@
 	custom_suicide = 1
 
 	New()
+		src.create_reagents(4)
+		src.reagents.add_reagent("iron", 3)
 		..()
 		BLOCK_SETUP(BLOCK_KNIFE)
 

--- a/code/obj/item/tool/wirecutters.dm
+++ b/code/obj/item/tool/wirecutters.dm
@@ -24,6 +24,8 @@
 
 	New()
 		..()
+		src.create_reagents(4)
+		src.reagents.add_reagent("iron", 4)
 		BLOCK_SETUP(BLOCK_KNIFE)
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)

--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -22,6 +22,8 @@
 
 	New()
 		..()
+		src.create_reagents(10)
+		src.reagents.add_reagent("iron", 10)
 		BLOCK_SETUP(BLOCK_ROD)
 
 	attack(mob/living/carbon/M, mob/user)

--- a/code/obj/item/toys.dm
+++ b/code/obj/item/toys.dm
@@ -264,6 +264,11 @@ TYPEINFO(/obj/item/toy/handheld)
 	throw_speed = 3
 	throw_range = 15
 
+	New()
+		..()
+		src.create_reagents(4)
+		src.reagents.add_reagent("rubber", 4)
+
 /obj/item/rubberduck/attack_self(mob/user as mob)
 	if (!ON_COOLDOWN(src,"quack",2 SECONDS))
 		if (ishuman(user))

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -148,7 +148,8 @@ TYPEINFO(/obj/machinery/deep_fryer)
 		if (!src.fryitem.reagents)
 			src.fryitem.create_reagents(50)
 
-
+		if (src.fryitem.reagents.is_full())
+			src.fryitem.reagents.maximum_volume += 2
 		src.reagents.trans_to(src.fryitem, 2)
 
 		if (src.cooktime < 60)
@@ -250,7 +251,6 @@ TYPEINFO(/obj/machinery/deep_fryer)
 		if (ismob(thing))
 			fryholder.w_class = W_CLASS_BULKY
 		if(thing.reagents)
-			fryholder.reagents.maximum_volume += thing.reagents.total_volume
 			thing.reagents.trans_to(fryholder, thing.reagents.total_volume)
 		fryholder.reagents.my_atom = fryholder
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Feature][A-Chemistry]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Items made of a given material do not necessarily contain any reagents.
For example, keypads would contain 2u silicon, 2u copper, and 1u aluminum.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you put a multitool in the deep fryer, the resulting food contains nothing but oil. Now the multitool would result in oil, copper, and silicon. To me, that makes more sense.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)gabringis
(*)Added soft soft pizza to the game - a tasty drink found in soda machines!
(+)Some items now contain the reagents that match what they're made of
```
