### PR TITLE
Adjusts Wraith Chance On Traitor

### DIFF
--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -39,7 +39,7 @@
 	if(traitor_scaling)
 		num_traitors = clamp(round((num_players + randomizer) / pop_divisor), 1, traitors_possible) // adjust the randomizer as needed
 
-	if(num_traitors > 2 && prob(10))
+	if(num_traitors >= 4 && prob(15))
 		num_traitors -= 1
 		num_wraiths = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the chance for a wraith to spawn on the traitor gamemode to 15% (was 10%), but also increases the minimum number of traitors needed for the chance to occur (minimum of 4 traitors, up from 3).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This makes the chance on par with the vampire and arcfiend gamemodes (not accounting for pop divisor), while also increasing the minimum amount of players needed to spawn a wraith. currently, there's a 10% chance of a wraith replacing one of traitors if at least 14 (23 on rp) players readied up, assuming the calc for traitors rolls it's maximum (7), which is WAY too low of a pop count for wraith. Now the minimum will be 21 (33 on rp). If this is still too low, let me know so I can increase it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)The chance for a wraith to spawn on the traitor gamemode has been increased to 15% (up from 10%)
(+)The minimum number of traitors needed for a wraith to replace a traitor in the traitor gamemode has been increased to 4 (up from 3)
```
