### PR TITLE
Refactors genetics ability handling

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -6,6 +6,8 @@
 
 	var/topBarRendered = 1
 	var/rendered = 1
+	///Is this holder temporarily hidden
+	var/hidden = FALSE
 	var/datum/targetable/shiftPower = null
 	var/datum/targetable/ctrlPower = null
 	var/datum/targetable/altPower = null
@@ -91,12 +93,6 @@
 				A.update_cooldown_cost()
 				num++
 
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			for(var/atom/movable/screen/ability/topBar/genetics/G in H.hud.objects)
-				G.update_cooldown_cost()
-				num++
-
 		return num
 
 
@@ -111,7 +107,7 @@
 		y_occupied = 0
 		any_abilities_displayed = 0
 
-		if (src.topBarRendered && src.rendered)
+		if (src.topBarRendered && src.rendered && !src.hidden)
 
 			if (!called_by_owner)
 				for(var/atom/movable/screen/ability/A in src.hud.objects)
@@ -908,8 +904,8 @@
 				localholder.updateButtons()
 
 		cast(atom/target)
-			if(interrupt_action_bars) actions.interrupt(holder.owner, INTERRUPT_ACT)
-			return
+			if(interrupt_action_bars)
+				actions.interrupt(holder.owner, INTERRUPT_ACT)
 
 		//Use this when you need to do something at the start of the ability where you need the holder or the mob owner of the holder. DO NOT change New()
 		onAttach(var/datum/abilityHolder/H)
@@ -1177,17 +1173,18 @@
 	updateButtons(var/called_by_owner = 0, var/start_x = 1, var/start_y = 0)
 		if (src.topBarRendered && src.rendered && src.hud)
 			for(var/atom/movable/screen/ability/A in src.hud.objects)
-				src.hud.objects -= A
+				src.hud.remove_object(A)
 
 		x_occupied = 1
 		y_occupied = 0
 		any_abilities_displayed = 0
-		for (var/datum/abilityHolder/H in holders)
-			if (H.topBarRendered || H.rendered)
-				H.updateButtons(called_by_owner = 1, start_x = x_occupied, start_y = y_occupied)
-				x_occupied = H.x_occupied
-				y_occupied = H.y_occupied
-				any_abilities_displayed = any_abilities_displayed || H.any_abilities_displayed
+		if (!src.hidden)
+			for (var/datum/abilityHolder/H in holders)
+				if (H.topBarRendered || H.rendered)
+					H.updateButtons(called_by_owner = 1, start_x = x_occupied, start_y = y_occupied)
+					x_occupied = H.x_occupied
+					y_occupied = H.y_occupied
+					any_abilities_displayed = any_abilities_displayed || H.any_abilities_displayed
 
 
 		if (src.topBarRendered)

--- a/code/datums/hud/ghostdrone.dm
+++ b/code/datums/hud/ghostdrone.dm
@@ -355,8 +355,6 @@
 			if(isdead(master))
 				return
 
-			for(var/atom/movable/screen/ability/topBar/genetics/G in master.client.screen)
-				master.client.screen -= G
 			for(var/atom/movable/screen/pseudo_overlay/PO in master.client.screen)
 				master.client.screen -= PO
 			for(var/obj/ability_button/B in master.client.screen)

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -42,7 +42,6 @@
 	var/list/atom/movable/screen/hud/inventory_bg = list()
 	var/list/obj/item/inventory_items = list()
 	var/show_inventory = 1
-	var/show_genetics_abilities = TRUE
 	var/icon/icon_hud = 'icons/mob/hud_human_new.dmi'
 
 	var/list/statusUiElements = list() //Assoc. List  STATUS EFFECT INSTANCE : UI ELEMENT add_screen(atom/movable/screen/S). Used to hold the ui elements since they shouldnt be on the status effects themselves.
@@ -496,14 +495,14 @@
 				//src.update_sprinting()
 
 			if ("ability")
-				if(show_genetics_abilities)
-					show_genetics_abilities = FALSE
-					boutput(master, "No longer showing genetic abilities.")
+				if(!master.abilityHolder.hidden)
+					master.abilityHolder.hidden = TRUE
+					boutput(master, "No longer showing abilities.")
 				else
-					show_genetics_abilities = TRUE
-					boutput(master, "Now showing genetic abilities.")
+					master.abilityHolder.hidden = FALSE
+					boutput(master, "Now showing abilities.")
 
-				ability_toggle.icon_state = "[layouts[layout_style]["ability_icon"]][show_genetics_abilities]"
+				ability_toggle.icon_state = "[layouts[layout_style]["ability_icon"]][!master.abilityHolder.hidden]"
 				update_ability_hotbar()
 
 			if ("health")
@@ -855,9 +854,6 @@
 		if(isdead(master))
 			return
 
-		// remove genetics buttons
-		for(var/atom/movable/screen/ability/topBar/genetics/G in src.objects)
-			remove_object(G)
 		for(var/atom/movable/screen/pseudo_overlay/PO in master.client.screen)
 			master.client.screen -= PO
 		for(var/obj/ability_button/B in master.client.screen)
@@ -878,22 +874,6 @@
 			if(pos_x > 15)
 				pos_x = 1
 				pos_y++
-
-		// if toggled off, do not show genetics abilities
-		if (show_genetics_abilities)
-			var/datum/bioEffect/power/P
-			for(var/ID in master.bioHolder.effects)
-				P = master.bioHolder.GetEffect(ID)
-				if (!istype(P, /datum/bioEffect/power/) || !istype(P.ability) || !istype(P.ability.object) || P.removed)
-					continue
-				var/datum/targetable/geneticsAbility/POWER = P.ability
-				var/atom/movable/screen/ability/topBar/genetics/BUTTON = POWER.object
-				BUTTON.update_on_hud(pos_x,pos_y)
-
-				pos_x++
-				if(pos_x > 15)
-					pos_x = 1
-					pos_y++
 
 		if (istype(master.loc,/obj/vehicle/)) //so we always see vehicle buttons
 			var/obj/vehicle/V = master.loc

--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -301,6 +301,11 @@ ABSTRACT_TYPE(/datum/bioEffect)
 			return FALSE
 		return ..()
 
+	handleCast(atom/target, params)
+		if (src.linked_power) //paranoia check to keep them synched
+			src.cooldown = src.linked_power.cooldown
+		..()
+
 	cast(atom/target)
 		if (ismob(target))
 			logTheThing(LOG_COMBAT, owner, "used the [linked_power.name] power on [constructTarget(target,"combat")].")

--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -274,44 +274,6 @@ ABSTRACT_TYPE(/datum/bioEffect)
 	var/lockcode = ""
 	var/locktries = 0
 
-/atom/movable/screen/ability/topBar/genetics
-	tens_offset_x = 19
-	tens_offset_y = 7
-	secs_offset_x = 23
-	secs_offset_y = 7
-
-	clicked(parameters)
-		var/mob/living/user = usr
-
-		if (!istype(user) || !istype(owner))
-			boutput(user, "<span class='alert'>Oh christ something's gone completely batshit. Report this to a coder.</span>")
-			return
-
-		if (!owner.cooldowncheck())
-			boutput(user, "<span class='alert'>That ability is on cooldown for [round((owner.last_cast - world.time) / 10)] seconds.</span>")
-			return
-
-		if (owner.targeted && user.targeting_ability == owner)
-			user.targeting_ability = null
-			user.update_cursor()
-			return
-
-		if (!owner.targeted)
-			owner.handleCast()
-			return
-		else
-			user.targeting_ability = owner
-			user.update_cursor()
-
-	get_controlling_mob()
-		if (!istype(owner,/datum/targetable/geneticsAbility/))
-			return null
-		var/datum/targetable/geneticsAbility/GA = owner
-		var/mob/M = GA.owner
-		if (!istype(M) || !M.client)
-			return null
-		return M
-
 /datum/targetable/geneticsAbility
 	icon = 'icons/mob/genetics_powers.dmi'
 	icon_state = "template"
@@ -325,90 +287,42 @@ ABSTRACT_TYPE(/datum/bioEffect)
 	var/datum/bioEffect/power/linked_power = null
 	var/mob/living/owner = null
 
-	New()
-		var/atom/movable/screen/ability/topBar/genetics/B = new /atom/movable/screen/ability/topBar/genetics(null)
-		B.icon = src.icon
-		B.icon_state = src.icon_state
-		B.name = src.name
-		B.desc = src.desc
-		B.owner = src
-		src.object = B
-
 	disposing()
 		owner = null
 		linked_power = null
 		..()
 
-	doCooldown()
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			last_cast = world.time + linked_power.cooldown
-			if (linked_power.cooldown > 0)
-				SPAWN(linked_power.cooldown)
-					if (src && H?.hud)
-						H.hud.update_ability_hotbar()
-
-	tryCast(atom/target)
+	castcheck(atom/target)
+		if (!owner)
+			return FALSE
+		if (!linked_power)
+			return FALSE
 		if (can_act_check && !can_act(owner, needs_hands))
-			return 999
-		if (last_cast > world.time)
-			if(holder)
-				boutput(holder.owner, "<span class='alert'>That ability is on cooldown for [round((last_cast - world.time) / 10)] seconds.</span>")
-			return 999
-
-		if (has_misfire)
-			var/success_prob = 100
-			if (ishuman(owner))
-				var/mob/living/carbon/human/H = owner
-				if (H.bioHolder)
-					var/datum/bioHolder/BH = H.bioHolder
-					success_prob = BH.genetic_stability
-					success_prob = lerp(clamp(success_prob, 0, 100), 100, success_prob_min_cap/100)
-
-			if (prob(success_prob))
-				. = cast(target)
-			else
-				. = cast_misfire(target)
-		else
-			. = cast(target)
-
-	handleCast(atom/target)
-		var/result = tryCast(target)
-		if (result && result != 999)
-			last_cast = 0 // reset cooldown
-		else if (result != 999)
-			doCooldown()
-		afterCast()
+			return FALSE
+		return ..()
 
 	cast(atom/target)
-		if (!owner)
-			return 1
-		if (!linked_power)
-			return 1
 		if (ismob(target))
 			logTheThing(LOG_COMBAT, owner, "used the [linked_power.name] power on [constructTarget(target,"combat")].")
 		else if (target)
 			logTheThing(LOG_COMBAT, owner, "used the [linked_power.name] power on [target].")
 		else
 			logTheThing(LOG_COMBAT, owner, "used the [linked_power.name] power.")
-		return 0
+		if (!has_misfire)
+			return ..(target)
+		var/success_prob = 100
+		success_prob = src.linked_power.holder.genetic_stability
+		success_prob = lerp(clamp(success_prob, 0, 100), 100, success_prob_min_cap/100)
+		if (prob(success_prob))
+			return ..(target)
+		else
+			return cast_misfire(target)
 
 	proc/cast_misfire(atom/target)
-		if (!owner)
-			return 1
-		if (!linked_power)
-			return 1
 		if (ismob(target))
 			logTheThing(LOG_COMBAT, owner, "misfired the [linked_power.name] power on [constructTarget(target,"combat")].")
 		else if (target)
 			logTheThing(LOG_COMBAT, owner, "misfired the [linked_power.name] power on [target].")
 		else
 			logTheThing(LOG_COMBAT, owner, "misfired the [linked_power.name] power.")
-		return 0
-
-	afterCast()
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			if (H?.hud)
-				H.hud.update_ability_hotbar()
 		return 0

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -42,10 +42,12 @@
 			if (!AB)
 				return
 			ability = AB
+			AB.cooldown = src.cooldown
 			AB.linked_power = src
 			icon = AB.icon
 			icon_state = AB.icon_state
 			AB.owner = src.owner
+			src.owner.abilityHolder.updateButtons() //have to manually update because the cooldown is stored on the bioeffect
 
 /datum/targetable/geneticsAbility/cryokinesis
 	name = "Cryokinesis"

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -13,7 +13,7 @@
 	var/using = 0
 	var/safety = 0
 	var/ability_path = /datum/targetable/geneticsAbility/cryokinesis
-	var/datum/targetable/geneticsAbility/ability = /datum/targetable/geneticsAbility/cryokinesis
+	var/datum/targetable/geneticsAbility/ability = null
 
 	New()
 		..()
@@ -22,30 +22,25 @@
 	disposing()
 		src.owner = null
 		if (ability)
-			ability.dispose()
 			ability.owner = null
+			qdel(ability)
 		src.ability = null
 		..()
 
 	OnAdd()
 		..()
-		if (ishuman(owner))
-			check_ability_owner()
-			var/mob/living/carbon/human/H = owner
-			H.hud.update_ability_hotbar()
-		return
+		check_ability_owner()
 
 	OnRemove()
 		..()
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			if (H.hud)
-				H.hud.update_ability_hotbar()
-		return
+		if (src.ability)
+			src.ability.holder.removeAbilityInstance(src.ability)
 
 	proc/check_ability_owner()
 		if (ispath(ability_path))
-			var/datum/targetable/geneticsAbility/AB = new ability_path(src)
+			var/datum/targetable/geneticsAbility/AB = src.owner?.abilityHolder?.addAbility(src.ability_path)
+			if (!AB)
+				return
 			ability = AB
 			AB.linked_power = src
 			icon = AB.icon

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -791,7 +791,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 				BE.holder = null
 				if(istype(BE, /datum/bioEffect/power))
 					var/datum/bioEffect/power/BEP = BE
-					BEP?.ability.owner = null
+					BEP?.ability?.owner = null
 				//qdel(BE)
 		return 1
 
@@ -804,7 +804,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 				BE.holder = null
 				if(istype(BE, /datum/bioEffect/power))
 					var/datum/bioEffect/power/BEP = BE
-					BEP?.ability.owner = null
+					BEP?.ability?.owner = null
 				//qdel(BE)
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [CODE QUALITY] [FREEZE-EXEMPT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors all the weird custom ability handling genetics bioEffects had into normal sane ability code.
Changes the "hide genetics abilities" button to hide all abilities instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduces jank by 0.2%
Bioeffects can now work on critters, and be hotkey bound like regular abilities.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)The "Hide genetics abilities" button now hides/unhides all abilities instead.
```
