### PR TITLE
Makes components display on the parent varedit menu

### DIFF
--- a/code/modules/admin/viewvariables/datumvars.dm
+++ b/code/modules/admin/viewvariables/datumvars.dm
@@ -183,7 +183,8 @@
 	for (var/datum/component/component in components)
 		body += {"
 		<hr>
-		<b>[component.type]</b>
+		<b><a href='byond://?src=\ref[src];Vars=\ref[component]'>[component.type]</a></b>
+		<br>
 		<table>
 			<thead>
 				<tr>

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)fri mar 3 23
+(u)LeahTheTech
+(*)Components now display their vars at the bottom of the parent's varedit page for easy and fast component varediting.
 (t)mon feb 27 23
 (u)Zamujasa
 (*)Toggle-Power-Debug, will show maptext over (most) things that draw power.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Components now display their vars on the varedit menu of the parent, in separate little tables at the bottom.
![image](https://user-images.githubusercontent.com/20713227/222832217-3f5a3a9f-3847-4054-aeb9-2b80b40716d7.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier component varediting.