### PR TITLE
Adds announcement to wraith evolve

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -813,7 +813,7 @@
 /datum/targetable/wraithAbility/specialize
 	name = "Evolve"
 	icon_state = "evolve"
-	desc = "Choose a form to evolve into once you have absorbed at least 3 souls"
+	desc = "Choose a form to evolve into once you have absorbed at least 3 souls. This will announce your presence to the station."
 	targeted = 0
 	pointCost = 150
 	tooltip_flags = TOOLTIP_LEFT
@@ -863,6 +863,9 @@
 					W = new/mob/living/intangible/wraith/wraith_trickster(holder.owner)
 					boutput(holder.owner, "<span class='notice'>You use some of your energy to evolve into a trickster! Decieve the crew and turn them against one another!</span>")
 					holder.owner.show_antag_popup("trickster")
+
+			if(!istype(ticker.mode, /datum/game_mode/disaster))
+				command_alert("Our sensors have detected that an astral entity has gained significant power. We recommend manifesting this entity by extinguishing candles-on-top-of-skulls near it, or creating salt piles in your workplaces.", "Entity Detected", alert_origin = ALERT_ANOMALY) //Let's crew know that the wraith has evolved, and how to deal with it.
 
 			W.real_name = holder.owner.real_name
 			W.UpdateName()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [PLAYER ACTIONS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds an announcement when a wraith evolves outside of the disaster gamemode.

![Goonstation Development_ NCS Atlas 2_16_2023 12_49_31 PM](https://user-images.githubusercontent.com/87689371/219448612-a7b4ac4f-2a0b-4c19-85e1-9a4318a780d3.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, it is still rather difficult to deal with wraiths. This is partly due to there being no in-game info about the wraith's counters. This pr makes it so that people will be aware when a wraith evolves, and get some info about how to manifest the wraith to fight it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeDude
(*)Wraiths evolving now cause an announcement that involves the spirit candles and salt.
```
