### PR TITLE
Requisition de-bork batch

### DIFF
--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -54,7 +54,8 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 
 /datum/rc_entry/stack/steelsheet
 	name = "NT-spec steel sheet"
-	typepath = /obj/item/sheet/steel
+	typepath = /obj/item/sheet
+	mat_id = "steel"
 	feemod = 30
 
 ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
@@ -326,9 +327,9 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 		switch(tilter)
 			if("food","rations")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/literallyanyfood,rand(30,48))
+				src.rc_entries += rc_buildentry(/datum/rc_entry/food/any,rand(30,48))
 			if("food and water")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/literallyanyfood,rand(24,40))
+				src.rc_entries += rc_buildentry(/datum/rc_entry/food/any,rand(24,40))
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/water,rand(18,36)*10)
 			if("furnace fuel")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/stack/char,rand(24,36))

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -197,7 +197,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		if(prob(30))
 			src.rc_entries += rc_buildentry(/datum/rc_entry/item/headset,crewcount)
 		if(prob(50)) //turns out they need something to eat too
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/literallyanyfood,crewcount)
+			src.rc_entries += rc_buildentry(/datum/rc_entry/food/any,crewcount)
 			src.flavor_desc += " Food would also be appreciated."
 			if(prob(70)) src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/water,crewcount*10*rand(1,3))
 		//job related gearsets could also be added here sometimes
@@ -260,7 +260,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	typepath = /obj/item/device/radio/headset
 	feemod = 940
 
-/datum/rc_entry/item/literallyanyfood
+/datum/rc_entry/food/any
 	name = "solid food, preferably nutritious"
 	typepath = /obj/item/reagent_containers/food/snacks
 	feemod = 250
@@ -307,16 +307,16 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		src.payout += rand(0,50) * 10
 
 		if (prob(70)) //pizza party
-			src.rc_entries += rc_buildentry(/datum/rc_entry/stack/pizza,rand(2,3)*6)
+			src.rc_entries += rc_buildentry(/datum/rc_entry/food/pizza,rand(2,3)*6)
 			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/cola,rand(10,20)*10)
 
 		switch (rand(1, 50)) //Special Outcomes Zone
 			if (1)
 				src.rc_entries += rc_buildentry(/datum/rc_entry/item/chaps,rand(3,6))
 			if (2 to 6)
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/grapes,rand(3,6))
+				src.rc_entries += rc_buildentry(/datum/rc_entry/food/grapes,rand(3,6))
 			if (7 to 11)
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/banana,rand(4,8))
+				src.rc_entries += rc_buildentry(/datum/rc_entry/food/banana,rand(4,8))
 			if (12 to 16)
 				src.rc_entries += rc_buildentry(/datum/rc_entry/item/cannabis,rand(4,8))
 			if (17 to 21)
@@ -329,9 +329,9 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		if(!length(src.rc_entries)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/paperhat,rand(6,12)) //fallback
 
 		if(prob(70)) //cookies or cakes?
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/cake,1+prob(20))
+			src.rc_entries += rc_buildentry(/datum/rc_entry/food/cake,1+prob(20))
 		else //yep cookies
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/cookie,rand(2,4)*6)
+			src.rc_entries += rc_buildentry(/datum/rc_entry/food/cookie,rand(2,4)*6)
 
 		var/bonusducks
 		if(prob(50))
@@ -385,17 +385,17 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	typepath = /obj/item/gift
 	feemod = 600
 
-/datum/rc_entry/item/cake
+/datum/rc_entry/food/cake
 	name = "cake"
 	typepath = /obj/item/reagent_containers/food/snacks/cake
 	feemod = 2500
 
-/datum/rc_entry/item/cookie
+/datum/rc_entry/food/cookie
 	name = "cookie"
 	typepath = /obj/item/reagent_containers/food/snacks/cookie
 	feemod = 600
 
-/datum/rc_entry/stack/pizza
+/datum/rc_entry/food/pizza
 	name = "slices' worth of pizza"
 	typepath = /obj/item/reagent_containers/food/snacks/pizza
 	feemod = 120
@@ -410,17 +410,15 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	typepath = /obj/item/clothing/under/gimmick/chaps
 	feemod = 5000
 
-/datum/rc_entry/item/grapes
+/datum/rc_entry/food/grapes
 	name = "grapes"
 	typepath = /obj/item/reagent_containers/food/snacks/plant/grape
-	commodity = /datum/commodity/produce
-	feemod = 400
+	feemod = 450
 
-/datum/rc_entry/item/banana
+/datum/rc_entry/food/banana
 	name = "banana"
 	typepath = /obj/item/reagent_containers/food/snacks/plant/banana
-	commodity = /datum/commodity/produce
-	feemod = 250
+	feemod = 300
 
 /datum/rc_entry/item/cannabis
 	name = "cannabis"

--- a/code/modules/economy/requisition/rc_special.dm
+++ b/code/modules/economy/requisition/rc_special.dm
@@ -149,7 +149,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 		src.rc_entries += rc_buildentry(/datum/rc_entry/item/megaweed,1)
 		src.rc_entries += rc_buildentry(/datum/rc_entry/item/whiteweed,1)
 		src.rc_entries += rc_buildentry(/datum/rc_entry/item/omegaweed,1)
-		src.rc_entries += rc_buildentry(/datum/rc_entry/stack/pizza/spacer,6)
+		src.rc_entries += rc_buildentry(/datum/rc_entry/food/pizza/spacer,6)
 		..()
 
 /datum/rc_entry/item
@@ -163,7 +163,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 		name = "Omega Weed"
 		typepath = /obj/item/plant/herb/cannabis/omega
 
-/datum/rc_entry/stack/pizza/spacer
+/datum/rc_entry/food/pizza/spacer
 	name = "Pizza Hexa-Subsections (May Be Unseparated)"
 
 
@@ -179,11 +179,11 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 		payout = 3300
 
 	New()
-		src.rc_entries += rc_buildentry(/datum/rc_entry/stack/pizza,rand(20,30)*6)
+		src.rc_entries += rc_buildentry(/datum/rc_entry/food/pizza,rand(20,30)*6)
 		..()
 
 //contract below defines the details itself based on variety of order - this is just a dummy so as not to use an abstract type
-/datum/rc_entry/item/mealfood
+/datum/rc_entry/food/mealfood
 
 ABSTRACT_TYPE(/datum/req_contract/special/chef)
 /datum/req_contract/special/chef
@@ -200,7 +200,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/chef)
 		New()
 			src.build_foodlist()
 			for(var/i in 1 to rand(3,6))
-				var/datum/rc_entry/item/nom = new /datum/rc_entry/item/mealfood
+				var/datum/rc_entry/item/nom = new /datum/rc_entry/food/mealfood
 				nom.typepath = pick(src.cornucopia)
 				nom.name = src.name_of_food[nom.typepath]
 				nom.count = pick(60; 1, 30; 2, 10; 3)
@@ -213,7 +213,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/chef)
 		New()
 			src.build_foodlist()
 			for(var/i in 1 to rand(3,6))
-				var/datum/rc_entry/item/nom = new /datum/rc_entry/item/mealfood
+				var/datum/rc_entry/item/nom = new /datum/rc_entry/food/mealfood
 				nom.typepath = pick(src.cornucopia)
 				nom.name = src.name_of_food[nom.typepath]
 				nom.count = pick(60; 1, 40; 2)
@@ -226,7 +226,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/chef)
 		New()
 			src.build_foodlist()
 			for(var/i in 1 to rand(3,6))
-				var/datum/rc_entry/item/nom = new /datum/rc_entry/item/mealfood
+				var/datum/rc_entry/item/nom = new /datum/rc_entry/food/mealfood
 				nom.typepath = pick(src.cornucopia)
 				nom.name = src.name_of_food[nom.typepath]
 				nom.count = pick(60; 1, 40; 2)
@@ -239,7 +239,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/chef)
 		New()
 			src.build_foodlist()
 			for(var/i in 1 to rand(3,6))
-				var/datum/rc_entry/item/nom = new /datum/rc_entry/item/mealfood
+				var/datum/rc_entry/item/nom = new /datum/rc_entry/food/mealfood
 				nom.typepath = pick(src.cornucopia)
 				nom.name = src.name_of_food[nom.typepath]
 				nom.count = pick(40; 1, 40; 2, 20; 3)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes two issues with requisition entry handling with some additions to the entry code and according changes in entries themselves.

- Adds an optional material ID parameter to the item stack entry; if defined, requires the provided material ID string to match one present on the stack. This is now used for steel sheet stack evaluation instead of the path, as the path isn't maintained when splitting sheet stacks. Much better.
- Adds and implements a new "food item" entry type that's aware of bites_left, now that that's a distinct thing from amount. Default behavior is to require initial bites_left on food (in other words: intact) and count per food item, but incrementing based on bites_left is also supported (currently used only for pizza, to allow slices).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #9809, #9889 and #13227.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Fixed some requisition handling goofs that could cause orders to fail, most notable in the handling of steel sheets for an aid contract.
```
