### PR TITLE
Fix Donut 2 armory communications console not working

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17491,6 +17491,9 @@
 /obj/stool/chair{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just fixes the Donut 2 armory communications console not working, from a missing wire.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix