### PR TITLE
Adds Atmos Pod Door Shields to Radio Station

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1278,6 +1278,12 @@
 	id = "radio_podbay1";
 	name = "Radio Ship Dock"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "adY" = (
@@ -1399,6 +1405,12 @@
 	id = "radio_podbay2";
 	name = "Radio Ship Dock"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aev" = (
@@ -1426,6 +1438,12 @@
 	dir = 4;
 	id = "radio_podbay1";
 	name = "Radio Ship Dock"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
@@ -1516,6 +1534,12 @@
 	id = "radio_podbay2";
 	name = "Radio Ship Dock"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aeV" = (
@@ -1524,6 +1548,12 @@
 	icon_state = "bdoorright1";
 	id = "radio_podbay1";
 	name = "Radio Ship Dock"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
@@ -1621,6 +1651,12 @@
 	icon_state = "bdoorright1";
 	id = "radio_podbay2";
 	name = "Radio Ship Dock"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds some atmos door shields to the pod bay doors on the radio station.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Often, the radio station pod bays are airless due to either someone visiting or the radio host leaving. The radio station having limited space and air, this is often just annoying, and not worth refilling the air in the pod bays due to how trivial it is to remove the air from them. This makes it so the pod bays will often have air in them unless structural damage is dealt to the station itself.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)The radio station pod bay doors now come with atmos shields.
```
