### PR TITLE
Fixes decay not applying to stimulated emission on the nuclear reactor

### DIFF
--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -144,12 +144,16 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			if(prob(src.material.getProperty("density")*10*src.neutron_cross_section)) //dense materials capture neutrons, configuration influences that
 				//if a neutron is captured, we either do fission or we slow it down
 				if(N.velocity <= 1 & prob(src.material.getProperty("n_radioactive")*10)) //neutron stimulated emission
+					src.material.adjustProperty("n_radioactive", -0.01)
+					src.material.setProperty("radioactive", src.material.getProperty("radioactive") + 0.005)
 					for(var/i in 1 to 5)
 						inNeutrons += new /datum/neutron(pick(alldirs), pick(2,3))
 					inNeutrons -= N
 					qdel(N)
 					src.temperature += 50
 				else if(N.velocity <= 1 & prob(src.material.getProperty("radioactive")*10)) //stimulated emission
+					src.material.adjustProperty("radioactive", -0.01)
+					src.material.setProperty("spent_fuel", src.material.getProperty("spent_fuel") + 0.005)
 					for(var/i in 1 to 5)
 						inNeutrons += new /datum/neutron(pick(alldirs), pick(1,2,3))
 					inNeutrons -= N


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Arguably this is more of a balance tweak than a fix, but I'm calling it a fix because I meant the decay to work this way and it doesn't. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fuel rods should decay from stimulated emission as well as spontaneous emission. This will make fuel rods decay slightly faster, and enable the setup of breeder reactors if you're a nerd.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Fuel rods in the nuclear reactor will decay faster if they are hit by more neutrons.
```
