### PR TITLE
Cargo sales no longer split into decimals

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -485,8 +485,10 @@
 
 		var/datum/signal/pdaSignal = get_free_signal()
 		if(scan && account)
-			wagesystem.shipping_budget += duckets / 2
-			account["current_money"] += duckets / 2
+			var/share_NT = round(duckets / 2,1) // NT gets half the money, decimals rounded up in case of uneven sale price
+			var/share_seller = duckets - share_NT // you get whatever remainds, sorry bud
+			wagesystem.shipping_budget += share_NT
+			account["current_money"] += share_seller
 			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SALES), "sender"="00000000", "message"="Notification: [duckets] credits earned from [salesource]. Splitting half of profits with [scan.registered].")
 		else
 			wagesystem.shipping_budget += duckets


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rounds decimals up for the half that the station budget receives, the half the bank account receives whatever remains.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Decimals in budgets and accounts yucky. Fixes #9241
