### PR TITLE
Fixes enzymatic reclaimer suicide bug that made bodies unreclaimable

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -1167,6 +1167,9 @@ TYPEINFO(/obj/machinery/clonegrinder)
 			return 0
 		if (src.process_timer > 0)
 			return 0
+		if (src.occupant)
+			boutput(user, "<span class='alert'>[src] is full, you can't climb inside!</span>")
+			return 0
 
 		src.visible_message("<span class='alert'><b>[user] climbs into [src] and turns it on!</b></span>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Medical] [C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Blocks players from suiciding into an enzymatic reclaimer with a body already inside. This fixes a bug that made reclaimers constantly emit miasma.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a player suicides into an enzymatic reclaimer with a body already inside, that body is not reclaimed, and remains in the reclaimer. It becomes effectively unreachable and constantly emits miasma as it decomposes. This change fixes that issue.

Internally, the issue occurs when the original body remains in the reclaimer's contents list but the value in the occupant variable is overwritten in the suicide proc.



