### PR TITLE
Fixes a discrepancy with the HoP's headset description

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -190,7 +190,7 @@
 
 /obj/item/device/radio/headset/command/hop
 	name = "head of personnel's headset"
-	desc = "The HoP can listen to the security frequency, but they can't speak on it anymore. Not since the incident."
+	desc = "The HoP cannot listen or speak on the security frequency anymore, not since the incident."
 	secure_frequencies = list(
 		"h" = R_FREQ_COMMAND,
 		"e" = R_FREQ_ENGINEERING,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A small change correcting the HoP's headset description to not point towards the HoP being able to actually listen in on security comms (seems to be a broken feature for now)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Item description not matching functionality is bad


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Piesuu
(+) The HoP's headset no longer hints towards the HoP being capable of listening in on security communications.
```
