### PR TITLE
Fixes #13303 - Antagonists Panel Will Now Correctly Display Dead Heads Of Staff

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -190,7 +190,7 @@
 	var/list/heads = list()
 
 	for(var/mob/living/carbon/human/player in mobs)
-		if(player.mind)
+		if(player.mind && !isdead(player))
 			var/role = player.mind.assigned_role
 			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director","Communications Officer"))
 				heads += player.mind

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -3627,7 +3627,7 @@ var/global/noir = 0
 									dat += "<tr><td><a href='?src=\ref[src];action=adminplayeropts;target=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][isdeadplayer(M) ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
 									dat += "<td><a href='?action=priv_msg&target=[M.ckey]'>PM</A></td></tr>"
 								dat += "</table><table cellspacing=5><tr><td><B>Target(s)</B></td><td></td><td><B>Location</B></td></tr>"
-								for(var/datum/mind/N in ticker.mode:get_living_heads())
+								for(var/datum/mind/N in ticker.mode:get_all_heads())
 									var/mob/M = N.current
 									if(!M) continue
 									dat += "<tr><td><a href='?src=\ref[src];action=adminplayeropts;target=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(logged out)</i>"][isdeadplayer(M) ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"


### PR DESCRIPTION
[Internal] [Bug]


## About the PR:
Fixes #13303 by replacing `get_living_heads()` with `get_all_heads()` when checking for heads of staff to be displayed.
Additionally fixes `get_living_heads()` returning dead heads of staff who have not yet ghosted.