### PR TITLE
Fix Splice disabler gene strain not working as intended

### DIFF
--- a/code/modules/hydroponics/gene_strains.dm
+++ b/code/modules/hydroponics/gene_strains.dm
@@ -110,6 +110,7 @@
 	name = "Splice Disabler"
 	desc = "Chromosomal alterations prevent seeds from this plant from being spliced at all."
 	negative = 1
+	chance = 100
 	splice_mod = 100
 
 /datum/plant_gene_strain/damage_res

--- a/code/modules/hydroponics/gene_strains.dm
+++ b/code/modules/hydroponics/gene_strains.dm
@@ -110,7 +110,7 @@
 	name = "Splice Disabler"
 	desc = "Chromosomal alterations prevent seeds from this plant from being spliced at all."
 	negative = 1
-	chance = 100
+	splice_mod = 100
 
 /datum/plant_gene_strain/damage_res
 	name = "Damage Resistance"


### PR DESCRIPTION
[Hydroponics][Bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes ~~two things about~~ the splice disabler gene strain. ~~Firstly, it changes the chance to occur on a plant from 100% to the standard 10%. Secondly, it actually~~ This PR makes the gene strain apply a -100% splice chance to the seed instead of the -20% chance of splice blocker


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The splice disabler gene would be nice to work like it is intended to. ~~And the 100% chance to occur doesn't seem to be intended either.~~