### PR TITLE
Fixes mobAI being able to attack too fast

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -7,7 +7,8 @@
 
 /datum/limb
 	var/obj/item/parts/holder = null
-
+	///used for ON_COOLDOWN stuff
+	var/cooldowns
 	var/special_next = 0
 	var/datum/item_special/disarm_special = null //Contains the datum which executes the items special, if it has one, when used beyond melee range.
 	var/datum/item_special/harm_special = null //Contains the datum which executes the items special, if it has one, when used beyond melee range.
@@ -58,6 +59,7 @@
 		else
 			user.melee_attack_normal(target, 0, 0, DAMAGE_BLUNT)
 		user.lastattacked = target
+		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
 
 	proc/help(mob/living/target, var/mob/living/user)
 		user.do_help(target)
@@ -70,6 +72,7 @@
 		else
 			user.disarm(target)
 		user.lastattacked = target
+		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
 
 	proc/grab(mob/living/target, var/mob/living/user)
 		if(target == user)
@@ -79,6 +82,7 @@
 			return
 		user.grab_other(target)
 		user.lastattacked = target
+		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
 
 	//calls attack specials if we got em
 	//Ok look i know this isn't a true pixelaction() but it fits into the itemspecial call so i'm doin it
@@ -98,7 +102,7 @@
 			.= 0
 
 	proc/is_on_cooldown()
-		return 0
+		return GET_COOLDOWN(src, "limb_cooldown")
 
 	//alt version of disarm that shoves the target away from the user instead of trying to slap item out of hand
 	proc/shove(mob/living/target, var/mob/living/user)
@@ -405,6 +409,10 @@
 		else
 			user.visible_message("<b><span class='combat'>[user] attempts to bite [target] but misses!</span></b>")
 		user.lastattacked = target
+		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
+
+
+
 
 /datum/limb/mouth/small // for cats/mice/etc
 	sound_attack = 'sound/impact_sounds/Flesh_Tear_1.ogg'
@@ -1431,6 +1439,7 @@
 		msgs.flush(SUPPRESS_LOGS)
 
 		user.lastattacked = target
+		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
 		attack_particle(user,target)
 		if (src != target)
 			attack_twitch(src)

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1296,7 +1296,7 @@ ABSTRACT_TYPE(/mob/living/critter)
 	proc/can_critter_attack()
 		var/datum/handHolder/HH = get_active_hand()
 		if(HH?.limb)
-			return !HH.limb.is_on_cooldown() //if we have limb cooldowns, use that, otherwise use can_act()
+			return !HH.limb.is_on_cooldown() && can_act(src,TRUE) //if we have limb cooldowns, use that, otherwise use can_act()
 		return can_act(src,TRUE)
 
 	/// Used for generic critter mobAI - returns TRUE when the mob is able to scavenge. For handling cooldowns, or other scavenge blocking conditions.

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -215,9 +215,10 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 		. = ..()
 
 	critter_attack(var/mob/target)
-		src.visible_message("<span class='combat'><B>[src]</B> bites [target]!</span>", "<span class='combat'>You bite [target]!</span>")
 		playsound(src.loc, 'sound/weapons/handcuffs.ogg', 50, 1, -1)
-		random_brute_damage(target, rand(src.attack_damage, src.attack_damage+2))
+		src.set_hand(2)
+		src.set_a_intent(INTENT_HARM)
+		src.hand_attack(target)
 
 	can_critter_eat()
 		src.active_hand = 2 // mouth hand
@@ -247,8 +248,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 			. += C
 
 	critter_attack(var/mob/target)
-		src.visible_message("<span class='combat'><B>[src]</B> bites [target]!</span>", "<span class='combat'>You bite [target]!</span>")
-		playsound(src.loc, 'sound/weapons/handcuffs.ogg', 50, 1, -1)
+		..()
 		if(prob(30) && ishuman(target))
 			var/mob/living/carbon/human/H = target
 			if(!H.clothing_protects_from_chems())

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -515,8 +515,9 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 				src.visible_message("<span class='combat'>[src] [pick("starts to claw the living <b>shit</b> out of ", "unleashes a flurry of claw at ")] [target]!</span>")
 				SPAWN(0)
 					while (iteration <= attackCount && (get_dist(src, target) <= 1))
-						random_brute_damage(target, src.attack_damage + 2, 1)
-						playsound(src.loc, 'sound/impact_sounds/Flesh_Tear_3.ogg', 60, 1)
+						src.set_hand(1) //claws
+						src.set_a_intent(INTENT_HARM)
+						src.hand_attack(target)
 						iteration++
 						sleep(0.3 SECONDS)
 			var/datum/targetable/critter/pounce/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/pounce)
@@ -525,13 +526,13 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 				pounce.handleCast(target)
 				return
 			if (prob(50))
-				src.visible_message("<span class='combat'><B>[src]</B> pounces on [target]!</span>", "<span class='combat'>You pounce on [target]!</span>")
-				playsound(src.loc, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, 1, -1)
-				random_brute_damage(target, src.attack_damage, 1)
+				src.set_hand(2) //mouth
+				src.set_a_intent(INTENT_HARM)
+				src.hand_attack(target)
 			else
-				src.visible_message("<span class='combat'><B>[src]</B> scratches [target]!</span>", "<span class='combat'>You scratch on [target]!</span>")
-				playsound(src.loc, 'sound/impact_sounds/Flesh_Tear_3.ogg', 50, 1, -1)
-				random_brute_damage(target, src.attack_damage + 2, 1)
+				src.set_hand(1) //claws
+				src.set_a_intent(INTENT_HARM)
+				src.hand_attack(target)
 				if (prob(10))
 					bleed(target, 2)
 					boutput(target, "<span class='alert'>[src] scratches you hard enough to draw some blood! [pick("Bad kitty", "Piece of shit", "Ow")]!</span>")

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -704,9 +704,9 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 				src.visible_message("<span class='combat'><B>[src]</B> barrels into [target] and trips them!</span>", "<span class='combat'>You run into [target]!</span>")
 				pounce.handleCast(target)
 				return
-			src.visible_message("<span class='combat'><B>[src]</B> bites [target]!</span>", "<span class='combat'>You bite [target]!</span>")
-			playsound(src.loc, 'sound/items/eatfoodshort.ogg', 50, 1, -1, 1.3)
-			random_brute_damage(target, src.attack_damage, 1)
+			src.set_hand(2) //mouth
+			src.set_a_intent(INTENT_HARM)
+			src.hand_attack(target)
 
 	disposing()
 		. = ..()

--- a/code/mob/living/critter/snake.dm
+++ b/code/mob/living/critter/snake.dm
@@ -5,7 +5,7 @@
 	icon_state = "snake"
 	density = FALSE
 	custom_gib_handler = /proc/gibs
-	hand_count = 0
+	hand_count = 1
 	can_help = TRUE
 	can_throw = FALSE
 	can_grab = TRUE
@@ -35,10 +35,15 @@
 	//note: this is not the best way to do this, but I'm showing it here as an example. It is better to create a peaceful AI holder with no attack tasks and use that.
 	var/aggressive = TRUE
 
-	critter_attack(var/mob/target)
-		src.visible_message("<span class='combat'><B>[src]</B> bites [target]!</span>", "<span class='combat'>You bite [target]!</span>")
-		playsound(src.loc, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, 1, -1)
-		random_brute_damage(target, rand(src.attack_damage, src.attack_damage+5))
+	setup_hands()
+		..()
+		var/datum/handHolder/HH = hands[1]
+		HH.limb = new /datum/limb/mouth	// if not null, the special limb to use when attack_handing
+		HH.icon = 'icons/mob/critter_ui.dmi'	// the icon of the hand UI background
+		HH.icon_state = "mouth"					// the icon state of the hand UI background
+		HH.name = "mouth"						// designation of the hand - purely for show
+		HH.limb_name = "teeth"					// name for the dummy holder
+		HH.can_hold_items = 0
 
 	seek_target(var/range)
 		. = list()

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -173,7 +173,7 @@
 	can_critter_attack()
 		var/datum/targetable/critter/spider_flail/flail = src.abilityHolder.getAbility(/datum/targetable/critter/spider_flail)
 		//if flail is diabled, we're flailing, so can't attack, otherwise we can always do bite/scratch
-		return can_act(src,TRUE) && !flail.disabled
+		return ..() && !flail?.disabled
 
 /mob/living/critter/spider/nice
 	name = "bumblespider"
@@ -365,10 +365,6 @@
 			else
 				src.set_a_intent(INTENT_HARM)
 				src.hand_attack(target)
-
-	can_critter_attack()
-		return can_act(src,TRUE)
-
 	cluwne
 		name = "cluwnespider"
 		desc = "Uhhh. That's not normal. Like, even for clownspiders."
@@ -404,8 +400,6 @@
 			var/datum/targetable/critter/spider_drain/drain = src.abilityHolder.getAbility(/datum/targetable/critter/spider_drain/cluwne)
 			return can_act(src,TRUE) && (!drain.disabled && drain.cooldowncheck())
 
-		can_critter_attack()
-			return can_act(src,TRUE)
 
 
 /mob/living/critter/spider/clownqueen
@@ -470,7 +464,7 @@
 
 		can_critter_attack()
 			var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample/cluwne)
-			return can_act(src,TRUE) && !trample.disabled
+			return ..() && !trample?.disabled
 
 	New()
 		..()
@@ -549,7 +543,7 @@
 
 	can_critter_attack()
 		var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample)
-		return can_act(src,TRUE) && !trample.disabled
+		return ..() && !trample?.disabled
 
 
 /proc/funnygibs(atom/location, var/list/ejectables, var/bDNA, var/btype)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
By adding cooldown to /datum/limb, we prevent mobs from attacking faster than default click delay. It's not pretty, and really the better solution is to rewrite the entirety of limb code, but I'm not doing that today.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
MobAI shouldn't stun lock you and kill you in seconds.
