### PR TITLE
Remove eating/drinking from silicons and robotic

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3180,6 +3180,9 @@
 /mob/proc/on_eat(var/atom/A)
 	return
 
+/mob/proc/can_drink(var/atom/A)
+	return 1
+
 
 // to check if someone is abusing cameras with stuff like artifacts, power gloves, etc
 /mob/proc/in_real_view_range(var/turf/T)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -68,9 +68,6 @@
 	var/speechpopupstyle = null
 	var/isFlying = 0 // for player controled flying critters
 
-	var/caneat = 1
-	var/candrink = 1
-
 	var/canbegrabbed = 1
 	var/grabresistmessage = null //Format: target.visible_message("<span class='alert'><B>[src] tries to grab [target], [target.grabresistmessage]</B></span>")
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1423,6 +1423,12 @@ ABSTRACT_TYPE(/mob/living/critter/robotic)
 		src.emag_act() // heh
 		src.TakeDamage(10 * emp_vuln, 10 * emp_vuln)
 
+	can_eat()
+		return 0
+
+	can_drink()
+		return 0
+
 	vomit()
 		return
 

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -52,6 +52,12 @@
 	req_access = null
 	return ..()
 
+/mob/living/silicon/can_eat()
+	return 0
+
+/mob/living/silicon/can_drink()
+	return 0
+
 ///mob/living/silicon/proc/update_canmove()
 //	..()
 	//canmove = !(src.hasStatus(list("weakened", "paralysis", "stunned")) || buckled)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -580,6 +580,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			return 0
 
 		if (M == user)
+			if(!M.can_drink(src))
+				boutput(M, "<span class='alert'>You can't drink [src]!</span>")
+				return 0
 			src.take_a_drink(M, user)
 			return 1
 		else
@@ -587,6 +590,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			logTheThing(LOG_COMBAT, user, "attempts to force [constructTarget(M,"combat")] to drink from [src] [log_reagents(src)] at [log_loc(user)].")
 			if (check_target_immunity(M))
 				user.visible_message("<span class='alert'>[user] attempts to force [M] to drink from [src], but fails!.</span>", "<span class='alert'>You try to force [M] to drink [src], but fail!</span>")
+				return 0
+			else if(!M.can_drink(src))
+				user.tri_message(M, "<span class='alert'><b>[user]</b> tries to make [M] drink [src], but they can't drink that!</span>",\
+					"<span class='alert'>You try to make [M] drink [src], but they can't drink that!</span>",\
+					"<span class='alert'><b>[user]</b> tries to give you a drink of [src], but you can't drink that!</span>")
 				return 0
 			if (!src.reagents || !src.reagents.total_volume)
 				boutput(user, "<span class='alert'>Nothing left in [src], oh no!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements a can_drink() on mob to match the existing can_eat().
Adds returns for both to /mob/living/critter/robotic and /mob/living/silicon.
Adds checks for can_drink() equivalent to the already implemented can_eat().
Removes unused caneat and candrink vars.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents robotic critters from healing (slightly) by eating food :) This was not the reagents, just on the action of eating.
Prevents silicon and robotic types from eating and drinking but with the capability to override per type.
Stops confusing ability to give drinks to borgs but not food.
Stops silent failure on trying to feed borgs.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(+)Silicon and robotic life can no longer eat, drink or be forcefed.
```
