### PR TITLE
Remove lifeprocesses from all dead critters

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -766,7 +766,21 @@ ABSTRACT_TYPE(/mob/living/critter)
 			drop_equipment()
 		hud?.update_health()
 		update_stunned_icon(canmove=1)//force it to go away
+		reduce_lifeprocess_on_death()
 		return ..(gibbed)
+
+	proc/reduce_lifeprocess_on_death() //quit doing stuff when you're dead
+		remove_lifeprocess(/datum/lifeprocess/blood)
+		remove_lifeprocess(/datum/lifeprocess/canmove)
+		remove_lifeprocess(/datum/lifeprocess/disability)
+		remove_lifeprocess(/datum/lifeprocess/fire)
+		remove_lifeprocess(/datum/lifeprocess/hud)
+		remove_lifeprocess(/datum/lifeprocess/mutations)
+		remove_lifeprocess(/datum/lifeprocess/organs)
+		remove_lifeprocess(/datum/lifeprocess/sight)
+		remove_lifeprocess(/datum/lifeprocess/skin)
+		remove_lifeprocess(/datum/lifeprocess/statusupdate)
+		remove_lifeprocess(/datum/lifeprocess/radiation)
 
 	proc/get_health_holder(var/assoc)
 		if (assoc in healthlist)

--- a/code/mob/living/critter/firefly.dm
+++ b/code/mob/living/critter/firefly.dm
@@ -109,7 +109,6 @@ TYPEINFO(/mob/living/critter/small_animal/firefly)
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 /mob/living/critter/small_animal/firefly/pyre
@@ -159,7 +158,6 @@ TYPEINFO(/mob/living/critter/small_animal/firefly)
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 /obj/effects/firefly_pyre
@@ -227,7 +225,6 @@ TYPEINFO(/mob/living/critter/small_animal/firefly)
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 /obj/effects/firefly_lightning
@@ -309,7 +306,6 @@ TYPEINFO(/mob/living/critter/small_animal/dragonfly)
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 	Move(NewLoc, direct)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -800,18 +800,6 @@
 /mob/living/critter/flock/drone/get_tracked_examine_atoms()
 	return ..() + src.flock.structures
 
-/mob/living/critter/flock/drone/proc/reduce_lifeprocess_on_death()
-	remove_lifeprocess(/datum/lifeprocess/blood)
-	remove_lifeprocess(/datum/lifeprocess/canmove)
-	remove_lifeprocess(/datum/lifeprocess/disability)
-	remove_lifeprocess(/datum/lifeprocess/fire)
-	remove_lifeprocess(/datum/lifeprocess/hud)
-	remove_lifeprocess(/datum/lifeprocess/mutations)
-	remove_lifeprocess(/datum/lifeprocess/organs)
-	remove_lifeprocess(/datum/lifeprocess/sight)
-	remove_lifeprocess(/datum/lifeprocess/skin)
-	remove_lifeprocess(/datum/lifeprocess/statusupdate)
-
 /mob/living/critter/flock/drone/death(var/gibbed)
 	if (src.selected_by)
 		var/mob/living/intangible/flock/selector = src.selected_by
@@ -834,7 +822,6 @@
 		src.pay_resources(src.resources) // just in case any weirdness happens let's pre-empt the dupe bug
 	..()
 	src.icon_state = "drone-dead"
-	src.reduce_lifeprocess_on_death()
 	src.set_density(FALSE)
 	src.desc = "[initial(desc)]<br><span class='alert'>\The [src] is a dead, broken heap.</span>"
 	src.remove_simple_light("drone_light")

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -107,18 +107,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 	canRideMailchutes()
 		return src.fits_under_table
 
-	proc/reduce_lifeprocess_on_death() //used for AI mobs we dont give a dang about them after theyre dead
-		remove_lifeprocess(/datum/lifeprocess/blood)
-		remove_lifeprocess(/datum/lifeprocess/canmove)
-		remove_lifeprocess(/datum/lifeprocess/disability)
-		remove_lifeprocess(/datum/lifeprocess/fire)
-		remove_lifeprocess(/datum/lifeprocess/hud)
-		remove_lifeprocess(/datum/lifeprocess/mutations)
-		remove_lifeprocess(/datum/lifeprocess/organs)
-		remove_lifeprocess(/datum/lifeprocess/sight)
-		remove_lifeprocess(/datum/lifeprocess/skin)
-		remove_lifeprocess(/datum/lifeprocess/statusupdate)
-		remove_lifeprocess(/datum/lifeprocess/radiation)
+
 
 /* =============================================== */
 /* -------------------- Mouse -------------------- */
@@ -2206,7 +2195,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 /* ================================================ */
@@ -2334,7 +2322,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 /* ================================================ */
@@ -3652,7 +3639,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 
@@ -3725,7 +3711,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()
 
 
@@ -3817,5 +3802,4 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		death(var/gibbed)
 			qdel(src.ai)
 			src.ai = null
-			reduce_lifeprocess_on_death()
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the `remove_lifeprocess_on_death()` from `critter/small_animal` to `critter`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12947 and makes critters slightly more efficient.
