### PR TITLE
Fixes #13031- Hauntium recipe broken

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -388,7 +388,6 @@ TYPEINFO(/obj/machinery/processor)
 					var/datum/material_recipe/RE = matchesMaterialRecipe(merged)
 					var/newtype = getProcessedMaterialForm(merged)
 					var/apply_material = 1
-					var/output_item = 0
 
 					if(RE)
 						if(!RE.result_id && !RE.result_item)
@@ -396,7 +395,6 @@ TYPEINFO(/obj/machinery/processor)
 						else if(RE.result_item)
 							newtype = RE.result_item
 							apply_material = 0
-							output_item = 1
 						else if(RE.result_id)
 							merged = getMaterial(RE.result_id)
 
@@ -408,7 +406,7 @@ TYPEINFO(/obj/machinery/processor)
 					piece.change_stack_amount(amt - piece.amount)
 					FP.change_stack_amount(-amt)
 					SP.change_stack_amount(-amt)
-					if(!output_item)
+					if(istype(piece, /obj/item/material_piece))
 						addMaterial(piece, usr)
 					else
 						piece.set_loc(get_turf(src))

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -374,7 +374,7 @@
 /obj/item/material_piece/cloth/hauntium
 	name = "hauntium fabric"
 	desc = "This cloth seems almost alive."
-	icon_state = "dyneema-fabric"
+	icon_state = "fabric"
 
 	setup_material()
 		src.setMaterial(getMaterial("hauntium"), appearance = TRUE, setname = FALSE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MATERIALS] [QOL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes a broken iconstate for `obj/item/material_piece/cloth/hauntium`, as well as changing the nanocrucible to attempt to reinsert unique item outputs (currently only used by hauntium and dyneema).

NOTE: currently this PR causes the affected materials to be given weird duplicate names. This should be fixed by #13321 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13031

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
