### PR TITLE
Changeling critter antag datums

### DIFF
--- a/_std/defines/antagonists.dm
+++ b/_std/defines/antagonists.dm
@@ -5,3 +5,4 @@
 #define ANTAGONIST_SOURCE_RANDOM_EVENT "random event "
 #define ANTAGONIST_SOURCE_ADMIN "admin-created "
 #define ANTAGONIST_SOURCE_MUTANT "antag-mutantrace "
+#define ANTAGONIST_SOURCE_SUMMONED "antag-summoned "

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -232,9 +232,12 @@ datum/mind
 		for (var/V in concrete_typesof(/datum/antagonist))
 			var/datum/antagonist/A = V
 			if (initial(A.id) == role_id)
-				src.antagonists.Add(new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup))
+				var/datum/antagonist/new_datum = new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup)
+				if (QDELETED(new_datum))
+					return FALSE
+				src.antagonists.Add(new_datum)
 				src.current.antagonist_overlay_refresh(TRUE, FALSE)
-				return !isnull(src.get_antagonist(role_id))
+				return TRUE
 		return FALSE
 
 	/// Attempts to remove existing antagonist datums of ID role_id from this mind.

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -147,7 +147,7 @@
 	hand_count = 1
 	var/absorbed_dna = 0
 
-	New()
+	New(loc, obj/item/bodypart)
 		..()
 		abilityHolder = new /datum/abilityHolder/critter/handspider(src)
 		//todo : move to add_abilities list because its cleaner that way
@@ -155,6 +155,10 @@
 		abilityHolder.addAbility(/datum/targetable/critter/boilgib)
 		abilityHolder.updateButtons()
 		src.flags ^= TABLEPASS
+
+		if (bodypart && istype(bodypart, /obj/item/parts/robot_parts))
+			src.icon_prefix = "robo"
+			src.UpdateIcon()
 
 		RegisterSignal(src, COMSIG_MOB_PICKUP, .proc/stop_sprint)
 		RegisterSignal(src, COMSIG_MOB_DROPPED, .proc/enable_sprint)

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -12,6 +12,10 @@ ABSTRACT_TYPE(/datum/antagonist)
 	var/mutually_exclusive = TRUE
 	/// The medal unlocked at the end of the round by succeeding as this antagonist.
 	var/success_medal = null
+	/// If TRUE, the antag status will be removed when the person dies (changeling critters etc.)
+	var/remove_on_death = FALSE
+	/// If TRUE, the antag status will be removed when the person is cloned (zombies etc.)
+	var/remove_on_clone = FALSE
 
 
 	/// The mind of the player that that this antagonist is assigned to.
@@ -199,3 +203,14 @@ ABSTRACT_TYPE(/datum/antagonist)
 				owner.current.unlock_medal(success_medal, TRUE)
 		else
 			. += "<span class='alert'><b>\The [src.display_name] has failed!</b></span>"
+
+	proc/on_death()
+		if (src.remove_on_death)
+			src.owner.remove_antagonist(src.id)
+
+//this is stupid, but it's more reliable than trying to keep signals attached to mobs
+/mob/death()
+	if (src.mind)
+		for (var/datum/antagonist/antag in src.mind.antagonists)
+			antag.on_death()
+	..()

--- a/code/modules/antagonists/changeling/abilities/_changeling_ability_holder.dm
+++ b/code/modules/antagonists/changeling/abilities/_changeling_ability_holder.dm
@@ -29,10 +29,10 @@
 	C.addAbility(/datum/targetable/changeling/sting/dna)
 	C.addAbility(/datum/targetable/changeling/transform)
 	C.addAbility(/datum/targetable/changeling/morph_arm)
-	C.addAbility(/datum/targetable/changeling/handspider)
-	C.addAbility(/datum/targetable/changeling/eyespider)
-	C.addAbility(/datum/targetable/changeling/legworm)
-	C.addAbility(/datum/targetable/changeling/buttcrab)
+	C.addAbility(/datum/targetable/changeling/critter/handspider)
+	C.addAbility(/datum/targetable/changeling/critter/eyespider)
+	C.addAbility(/datum/targetable/changeling/critter/legworm)
+	C.addAbility(/datum/targetable/changeling/critter/buttcrab)
 	C.addAbility(/datum/targetable/changeling/hivesay)
 	C.addAbility(/datum/targetable/changeling/boot)
 	C.addAbility(/datum/targetable/changeling/give_control)
@@ -141,6 +141,11 @@
 	//Insert a mob into the hivemind by creating a hivemind_observer for them and transferring Mind
 	proc/insert_into_hivemind(var/mob/victim, var/restore_name=0)
 		var/mob/dead/target_observer/hivemind_observer/obs
+		//since getting absorbed into the hivemind yoinks your mind away before calling death, we need to do this here
+		if (victim.mind)
+			for (var/datum/antagonist/antag in victim.mind.antagonists)
+				if (istype(antag, /datum/antagonist/changeling_critter))
+					victim.mind.remove_antagonist(antag.id)
 		//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		//Just inserting a random chumpler (regular human)
 		//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/code/modules/antagonists/changeling/abilities/hivemind.dm
+++ b/code/modules/antagonists/changeling/abilities/hivemind.dm
@@ -105,10 +105,6 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 			spider.icon_prefix = "robo"
 			spider.UpdateIcon()
 
-		spider.show_antag_popup("handspider")
-		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
-		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces. You are still connected to the hivemind.</font>")
-
 		return FALSE
 
 /datum/targetable/changeling/critter/eyespider
@@ -152,10 +148,6 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		use_mob.mind.transfer_to(spider)
 		spider.mind.add_antagonist(ROLE_EYESPIDER)
 		src.attach_to_hivemind(spider)
-
-		spider.show_antag_popup("eyespider")
-		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
-		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces, and see through walls. You are still connected to the hivemind.</font>")
 
 		return FALSE
 
@@ -201,10 +193,6 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		worm.mind.add_antagonist(ROLE_LEGWORM)
 		src.attach_to_hivemind(worm)
 
-		worm.show_antag_popup("legworm")
-		boutput(worm, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
-		boutput(worm, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
-
 		return FALSE
 
 /datum/targetable/changeling/critter/buttcrab
@@ -236,10 +224,6 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		use_mob.mind.transfer_to(crab)
 		crab.mind.add_antagonist(ROLE_BUTTCRAB)
 		src.attach_to_hivemind(crab)
-
-		crab.show_antag_popup("buttcrab")
-		boutput(crab, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
-		boutput(crab, "<font color=red>You are a very small, very smelly, and weak creature. You are still connected to the hivemind.</font>")
 
 		return FALSE
 

--- a/code/modules/antagonists/changeling/abilities/hivemind.dm
+++ b/code/modules/antagonists/changeling/abilities/hivemind.dm
@@ -98,7 +98,7 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		if (!use_mob.mind)
 			CRASH("handspider created from mob with no mind")
 		use_mob.mind.transfer_to(spider)
-		spider.mind.add_antagonist(ROLE_HANDSPIDER)
+		spider.mind.add_antagonist(ROLE_HANDSPIDER, source = ANTAGONIST_SOURCE_SUMMONED)
 		src.attach_to_hivemind(spider)
 
 		if (original_arm && istype(original_arm, /obj/item/parts/robot_parts))
@@ -146,7 +146,7 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		if (!use_mob.mind)
 			CRASH("eyespider created from mob with no mind")
 		use_mob.mind.transfer_to(spider)
-		spider.mind.add_antagonist(ROLE_EYESPIDER)
+		spider.mind.add_antagonist(ROLE_EYESPIDER, source = ANTAGONIST_SOURCE_SUMMONED)
 		src.attach_to_hivemind(spider)
 
 		return FALSE
@@ -190,7 +190,7 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		if (!use_mob.mind)
 			CRASH("legworm created from mob with no mind")
 		use_mob.mind.transfer_to(worm)
-		worm.mind.add_antagonist(ROLE_LEGWORM)
+		worm.mind.add_antagonist(ROLE_LEGWORM, source = ANTAGONIST_SOURCE_SUMMONED)
 		src.attach_to_hivemind(worm)
 
 		return FALSE
@@ -222,7 +222,7 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 		if (!use_mob.mind)
 			CRASH("buttcrab created from mob with no mind")
 		use_mob.mind.transfer_to(crab)
-		crab.mind.add_antagonist(ROLE_BUTTCRAB)
+		crab.mind.add_antagonist(ROLE_BUTTCRAB, source = ANTAGONIST_SOURCE_SUMMONED)
 		src.attach_to_hivemind(crab)
 
 		return FALSE

--- a/code/modules/antagonists/changeling/abilities/hivemind.dm
+++ b/code/modules/antagonists/changeling/abilities/hivemind.dm
@@ -188,7 +188,7 @@ ABSTRACT_TYPE(/datum/targetable/changeling/critter)
 
 		var/mob/living/critter/changeling/legworm/worm = new /mob/living/critter/changeling/legworm(get_turf(owner.loc), original_leg)
 		if (!use_mob.mind)
-			CRASH("handspider created from mob with no mind")
+			CRASH("legworm created from mob with no mind")
 		use_mob.mind.transfer_to(worm)
 		worm.mind.add_antagonist(ROLE_LEGWORM)
 		src.attach_to_hivemind(worm)

--- a/code/modules/antagonists/changeling/abilities/hivemind.dm
+++ b/code/modules/antagonists/changeling/abilities/hivemind.dm
@@ -1,31 +1,35 @@
-/datum/targetable/changeling/handspider
-	name = "Handspider"
-	desc = "Detach one of your arms and bring it to life using one of the members of your hivemind."
-	icon_state = "handspider"
+//since I have now unfucked this file, here are what each successive person who copy pasted the same ability code had to say for themselves:
+// feels bad copy-pasting this, maybe refactor this in future - cirr
+// oh what's this? I copypasted it again, ooopsy! maybe refactor this in future  - mbc
+// Oh fuck. Did I copy paste this yet again? Damn. Maybe one day we'll get around to refactoring this. -fire
+
+ABSTRACT_TYPE(/datum/targetable/changeling/critter)
+/datum/targetable/changeling/critter
 	cooldown = 600
 	targeted = 0
 	target_anything = 0
 	human_only = 0
-	pointCost = 4
 	can_use_in_container = 1
 	dont_lock_holder = 0
+	///The observer mob we chose to transfer mind from, this should just be returned from New, but datum/targetable/New relies on truthy fail states
+	var/mob/dead/target_observer/hivemind_observer/use_mob = null
 
 	incapacitationCheck()
 		return 0
 
 	cast(atom/target)
 		if (..())
-			return 1
+			return TRUE
 
 		var/datum/abilityHolder/changeling/H = holder
 		if (!istype(H))
 			boutput(holder.owner, "<span class='alert'>That ability is incompatible with our abilities. We should report this to a coder.</span>")
-			return 1
+			return TRUE
 
 		//Verify that you are not in control of your master's body.
 		if(H.master && H.owner != H.master)
 			boutput(holder.owner, "<span class='alert'>A member of the hivemind cannot release a sub-form!.</span>")
-			return 1
+			return TRUE
 
 		var/list/eligible = list()
 		for (var/mob/dead/target_observer/hivemind_observer/O in H.hivemind)
@@ -34,18 +38,42 @@
 
 		if (eligible.len < 1)
 			boutput(holder.owner, "<span class='alert'>There are no minds eligible for this ability. We need to absorb another.</span>")
-			return 1
+			return TRUE
 
 		var/use_mob_name = tgui_input_list(holder.owner, "Select the mind to transfer into the handspider:", "Select Mind", sortList(eligible, /proc/cmp_text_asc))
 		if (!use_mob_name)
 			boutput(holder.owner, "<span class='notice'>We change our mind.</span>")
-			return 1
-		var/mob/dead/target_observer/hivemind_observer/use_mob = eligible[use_mob_name]
+			return TRUE
+
+		src.use_mob = eligible[use_mob_name]
+
+	proc/attach_to_hivemind(mob/living/critter/changeling/critter)
+		var/datum/abilityHolder/changeling/lingHolder = src.holder
+		lingHolder.hivemind -= src.use_mob
+		lingHolder.hivemind += critter
+		critter.hivemind_owner = lingHolder
+		if (src.holder.owner.mind && src.holder.owner.mind.current && critter.client)
+			var/I = image(antag_changeling, loc = src.holder.owner.mind.current)
+			critter.client.images += I
+		src.use_mob.client = null
+		src.use_mob.key = null
+		qdel(src.use_mob)
+		src.use_mob = null
+
+/datum/targetable/changeling/critter/handspider
+	name = "Handspider"
+	desc = "Detach one of your arms and bring it to life using one of the members of your hivemind."
+	icon_state = "handspider"
+	pointCost = 4
+
+	cast(atom/target)
+		if (..())
+			return TRUE
 
 		var/mob/living/carbon/human/owner = holder.owner
 		if (!(owner.limbs.l_arm || owner.limbs.r_arm) || !ishuman(holder.owner))
 			boutput(holder.owner, "<span class='notice'>We have no arms to detach!</span>")
-			return 1
+			return TRUE
 
 		var/obj/item/parts/original_arm = null
 
@@ -67,13 +95,11 @@
 		logTheThing(LOG_COMBAT, holder.owner, "drops a handspider [use_mob] as a changeling [log_loc(holder.owner)].")
 
 		var/mob/living/critter/changeling/handspider/spider = new /mob/living/critter/changeling/handspider(get_turf(owner.loc), original_arm)
-		if (use_mob.mind)
-			use_mob.mind.transfer_to(spider)
-		else if (use_mob.client)
-			use_mob.client.mob = spider
-		H.hivemind -= use_mob
-		H.hivemind += spider
-		spider.hivemind_owner = H
+		if (!use_mob.mind)
+			CRASH("handspider created from mob with no mind")
+		use_mob.mind.transfer_to(spider)
+		spider.mind.add_antagonist(ROLE_HANDSPIDER)
+		src.attach_to_hivemind(spider)
 
 		if (original_arm && istype(original_arm, /obj/item/parts/robot_parts))
 			spider.icon_prefix = "robo"
@@ -83,64 +109,17 @@
 		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces. You are still connected to the hivemind.</font>")
 
-		if (spider.mind && ticker.mode)
-			if (!spider.mind.special_role)
-				spider.mind.special_role = ROLE_HANDSPIDER
-			if (!(spider.mind in ticker.mode.Agimmicks))
-				ticker.mode.Agimmicks += spider.mind
-			spider.mind.master = owner.ckey
+		return FALSE
 
-		if (owner.mind && owner.mind.current && spider.client)
-			var/I = image(antag_changeling, loc = owner.mind.current)
-			spider.client.images += I
-
-		qdel(use_mob)
-		return 0
-
-// feels bad copy-pasting this, maybe refactor this in future - cirr
-/datum/targetable/changeling/eyespider
+/datum/targetable/changeling/critter/eyespider
 	name = "Eyespider"
 	desc = "Eject one of your eyes as a non-combatant utility form and bring it to life using one of the members of your hivemind."
 	icon_state = "eyespider"
-	cooldown = 600
-	targeted = 0
-	target_anything = 0
-	human_only = 0
 	pointCost = 0 // free for now, given you have to lose a fuckin' EYE
-	can_use_in_container = 1
-	dont_lock_holder = 0
-
-	incapacitationCheck()
-		return 0
 
 	cast(atom/target)
 		if (..())
-			return 1
-
-		var/datum/abilityHolder/changeling/H = holder
-		if (!istype(H))
-			boutput(holder.owner, "<span class='alert'>That ability is incompatible with our abilities. We should report this to a coder.</span>")
-			return 1
-
-		//Verify that you are not in control of your master's body.
-		if(H.master && H.owner != H.master)
-			boutput(holder.owner, "<span class='alert'>A member of the hivemind cannot release a sub-form!.</span>")
-			return 1
-
-		var/list/eligible = list()
-		for (var/mob/dead/target_observer/hivemind_observer/O in H.hivemind)
-			if (O.client)
-				eligible[O.real_name] = O
-
-		if (eligible.len < 1)
-			boutput(holder.owner, "<span class='alert'>There are no minds eligible for this ability. We need to absorb another.</span>")
-			return 1
-
-		var/use_mob_name = tgui_input_list(holder.owner, "Select the mind to transfer into the eyespider:", "Select Mind", sortList(eligible, /proc/cmp_text_asc))
-		if (!use_mob_name)
-			boutput(holder.owner, "<span class='notice'>We change our mind.</span>")
-			return 1
-		var/mob/dead/target_observer/hivemind_observer/use_mob = eligible[use_mob_name]
+			return TRUE
 
 		var/mob/living/carbon/human/owner = holder.owner
 		if (!(owner.organHolder.left_eye || owner.organHolder.right_eye) || !ishuman(holder.owner))
@@ -168,83 +147,33 @@
 
 		var/mob/living/critter/changeling/eyespider/spider = new /mob/living/critter/changeling/eyespider(get_turf(owner.loc), original_eye)
 
-		if (use_mob.mind)
-			use_mob.mind.transfer_to(spider)
-		else if (use_mob.client)
-			use_mob.client.mob = spider
-		H.hivemind -= use_mob
-		H.hivemind += spider
-		spider.hivemind_owner = H
+		if (!use_mob.mind)
+			CRASH("eyespider created from mob with no mind")
+		use_mob.mind.transfer_to(spider)
+		spider.mind.add_antagonist(ROLE_EYESPIDER)
+		src.attach_to_hivemind(spider)
 
 		spider.show_antag_popup("eyespider")
 		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces, and see through walls. You are still connected to the hivemind.</font>")
 
-		if (spider.mind && ticker.mode)
-			if (!spider.mind.special_role)
-				spider.mind.special_role = ROLE_EYESPIDER
-			if (!(spider.mind in ticker.mode.Agimmicks))
-				ticker.mode.Agimmicks += spider.mind
-			spider.mind.master = owner.ckey
+		return FALSE
 
-		if (owner.mind && owner.mind.current && spider.client)
-			var/I = image(antag_changeling, loc = owner.mind.current)
-			spider.client.images += I
-
-		qdel(use_mob)
-		return 0
-
-
-// oh what's this? I copypasted it again, ooopsy! maybe refactor this in future  - mbc
-/datum/targetable/changeling/legworm
+/datum/targetable/changeling/critter/legworm
 	name = "Legworm"
 	desc = "Detach one of your legs and bring it to life using one of the members of your hivemind."
 	icon_state = "legworm"
 	cooldown = 1200
-	targeted = 0
-	target_anything = 0
-	human_only = 0
 	pointCost = 6
-	can_use_in_container = 1
-	dont_lock_holder = 0
-
-	incapacitationCheck()
-		return 0
 
 	cast(atom/target)
 		if (..())
-			return 1
-
-		var/datum/abilityHolder/changeling/H = holder
-		if (!istype(H))
-			boutput(holder.owner, "<span class='alert'>That ability is incompatible with our abilities. We should report this to a coder.</span>")
-			return 1
-
-		//Verify that you are not in control of your master's body.
-		if(H.master && H.owner != H.master)
-			boutput(holder.owner, "<span class='alert'>A member of the hivemind cannot release a sub-form!.</span>")
-			return 1
-
-		var/list/eligible = list()
-		for (var/mob/dead/target_observer/hivemind_observer/O in H.hivemind)
-			if (O.client)
-				eligible[O.real_name] = O
-
-		if (eligible.len < 1)
-			boutput(holder.owner, "<span class='alert'>There are no minds eligible for this ability. We need to absorb another.</span>")
-			return 1
-
-		var/use_mob_name = tgui_input_list(holder.owner, "Select the mind to transfer into the legworm:", "Select Mind", sortList(eligible, /proc/cmp_text_asc))
-		if (!use_mob_name)
-			boutput(holder.owner, "<span class='notice'>We change our mind.</span>")
-			return 1
-		var/mob/dead/target_observer/hivemind_observer/use_mob = eligible[use_mob_name]
+			return TRUE
 
 		var/mob/living/carbon/human/owner = holder.owner
 		if (!(owner.limbs.l_leg || owner.limbs.r_leg) || !ishuman(holder.owner))
 			boutput(holder.owner, "<span class='notice'>We have no legs to detach!</span>")
 			return 1
-
 
 		var/obj/item/parts/original_leg = null
 
@@ -265,77 +194,29 @@
 		holder.owner.visible_message(text("<span class='alert'><B>[holder.owner]'s leg falls off and starts moving!</B></span>"))
 		logTheThing(LOG_COMBAT, holder.owner, "drops a legworm [use_mob] as a changeling [log_loc(holder.owner)].")
 
-		var/mob/living/critter/changeling/legworm/spider = new /mob/living/critter/changeling/legworm(get_turf(owner.loc), original_leg)
-		if (use_mob.mind)
-			use_mob.mind.transfer_to(spider)
-		else if (use_mob.client)
-			use_mob.client.mob = spider
-		H.hivemind -= use_mob
-		H.hivemind += spider
-		spider.hivemind_owner = H
+		var/mob/living/critter/changeling/legworm/worm = new /mob/living/critter/changeling/legworm(get_turf(owner.loc), original_leg)
+		if (!use_mob.mind)
+			CRASH("handspider created from mob with no mind")
+		use_mob.mind.transfer_to(worm)
+		worm.mind.add_antagonist(ROLE_LEGWORM)
+		src.attach_to_hivemind(worm)
 
-		spider.show_antag_popup("legworm")
-		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
-		boutput(spider, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
+		worm.show_antag_popup("legworm")
+		boutput(worm, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
+		boutput(worm, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
 
-		if (spider.mind && ticker.mode)
-			if (!spider.mind.special_role)
-				spider.mind.special_role = ROLE_LEGWORM
-			if (!(spider.mind in ticker.mode.Agimmicks))
-				ticker.mode.Agimmicks += spider.mind
-			spider.mind.master = owner.ckey
+		return FALSE
 
-		if (owner.mind && owner.mind.current && spider.client)
-			var/I = image(antag_changeling, loc = owner.mind.current)
-			spider.client.images += I
-
-		qdel(use_mob)
-		return 0
-
-// Oh fuck. Did I copy paste this yet again? Damn. Maybe one day we'll get around to refactoring this. -fire
-/datum/targetable/changeling/buttcrab
+/datum/targetable/changeling/critter/buttcrab
 	name = "Buttcrab"
 	desc = "You butt fall off and hivemind person become butt"
 	icon_state = "buttcrab"
 	cooldown = 600
-	targeted = 0
-	target_anything = 0
-	human_only = 0
 	pointCost = 1
-	can_use_in_container = 1
-	dont_lock_holder = 0
-
-	incapacitationCheck()
-		return 0
 
 	cast(atom/target)
 		if (..())
-			return 1
-
-		var/datum/abilityHolder/changeling/H = holder
-		if (!istype(H))
-			boutput(holder.owner, "<span class='alert'>That ability is incompatible with our abilities. We should report this to a coder.</span>")
-			return 1
-
-		//Verify that you are not in control of your master's body.
-		if(H.master && H.owner != H.master)
-			boutput(holder.owner, "<span class='alert'>A member of the hivemind cannot release a sub-form!.</span>")
-			return 1
-
-		var/list/eligible = list()
-		for (var/mob/dead/target_observer/hivemind_observer/O in H.hivemind)
-			if (O.client)
-				eligible[O.real_name] = O
-
-		if (eligible.len < 1)
-			boutput(holder.owner, "<span class='alert'>There are no minds eligible for this ability. We need to absorb another.</span>")
-			return 1
-
-		var/use_mob_name = tgui_input_list(holder.owner, "Select the mind to transfer into the buttspider:", "Select Mind", sortList(eligible, /proc/cmp_text_asc))
-		if (!use_mob_name)
-			boutput(holder.owner, "<span class='notice'>We change our mind.</span>")
-			return 1
-		var/mob/dead/target_observer/hivemind_observer/use_mob = eligible[use_mob_name]
+			return TRUE
 
 		var/mob/living/carbon/human/owner = holder.owner
 		if (!(owner.organHolder.butt) || !ishuman(holder.owner))
@@ -350,31 +231,17 @@
 
 		var/mob/living/critter/changeling/buttcrab/crab = new /mob/living/critter/changeling/buttcrab(get_turf(owner.loc), original_butt)
 
-		if (use_mob.mind)
-			use_mob.mind.transfer_to(crab)
-		else if (use_mob.client)
-			use_mob.client.mob = crab
-		H.hivemind -= use_mob
-		H.hivemind += crab
-		crab.hivemind_owner = H
+		if (!use_mob.mind)
+			CRASH("buttcrab created from mob with no mind")
+		use_mob.mind.transfer_to(crab)
+		crab.mind.add_antagonist(ROLE_BUTTCRAB)
+		src.attach_to_hivemind(crab)
 
 		crab.show_antag_popup("buttcrab")
 		boutput(crab, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(crab, "<font color=red>You are a very small, very smelly, and weak creature. You are still connected to the hivemind.</font>")
 
-		if (crab.mind && ticker.mode)
-			if (!crab.mind.special_role)
-				crab.mind.special_role = ROLE_BUTTCRAB
-			if (!(crab.mind in ticker.mode.Agimmicks))
-				ticker.mode.Agimmicks += crab.mind
-			crab.mind.master = owner.ckey
-
-		if (owner.mind && owner.mind.current && crab.client)
-			var/I = image(antag_changeling, loc = owner.mind.current)
-			crab.client.images += I
-
-		qdel(use_mob)
-		return 0
+		return FALSE
 
 
 /datum/targetable/changeling/hivesay

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -36,10 +36,10 @@
 		src.ability_holder.addAbility(/datum/targetable/changeling/sting/dna)
 		src.ability_holder.addAbility(/datum/targetable/changeling/transform)
 		src.ability_holder.addAbility(/datum/targetable/changeling/morph_arm)
-		src.ability_holder.addAbility(/datum/targetable/changeling/handspider)
-		src.ability_holder.addAbility(/datum/targetable/changeling/eyespider)
-		src.ability_holder.addAbility(/datum/targetable/changeling/legworm)
-		src.ability_holder.addAbility(/datum/targetable/changeling/buttcrab)
+		src.ability_holder.addAbility(/datum/targetable/changeling/critter/handspider)
+		src.ability_holder.addAbility(/datum/targetable/changeling/critter/eyespider)
+		src.ability_holder.addAbility(/datum/targetable/changeling/critter/legworm)
+		src.ability_holder.addAbility(/datum/targetable/changeling/critter/buttcrab)
 		src.ability_holder.addAbility(/datum/targetable/changeling/hivesay)
 		src.ability_holder.addAbility(/datum/targetable/changeling/boot)
 		src.ability_holder.addAbility(/datum/targetable/changeling/give_control)
@@ -70,10 +70,10 @@
 		src.ability_holder.removeAbility(/datum/targetable/changeling/dna_target_select)
 		src.ability_holder.removeAbility(/datum/targetable/changeling/transform)
 		src.ability_holder.removeAbility(/datum/targetable/changeling/morph_arm)
-		src.ability_holder.removeAbility(/datum/targetable/changeling/handspider)
-		src.ability_holder.removeAbility(/datum/targetable/changeling/eyespider)
-		src.ability_holder.removeAbility(/datum/targetable/changeling/legworm)
-		src.ability_holder.removeAbility(/datum/targetable/changeling/buttcrab)
+		src.ability_holder.removeAbility(/datum/targetable/changeling/critter/handspider)
+		src.ability_holder.removeAbility(/datum/targetable/changeling/critter/eyespider)
+		src.ability_holder.removeAbility(/datum/targetable/changeling/critter/legworm)
+		src.ability_holder.removeAbility(/datum/targetable/changeling/critter/buttcrab)
 		src.ability_holder.removeAbility(/datum/targetable/changeling/hivesay)
 		src.ability_holder.removeAbility(/datum/targetable/changeling/boot)
 		src.ability_holder.removeAbility(/datum/targetable/changeling/give_control)
@@ -99,3 +99,27 @@
 				dat.Insert(3, {"Their body was destroyed."})
 
 		return dat
+
+ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
+/datum/antagonist/changeling_critter
+	remove_on_death = TRUE
+	remove_on_clone = TRUE
+
+	is_compatible_with(datum/mind/mind)
+		return istype(mind.current, /mob/living/critter/changeling)
+
+/datum/antagonist/changeling_critter/handspider
+	id = ROLE_HANDSPIDER
+	display_name = "handspider"
+
+/datum/antagonist/changeling_critter/eyespider
+	id = ROLE_EYESPIDER
+	display_name = "eyespider"
+
+/datum/antagonist/changeling_critter/legworm
+	id = ROLE_LEGWORM
+	display_name = "legworm"
+
+/datum/antagonist/changeling_critter/buttcrab
+	id = ROLE_BUTTCRAB
+	display_name = "buttcrab"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -108,18 +108,44 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 	is_compatible_with(datum/mind/mind)
 		return istype(mind.current, /mob/living/critter/changeling)
 
+	announce()
+		var/mob/living/critter/changeling/critter = src.owner.current
+		if (!istype(critter))
+			return ..()
+		boutput(src.owner.current, "<h3><font color=red>You have reawakened to serve your host [critter.hivemind_owner]! You must follow their commands!</font></h3>")
+
+	//it's pretty obvious when you return to the changeling
+	announce_removal()
+		return
+
 /datum/antagonist/changeling_critter/handspider
 	id = ROLE_HANDSPIDER
 	display_name = "handspider"
+
+	announce()
+		..()
+		boutput(src.owner.current, "<font color=red>You are a very small and weak creature that can fit into tight spaces. You are still connected to the hivemind.</font>")
 
 /datum/antagonist/changeling_critter/eyespider
 	id = ROLE_EYESPIDER
 	display_name = "eyespider"
 
+	announce()
+		..()
+		boutput(src.owner.current, "<font color=red>You are a very small and weak creature that can fit into tight spaces, and see through walls. You are still connected to the hivemind.</font>")
+
 /datum/antagonist/changeling_critter/legworm
 	id = ROLE_LEGWORM
 	display_name = "legworm"
 
+	announce()
+		..()
+		boutput(src.owner.current, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
+
 /datum/antagonist/changeling_critter/buttcrab
 	id = ROLE_BUTTCRAB
 	display_name = "buttcrab"
+
+	announce()
+		..()
+		boutput(src.owner.current, "<font color=red>You are a very small, very smelly, and weak creature. You are still connected to the hivemind.</font>")

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -104,9 +104,20 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 /datum/antagonist/changeling_critter
 	remove_on_death = TRUE
 	remove_on_clone = TRUE
+	var/critter_type = null
 
-	is_compatible_with(datum/mind/mind)
-		return istype(mind.current, /mob/living/critter/changeling)
+	give_equipment(obj/item/bodypart, datum/abilityHolder/changeling/holder)
+		var/mob/old_mob = src.owner.current
+		var/mob/living/critter/changeling/critter = new src.critter_type(get_turf(old_mob), bodypart)
+		if (holder)
+			holder.hivemind -= old_mob
+			holder.hivemind += critter
+			critter.hivemind_owner = holder
+			if (holder.owner.mind && holder.owner.mind.current && critter.client)
+				var/I = image(antag_changeling, loc = holder.owner.mind.current)
+				critter.client.images += I
+		src.owner.transfer_to(critter)
+		qdel(old_mob)
 
 	announce()
 		var/mob/living/critter/changeling/critter = src.owner.current
@@ -119,6 +130,7 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 		return
 
 /datum/antagonist/changeling_critter/handspider
+	critter_type = /mob/living/critter/changeling/handspider
 	id = ROLE_HANDSPIDER
 	display_name = "handspider"
 
@@ -127,6 +139,7 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 		boutput(src.owner.current, "<font color=red>You are a very small and weak creature that can fit into tight spaces. You are still connected to the hivemind.</font>")
 
 /datum/antagonist/changeling_critter/eyespider
+	critter_type = /mob/living/critter/changeling/eyespider
 	id = ROLE_EYESPIDER
 	display_name = "eyespider"
 
@@ -135,6 +148,7 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 		boutput(src.owner.current, "<font color=red>You are a very small and weak creature that can fit into tight spaces, and see through walls. You are still connected to the hivemind.</font>")
 
 /datum/antagonist/changeling_critter/legworm
+	critter_type = /mob/living/critter/changeling/legworm
 	id = ROLE_LEGWORM
 	display_name = "legworm"
 
@@ -143,6 +157,7 @@ ABSTRACT_TYPE(/datum/antagonist/changeling_critter)
 		boutput(src.owner.current, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
 
 /datum/antagonist/changeling_critter/buttcrab
+	critter_type = /mob/living/critter/changeling/buttcrab
 	id = ROLE_BUTTCRAB
 	display_name = "buttcrab"
 

--- a/code/modules/antagonists/zombie/zombie.dm
+++ b/code/modules/antagonists/zombie/zombie.dm
@@ -1,6 +1,7 @@
 /datum/antagonist/zombie
 	id = ROLE_ZOMBIE
 	display_name = "zombie"
+	remove_on_clone = TRUE
 
 	is_compatible_with(datum/mind/mind)
 		return ishuman(mind.current)

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -371,16 +371,17 @@ TYPEINFO(/obj/machinery/clonepod)
 				logTheThing(LOG_COMBAT, src.occupant, "was mindhack cloned. Mindhacker: [constructTarget(implant_hacker,"combat")]")
 				src.occupant.setStatus("mindhack", null, implant_hacker)
 
-		// Remove zombie antag status as zombie race is removed on cloning
-		var/mob/M = src.occupant
-		if (!M?.mind)
-			logTheThing(LOG_DEBUG, src, "Cloning pod failed to check mind status of occupant [M].")
-		else if (M.mind.get_antagonist(ROLE_ZOMBIE))
-			var/success = M.mind.remove_antagonist(ROLE_ZOMBIE)
-			if (success)
-				logTheThing(LOG_COMBAT, M, "Cloning pod removed zombie antag status.")
-			else
-				logTheThing(LOG_DEBUG, src, "Cloning pod failed to remove zombie antag status from [M] with return code [success].")
+		if (!src.occupant?.mind)
+			logTheThing(LOG_DEBUG, src, "Cloning pod failed to check mind status of occupant [src.occupant].")
+		else
+			for (var/datum/antagonist/antag in src.occupant.mind.antagonists)
+				if (!antag.remove_on_clone)
+					continue
+				var/success = src.occupant.mind.remove_antagonist(antag.id)
+				if (success)
+					logTheThing(LOG_COMBAT, src.occupant, "Cloning pod removed [antag.display_name] antag status.")
+				else
+					logTheThing(LOG_DEBUG, src, "Cloning pod failed to remove zombie antag status from [src.occupant] with return code [success].")
 
 		// Someone is having their brain zapped. 75% chance of them being de-antagged if they were one
 		//MBC todo : logging. This shouldn't be an issue thoug because the mindwipe doesn't even appear ingame (yet?)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CODE QUALITY] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Datumizes changeling critters, also adds `remove_on_death` and `remove_on_clone` vars to antag datums and refactors zombies to use them. Also refactors the godawful mess that was `hivemind.dm` and fixes a related bug with antag datum incompatibility.
Fixes #12969


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad, antag datums good.