### PR TITLE
Add miscellaneous Flock game mode type additions

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -12,6 +12,8 @@
 #define ROLE_HEAD_REV "head_rev"
 #define ROLE_CONSPIRATOR "conspirator"
 #define ROLE_ARCFIEND "arcfiend"
+#define ROLE_FLOCKMIND "flockmind"
+#define ROLE_FLOCKTRACE "flocktrace"
 #define ROLE_MISC "misc"
 
 // special antagonist roles
@@ -34,8 +36,6 @@
 
 // gimmicks
 #define ROLE_BATTLER "battler"
-#define ROLE_FLOCKMIND "flockmind"
-#define ROLE_FLOCKTRACE "flocktrace"
 #define ROLE_OMNITRAITOR "omnitraitor"
 #define ROLE_GRINCH "grinch"
 #define ROLE_FLOOR_GOBLIN "floor_goblin"

--- a/code/area.dm
+++ b/code/area.dm
@@ -400,6 +400,8 @@ TYPEINFO(/area)
 		var/list/dirtyStuff = list(/obj/decal/cleanable,/obj/fluid)
 
 		for (var/turf/simulated/T in src.contents)
+			if (isfeathertile(T))
+				continue
 			dirty = 0
 			total_count++
 			for (var/thing in T.contents)

--- a/code/area.dm
+++ b/code/area.dm
@@ -386,6 +386,11 @@ TYPEINFO(/area)
 		for (var/obj/window/W in our_contents)
 			value++
 
+		if (length(flocks))
+			for (var/atom/A as anything in our_contents)
+				if (isfeathertile(A) || istype(A, /obj/machinery/light/flock) || istype(A, /obj/window/auto/feather))
+					value--
+
 		return value
 
 	proc/calculate_area_cleanliness()

--- a/code/area.dm
+++ b/code/area.dm
@@ -373,23 +373,25 @@ TYPEINFO(/area)
 	proc/calculate_structure_value()
 		var/value = 0
 		var/list/atom/our_contents = src.contents.Copy()
-		for (var/turf/simulated/wall/W in our_contents)
-			value++
-		for (var/turf/simulated/floor/F in our_contents)
-			if (F.broken || F.burnt)
-				continue
-			value++
-		for (var/obj/machinery/light/L in our_contents)
-			if (L.current_lamp.light_status != 0) //See LIGHT_OK
-				continue
-			value++
-		for (var/obj/window/W in our_contents)
-			value++
 
-		if (length(flocks))
-			for (var/atom/A as anything in our_contents)
+		for (var/atom/A as anything in our_contents)
+			if (length(flocks))
 				if (isfeathertile(A) || istype(A, /obj/machinery/light/flock) || istype(A, /obj/window/auto/feather))
-					value--
+					continue
+			if (istype(A, /turf/simulated/wall))
+				value++
+			else if (istype(A, /turf/simulated/floor))
+				var/turf/simulated/floor/F = A
+				if (F.broken || F.burnt)
+					continue
+				value++
+			else if (istype(A, /obj/machinery/light))
+				var/obj/machinery/light/L = A
+				if (L.current_lamp.light_status != 0) //See LIGHT_OK
+					continue
+				value++
+			else if (istype(A, /obj/window))
+				value++
 
 		return value
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -393,7 +393,7 @@ ABSTRACT_TYPE(/datum/game_mode)
 	intercepttext += " Cent. Com has recently been contacted by the following syndicate affiliated organisations in your area, please investigate any information you may have:"
 
 	var/list/possible_modes = list()
-	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "vampire", ROLE_CHANGELING)
+	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "vampire", "flock", ROLE_CHANGELING)
 	for(var/i = 1 to pick(2, 3))
 		possible_modes.Remove(pick(possible_modes))
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -690,7 +690,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && (player.mind in all_the_baddies)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player))  || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
+			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -690,7 +690,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && (player.mind in all_the_baddies)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) ||  (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
+			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) \
+					|| iswraith(player) || isflockmob(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -690,7 +690,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && (player.mind in all_the_baddies)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
+			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player))  || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -690,7 +690,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && (player.mind in all_the_baddies)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
+			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) ||  (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -690,8 +690,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			else if (istype(player.loc, /obj/cryotron) || player.mind && (player.mind in all_the_baddies)) // Cryo'd or was a baddie at any point? Keep your shit, but you don't get the extra bux
 				player_loses_held_item = 0
 			//some might not actually have a wage
-			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) \
-					|| iswraith(player) || isflockmob(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
+			if (!isvirtual(player) && ((isnukeop(player) || isnukeopgunbot(player)) || (isblob(player) && (player.mind && player.mind.special_role == ROLE_BLOB)) || iswraith(player) || (iswizard(player) && (player.mind && player.mind.special_role == ROLE_WIZARD)) ))
 				bank_earnings.wage_base = 0 //only effects the end of round display
 				earnings = 800
 

--- a/code/datums/intercept_text.dm
+++ b/code/datums/intercept_text.dm
@@ -144,4 +144,4 @@
 	src.text += {"<BR><BR>An anomalous radio entity has been detected by long range sensors in your sector. Its goal is unclear, but from previous
 				 reports, it's believed that it will attempt to collect your station's resources through the use of swarms of drones. This entity is
 				 also believed to have a remarkable influence over radio devices, so caution around trusted technology is highly advised. It's unclear
-				 how aggressive the entity actually is, but extreme reservation must be taken.}
+				 how aggressive the entity actually is, but extreme reservation must be taken."}

--- a/code/datums/intercept_text.dm
+++ b/code/datums/intercept_text.dm
@@ -46,6 +46,10 @@
 			src.text = ""
 			src.build_changeling(correct_mob)
 			return src.text
+		if ("flock")
+			src.text = ""
+			src.build_flock(correct_mob)
+			return src.text
 		else
 			return null
 
@@ -135,3 +139,9 @@
 	src.text += "<BR><BR>We have intercepted reports that a Space Wizard Federation menagerie facility in your sector has suffered a containment breach. "
 	src.text += "It is possible that a Vampire has escaped from their cells and is likely to have taken refuge on the station. It is likely weak from its "
 	src.text += "extended containment, but it will become increasingly more powerful if allowed to consume human blood. If caught, it must be terminated."
+
+/datum/intercept_text/proc/build_flock(correct_mob)
+	src.text += {"<BR><BR>An anomalous radio entity has been detected by long range sensors in your sector. This entity is likely a Flockmind. From
+				 previous reports, it's believed that it will attempt to use your station's resources to build a massive superstructure to transmit a
+				 radio signal, which is harmful to the station and crew. Its Flock may be indirectly aggressive but it could become a threat at any
+				 time."}

--- a/code/datums/intercept_text.dm
+++ b/code/datums/intercept_text.dm
@@ -141,7 +141,7 @@
 	src.text += "extended containment, but it will become increasingly more powerful if allowed to consume human blood. If caught, it must be terminated."
 
 /datum/intercept_text/proc/build_flock(correct_mob)
-	src.text += {"<BR><BR>An anomalous radio entity has been detected by long range sensors in your sector. This entity is likely a Flockmind. From
-				 previous reports, it's believed that it will attempt to use your station's resources to build a massive superstructure to transmit a
-				 radio signal, which is harmful to the station and crew. Its Flock may be indirectly aggressive but it could become a threat at any
-				 time."}
+	src.text += {"<BR><BR>An anomalous radio entity has been detected by long range sensors in your sector. Its goal is unclear, but from previous
+				 reports, it's believed that it will attempt to collect your station's resources through the use of swarms of drones. This entity is
+				 also believed to have a remarkable influence over radio devices, so caution around trusted technology is highly advised. It's unclear
+				 how aggressive the entity actually is, but extreme reservation must be taken.}

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -77,6 +77,8 @@
 		return 1
 	if (src.client)
 		src.antagonist_overlay_refresh(0, 0)
+	if (src.flock?.relay_finished)
+		return TRUE
 	if (get_turf(src) == src.previous_turf)
 		src.afk_counter += parent.schedule_interval
 	else

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -48,7 +48,8 @@
 			if (istype(ticker.mode, /datum/game_mode/nuclear))
 				var/datum/game_mode/nuclear/mode = ticker.mode
 				name = "Drone [mode.agent_radiofreq]"
-
+			else if (length(flocks))
+				name = "Flockdrone"
 			else
 				//Make them suffer with an overly cute name
 				name = "Drone [pick(list("Princess", "Lord", "King", "Queen", "Duke", "Baron"))] [pick(list("Bubblegum", "Wiffleypop", "Shnookems", "Cutesypie", "Fartbiscuits", "Rolypoly"))]"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1146,8 +1146,8 @@ var/list/fun_images = list()
 			return
 		send_to_arrival_shuttle = 1
 	else if (isintangible(M))
-		if (M.mind && M.mind.special_role == ROLE_BLOB)
-			remove_antag(M, src, 0, 1) // Ditto.
+		if (M.mind && M.mind.special_role == ROLE_BLOB || M.mind.special_role == ROLE_FLOCKMIND || M.mind.special_role == ROLE_FLOCKTRACE)
+			remove_antag(M, src, FALSE, TRUE) // Ditto.
 			return
 		send_to_arrival_shuttle = 1
 	else if (isAI(M))

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1774,8 +1774,7 @@
 		if (ROLE_MINDHACK) M.delStatus("mindhack")
 		if (ROLE_VAMPTHRALL) return
 		if ("spyminion") return
-		if (ROLE_BLOB) M.humanize(1)
-		if (ROLE_WRAITH) M.humanize(1)
+		if (ROLE_BLOB, ROLE_WRAITH, ROLE_FLOCKMIND, ROLE_FLOCKTRACE) M.humanize(TRUE)
 		else
 			if (ishuman(M))
 				// They could be in a pod or whatever, which would have unfortunate results when respawned.

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -40,6 +40,7 @@ TYPEINFO(/obj/flock_structure/relay)
 	var/shuttle_departure_delayed = FALSE
 
 /obj/flock_structure/relay/New()
+	START_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_TELEPORT_JAMMER, src, 9)
 	..()
 	logTheThing(LOG_GAMEMODE, src, "Flock relay is constructed[src.flock ? " by flock [src.flock.name]" : ""] at [log_loc(src)].")
@@ -83,6 +84,7 @@ TYPEINFO(/obj/flock_structure/relay)
 		turfs_to_convert["[dist]"] |= T
 
 /obj/flock_structure/relay/disposing()
+	STOP_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 	REMOVE_ATOM_PROPERTY(src, PROP_ATOM_TELEPORT_JAMMER, src)
 	var/mob/living/intangible/flock/flockmind/F = src.flock?.flockmind
 	logTheThing(LOG_GAMEMODE, src, "Flock relay[src.flock ? " belonging to flock [src.flock.name]" : ""] is destroyed at [log_loc(src)].")
@@ -148,7 +150,6 @@ TYPEINFO(/obj/flock_structure/relay)
 		return
 	logTheThing(LOG_GAMEMODE, src, "Flock relay[src.flock ? " belonging to flock [src.flock.name]" : ""] unleashes the signal, exploding at [log_loc(src)].")
 	src.finished = TRUE
-	src.flock.relay_finished = TRUE
 	src.flock.stats.won = TRUE
 	var/turf/location = get_turf(src)
 	overlays += "structure-relay-sparks"
@@ -178,6 +179,7 @@ TYPEINFO(/obj/flock_structure/relay)
 			for(var/y = -2 to 2)
 				flockdronegibs(locate(location.x + x, location.y + y, location.z))
 		explosion_new(src, location, 2000)
+		src.flock.relay_finished = TRUE
 		gib(location)
 		flock_signal_unleashed = TRUE
 		sleep(2 SECONDS) //allow them to hear the explosion before their headsets scream and die

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -163,6 +163,26 @@
 				if (M.master)
 					var/mob/mymaster = ckey_to_mob(M.master)
 					if (mymaster) special = mymaster.real_name
+			if (ROLE_FLOCKMIND)
+				var/relay_successful = FALSE
+				if (isflockmob(M.current))
+					if (!istype(M.current, /mob/living/critter/flock/drone))
+						var/mob/living/intangible/flock/flockmind/flockmind = M.current
+						relay_successful = flockmind.flock.relay_finished
+					else
+						var/mob/living/critter/flock/drone/flockdrone = M.current
+						relay_successful = flockdrone.flock.relay_finished
+				special = "Relay transmission [relay_successful ? "successful" : "unsuccessful"]"
+			if (ROLE_FLOCKTRACE)
+				if (isflockmob(M.current))
+					var/datum/flock/flock_joined = null
+					if (!istype(M.current, /mob/living/critter/flock/drone))
+						var/mob/living/intangible/flock/trace/flocktrace = M.current
+						flock_joined = flocktrace.flock
+					else
+						var/mob/living/critter/flock/drone/flockdrone = M.current
+						flock_joined = flockdrone.flock
+					special = "Part of Flock [flock_joined.name]"
 			if (ROLE_NUKEOP, ROLE_NUKEOP_COMMANDER)
 				if (istype(ticker.mode, /datum/game_mode/nuclear))
 					special = syndicate_name()


### PR DESCRIPTION
[GAME MODES][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds some Flock game mode type changes, pulled from #11809, notable ones are listed below

Additions-
-Station score value takes into account Flocktiles
-Flock intercept text
-Low chance for Flock themed naming for Ghostdrones
-Relay as a ghost observable

Fixes-
-Possible Flock death for having nothing after the Relay dies
-Relay finished var set before it goes off

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Small game mode type additions and bug fix