### PR TITLE
Fixes #12902 - Fixes A Typo Error With Changeling Random Event Respawns

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -339,7 +339,7 @@
 						M3 = L
 						L.mind?.wipe_antagonists()
 						L.mind?.add_antagonist(ROLE_CHANGELING, source = ANTAGONIST_SOURCE_RANDOM_EVENT)
-						role = ROLE_HUNTER
+						role = ROLE_CHANGELING
 					else
 						failed = 1
 


### PR DESCRIPTION
[Gamemodes] [Bug]



## About the PR:
Fixes #12902 by correcting `role = ROLE_HUNTER` to `role = ROLE_CHANGELING` in the random event datum.
_I should have spotted this when datumising changelings._