### PR TITLE
Fixes #13190 - VR Antagonist Roles Now Remove Themselves Upon Exiting VR

### DIFF
--- a/code/datums/Vspace.dm
+++ b/code/datums/Vspace.dm
@@ -119,6 +119,11 @@ datum/v_space
 		if (user.client)
 			user.client.reset_view()
 
+		if (user.mind)
+			for (var/datum/antagonist/antag_role in user.mind.antagonists)
+				if (antag_role.vr)
+					antag_role.on_death()
+
 		for(var/mob/O in oviewers())
 			boutput(O, "<span class='alert'><b>[user] logs out!</b></span>")
 		if (istype(user.loc,/obj/racing_clowncar/kart))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -217,19 +217,19 @@ datum/mind
 		return null
 
 	/// Attempts to add the antagonist datum of ID role_id to this mind.
-	proc/add_antagonist(role_id, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_ROUND_START, respect_mutual_exclusives = TRUE, do_pseudo = FALSE, late_setup = FALSE)
+	proc/add_antagonist(role_id, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_ROUND_START, respect_mutual_exclusives = TRUE, do_pseudo = FALSE, do_vr = FALSE, late_setup = FALSE)
 		// Check for mutual exclusivity for real antagonists
-		if (respect_mutual_exclusives && !do_pseudo && length(src.antagonists))
+		if (respect_mutual_exclusives && !do_pseudo && !do_vr && length(src.antagonists))
 			for (var/datum/antagonist/A as anything in src.antagonists)
 				if (A.mutually_exclusive)
 					return FALSE
 		// To avoid wacky shenanigans, refuse to add multiple types of the same antagonist
-		if (!isnull(src.get_antagonist(role_id)))
+		if (!isnull(src.get_antagonist(role_id)) && !do_vr)
 			return FALSE
 		for (var/V in concrete_typesof(/datum/antagonist))
 			var/datum/antagonist/A = V
 			if (initial(A.id) == role_id)
-				var/datum/antagonist/new_datum = new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup)
+				var/datum/antagonist/new_datum = new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup)
 				if (QDELETED(new_datum))
 					return FALSE
 				src.antagonists.Add(new_datum)

--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -184,7 +184,7 @@
 
 		makeAntag(mob/living/carbon/human/M as mob)
 			boutput(M, "<span class='combat'>Awooooooo!</span>")
-			M.mind.add_antagonist(ROLE_WEREWOLF, respect_mutual_exclusives = FALSE, do_pseudo = TRUE)
+			M.mind.add_antagonist(ROLE_WEREWOLF, do_vr = TRUE)
 
 	wrestler
 		name = "WRESTL~1.EXE"
@@ -194,7 +194,7 @@
 
 		makeAntag(mob/living/carbon/human/M as mob)
 			boutput(M, "<span class='combat'>Time to step into the squared circle, son.</span>")
-			M.mind.add_antagonist(ROLE_WRESTLER, respect_mutual_exclusives = FALSE, do_pseudo = TRUE)
+			M.mind.add_antagonist(ROLE_WRESTLER, do_vr = TRUE)
 
 	wizard
 		name = "WIZARD.EXE"
@@ -204,9 +204,7 @@
 
 		makeAntag(mob/living/carbon/human/M as mob)
 			boutput(M, "<span class='combat'>You're a wizard, <s>Harry</s> [M]! Don't forget to pick your spells.</span>")
-			M.mind?.add_antagonist(ROLE_WIZARD, do_equip = FALSE, do_relocate = FALSE, do_pseudo = TRUE, respect_mutual_exclusives = FALSE)
-			var/datum/antagonist/wizard/antag_role = M.mind?.get_antagonist(ROLE_WIZARD)
-			antag_role.give_equipment(TRUE)
+			M.mind?.add_antagonist(ROLE_WIZARD, do_vr = TRUE)
 
 	nuclear
 		name = "NUKE_TKN.EXE"
@@ -227,5 +225,4 @@
 
 		makeAntag(mob/living/carbon/human/M)
 			boutput(M, "<span class='combat'>The simulation grants you a small portion of its power.</span>")
-			// No need to specify other arguments here; pseudo does most of this on its own
-			M.mind?.add_antagonist(ROLE_ARCFIEND, do_pseudo = TRUE, respect_mutual_exclusives = FALSE)
+			M.mind?.add_antagonist(ROLE_ARCFIEND, do_vr = TRUE)

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -26,10 +26,12 @@ ABSTRACT_TYPE(/datum/antagonist)
 	var/assigned_by = ANTAGONIST_SOURCE_ROUND_START
 	/// Pseudo antagonists are not "real" antagonists, as determined by the round. They have the abilities, but do not have objectives and ideally should not considered antagonists for the purposes of griefing rules, etc.
 	var/pseudo = FALSE
+	/// VR antagonists, similar to pseudo antagonists, are not real antagonists. They lack some exploitative abilities, are not relocated, and are removed on death.
+	var/vr = FALSE
 	/// The objectives assigned to the player by this specific antagonist role.
 	var/list/datum/objective/objectives = list()
 
-	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup)
+	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup)
 		. = ..()
 		if (!istype(new_owner))
 			message_admins("Antagonist datum of type [src.type] and usr [usr] attempted to spawn without a mind. This should never happen!!")
@@ -40,12 +42,21 @@ ABSTRACT_TYPE(/datum/antagonist)
 			return FALSE
 		src.owner = new_owner
 		src.pseudo = do_pseudo
-		if (!do_pseudo) // there is a special place in code hell for mind.special_role
+		src.vr = do_vr
+		if (!do_pseudo && !do_vr) // there is a special place in code hell for mind.special_role
 			new_owner.special_role = id
 			if (source == ANTAGONIST_SOURCE_ADMIN)
 				ticker.mode.Agimmicks |= new_owner
 			else
 				ticker.mode.traitors |= new_owner // same with this variable in particular, but it's necessary for antag HUDs
+		if (do_vr)
+			src.pseudo = TRUE
+			src.remove_on_death = TRUE
+			src.remove_on_clone = TRUE
+			do_equip = TRUE
+			do_objectives = FALSE
+			do_relocate = FALSE
+			silent = TRUE
 		src.setup_antagonist(do_equip, do_objectives, do_relocate, silent, source, late_setup)
 
 	Del()

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -9,7 +9,7 @@
 	is_compatible_with(datum/mind/mind)
 		return ishuman(mind.current)
 
-	give_equipment(vr_equipment_restrictions = FALSE)
+	give_equipment()
 		if (!ishuman(src.owner.current))
 			return FALSE
 
@@ -24,7 +24,7 @@
 		H.RegisterSignal(H, COMSIG_LIVING_LIFE_TICK, /mob/proc/emp_hands)
 
 		// Initial abilities; all unlockable abilities will be handled by the abilityHolder.
-		if (!vr_equipment_restrictions)
+		if (!src.vr)
 			src.ability_holder.addAbility(/datum/targetable/spell/phaseshift)
 			src.ability_holder.addAbility(/datum/targetable/spell/magicmissile)
 			src.ability_holder.addAbility(/datum/targetable/spell/clairvoyance)
@@ -50,10 +50,10 @@
 		H.equip_if_possible(new /obj/item/paper/Wizardry101(H), H.slot_r_store)
 		H.equip_if_possible(new /obj/item/staff(H), H.slot_r_hand)
 
-		if (!vr_equipment_restrictions)
+		if (!src.vr)
 			H.equip_if_possible(new /obj/item/teleportation_scroll(H), H.slot_l_hand)
 
-		var/obj/item/SWF_uplink/SB = new /obj/item/SWF_uplink(vr_equipment_restrictions)
+		var/obj/item/SWF_uplink/SB = new /obj/item/SWF_uplink(src.vr)
 		SB.wizard_key = src.owner.key
 		H.equip_if_possible(SB, H.slot_belt)
 
@@ -68,7 +68,7 @@
 		else
 			randomname = pick_string_autokey("names/wizard_male.txt")
 
-		if (!vr_equipment_restrictions)
+		if (!src.vr)
 			SPAWN(0)
 				var/newname = tgui_input_text(H, "You are a Wizard. Would you like to change your name to something else?", "Name change", randomname)
 				if(newname && newname != randomname)


### PR DESCRIPTION
[Gamemodes] [Internal] [Bug]


## About the PR:
Fixes #13190 by implementing a new `vr` variable to `/datum/antagonist`, which forces an antagonist role to be silent, pseudo, and removed on death, and prevents objectives from being assigned or the player from being relocated.
`Leave_Vspace()` will also now remove VR antagonists from a player.