### PR TITLE
Rename mustard plant

### DIFF
--- a/code/modules/hydroponics/plants_fruit.dm
+++ b/code/modules/hydroponics/plants_fruit.dm
@@ -375,7 +375,7 @@ ABSTRACT_TYPE(/datum/plant/fruit)
 	commuts = list(/datum/plant_gene_strain/damage_res,/datum/plant_gene_strain/stabilizer)
 
 /datum/plant/fruit/mustard
-	name = "Mustard" //oh god
+	name = "Sinapis cosmicus" //oh god
 	seedcolor = "#FFCC00"
 	crop = /obj/item/reagent_containers/food/snacks/plant/mustard
 	starthealth = 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Hydroponics]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes mustard plant name from "Mustard" to "Sinapis cosmicus" (space mustard, if my latin is correct)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mustard as is, when spliced as recessive with another plant always leaves the last 4 characters of the word "mustard" in the new hybrid seed. Knowing how this server usually does not tolerate such language I thought this should be fixed before any harm could be done.

No need for changelog, I think.
