### PR TITLE
Dynamic Player Memories

### DIFF
--- a/_std/defines/component_defines/component_defines_datum.dm
+++ b/_std/defines/component_defines/component_defines_datum.dm
@@ -15,6 +15,8 @@
 	#define COMSIG_MIND_ATTACH_TO_MOB "mind_attach_to_mob"
 	/// when a mind detaches from a mob (mind, mob)
 	#define COMSIG_MIND_DETACH_FROM_MOB "mind_detach_from_mob"
+	/// when a mind should update the contents of its memory
+	#define COMSIG_MIND_UPDATE_MEMORY "update_dynamic_player_memory"
 
 // ---- area signals ----
 

--- a/code/datums/dynamic_player_memory.dm
+++ b/code/datums/dynamic_player_memory.dm
@@ -1,0 +1,36 @@
+/datum/dynamic_player_memory
+	var/datum/mind/owner
+	var/memory_text
+
+	New(datum/mind/owner, memory_text)
+		if (!istype(owner))
+			return
+
+		. = ..()
+		src.owner = owner
+		src.memory_text = memory_text
+		RegisterSignal(src.owner, COMSIG_MIND_UPDATE_MEMORY, .proc/update_memory)
+		src.update_memory()
+
+	proc/update_memory()
+		return
+
+/datum/dynamic_player_memory/conspirator_list
+	var/datum/antagonist/conspirator/antag_datum
+
+	New(datum/mind/owner)
+		if (!istype(owner) || !owner.get_antagonist(ROLE_CONSPIRATOR))
+			return
+
+		src.owner = owner
+		src.antag_datum = src.owner.get_antagonist(ROLE_CONSPIRATOR)
+		. = ..()
+
+	update_memory()
+		src.memory_text = "The conspiracy consists of: "
+
+		for (var/datum/mind/conspirator in src.antag_datum.conspirators)
+			if (conspirator.assigned_role == "Clown")
+				src.memory_text += "<b>a Clown</b>, "
+			else
+				src.memory_text += "<b>[conspirator.current.real_name]</b>, "

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -6,6 +6,7 @@ datum/mind
 	var/mob/virtual
 
 	var/memory
+	var/list/datum/dynamic_player_memory/dynamic_memories = list()
 	var/remembered_pin = null
 	var/last_memory_time = 0 //Give a small delay when adding memories to prevent spam. It could happen!
 	var/miranda // sec's miranda rights thingy.
@@ -169,9 +170,17 @@ datum/mind
 	proc/store_memory(new_text)
 		memory += "[new_text]<BR>"
 
+	proc/remove_dynamic_memories_by_type(dynamic_memory_type)
+		for (var/datum/dynamic_player_memory/dynamic_memory in src.dynamic_memories)
+			if (dynamic_memory.type == dynamic_memory_type)
+				src.dynamic_memories -= dynamic_memory
+
 	proc/show_memory(mob/recipient)
 		var/output = "<B>[current.real_name]'s Memory</B><HR>"
 		output += memory
+
+		for (var/datum/dynamic_player_memory/dynamic_memory in src.dynamic_memories)
+			output += dynamic_memory.memory_text
 
 		if (objectives.len>0)
 			output += "<HR><B>Objectives:</B><br>"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -82,6 +82,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\disease.dm"
 #include "code\datums\disjoint_turf.dm"
 #include "code\datums\dna.dm"
+#include "code\datums\dynamic_player_memory.dm"
 #include "code\datums\dynamicQueue.dm"
 #include "code\datums\ehjax.dm"
 #include "code\datums\embedded_controller.dm"


### PR DESCRIPTION
[Internal] [Code Quality]

## About the PR:
Permits player memories to display dynamic memories of type `/datum/dynamic_player_memory`, which will be updated when the `COMSIG_MIND_UPDATE_MEMORY` signal is sent to the mind that owns the dynamic memory.

Conspirator antagonists' will now receive a `/datum/dynamic_player_memory/conspirator_list` memory, which will be updated with the names of every conspirator each time a new conspirator antagonist is added or removed.



## Why's this needed?
Dynamic player memory datums should provide a way for player memories to be updated with new information when appropriate.

Provides a more robust solution to the issue raised in #12953.