### PR TITLE
Fools pyrite is now actually gold

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -442,3 +442,12 @@
 	setup_material()
 		src.setMaterial(getMaterial("plutonium"), appearance = 0, setname = 0)
 		..()
+
+/obj/item/material_piece/foolsfoolsgold
+	name = "fool's pyrite bar"
+	desc = "It's gold that isn't. Except it is. MINDFUCK"
+	icon_state = "bar"
+
+	setup_material()
+		src.setMaterial(getMaterial("gold"), appearance = TRUE, setname = FALSE)
+		..()

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -1,16 +1,3 @@
-/obj/item/goldbar //deprecated, needs getting rid of except the map is being weird about it
-	name = "fool's pyrite bar"
-	desc = "It's gold that isn't. Except it is. MINDFUCK"
-	icon = 'icons/obj/materials.dmi'
-	icon_state = "gold-bar"
-	force = 8
-	throwforce = 10
-	//metal = 1
-	//conductor = 1
-	New()
-		src.setMaterial(getMaterial("gold"), appearance = 0, setname = 0, copy = FALSE)
-		return ..()
-
 /datum/ore
 	var/name = null
 	var/output = null

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18347,7 +18347,7 @@
 	pixel_x = 4;
 	pixel_y = 11
 	},
-/obj/item/goldbar,
+/obj/item/material_piece/foolsfoolsgold,
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/heads)
 "Vw" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16856,7 +16856,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/obj/item/goldbar,
+/obj/item/material_piece/foolsfoolsgold,
 /obj/item/device/gps,
 /turf/simulated/floor/carpet{
 	dir = 8;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -31016,7 +31016,7 @@
 /area/station/crew_quarters/heads)
 "byA" = (
 /obj/table/wood/auto,
-/obj/item/goldbar,
+/obj/item/material_piece/foolsfoolsgold,
 /obj/item/stamp/hop,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -15978,7 +15978,7 @@
 /area/station/hos/quarter)
 "aTQ" = (
 /obj/table/wood/auto/desk,
-/obj/item/goldbar,
+/obj/item/material_piece/foolsfoolsgold,
 /obj/item/device/gps,
 /turf/simulated/floor/wood,
 /area/station/hos/quarter)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -26446,7 +26446,7 @@
 	},
 /area/station/bridge)
 "bve" = (
-/obj/item/goldbar,
+/obj/item/material_piece/foolsfoolsgold,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bvf" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->[Materials] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the fool's pyrite bar item with a renamed gold bar keeping the fool's pyrite bar description. Note that this turns it into normal gold bars, not the valuable stamped bullion. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The fool's pyrite bar description is: "It's gold that isn't. Except it is. MINDFUCK" It makes more sense for it to actually be gold with all of gold's properties since the joke is that it actually is gold. Currently, fool's pyrite cannot actually be used like a gold bar in matsci.
This also fixes #12924