### PR TITLE
fix artifact glow being invisible in inventories

### DIFF
--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -27,6 +27,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 	// These are automatically handled. They're used to make the artifact glow different colors.
 	/// the glowy overlay used for when the artifact is activated
 	var/obj/effect/artifact_glowie/fx_image = null
+	var/obj/effect/artifact_glowie/fx_image2 = null
 	/// the actual /obj that belongs to this specific artifact instance
 	var/obj/holder = null
 

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -27,7 +27,8 @@ ABSTRACT_TYPE(/datum/artifact/)
 	// These are automatically handled. They're used to make the artifact glow different colors.
 	/// the glowy overlay used for when the artifact is activated
 	var/obj/effect/artifact_glowie/fx_image = null
-	var/obj/effect/artifact_glowie/fx_image2 = null
+	/// the glowy overlay used to ensure the glow is visible
+	var/obj/effect/artifact_glowie/fx_fallback = null
 	/// the actual /obj that belongs to this specific artifact instance
 	var/obj/holder = null
 

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -101,6 +101,15 @@
 	A.fx_image.alpha = rand(AO.fx_alpha_min, AO.fx_alpha_max)
 	A.fx_image.plane = PLANE_ABOVE_LIGHTING
 
+	A.fx_image2 = new
+	A.fx_image2.icon = src.icon
+	A.fx_image2.icon_state = src.icon_state + "fx"
+	A.fx_image2.color = A.fx_image.color
+	A.fx_image2.alpha = A.fx_image.alpha
+	A.fx_image2.vis_flags |= VIS_INHERIT_LAYER
+	A.fx_image2.vis_flags |= VIS_INHERIT_PLANE
+	// the first fx_image layers under the hud, this one stays with the artifact even on the hud
+
 	A.react_mpct[1] = AO.impact_reaction_one
 	A.react_mpct[2] = AO.impact_reaction_two
 	A.react_heat[1] = AO.heat_reaction_one
@@ -151,6 +160,7 @@
 		src.icon_state = src.icon_state + "fx"
 	else
 		src.vis_contents += A.fx_image
+		src.vis_contents += A.fx_image2
 	A.effect_activate(src)
 
 /obj/proc/ArtifactDeactivated()
@@ -169,6 +179,7 @@
 		src.icon_state = src.icon_state - "fx"
 	else
 		src.vis_contents -= A.fx_image
+		src.vis_contents -= A.fx_image2
 	A.effect_deactivate(src)
 
 /obj/proc/Artifact_emp_act()

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -101,14 +101,13 @@
 	A.fx_image.alpha = rand(AO.fx_alpha_min, AO.fx_alpha_max)
 	A.fx_image.plane = PLANE_ABOVE_LIGHTING
 
-	A.fx_image2 = new
-	A.fx_image2.icon = src.icon
-	A.fx_image2.icon_state = src.icon_state + "fx"
-	A.fx_image2.color = A.fx_image.color
-	A.fx_image2.alpha = A.fx_image.alpha
-	A.fx_image2.vis_flags |= VIS_INHERIT_LAYER
-	A.fx_image2.vis_flags |= VIS_INHERIT_PLANE
-	// the first fx_image layers under the hud, this one stays with the artifact even on the hud
+	A.fx_fallback = new
+	A.fx_fallback.icon = src.icon
+	A.fx_fallback.icon_state = src.icon_state + "fx"
+	A.fx_fallback.color = A.fx_image.color
+	A.fx_fallback.alpha = A.fx_image.alpha
+	A.fx_fallback.vis_flags |= VIS_INHERIT_LAYER
+	A.fx_fallback.vis_flags |= VIS_INHERIT_PLANE
 
 	A.react_mpct[1] = AO.impact_reaction_one
 	A.react_mpct[2] = AO.impact_reaction_two
@@ -160,7 +159,7 @@
 		src.icon_state = src.icon_state + "fx"
 	else
 		src.vis_contents += A.fx_image
-		src.vis_contents += A.fx_image2
+		src.vis_contents += A.fx_fallback
 	A.effect_activate(src)
 
 /obj/proc/ArtifactDeactivated()
@@ -179,7 +178,7 @@
 		src.icon_state = src.icon_state - "fx"
 	else
 		src.vis_contents -= A.fx_image
-		src.vis_contents -= A.fx_image2
+		src.vis_contents -= A.fx_fallback
 	A.effect_deactivate(src)
 
 /obj/proc/Artifact_emp_act()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[objects] [bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds another image for the artifact glow which will remain visible when the original one is hidden under the hud. this allows them to still glow, but also be visible in the hud
![image](https://user-images.githubusercontent.com/64938519/218164074-e1328923-339e-4a3b-950a-4db706d0c51c.png)
![image](https://user-images.githubusercontent.com/64938519/218164162-89dfc012-ac54-40ed-8f17-7a8ca874bd6e.png)
fx_fallback inherits the plane and layer of the artifact, meaning it will show up correctly when fx_image is hidden.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #12979
the glow that indicates that an artifact is activated currently is on a plane below the hud,
making it so you cant tell at a glance if its activated or not in a bag

