### PR TITLE
Fixes  #13282 - WEREWOLVES CANNOT WOOF

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2315,7 +2315,7 @@
 					src.show_text("You don't know how to do that but you feel deeply ashamed for trying", "red")
 
 			if ("woof")
-				if (!ispug(src)) // not accounting for critter dogs since they have their own bark handling
+				if (!ispug(src) && !iswerewolf(src) ) // not accounting for critter dogs since they have their own bark handling
 					src.say("Woof.")
 					return
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #13282 
Werewolves can now bark, just like pugs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
werewovles = wolf = woof 👍 
