### PR TITLE
Bedsheets have proper examine flags when cut/cape

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -810,7 +810,7 @@
 		else if(src.eyeholes)
 			src.hides_from_examine = (C_UNIFORM|C_GLOVES|C_SHOES|C_EARS)
 		else
-			src.hides_from_examine = (C_UNIFORM|C_GLOVES|C_SHOES|C_GLASSES|C_EARS|C_MASK)
+			src.hides_from_examine = initial(src.hides_from_examine)
 
 /obj/item/clothing/suit/bedsheet/red
 	icon_state = "bedsheet-red"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -651,7 +651,7 @@
 	throw_speed = 2
 	throw_range = 10
 	c_flags = COVERSEYES | COVERSMOUTH
-	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_GLASSES|C_EARS
+	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_GLASSES|C_EARS|C_MASK
 	body_parts_covered = TORSO|ARMS
 	see_face = FALSE
 	over_hair = TRUE
@@ -777,6 +777,7 @@
 		src.eyeholes = TRUE
 		block_vision = FALSE
 		src.UpdateIcon()
+		src.update_examine()
 		desc = "It's a bedsheet with eye holes cut in it."
 
 	proc/make_cape()
@@ -788,6 +789,7 @@
 		src.cape = TRUE
 		block_vision = FALSE
 		src.UpdateIcon()
+		src.update_examine()
 		desc = "It's a bedsheet that's been tied into a cape."
 
 	proc/cut_cape()
@@ -799,7 +801,16 @@
 		src.cape = FALSE
 		block_vision = !src.eyeholes
 		src.UpdateIcon()
+		src.update_examine()
 		desc = "A linen sheet used to cover yourself while you sleep. Preferably on a bed."
+
+	proc/update_examine()
+		if(src.cape)
+			src.hides_from_examine = null
+		else if(src.eyeholes)
+			src.hides_from_examine = (C_UNIFORM|C_GLOVES|C_SHOES|C_EARS)
+		else
+			src.hides_from_examine = (C_UNIFORM|C_GLOVES|C_SHOES|C_GLASSES|C_EARS|C_MASK)
 
 /obj/item/clothing/suit/bedsheet/red
 	icon_state = "bedsheet-red"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -806,7 +806,7 @@
 
 	proc/update_examine()
 		if(src.cape)
-			src.hides_from_examine = null
+			src.hides_from_examine = 0
 		else if(src.eyeholes)
 			src.hides_from_examine = (C_UNIFORM|C_GLOVES|C_SHOES|C_EARS)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes bedsheets always having the same hides from examine regardless of state


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bad bug



