### PR TITLE
Stops you from deep frying phone handsets

### DIFF
--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -83,6 +83,11 @@ TYPEINFO(/obj/machinery/deep_fryer)
 		boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 		return
 
+	var/list/dont_deepfry = list(/obj/item/phone_handset) //Should I be doing this for a single item? Might be useful to SOMEONE in the future.
+	if(locate(W) in dont_deepfry)
+		boutput(user, "<span class='alert'>There's no way you could deep fry [W].</span>")
+		return
+
 	src.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>")
 	user.u_equip(W)
 	W.dropped(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. I have tested this and it does work with multiple items. I made this in a way that more things could be added to it easily.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You __probably shouldn't__ be able to deepfry phone handsets.
Fixes #12841

I don't think this needs a changelog.