### PR TITLE
Restore manufacturer search & category filter

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -66,7 +66,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	// Production options
 	var/search = null
 	var/category = null
-	var/list/categories = list("Tool","Clothing","Resource","Component","Machinery","Miscellaneous", "Downloaded")
+	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE
 	var/list/available = list() //! A list of every option available in this unit subtype by default
 	var/list/download = list() //! Options gained from scanned blueprints

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -65,6 +65,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 	// Production options
 	var/search = null
+	var/category = null
+	var/list/categories = list("Tool","Clothing","Resource","Component","Machinery","Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE
 	var/list/available = list() //! A list of every option available in this unit subtype by default
 	var/list/download = list() //! Options gained from scanned blueprints
@@ -469,6 +471,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 			if (istext(src.search) && !findtext(A.name, src.search, 1, null))
 				continue
+			else if (istext(src.category) && src.category != A.category)
+				continue
 
 			can_be_made = (mats_used.len >= A.item_paths.len)
 			if(delete_allowed && src.download.Find(A))
@@ -517,6 +521,10 @@ TYPEINFO(/obj/machinery/manufacturer)
 		dat += "</div><div id='info'>"
 		dat += build_material_list(user)
 
+		//Search
+		dat += " <A href='?src=\ref[src];search=1'>(Search: \"[istext(src.search) ? html_encode(src.search) : "----"]\")</A><BR>"
+		//Filter
+		dat += " <A href='?src=\ref[src];category=1'>(Filter: \"[istext(src.category) ? html_encode(src.category) : "----"]\")</A><HR>"
 		// This is not re-formatted yet just b/c i don't wanna mess with it
 		dat +="<B>Scanned Card:</B> <A href='?src=\ref[src];card=1'>([src.scan])</A><BR>"
 		if(scan)
@@ -662,6 +670,15 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 			if (href_list["repeat"])
 				src.repeat = !src.repeat
+
+			if (href_list["search"])
+				src.search = input("Enter text to search for in schematics.","Manufacturing Unit") as null|text
+				if (length(src.search) == 0)
+					src.search = null
+
+			if (href_list["category"])
+				var/selection = input("Select which category to filter by.","Manufacturing Unit") as null|anything in list("REMOVE FILTER") + src.categories
+				src.category = ((selection == "REMOVE FILTER") ? null : selection)
 
 			if (href_list["continue"])
 				if (length(src.queue) < 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Restores a text search and category filter to manufacturers, which used to be commented out (nor would they show up on the UI if uncommented)

Much of this was stripped out in #8891 but since all the categories on the manufacturing datums are intact I figured I might as well bring it back.
![image](https://user-images.githubusercontent.com/31984217/216787579-4688dc0a-3e97-4695-90cc-90fa6993a506.png)
The only really new things here are hooking both of these into the current UI and adding the REMOVE FILTER bit. The rest is just copy-pasting old code back in.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Considerable QOL if you're searching a cluttered manufacturer.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)BatElite
(+)Restored search and category filter functions to manufacturers
```
