### PR TITLE
Fixes #13302 - Stick barcode labels to UI elements

### DIFF
--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -458,6 +458,8 @@
 		return
 
 	afterattack(atom/target as mob|obj|turf, mob/user as mob, reach, params)
+		if (target.plane == PLANE_HUD || isgrab(target)) //just don't stick hud stuff or grabs PLEASE
+			return
 		if(BOUNDS_DIST(get_turf(target), get_turf(src)) == 0 && istype(target, /atom/movable))
 			if(target==loc && target != user) return //Backpack or something
 			target:delivery_destination = destination


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #13302 
Barcode labels will no longer stick to UI elements

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs need to be fixed :D
