### PR TITLE
Replaces haloperidol in Omega Weed with neurotoxin

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -155,7 +155,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 	crop_prefix = "glowing "
 	desc = "You feel dizzy looking at it. What the fuck?"
 	icon_state = "Oweedleaf"
-	brew_result = list("THC", "LSD", "suicider", "space_drugs", "mercury", "lithium", "atropine", "haloperidol", "methamphetamine",\
+	brew_result = list("THC", "LSD", "suicider", "space_drugs", "mercury", "lithium", "atropine", "neurotoxin", "methamphetamine",\
 	"capsaicin", "psilocybin", "hairgrownium", "ectoplasm", "bathsalts", "itching", "crank", "krokodil", "catdrugs", "histamine")
 
 /obj/item/plant/herb/cannabis/omega/spawnable
@@ -168,7 +168,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 		reagents.add_reagent("mercury", 40)
 		reagents.add_reagent("lithium", 40)
 		reagents.add_reagent("atropine", 40)
-		reagents.add_reagent("haloperidol", 40)
+		reagents.add_reagent("neurotoxin", 40)
 		reagents.add_reagent("methamphetamine", 40)
 		reagents.add_reagent("THC", 40)
 		reagents.add_reagent("capsaicin", 40)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [CATERING] [OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The PR replaces the haloperidol reagent in Omega Weed (`/obj/item/plant/herb/cannabis/omega`) with neurotoxin reagent.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Haloperidol purges about a third of the fun drugs inside Omega Weed, and Omega Weed is a **terrible** source for Haloperidol.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Caio029
(+)The haloperidol in Omega Cannabis has been replaced with neurotoxin. Expect stronger trips.
```
