### PR TITLE
Add T-Ray Scanner to the general fabricator

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -354,6 +354,13 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Tool"
 
+/datum/manufacture/t_scanner
+	name = "T-ray scanner"
+	item_outputs = list(/obj/item/device/t_scanner)
+	time = 8 SECONDS
+	create = 1
+	category = "Tool"
+
 /datum/manufacture/weldingmask
 	name = "Welding Mask"
 	item_paths = list("MET-2","CRY-1")

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -12,7 +12,7 @@ Contains:
 //////////////////////////////////////////////// T-ray scanner //////////////////////////////////
 
 TYPEINFO(/obj/item/device/t_scanner)
-	mats = 5
+	mats = list("CRY-1", "CON-1")
 
 /obj/item/device/t_scanner
 	name = "T-ray scanner"
@@ -23,7 +23,8 @@ TYPEINFO(/obj/item/device/t_scanner)
 	c_flags = ONBELT
 	w_class = W_CLASS_SMALL
 	item_state = "electronic"
-	m_amt = 150
+	m_amt = 50
+	g_amt = 20
 	var/scan_range = 3
 	var/client/last_client = null
 	var/image/last_display = null

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2231,6 +2231,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/flashlight,
 		/datum/manufacture/weldingmask,
 		/datum/manufacture/multitool,
+		/datum/manufacture/t_scanner,
 		/datum/manufacture/metal,
 		/datum/manufacture/metalR,
 		/datum/manufacture/rods2,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[FEATURE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add the T-Ray scanner to the general fabricator. Adjusting the default recipe to a recipe similar to the multitool.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Frequently used by Cargo for QM requisitions. Its also present in electrical toolboxes but it costs a lot more for stuff not usually required in the requisitions.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Added the T-Ray scanner to the general fabricator.
```
