### PR TITLE
GPS properly gets coordinates for its location

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -157,7 +157,7 @@ TYPEINFO(/obj/item/device/gps)
 			return
 		if (usr.contents.Find(src) || usr.contents.Find(src.master) || in_interact_range(src, usr) || issilicon(usr) || isAIeye(usr))
 			src.add_dialog(usr)
-			var/turf/T = get_turf(usr)
+			var/turf/T = get_turf(src)
 			if(href_list["getcords"])
 				boutput(usr, "<span class='notice'>Located at: <b>X</b>: [T.x], <b>Y</b>: [T.y]</span>")
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Previously the GPS would call `get_turf(usr)` for its coordinates. This meant if you interacted with it while not being on the exact same tile, it would give false coordinates. i.e. you're a cyborg using it from a distance, or human using it while its on the floor next to you


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It probably shouldn't care about the users location and instead report its own.  
Fixes #13232