### PR TITLE
Adds Pod Door Atmos Shields To Space Diner

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -16736,6 +16736,12 @@
 	layer = 4;
 	name = "pod bay door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
 "bnW" = (
@@ -16851,6 +16857,12 @@
 	id = "hangar_spacediner1";
 	layer = 4;
 	name = "pod bay door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
@@ -18607,6 +18619,12 @@
 	layer = 4;
 	name = "pod bay door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
 "gLC" = (
@@ -19197,6 +19215,12 @@
 	id = "hangar_spacediner2";
 	layer = 4;
 	name = "pod bay door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
@@ -22446,6 +22470,12 @@
 	layer = 4;
 	name = "pod bay door"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
 "rtw" = (
@@ -24228,6 +24258,12 @@
 	id = "hangar_spacediner2";
 	layer = 4;
 	name = "pod bay door"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 8;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds atmos door shields to the space diner's pod doors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Similar reasons as #12980 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)The space diner's parking lots now have atmos door shields
```
