### PR TITLE
Kondaru mining staff room APC is connected to power grid now

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -43369,6 +43369,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"jAk" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/mining/staff_room)
 "jAw" = (
 /turf/simulated/floor/caution/west,
 /area/station/quartermaster/cargobay)
@@ -107503,7 +107511,7 @@ cJr
 rTt
 bki
 xYT
-bzk
+jAk
 bzk
 rgh
 coJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Literally just added a single wire. Kondaru's mining staff room APC just didn't have a wire for some reason, I checked all other APCs and they seem fine, very weird, where'd it go??

![we'll never know where it went...](https://user-images.githubusercontent.com/111906440/222533153-07f93f1e-cb14-4ff0-81fa-af461e3d28e4.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13250, unconnected APCs very bad

