### PR TITLE
Fixes breaches under doors not updating

### DIFF
--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -581,21 +581,21 @@ var/global/list/turf/hotly_processed_turfs = list()
 
 	air_master.active_super_conductivity += src
 
-/turf/simulated/proc/update_nearby_tiles(need_rebuild)
+/turf/proc/update_nearby_tiles(need_rebuild)
 	if(!air_master)
 		return FALSE
 
 	src.selftilenotify() //used in fluids.dm for displaced fluid
-
+	var/turf/simulated/center = src //this is fine and normal
 	var/turf/simulated/north = get_step(src,NORTH)
 	var/turf/simulated/south = get_step(src,SOUTH)
 	var/turf/simulated/east = get_step(src,EAST)
 	var/turf/simulated/west = get_step(src,WEST)
 
 	if(need_rebuild)
-		if(istype(src)) //Rebuild/update nearby group geometry
-			if(src.parent)
-				air_master.groups_to_rebuild |= src.parent
+		if(istype(center)) //Rebuild/update nearby group geometry
+			if(center.parent)
+				air_master.groups_to_rebuild |= center.parent
 			else
 				air_master.tiles_to_update |= src
 
@@ -624,7 +624,8 @@ var/global/list/turf/hotly_processed_turfs = list()
 			else
 				air_master.tiles_to_update |= west
 	else
-		if(istype(src)) air_master.tiles_to_update |= src
+		if(istype(center))
+			air_master.tiles_to_update |= src
 		if(istype(north))
 			north.tilenotify(src)
 			air_master.tiles_to_update |= north

--- a/code/obj/cement.dm
+++ b/code/obj/cement.dm
@@ -115,7 +115,7 @@
 		..()
 
 	proc/update_nearby_tiles(need_rebuild)
-		var/turf/simulated/source = loc
+		var/turf/source = src.loc
 		if (istype(source))
 			return source.update_nearby_tiles(need_rebuild)
 

--- a/code/obj/foamedmetal.dm
+++ b/code/obj/foamedmetal.dm
@@ -79,7 +79,7 @@
 			dispose()
 
 	proc/update_nearby_tiles(need_rebuild)
-		var/turf/simulated/source = loc
+		var/turf/source = src.loc
 		if (istype(source))
 			return source.update_nearby_tiles(need_rebuild)
 

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -146,7 +146,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	return !density
 
 /obj/machinery/door/proc/update_nearby_tiles(need_rebuild)
-	var/turf/simulated/source = loc
+	var/turf/source = src.loc
 	if (istype(source))
 		return source.update_nearby_tiles(need_rebuild)
 

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -530,7 +530,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 			src.set_density(FALSE)
 
 	proc/update_nearby_tiles(need_rebuild)
-		var/turf/simulated/source = loc
+		var/turf/source = src.loc
 		if(istype(source))
 			return source.update_nearby_tiles(need_rebuild)
 

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -150,7 +150,7 @@ Shield and graivty well generators
 
 		..()
 	proc/update_nearby_tiles(need_rebuild)
-		var/turf/simulated/source = loc
+		var/turf/source = src.loc
 		if (istype(source))
 			return source.update_nearby_tiles(need_rebuild)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes doors not updating atmos groups around them if they are on an unsimulated turf (such as space).
Also applies to other things that use `update_nearby_tiles` such as shield generators.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While testing out a breach pinpointer I noticed that breaches under doors weren't showing up properly, this fixes that.
