### PR TITLE
Atlas minor fixes

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2092,6 +2092,8 @@
 /area/station/crewquarters/cryotron)
 "agC" = (
 /obj/machinery/light_switch/auto,
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/item/gun/flamethrower/assembled/loaded,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -2529,8 +2531,7 @@
 	light_type = /obj/item/light/tube/reddish;
 	pixel_y = 21
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/flamethrower/assembled/loaded,
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -2669,6 +2670,7 @@
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "aiz" = (
@@ -8215,6 +8217,7 @@
 	tag = ""
 	},
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "azV" = (
@@ -8222,6 +8225,7 @@
 /obj/health_scanner/wall,
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "azX" = (
@@ -18267,6 +18271,7 @@
 	pixel_x = -12;
 	pixel_y = 4
 	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "lHo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Brings Atlas closer to feature parity by fixing two things:
- Thin glass airlocks for Medbay and QM now have proper access spawns
- Security now has a Confiscated Items locker with Contraband stickers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Atlas is lacking contraband stickers and people have complained about the wonky airlocks missing access requirements. Should probably have all maps have the same access to important tools, and the access spawns is a long standing bug.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Soleilan
(+)Atlas has received a Confiscated Items locker with its Contraband stickers!
(+)Atlas QM and Medbay windows have received access requirements.
```
