### PR TITLE
Fixes #13218 - Salvager And Hunter Respawn Events Should No Longer Runtime

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -274,6 +274,7 @@
 				if ("Hunter")
 					var/mob/living/L = M3.humanize()
 					if (istype(L))
+						M3 = L
 						L.mind?.wipe_antagonists()
 						L.mind?.add_antagonist(ROLE_HUNTER, do_equip = FALSE, do_relocate = TRUE, source = ANTAGONIST_SOURCE_RANDOM_EVENT)
 						role = ROLE_HUNTER
@@ -283,6 +284,7 @@
 				if ("Salvager")
 					var/mob/living/L = M3.humanize(equip_rank=FALSE)
 					if (istype(L))
+						M3 = L
 						L.mind?.wipe_antagonists()
 						L.mind?.add_antagonist(ROLE_SALVAGER, do_equip = TRUE, do_relocate = TRUE, source = ANTAGONIST_SOURCE_RANDOM_EVENT)
 						role = ROLE_SALVAGER


### PR DESCRIPTION
[Gamemodes] [Internal] [Bug]


## About the PR:
Fixes #13218 by adding missing `M3 = L` assignments to the Hunter and Salvager switch branches of antagonist respawn random events.