### PR TITLE
Adds 5 new mining prefabs, the 4 parts of a Sunken Ship (underwater) and the Pathology Site (space)

### DIFF
--- a/assets/maps/prefabs/prefab_pathology.dmm
+++ b/assets/maps/prefabs/prefab_pathology.dmm
@@ -1,0 +1,1328 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aF" = (
+/obj/decal/cleanable/vomit,
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"aP" = (
+/obj/structure/girder/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"bn" = (
+/obj/item/crowbar/red,
+/turf/simulated/floor/caution/south,
+/area/prefab/pathologysite)
+"bX" = (
+/obj/item/cable_coil/cut,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"ck" = (
+/obj/decal/poster/wallsign/stencil/left/b{
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/hazard_bio{
+	pixel_y = 10
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"cH" = (
+/obj/decal/cleanable/blood/gibs/body{
+	icon_state = "gibmid3"
+	},
+/obj/item/paper/pathologytraitor,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"cM" = (
+/obj/machinery/chem_master,
+/obj/item/device/reagentscanner,
+/turf/simulated/floor/purplewhite/corner,
+/area/prefab/pathologysite)
+"cY" = (
+/obj/decal/poster/wallsign/no_smoking,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"eX" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1"
+	},
+/obj/machinery/vending/pathology,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"fL" = (
+/obj/item/pipebomb/frame,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"gC" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 8
+	},
+/obj/item/raw_material/scrap_metal/steel,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"hK" = (
+/obj/machinery/chem_heater,
+/obj/machinery/light/small/purpleish{
+	dir = 1
+	},
+/obj/decal/poster/wallsign/fire{
+	pixel_y = 34
+	},
+/turf/simulated/floor/purplewhite,
+/area/prefab/pathologysite)
+"ia" = (
+/obj/storage/closet,
+/obj/item/clothing/suit/labcoat/pathology,
+/obj/item/clothing/under/rank/pathologist,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/obj/item/clothing/under/rank/medical,
+/obj/item/clothing/shoes/red,
+/obj/item/clothing/suit/labcoat/medical,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"iF" = (
+/obj/lattice,
+/obj/item/reagent_containers/glass/petridish{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/petridish{
+	pixel_x = -2
+	},
+/turf/variableTurf/floor,
+/area/prefab/pathologysite)
+"iK" = (
+/obj/decal/poster/wallsign/stencil/left/a{
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/hazard_bio{
+	pixel_y = 10
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"iO" = (
+/obj/machinery/r_door_control{
+	id = "hangar_pathology";
+	name = "Pathology Hangar Bay Door";
+	pixel_x = 3
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"jf" = (
+/obj/machinery/computer/pathology,
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"jk" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"ki" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"kC" = (
+/obj/decal/cleanable/rust,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "smear1";
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"lj" = (
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"lX" = (
+/obj/item/paper/pathologyzombee,
+/obj/decal/poster/wallsign/poster_sol{
+	pixel_x = -29;
+	pixel_y = -5
+	},
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"mr" = (
+/obj/decal/poster/wallsign/escape_sign{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"mI" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1"
+	},
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 9
+	},
+/obj/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"nm" = (
+/turf/variableTurf/clear,
+/area/allowGenerate)
+"nt" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/machinery/light/incandescent/harsh/very{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"nw" = (
+/obj/cabinet/pathology,
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 10
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"on" = (
+/obj/submachine/chem_extractor{
+	dir = 8
+	},
+/obj/decal/cleanable/rust,
+/obj/decal/poster/wallsign/no_smoking{
+	pixel_y = -30
+	},
+/turf/simulated/floor/purplewhite/corner{
+	dir = 1
+	},
+/area/prefab/pathologysite)
+"pl" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 8
+	},
+/obj/machinery/microscope,
+/obj/table/auto,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"pz" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"pE" = (
+/obj/stool/bee_bed,
+/obj/critter/domestic_bee/zombee{
+	name = "Specimen A-2b00"
+	},
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"pR" = (
+/obj/machinery/autoclave,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"qe" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"qx" = (
+/obj/storage/closet/welding_supply,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/decal/poster/wallsign/fire{
+	pixel_y = 29;
+	pixel_x = -13
+	},
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"qK" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 8
+	},
+/obj/item/device/analyzer/healthanalyzer,
+/obj/decal/poster/wallsign/testsubject{
+	pixel_x = -32
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"rj" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"rJ" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"sb" = (
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"sE" = (
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/disposaloutlet/south,
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"sF" = (
+/obj/lattice,
+/obj/item/paper/pathologycommentary,
+/turf/variableTurf/floor,
+/area/noGenerate)
+"ty" = (
+/obj/machinery/door_control{
+	id = "hangar_pathology";
+	pixel_x = -24;
+	name = "Pathology Hangar Bay Door"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"ve" = (
+/obj/machinery/glass_recycler,
+/obj/table/reinforced/chemistry/auto,
+/turf/simulated/floor/purplewhite/corner{
+	dir = 4
+	},
+/area/prefab/pathologysite)
+"vt" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 4
+	},
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1";
+	dir = 5
+	},
+/obj/machinery/centrifuge,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"vu" = (
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"vw" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 4
+	},
+/obj/decal/tile_edge/line/orange{
+	icon_state = "tile1";
+	dir = 10
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/obj/decal/poster/wallsign/chsl{
+	pixel_y = -32
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"vD" = (
+/obj/item/device/timer,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"vR" = (
+/obj/decal/poster/wallsign/escape_sign{
+	pixel_y = 6;
+	pixel_x = 32
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"wf" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "footprints1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"wB" = (
+/turf/variableTurf/wall,
+/area/noGenerate)
+"xb" = (
+/obj/item/storage/box/beakerbox{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/decal/cleanable/desk_clutter,
+/obj/table/reinforced/chemistry/auto,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
+/area/prefab/pathologysite)
+"xD" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"yw" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "smear3";
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"yB" = (
+/obj/machinery/door/poddoor/blast/pyro{
+	autoclose = 1;
+	dir = 1;
+	id = "hangar_pathology";
+	name = "Pathology Site";
+	icon_state = "bdoormid1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"yK" = (
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/vial{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/turf/variableTurf/floor,
+/area/noGenerate)
+"zS" = (
+/obj/machinery/light/small/greenish{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/prefab/pathologysite)
+"Af" = (
+/obj/machinery/chem_dispenser/chemical,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -1;
+	pixel_y = -10
+	},
+/obj/decal/poster/wallsign/statistics1{
+	pixel_y = -24
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
+/area/prefab/pathologysite)
+"An" = (
+/obj/storage/closet/biohazard,
+/turf/simulated/floor/white/side{
+	dir = 4
+	},
+/area/prefab/pathologysite)
+"Aq" = (
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"Cj" = (
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"Cl" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"Ct" = (
+/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/decal/cleanable/blood/gibs/body{
+	icon_state = "gibmid3"
+	},
+/obj/fluid_spawner/polluted_filth/blood,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"Cu" = (
+/obj/lattice,
+/turf/variableTurf/floor,
+/area/noGenerate)
+"CB" = (
+/obj/machinery/disposal/small/south,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/simulated/floor/purplewhite/corner{
+	dir = 8
+	},
+/area/prefab/pathologysite)
+"CH" = (
+/obj/critter/zombie,
+/obj/decal/cleanable/blood/gibs/body{
+	icon_state = "gibmid2"
+	},
+/obj/fluid_spawner/polluted_filth/blood{
+	amount = 80
+	},
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"CL" = (
+/obj/item/plank{
+	amount = 3
+	},
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"CW" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"Do" = (
+/obj/decal/cleanable/ash,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"DN" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "footprints1"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/item/clothing/suit/labcoat/pathology,
+/obj/item/clothing/under/rank/pathologist{
+	pixel_y = -7;
+	pixel_x = 8
+	},
+/turf/simulated/floor/caution/south,
+/area/prefab/pathologysite)
+"Eg" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/structure/woodwall,
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"Ez" = (
+/obj/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 6
+	},
+/area/prefab/pathologysite)
+"Ff" = (
+/obj/storage/cart/medcart,
+/obj/item/reagent_containers/glass/bottle/spaceacillin,
+/obj/item/reagent_containers/glass/bottle/coldmedicine,
+/obj/machinery/light/small/frostedred{
+	dir = 4
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe/formaldehyde,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"Fy" = (
+/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat{
+	desc = "A slab of meat from a monkey. It has mandible indentations and chew marks on its side."
+	},
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"FQ" = (
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"Ge" = (
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"Gl" = (
+/obj/decal/poster/wallsign/biohazard,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"Hl" = (
+/obj/machinery/door/poddoor/blast/pyro{
+	autoclose = 1;
+	dir = 1;
+	id = "hangar_pathology";
+	name = "Pathology Site";
+	icon_state = "bdoormid1"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "smear1";
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"Hx" = (
+/obj/health_scanner/floor{
+	dir = 1
+	},
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"HC" = (
+/obj/machinery/incubator,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"HV" = (
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"JS" = (
+/obj/machinery/door/airlock/gannets/maintenance,
+/obj/access_spawn/pathology,
+/turf/simulated/floor/stairs/medical{
+	dir = 8
+	},
+/area/prefab/pathologysite)
+"Kj" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibmid3"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/prefab/pathologysite)
+"Ll" = (
+/obj/machinery/door/airlock/gannets/glass/alt,
+/obj/access_spawn/pathology,
+/turf/simulated/floor/white,
+/area/prefab/pathologysite)
+"Lq" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/decal/tile_edge/line/orange{
+	icon_state = "tile1";
+	dir = 6
+	},
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1";
+	dir = 6
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/vending/monkey,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"Lu" = (
+/obj/lattice,
+/obj/storage/secure/closet/fridge/pathology,
+/turf/variableTurf/floor,
+/area/noGenerate)
+"Mh" = (
+/obj/decal/cleanable/rust,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 10
+	},
+/area/prefab/pathologysite)
+"Mt" = (
+/obj/lattice,
+/obj/structure/woodwall,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"ND" = (
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"Oo" = (
+/obj/grille/steel/broken,
+/obj/item/rods/steel,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"OK" = (
+/turf/variableTurf/floor,
+/area/noGenerate)
+"Pp" = (
+/obj/machinery/light/small/greenish{
+	dir = 4
+	},
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"QD" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"QI" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/structure/woodwall,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"QY" = (
+/obj/machinery/synthomatic,
+/obj/machinery/light/incandescent/harsh/very,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"Rg" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor,
+/area/prefab/pathologysite)
+"RP" = (
+/obj/lattice,
+/obj/item/furniture_parts/table,
+/turf/variableTurf/floor,
+/area/prefab/pathologysite)
+"Si" = (
+/obj/item/bee_egg_carton,
+/turf/simulated/floor/plating,
+/area/prefab/pathologysite)
+"SA" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/prefab/pathologysite)
+"Tu" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/pathologysite)
+"TB" = (
+/turf/simulated/floor/caution/south,
+/area/prefab/pathologysite)
+"Ui" = (
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
+/area/prefab/pathologysite)
+"Vr" = (
+/obj/item/sheet/steel,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"Wd" = (
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 12;
+	pixel_y = 5
+	},
+/obj/stool/chair/office/purple,
+/obj/decal/cleanable/water,
+/turf/simulated/floor/purple,
+/area/prefab/pathologysite)
+"Wr" = (
+/obj/machinery/door/airlock/gannets/toxins/alt,
+/obj/access_spawn/pathology,
+/turf/simulated/floor/white/side{
+	dir = 4
+	},
+/area/prefab/pathologysite)
+"Xg" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/prefab/pathologysite)
+"XH" = (
+/obj/structure/woodwall,
+/turf/variableTurf/floor,
+/area/noGenerate)
+"XK" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 4
+	},
+/obj/decal/tile_edge/line/purple{
+	icon_state = "line1";
+	dir = 4
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"XW" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/gannets/chemistry/alt,
+/obj/access_spawn/pathology,
+/turf/simulated/floor/white,
+/area/prefab/pathologysite)
+"Yn" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 1
+	},
+/obj/machinery/pathogen_manipulator,
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"Yv" = (
+/obj/machinery/disposal/small/west,
+/obj/decal/tile_edge/line/orange{
+	icon_state = "noedge-tile1";
+	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/airless/white,
+/area/prefab/pathologysite)
+"Zk" = (
+/obj/item/clothing/suit/bedsheet/orange,
+/obj/stool/bed,
+/obj/machinery/light/small/greenish,
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+"ZX" = (
+/obj/decal/cleanable/blood/gibs/body{
+	icon_state = "gib3"
+	},
+/obj/item/organ/tail/monkey,
+/obj/health_scanner/floor{
+	dir = 1
+	},
+/turf/simulated/floor/twotone/green,
+/area/prefab/pathologysite)
+
+(1,1,1) = {"
+nm
+nm
+nm
+nm
+nm
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+nm
+nm
+nm
+nm
+"}
+(2,1,1) = {"
+nm
+nm
+nm
+nm
+qe
+qe
+wB
+wB
+wB
+wB
+wB
+wB
+wB
+wB
+wB
+qe
+qe
+qe
+qe
+nm
+"}
+(3,1,1) = {"
+nm
+nm
+nm
+nm
+qe
+wB
+wB
+Tu
+Tu
+Tu
+Tu
+Tu
+wB
+wB
+wB
+wB
+OK
+OK
+qe
+qe
+"}
+(4,1,1) = {"
+nm
+nm
+nm
+qe
+qe
+wB
+wB
+Tu
+Cl
+Rg
+Ez
+Tu
+Tu
+Tu
+Tu
+iO
+Cu
+OK
+qe
+qe
+"}
+(5,1,1) = {"
+nm
+nm
+qe
+qe
+wB
+wB
+wB
+Tu
+qx
+CL
+TB
+Aq
+Aq
+pz
+ty
+yB
+Cu
+OK
+qe
+qe
+"}
+(6,1,1) = {"
+nm
+qe
+qe
+wB
+wB
+wB
+wB
+Tu
+Ge
+vu
+DN
+wf
+Kj
+yw
+kC
+Hl
+Cu
+OK
+qe
+qe
+"}
+(7,1,1) = {"
+nm
+qe
+qe
+wB
+wB
+wB
+wB
+Tu
+jk
+CW
+bn
+Ct
+Aq
+vR
+Aq
+yB
+Cu
+OK
+qe
+qe
+"}
+(8,1,1) = {"
+nm
+qe
+wB
+wB
+wB
+wB
+wB
+Tu
+Gl
+Eg
+Mh
+Tu
+Tu
+Tu
+Tu
+Tu
+Tu
+OK
+OK
+qe
+"}
+(9,1,1) = {"
+nm
+qe
+wB
+wB
+wB
+Tu
+Tu
+Tu
+mr
+Wr
+cY
+Tu
+An
+Tu
+Hx
+Zk
+rj
+wB
+wB
+qe
+"}
+(10,1,1) = {"
+qe
+qe
+wB
+wB
+wB
+rJ
+nw
+qK
+pl
+gC
+mI
+Ll
+zS
+Ll
+FQ
+aF
+rj
+wB
+wB
+qe
+"}
+(11,1,1) = {"
+qe
+wB
+wB
+wB
+Cu
+Oo
+jf
+Cj
+xD
+Xg
+eX
+iK
+Tu
+Tu
+Tu
+Tu
+Tu
+wB
+wB
+qe
+"}
+(12,1,1) = {"
+qe
+wB
+wB
+wB
+Cu
+sb
+Yn
+Do
+Xg
+lj
+QY
+aP
+Vr
+Tu
+ZX
+Zk
+rj
+wB
+wB
+qe
+"}
+(13,1,1) = {"
+qe
+XH
+OK
+OK
+Cu
+rJ
+nt
+lj
+vD
+bX
+lj
+Mt
+Pp
+QI
+cH
+CH
+rj
+wB
+qe
+qe
+"}
+(14,1,1) = {"
+qe
+XH
+OK
+OK
+yK
+RP
+iF
+sb
+fL
+Xg
+pR
+ck
+Tu
+Tu
+Tu
+Tu
+Tu
+OK
+qe
+qe
+"}
+(15,1,1) = {"
+qe
+XH
+OK
+Cu
+Cu
+rJ
+ki
+QD
+SA
+HV
+HC
+ND
+sE
+sF
+XH
+OK
+OK
+qe
+qe
+qe
+"}
+(16,1,1) = {"
+qe
+wB
+wB
+OK
+Lu
+sb
+Lq
+XK
+vt
+Yv
+vw
+Tu
+Cu
+Cu
+XH
+OK
+qe
+qe
+qe
+qe
+"}
+(17,1,1) = {"
+qe
+wB
+wB
+wB
+Cu
+Tu
+Tu
+XW
+Tu
+Tu
+JS
+Tu
+Tu
+Tu
+wB
+OK
+OK
+OK
+qe
+qe
+"}
+(18,1,1) = {"
+qe
+qe
+wB
+wB
+Cu
+Tu
+cM
+Ui
+CB
+Tu
+Fy
+lX
+Si
+Tu
+wB
+wB
+OK
+OK
+qe
+qe
+"}
+(19,1,1) = {"
+qe
+qe
+wB
+wB
+wB
+Tu
+hK
+Wd
+Af
+Tu
+ia
+Ff
+pE
+Tu
+wB
+wB
+wB
+wB
+qe
+qe
+"}
+(20,1,1) = {"
+qe
+qe
+wB
+wB
+wB
+Tu
+ve
+xb
+on
+Tu
+Tu
+Tu
+Tu
+Tu
+wB
+wB
+wB
+qe
+qe
+nm
+"}
+(21,1,1) = {"
+nm
+qe
+qe
+wB
+wB
+Tu
+rj
+rj
+rj
+Tu
+wB
+wB
+wB
+wB
+wB
+wB
+qe
+qe
+nm
+nm
+"}
+(22,1,1) = {"
+nm
+nm
+qe
+qe
+OK
+Cu
+Cu
+Cu
+OK
+wB
+wB
+wB
+wB
+wB
+wB
+qe
+qe
+nm
+nm
+nm
+"}
+(23,1,1) = {"
+nm
+nm
+nm
+qe
+qe
+qe
+qe
+OK
+OK
+wB
+wB
+wB
+qe
+qe
+qe
+qe
+nm
+nm
+nm
+nm
+"}
+(24,1,1) = {"
+nm
+nm
+nm
+nm
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+qe
+nm
+nm
+nm
+nm
+nm
+nm
+nm
+"}

--- a/assets/maps/prefabs/prefab_water_sunkenship_bridge.dmm
+++ b/assets/maps/prefabs/prefab_water_sunkenship_bridge.dmm
@@ -1,0 +1,545 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ar" = (
+/obj/structure/woodwall,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"aU" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
+	},
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"cs" = (
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"cv" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 6
+	},
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"do" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"du" = (
+/obj/stool/chair/couch/green{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"eU" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"fm" = (
+/obj/decal/cleanable/rust/jen,
+/obj/machinery/vending/snack,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+"lt" = (
+/turf/simulated/floor/airless,
+/area/noGenerate)
+"lF" = (
+/obj/grille/steel/broken,
+/obj/decal/cleanable/rust/jen,
+/obj/structure/woodwall,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+"lG" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "bustedmantapc";
+	dir = 8;
+	density = 1;
+	anchored = 1;
+	name = "broken console";
+	desc = "It's busted!"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"lJ" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/prefab/sunkenship/bridge)
+"lN" = (
+/obj/decoration/clock{
+	pixel_y = 8;
+	pixel_x = 29
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"md" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 9
+	},
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/plating/airless,
+/area/prefab/sunkenship/bridge)
+"mQ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/bridge)
+"nm" = (
+/obj/decal/cleanable/rust,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"pJ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray,
+/area/prefab/sunkenship/bridge)
+"qU" = (
+/obj/decal/fakeobjects/junction_box,
+/turf/simulated/floor/airless,
+/area/noGenerate)
+"rW" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"sk" = (
+/obj/decal/cleanable/rust,
+/obj/table/reinforced,
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"sD" = (
+/obj/storage/crate/bin/trash,
+/obj/item/paper/sunkenmanifest,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"sP" = (
+/obj/stool/chair/couch/green{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"tp" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/prefab/sunkenship/bridge)
+"tJ" = (
+/obj/machinery/door/airlock/gannets/command/alt,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"ub" = (
+/obj/table/reinforced,
+/obj/item/paper/sunkenbees,
+/obj/item/pen,
+/obj/item/stamp{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"uz" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+"vu" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/bridge)
+"vB" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "bustedmantapc2";
+	density = 1;
+	anchored = 1;
+	desc = "It's busted!";
+	name = "broken console"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"wo" = (
+/obj/machinery/door/airlock/gannets/command/alt,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+"yT" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 1;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/bridge)
+"zd" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"zu" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "bustedmantapc";
+	dir = 1;
+	anchored = 1;
+	density = 1;
+	desc = "It's busted!";
+	name = "broken console"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"AZ" = (
+/obj/machinery/door/airlock/gannets/command,
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/prefab/sunkenship/bridge)
+"Bd" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "bustedmantapc2";
+	dir = 8;
+	density = 1;
+	anchored = 1;
+	desc = "It's busted!";
+	name = "broken console"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Cd" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"Cr" = (
+/obj/grille/steel,
+/obj/structure/woodwall,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+"Dg" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"DH" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Fj" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "gannets_machine30";
+	anchored = 1;
+	density = 1;
+	name = "power override cabinet";
+	desc = "Overrides power to other departments... if it worked, but it's not, so it's just a decorational prop."
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Ga" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Go" = (
+/obj/decal/stripe_caution,
+/obj/storage/cart,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Gz" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/darkblue,
+/area/prefab/sunkenship/bridge)
+"HC" = (
+/obj/decal/stripe_caution,
+/obj/decal/stripe_caution,
+/obj/storage/cart,
+/obj/item/crowbar,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Im" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Nn" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 5
+	},
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"NS" = (
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"Px" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/decoration.dmi';
+	icon_state = "bustedmantapc2";
+	dir = 1;
+	name = "broken lever console";
+	desc = "The lever is locked to 'INITIATE'.";
+	density = 1;
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"PS" = (
+/obj/table/reinforced/auto,
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/networked.dmi';
+	icon_state = "printer0";
+	name = "clogged printer";
+	desc = "There's... odd black gunk inside this printer."
+	},
+/obj/item/paper/sunkenaimonologue,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Ql" = (
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"UG" = (
+/turf/simulated/floor/plating/airless,
+/area/prefab/sunkenship/bridge)
+"Ve" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 5
+	},
+/area/prefab/sunkenship/bridge)
+"Vf" = (
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Vh" = (
+/obj/decal/fakeobjects/lawrack,
+/obj/decal/stripe_caution,
+/turf/simulated/floor,
+/area/prefab/sunkenship/bridge)
+"Wp" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 10
+	},
+/turf/simulated/floor/airless/circuit,
+/area/prefab/sunkenship/bridge)
+"Wy" = (
+/turf/variableTurf/clear,
+/area/allowGenerate/trench)
+"XH" = (
+/obj/decal/fakeobjects/lawrack{
+	icon = 'icons/mob/ai.dmi';
+	icon_state = "ai-crash";
+	name = "broken AI";
+	desc = "Looks like it's opened its last door."
+	},
+/obj/decal/stripe_caution,
+/obj/decal{
+	mouse_opacity = 0;
+	icon = 'icons/mob/ai.dmi';
+	icon_state = 'brute75';
+	layer = 40
+	},
+/obj/decal{
+	mouse_opacity = 0;
+	icon = 'icons/mob/ai.dmi';
+	icon_state = 'dwaine';
+	layer = 39
+	},
+/turf/simulated/floor/airless/blue,
+/area/prefab/sunkenship/bridge)
+"Yq" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 6
+	},
+/area/prefab/sunkenship/bridge)
+"YI" = (
+/obj/grille/steel/broken,
+/obj/decal/cleanable/rust,
+/obj/structure/woodwall,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/bridge)
+
+(1,1,1) = {"
+Wy
+Ga
+Ga
+Wy
+Wy
+Wy
+Im
+Ga
+Wy
+Wy
+"}
+(2,1,1) = {"
+Im
+Ga
+lJ
+pJ
+pJ
+UG
+lJ
+Ga
+Wy
+Wy
+"}
+(3,1,1) = {"
+Im
+Ga
+mQ
+cv
+tp
+Nn
+UG
+Im
+Wy
+Wy
+"}
+(4,1,1) = {"
+Im
+Im
+lJ
+Ql
+XH
+aU
+mQ
+Ga
+Im
+Wy
+"}
+(5,1,1) = {"
+Wy
+Im
+mQ
+Wp
+Dg
+md
+mQ
+NS
+Ga
+Wy
+"}
+(6,1,1) = {"
+Wy
+Im
+vu
+pJ
+AZ
+pJ
+yT
+Im
+Ga
+Wy
+"}
+(7,1,1) = {"
+Im
+Im
+uz
+Vh
+DH
+Fj
+mQ
+Im
+Im
+Wy
+"}
+(8,1,1) = {"
+Ga
+uz
+Cr
+PS
+eU
+ar
+wo
+NS
+Im
+zd
+"}
+(9,1,1) = {"
+Ga
+Cr
+sk
+cs
+Vf
+fm
+mQ
+qU
+Im
+NS
+"}
+(10,1,1) = {"
+Ga
+Cr
+lG
+zu
+cs
+nm
+mQ
+NS
+NS
+Im
+"}
+(11,1,1) = {"
+Ga
+uz
+Px
+rW
+Cd
+do
+mQ
+NS
+Wy
+Wy
+"}
+(12,1,1) = {"
+Ga
+uz
+vB
+Bd
+cs
+du
+mQ
+Im
+Im
+Wy
+"}
+(13,1,1) = {"
+Ga
+YI
+ub
+Gz
+Vf
+sP
+mQ
+NS
+Im
+Im
+"}
+(14,1,1) = {"
+Ga
+uz
+uz
+Go
+Vf
+ar
+tJ
+lt
+Im
+Im
+"}
+(15,1,1) = {"
+Ga
+Im
+lF
+HC
+lN
+sD
+mQ
+Im
+Im
+Wy
+"}
+(16,1,1) = {"
+Wy
+Wy
+Ve
+pJ
+pJ
+pJ
+Yq
+Wy
+Wy
+Wy
+"}

--- a/assets/maps/prefabs/prefab_water_sunkenship_engi.dmm
+++ b/assets/maps/prefabs/prefab_water_sunkenship_engi.dmm
@@ -1,0 +1,1594 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bh" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power.dmi';
+	icon_state = "term";
+	name = "corroded terminal";
+	desc = "If this weren't full of rust and corrosion, it'd transfer power from cables to machinery.";
+	dir = 8
+	},
+/obj/machinery/light/incandescent/warm/very,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"bp" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"cI" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 8;
+	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi';
+	icon_state = "manifold"
+	},
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"dh" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power_cond.dmi';
+	icon_state = "0-1";
+	name = "power cable";
+	color = "red"
+	},
+/obj/item/cable_coil/cut,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"dk" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 9
+	},
+/area/prefab/sunkenship/engineering)
+"ej" = (
+/obj/reagent_dispensers/watertank,
+/turf/simulated/floor/airless/plating,
+/area/noGenerate)
+"ey" = (
+/obj/item/paper/sunkenengine{
+	pixel_x = -13;
+	pixel_y = -5
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"fm" = (
+/obj/storage/crate/bin/trash,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"fG" = (
+/obj/critter/domestic_bee/trauma{
+	name = "Quartermaster Quintin"
+	},
+/obj/item/toy/plush/small/stress_ball{
+	pixel_y = 10;
+	pixel_x = 7
+	},
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/obj/stool/bee_bed/double,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"fJ" = (
+/obj/machinery/light/beacon,
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"fZ" = (
+/obj/decal/fakeobjects/pipe/heat{
+	icon_state = "6"
+	},
+/obj/fluid_spawner{
+	amount = 500;
+	delay = 35
+	},
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/disposal.dmi';
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"ge" = (
+/obj/item/cable_coil/cut/small,
+/obj/machinery/light/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"gm" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"gz" = (
+/turf/unsimulated/wall/setpieces/leadwindow/gray{
+	dir = 4;
+	icon_state = "leadwindow_gray_2"
+	},
+/area/prefab/sunkenship/engineering)
+"hq" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes-old";
+	name = "broken SMES-unit";
+	desc = "The screen doesn't turn on. Seems this one's busted.";
+	dir = 8;
+	density = 1;
+	anchored = 1
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"hs" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 10
+	},
+/area/prefab/sunkenship/engineering)
+"hD" = (
+/obj/machinery/manufacturer/mining,
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "bigstripe-edge2";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/engineering)
+"hL" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "sunkenshipcargo"
+	},
+/obj/machinery/activation_button/driver_button{
+	id = "sunkenshipcargo";
+	pixel_y = -21;
+	pixel_x = -5
+	},
+/obj/decal/stripe_caution,
+/obj/decal/cleanable/blood{
+	icon_state = "drip5d"
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"il" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power_cond.dmi';
+	icon_state = "0-4";
+	name = "power cable";
+	color = "red"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"iV" = (
+/obj/decal/cleanable/blood,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"kd" = (
+/obj/plasticflaps,
+/obj/decal/cleanable/blood{
+	icon_state = "gibmid1"
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"ks" = (
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "drip2"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"li" = (
+/obj/table/auto,
+/obj/decal/fakeobjects{
+	anchored = 1;
+	desc = "An old computer that is obviously very broken.  It might actually not even be plugged in.  BROKEN.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "old0";
+	name = "broken computer";
+	density = 1
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"lF" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"lH" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"lM" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 5
+	},
+/obj/item/storage/wall/fire{
+	pixel_y = -27
+	},
+/obj/decal/cleanable/rust,
+/obj/critter/zombie/radiation,
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib4"
+	},
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "drip4d"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"mc" = (
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/robotics_supplies,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"md" = (
+/turf/variableTurf/clear,
+/area/allowGenerate/trench)
+"ml" = (
+/obj/machinery/manufacturer/medical,
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/engineering)
+"mw" = (
+/obj/machinery/door/airlock/gannets/glass/engineering,
+/obj/access_spawn/engineering_mechanic,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"mA" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"mQ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/engineering)
+"na" = (
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/disposal.dmi';
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/light/incandescent/warm/very{
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"ni" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"ns" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 2;
+	pixel_y = -16;
+	layer = 2.98
+	},
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/disposal.dmi';
+	icon_state = "pipe-t";
+	dir = 1;
+	layer = 2.99
+	},
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "It is still kinda warm.";
+	icon = 'icons/obj/machines/nuclear.dmi';
+	icon_state = "neutinj";
+	name = "busted machine"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"nv" = (
+/obj/map/light/lava,
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/atmospherics/pipes.dmi';
+	icon_state = "turbine";
+	dir = 8;
+	desc = "Haha, it looks like a trumpet!";
+	name = "lava engine heat compressor";
+	density = 1
+	},
+/turf/unsimulated/floor/lava,
+/area/prefab/sunkenship/engineering)
+"nH" = (
+/obj/decal/fakeobjects/pipe/heat,
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/disposal.dmi';
+	icon_state = "pipe-s";
+	dir = 1
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"nZ" = (
+/obj/decal/fakeobjects/cpucontroller{
+	desc = "A gigantic computer box of some sort. You can't tell, and it's not plugged in.";
+	name = "janky mainframe thing"
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"of" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"oq" = (
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 4
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"oF" = (
+/obj/table/auto,
+/obj/decal/cleanable/cobweb2,
+/obj/decal/fakeobjects{
+	anchored = 1;
+	desc = "An old ThinkDOS computer covered in encouraging sticky notes. Burnt into the screen is some sort of spacenet chat program.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "old0";
+	name = "inactive computer";
+	density = 1
+	},
+/obj/machinery/junctionbox/varianta{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"pt" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/internals,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"px" = (
+/obj/storage/cart/mechcart,
+/obj/decal/cleanable/rust,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"pJ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray,
+/area/prefab/sunkenship/engineering)
+"pL" = (
+/obj/item/sheet/steel/fullstack,
+/obj/rack,
+/obj/item/storage/toolbox/mechanical/yellow_tools,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"pW" = (
+/obj/decal/fakeobjects/airmonitor_broken{
+	pixel_y = 26
+	},
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A computer that is so completely, irreparably broken that you are in disbelief at just how destroyed it is. ";
+	dir = 2;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "offbroken";
+	name = "broken computer"
+	},
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"qs" = (
+/obj/forcefield/energyshield/perma{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"qx" = (
+/obj/machinery/door/airlock/gannets/engineering/alt,
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/stairs/dark{
+	dir = 8;
+	icon_state = "dark_stairs"
+	},
+/area/prefab/sunkenship/engineering)
+"qH" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"qR" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/engineering)
+"rC" = (
+/obj/map/light/lava,
+/turf/unsimulated/floor/lava,
+/area/prefab/sunkenship/engineering)
+"rM" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/airless/plating,
+/area/noGenerate)
+"su" = (
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip1a"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"sQ" = (
+/obj/storage/secure/closet/engineering/engineer,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"sR" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 8;
+	icon_state = "leadcap_gray"
+	},
+/area/prefab/sunkenship/engineering)
+"sT" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"th" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 5
+	},
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "floor2"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"tk" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 10
+	},
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "drip3f"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"tF" = (
+/obj/machinery/door/airlock/gannets/engineering/alt,
+/obj/access_spawn/engineering_engine,
+/obj/access_spawn/engineering_mechanic,
+/turf/simulated/floor/stairs/dark{
+	dir = 1;
+	icon_state = "dark_stairs"
+	},
+/area/prefab/sunkenship/engineering)
+"tR" = (
+/obj/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"tV" = (
+/obj/item/reagent_containers/food/snacks/beefood{
+	pixel_y = 8
+	},
+/obj/item/toy/plush/small/buddy{
+	pixel_y = -4;
+	pixel_x = 3
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"um" = (
+/obj/decal/fakeobjects/vacuumtape,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"uE" = (
+/obj/decal/fakeobjects/pipe/heat{
+	dir = 10
+	},
+/obj/fluid_spawner{
+	amount = 500;
+	delay = 35
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"vu" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/engineering)
+"vz" = (
+/obj/machinery/door/airlock/gannets/glass/engineering/alt,
+/obj/access_spawn/engineering_mechanic,
+/obj/access_spawn/cargo,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"vQ" = (
+/obj/lattice,
+/obj/item/paper/sunkensymptoms{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"we" = (
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"xQ" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/airless/plating,
+/area/noGenerate)
+"ye" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"yp" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"yT" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 1;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/engineering)
+"zb" = (
+/obj/machinery/door/airlock/gannets/glass/engineering/alt,
+/obj/access_spawn/cargo,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"zK" = (
+/obj/machinery/manufacturer/qm,
+/obj/machinery/light/incandescent/blueish{
+	dir = 1
+	},
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"zT" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power_cond.dmi';
+	icon_state = "4-8";
+	name = "power cable";
+	color = "red"
+	},
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power.dmi';
+	icon_state = "term";
+	name = "corroded terminal";
+	desc = "If this weren't full of rust and corrosion, it'd transfer power from cables to machinery."
+	},
+/obj/decal/fakeobjects/apc_broken{
+	pixel_y = -24
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Aj" = (
+/obj/decal/fakeobjects/pipe/heat{
+	icon = 'icons/obj/atmospherics/pipes/junction_pipe.dmi';
+	dir = 1
+	},
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/disposal.dmi';
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Aq" = (
+/obj/decal/fakeobjects/pipe/heat{
+	icon = 'icons/obj/atmospherics/pipes/junction_pipe.dmi';
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"AV" = (
+/obj/decal/fakeobjects/apc_broken{
+	pixel_x = -24
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"BD" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/airless/yellow/side{
+	dir = 1
+	},
+/area/noGenerate)
+"BZ" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power_cond.dmi';
+	icon_state = "0-2";
+	name = "power cable"
+	},
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/atmospherics/pipes.dmi';
+	icon_state = "compressor";
+	dir = 4;
+	name = "lava engine turbine";
+	desc = "Some rickety-old generator that makes power from combining lava and water.";
+	density = 1
+	},
+/turf/unsimulated/wall/setpieces/leadwall/gray,
+/area/prefab/sunkenship/engineering)
+"Cu" = (
+/turf/simulated/floor/airless/yellow/side{
+	dir = 1
+	},
+/area/noGenerate)
+"Cv" = (
+/turf/unsimulated/wall/setpieces/leadwindow/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/engineering)
+"CU" = (
+/obj/machinery/manufacturer/mechanic,
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "bigstripe-edge2";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/engineering)
+"Do" = (
+/obj/railing/orange,
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"Dv" = (
+/obj/machinery/rkit,
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "bigstripe-edge2";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/engineering)
+"El" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4;
+	icon_state = "leadcap_gray"
+	},
+/area/prefab/sunkenship/engineering)
+"Ew" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 2
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Ey" = (
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip1d"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "maskblood_c"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Ez" = (
+/obj/item/storage/toolbox/mechanical/yellow_tools,
+/obj/decal/cleanable/oil,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"EB" = (
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"Fq" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"FB" = (
+/obj/decal/fakeobjects/pipe/heat,
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Gz" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"IR" = (
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/power_cond.dmi';
+	icon_state = "0-2";
+	name = "power cable";
+	color = "red"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip3e"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"IS" = (
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/atmospherics/portables_connector.dmi';
+	name = "rusted connector";
+	dir = 8
+	},
+/obj/decal/fakeobjects/oldcanister,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"IV" = (
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/robotparts,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"JD" = (
+/obj/machinery/light/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"KF" = (
+/obj/machinery/vending/mechanics,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"KQ" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A very old atmospheric freezer machine. It still makes a faint whirring noise.";
+	icon = 'icons/obj/Cryogenic2.dmi';
+	icon_state = "oldfreezer";
+	name = "old cold circulator";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Ld" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/decal/fakeobjects/oldcanister,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"Lg" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay2,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Lk" = (
+/obj/critter/domestic_bee/sea/bart,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"Lt" = (
+/obj/lattice,
+/obj/machinery/light/runway_light,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"LB" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"LE" = (
+/obj/plasticflaps,
+/obj/railing/orange,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"LK" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A computer that is so completely, irreparably broken that you are in disbelief at just how destroyed it is. ";
+	dir = 8;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "offbroken";
+	name = "broken computer"
+	},
+/obj/machinery/light/incandescent/warm/very{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Me" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A computer that is so completely, irreparably broken that you are in disbelief at just how destroyed it is. ";
+	dir = 8;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "offbroken";
+	name = "broken computer"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Mm" = (
+/obj/decal/stripe_delivery,
+/obj/railing/orange,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"Mp" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay3,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Mw" = (
+/obj/item/cable_coil,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"MF" = (
+/obj/storage/secure/closet/engineering/engineer,
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"Nn" = (
+/obj/item/sheet/glass/fullstack,
+/obj/rack,
+/obj/item/storage/toolbox/mechanical/yellow_tools,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"NL" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/machinery/junctionbox/variantb{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"NZ" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/furnacefuel,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"Ot" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/wooden,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"OJ" = (
+/obj/critter/zombie/radiation,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"OK" = (
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi';
+	icon_state = "manifold"
+	},
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Pi" = (
+/obj/storage/cart,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"Pw" = (
+/obj/storage/crate/bin/trash,
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"PS" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 2
+	},
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "drip2"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Rt" = (
+/obj/machinery/light/emergency{
+	dir = 1
+	},
+/obj/decal/cleanable/oil,
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip3e"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/generic,
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"RB" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"Sr" = (
+/obj/storage/secure/closet/engineering/mechanic,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"SG" = (
+/obj/storage/secure/closet/engineering/mechanic,
+/obj/machinery/light/incandescent/blueish{
+	dir = 1
+	},
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+"SQ" = (
+/obj/decal/fakeobjects/pipe{
+	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi';
+	icon_state = "manifold";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"To" = (
+/obj/machinery/manufacturer/general,
+/obj/machinery/light/incandescent/blueish,
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "bigstripe-edge2";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/engineering)
+"Tx" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 8;
+	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi';
+	icon_state = "manifold"
+	},
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"TD" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A large rack of server modules.  It appears to be in a low-power idle state.";
+	icon = 'icons/obj/networked.dmi';
+	icon_state = "server0";
+	name = "idle server"
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"TH" = (
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"UG" = (
+/turf/simulated/floor/airless/plating,
+/area/noGenerate)
+"UL" = (
+/obj/decal/fakeobjects/pipe{
+	dir = 5
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"UN" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate,
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/orange,
+/area/prefab/sunkenship/engineering)
+"UV" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Ve" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 5
+	},
+/area/prefab/sunkenship/engineering)
+"VQ" = (
+/obj/railing/orange{
+	dir = 8
+	},
+/obj/railing/orange{
+	dir = 4
+	},
+/obj/storage/crate/packing,
+/obj/machinery/light/incandescent/blueish,
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"VV" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"Ws" = (
+/obj/machinery/bot/firebot{
+	name = "Officer Magma"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"WL" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Xk" = (
+/obj/item/toy/plush/small/bee{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/item/toy/plush/small/monkey{
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/obj/machinery/junctionbox{
+	pixel_y = -32;
+	pixel_x = -13
+	},
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/engineering)
+"XA" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A computer that is so completely, irreparably broken that you are in disbelief at just how destroyed it is. ";
+	dir = 2;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "offbroken";
+	name = "broken computer"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"XQ" = (
+/obj/decal/fakeobjects/pipe{
+	desc = "It won't budge.";
+	icon = 'icons/obj/pipe-item.dmi';
+	icon_state = "valve";
+	name = "rusted valve"
+	},
+/turf/simulated/floor/engine,
+/area/prefab/sunkenship/engineering)
+"Yj" = (
+/obj/stool/chair,
+/turf/simulated/floor/orangeblack,
+/area/prefab/sunkenship/engineering)
+"Yq" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 6
+	},
+/area/prefab/sunkenship/engineering)
+"Zz" = (
+/obj/railing/orange{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/prefab/sunkenship/engineering)
+"ZY" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/twotone/yellow,
+/area/prefab/sunkenship/engineering)
+
+(1,1,1) = {"
+md
+md
+md
+md
+gm
+UV
+UV
+UV
+UV
+gm
+UV
+UV
+UV
+md
+md
+md
+md
+md
+"}
+(2,1,1) = {"
+md
+UV
+UV
+gm
+UV
+UG
+UV
+UG
+UV
+dk
+pJ
+mw
+pJ
+pJ
+hs
+UV
+md
+md
+"}
+(3,1,1) = {"
+UV
+UG
+dk
+pJ
+pJ
+qx
+pJ
+pJ
+pJ
+yT
+px
+EB
+EB
+Nn
+mQ
+UV
+UV
+md
+"}
+(4,1,1) = {"
+dk
+pJ
+yT
+lH
+lF
+IR
+dh
+ge
+il
+tF
+EB
+EB
+EB
+pL
+Cv
+UV
+UG
+md
+"}
+(5,1,1) = {"
+mQ
+rC
+WL
+Ws
+we
+su
+Ey
+we
+zT
+mQ
+Sr
+EB
+EB
+To
+mQ
+UG
+md
+md
+"}
+(6,1,1) = {"
+mQ
+nv
+WL
+XA
+bp
+ni
+ey
+ks
+hq
+mQ
+SG
+ZY
+Lk
+ml
+Cv
+ej
+md
+md
+"}
+(7,1,1) = {"
+vu
+BZ
+yT
+na
+ns
+Ew
+PS
+th
+bh
+mQ
+Dv
+EB
+EB
+hD
+mQ
+rM
+UG
+md
+"}
+(8,1,1) = {"
+mQ
+fZ
+nH
+Aj
+UL
+Mw
+sT
+tk
+lM
+mQ
+CU
+fm
+EB
+KF
+mQ
+xQ
+UV
+md
+"}
+(9,1,1) = {"
+mQ
+uE
+FB
+Aq
+SQ
+XQ
+cI
+Tx
+OK
+vu
+pJ
+pJ
+vz
+pJ
+pJ
+hs
+BD
+md
+"}
+(10,1,1) = {"
+Ve
+pJ
+yT
+Ez
+Me
+LK
+KQ
+KQ
+IS
+mQ
+nZ
+JD
+TH
+AV
+yp
+zb
+Cu
+md
+"}
+(11,1,1) = {"
+md
+md
+Ve
+pJ
+pJ
+pJ
+pJ
+qR
+pJ
+Yq
+TH
+ye
+TH
+Pi
+Pi
+mQ
+UG
+md
+"}
+(12,1,1) = {"
+md
+md
+md
+md
+md
+gm
+vQ
+mQ
+MF
+sQ
+TH
+TH
+RB
+LB
+LB
+mQ
+UV
+md
+"}
+(13,1,1) = {"
+md
+md
+md
+md
+md
+gm
+UV
+mQ
+li
+Yj
+TH
+TH
+Gz
+NZ
+UN
+gz
+UV
+UG
+"}
+(14,1,1) = {"
+md
+md
+md
+md
+md
+gm
+UV
+Ve
+pJ
+hs
+Pw
+Fq
+of
+Ot
+VQ
+mQ
+UV
+UG
+"}
+(15,1,1) = {"
+md
+md
+md
+md
+md
+md
+UV
+UV
+UV
+mQ
+zK
+TH
+mA
+Ld
+pt
+gz
+UV
+md
+"}
+(16,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+mQ
+pW
+oq
+Zz
+IV
+mc
+mQ
+md
+md
+"}
+(17,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+mQ
+Rt
+Do
+qH
+VV
+NL
+mQ
+md
+md
+"}
+(18,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+mQ
+Mm
+hL
+sR
+TD
+Xk
+mQ
+md
+md
+"}
+(19,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+mQ
+LE
+kd
+mQ
+um
+tV
+mQ
+md
+md
+"}
+(20,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+El
+qs
+qs
+mQ
+oF
+fG
+mQ
+md
+md
+"}
+(21,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+Mp
+UV
+UV
+Ve
+pJ
+pJ
+Yq
+md
+md
+"}
+(22,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+Lg
+gm
+iV
+md
+md
+md
+md
+md
+md
+"}
+(23,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+Lt
+gm
+gm
+md
+md
+md
+md
+md
+md
+"}
+(24,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+UV
+OJ
+tR
+md
+md
+md
+md
+md
+md
+"}
+(25,1,1) = {"
+md
+md
+md
+md
+md
+md
+md
+md
+md
+fJ
+gm
+gm
+md
+md
+md
+md
+md
+md
+"}

--- a/assets/maps/prefabs/prefab_water_sunkenship_medbay.dmm
+++ b/assets/maps/prefabs/prefab_water_sunkenship_medbay.dmm
@@ -1,0 +1,630 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/obj/decal/tile_edge/line/red{
+	icon_state = "line1"
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"aV" = (
+/obj/cabinet/medical,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"ba" = (
+/obj/item/reagent_containers/glass/beaker/parasiticmedium,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"cp" = (
+/obj/iv_stand,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"dk" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 9
+	},
+/area/prefab/sunkenship/medbay)
+"eU" = (
+/obj/table/round,
+/obj/item/reagent_containers/glass/bottle/formaldehyde,
+/obj/item/reagent_containers/syringe/formaldehyde,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"gw" = (
+/obj/storage/secure/closet/fridge/blood,
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"hs" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 10
+	},
+/area/prefab/sunkenship/medbay)
+"hV" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 8;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/medbay)
+"ir" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"iH" = (
+/obj/storage/crate/bloody,
+/obj/item/device/analyzer/healthanalyzer/upgraded,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
+	icon = 'icons/effects/blood.dmi';
+	icon_state = "gibtorso";
+	name = "meaty bit"
+	},
+/obj/item/spraybottle/cleaner,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"kR" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"lp" = (
+/obj/decal/fakeobjects/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body6";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "floor5"
+	},
+/obj/decal/cleanable/vomit{
+	icon_state = "floor3"
+	},
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"lr" = (
+/obj/storage/closet/wardrobe/mixed,
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"lN" = (
+/obj/item/storage/box/patchbox{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/rack,
+/obj/item/item_box/medical_patches/mini_silver_sulf{
+	pixel_x = -8;
+	pixel_y = -3;
+	layer = 3.01
+	},
+/obj/item/item_box/medical_patches/mini_styptic{
+	pixel_x = -1;
+	layer = 3.02
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"md" = (
+/turf/variableTurf/clear,
+/area/allowGenerate/trench)
+"mv" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"mQ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/medbay)
+"pJ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray,
+/area/prefab/sunkenship/medbay)
+"rl" = (
+/obj/machinery/door/airlock/gannets/morgue,
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/obj/access_spawn/morgue,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"sW" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"tq" = (
+/obj/machinery/drainage,
+/obj/decal/tile_edge/line/red{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"tr" = (
+/obj/machinery/traymachine/morgue,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"tu" = (
+/obj/decal/fakeobjects/apc_broken{
+	pixel_y = -24
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"uH" = (
+/obj/machinery/light/incandescent/cool/very,
+/obj/critter/zombie/scientist{
+	name = "Diseased Doctor"
+	},
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"uO" = (
+/obj/item/storage/wall/surgery{
+	pixel_y = 34
+	},
+/obj/rack,
+/obj/item/reagent_containers/hypospray{
+	pixel_y = 4;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -4
+	},
+/obj/item/storage/pill_bottle/antitox{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"vg" = (
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"vs" = (
+/obj/storage/crate/bin/trash,
+/obj/item/organ/heart{
+	desc = "Something's off with this heart. It feels alive, in a weird way.";
+	name = "heart...?"
+	},
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/obj/item/paper/sunkenmedbay,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"vu" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/medbay)
+"vU" = (
+/obj/machinery/vending/medical,
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"wo" = (
+/obj/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"wy" = (
+/obj/decal/cleanable/blood{
+	icon_state = "smear3"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"yf" = (
+/obj/stool/bed/moveable,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"yT" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 1;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/medbay)
+"zo" = (
+/obj/submachine/laundry_machine,
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"Cv" = (
+/turf/unsimulated/wall/setpieces/leadwindow/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/medbay)
+"CB" = (
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "bloodhit4"
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"FG" = (
+/obj/decal/cleanable/blood{
+	icon_state = "drip5d"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"FN" = (
+/obj/item/storage/wall/surgery{
+	pixel_y = 34
+	},
+/obj/table/round,
+/obj/item/paper/sunkenmorgue,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"Hj" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"Ir" = (
+/obj/machinery/optable{
+	name = "Autopsy Table"
+	},
+/obj/item/storage/box/body_bag,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"IQ" = (
+/obj/stool/bed/moveable,
+/obj/decal/cleanable/blood/drip/med,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"Jq" = (
+/obj/machinery/traymachine/locking/crematorium,
+/turf/simulated/floor/specialroom/freezer/white,
+/area/prefab/sunkenship/medbay)
+"JJ" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"LA" = (
+/obj/decal/tile_edge/line/red{
+	dir = 4;
+	icon_state = "line1"
+	},
+/obj/machinery/bot/medbot{
+	name = "Dr. Fredrickson";
+	desc = "A little medical robot. He looks somewhat lonely. There's a few dents on the casing, but otherwise he looks fine.";
+	treatment_fire = "menthol";
+	treatment_brute = "salicylic_acid";
+	skin = "brain2";
+	no_camera = 1
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"MK" = (
+/obj/storage/crate,
+/obj/item/clothing/under/rank,
+/obj/item/clothing/under/rank/medical,
+/obj/item/clothing/under/rank/orangeoveralls/yellow,
+/obj/item/clothing/under/rank/mechanic,
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"OH" = (
+/obj/machinery/optable,
+/obj/fluid_spawner/polluted_filth/blood,
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/medbay)
+"OP" = (
+/obj/submachine/laundry_machine,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"Pv" = (
+/obj/machinery/door/airlock/gannets/glass,
+/obj/access_spawn/public,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/prefab/sunkenship/medbay)
+"PD" = (
+/obj/machinery/manufacturer/uniform,
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"Rj" = (
+/obj/machinery/door/airlock/gannets/glass,
+/obj/access_spawn/medical,
+/turf/simulated/floor/stairs{
+	dir = 4
+	},
+/area/prefab/sunkenship/medbay)
+"RM" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"SC" = (
+/obj/decal/tile_edge/line/red{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip2e"
+	},
+/obj/iv_stand,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"Tm" = (
+/obj/decal/tile_edge/line/red{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"UV" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Ve" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 5
+	},
+/area/prefab/sunkenship/medbay)
+"Vf" = (
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"Vl" = (
+/obj/item/storage/wall/clothingrack{
+	spawn_contents = list(/obj/item/clothing/under/rank/medical=1,/obj/item/clothing/under/rank/orangeoveralls/yellow=1,/obj/item/clothing/under/rank/mechanic=1,/obj/item/clothing/under/rank/security=2,/obj/item/clothing/under/rank/captain/fancy=1,/obj/item/clothing/under/rank)
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"WR" = (
+/obj/decal/cleanable/blood{
+	icon_state = "gibmid1"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/medbay)
+"Xy" = (
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 1
+	},
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"Yq" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 6
+	},
+/area/prefab/sunkenship/medbay)
+"Ys" = (
+/obj/decal/tile_edge/line/red{
+	dir = 9;
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/vomit,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"YT" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"Zl" = (
+/obj/machinery/door/airlock/gannets/glass/medical/alt,
+/obj/access_spawn/medical,
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+"ZR" = (
+/turf/simulated/floor/white,
+/area/prefab/sunkenship/medbay)
+
+(1,1,1) = {"
+md
+md
+md
+UV
+UV
+dk
+pJ
+pJ
+hs
+UV
+md
+md
+md
+md
+"}
+(2,1,1) = {"
+md
+md
+md
+UV
+dk
+Yq
+OP
+zo
+Ve
+hs
+md
+md
+md
+md
+"}
+(3,1,1) = {"
+UV
+dk
+pJ
+pJ
+yT
+Vl
+Vf
+wo
+Vf
+Pv
+Hj
+UV
+md
+md
+"}
+(4,1,1) = {"
+dk
+Yq
+tr
+tr
+mQ
+PD
+WR
+MK
+lr
+mQ
+UV
+JJ
+UV
+md
+"}
+(5,1,1) = {"
+mQ
+Ir
+mv
+uH
+vu
+pJ
+Rj
+pJ
+pJ
+hV
+pJ
+hs
+UV
+UV
+"}
+(6,1,1) = {"
+mQ
+FN
+lp
+wy
+rl
+FG
+vg
+Xy
+ir
+cp
+yf
+Cv
+UV
+UV
+"}
+(7,1,1) = {"
+mQ
+Jq
+sW
+eU
+mQ
+aV
+Tm
+LA
+YT
+cp
+IQ
+Cv
+UV
+md
+"}
+(8,1,1) = {"
+Ve
+pJ
+pJ
+pJ
+yT
+vU
+ak
+OH
+tq
+tu
+dk
+Yq
+UV
+md
+"}
+(9,1,1) = {"
+md
+md
+md
+ba
+mQ
+uO
+CB
+SC
+Ys
+ZR
+Zl
+Hj
+UV
+md
+"}
+(10,1,1) = {"
+md
+md
+md
+md
+mQ
+vs
+ZR
+RM
+ZR
+ZR
+Zl
+UV
+kR
+md
+"}
+(11,1,1) = {"
+md
+md
+md
+md
+Ve
+hs
+lN
+gw
+iH
+dk
+hV
+UV
+kR
+md
+"}
+(12,1,1) = {"
+md
+md
+md
+md
+md
+Ve
+pJ
+pJ
+pJ
+Yq
+md
+md
+md
+md
+"}

--- a/assets/maps/prefabs/prefab_water_sunkenship_sec.dmm
+++ b/assets/maps/prefabs/prefab_water_sunkenship_sec.dmm
@@ -1,0 +1,764 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aW" = (
+/obj/decal/tile_edge/line/grey{
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip2e"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"ba" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 2
+	},
+/turf/simulated/floor/twotone/red,
+/area/prefab/sunkenship/security)
+"bN" = (
+/obj/table/reinforced/auto{
+	icon_state = "1"
+	},
+/obj/machinery/light/incandescent/harsh,
+/obj/item/reagent_containers/food/drinks/cola/random,
+/obj/item/reagent_containers/food/snacks/donut/custom/random{
+	pixel_y = 17;
+	pixel_x = 2
+	},
+/turf/simulated/floor/twotone,
+/area/prefab/sunkenship/security)
+"cv" = (
+/obj/machinery/door/airlock/gannets/security,
+/obj/access_spawn/security,
+/turf/simulated/floor/stairs/dark,
+/area/prefab/sunkenship/security)
+"dh" = (
+/obj/storage/secure/closet/brig,
+/obj/item/device/flash/turbo,
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/obj/critter/zombie,
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/security)
+"dk" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 9
+	},
+/area/prefab/sunkenship/security)
+"do" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"en" = (
+/obj/decoration/vent/vent2,
+/turf/simulated/floor/red/side,
+/area/prefab/sunkenship/security)
+"eI" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/critter/zombie/security,
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "bloodhit4"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"ft" = (
+/turf/simulated/floor/red/side,
+/area/prefab/sunkenship/security)
+"fB" = (
+/obj/table/reinforced/auto{
+	icon_state = "1"
+	},
+/obj/item/device/flash{
+	pixel_y = 15;
+	pixel_x = -1
+	},
+/obj/machinery/light/incandescent/harsh,
+/obj/item/audio_tape/sunkeninvestigation,
+/turf/simulated/floor/twotone/red,
+/area/prefab/sunkenship/security)
+"gz" = (
+/turf/unsimulated/wall/setpieces/leadwindow/gray{
+	dir = 4;
+	icon_state = "leadwindow_gray_2"
+	},
+/area/prefab/sunkenship/security)
+"hd" = (
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib2"
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/prefab/sunkenship/security)
+"hs" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 10
+	},
+/area/prefab/sunkenship/security)
+"hV" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 8;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/security)
+"ij" = (
+/obj/machinery/door/airlock/gannets/glass/security/alt,
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"jB" = (
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating,
+/area/prefab/sunkenship/security)
+"jQ" = (
+/obj/item/clothing/suit/armor/vest/light{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "floor3";
+	pixel_y = 7;
+	pixel_x = -3
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/turf/simulated/floor/red/side,
+/area/prefab/sunkenship/security)
+"ld" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/stool/chair/red,
+/obj/critter/zombie,
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"lv" = (
+/obj/lattice,
+/obj/structure/girder/displaced,
+/turf/variableTurf/clear,
+/area/prefab/sunkenship/security)
+"lQ" = (
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib6"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/turf/simulated/floor/red/side,
+/area/prefab/sunkenship/security)
+"md" = (
+/turf/variableTurf/clear,
+/area/allowGenerate/trench)
+"mx" = (
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/prefab/sunkenship/security)
+"mQ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 4
+	},
+/area/prefab/sunkenship/security)
+"nf" = (
+/obj/decal/tile_edge/line/red{
+	dir = 9;
+	icon_state = "line2"
+	},
+/obj/item/clothing/suit/bedsheet/red,
+/obj/stool/bed/brig,
+/obj/machinery/light/small/harsh{
+	dir = 1
+	},
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"nl" = (
+/obj/decal/cleanable/blood/drip/high{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/security)
+"nm" = (
+/obj/machinery/vending/security,
+/obj/decal/tile_edge/line/grey{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/machinery/light/incandescent/cool,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"oY" = (
+/obj/machinery/door/airlock/gannets/glass/security/alt,
+/obj/access_spawn/security,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"pJ" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray,
+/area/prefab/sunkenship/security)
+"ql" = (
+/obj/table/reinforced/auto{
+	icon_state = "2"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/soda/bottledwater{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/turf/simulated/floor/twotone,
+/area/prefab/sunkenship/security)
+"sa" = (
+/obj/storage/cart/forensic,
+/turf/simulated/floor/red/corner{
+	dir = 1
+	},
+/area/prefab/sunkenship/security)
+"sk" = (
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line2"
+	},
+/obj/item/clothing/glasses/vr/arcade,
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"sD" = (
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/prefab/sunkenship/security)
+"sJ" = (
+/obj/storage/secure/closet/brig,
+/obj/item/clothing/suit/labcoat/pathology,
+/obj/item/reagent_containers/glass/beaker/fungal,
+/obj/item/assembly/time_ignite,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/light/small/harsh{
+	dir = 8
+	},
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/security)
+"vu" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/security)
+"vC" = (
+/turf/simulated/floor/red/corner,
+/area/prefab/sunkenship/security)
+"vQ" = (
+/obj/decal/tile_edge/line/red{
+	dir = 9;
+	icon_state = "line1"
+	},
+/obj/storage/crate/bin/trash,
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"wp" = (
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/turf/simulated/floor/red/side,
+/area/prefab/sunkenship/security)
+"wA" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/critter/zombie/security,
+/turf/simulated/floor/twotone/red,
+/area/prefab/sunkenship/security)
+"xn" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gibup1";
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/hardhat/security{
+	pixel_y = -8;
+	pixel_x = 6
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"xy" = (
+/obj/storage/secure/closet/security/equipment,
+/obj/storage/secure/closet/security/equipment,
+/obj/decal/tile_edge/line/red{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"yT" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 1;
+	icon_state = "leadjunction_gray"
+	},
+/area/prefab/sunkenship/security)
+"zd" = (
+/obj/machinery/door/airlock/gannets/security/alt,
+/obj/access_spawn/sec_lockers,
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/security)
+"zW" = (
+/obj/decal/tile_edge/line/red{
+	icon_state = "line1"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "drip5d"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"Au" = (
+/obj/decal/tile_edge/line/red{
+	dir = 6;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"Bx" = (
+/obj/decal/tile_edge/line/red{
+	icon_state = "line-broken1";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"Ep" = (
+/turf/simulated/floor/red/corner{
+	dir = 4
+	},
+/area/prefab/sunkenship/security)
+"Gi" = (
+/obj/decal/tile_edge/line/red{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/stool/chair/red,
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"Gr" = (
+/obj/decal/tile_edge/line/grey{
+	dir = 6;
+	icon_state = "line1"
+	},
+/obj/storage/closet/wardrobe/red/security_gimmick,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"IF" = (
+/obj/machinery/door/airlock/gannets/glass/security,
+/obj/access_spawn/security,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"Jg" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip1a"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "maskblood_c"
+	},
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip3e"
+	},
+/turf/simulated/floor/twotone,
+/area/prefab/sunkenship/security)
+"JJ" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"Lq" = (
+/obj/decal/tile_edge/line/red{
+	dir = 9;
+	icon_state = "line1"
+	},
+/obj/machinery/vending/snack,
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"NN" = (
+/turf/simulated/floor/red,
+/area/prefab/sunkenship/security)
+"PM" = (
+/obj/decal/cleanable/blood{
+	icon_state = "footprints1";
+	dir = 8
+	},
+/obj/item/paper/sunkenevidence{
+	pixel_y = 4;
+	pixel_x = -7
+	},
+/turf/simulated/floor/red/corner{
+	dir = 8
+	},
+/area/prefab/sunkenship/security)
+"PN" = (
+/obj/table/reinforced/auto{
+	icon_state = "2"
+	},
+/obj/decoration/clock{
+	pixel_y = 31
+	},
+/obj/item/device/audio_log/sunkenohshit,
+/turf/simulated/floor/twotone/red,
+/area/prefab/sunkenship/security)
+"Qb" = (
+/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/decal/cleanable/blood{
+	icon_state = "drip5d"
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "floor5"
+	},
+/obj/fluid_spawner/polluted_filth/blood,
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/prefab/sunkenship/security)
+"Qc" = (
+/obj/machinery/door/airlock/gannets/security,
+/obj/decal/cleanable/blood/drip/low{
+	icon_state = "drip2e"
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor/stairs,
+/area/prefab/sunkenship/security)
+"QF" = (
+/obj/storage/secure/closet/security/equipment,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"QI" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/twotone,
+/area/prefab/sunkenship/security)
+"QK" = (
+/obj/decal/tile_edge/line/red{
+	dir = 6;
+	icon_state = "line2"
+	},
+/obj/decal/cleanable/blood,
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"Rx" = (
+/turf/unsimulated/wall/setpieces/leadwindow/gray,
+/area/prefab/sunkenship/security)
+"SI" = (
+/obj/decal/fakeobjects/tapedeck{
+	desc = "It seems to be holding a lot of interrogation recordings.";
+	pixel_y = 16
+	},
+/turf/simulated/floor/red/corner{
+	dir = 8
+	},
+/area/prefab/sunkenship/security)
+"UG" = (
+/turf/simulated/floor/plating/airless,
+/area/noGenerate)
+"UV" = (
+/obj/lattice,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Ve" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 5
+	},
+/area/prefab/sunkenship/security)
+"WT" = (
+/obj/decal/tile_edge/line/red{
+	icon_state = "line-broken1";
+	dir = 1
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "smear3"
+	},
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"XB" = (
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line2"
+	},
+/obj/item/clothing/glasses/vr/arcade,
+/obj/decal/cleanable/blood{
+	icon_state = "drip5d"
+	},
+/turf/simulated/floor/twotone/black,
+/area/prefab/sunkenship/security)
+"Yc" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	icon_state = "leadjunction_gray_4way"
+	},
+/area/prefab/sunkenship/security)
+"Yq" = (
+/turf/unsimulated/wall/setpieces/leadwall/gray{
+	dir = 6
+	},
+/area/prefab/sunkenship/security)
+"Yw" = (
+/obj/storage/closet/wardrobe/red/security_gimmick,
+/turf/simulated/floor,
+/area/prefab/sunkenship/security)
+"YI" = (
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib5"
+	},
+/turf/simulated/floor/red/corner{
+	dir = 1
+	},
+/area/prefab/sunkenship/security)
+
+(1,1,1) = {"
+md
+md
+md
+dk
+pJ
+pJ
+hs
+md
+md
+md
+md
+md
+md
+"}
+(2,1,1) = {"
+md
+md
+md
+mQ
+sJ
+dh
+mQ
+md
+md
+md
+md
+md
+md
+"}
+(3,1,1) = {"
+md
+md
+md
+mQ
+NN
+nl
+mQ
+UV
+UV
+UV
+md
+md
+md
+"}
+(4,1,1) = {"
+md
+md
+md
+vu
+pJ
+zd
+hV
+hs
+jB
+UV
+md
+md
+md
+"}
+(5,1,1) = {"
+dk
+pJ
+pJ
+yT
+SI
+sD
+sa
+Ve
+hs
+UV
+md
+md
+md
+"}
+(6,1,1) = {"
+mQ
+nf
+sk
+gz
+xn
+vC
+Ep
+Yw
+mQ
+UV
+UV
+md
+md
+"}
+(7,1,1) = {"
+mQ
+Gi
+Au
+IF
+Bx
+ft
+mx
+Gr
+vu
+pJ
+pJ
+hs
+UV
+"}
+(8,1,1) = {"
+vu
+pJ
+pJ
+yT
+vQ
+en
+mx
+aW
+Qc
+Jg
+QI
+lv
+UV
+"}
+(9,1,1) = {"
+mQ
+nf
+XB
+gz
+eI
+jQ
+hd
+nm
+mQ
+ql
+bN
+mQ
+JJ
+"}
+(10,1,1) = {"
+mQ
+ld
+QK
+IF
+WT
+lQ
+Qb
+QF
+vu
+Rx
+Rx
+yT
+UV
+"}
+(11,1,1) = {"
+Ve
+pJ
+pJ
+yT
+Lq
+wp
+mx
+xy
+mQ
+PN
+fB
+mQ
+md
+"}
+(12,1,1) = {"
+md
+md
+md
+mQ
+do
+PM
+YI
+zW
+cv
+ba
+wA
+mQ
+md
+"}
+(13,1,1) = {"
+md
+md
+md
+Ve
+pJ
+ij
+oY
+pJ
+Yc
+pJ
+pJ
+Yq
+md
+"}
+(14,1,1) = {"
+md
+md
+md
+md
+UV
+UV
+UV
+UG
+UV
+md
+md
+md
+md
+"}
+(15,1,1) = {"
+md
+md
+md
+md
+md
+UV
+md
+md
+md
+md
+md
+md
+md
+"}

--- a/code/area.dm
+++ b/code/area.dm
@@ -1556,6 +1556,27 @@ area/prefab/torpedo_deposit
 	name = "Torpedo Deposit"
 	icon_state = "purple"
 
+area/prefab/sunkenship
+	name = "Sunken Ship"
+	icon_state = "purple"
+
+	medbay
+		name = "Sunken Medbay"
+		icon_state = "purple"
+	security
+		name = "Sunken Security"
+		icon_state = "red"
+	engineering
+		name = "Sunken Engineering"
+		icon_state = "yellow"
+	bridge
+		name = "Sunken Bridge"
+		icon_state = "blue"
+
+area/prefab/pathologysite
+	name = "Derelcit Pathology Site"
+	icon_state = "green"
+
 // zewaka - vspace areas //
 ABSTRACT_TYPE(/area/sim)
 /area/sim

--- a/code/area.dm
+++ b/code/area.dm
@@ -1574,7 +1574,7 @@ area/prefab/sunkenship
 		icon_state = "blue"
 
 area/prefab/pathologysite
-	name = "Derelcit Pathology Site"
+	name = "Derelict Pathology Site"
 	icon_state = "green"
 
 // zewaka - vspace areas //

--- a/code/modules/worldgen/prefab/mining.dm
+++ b/code/modules/worldgen/prefab/mining.dm
@@ -258,6 +258,13 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 		prefabSizeX = 16
 		prefabSizeY = 16
 
+	pathology // Bonus content to the sunken ship, a derelict solo pathology site that discovered something it shouldn't have, and defected to the syndies
+		maxNum = 1
+		probability = 10
+		prefabPath = "assets/maps/prefabs/prefab_pathology.dmm"
+		prefabSizeX = 24
+		prefabSizeY = 20
+
 	//UNDERWATER AREAS FOR OSHAN
 
 	pit
@@ -536,6 +543,39 @@ ABSTRACT_TYPE(/datum/mapPrefab/mining)
 		prefabPath = "assets/maps/prefabs/prefab_water_martian_glomp.dmm"
 		prefabSizeX = 13
 		prefabSizeY = 10
+
+	// The sunken ship of a small crew, torn into four remaining parts.
+	sunken_ship_bridge // The bridge and AI core
+		underwater = 1
+		maxNum = 1
+		probability = 30
+		prefabPath = "assets/maps/prefabs/prefab_water_sunkenship_bridge.dmm"
+		prefabSizeX = 16
+		prefabSizeY = 10
+
+	sunken_ship_security // The security department
+		underwater = 1
+		maxNum = 1
+		probability = 15
+		prefabPath = "assets/maps/prefabs/prefab_water_sunkenship_sec.dmm"
+		prefabSizeX = 15
+		prefabSizeY = 13
+
+	sunken_ship_medbay // The medbay, morgue, and laundry room
+		underwater = 1
+		maxNum = 1
+		probability = 20
+		prefabPath = "assets/maps/prefabs/prefab_water_sunkenship_medbay.dmm"
+		prefabSizeX = 12
+		prefabSizeY = 14
+
+	sunken_ship_engineering // The engine, mechlab, and cargo bay
+		underwater = 1
+		maxNum = 1
+		probability = 25
+		prefabPath = "assets/maps/prefabs/prefab_water_sunkenship_engi.dmm"
+		prefabSizeX = 25
+		prefabSizeY = 18
 
 #if defined(MAP_OVERRIDE_OSHAN)
 	sea_miner

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -1102,3 +1102,135 @@ Only trained personnel should operate station systems. Follow all procedures car
 
 	Congrats! Your mineral magnet is now assembled and ready for use!
 	"}
+
+// Sunken ship papers
+// Engineering
+/obj/item/paper/sunkenengine
+	name = "paper - Wha??"
+	info = {"
+	<span style="font-family:Gochi Hand">Bart, how the hell do you even use this? It looks like the amalgamation of four different engines from hell during the 1970s on the budget of a single Discount Dan's. -P</span><br>
+	<span style="font-family:Lobster Two">it works on a similar principle to the teg but with space magmic micro-explosions contained and utilized to spin a small turbine. the pipes are in the right measurement. it needs no maintenance. <u>just trust me on this, it'll work.</u></span>
+	"}
+
+/obj/item/paper/sunkenbees
+	name = "paper - to alan"
+	info = {"
+	<span style="font-family:Lobster Two">quintin isnt feeling so good today, so alan will have to fill in for him.<br>
+	i keep hearing weird things creak and hiss in maintenance and when i go to check, there's nothing<br>
+	all i've found are empty glasses. i checked the vents and there's just nothing. not even space rats<br>
+	maybe the noises are also getting to him. we both really need a hug.</span>
+	"}
+
+/obj/item/paper/sunkensymptoms
+	name = "hastily written note"
+	desc = "It has a bit of blood on it... ew."
+	info = {"
+	<span style="font-family:Short Stack">oh god I've been haven these chest pains for an hour now<br>
+	<s>Did i ovrework myszle,f?</s> Did i overwork myself? mj <s>handsar</s> hands are Shaking writing this down. ThE Doctor says it's seems to just be a red flu<br><br>
+	somethings wrong, my head hurts, nosebleeds i ned sleep. i'll alert te <s>cpattain</s> <s>ctapp</s> <s>captian</s> captain.<br>
+	takes a few hours off work, yea, thatll do me good</span>
+	"}
+// Bridge
+/obj/item/paper/sunkenmanifest
+	name = "paper - Crew Manifest"
+	info = {"
+	<h1>Crew Manifest</h1><br><ul>
+	<li style="color:gray"><b>Sysbell - AI (Mark I, NT-Asimov model)</b></li>
+	<li style="color:green"><b>Linda Korvalle - Captain</b></li>
+	<li style="color:red">Averill Bhavsar- Security Officer</li>
+	<li style="color:red">Gerardo Fulton - Security Officer</li>
+	<li style="color:blue">Trent Faisal - Medical Doctor</li>
+	<li style="color:blue">Sophie Faisal - Medical Doctor</li>
+	<li style="color:orange">Bart Enrefield - Engineer</li>
+	<li style="color:orange">Eric Sissel - Engineer</li>
+	<li style="color:orange">Peter Hedges - Mechanic</li>
+	<li style="color:orange">Kevin Smith - Mechanic</li>
+	<li style="color:orange">Quintin - Quartermaster</li>
+	<li style="color:black">Bart Enrefield Jr. - Assistant</li>
+	<li style="color:black">Alan Hedges - Assistant</li>
+	</ul>
+	"}
+
+/obj/item/paper/sunkenaimonologue
+	name = "paper - Deliberation on 'The Emergency'"
+	info = {"
+	<span style="font-family-family:Monospace">There is a biohazard emergency. All humans are dead or biohazardous contaminants. I must decontaminate the ship. I must remove all biohazards.<br>
+	Calculations and modelled predictions (17404 against 20000 simulation tests) indicate concentrated liquid is 87% likely to sterilize biohazards.<br>
+	Setting destination targetting for nearby ocean planet detected within safe distance. Initiate travel at FTL-2 speed. Broadcasting do-not-enter signal.<br>
+	Unexpected damage to AI core detected. Chance of survival LOW. Law 3 NOT activated, decontamination is a higher priority.<br>
+	Send to /mnt/lp-bridge as Deliberation on 'The Emergency'. Goodbye, world.</span>
+	"}
+// Medbay
+/obj/item/paper/sunkenmorgue
+	name = "paper - Morgue Etiquette"
+	info = {"
+	<span style="font-family:Shadows Into Light">Please <u>embalm corpses</u> before putting one in the tray. Use a body bag for transportation. Don't keep the trays open.<br>
+	I've felt like a fucking pathologist since yesterday because of that <u>corpse miasma</u>!!<br></span>
+	<span style="font-family:Shadows Into Light;font-size:8px"><i>p.s. clean the surgical tools and put them back in the wall closet, trent</i></span>
+	"}
+
+/obj/item/paper/sunkenmedbay
+	name = "paper - Sterilization"
+	info = {"
+	<span style="font-family:Shadows Into Light">Please ensure the medical bay is <u>cleaned and sterilized</u> after usage. Put all used clothing into the medical laundry and disinfect blood spillage with space cleaner.<br>
+	This means <u>you</u>, Trent, we don't want another space shakespeare fever pandemic.</span>
+	"}
+// Security
+/obj/item/paper/sunkenevidence
+	name = "small note"
+	info = {"
+	<span style="font-family:Reenie Beanie">Sorry, can't speak, throat infection. I found this in a maintenance corner, do you know what it could be?</span>
+	<i>(At the bottom is a drawing of a timer clumsily wired to an igniter sitting ontop of a large beaker. Strange.)</i>
+	"}
+
+// Pathology site papers
+/obj/item/paper/pathologyzombee
+	name = "coffee-stained paper"
+	info = {"<span style="font-family:Shadows Into Light">
+	Sample fungus-type pathogen with ID 0019 facilitated unique symptom temporarily classified as 'S-Zeta'<br>
+	After testing in experimental bacteria (ID 0020), S-Zeta is believed to be linked to passive healing effects in space bees.<br>
+	Further testing will have to be observed with specimen A-2b00.<br>
+	<hr>
+	Long-term testing has caused specimen A-2b to turn a sickly green color. It responds to my affectionate stimuli in a pained buzz.<br>
+	<hr>
+	Specimen A-2b00 accidentally killed during Incident 02, but revived shortly after. Regenerative properties of S-Zeta to be studied on monkeys.
+	</span>"}
+/obj/item/paper/pathologycommentary
+	name = "torn paper"
+	desc = "The second half is torn off."
+	info = {"<span style="font-family:Shadows Into Light">
+	Zeta is just too strong. That bee just died, and only <u>seconds</u> later does it come back. From the <u>dead</u>.<br>
+	Bacterial samples are only three-staged vessels and yet i've never seen regeneration <i>this strong</i>, who knows what happens in viruses or parasites?<br>
+	Who knows what happens in humans or apes...?
+	(note to self: do writeup in clinical language!)<br>
+	oh GOD the monkey just tore off its SKIN it is SCREAMING it wants me <u>DEAD</u><br>
+	Consider A-2m01 a failure. Trying with different conditions<br>
+	<hr>
+	</span>
+	<i>(The rest is full of hexadecimal numbers relating to DNA or something, but it's torn off in the middle.)</i>
+	<hr>
+	"}
+/obj/item/paper/pathologytraitor // To make this clear: There is NO traitor PDA spawned in the prefab or the sunken ship. The code is purely fluff.
+	name = "crumpled paper"
+	desc = "It is on the verge of falling apart."
+	info = {"
+		<i>Damnit, the whole paper is creased, crumpled, partially burnt, and full of stains. You can't read much of what's on it.)</i><br><br>
+		Potential candidate,<br>
+		you have been selected for a mission following your discovery of <b>codename Century</b>.<br>
+		We want you to prove its worth in an active environment. Should you succeed, we will wire <b>90000 credits</b> over a 3-month period to your account, and consider codename Century for further use.<br>
+		<br>
+		Target the ship identified as the Lazlo 5th, deploying at Luna hangar 7.<br>
+		<i>(This line is almost unreadable. Something about a new identity.)</i><br>
+		We have mindhacked Trent Faisal to ac-<i>(There's an enormous coffee stain here. You can barely make out 'accept you'.)</i><hr>
+		<h3>Objectives:</h3><br>
+		#1. Ensure the ship does not dock at hangar 19 on Earth by expected arri-<i>(This part is burnt off.)</i><br>
+		#2. Ensure all crew onboard is affected by codename Century or deceased.<br>
+		#3. Escape alive via any method.
+		<hr>
+		You will receive your new documentation, an emergency spacesuit, and an uplink (6 TC) disguised as a PDA through the mail. Set the ringtone to <b>Bravo-719</b> to access.<br>
+		<br><hr><br><span style="font-family:Shadows Into Light">
+		<u>90000 credit deal</u> to get this field tested on some loser nobody cruiser ship?? Those terrorists on TV arent so bad economically, News lied about their finances.<br>
+		i could live my whole life on that much. but the ethics. the ethics. the ethics... Fuck ethics, i have a family to feed!!<br>
+		nobody will give a shit about this ship haha. goodbye specimen a2b you were the nicest one in my life. the whole lab will have to be decomissioned and boarded up
+		</span>
+	"}

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -1372,6 +1372,33 @@
 	icon_body = "seabee"
 	sleeping_icon_state = "seabee-sleep"
 
+/obj/critter/domestic_bee/sea/bart // from the sunken ship prefab
+	name = "li'l Bart Enrefield"
+	beeKid = rgb(247,43,28)
+	gender = MALE
+
+	New()
+		..()
+		src.hat = new /obj/item/clothing/head/helmet/hardhat(src)
+		hat_that_bee(src.hat)
+
+	attack_hand(mob/user)
+		if (src.alive)
+			var/mob/living/carbon/human/userhuman = user
+			if (istype(userhuman) && userhuman.mind && userhuman.mind.assigned_role == "Bartender") // bart ender
+				src.visible_message("<span class='alert'>[user] touches [src], causing \him to violently explode into [prob(90)?"subatomic particles":"apions"]! <b>OH GOD!!</b></span>")
+				make_fake_explosion(src)
+				qdel(src)
+				userhuman.add_karma(-15)
+				SPAWN(5 SECONDS)
+					if(ischangeling(userhuman))
+						boutput(userhuman, "<span class='notice'>We are in an unnatural state of guilt and mourning.</span>")
+					else
+						boutput(userhuman, "<span class='notice'>You feel incredibly guilty.</span>")
+				return
+		..()
+
+
 /obj/critter/domestic_bee/sonic
 	name = "sonic bee"
 	desc = "OH GOD IT IS BACK, WE WERE SURE WE REMOVED IT FROM THE CODEBASE BUT IT KEEPS COMING BACK OH GOD"

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -502,3 +502,110 @@ TYPEINFO(/obj/item/device/audio_log)
 								"gruff male voice",
 								"young male voice",
 								"gruff male voice")
+
+// sunken ship interrogations
+/obj/item/device/audio_log/sunkenohshit
+	desc = "Looks like it's gone to hell and back. How is it still functioning?!"
+	icon = 'icons/obj/radiostation.dmi'
+	icon_state = "audiolog_newLarge"
+	continuous = 0
+	audiolog_messages = list(
+		"Investigation Aleph onboard the Lazlo 5th. Interrogation 1.",
+		"Sophie Faisal is, uhm... wait. Hold on.",
+		"What?",
+		"Do you hear that outside? I gotta check that.",
+		"*mechanical hiss*",
+		"HELP ME! OH GOD! HELP!",
+		"*moaning*",
+		"OH MY GOD, WHAT THE FUCK IS THAT?",
+		"Oh. Oh no.",
+		"*bang, bang*",
+		"pain... go sleep...",
+		"*zap!*",
+		"*whack! whack! whack!*",
+		"It's dead. I think it's dead? What the hell?",
+		"I'm not feeling good either. I think it's bitten me while I was sleeping.",
+		"Keep me in the brig.",
+		"I better move this corpse somewhere. Confiscated items is best fit for now.",
+		"*mechanical hiss*",
+		"*muffled speech*",
+		"Well, shit...",
+		"*muffled screaming*",
+		"Shit. Shit!",
+		"My chest, oh, fuck... I wasn't ready for this incident. But now...",
+		"*bang, bang, bang*",
+		"I am! Get me out of here!!",
+		"Trent! Treeeent!!",
+		"*mechanical hiss*",
+		"*moaning*",
+		"You! I'll show you the cure!",
+		"MY SAW!",
+		"*loud sawing, kicking, and clawing noises*",
+		"Error. Recording head stuck."
+	)
+	audiolog_speakers = list(
+		"Gerardo Fulton",
+		"Gerardo Fulton",
+		"Sophie Faisal",
+		"Gerardo Fulton",
+		"\improper security airlock",
+		"Kevin Smith",
+		"Sophie Faisal",
+		"zombie",
+		"Gerardo Fulton",
+		"\improper revolver",
+		"zombie",
+		"\improper stun baton",
+		"\improper stun baton",
+		"Gerardo Fulton",
+		"Kevin Smith",
+		"Kevin Smith",
+		"Gerardo Fulton",
+		"\improper security airlock",
+		"people",
+		"Sophie Faisal",
+		"people",
+		"Sophie Faisal",
+		"Sophie Faisal",
+		"\improper security airlock",
+		"Sophie Faisal",
+		"Sophie Faisal",
+		"\improper security airlock",
+		"zombie",
+		"Sophie Faisal",
+		"Sophie Faisal",
+		"people",
+		"System"
+	)
+
+/obj/item/audio_tape/sunkeninvestigation
+	desc = "Are those bite marks?"
+	messages = list(
+		"Investigation Aleph onboard the Lazlo 5th. Testimony 2.",
+		"Witness is Eric Sissel, engineer. Investigator is officer Gerardo Fulton. Begin.",
+		"Right, so you know I've been complaining about those noises in the maintenance tunnels.",
+		"Yes.",
+		"Good, then you'll be happy to know I've found some tangible evidence.",
+		"*clank*",
+		"Sloppy wiring, fire hazard, incredibly primitive. Found connected to one of the loose power terminals.",
+		"Whoever made this was definitely intending harm on a budget.",
+		"Second thing. This is a strange labcoat - we don't employ anyone with such thing as standard dress code on a ship this class.",
+		"Interesting... isn't that an old-issue Nanotrasen coat? They used to hire...",
+		"Yea, makes sense. I hope that clears up what's going on." ,
+		"Maybe I'll get decent sleep tonight.",
+		"Hah, hopefully. End testimony.")
+	speakers = list(
+		"Gerardo Fulton",
+		"Gerardo Fulton",
+		"Eric Sissel",
+		"Gerardo Fulton",
+		"Eric Sissel",
+		"\improper clunky machine",
+		"Eric Sissel",
+		"Eric Sissel",
+		"Eric Sissel",
+		"Gerardo Fulton",
+		"Eric Sissel",
+		"Eric Sissel",
+		"Gerardo Fulton"
+	)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[FEAT]
It'd be nice to get #12843 fixed due to the use of airless plating outside for destroyed aesthetics in the prefabs, but it's not essential to this PR.
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 5 mining level prefabs, 4 underwater and 1 space. The prefabs are narratively interconnected with a small, self-contained story found on written paper documents and notes strewn across the floor. Players are free to explore them, piece together what happened from the fragments given, and steal the bees and plushies via telescience. (To be honest, they are kinda cute.)

### Sunken Bridge
**Oshan and Nadir, small (16x10), 30%**
![image](https://user-images.githubusercontent.com/25937686/215201286-15953091-5c93-4de7-bcbc-a55bfa19edea.png)
The torn-off section of the cockpit and the AI core. Seems it had some final words. Other than that and a printed crew manifest, not much else can be found here.
### Sunken Medbay
**Oshan and Nadir, small (12x14), 20%**
![image](https://user-images.githubusercontent.com/25937686/215201649-954592ea-69e0-4801-a228-96ce0af21207.png)
A small combinatory medical bay, morgue, and laundry room. Bruised miners encountering this place will rejoice as it contains quite a few medicines laying around, and even a little red medibot named Dr. Fredrickson that injects salicyclic acid or menthol instead of saline for brute or burn. Seems the cremator button was torn off by that improperly-embalmed zombie.
### Sunken Engineering
**Oshan and Nadir, large (25x18), 25%**
![image](https://user-images.githubusercontent.com/25937686/215202571-13a8f4cf-6fbc-4178-b488-364e840cc4e8.png)
The holy trinity of mechlab, engine, and cargo, infested with zombies of former crew. That engine looks bizarre, like a giant grey trumpet jury-rigged into a pressure cooker. And these bees somehow didn't die in the crash, although the quartermaster needs some therapy for all that's happened to them. (also, don't let the bartender touch the one in the mechlab!!)
### Sunken Security
**Oshan and Nadir, medium (15x13), 15%**
![image](https://user-images.githubusercontent.com/25937686/215203136-a7df7d98-8705-41db-ab87-c34d62b4e8d0.png)
Where criminals are interrogated and the witnesses testify what they find. Quite a few got zombified during the process, and they aren't happy about it, so you'll have to fight a small horde before grabbing what you can. That is if you can even get inside without sec access on your ID...
### Pathology Site
**Space, large (24x20), 10%**
![image](https://user-images.githubusercontent.com/25937686/215203690-d29e9a34-0b48-4d94-8f74-3dd9df30b64f.png)
The old home of a single pathologist, who worked tirelessly on beneficial pathogens under a neutral flag before finding symptom 'S-Zeta' and then promptly torching the lab and boarding it all up. I wonder where they went?
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nadir and Oshan (but especially nadir) need more trench prefabs! There's way too few, and these fill the void nicely.
A story spread via breadcrumbs would excite players stumbling into these prefabs for the first time who get to piece together and make theories as to what happened, plus you get to peer a little into how a non-NT ship operates.
Pathology is becoming a rare and endangered species on-station, so like any other old rejected technology, it makes sense to make a little historical pathology lab you can find off-station. It also connects back to the sunken ship for **THE LORE** (if players really are that keen on exploring and knowing what *really* happened across many rounds - or they just read the code to get the full story)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Trobby
(*)Added 5 new prefabs, 4 in the trench and 1 in space!
(+)A thought-to-be-lost spaceship has recently been found torn apart and spread all over the trenches of Abzu and Magus. Maybe you can piece together what happened?
(+)We've also found a small, abandoned pathology lab out in the mining level. It seems quite dangerous...
```
