### PR TITLE
Fixes cog1 ptl camera being labeled space2

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33994,8 +33994,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/computer/chem_requester/science{
-	dir = 4;
-	area_name = "Quartermaster's office"
+	area_name = "Quartermaster's office";
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 10
@@ -55462,8 +55462,8 @@
 	},
 /obj/machinery/light_switch{
 	name = "N light switch";
-	pixel_y = 24;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 24
 	},
 /obj/blind_switch/area/north{
 	pixel_x = 6
@@ -61622,7 +61622,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/space)
+/area/station/engine/ptl)
 "tdI" = (
 /obj/table/auto,
 /obj/item/storage/box/stma_kit{
@@ -65360,8 +65360,8 @@
 /area/station/maintenance/southeast)
 "xox" = (
 /obj/item/toy/plush/small{
-	pixel_y = 4;
-	layer = 3.1
+	layer = 3.1;
+	pixel_y = 4
 	},
 /obj/stool/chair/comfy,
 /obj/cable{
@@ -66129,12 +66129,12 @@
 	pixel_y = -2
 	},
 /obj/item/pen{
-	pixel_y = 4;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/item/kitchen/food_box/lollipop{
-	pixel_y = 8;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a missing area in the ptl room on cog1, specifically under the camera there.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12988


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

