### PR TITLE
Increase haloperidol depletion rate to 1

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -731,6 +731,7 @@ datum
 			fluid_g = 220
 			fluid_b = 255
 			transparency = 255
+			depletion_rate = 1
 			value = 8 // 2c + 3c + 1c + 1c + 1c
 			threshold = THRESHOLD_INIT
 			var/list/flushed_reagents = list("LSD","lsd_bee","psilocybin","crank","bathsalts","THC","space_drugs","catdrugs","methamphetamine","epinephrine","synaptizine")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the depletion rate of haloperidol to 1 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Haloperidol is very debilitating even in extremely small doses, such as removing a dart as soon as it hits you. This makes one dart, even if you remove it ASAP, remove 3-4 minutes of the stimulants status effect or give you slowdown as long as a minute after.
