### PR TITLE
Makes Audio Tapes and Audio Logs printable in science fabricators

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1798,7 +1798,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 /datum/manufacture/audiotape
 	name ="Audio Tape"
 	item_paths = list("MET-1")
-	item_amounts = list(1)
+	item_amounts = list(2)
 	item_outputs = list(/obj/item/audio_tape)
 	time = 4 SECONDS
 	create = 1
@@ -1806,8 +1806,8 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/audiolog
 	name ="Audio Log"
-	item_paths = list("MET-1")
-	item_amounts = list(1)
+	item_paths = list("MET-1", "CON-1")
+	item_amounts = list(3,5)
 	item_outputs = list(/obj/item/device/audio_log)
 	time = 5 SECONDS
 	create = 1

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1795,6 +1795,24 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Resource"
 
+/datum/manufacture/audiotape
+	name ="Audio Tape"
+	item_paths = list("MET-1")
+	item_amounts = list(1)
+	item_outputs = list(/obj/item/audio_tape)
+	time = 4 SECONDS
+	create = 1
+	category = "Tool"
+
+/datum/manufacture/audiolog
+	name ="Audio Log"
+	item_paths = list("MET-1")
+	item_amounts = list(1)
+	item_outputs = list(/obj/item/device/audio_log)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
 // Mining Gear
 #ifndef UNDERWATER_MAP
 /datum/manufacture/mining_magnet

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2493,6 +2493,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/gasmask,
 		/datum/manufacture/latex_gloves,
 		/datum/manufacture/shoes_white,
+		/datum/manufacture/audiotape,
+		/datum/manufacture/audiolog,
 		/datum/manufacture/rods2,
 		/datum/manufacture/metal,
 		/datum/manufacture/glass)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-QoL] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows printing of Audio Logs and Audio Tapes from science fabricators.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pretty much entirely for RP for the few people who use audio logs a lot, they can quickly run out and many maps do not have spares, this makes it easier to get new ones! 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Munien
(+)Audio logs and tapes are now printable from science fabricators.
```
