### PR TITLE
Adds get_effective_value on plant code that missed it

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -706,7 +706,7 @@
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth > (P.growtime + DNA.growtime) && prob(5))
+		if (POT.growth > (P.growtime + DNA?.get_effective_value("growtime")) && prob(5))
 			POT.visible_message("<span class='combat'><b>[POT.name]</b> [pick("howls","bays","whines","barks","croons")]!</span>")
 			playsound(POT, pick('sound/voice/animal/howl1.ogg','sound/voice/animal/howl2.ogg','sound/voice/animal/howl3.ogg','sound/voice/animal/howl4.ogg','sound/voice/animal/howl5.ogg','sound/voice/animal/howl6.ogg'), 30, 1,-1)
 
@@ -716,7 +716,7 @@
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth < (P.growtime + DNA.growtime)) return 0
+		if (POT.growth < (P.growtime + DNA?.get_effective_value("growtime"))) return 0
 		playsound(POT, pick('sound/voice/animal/howl1.ogg','sound/voice/animal/howl2.ogg','sound/voice/animal/howl3.ogg','sound/voice/animal/howl4.ogg','sound/voice/animal/howl5.ogg','sound/voice/animal/howl6.ogg'), 30, 1,-1)
 		boutput(user, "<span class='alert'>[POT.name] angrily bites you!</span>")
 		random_brute_damage(user, 3)

--- a/code/modules/hydroponics/plants_alien.dm
+++ b/code/modules/hydroponics/plants_alien.dm
@@ -113,7 +113,7 @@ ABSTRACT_TYPE(/datum/plant/artifact)
 		if(src.focused)
 			pr += 10
 
-		if (POT.growth > (P.growtime + DNA.growtime) && prob(pr))
+		if (POT.growth > (P.growtime + DNA?.get_effective_value("growtime")) && prob(pr))
 			if(focused)
 				if(stare_extreme(focused, POT))
 					return
@@ -296,7 +296,7 @@ ABSTRACT_TYPE(/datum/plant/artifact)
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth < (P.growtime + DNA.growtime)) return 0
+		if (POT.growth < (P.growtime + DNA?.get_effective_value("growtime"))) return 0
 
 		var/MEspeech = pick("Hands off, asshole!","The hell d'you think you're doin'?!","You dick!","Bite me, motherfucker!")
 		for(var/mob/O in hearers(POT, null))

--- a/code/modules/hydroponics/plants_weed.dm
+++ b/code/modules/hydroponics/plants_weed.dm
@@ -45,7 +45,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth > (P.growtime + DNA.growtime) && prob(33))
+		if (POT.growth > (P.growtime + DNA?.get_effective_value("growtime")) && prob(33))
 			for (var/mob/living/M in range(1,POT))
 				if (POT.health > P.starthealth / 2)
 					random_brute_damage(M, 8, 1)//slight bump to damage to account for everyone having 1 armor from jumpsuit, further bump to damage to make blooming lasher more difficult to cultivate
@@ -60,7 +60,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth < (P.growtime + DNA.growtime)) return 0
+		if (POT.growth < (P.growtime + DNA?.get_effective_value("growtime"))) return 0
 		// It's not big enough to be violent yet, so nothing happens
 
 		POT.visible_message("<span class='alert'><b>[POT.name]</b> violently retaliates against [user.name]!</span>")
@@ -102,7 +102,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 		var/datum/plant/P = POT.current
 		var/datum/plantgenes/DNA = POT.plantgenes
 
-		if (POT.growth > (P.growtime + DNA.growtime) && POT.health > P.starthealth / 2 && prob(33))
+		if (POT.growth > (P.growtime + DNA?.get_effective_value("growtime")) && POT.health > P.starthealth / 2 && prob(33))
 			for (var/obj/machinery/plantpot/C in range(1,POT))
 				var/datum/plant/growing = C.current
 				if (!C.dead && C.current && !istype(growing,/datum/plant/crystal) && !istype(growing,/datum/plant/weed/creeper)) C.health -= 10


### PR DESCRIPTION
[Hydroponics][Code-Quality]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the `get_effective_value`-proc on some plant-procs that i have missed when i introduced the proc in #12518

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Since these cases asked for `DNA.growtime`, this PR currently don't affect anything gameplay-wise. However this would lead to inconsistencies when a gene strain is added that affects the growtime-variable.