### PR TITLE
MedTrak will now properly search DNA records upon entering a DNA string

### DIFF
--- a/code/modules/networks/computer3/med_rec.dm
+++ b/code/modules/networks/computer3/med_rec.dm
@@ -515,7 +515,7 @@
 
 				var/list/datum/db_record/results = list()
 				for(var/datum/db_record/R as anything in data_core.general.records)
-					var/haystack = jointext(list(ckey(R["name"]), ckey(R["id"]), ckey(R["id"]), ckey(R["fingerprint"]), ckey(R["rank"])), " ")
+					var/haystack = jointext(list(ckey(R["name"]), ckey(R["dna"]), ckey(R["id"]), ckey(R["fingerprint"]), ckey(R["rank"])), " ")
 					if(findtext(haystack, searchText))
 						results += R
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [BUG] [MAJOR]

## About the PR
Like my previous PR, #13236 (which fixes SecMate's searching to actually search DNA records), but for MedTrak. This one's for the one doctor who actually uses the MedTrak Computer.