### PR TITLE
Makes it so ghostdrones cant set message sign text directly

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3801,6 +3801,9 @@
 		src.display()
 
 	proc/setTextManually(obj/item/W as obj, mob/user as mob)
+		if (isghostdrone(user))
+			boutput(user, "You're a ghostdrone, so you probably shouldn't be doing this.")
+			return FALSE
 		var/input = input(user, "Message Text", "Text", replacetext(html_decode(src.display_text), "<br>", "|n")) as text | null
 		if (!input || !in_interact_range(src, user) || user.stat || isnull(input))
 			return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
This FEELS like a [GAME OBJECTS], maybe PLAYER ACTIONS. I never know what category to put things into. Maybe [BUG]??
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. This only stops them from setting text DIRECTLY, they can still set it through mechcomp. I'm not sure what can be done about that. But this PR stops them from directly setting text.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They can't write, so they shouldn't be able to edit message sign text.

I don't think this needs a changelog.
