### PR TITLE
Fixes #10034 - Antagonist Datums Now Remove Associated Antagonist Objectives Upon Their Own Removal

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -440,11 +440,11 @@ ABSTRACT_TYPE(/datum/game_mode)
 //what do we do when a mob dies
 /datum/game_mode/proc/on_human_death(var/mob/M)
 
-/datum/game_mode/proc/bestow_objective(var/datum/mind/traitor,var/objective_path)
+/datum/game_mode/proc/bestow_objective(var/datum/mind/traitor, var/objective_path, var/datum/antagonist/antag_role)
 	if (!istype(traitor) || !ispath(objective_path))
 		return null
 
-	var/datum/objective/O = new objective_path(null, traitor)
+	var/datum/objective/O = new objective_path(null, traitor, antag_role)
 
 	return O
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -6,13 +6,15 @@ ABSTRACT_TYPE(/datum/objective)
 	var/medal_name = null // Called by ticker.mode.declare_completion().
 	var/medal_announce = 1
 
-	New(text, datum/mind/owner)
+	New(text, datum/mind/owner, datum/antagonist/antag_role)
 		..()
 		if(text)
 			src.explanation_text = text
 		if(istype(owner))
 			src.owner = owner
 			owner.objectives += src
+			if (antag_role)
+				antag_role.objectives += src
 		else
 			stack_trace("objective/New got called without a mind")
 		src.set_up()
@@ -1429,7 +1431,7 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 	/datum/objective/escape/hijack,
 	/datum/objective/escape/kamikaze)
 
-	New(datum/mind/enemy)
+	New(datum/mind/enemy, datum/antagonist/antag_role)
 		..()
 		if(!istype(enemy))
 			return 1
@@ -1441,7 +1443,9 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 			if(!initial(objective.enabled))
 				src.objective_list -= X
 				continue
-			ticker.mode.bestow_objective(enemy,X)
+			objective = new X(null, enemy)
+			if (antag_role)
+				antag_role.objectives.Add(objective)
 
 		for(var/X in escape_choices)
 			var/datum/objective/objective = X
@@ -1451,7 +1455,9 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 		if (escape_choices.len > 0)
 			var/escape_path = pick(escape_choices)
 			if (ispath(escape_path))
-				ticker.mode.bestow_objective(enemy,escape_path)
+				var/datum/objective/objective = new escape_path(null, enemy)
+				if (antag_role)
+					antag_role.objectives.Add(objective)
 
 		SPAWN(0)
 			qdel(src)

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -20,6 +20,8 @@ ABSTRACT_TYPE(/datum/antagonist)
 	var/assigned_by = ANTAGONIST_SOURCE_ROUND_START
 	/// Pseudo antagonists are not "real" antagonists, as determined by the round. They have the abilities, but do not have objectives and ideally should not considered antagonists for the purposes of griefing rules, etc.
 	var/pseudo = FALSE
+	/// The objectives assigned to the player by this specific antagonist role.
+	var/list/datum/objective/objectives = list()
 
 	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup)
 		. = ..()
@@ -55,8 +57,11 @@ ABSTRACT_TYPE(/datum/antagonist)
 		if (take_gear)
 			src.remove_equipment()
 
+		src.remove_objectives()
+
 		if (!silent)
 			src.announce_removal()
+			src.announce_objectives()
 
 	/// Returns TRUE if this antagonist can be assigned to the given mind, and FALSE otherwise. This is intended to be special logic, overriden by subtypes; mutual exclusivity and other selection logic is not performed here.
 	proc/is_compatible_with(datum/mind/mind)
@@ -123,12 +128,17 @@ ABSTRACT_TYPE(/datum/antagonist)
 	proc/assign_objectives()
 		return
 
+	/// Remove objectives from the antagonist and the mind.
+	proc/remove_objectives()
+		for (var/datum/objective/objective in src.objectives)
+			src.owner.objectives.Remove(objective)
+			src.objectives.Remove(objective)
+			qdel(objective)
+
 	// Show the player what objectives they have in their mind.
 	proc/announce_objectives()
 		var/obj_count = 1
 		for (var/datum/objective/objective in owner.objectives)
-			if (istype(objective, /datum/objective/crew))
-				continue
 			boutput(owner.current, "<b>Objective #[obj_count]:</b> [objective.explanation_text]")
 			obj_count++
 

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -1,7 +1,7 @@
 /datum/antagonist/arcfiend
 	id = ROLE_ARCFIEND
 	display_name = "arcfiend"
-	
+
 	/// The ability holder of this arcfiend, containing their respective abilities. We also use this for tracking power, at the moment.
 	var/datum/abilityHolder/arcfiend/ability_holder
 
@@ -28,7 +28,7 @@
 
 		H.bioHolder.AddEffect("resist_electric", power = 2, magical = TRUE)
 		H.ClearSpecificOverlays("resist_electric")
-	
+
 	remove_equipment()
 		// now this is pod racing
 		src.ability_holder.removeAbility(/datum/targetable/arcfiend/sap_power)
@@ -42,7 +42,7 @@
 		src.owner.current.remove_ability_holder(/datum/abilityHolder/arcfiend)
 
 	assign_objectives()
-		new /datum/objective_set/arcfiend(src.owner)
+		new /datum/objective_set/arcfiend(src.owner, src)
 
 	handle_round_end(log_data)
 		var/list/dat = ..()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -86,7 +86,7 @@
 		src.owner.current.assign_gimmick_skull()
 
 	assign_objectives()
-		new /datum/objective_set/changeling(src.owner)
+		new /datum/objective_set/changeling(src.owner, src)
 
 	handle_round_end(log_data)
 		var/list/dat = ..()

--- a/code/modules/antagonists/hunter/hunter.dm
+++ b/code/modules/antagonists/hunter/hunter.dm
@@ -38,7 +38,7 @@
 		M.set_loc(pick_landmark(LANDMARK_LATEJOIN))
 
 	assign_objectives()
-		new /datum/objective_set/hunter(src.owner)
+		new /datum/objective_set/hunter(src.owner, src)
 
 	handle_round_end(log_data)
 		var/list/dat = ..()

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -69,7 +69,7 @@
 			M.set_loc(pick_landmark(LANDMARK_SYNDICATE))
 
 	assign_objectives()
-		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/nuclear)
+		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/nuclear, src)
 
 	remove_self()
 		if (istype(ticker.mode, /datum/game_mode/nuclear))

--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -50,7 +50,7 @@
 		H.traitHolder.addTrait("training_engineer")
 
 	assign_objectives()
-		new /datum/objective_set/salvager(src.owner)
+		new /datum/objective_set/salvager(src.owner, src)
 
 	relocate()
 #ifdef SECRETS_ENABLED

--- a/code/modules/antagonists/traitor/sleeper_agent.dm
+++ b/code/modules/antagonists/traitor/sleeper_agent.dm
@@ -31,7 +31,7 @@
 	var/datum/objective/new_objective = null
 	for (var/i in 0 to rand(1, 3))
 		new_objective = pick(eligible_objectives)
-		objectives += new new_objective(null, owner)
+		objectives += new new_objective(null, owner, src)
 	var/datum/objective/escape/E = pick(escape_objectives)
-	objectives += new /datum/objective/regular/gimmick(null, owner)
-	objectives += new E(null, owner)
+	objectives += new /datum/objective/regular/gimmick(null, owner, src)
+	objectives += new E(null, owner, src)

--- a/code/modules/antagonists/traitor/traitor.dm
+++ b/code/modules/antagonists/traitor/traitor.dm
@@ -82,7 +82,7 @@
 		#else
 		objective_set_path = pick(typesof(/datum/objective_set/traitor))
 		#endif
-		new objective_set_path(src.owner)
+		new objective_set_path(src.owner, src)
 
 	do_popup(override)
 		if (!override) // Display a different popup depending on the type of uplink we got

--- a/code/modules/antagonists/vampire/vampire.dm
+++ b/code/modules/antagonists/vampire/vampire.dm
@@ -41,7 +41,7 @@
 		src.owner.current.assign_gimmick_skull()
 
 	assign_objectives()
-		new /datum/objective_set/vampire(src.owner)
+		new /datum/objective_set/vampire(src.owner, src)
 
 	handle_round_end(log_data)
 		var/list/dat = ..()


### PR DESCRIPTION
[Internal] [Bug]


## About the PR:
Fixes #10034 by allowing antagonist datums to store objectives created by them, then iterate over and delete them upon the datum's removal.