### PR TITLE
Critters now have composite abilityHolders

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -130,7 +130,7 @@ ABSTRACT_TYPE(/mob/living/critter)
 
 		health_update_queue |= src
 
-		src.abilityHolder = new /datum/abilityHolder/critter(src)
+		src.abilityHolder = new /datum/abilityHolder/composite(src)
 		if (islist(src.add_abilities) && length(src.add_abilities))
 			for (var/abil in src.add_abilities)
 				if (ispath(abil))

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -149,7 +149,7 @@
 
 	New(loc, obj/item/bodypart)
 		..()
-		abilityHolder = new /datum/abilityHolder/critter/handspider(src)
+		src.add_ability_holder(/datum/abilityHolder/critter/handspider)
 		//todo : move to add_abilities list because its cleaner that way
 		abilityHolder.addAbility(/datum/targetable/critter/dna_gnaw)
 		abilityHolder.addAbility(/datum/targetable/critter/boilgib)
@@ -349,7 +349,7 @@
 
 	New()
 		..()
-		abilityHolder = new /datum/abilityHolder/critter/eyespider(src)
+		src.add_ability_holder(/datum/abilityHolder/critter/eyespider)
 		// TODO: ACTUAL ABILITIES
 		abilityHolder.addAbility(/datum/targetable/critter/mark)
 		abilityHolder.addAbility(/datum/targetable/critter/boilgib)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -41,9 +41,7 @@
 /mob/living/critter/flock/drone/New(var/atom/location, var/datum/flock/F=null)
 	src.ai = new /datum/aiHolder/flock/drone(src)
 	..()
-	var/datum/abilityHolder/composite/composite = new(src)
-	abilityHolder = composite
-	composite.addHolder(/datum/abilityHolder/critter/flockdrone)
+	src.add_ability_holder(/datum/abilityHolder/critter/flockdrone)
 
 	SPAWN(3 SECONDS)
 		//this is terrible, but diffracting a drone immediately causes a runtime

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -60,8 +60,6 @@
 /mob/living/critter/flock/New(var/atom/L, var/datum/flock/F=null)
 	..()
 	remove_lifeprocess(/datum/lifeprocess/radiation)
-	qdel(abilityHolder)
-	src.abilityHolder = null
 	setMaterial(getMaterial("gnesis"), copy = FALSE)
 	src.material.setProperty("reflective", 5)
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 100)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2938,7 +2938,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 
 	New()
 		..()
-		abilityHolder = new /datum/abilityHolder/critter(src)
 		//todo : move to add_abilities list because its cleaner that way
 		abilityHolder.addAbility(/datum/targetable/critter/vomit)
 		abilityHolder.updateButtons()
@@ -3003,7 +3002,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 
 	New()
 		..()
-		abilityHolder = new /datum/abilityHolder/critter(src)
 		//todo : move to add_abilities list because its cleaner that way
 		abilityHolder.addAbility(/datum/targetable/critter/blood_bite)
 		abilityHolder.updateButtons()

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -6,12 +6,9 @@
 	var/datum/abilityHolder/arcfiend/ability_holder
 
 	is_compatible_with(datum/mind/mind)
-		return ishuman(mind.current)
+		return ishuman(mind.current) || ismobcritter(mind.current)
 
 	give_equipment()
-		if (!ishuman(src.owner.current))
-			return FALSE
-		var/mob/living/carbon/human/H = src.owner.current
 		var/datum/abilityHolder/arcfiend/A = src.owner.current.get_ability_holder(/datum/abilityHolder/arcfiend)
 		if (!A)
 			src.ability_holder = src.owner.current.add_ability_holder(/datum/abilityHolder/arcfiend)
@@ -26,8 +23,8 @@
 		src.ability_holder.addAbility(/datum/targetable/arcfiend/jamming_field)
 		src.ability_holder.addAbility(/datum/targetable/arcfiend/jolt)
 
-		H.bioHolder.AddEffect("resist_electric", power = 2, magical = TRUE)
-		H.ClearSpecificOverlays("resist_electric")
+		src.owner.current.bioHolder.AddEffect("resist_electric", power = 2, magical = TRUE)
+		src.owner.current.ClearSpecificOverlays("resist_electric")
 
 	remove_equipment()
 		// now this is pod racing

--- a/code/modules/antagonists/vampire/vampire.dm
+++ b/code/modules/antagonists/vampire/vampire.dm
@@ -6,12 +6,9 @@
 	var/datum/abilityHolder/vampire/ability_holder
 
 	is_compatible_with(datum/mind/mind)
-		return ishuman(mind.current)
+		return ishuman(mind.current) || ismobcritter(mind.current)
 
 	give_equipment()
-		if (!ishuman(src.owner.current))
-			return FALSE
-
 		var/datum/abilityHolder/vampire/A = src.owner.current.get_ability_holder(/datum/abilityHolder/vampire)
 		if (!A)
 			src.ability_holder = src.owner.current.add_ability_holder(/datum/abilityHolder/vampire)

--- a/code/modules/antagonists/wraith/critters/trickster_puppet.dm
+++ b/code/modules/antagonists/wraith/critters/trickster_puppet.dm
@@ -27,8 +27,7 @@
 		last_life_update = TIME
 
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
-		src.abilityHolder = new /datum/abilityHolder/wraith(src)
-		AH = src.abilityHolder
+		AH = src.add_ability_holder(/datum/abilityHolder/wraith)
 		var/datum/abilityHolder/wraith/master_ability_holder = master.abilityHolder
 		AH.points = master_ability_holder.points
 		AH.possession_points = master_ability_holder.possession_points


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [BUG] [CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes all mob critters to have a composite abilityHolder instead of a single default one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13197
Removes the need for special critter handling like #13197
Flockdrones already did this because they are smart and cool
Technically allows for arcfiend chickens or something?
It Just Makes Sense