### PR TITLE
Lotsa CI fuckery and updates

### DIFF
--- a/.github/workflows/automaton.yml
+++ b/.github/workflows/automaton.yml
@@ -1,4 +1,4 @@
-# Automaton, a beepsky supplement for checking runtime violations in maps
+# Automaton, a beepsky supplement for checking runtime violations in maps and much more
 # Based on Turdis by Yogstation
 
 name: Automaton

--- a/.github/workflows/automaton.yml
+++ b/.github/workflows/automaton.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Fetch cached i386 packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libstdc++6:i386 libssl1.1:i386
+          packages: libstdc++6:i386 libssl-dev:i386
           version: automaton
 
       - name: Cache BYOND
@@ -113,7 +113,7 @@ jobs:
       - name: Fetch cached i386 packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libstdc++6:i386 libssl1.1:i386
+          packages: libstdc++6:i386 libssl-dev:i386
           version: automaton
 
       - name: Cache BYOND
@@ -183,7 +183,7 @@ jobs:
       - name: Fetch cached i386 packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libstdc++6:i386 libssl1.1:i386
+          packages: libstdc++6:i386 libssl-dev:i386
           version: automaton
 
       - name: Cache BYOND

--- a/.github/workflows/automaton.yml
+++ b/.github/workflows/automaton.yml
@@ -27,9 +27,14 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo dpkg --add-architecture i386
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo sed -i'' -E 's/^(deb|deb-src) http:\/\/(azure.archive|security).ubuntu.com/\1 [arch=amd64,i386] http:\/\/\2.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt install -o Acquire::Retries=3 libstdc++6:i386 libssl1.1:i386
+
+      - name: Fetch cached i386 packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libstdc++6:i386 libssl1.1:i386
+          version: automaton
 
       - name: Cache BYOND
         uses: actions/cache@v3
@@ -102,9 +107,14 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo dpkg --add-architecture i386
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo sed -i'' -E 's/^(deb|deb-src) http:\/\/(azure.archive|security).ubuntu.com/\1 [arch=amd64,i386] http:\/\/\2.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt install -o Acquire::Retries=3 libstdc++6:i386 libssl1.1:i386
+
+      - name: Fetch cached i386 packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libstdc++6:i386 libssl1.1:i386
+          version: automaton
 
       - name: Cache BYOND
         uses: actions/cache@v3
@@ -169,7 +179,12 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt install -o Acquire::Retries=3 libstdc++6:i386 libssl1.1:i386
+
+      - name: Fetch cached i386 packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libstdc++6:i386 libssl1.1:i386
+          version: automaton
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/automaton.yml
+++ b/.github/workflows/automaton.yml
@@ -14,7 +14,7 @@ jobs:
 
   runtime:
     name: Runtime Checker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       fail-fast: false
@@ -84,7 +84,7 @@ jobs:
 
   runtime_full:
     name: "Runtime Checker with Secret Submodule"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ((github.event_name == 'push' && github.repository == 'goonstation/goonstation') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'goonstation/goonstation')) && !contains(github.event.head_commit.message, 'skip ci')
     strategy:
@@ -159,7 +159,7 @@ jobs:
 
   unit_test:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -101,7 +101,7 @@ jobs:
 
   compile_full:
     name: "Compile and Lint with Secret Submodule"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     if: |
       ((github.event_name == 'push' && github.repository == 'goonstation/goonstation') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'goonstation/goonstation')) && !contains(github.event.head_commit.message, 'skip ci')
     steps:
@@ -120,7 +120,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libstdc++6:i386
-          version: latest
+          version: pyshit2
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -60,7 +60,8 @@ jobs:
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      - name: Fetch cached i386 packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libstdc++6:i386
           version: latest
@@ -109,12 +110,17 @@ jobs:
           submodules: true
           token: '${{ secrets.ROBUDDYBOT_PAT }}'
 
-      - name: Install Dependencies
+      - name: Install i386 Architecture
         run: |
           sudo dpkg --add-architecture i386
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt install -o Acquire::Retries=3 libstdc++6:i386
+
+      - name: Fetch cached i386 packages
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libstdc++6:i386
+          version: latest
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Run Linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
 
   compile:
     name: Compile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
 
   compile_full:
     name: "Compile and Lint with Secret Submodule"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ((github.event_name == 'push' && github.repository == 'goonstation/goonstation') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'goonstation/goonstation')) && !contains(github.event.head_commit.message, 'skip ci')
     steps:

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -120,7 +120,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libstdc++6:i386
-          version: beepsky-pyshit2
+          version: beepsky
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Run Linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
 
   compile_full:
     name: "Compile and Lint with Secret Submodule"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ((github.event_name == 'push' && github.repository == 'goonstation/goonstation') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'goonstation/goonstation')) && !contains(github.event.head_commit.message, 'skip ci')
     steps:

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Run Linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -54,12 +54,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Dependencies
+      - name: Install i386 Architecture
         run: |
           sudo dpkg --add-architecture i386
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt install -o Acquire::Retries=3 libstdc++6:i386
+
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libstdc++6:i386
+          version: latest
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -57,14 +57,14 @@ jobs:
       - name: Install i386 Architecture
         run: |
           sudo dpkg --add-architecture i386
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo sed -i'' -E 's/^(deb|deb-src) http:\/\/(azure.archive|security).ubuntu.com/\1 [arch=amd64,i386] http:\/\/\2.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
 
       - name: Fetch cached i386 packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libstdc++6:i386
-          version: latest
+          version: beepsky
 
       - name: Cache BYOND
         uses: actions/cache@v3
@@ -113,14 +113,14 @@ jobs:
       - name: Install i386 Architecture
         run: |
           sudo dpkg --add-architecture i386
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo sed -i'' -E 's/^(deb|deb-src) http:\/\/(azure.archive|security).ubuntu.com/\1 [arch=amd64,i386] http:\/\/\2.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
 
       - name: Fetch cached i386 packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libstdc++6:i386
-          version: pyshit2
+          version: beepsky-pyshit2
 
       - name: Cache BYOND
         uses: actions/cache@v3

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   merge-upstream:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '!merge_upstream' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: PR Data

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   merge-upstream:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '!merge_upstream' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: PR Data

--- a/_std/rust_g.dm
+++ b/_std/rust_g.dm
@@ -38,8 +38,15 @@
 #define RUST_G (__rust_g || __detect_rust_g())
 #endif
 
+// Handle 515 call() -> call_ext() changes
+#if DM_VERSION >= 515
+#define RUSTG_CALL call_ext
+#else
+#define RUSTG_CALL call
+#endif
+
 /// Gets the version of rust_g
-/proc/rustg_get_version() return call(RUST_G, "get_version")()
+/proc/rustg_get_version() return RUSTG_CALL(RUST_G, "get_version")()
 
 
 /**
@@ -51,7 +58,7 @@
  * * patterns - A non-associative list of strings to search for
  * * replacements - Default replacements for this automaton, used with rustg_acreplace
  */
-#define rustg_setup_acreplace(key, patterns, replacements) call(RUST_G, "setup_acreplace")(key, json_encode(patterns), json_encode(replacements))
+#define rustg_setup_acreplace(key, patterns, replacements) RUSTG_CALL(RUST_G, "setup_acreplace")(key, json_encode(patterns), json_encode(replacements))
 
 /**
  * Sets up the Aho-Corasick automaton using supplied options.
@@ -63,7 +70,7 @@
  * * patterns - A non-associative list of strings to search for
  * * replacements - Default replacements for this automaton, used with rustg_acreplace
  */
-#define rustg_setup_acreplace_with_options(key, options, patterns, replacements) call(RUST_G, "setup_acreplace")(key, json_encode(options), json_encode(patterns), json_encode(replacements))
+#define rustg_setup_acreplace_with_options(key, options, patterns, replacements) RUSTG_CALL(RUST_G, "setup_acreplace")(key, json_encode(options), json_encode(patterns), json_encode(replacements))
 
 /**
  * Run the specified replacement engine with the provided haystack text to replace, returning replaced text.
@@ -72,7 +79,7 @@
  * * key - The key for the automaton
  * * text - Text to run replacements on
  */
-#define rustg_acreplace(key, text) call(RUST_G, "acreplace")(key, text)
+#define rustg_acreplace(key, text) RUSTG_CALL(RUST_G, "acreplace")(key, text)
 
 /**
  * Run the specified replacement engine with the provided haystack text to replace, returning replaced text.
@@ -82,7 +89,7 @@
  * * text - Text to run replacements on
  * * replacements - Replacements for this call. Must be the same length as the set-up patterns
  */
-#define rustg_acreplace_with_replacements(key, text, replacements) call(RUST_G, "acreplace_with_replacements")(key, text, json_encode(replacements))
+#define rustg_acreplace_with_replacements(key, text, replacements) RUSTG_CALL(RUST_G, "acreplace_with_replacements")(key, text, json_encode(replacements))
 
 /**
  * This proc generates a cellular automata noise grid which can be used in procedural generation methods.
@@ -98,7 +105,7 @@
  * * height: The height of the grid.
  */
 #define rustg_cnoise_generate(percentage, smoothing_iterations, birth_limit, death_limit, width, height) \
-	call(RUST_G, "cnoise_generate")(percentage, smoothing_iterations, birth_limit, death_limit, width, height)
+	RUSTG_CALL(RUST_G, "cnoise_generate")(percentage, smoothing_iterations, birth_limit, death_limit, width, height)
 
 /**
  * This proc generates a grid of perlin-like noise
@@ -114,32 +121,32 @@
  * * upper_range: upper bound of values selected for. (exclusive)
  */
 #define rustg_dbp_generate(seed, accuracy, stamp_size, world_size, lower_range, upper_range) \
-	call(RUST_G, "dbp_generate")(seed, accuracy, stamp_size, world_size, lower_range, upper_range)
+	RUSTG_CALL(RUST_G, "dbp_generate")(seed, accuracy, stamp_size, world_size, lower_range, upper_range)
 
 
-#define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
-#define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
-#define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
+#define rustg_dmi_strip_metadata(fname) RUSTG_CALL(RUST_G, "dmi_strip_metadata")(fname)
+#define rustg_dmi_create_png(path, width, height, data) RUSTG_CALL(RUST_G, "dmi_create_png")(path, width, height, data)
+#define rustg_dmi_resize_png(path, width, height, resizetype) RUSTG_CALL(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
 
-#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
-#define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
-#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
-#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
-#define rustg_file_get_line_count(fname) text2num(call(RUST_G, "file_get_line_count")(fname))
-#define rustg_file_seek_line(fname, line) call(RUST_G, "file_seek_line")(fname, "[line]")
+#define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
+#define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)
+#define rustg_file_write(text, fname) RUSTG_CALL(RUST_G, "file_write")(text, fname)
+#define rustg_file_append(text, fname) RUSTG_CALL(RUST_G, "file_append")(text, fname)
+#define rustg_file_get_line_count(fname) text2num(RUSTG_CALL(RUST_G, "file_get_line_count")(fname))
+#define rustg_file_seek_line(fname, line) RUSTG_CALL(RUST_G, "file_seek_line")(fname, "[line]")
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define file2text(fname) rustg_file_read("[fname]")
 	#define text2file(text, fname) rustg_file_append(text, "[fname]")
 #endif
 
-#define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
-#define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
+#define rustg_git_revparse(rev) RUSTG_CALL(RUST_G, "rg_git_revparse")(rev)
+#define rustg_git_commit_date(rev) RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev)
 
-#define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
-#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
-#define rustg_hash_generate_totp(seed) call(RUST_G, "generate_totp")(seed)
-#define rustg_hash_generate_totp_tolerance(seed, tolerance) call(RUST_G, "generate_totp_tolerance")(seed, tolerance)
+#define rustg_hash_string(algorithm, text) RUSTG_CALL(RUST_G, "hash_string")(algorithm, text)
+#define rustg_hash_file(algorithm, fname) RUSTG_CALL(RUST_G, "hash_file")(algorithm, fname)
+#define rustg_hash_generate_totp(seed) RUSTG_CALL(RUST_G, "generate_totp")(seed)
+#define rustg_hash_generate_totp_tolerance(seed, tolerance) RUSTG_CALL(RUST_G, "generate_totp_tolerance")(seed, tolerance)
 
 #define RUSTG_HASH_MD5 "md5"
 #define RUSTG_HASH_SHA1 "sha1"
@@ -158,26 +165,29 @@
 #define RUSTG_HTTP_METHOD_PATCH "patch"
 #define RUSTG_HTTP_METHOD_HEAD "head"
 #define RUSTG_HTTP_METHOD_POST "post"
-#define rustg_http_request_blocking(method, url, body, headers, options) call(RUST_G, "http_request_blocking")(method, url, body, headers, options)
-#define rustg_http_request_async(method, url, body, headers, options) call(RUST_G, "http_request_async")(method, url, body, headers, options)
-#define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
+#define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
+#define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
+#define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)
 
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
 #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
 #define RUSTG_JOB_ERROR "JOB PANICKED"
 
-#define rustg_json_is_valid(text) (call(RUST_G, "json_is_valid")(text) == "true")
+#define rustg_json_is_valid(text) (RUSTG_CALL(RUST_G, "json_is_valid")(text) == "true")
 
-#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
-/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+#define rustg_log_write(fname, text, format) RUSTG_CALL(RUST_G, "log_write")(fname, text, format)
+/proc/rustg_log_close_all() return RUSTG_CALL(RUST_G, "log_close_all")()
 
-#define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
+#define rustg_noise_get_at_coordinates(seed, x, y) RUSTG_CALL(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 
-#define rustg_time_microseconds(id) text2num(call(RUST_G, "time_microseconds")(id))
-#define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
-#define rustg_time_reset(id) call(RUST_G, "time_reset")(id)
+#define rustg_time_microseconds(id) text2num(RUSTG_CALL(RUST_G, "time_microseconds")(id))
+#define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
+#define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
 
-#define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+/proc/rustg_unix_timestamp()
+	return text2num(RUSTG_CALL(RUST_G, "unix_timestamp")())
+
+#define rustg_raw_read_toml_file(path) json_decode(RUSTG_CALL(RUST_G, "toml_file_to_json")(path) || "null")
 
 /proc/rustg_read_toml_file(path)
 	var/list/output = rustg_raw_read_toml_file(path)
@@ -186,8 +196,17 @@
 	else
 		CRASH(output["content"])
 
-#define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
-#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+#define rustg_raw_toml_encode(value) json_decode(RUSTG_CALL(RUST_G, "toml_encode")(json_encode(value)))
+
+/proc/rustg_toml_encode(value)
+	var/list/output = rustg_raw_toml_encode(value)
+	if (output["success"])
+		return output["content"]
+	else
+		CRASH(output["content"])
+
+#define rustg_url_encode(text) RUSTG_CALL(RUST_G, "url_encode")("[text]")
+#define rustg_url_decode(text) RUSTG_CALL(RUST_G, "url_decode")(text)
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define url_encode(text) rustg_url_encode(text)
@@ -208,6 +227,6 @@
  * * node_max: maximum amount of nodes in a region
  */
 #define rustg_worley_generate(region_size, threshold, node_per_region_chance, size, node_min, node_max) \
-	call(RUST_G, "worley_generate")(region_size, threshold, node_per_region_chance, size, node_min, node_max)
+	RUSTG_CALL(RUST_G, "worley_generate")(region_size, threshold, node_per_region_chance, size, node_min, node_max)
 
 

--- a/buildByond.conf
+++ b/buildByond.conf
@@ -5,7 +5,7 @@ SPACEMAN_DMM_VERSION=suite-1.7.3
 
 # 93ae889
 # --no-default-features --features "acreplace, cellularnoise, dmi, file, git, http, json, log, noise, time, toml, url, batchnoise, hash, worleynoise"
-RUST_G_VERSION=1.0.2
+RUST_G_VERSION=1.2.0
 
 NODE_VERSION=16
 

--- a/buildByond.conf
+++ b/buildByond.conf
@@ -3,8 +3,8 @@ BYOND_MINOR_VERSION=1589
 
 SPACEMAN_DMM_VERSION=suite-1.7.3
 
-# See: goonstation/rust-g
-RUST_G_VERSION=1.2.0-G
+# See: goonstation/rust-g - is the tag for the release
+RUST_G_VERSION=v1.2.0-G
 
 NODE_VERSION=16
 

--- a/buildByond.conf
+++ b/buildByond.conf
@@ -3,9 +3,8 @@ BYOND_MINOR_VERSION=1589
 
 SPACEMAN_DMM_VERSION=suite-1.7.3
 
-# 93ae889
-# --no-default-features --features "acreplace, cellularnoise, dmi, file, git, http, json, log, noise, time, toml, url, batchnoise, hash, worleynoise"
-RUST_G_VERSION=1.2.0
+# See: goonstation/rust-g
+RUST_G_VERSION=1.2.0-G
 
 NODE_VERSION=16
 

--- a/buildByond.conf
+++ b/buildByond.conf
@@ -10,4 +10,4 @@ RUST_G_VERSION=1.0.2
 NODE_VERSION=16
 
 # Python version for mapmerge and other tools
-PYTHON_VERSION=3.6.8
+PYTHON_VERSION=3.9.0

--- a/tools/bootstrap/python.bat
+++ b/tools/bootstrap/python.bat
@@ -1,1 +1,2 @@
+@echo off
 @call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*

--- a/tools/bootstrap/python36._pth
+++ b/tools/bootstrap/python36._pth
@@ -1,6 +1,0 @@
-python36.zip
-.
-..\..\..
-
-# Uncomment to run site.main() automatically
-import site

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -49,8 +49,14 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
+	$PythonVersionArray = $PythonVersion.Split(".")
+	$PythonVersionString = "python$($PythonVersionArray[0])$($PythonVersionArray[1])"
+	Write-Output "Generating PATH descriptor."
+	New-Item "$Cache/$PythonVersionString._pth" | Out-Null
+	Set-Content "$Cache/$PythonVersionString._pth" "$PythonVersionString.zip`n.`n..\..\..`nimport site`n"
+
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python36._pth" $PythonDir `
+	Copy-Item "$Cache/$PythonVersionString._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/ci/install_rust_g.sh
+++ b/tools/ci/install_rust_g.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 source buildByond.conf
 
-wget -O ./librust_g.so "https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
+wget -O ./librust_g.so "https://github.com/goonstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
 chmod +x ./librust_g.so
 ldd ./librust_g.so

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==1.6.1
-bidict==0.13.1
+pygit2==1.7.1
+bidict==0.21.4
 Pillow==8.4.0


### PR DESCRIPTION
## About the PR

This PR does multiple things:
* Implements caching of apt packages we use to hopefully cut down on random actions failures.
* Upgrades our bootstrap python version to 3.9 - ***The existing cache will need to be deleted***
* Upgrades our rust-g version, and switches CI to pulling from a vendored version at https://github.com/goonstation/rust-g
* Upgrades our action runners to Ubuntu 22 to stay ahead of deprecations 

Needs wire to update rust-g on the servers when this is merged
1. Clone and checkout https://github.com/goonstation/rust-g
2. `cd rust-g && bash ./apply_patches.sh`
3. `export RUSTFLAGS="-C target-cpu=native"`
4. `export PKG_CONFIG_ALLOW_CROSS=1`
5. `cargo build --release --target=i686-unknown-linux-gnu` - we patch the default features to be our wanted ones

## Why's this needed? 

fix?
