### PR TITLE
Fixes #13279 - Antagonists Are Now Removed From The Admin Gimmick Antagonists List On Removal

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -246,6 +246,7 @@ datum/mind
 				if (!length(src.antagonists) && src.special_role == A.id)
 					src.special_role = null
 					ticker.mode.traitors.Remove(src)
+					ticker.mode.Agimmicks.Remove(src)
 				qdel(A)
 				return TRUE
 		return FALSE


### PR DESCRIPTION
[Internal] [Bug]


## About the PR:
Fixes #13279, which was caused by a wrestler doodle antagonist datum being removed from a mind without being removed from `Agimmicks` on `/datum/game_mode`.