### PR TITLE
Void Door Fix

### DIFF
--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -200,7 +200,7 @@
 /obj/nerd_trap_door/voidoor
 	name = "V O I D O O R"
 	desc = "This door cannot be returned. You see, the warranty is void."
-	expected = list("silver key", /*"skeleton key",*/ /*"literal skeleton key",*/ "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key"*/, /*"virtual key",*/ "golden key", "bee key", "iron key", /*"iridium key",*/ "lunar key")
+	expected = list("silver key", /*"skeleton key",*/ /*"literal skeleton key",*/ "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key"*/ /*"virtual key",*/ "golden key", /*"bee key"*/ "iron key", "iridium key", "lunar key")
 	icon_state = "hld2"
 
 /obj/steel_beams

--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -200,7 +200,7 @@
 /obj/nerd_trap_door/voidoor
 	name = "V O I D O O R"
 	desc = "This door cannot be returned. You see, the warranty is void."
-	expected = list("silver key", /*"skeleton key",*/ /*"literal skeleton key",*/ "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key"*/ /*"virtual key",*/ "golden key", /*"bee key"*/ "iron key", "iridium key", "lunar key")
+	expected = list("silver key", /*"skeleton key",*/ /*"literal skeleton key",*/ "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key",*/ /*"virtual key",*/ "golden key", /*"bee key",*/ "iron key", "iridium key", "lunar key")
 	icon_state = "hld2"
 
 /obj/steel_beams

--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -200,7 +200,7 @@
 /obj/nerd_trap_door/voidoor
 	name = "V O I D O O R"
 	desc = "This door cannot be returned. You see, the warranty is void."
-	expected = list("silver key", /*"skeleton key",*/ /*"literal skeleton key",*/ "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key",*/ /*"virtual key",*/ "golden key", /*"bee key",*/ "iron key", "iridium key", "lunar key")
+	expected = list("silver key", /*"skeleton key",*/ "literal skeleton key", "hot iron key", "cold steel key", "onyx key", /*"key lime pie",*/ /*"futuristic key",*/ /*"virtual key",*/ "golden key", /*"bee key",*/ "iron key", /*"iridium key",*/ "lunar key")
 	icon_state = "hld2"
 
 /obj/steel_beams


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the void door, by changing the required bee key (which was removed) to the ~~iridium~~ literal skeleton key.
Also removes a check for a 'NULL' key, which was caused by the improper commenting of the futuristic key.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for the void door to be opened again.

