### PR TITLE
Give HoP consistent green carpets

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -28567,7 +28567,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bsT" = (
 /obj/table/wood/auto,
@@ -28576,27 +28576,18 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/heads)
 "bsU" = (
 /obj/machinery/computer/bank_data,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/heads)
 "bsV" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/manufacturer/personnel,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/heads)
 "bsW" = (
 /obj/stool/bed,
@@ -28604,17 +28595,14 @@
 	bcolor = "green";
 	icon_state = "bedsheet-green"
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/heads)
 "bsX" = (
 /obj/item/device/radio/intercom/bridge{
 	broadcasting = 0
 	},
 /obj/storage/secure/closet/command/hop,
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bsY" = (
 /obj/grille/catwalk/cross{
@@ -29335,7 +29323,7 @@
 /obj/blind_switch/area{
 	pixel_x = -24
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "buK" = (
 /obj/cable{
@@ -29347,16 +29335,10 @@
 /obj/stool/chair/office/blue{
 	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/west,
 /area/station/crew_quarters/heads)
 "buL" = (
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fblue3"
-	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/se,
 /area/station/crew_quarters/heads)
 "buM" = (
 /obj/cable{
@@ -29365,16 +29347,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fblue3"
-	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/sw,
 /area/station/crew_quarters/heads)
 "buN" = (
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/heads)
 "buO" = (
 /obj/grille/catwalk{
@@ -30078,7 +30054,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bwz" = (
 /obj/cable{
@@ -30087,19 +30063,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/west,
 /area/station/crew_quarters/heads)
 "bwA" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fblue3"
-	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/ne,
 /area/station/crew_quarters/heads)
 "bwB" = (
 /obj/cable{
@@ -30108,10 +30078,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fblue3"
-	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/nw,
 /area/station/crew_quarters/heads)
 "bwC" = (
 /obj/machinery/light{
@@ -30119,7 +30086,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bwD" = (
 /obj/cable{
@@ -31004,22 +30971,17 @@
 /obj/item/dice/d100,
 /obj/item/reagent_containers/food/drinks/bottle/ntbrew,
 /obj/machinery/light_switch/west,
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "byz" = (
 /obj/vehicle/segway,
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/heads)
 "byA" = (
 /obj/table/wood/auto,
 /obj/item/material_piece/foolsfoolsgold,
 /obj/item/stamp/hop,
-/turf/simulated/floor/carpet{
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/crew_quarters/heads)
 "byB" = (
 /obj/machinery/light,
@@ -31029,15 +30991,10 @@
 /obj/table/wood/auto,
 /obj/item/storage/firstaid/regular,
 /obj/item/pen/crayon/golden,
-/turf/simulated/floor/carpet{
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/crew_quarters/heads)
 "byC" = (
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/heads)
 "byD" = (
 /obj/machinery/firealarm{
@@ -31045,7 +31002,7 @@
 	pixel_x = 26;
 	pixel_y = 1
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "byE" = (
 /obj/grille/catwalk/cross,
@@ -59910,10 +59867,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "fblue2"
-	},
+/turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/heads)
 "cOx" = (
 /obj/machinery/power/data_terminal,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -9392,7 +9392,7 @@
 /obj/machinery/light/incandescent/greenish{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/bridge/captain)
 "cEV" = (
 /obj/cable{
@@ -14587,8 +14587,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 8
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "elE" = (
@@ -15031,7 +15032,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge,
+/turf/simulated/floor/carpet{
+	icon_state = "fblue2"
+	},
 /area/station/bridge/captain)
 "euw" = (
 /obj/railing/orange,
@@ -17962,8 +17965,9 @@
 /obj/railing/orange{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 4
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "foY" = (
@@ -18332,8 +18336,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 1
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "fux" = (
@@ -25257,8 +25262,9 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "hyO" = (
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 8
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "hyP" = (
@@ -25667,7 +25673,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/bridge/captain)
 "hGS" = (
 /obj/machinery/disposal/small,
@@ -31122,8 +31128,9 @@
 	pixel_x = 10;
 	pixel_y = 9
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 5
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "jtC" = (
@@ -32138,8 +32145,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 1
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "jHF" = (
@@ -32974,8 +32982,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 8
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "jTV" = (
@@ -37641,8 +37650,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 10
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "ltc" = (
@@ -41599,7 +41609,7 @@
 /obj/item/tank/jetpack,
 /obj/item/clothing/suit/space/captain,
 /obj/item/clothing/head/helmet/space/captain,
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/black,
 /area/station/bridge/captain)
 "mDD" = (
 /obj/decal/tile_edge/line/yellow{
@@ -44626,9 +44636,7 @@
 /mob/living/critter/small_animal/cat/jones{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 8
-	},
+/turf/simulated/floor/black,
 /area/station/bridge/captain)
 "nxW" = (
 /obj/cable{
@@ -44733,8 +44741,9 @@
 	pixel_x = -8;
 	pixel_y = -2
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 4
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "nzB" = (
@@ -46952,8 +46961,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 6
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "olM" = (
@@ -70273,7 +70283,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge,
+/turf/simulated/floor/carpet{
+	icon_state = "fblue2"
+	},
 /area/station/bridge/captain)
 "vhh" = (
 /obj/cable{
@@ -70418,8 +70430,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 8
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "vkt" = (
@@ -71125,8 +71138,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 4
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "vtO" = (
@@ -72715,8 +72729,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 6
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "vRz" = (
@@ -75484,8 +75499,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 10
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "wHp" = (
@@ -75669,8 +75685,9 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "wJP" = (
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 4
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "wJS" = (
@@ -78804,8 +78821,9 @@
 	pixel_x = -24;
 	pixel_y = -1
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 9
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "xBr" = (
@@ -80152,8 +80170,9 @@
 /obj/item/card/id/captains_spare{
 	pixel_x = -13
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner{
-	dir = 9
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fblue3"
 	},
 /area/station/bridge/captain)
 "xTJ" = (
@@ -81324,8 +81343,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 29
 	},
-/turf/simulated/floor/carpet/green/fancy/edge{
-	dir = 5
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
 "ykH" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -10972,7 +10972,7 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "eyf" = (
-/turf/simulated/floor/carpet/green/fancy/edge/south,
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/crew_quarters/captain)
 "eyq" = (
 /obj/table/wood/round/auto,
@@ -22640,7 +22640,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/south,
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/crew_quarters/captain)
 "jyH" = (
 /obj/item/device/radio/beacon,
@@ -25824,7 +25824,7 @@
 /turf/space,
 /area/space)
 "kTr" = (
-/turf/simulated/floor/carpet/green/fancy/edge/se,
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/captain)
 "kTu" = (
 /obj/machinery/recharge_station,
@@ -27273,7 +27273,7 @@
 	name = "Captain"
 	},
 /obj/disposalpipe/trunk/mail,
-/turf/simulated/floor/carpet/green/fancy/edge/south,
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/crew_quarters/captain)
 "lAX" = (
 /obj/stool/chair/moveable,
@@ -50695,7 +50695,7 @@
 	dir = 6;
 	icon_state = "delivery2"
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/north,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "vth" = (
 /obj/machinery/atmospherics/pipe/simple{

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -8412,7 +8412,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/turf/simulated/floor/carpet/blue/fancy/narrow/north,
+/turf/simulated/floor/carpet/green/fancy/narrow/north,
 /area/station/bridge/hos)
 "dvd" = (
 /obj/machinery/light/small/cool,
@@ -9585,7 +9585,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/bridge/hos)
 "dTJ" = (
 /obj/machinery/disposal,
@@ -11627,7 +11627,7 @@
 /area/station/crew_quarters/fitness)
 "eOP" = (
 /obj/storage/secure/closet/command/hop,
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/bridge/hos)
 "ePC" = (
 /obj/table/glass/auto,
@@ -16024,7 +16024,7 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/bridge/hos)
 "gKC" = (
 /obj/submachine/ATM/atm_alt{
@@ -26240,7 +26240,7 @@
 	pixel_x = -10
 	},
 /obj/storage/closet/office,
-/turf/simulated/floor/carpet/blue/fancy/narrow/south,
+/turf/simulated/floor/carpet/green/fancy/narrow/south,
 /area/station/bridge/hos)
 "ldp" = (
 /obj/cable{
@@ -39268,7 +39268,7 @@
 /obj/decoration/clock{
 	pixel_y = 30
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/bridge/hos)
 "qEZ" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
@@ -47867,7 +47867,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /obj/item/item_box/postit,
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/bridge/hos)
 "ujW" = (
 /obj/machinery/disposal_pipedispenser,
@@ -53192,7 +53192,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/bridge/hos)
 "wxp" = (
 /obj/table/glass/auto,
@@ -57234,9 +57234,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 10
-	},
+/turf/simulated/floor/black,
 /area/station/hallway/primary/south)
 "ygI" = (
 /obj/disposalpipe/junction/right,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives the HoP bedrooms green carpets instead of blue in cogmap2, donut3 and wrestlemap.
Change green carpet in wrestlemap captain's quarters to blue.
Removes arcade carpet from cogmap2 HoP bedroom.
Replaces some mismatched carpeting in the Donut3 captain's quarters with standard floor tiles.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Most maps give the HoP green carpets and blue for the captain. This makes it a bit easier to tell their areas apart and increases the consistency across our maps.
AFAIK the arcade carpeting is a joke about the captain just like the bedsheets. This is even more consistent across maps in being captain only.