### PR TITLE
Health implants no longer send the coords of the implantee.

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -329,19 +329,17 @@ THROWING DARTS
 	proc/health_alert()
 		if (!src.owner)
 			return
-		src.send_message("HEALTH ALERT: [src.owner][src.get_coords()] in [get_area(src)]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
+		src.send_message("HEALTH ALERT: [src.owner]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
 
 	proc/death_alert()
 		if (!src.owner)
 			return
-		var/coords = src.get_coords()
-		var/myarea = get_area(src)
 		var/list/cloner_areas = list()
 		for(var/obj/item/implant/cloner/cl_implant in src.owner)
 			if(cl_implant.owner != src.owner)
 				continue
 			cloner_areas += "[cl_implant.scanned_here]"
-		var/message = "DEATH ALERT: [src.owner][coords] in [myarea], " //youre lucky im not onelining this
+		var/message = "DEATH ALERT: [src.owner], " //youre lucky im not onelining this
 		if (he_or_she(src.owner) == "they")
 			message += "they " + (length(cloner_areas) ? "have been clone-scanned in [jointext(cloner_areas, ", ")]." : "do not have a cloning record.")
 		else

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -353,7 +353,7 @@ THROWING DARTS
 	name = "health implant - security issue"
 
 	New()
-		mailgroups.Add(MGD_COMMAND)
+		mailgroups.Add(MGD_SECURITY)
 		..()
 
 /obj/item/implant/health/security/anti_mindhack //HoS implant

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -353,7 +353,7 @@ THROWING DARTS
 	name = "health implant - security issue"
 
 	New()
-		mailgroups.Add(MGD_SECURITY)
+		mailgroups.Add(MGD_COMMAND)
 		..()
 
 /obj/item/implant/health/security/anti_mindhack //HoS implant

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -329,17 +329,18 @@ THROWING DARTS
 	proc/health_alert()
 		if (!src.owner)
 			return
-		src.send_message("HEALTH ALERT: [src.owner]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
+		src.send_message("HEALTH ALERT: [src.owner] in [get_area(src)]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
 
 	proc/death_alert()
 		if (!src.owner)
 			return
+		var/myarea = get_area(src)
 		var/list/cloner_areas = list()
 		for(var/obj/item/implant/cloner/cl_implant in src.owner)
 			if(cl_implant.owner != src.owner)
 				continue
 			cloner_areas += "[cl_implant.scanned_here]"
-		var/message = "DEATH ALERT: [src.owner], " //youre lucky im not onelining this
+		var/message = "DEATH ALERT: [src.owner] in [myarea], " //youre lucky im not onelining this
 		if (he_or_she(src.owner) == "they")
 			message += "they " + (length(cloner_areas) ? "have been clone-scanned in [jointext(cloner_areas, ", ")]." : "do not have a cloning record.")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [STATION SYSTEMS] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the health implants to no longer send the cords of the implantee. This applies to the normal and security ones.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sec currently has a lot of things that let them know when an officer is in trouble, including announcing over coms, a button that sends an alert, and 2 alerts from their health implants (1 when they are in crit, another when they die.) This aims to give antags that ambush a sec off some more breathing room before sec finds them.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)The health implants no longer send the coordinates of the implantee on an alert. The area is still sent.
```
