### PR TITLE
Fixes being unable to save more than 1 cloning record on a floppy disc

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -787,7 +787,7 @@ TYPEINFO(/obj/machinery/clone_scanner)
 				. = TRUE
 
 			for (var/datum/computer/file/clone/R in src.diskette.root.contents)
-				if (R["ckey"] == selected_record["ckey"])
+				if (R.fields["ckey"] == selected_record.get_field("ckey"))
 					show_message("Record already exists on disk.", "info")
 					. = TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes a runtime that made it impossible to save more than 1 cloning record on a floppy disc at a time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Well, runtimes are bad. And i am too lazy to print a new floppy disc for every single cloning record.
