### PR TITLE
changes flower hats to headbands, like cat ears.

### DIFF
--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -300,7 +300,7 @@
 			var/obj/item/reagent_containers/food/snacks/plant/I = W
 			base_score = 2 + I.quality
 
-		else if (istype(W, /obj/item/plant) || istype(W, /obj/item/clothing/head/flower))
+		else if (istype(W, /obj/item/plant) || istype(W, /obj/item/clothing/head/headband/plant/))
 			var/obj/item/plant/I = W
 			base_score = 2 + I.quality
 

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -435,7 +435,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 		if (istype(W,/obj/item/reagent_containers/food/snacks/plant/)) src.reagents.add_reagent("poo", 20)
 		else if (istype(W,/obj/item/reagent_containers/food/snacks/mushroom/)) src.reagents.add_reagent("poo", 25)
 		else if (istype(W,/obj/item/seed/)) src.reagents.add_reagent("poo", 2)
-		else if (istype(W,/obj/item/plant/) || istype(W,/obj/item/clothing/head/flower/)) src.reagents.add_reagent("poo", 15)
+		else if (istype(W,/obj/item/plant/) || istype(W,/obj/item/clothing/head/headband/plant/)) src.reagents.add_reagent("poo", 15)
 		else if (istype(W,/obj/item/organ/)) src.reagents.add_reagent("poo", 35)
 		else load = 0
 
@@ -458,7 +458,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 		if (BOUNDS_DIST(O, src) > 0 || BOUNDS_DIST(O, user) > 0)
 			boutput(user, "<span class='alert'>[O] is too far away to load into [src]!</span>")
 			return
-		if (istype(O, /obj/item/reagent_containers/food/snacks/plant/) || istype(O, /obj/item/reagent_containers/food/snacks/mushroom/) || istype(O, /obj/item/seed/) || istype(O, /obj/item/plant/) || istype(O, /obj/item/clothing/head/flower/))
+		if (istype(O, /obj/item/reagent_containers/food/snacks/plant/) || istype(O, /obj/item/reagent_containers/food/snacks/mushroom/) || istype(O, /obj/item/seed/) || istype(O, /obj/item/plant/) || istype(O, /obj/item/clothing/head/headband/plant/))
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing [O] into [src]!</span>")
 			var/itemtype = O.type
 			var/staystill = user.loc

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -63,7 +63,7 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/critter/slug = 10,\
 	/mob/living/critter/small_animal/snake = 10,\
 	/obj/critter/frog = 10,\
-	/obj/item/clothing/head/rafflesia = 5)
+	/obj/item/clothing/head/headband/plant/rafflesia = 5)
 
 /datum/fishing_spot/test
 	fishing_atom_type = /turf/simulated/floor/ancient

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -802,7 +802,7 @@
 	name = "Pink Hydrangea"
 	name_prefix = "Pink "
 	flower_color = "pink"
-	crop = /obj/item/clothing/head/flower/hydrangea/pink
+	crop = /obj/item/clothing/head/headband/plant/hydrangea/pink
 	PTrange = list(10,30)
 	chance = 25
 
@@ -810,7 +810,7 @@
 	name = "Blue Hydrangea"
 	name_prefix = "Blue "
 	flower_color = "blue"
-	crop = /obj/item/clothing/head/flower/hydrangea/blue
+	crop = /obj/item/clothing/head/headband/plant/hydrangea/blue
 	PTrange = list(30,50)
 	chance = 25
 
@@ -818,6 +818,6 @@
 	name = "Purple Hydrangea"
 	name_prefix = "Purple "
 	flower_color = "purple"
-	crop = /obj/item/clothing/head/flower/hydrangea/purple
+	crop = /obj/item/clothing/head/headband/plant/hydrangea/purple
 	PTrange = list(50,null)
 	chance = 25

--- a/code/modules/hydroponics/plants_flower.dm
+++ b/code/modules/hydroponics/plants_flower.dm
@@ -31,7 +31,7 @@ ABSTRACT_TYPE(/datum/plant/flower)
 /datum/plant/flower/rafflesia
 	name = "Rafflesia"
 	seedcolor = "#A4000F"
-	crop = /obj/item/clothing/head/rafflesia
+	crop = /obj/item/clothing/head/headband/plant/rafflesia
 	growthmode = "weed"
 	starthealth = 40
 	growtime = 50
@@ -64,7 +64,7 @@ ABSTRACT_TYPE(/datum/plant/flower)
 /datum/plant/flower/gardenia
 	name = "Gardenia"
 	seedcolor = "#d5b984"
-	crop = /obj/item/clothing/head/flower/gardenia
+	crop = /obj/item/clothing/head/headband/plant/gardenia
 	cropsize = 3
 	commuts = list(/datum/plant_gene_strain/metabolism_fast, /datum/plant_gene_strain/splicing/disabled)
 
@@ -72,7 +72,7 @@ ABSTRACT_TYPE(/datum/plant/flower)
 	name = "Bird of Paradise"
 	sprite = "BirdofParadise"
 	seedcolor = "#ffb426"
-	crop = /obj/item/clothing/head/flower/bird_of_paradise
+	crop = /obj/item/clothing/head/headband/plant/bird_of_paradise
 	growtime = 300
 	harvtime = 400
 	cropsize = 1
@@ -83,7 +83,7 @@ ABSTRACT_TYPE(/datum/plant/flower)
 /datum/plant/flower/hydrangea
 	name = "Hydrangea"
 	seedcolor = "#875dbc"
-	crop = /obj/item/clothing/head/flower/hydrangea
+	crop = /obj/item/clothing/head/headband/plant/hydrangea
 	growtime = 70
 	harvtime = 120
 	harvests = 3

--- a/code/modules/hydroponics/plants_herb.dm
+++ b/code/modules/hydroponics/plants_herb.dm
@@ -316,7 +316,7 @@ ABSTRACT_TYPE(/datum/plant/herb)
 /datum/plant/herb/lavender
 	name = "Lavender"
 	seedcolor = "#be9ffe"
-	crop = /obj/item/clothing/head/flower/lavender
+	crop = /obj/item/clothing/head/headband/plant/lavender
 	starthealth = 20
 	growtime = 80
 	harvtime = 120

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1415,7 +1415,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 			H.icon_state = src.icon_state
 			H.wear_image_icon = src.wear_image_icon
 			H.wear_image = src.wear_image
-			H.desc = "Aww, cute and fuzzy. Someone has taped a radio headset onto the headband."
+			H.desc = "[src.desc] Someone has taped a radio headset onto the [src.name]." //no more overriding text!
 			qdel(src)
 
 ABSTRACT_TYPE(/obj/item/clothing/head/headband/nyan)

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -1,43 +1,51 @@
-/obj/item/clothing/head/rafflesia
+ABSTRACT_TYPE(/obj/item/clothing/head/headband/plant)
+/obj/item/clothing/head/headband/plant
+	name = "flower"
+	desc = "you probably shouldn't be seeing this!!"
+	icon = 'icons/obj/clothing/item_hats.dmi'
+	wear_image_icon = 'icons/mob/clothing/head.dmi'
+	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
+
+/obj/item/clothing/head/headband/plant/rafflesia
 	name = "rafflesia"
 	desc = "Usually reffered to as corpseflower due to its horrid odor, perfect for masking the smell of your stinky head."
 	icon_state = "rafflesiahat"
 	item_state = "rafflesiahat"
 
-/obj/item/clothing/head/flower/gardenia
+/obj/item/clothing/head/headband/plant/gardenia
 	name = "gardenia"
 	desc = "A delicate flower from the Gardenia shrub native to Earth, trimmed for you to wear. These white flowers are known for their strong and sweet floral scent."
 	icon_state = "flower_gard"
 	item_state = "flower_gard"
 
-/obj/item/clothing/head/flower/bird_of_paradise
+/obj/item/clothing/head/headband/plant/bird_of_paradise
 	name = "bird of paradise"
 	desc = "Bird of Paradise flowers, or Crane Flowers, are named for their resemblance to the ACTUAL birds of the same name. Both look great sitting on your head either way."
 	icon_state = "flower_bop"
 	item_state = "flower_bop"
 
-/obj/item/clothing/head/flower/hydrangea
+/obj/item/clothing/head/headband/plant/hydrangea
 	name = "hydrangea"
 	desc = "Hydrangeas are popular ornamental flowers due to their colourful, pastel flower arrangements; this one has been trimmed nicely for wear as an accessory."
 	icon_state = "flower_hyd"
 	item_state = "flower_hyd"
 
-/obj/item/clothing/head/flower/hydrangea/pink
+/obj/item/clothing/head/headband/plant/hydrangea/pink
 	name = "pink hydrangea"
 	icon_state = "flower_hyd-pink"
 	item_state = "flower_hyd-pink"
 
-/obj/item/clothing/head/flower/hydrangea/blue
+/obj/item/clothing/head/headband/plant/hydrangea/blue
 	name = "blue hydrangea"
 	icon_state = "flower_hyd-blue"
 	item_state = "flower_hyd-blue"
 
-/obj/item/clothing/head/flower/hydrangea/purple
+/obj/item/clothing/head/headband/plant/hydrangea/purple
 	name = "purple hydrangea"
 	icon_state = "flower_hyd-purple"
 	item_state = "flower_hyd-purple"
 
-/obj/item/clothing/head/flower/lavender
+/obj/item/clothing/head/headband/plant/lavender
 	name = "lavender"
 	desc = "Lavender is usually used as an ingredient or as a source of essential oil; you can tuck a sprig behind your ear for that garden aesthetic too."
 	icon_state = "flower_lav"

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -188,7 +188,7 @@
 		icon_state = "hydrosatchel"
 		allowed = list(/obj/item/seed,
 		/obj/item/plant,
-		/obj/item/clothing/head/flower,
+		/obj/item/clothing/head/headband/plant/,
 		/obj/item/reagent_containers/food/snacks,
 		/obj/item/organ,
 		/obj/item/clothing/head/butt,

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1214,7 +1214,7 @@ TYPEINFO(/obj/machinery/plantpot)
 					HYPadd_harvest_reagents(F,growing,DNA,quality_status)
 					// We also want to put any reagents the plant produces into the new item.
 
-				else if(istype(CROP,/obj/item/plant/) || istype(CROP,/obj/item/reagent_containers) || istype(CROP,/obj/item/clothing/head/flower/))
+				else if(istype(CROP,/obj/item/plant/) || istype(CROP,/obj/item/reagent_containers) || istype(CROP,/obj/item/clothing/head/headband/plant/))
 					// If we've got a herb or some other thing like wheat or shit like that.
 					HYPadd_harvest_reagents(CROP,growing,DNA,quality_status)
 

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -687,7 +687,7 @@ TYPEINFO(/obj/submachine/chem_extractor)
 	var/obj/item/reagent_containers/glass/storage_tank_1 = null
 	var/obj/item/reagent_containers/glass/storage_tank_2 = null
 	var/list/ingredients = list()
-	var/list/allowed = list(/obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/clothing/head/flower/,/obj/item/seashell)
+	var/list/allowed = list(/obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/clothing/head/headband/plant/,/obj/item/seashell)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Clothing] [C-QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-changes all flower hats (rafflesia, gardenia, bird of paradise, hydrangea, pink/blue/purple hidrangea, and lavender) into headbands
-combine flowers with headsets to wear them on ears basically
-head bands now inherit the description of the item used


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
people who play mutantraces/people who wanna wear hats should be able to wear flowers too, see below image for what that might look like

![image (4)](https://user-images.githubusercontent.com/84998542/215222117-22725006-ffa9-4b3a-a508-28b4b9bcc861.png)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mora
(+)Flower hats can be combined with headsets to get headset flowers
```
