### PR TITLE
Fix cockroaches not being resistant to radiation

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -1661,6 +1661,10 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	ai_type = /datum/aiHolder/roach
 	is_npc = TRUE
 
+	New()
+		.=..()
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 100)
+
 	setup_healths()
 		. = ..()
 		qdel(src.healthlist["toxin"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just adds 100 radohms of internal resistance to cockroaches.

I admit, this stretches the bounds of the word "fix".

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's like, the one thing cockroaches are famous for.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Cockroaches are now very resistant to radiation.
```
