### PR TITLE
Doubles atmos process tick rate

### DIFF
--- a/code/datums/controllers/process/air_system.dm
+++ b/code/datums/controllers/process/air_system.dm
@@ -4,7 +4,7 @@
 
 	setup()
 		name = "Atmos"
-		schedule_interval = 2 SECONDS
+		schedule_interval = 1 SECOND
 
 		if(!air_master)
 			air_master = new /datum/controller/air_system()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [EXPERIMENTAL] [FREEZE-IMMUNE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the atmos process interval from 2 seconds to 1 second.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Faster and more responsive atmos is great... If the server can handle it. This PR will be testmerged to find out if it can.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)[VERY EXPERIMENTAL] The atmos process will now tick twice as fast, this should make repressurizing and so on a lot less tedious, but may cause Issues. Please report any if you find them.
```
