### PR TITLE
Thralls are harmed by Chaplain's bible beatings

### DIFF
--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -30,7 +30,7 @@ var/global/list/bible_contents = list()
 		STOP_TRACKING
 
 	proc/bless(mob/M as mob, var/mob/user)
-		if (isvampire(M) || iswraith(M) || M.bioHolder.HasEffect("revenant"))
+		if (isvampire(M) || isvampiricthrall(M) || iswraith(M) || M.bioHolder.HasEffect("revenant"))
 			M.visible_message("<span class='alert'><B>[M] burns!</span>", 1)
 			var/zone = "chest"
 			if (user.zone_sel)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The PR makes it so thralls, just like vampires and wraiths, get burned from bible beatings instead of healed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

For consistency with the vampire, where they get harmed from bible beatings.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Caio029
(+)Bible beatings from the Chaplain can now burn thralls as well.
```
