### PR TITLE
Fixes Cog1 Telesci Door Access

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -59820,7 +59820,7 @@
 	name = "Teleporter Pad";
 	req_access_txt = null
 	},
-/obj/access_spawn/tox,
+/obj/access_spawn/telesci,
 /obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the cog1 telescience teleporter door having the wrong access spawner on it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
That very much isn't toxins.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


