### PR TITLE
Fixes #12898 - The NukeOp Mission Briefing Will No Longer Spawn If It Cannot Be Placed Into The Commander's Hand

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -221,7 +221,8 @@
 
 		if(synd_mind == leader_mind)
 			synd_mind.add_antagonist(ROLE_NUKEOP_COMMANDER)
-			new /obj/item/device/audio_log/nuke_briefing(synd_mind.current.loc, concatenated_location_names)
+			var/mob/living/carbon/human/H = synd_mind.current
+			H.equip_if_possible(new /obj/item/device/audio_log/nuke_briefing(H, concatenated_location_names), H.slot_r_hand)
 		else
 			synd_mind.add_antagonist(ROLE_NUKEOP)
 


### PR DESCRIPTION
[Gamemodes] [Bug]

## About the PR:
Fixes #12898 by preventing the Mission Briefing tape from spawning if it cannot be placed into the Syndicate Commander's right hand.

I cannot recreate this issue, however given the nature of the issue, potentially revealing Nuclear Operatives early into the round and disclosing their plant locations, it would be prudent to have measures in place to prevent it from ever occurring.