### PR TITLE
I accidentally rewrote the mobAI process

### DIFF
--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -31,7 +31,7 @@ datum/controller/process/mob_ai
 					var/mob/living/L = X
 					L.Life(src)
 				//Lightweight mobs get ticked every 6 seconds
-				if(M.ai && (M.mob_flags & LIGHTWEIGHT_AI_MOB))
+				if(M.mob_flags & LIGHTWEIGHT_AI_MOB)
 					tickme = TRUE
 
 			//normal mobs get ticked every second, heavyweight mobs get ticked every 0.2 seconds

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -8,50 +8,56 @@ datum/controller/process/mob_ai
 	doWork()
 		for(var/X in ai_mobs)
 			var/mob/M = X
-
 			last_object = X
 
 			if (QDELETED(M))
 				continue
+
+			if( M.z == 4 && !Z4_ACTIVE ) continue
 
 			//in case it isn't obvious, what we're doing here is giving each mob a raffle ticket, and mod 30ing it to determine if a mob should tick
 			//this spreads out mob ticks, which still happen once every 6 seconds, but not all at the same time
 			if(isnull(M.ai_tick_schedule))
 				M.ai_tick_schedule = rand(0,30) //if you need bigger delays in the future, don't forget to increase this number proportionally
 			var/ticknum = M.ai_tick_schedule + ticks
-			if ((M.mob_flags & LIGHTWEIGHT_AI_MOB) && (ticknum % 30) == 0) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
-				if( M.z == 4 && !Z4_ACTIVE ) continue
-				if (istype(X, /mob/living))
+
+			var/tickme = FALSE
+
+			if ((ticknum % 30) == 0)
+				//call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
+				if (istype(X, /mob/living) && M.ai?.exclude_from_mobs_list)
 					var/mob/living/L = X
 					L.Life(src)
-				scheck()
+				//Lightweight mobs get ticked every 6 seconds
+				if(M.ai && (M.mob_flags & LIGHTWEIGHT_AI_MOB))
+					tickme = TRUE
 
-			if ((ticknum % 15) == 0)
-				M.handle_stamina_updates()
-				if (!M.client) continue
-
-				if (M.abilityHolder && !M.abilityHolder.composite_owner)
-					if (world.time >= M.abilityHolder.next_update) //after a failure to update (no abbilities!!) wait 10 seconds instead of checking again next process
-						if (M.abilityHolder.updateCounters() > 0)
-							M.abilityHolder.next_update = 1 SECOND
-						else
-							M.abilityHolder.next_update = 10 SECONDS
-				scheck()
-
+			//normal mobs get ticked every second, heavyweight mobs get ticked every 0.2 seconds
 			if((M.mob_flags & HEAVYWEIGHT_AI_MOB) || (ticknum % 5) == 0) //either we can tick every time, or we tick every 1 second
+				tickme = TRUE
+
+			if(tickme)
 				var/mob/living/L = M
-				if((isliving(M) && (L.is_npc || L.ai_active) || !isliving(M)))
-					if(istype(X, /mob/living/carbon/human))
-						var/mob/living/carbon/human/H = X
-						if(H.uses_mobai && H.ai)
-							H.ai.tick()
-						else
-							H.ai_process()
+				if(istype(X, /mob/living/carbon/human) && (L.is_npc || L.ai_active))
+					var/mob/living/carbon/human/H = X
+					if(!(H.uses_mobai && H.ai))
+						H.ai_process() //old human AI gets to be special until I get around to removing it
 						scheck()
-					else if(istype(X,/mob/living/critter))
-						var/mob/living/critter/C = X
-						if(C.is_npc && C.ai)
-							C.ai.tick()
-					else if(M.ai)
+						continue
+
+				if(isliving(M) && M.ai)
+					if(!L.is_npc)
+						continue
+
+				if(M.ai._mobai_being_processed)
+					logTheThing(LOG_DEBUG, "mobAI process", "The mob [constructTarget(M)] overran while processing its AI, and will be skipped for one tick. You should probably check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
+					continue
+
+				SPAWN(0)
+					try
+						M.ai._mobai_being_processed = TRUE
 						M.ai.tick()
-						scheck()
+					catch
+						logTheThing(LOG_DEBUG, "mobAI process", "A runtime was thrown by [constructTarget(M)] while processing its AI")
+					M?.ai?._mobai_being_processed = FALSE //null checks just in case something went *really* wrong
+				scheck()

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -50,6 +50,8 @@ datum/controller/process/mob_ai
 				if(isliving(M) && M.ai)
 					if(!L.is_npc || !M.ai.enabled)
 						continue
+				else if(!M.ai || !M.ai.enabled)
+					continue
 
 				if(M.ai._mobai_being_processed)
 					M.ai._mobai_being_processed++

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -8,6 +8,7 @@ datum/controller/process/mob_ai
 		schedule_interval = 0.2 SECONDS
 
 	doWork()
+		scheck()
 		for(var/X in ai_mobs)
 			var/mob/M = X
 			last_object = X
@@ -27,9 +28,10 @@ datum/controller/process/mob_ai
 
 			if ((ticknum % 30) == 0)
 				//call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
-				if (istype(X, /mob/living) && M.ai?.exclude_from_mobs_list)
+				if (M.ai?.exclude_from_mobs_list && istype(X, /mob/living))
 					var/mob/living/L = X
 					L.Life(src)
+					scheck()
 				//Lightweight mobs get ticked every 6 seconds
 				if(M.mob_flags & LIGHTWEIGHT_AI_MOB)
 					tickme = TRUE

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -50,7 +50,8 @@ datum/controller/process/mob_ai
 						continue
 
 				if(M.ai._mobai_being_processed)
-					logTheThing(LOG_DEBUG, "mobAI process", "The mob [constructTarget(M)] overran while processing its AI, and will be skipped for one tick. You should probably check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
+					if(!ON_COOLDOWN(M, "mobAI_overran_warning", 30 SECONDS))
+						logTheThing(LOG_DEBUG, "mobAI process", "The mob [constructTarget(M)] overran while processing its AI, and will be skipped for one tick. You should probably check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
 					continue
 
 				SPAWN(0)

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -1,3 +1,5 @@
+///How many ticks a mobAI can skip before we decide it needs interupting and reporting
+#define MOBAI_STUCK_THRESHOLD 10
 
 /// handles mobcritters
 datum/controller/process/mob_ai
@@ -46,12 +48,18 @@ datum/controller/process/mob_ai
 						continue
 
 				if(isliving(M) && M.ai)
-					if(!L.is_npc)
+					if(!L.is_npc || !M.ai.enabled)
 						continue
 
 				if(M.ai._mobai_being_processed)
+					M.ai._mobai_being_processed++
+					if(M.ai._mobai_being_processed > MOBAI_STUCK_THRESHOLD)
+						logTheThing(LOG_DEBUG, "mobAI process", "!BAD! The mob [constructTarget(M)](\ref[M]) appears to be stuck processing its AI, and has been skipped for [M.ai._mobai_being_processed] ticks. Attempting a reset! You should *really* check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
+						M.ai.current_task?.reset()
+						M.ai.switch_to(M.ai.default_task)
+						M.ai._mobai_being_processed = FALSE
 					if(!ON_COOLDOWN(M, "mobAI_overran_warning", 30 SECONDS))
-						logTheThing(LOG_DEBUG, "mobAI process", "The mob [constructTarget(M)] overran while processing its AI, and will be skipped for one tick. You should probably check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
+						logTheThing(LOG_DEBUG, "mobAI process", "The mob [constructTarget(M)](\ref[M]) overran while processing its AI, and will be skipped for one tick. You should probably check why it's slow. AI = [M.ai] AI task = [M.ai?.current_task]")
 					continue
 
 				SPAWN(0)
@@ -59,6 +67,8 @@ datum/controller/process/mob_ai
 						M.ai._mobai_being_processed = TRUE
 						M.ai.tick()
 					catch
-						logTheThing(LOG_DEBUG, "mobAI process", "A runtime was thrown by [constructTarget(M)] while processing its AI")
+						logTheThing(LOG_DEBUG, "mobAI process", "A runtime was thrown by [constructTarget(M)](\ref[M]) while processing its AI")
 					M?.ai?._mobai_being_processed = FALSE //null checks just in case something went *really* wrong
 				scheck()
+
+#undef MOBAI_STUCK_THRESHOLD

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -70,8 +70,8 @@ datum/controller/process/mob_ai
 					try
 						M.ai._mobai_being_processed = TRUE
 						M.ai.tick()
-					catch
-						logTheThing(LOG_DEBUG, "mobAI process", "A runtime was thrown by [constructTarget(M)](\ref[M]) while processing its AI")
+					catch(var/exception/e)
+						logTheThing(LOG_DEBUG, "mobAI process", "A runtime was thrown by [constructTarget(M)](\ref[M]) while processing its AI. [e] on [e.file]:[e.line]")
 					M?.ai?._mobai_being_processed = FALSE //null checks just in case something went *really* wrong
 				scheck()
 

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -71,6 +71,7 @@ var/list/ai_move_scheduled = list()
 		..()
 
 	proc/switch_to(var/datum/aiTask/task)
+		SHOULD_NOT_SLEEP(TRUE)
 		current_task = task
 		if(task?.ai_turbo)
 			owner.mob_flags |= HEAVYWEIGHT_AI_MOB
@@ -284,6 +285,7 @@ var/list/ai_move_scheduled = list()
 		on_tick()
 
 	proc/reset()
+		SHOULD_NOT_SLEEP(TRUE)
 		on_reset()
 
 // an AI task that evaluates all tasks within its list of transition tasks

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -71,6 +71,8 @@ var/list/ai_move_scheduled = list()
 		..()
 
 	proc/switch_to(var/datum/aiTask/task)
+		//This SHOULD_NOT_SLEEP is *absolutely necessary* for protecting the mobAI loop from hangs.
+		//Do not remove unless you understand the implications.
 		SHOULD_NOT_SLEEP(TRUE)
 		current_task = task
 		if(task?.ai_turbo)
@@ -285,6 +287,8 @@ var/list/ai_move_scheduled = list()
 		on_tick()
 
 	proc/reset()
+		//This SHOULD_NOT_SLEEP is *absolutely necessary* for protecting the mobAI loop from hangs.
+		//Do not remove unless you understand the implications.
 		SHOULD_NOT_SLEEP(TRUE)
 		on_reset()
 

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -14,6 +14,9 @@ var/list/ai_move_scheduled = list()
 	var/list/datum/aiTask/priority_tasks = list()
 	var/move_target = null
 
+	///INTERNAL: Set to true when the mobai loop is processing this mob.
+	var/_mobai_being_processed = FALSE
+
 	var/move_dist = 0
 	var/move_reverse = 0
 	var/move_side = 0 //merge with reverse later ok messy


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I only wanted to make sure that `sleep()` calls wouldn't kill the AI process...

Anyway, I removed some behaviour that was handled by other processes and left in the mobAI loop for some reason. Cleaned up the code. Made it use `SPAWN()` for each AI `tick()` and some handling to make sure the last tick finished before you get a new one. Also logging for when it overruns.
EDIT: Also error recovery if it get's *really* stuck


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Old code was full of technical debt and grossness and was liable to cause mobs to stop being responsive.

