### PR TITLE
Fix some disposal unit bugs

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -116,6 +116,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 				for(var/obj/item/O in S.contents) O.set_loc(src)
 				S.UpdateIcon()
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
+				src.update()
 				return
 		//first time they click with a storage, it gets dumped. second time container itself is added
 		if ((istype(I,/obj/item/storage/) && I.contents.len) && user.a_intent == INTENT_HELP) //if they're not on help intent it'll default to placing it in while full
@@ -124,15 +125,19 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			if(istype(S, /obj/item/storage/secure))
 				var/obj/item/storage/secure/secS = S
 				if(secS.locked)
-					boutput("<span class='alert'> Unable to open it, you place the whole [secS] into the container.</span>")
-					I.set_loc(src)
+					user.visible_message("[user.name] places \the [secS] into \the [src].",\
+						"You place \the [secS] into \the [src].")
+					user.drop_item()
+					secS.set_loc(src)
 					actions.interrupt(user, INTERRUPT_ACT)
+					src.update()
 					return
 			for(var/obj/item/O in S)
 				O.set_loc(src)
 				S.hud.remove_object(O)
 			user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 			actions.interrupt(user, INTERRUPT_ACT)
+			src.update()
 			return
 
 		if (istype(I, /obj/item/storage/mechanics/housing_handheld)) //override to normal activity

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -140,13 +140,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			src.update()
 			return
 
-		if (istype(I, /obj/item/storage/mechanics/housing_handheld)) //override to normal activity
-			I.set_loc(src)
-			user.visible_message("[user.name] places \the [I] into \the [src].",\
-			"You place \the [I] into \the [src].")
-			actions.interrupt(user, INTERRUPT_ACT)
-			return
-
 		var/obj/item/magtractor/mag
 		if (istype(I.loc, /obj/item/magtractor))
 			mag = I.loc


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes some bugs with the disposal unit where the contents indicator light wasn't lighting up in some cases, and you couldn't put secure briefcases in disposal units along with no message being given.

Also removes a redundant check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes