### PR TITLE
Allow pitchers in the Chem Heater

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -34,12 +34,13 @@ TYPEINFO(/obj/machinery/chem_heater)
 		..()
 		output_target = src.loc
 
-	attackby(var/obj/item/reagent_containers/glass/B, var/mob/user)
+	attackby(var/obj/item/reagent_containers/B, var/mob/user)
 
-		if(istype(B, /obj/item/reagent_containers/glass))
+		if (istype(B, /obj/item/reagent_containers/glass) || \
+			istype(B, /obj/item/reagent_containers/food/drinks/drinkingglass))
 			tryInsert(B, user)
 
-	proc/tryInsert(obj/item/reagent_containers/glass/B, var/mob/user)
+	proc/tryInsert(obj/item/reagent_containers/B, var/mob/user)
 		if (status & (NOPOWER|BROKEN))
 			user.show_text("[src] seems to be out of order.", "red")
 			return
@@ -110,7 +111,7 @@ TYPEINFO(/obj/machinery/chem_heater)
 
 	ui_data(mob/user)
 		. = list()
-		var/obj/item/reagent_containers/glass/container = src.beaker
+		var/obj/item/reagent_containers/container = src.beaker
 		// Container data
 		var/list/containerData
 		if(container)
@@ -147,7 +148,7 @@ TYPEINFO(/obj/machinery/chem_heater)
 		. = ..()
 		if(.)
 			return
-		var/obj/item/reagent_containers/glass/container = src.beaker
+		var/obj/item/reagent_containers/container = src.beaker
 		switch(action)
 			if("eject")
 				if(!container)
@@ -168,7 +169,7 @@ TYPEINFO(/obj/machinery/chem_heater)
 			if("insert")
 				if (container)
 					return
-				var/obj/item/reagent_containers/glass/inserting = usr.equipped()
+				var/obj/item/reagent_containers/inserting = usr.equipped()
 				if(istype(inserting))
 					tryInsert(inserting, usr)
 			if("adjustTemp")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows `/obj/item/reagent_containers/food/drinks/drinkingglass` ( drinking glass, pitchers, shot glasses, artifact pitcher,  etc ) in the Chem Heater.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When chilling or heating drinks, bartenders are forced to move the contents of a pitcher (120 units) to a beaker (100 units). This change cuts the middle-man.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Pitchers can now go in the chem heater/cooler
```
