### PR TITLE
Changes foam dart shotgun's lethality examine text to match other foam dart guns.

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -291,6 +291,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	name = "foam dart"
 	sname = "foam dart"
 	spread_angle_variance = 22.5
+	damage = 0
 	speed_max = 32
 	speed_min = 20
 	cost = 6


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[C-Bug] [A-Game-Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the issue opened in #13178. Caused by spreader projectile inheriting the damage value of buckshot. Now it'll state it has a lethality of 0-100% like other foam dart guns, rather than 15-100%.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Just an examine text bugfix.