### PR TITLE
Changes some cyborg cell cable messages

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -521,9 +521,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 
 			var/overspill = 250 - recipient_cell.charge
 			if (recipient_cell.charge >= recipient_cell.maxcharge)
-				boutput(user, "<span class='notice'>[jumper.positive ? "[src]" : "Your"] cell is already fully charged.</span>")
+				boutput(user, "<span class='notice'>[jumper.positive ? "[src]" : "Your cell"] is already fully charged.</span>")
 			else if (donor_cell.charge <= 250)
-				boutput(user, "<span class='alert'>You do not have enough charge left to do this!</span>")
+				boutput(user, "<span class='alert'>[jumper.positive ? "You don't" : "[src] doesn't"] have enough power to transfer!</span>")
 			else if (overspill >= 250)
 				donor_cell.charge -= overspill
 				recipient_cell.charge += overspill


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

Probably [GAME OBJECTS] (maybe PLAYER ACTIONS but I dont know), I have no clue what category this would go under.
## About the PR + Why's this needed?
By the way there MIGHT be an issue for this but I haven't bothered to look, I have no clue
I changed some messages the APC gave you when using cell cables on it.
`[jumper.positive ? "[src]" : "Your"] cell is already fully charged.`
to
`[jumper.positive ? "[src]" : "Your cell"] is already fully charged.`
Because `North Primary Hallway APC cell is already fully charged.` didn't sound right to me.

`You do not have enough charge left to do this!`
to
`[jumper.positive ? "You don't" : "[src] doesn't"] have enough power to transfer!`
Because it said `You don't` even when the APC didn't have power for the transfer.