### PR TITLE
Fixes #13063 - Observers Are Now Added To The Respawnee List

### DIFF
--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -889,7 +889,7 @@ a.latejoin-card:hover {
 			if(observer?.client)
 				observer.client.loadResources()
 
-			respawn_controller.subscribeNewRespawnee(src.ckey)
+			respawn_controller.subscribeNewRespawnee(observer?.client?.ckey)
 
 			qdel(src)
 


### PR DESCRIPTION
[RP] [Bug]


## About the PR:
Fixes a minor typo in PR #13010, which resulted in a null ckey value being passed to `subscribeNewRespawnee()`.

Fixes #13063.
Fixes #13062.