### PR TITLE
fix eyespider vision

### DIFF
--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -354,9 +354,7 @@
 		src.flags ^= TABLEPASS | DOORPASS
 
 		// EYE CAN SEE FOREVERRRR
-		src.sight |= SEE_MOBS | SEE_TURFS | SEE_OBJS
-		src.see_in_dark = SEE_DARK_FULL
-		src.see_invisible = INVIS_CLOAK
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_XRAYVISION, src)
 
 	// a slight breeze will kill these guys, such is life as a squishy li'l eye
 	setup_healths()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rather than setting the flags manually eyespiders now just get the xray vision property, which as best as I can tell is equivalent to what eyespiders are supposed to have. I think something in the sight lifeprocess was nuking their xray but I don't know what exactly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fix #12920
