### PR TITLE
allow regex filtering on dispatch components

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -203,7 +203,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 	var/fired = 0
 	for(var/atom/A in src.connected_outgoing)
 		//Note: a target not handling a signal returns 0.
-		var/validated = SEND_SIGNAL(parent,_COMSIG_MECHCOMP_DISPATCH_VALIDATE, A, msg.signal)
+		var/validated = SEND_SIGNAL(parent,_COMSIG_MECHCOMP_DISPATCH_VALIDATE, A, msg)
 		if(validated == _MECHCOMP_VALIDATE_RESPONSE_HALT) //The component wants signal processing to stop NOW
 			return fired
 		if(validated == _MECHCOMP_VALIDATE_RESPONSE_BAD) //The component wants this signal to be skipped


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://user-images.githubusercontent.com/64938519/217130909-10fcda16-ffac-4a3f-93c6-eda49816d1ec.png)
![image](https://user-images.githubusercontent.com/64938519/217130938-8b060f1f-b30d-4129-9c69-b3cc336ba3bd.png)
this PR aims to allow the dispatch component to accept regex.

currently it just uses a default flag on everything that passes through that cant be set

did some basic testing with lookaround groups and it appears to be working

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
allows for more compact mechcomp designs that use less regex find components, mostly for big nerds


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(+)The MechComp Dispatch Component now accepts regex filters
```
