### PR TITLE
fix wifi splitter tooltip not updating

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1246,6 +1246,7 @@
 		if(length(inp))
 			inp = strip_html_tags(html_decode(inp))
 			triggerSignal = inp
+			tooltip_rebuild = 1
 			boutput(user, "Signal set to [inp]")
 			return 1
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where the wifi signal splitter component wouldn't update its tooltip to reflect new trigger strings
![image](https://user-images.githubusercontent.com/64938519/217132947-14282f33-a192-4ac5-bb91-c65369c61d57.png)

did some basic testing to see if it worked, and it appears to

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, fix good.
confused the hell out of people who were using it in cabinets a while back.

