### PR TITLE
Cables now give you actual rubber instead of rubber fabric

### DIFF
--- a/code/modules/power/cablecolors.dm
+++ b/code/modules/power/cablecolors.dm
@@ -15,11 +15,11 @@
 /obj/cable/_color/name = ""+#_color+" power cable";\
 /obj/cable/_color/color = _hexcolor;\
 /obj/cable/_color/insulator_default = ""+#_color+" rubber";\
-/datum/material/fabric/synthrubber/_color;\
-/datum/material/fabric/synthrubber/_color/mat_id = ""+#_color+" rubber";\
-/datum/material/fabric/synthrubber/_color/name = ""+#_color+" rubber";\
-/datum/material/fabric/synthrubber/_color/desc = ""+"A type of synthetic rubber. This one is "+#_color+".";\
-/datum/material/fabric/synthrubber/_color/color = _hexcolor;\
+/datum/material/rubber/synthrubber/_color;\
+/datum/material/rubber/synthrubber/_color/mat_id = ""+#_color+" rubber";\
+/datum/material/rubber/synthrubber/_color/name = ""+#_color+" rubber";\
+/datum/material/rubber/synthrubber/_color/desc = ""+"A type of synthetic rubber. This one is "+#_color+".";\
+/datum/material/rubber/synthrubber/_color/color = _hexcolor;\
 /obj/item/storage/box/cablesbox/_color;\
 /obj/item/storage/box/cablesbox/_color/name = ""+"electrical cables storage ("+#_color+")";\
 /obj/item/storage/box/cablesbox/_color/spawn_contents = list(/obj/item/cable_coil/_color = 7);\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS], no clue what category this would be.
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Red cables give you real synthrubber. Every other color of cable gives you "rubber fabric" (that cant be used as rubber), this PR fixes that by making it give you real synthrubber. Rubber.
Fixes #12068
![image](https://user-images.githubusercontent.com/117641137/222986559-7a4c79a5-79b1-4497-8314-91116a057c34.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Red cables give you real synthrubber. Colored cables dont.  They probably should.

Does this need a changelog? I don't think it does.