### PR TITLE
Vending machine slogans now have maptext

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -156,6 +156,7 @@ TYPEINFO(/obj/machinery/vending)
 		src.panel_image = image(src.icon, src.icon_panel)
 		if (!src.chat_text)
 			src.chat_text = new
+		src.vis_contents += src.chat_text
 	var/lastvend = 0
 
 	disposing()
@@ -858,7 +859,7 @@ TYPEINFO(/obj/machinery/vending)
 		else
 			text_out = message
 		slogan_text = make_chat_maptext(src, text_out, "color: [src.slogan_text_color];", alpha = src.slogan_text_alpha)
-		if (slogan_text && src.chat_text)
+		if (slogan_text && src.chat_text && length(src.chat_text.lines))
 			slogan_text.measure(src)
 			for (var/image/chat_maptext/I in src.chat_text.lines)
 				if (I != slogan_text)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -87,6 +87,8 @@ TYPEINFO(/obj/machinery/vending)
 	var/last_slogan = 0 //When did we last pitch?
 	var/slogan_delay = 600 //How long until we can pitch again?
 	var/slogan_chance = 5
+	var/slogan_text_alpha = 140
+	var/slogan_text_color = "#C2BEBE"
 
 	//Icons
 	var/icon_panel = "generic-panel"
@@ -152,6 +154,8 @@ TYPEINFO(/obj/machinery/vending)
 		light.set_color(light_r, light_g, light_b)
 		..()
 		src.panel_image = image(src.icon, src.icon_panel)
+		if (!src.chat_text)
+			src.chat_text = new
 	var/lastvend = 0
 
 	disposing()
@@ -846,11 +850,24 @@ TYPEINFO(/obj/machinery/vending)
 	if (!message)
 		return
 
-	for (var/mob/O in hearers(src, null))
+	var/image/chat_maptext/slogan_text
+	if (istype(src.loc, /turf))
+		var/text_out
 		if (src.glitchy_slogans)
-			O.show_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[voidSpeak(message)]\"", 2)
+			text_out = voidSpeak(message)
 		else
-			O.show_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"</span></span>", 2)
+			text_out = message
+		slogan_text = make_chat_maptext(src, text_out, "color: [src.slogan_text_color];", alpha = src.slogan_text_alpha)
+		if (slogan_text && src.chat_text)
+			slogan_text.measure(src)
+			for (var/image/chat_maptext/I in src.chat_text.lines)
+				if (I != slogan_text)
+					I.bump_up(slogan_text.measured_height)
+
+	if (src.glitchy_slogans)
+		src.audible_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[voidSpeak(message)]\"", 2, assoc_maptext = slogan_text)
+	else
+		src.audible_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"</span></span>", 2, assoc_maptext = slogan_text)
 
 	return
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -852,8 +852,9 @@ TYPEINFO(/obj/machinery/vending)
 		return
 
 	var/image/chat_maptext/slogan_text
+	var/text_out
+
 	if (istype(src.loc, /turf))
-		var/text_out
 		if (src.glitchy_slogans)
 			text_out = voidSpeak(message)
 		else
@@ -865,10 +866,13 @@ TYPEINFO(/obj/machinery/vending)
 				if (I != slogan_text)
 					I.bump_up(slogan_text.measured_height)
 
+	if (!text_out)
+		return
+
 	if (src.glitchy_slogans)
-		src.audible_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[voidSpeak(message)]\"", 2, assoc_maptext = slogan_text)
+		src.audible_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[voidSpeak(text_out)]\"", 2, assoc_maptext = slogan_text)
 	else
-		src.audible_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"</span></span>", 2, assoc_maptext = slogan_text)
+		src.audible_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[text_out]\"</span></span>", 2, assoc_maptext = slogan_text)
 
 	return
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -870,7 +870,7 @@ TYPEINFO(/obj/machinery/vending)
 		return
 
 	if (src.glitchy_slogans)
-		src.audible_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[voidSpeak(text_out)]\"", 2, assoc_maptext = slogan_text)
+		src.audible_message("<span class='game say'><span class='name'>[src]</span> beeps,</span> \"[text_out]\"", 2, assoc_maptext = slogan_text)
 	else
 		src.audible_message("<span class='subtle'><span class='game say'><span class='name'>[src]</span> beeps, \"[text_out]\"</span></span>", 2, assoc_maptext = slogan_text)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE][OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Vending machines, when outputting the slogans loaded onto them, now have associated maptext.
![image](https://user-images.githubusercontent.com/66253095/215273321-807da507-81ff-4c7d-b3a3-30fcc23b50e5.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slogans are presently quite easy to miss when they're outputted. This should hopefully add more flavour.