### PR TITLE
Adds a warp beacon for cog1's catering hanger

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56077,6 +56077,14 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"mMD" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "mMJ" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/blue/checker,
@@ -58609,6 +58617,16 @@
 /obj/access_spawn/rancher,
 /turf/simulated/floor/plating,
 /area/station/ranch)
+"pUU" = (
+/obj/warp_beacon{
+	name = "Catering Hanger Beacon"
+	},
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "pVj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -125248,7 +125266,7 @@ adC
 adC
 adC
 adC
-bSY
+mMD
 adC
 adC
 adC
@@ -125550,7 +125568,7 @@ adC
 adC
 adC
 adC
-adC
+aah
 adC
 adC
 adC
@@ -125852,7 +125870,7 @@ adC
 adC
 adC
 adC
-adC
+aah
 adC
 adC
 adC
@@ -126154,7 +126172,7 @@ adC
 adC
 adC
 adC
-adC
+pUU
 adC
 adC
 adC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a warp beacon outside of cog1's catering hanger.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For a moderately used hanger, the closest beacon leading to it is the qm hangar beacon. This will reduce the time it takes for people to travel to the hangar, and reduce traffic outside of the qm hangar, consequently reducing intake blockages for qm.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Added a warp beacon for cog1's catering hanger.
```
