### PR TITLE
Nuclear Waste Random Room

### DIFF
--- a/assets/maps/random_rooms/3x5/waste_dump.dmm
+++ b/assets/maps/random_rooms/3x5/waste_dump.dmm
@@ -1,0 +1,141 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"e" = (
+/obj/item/reactor_component/fuel_rod/random_material{
+	pixel_x = 11
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"i" = (
+/obj/decal/cleanable/machine_debris/radioactive{
+	pixel_x = -21
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"r" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"t" = (
+/obj/item/device/geiger{
+	pixel_y = -7;
+	pixel_x = -2
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"u" = (
+/obj/decal/cleanable/machine_debris/radioactive{
+	pixel_y = 16
+	},
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_y = -32;
+	pixel_x = -3
+	},
+/obj/item/reactor_component/heat_exchanger/random_material,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"v" = (
+/obj/tombstone/nuclear_warning,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"x" = (
+/obj/item/nuclear_waste{
+	pixel_x = -11;
+	layer = 3.1;
+	pixel_y = 2
+	},
+/obj/item/nuclear_waste{
+	pixel_x = -7;
+	layer = 3.09;
+	pixel_y = 15
+	},
+/obj/item/nuclear_waste{
+	pixel_x = 8;
+	layer = 3.1
+	},
+/obj/item/nuclear_waste{
+	pixel_x = 6;
+	layer = 3.09;
+	pixel_y = 12
+	},
+/obj/item/plank,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"z" = (
+/obj/item/plank,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"D" = (
+/obj/item/nuclear_waste{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_y = 28;
+	pixel_x = -1
+	},
+/obj/item/nuclear_waste{
+	pixel_x = 7
+	},
+/obj/item/nuclear_waste{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"J" = (
+/obj/item/nuclear_waste{
+	pixel_x = 7
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"K" = (
+/obj/decal/cleanable/dirt/dirt5,
+/mob/living/critter/small_animal/cockroach,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"P" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/item/nuclear_waste,
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_y = -32;
+	pixel_x = 4
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"V" = (
+/obj/item/nuclear_waste,
+/obj/fluid_spawner{
+	reagent_id = "radium";
+	amount = 30
+	},
+/obj/decal/poster/wallsign/hazard_rad{
+	pixel_y = 28;
+	pixel_x = 2
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+D
+J
+K
+z
+u
+"}
+(2,1,1) = {"
+P
+e
+v
+r
+r
+"}
+(3,1,1) = {"
+V
+t
+i
+x
+S
+"}

--- a/assets/maps/random_rooms/3x5/waste_dump.dmm
+++ b/assets/maps/random_rooms/3x5/waste_dump.dmm
@@ -7,7 +7,8 @@
 /area/dmm_suite/clear_area)
 "i" = (
 /obj/decal/cleanable/machine_debris/radioactive{
-	pixel_x = -21
+	pixel_x = -21;
+	layer = 3.1
 	},
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -629,3 +629,17 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 		current_loc.assume_air(leak_gas)
 		qdel(src)
 
+/obj/tombstone/nuclear_warning
+	name = "inscribed stone"
+	desc = {"A stone block, inscribed with a message. It says:<br>
+	This place is a message... and part of a system of messages... pay attention to it!<br>
+    Sending this message was important to us. We considered ourselves to be a powerful culture.<br>
+    This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.<br>
+    What is here was dangerous and repulsive to us. This message is a warning about danger.<br>
+    The danger is in a particular location... it increases towards a center... the center of danger is here... of a particular size and shape, and below us.<br>
+    The danger is still present, in your time, as it was in ours.<br>
+    The danger is to the body, and it can kill.<br>
+    The form of the danger is an emanation of energy.<br>
+    The danger is unleashed only if you substantially disturb this place physically. This place is best shunned and left uninhabited.<br>
+	<br>
+	...spooky!"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a 3x5 random room with some nuclear waste in it. Also a spooky message to future civilisations.
Minor loot: a couple random reactor components made of a random material. 

![image](https://user-images.githubusercontent.com/3855802/221186246-b230a299-d5d2-493d-8112-eabcde6e1f0c.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Variety is the spice of life.
