### PR TITLE
Increases minimum traitor count for wraith

### DIFF
--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -39,7 +39,7 @@
 	if(traitor_scaling)
 		num_traitors = clamp(round((num_players + randomizer) / pop_divisor), 1, traitors_possible) // adjust the randomizer as needed
 
-	if(num_traitors > 2 && prob(10))
+	if(num_traitors >= 4 && prob(10))
 		num_traitors -= 1
 		num_wraiths = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr increases the minimum number of antags for a wraith to spawn on traitors from 3 to 4. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See #13083


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)The minimum number of traitors needed for a wraith to replace a traitor in the traitor gamemode has been increased to 4 (up from 3)
```
