### PR TITLE
Add examine text for when someone is using VR goggles or other

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -351,9 +351,9 @@
 
 				if (istype(mob, /mob/living/carbon/human/virtual))
 					using_vr_goggles = TRUE
-				else if (istype(mob, /mob/living/critter/robotic/scuttlebot)) // in case you mindswap into a scuttlebot
+				else if (istype(mob, /mob/living/critter/robotic/scuttlebot))
 					var/mob/living/critter/robotic/scuttlebot/scuttlebot = mob
-					if (scuttlebot.controller == src)
+					if (scuttlebot.controller == src) // in case you mindswap into a scuttlebot
 						using_vr_goggles = TRUE
 
 				if (using_vr_goggles)

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -350,7 +350,9 @@
 				var/mob = find_player(src.last_ckey)?.client?.mob
 
 				if (istype(mob, /mob/living/carbon/human/virtual))
-					using_vr_goggles = TRUE
+					var/mob/living/carbon/human/virtual/vr_person = mob
+					if (!vr_person.isghost)
+						using_vr_goggles = TRUE
 				else if (istype(mob, /mob/living/critter/robotic/scuttlebot))
 					var/mob/living/critter/robotic/scuttlebot/scuttlebot = mob
 					if (scuttlebot.controller == src) // in case you mindswap into a scuttlebot

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -346,7 +346,17 @@
 				. += "<br><span class='alert'>[src.name] has a blank expression on [his_or_her(src)] face.</span>"
 
 			if (!src.client && !src.ai_active)
-				if (find_player(src.last_ckey)?.client) // using vr goggles or something similar
+				var/using_vr_goggles = FALSE
+				var/mob = find_player(src.last_ckey)?.client?.mob
+
+				if (istype(mob, /mob/living/carbon/human/virtual))
+					using_vr_goggles = TRUE
+				else if (istype(mob, /mob/living/critter/robotic/scuttlebot)) // in case you mindswap into a scuttlebot
+					var/mob/living/critter/robotic/scuttlebot/scuttlebot = mob
+					if (scuttlebot.controller == src)
+						using_vr_goggles = TRUE
+
+				if (using_vr_goggles)
 					if (!(src.wear_suit?.hides_from_examine & C_GLASSES) && !(src.head?.hides_from_examine & C_GLASSES))
 						. += "<br><span style='color:#8600C8'>[src.name]'s mind is elsewhere.</span>"
 				else

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -346,7 +346,11 @@
 				. += "<br><span class='alert'>[src.name] has a blank expression on [his_or_her(src)] face.</span>"
 
 			if (!src.client && !src.ai_active)
-				. += "<br>[src.name] seems to be staring blankly into space."
+				if (find_player(src.last_ckey)?.client) // using vr goggles or something similar
+					if (!(src.wear_suit?.hides_from_examine & C_GLASSES) && !(src.head?.hides_from_examine & C_GLASSES))
+						. += "<br><span style='color:#8600C8'>[src.name]'s mind is elsewhere.</span>"
+				else
+					. += "<br>[src.name] seems to be staring blankly into space."
 
 	switch (src.decomp_stage)
 		if (DECOMP_STAGE_BLOATED)

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -351,7 +351,7 @@
 
 				if (istype(mob, /mob/living/carbon/human/virtual))
 					var/mob/living/carbon/human/virtual/vr_person = mob
-					if (!vr_person.isghost)
+					if (!vr_person.isghost) // rare but can happen if you leave your body while alive, and then decide to go into vr as a ghost
 						using_vr_goggles = TRUE
 				else if (istype(mob, /mob/living/critter/robotic/scuttlebot))
 					var/mob/living/critter/robotic/scuttlebot/scuttlebot = mob


### PR DESCRIPTION
[PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds a unique examine text for people that appears if they are using something like VR or scuttlebot goggles.

It will appear instead of the "appears to be staring blankly into space." message if they are still in the game

![image](https://user-images.githubusercontent.com/53062374/220509073-b7a5d57a-e88a-4d92-a969-5ef4f7d54af3.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents confusion from if someone actually quit the game or not

## Changelog <!-- Describe why you think this should be added to the game. -->

```changelog
(u)FlameArrow57
(+)Players using VR goggles or a scuttlebot controller will now have an examine text saying their mind is "elsewhere."
```
