### PR TITLE
Make meteor shield generator non dense

### DIFF
--- a/code/obj/machinery/shield_generators/meteor_shield.dm
+++ b/code/obj/machinery/shield_generators/meteor_shield.dm
@@ -3,6 +3,7 @@
 	desc = "Generates a force field that stops meteors."
 	icon = 'icons/obj/meteor_shield.dmi'
 	icon_state = "shieldgen"
+	density = FALSE
 
 	nocell
 		starts_with_cell = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes density from meteor shield generator. Meaning they can now be walked over and can stack in crates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Keep it similar to the other shield generator which is not dense.

The shield generators don't stack in crates which makes preparing for a meteor shower event troublesome.

In some maps like Oshan the maintenance can be 1 tile wide, which makes installing the shield generators all the more difficult.