### PR TITLE
Fixes #13216 - Door graphic won't glitch if ID wire is pulsed and door is open

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -950,7 +950,8 @@ About the new airlock wires panel:
 *		one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds. Cutting this wire electrifies the door, so that the next person to touch the door without insulated gloves gets electrocuted. (Currently it is also STAYING electrified until someone mends the wire)
 */
 /obj/machinery/door/airlock/proc/play_deny()
-	play_animation("deny")
+	if(src.density && !src.operating) // only play the animation while fully closed
+		play_animation("deny")
 	playsound(src, src.sound_deny_temp, 35, 0, 0.8) //if this doesn't carry far enough, tweak the extrarange number, not the volume
 
 /obj/machinery/door/airlock/proc/try_pulse(var/wire_color, mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes sure the door is closed and not in the middle of an animation before playing the deny animation.
Now it'll only animate the red flashing lights if a door is fully closed and not flash a closed door graphic over open doors or animating doors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #13216


