### PR TITLE
Convert zoldorf ghost to living/intangible

### DIFF
--- a/code/datums/abilities/zoldorfabilities.dm
+++ b/code/datums/abilities/zoldorfabilities.dm
@@ -442,7 +442,7 @@
 				deadpeople += M.real_name
 				if(the_mob == user || (the_mob.client && (get_turf(the_mob) in range(the_mob.client.view, get_turf(user)))))
 					var/mobloc = get_turf(the_mob) // TODO add consent
-					var/mob/living/seanceghost/sg
+					var/mob/living/intangible/seanceghost/sg
 					if(istype(the_mob,/mob/zoldorf))
 						sg = the_mob.make_seance(null,the_mob,deadpeople)
 					else

--- a/code/datums/components/glue_ready.dm
+++ b/code/datums/components/glue_ready.dm
@@ -74,7 +74,7 @@ TYPEINFO(/datum/component/glue_ready)
 		return FALSE
 	if(istype(glued_to, /obj/machinery/door) || istype(glued_to, /obj/grille))
 		return FALSE
-	if(istype(glued_to, /mob/dead) || istype(glued_to, /mob/living/intangible) || istype(glued_to, /mob/living/seanceghost))
+	if(istype(glued_to, /mob/dead) || istype(glued_to, /mob/living/intangible) )
 		if(user)
 			boutput(user, "<span class='alert'>Your hand with [thing_glued] passes straight through \the [glued_to].</span>")
 		return FALSE

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -430,7 +430,7 @@
 		hud.update_charge()
 		hud.update_tools()
 
-/mob/living/seanceghost/Life(parent)
+/mob/living/intangible/seanceghost/Life(parent)
 	if (..(parent))
 		return 1
 	if (!src.abilityHolder)

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -1,5 +1,5 @@
 // TODO make this mob/living/intangible. the fuck is it doing here?
-/mob/living/seanceghost
+/mob/living/intangible/seanceghost
 	name = "Seance Ghost"
 	desc = "Ominous hooded figure!"
 	icon = 'icons/obj/zoldorf.dmi'
@@ -16,6 +16,7 @@
 
 	New(var/mob/M)
 		..()
+		invisibility = INVIS_NONE
 
 	is_spacefaring()
 		return 1
@@ -161,7 +162,7 @@
 	if(originalz) //theres different handling for if that previous mob was a zoldorf or not
 		originalg = originalz
 	if (src.mind || src.client)
-		var/mob/living/seanceghost/Z = new/mob/living/seanceghost(src)
+		var/mob/living/intangible/seanceghost/Z = new/mob/living/intangible/seanceghost(src)
 
 		var/turf/T = get_turf(src)
 		if (!(T && isturf(T)) || ((isrestrictedz(T.z) || T.z != 1) && !(src.client && src.client.holder)))

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -688,7 +688,7 @@ proc/get_angle(atom/a, atom/b)
 	for(var/mob/zoldorf/M in mobs)
 		. += M
 		LAGCHECK(LAG_REALTIME)
-	for(var/mob/living/seanceghost/M in mobs)
+	for(var/mob/living/intangible/seanceghost/M in mobs)
 		. += M
 		LAGCHECK(LAG_REALTIME)
 

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -276,7 +276,7 @@
 			if (!the_wraith.hearghosts)
 				continue
 
-		if (isdead(M) || iswraith(M) || isghostdrone(M) || isVRghost(M) || inafterlifebar(M) || istype(M, /mob/living/seanceghost))
+		if (isdead(M) || iswraith(M) || isghostdrone(M) || isVRghost(M) || inafterlifebar(M) || istype(M, /mob/living/intangible/seanceghost))
 			if(chat_text && !M.client.preferences.flying_chat_hidden)
 				chat_text.show_to(C)
 			boutput(M, rendered)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Converts seanceghost from var/mob/living to var/mob/living/intangible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lots of annoying implications from it being a conventional living mob.
Fixes [#6807](https://github.com/goonstation/goonstation/issues/6807)

From what I can tell the only change is you can no longer punch the ghost.