### PR TITLE
Positive-ize parameters of seed requisition contract

### DIFF
--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -174,15 +174,15 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		src.cropname = initial(plantalyze.name)
 
 		switch(rand(1,7))
-			if(1) src.gene_reqs["Maturation"] = rand(10,20) * -1
-			if(2) src.gene_reqs["Production"] = rand(10,20) * -1
+			if(1) src.gene_reqs["Maturation"] = rand(10,20)
+			if(2) src.gene_reqs["Production"] = rand(10,20)
 			if(3) src.gene_reqs["Lifespan"] = rand(3,5)
 			if(4) src.gene_reqs["Yield"] = rand(3,5)
 			if(5) src.gene_reqs["Potency"] = rand(3,5)
 			if(6) src.gene_reqs["Endurance"] = rand(3,5)
 			if(7)
-				src.gene_reqs["Maturation"] = rand(5,10) * -1
-				src.gene_reqs["Production"] = rand(5,10) * -1
+				src.gene_reqs["Maturation"] = rand(5,10)
+				src.gene_reqs["Production"] = rand(5,10)
 		..()
 
 

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -191,9 +191,9 @@ ABSTRACT_TYPE(/datum/rc_entry/seed)
 		for(var/index in gene_reqs) // Iterate over each parameter to see if the genome meets it, or exceeds it in the right direction
 			switch(index)
 				if("Maturation")
-					if(cultivar.plantgenes.growtime <= gene_reqs["Maturation"]) gene_count++
+					if(cultivar.plantgenes.growtime >= gene_reqs["Maturation"]) gene_count++
 				if("Production")
-					if(cultivar.plantgenes.harvtime <= gene_reqs["Production"]) gene_count++
+					if(cultivar.plantgenes.harvtime >= gene_reqs["Production"]) gene_count++
 				if("Lifespan")
 					if(cultivar.plantgenes.harvests >= gene_reqs["Lifespan"]) gene_count++
 				if("Yield")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUGFIX][MINOR][HYDROPONICS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Maturation and production characteristics requested by the botany seed contract were negative, reflecting their previous behavior of being a representation of time to mature or produce (lower being better); this swaps that around in both the contract and the baseline evaluation of seed entries.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #12943 