### PR TITLE
Fixes #13285 - Revolutionaries Will No Longer Receive The Mission Complete Medal Should They Fail To Overthrow The Station

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -201,7 +201,7 @@
 		return heads
 
 
-/datum/game_mode/proc/get_all_heads()
+/datum/game_mode/revolution/proc/get_all_heads()
 	var/list/heads = list()
 
 	for(var/mob/player in mobs)

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -201,7 +201,7 @@
 		return heads
 
 
-/datum/game_mode/revolution/proc/get_all_heads()
+/datum/game_mode/proc/get_all_heads()
 	var/list/heads = list()
 
 	for(var/mob/player in mobs)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1011,7 +1011,7 @@
 
 			if (damage > 1)
 				if (isrevolutionary(owner))	//attacker is rev, all heads who see the attack get mutiny buff
-					for (var/datum/mind/M in ticker?.mode.get_living_heads())
+					for (var/datum/mind/M in ticker?.mode?.get_living_heads())
 						if (M.current)
 							if (GET_DIST(owner,M.current) <= 7)
 								if (owner in viewers(7,M.current))

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -49,13 +49,10 @@
 		..(override)
 
 	check_success()
-		var/list/heads_of_staff = ticker?.mode?.get_all_heads()
+		var/list/heads_of_staff = ticker?.mode?.get_living_heads()
 
 		for(var/datum/mind/head_mind in heads_of_staff)
 			if(head_mind?.current && !isdead(head_mind.current))
-				if(issilicon(head_mind.current) || isghostcritter(head_mind.current) || isVRghost(head_mind.current))
-					continue
-
 				if(istype(head_mind.current.loc, /obj/cryotron))
 					continue
 

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -60,7 +60,7 @@
 					continue
 
 				var/turf/T = get_turf(head_mind.current)
-				if(T.z != 1)
+				if(T.z != Z_LEVEL_STATION)
 					continue
 
 				return FALSE

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -49,4 +49,19 @@
 		..(override)
 
 	check_success()
-		return FALSE
+		var/list/heads_of_staff = ticker?.mode.get_all_heads()
+
+		for(var/datum/mind/head_mind in heads_of_staff)
+			if(head_mind?.current && !isdead(head_mind.current))
+				if(issilicon(head_mind.current) || isghostcritter(head_mind.current) || isVRghost(head_mind.current))
+					continue
+
+				if(istype(head_mind.current.loc, /obj/cryotron))
+					continue
+
+				var/turf/T = get_turf(head_mind.current)
+				if(T.z != 1)
+					continue
+
+				return FALSE
+		return TRUE

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -47,3 +47,6 @@
 			override = "revved"
 
 		..(override)
+
+	check_success()
+		return FALSE

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -49,7 +49,7 @@
 		..(override)
 
 	check_success()
-		var/list/heads_of_staff = ticker?.mode.get_all_heads()
+		var/list/heads_of_staff = ticker?.mode?.get_all_heads()
 
 		for(var/datum/mind/head_mind in heads_of_staff)
 			if(head_mind?.current && !isdead(head_mind.current))

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -64,4 +64,5 @@
 					continue
 
 				return FALSE
+
 		return TRUE


### PR DESCRIPTION
[Internal] [Bug]


## About the PR:
Fixes #13285, caused by revolutionaries not being assigned objective datums, and therefore resulting in `check_success()` always returning `TRUE`.