### PR TITLE
SecMate will now properly search DNA records upon entering a DNA string

### DIFF
--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -571,7 +571,7 @@
 
 				var/list/datum/db_record/results = list()
 				for(var/datum/db_record/R as anything in data_core.general.records)
-					var/haystack = jointext(list(ckey(R["name"]), ckey(R["id"]), ckey(R["id"]), ckey(R["fingerprint"]), ckey(R["rank"])), " ")
+					var/haystack = jointext(list(ckey(R["name"]), ckey(R["dna"]), ckey(R["id"]), ckey(R["fingerprint"]), ckey(R["rank"])), " ")
 					if(findtext(haystack, searchText))
 						results += R
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BUG] [MAJOR] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #12061, allowing SecMate searches to now properly return DNA matches.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In commit dae5aa95ea949e54ad38670f5628a461cba3010b, which changed how SecMate searching works, the DNA matching check was inadvertantly replaced with a redundant Record ID, causing DNA to no longer be searchable via SecMate (but not affecting the Forensic Scanner, hence MAJOR and not CRITICAL as there's a workaround). This PR fixes that.


P.S. We need a `A-Security` label, since there's an `A-Medical` and `A-Science` label.