### PR TITLE
roundstart walls don't zero air on decon

### DIFF
--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -537,6 +537,7 @@ proc/generate_space_color()
 
 	var/datum/gas_mixture/oldair = null //Set if old turf is simulated and has air on it.
 	var/datum/air_group/oldparent = null //Ditto.
+	var/zero_new_turf_air = (turf_flags & CAN_BE_SPACE_SAMPLE)
 
 	//For unsimulated static air tiles such as ice moon surface.
 	var/temp_old = null
@@ -708,7 +709,7 @@ proc/generate_space_color()
 			var/turf/simulated/N = new_turf
 			if (oldair) //Simulated tile -> Simulated tile
 				N.air = oldair
-			else if(istype(N.air)) //Unsimulated tile (likely space) - > Simulated tile  // fix runtime: Cannot execute null.zero()
+			else if(zero_new_turf_air && istype(N.air)) // fix runtime: Cannot execute null.zero()
 				N.air.zero()
 
 			#define _OLD_GAS_VAR_NOT_NULL(GAS, ...) GAS ## _old ||


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][major][cleanup]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes ReplaceWith logic intended for space->floor transitions to not trip up roundstart wall (which doesn't initialise its air) to floor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A major problem with remodeling the station is that removing walls quickly drops air pressure below breathable levels, this fixes that.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)BatElite
(+)Deconstructing roundstart walls no longer generates gaps in the station's atmosphere, so remodeling projects are more viable.
```
