### PR TITLE
Mindhack rebalance

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2462,7 +2462,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	receives_miranda = 1
-	receives_implant = /obj/item/implant/health/security
+	receives_implant = /obj/item/implant/health/security/anti_mindhack
 	slot_back = list(/obj/item/storage/backpack/NT)
 	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
 	slot_jump = list(/obj/item/clothing/under/misc/turds)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -447,7 +447,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	allow_spy_theft = 0
 	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
-	receives_implant = /obj/item/implant/health/security
+	receives_implant = /obj/item/implant/health/security/anti_mindhack
 	receives_disk = 1
 	receives_security_disk = 1
 	receives_badge = 1
@@ -478,6 +478,7 @@ ABSTRACT_TYPE(/datum/job/security)
 		name = "Security Assistant"
 		limit = 3
 		cant_spawn_as_con = 1
+		receives_implant = /obj/item/implant/health/security
 		wages = PAY_UNTRAINED
 		slot_back = list(/obj/item/storage/backpack/security)
 		slot_jump = list(/obj/item/clothing/under/rank/security/assistant)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -111,6 +111,12 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY_THIEF
 
+/datum/syndicate_buylist/generic/implant_remover
+	name = "Implant Remover"
+	item = /obj/item/device/implant_remover
+	cost = 2
+	desc = "A powerful electromagnet, capable of annihilating any non-syndicate implants in someone's body after a short delay. Useful for those pesky security implants or for ditching a tracker."
+	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/generic/empgrenades
 	name = "EMP Grenades"

--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -617,12 +617,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 					"<span class='alert'>You cut out \an [I] from [surgeon == patient ? "yourself" : "[patient]"] with [src]!</span>",\
 					"<span class='alert'>[patient == surgeon ? "You cut" : "<b>[surgeon]</b> cuts"] out \an [I] from you with [src]!</span>")
 
-				I.on_remove(patient)
-				patient.implant.Remove(I)
-				I.set_loc(patient.loc)
-				// offset approximately around chest area, based on cutting over operating table
-				I.pixel_x = rand(-2, 5)
-				I.pixel_y = rand(-6, 1)
+				I.cut_out()
 				return 1
 
 			for (var/obj/item/implant/I in patient.implant)
@@ -645,7 +640,6 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 					newcase.pixel_x = rand(-2, 5)
 					newcase.pixel_y = rand(-6, 1)
 					I.on_remove(patient)
-					patient.implant.Remove(I)
 					var/image/wadblood = image('icons/obj/surgery.dmi', icon_state = "implantpaper-blood")
 					wadblood.color = patient.blood_color
 					newcase.UpdateOverlays(wadblood, "blood")
@@ -661,11 +655,7 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 						surgeon.tri_message(patient, "<span class='alert'><b>[surgeon]</b> cuts out something alien from [patient == surgeon ? "[him_or_her(patient)]self" : "[patient]"] with [src]!</span>",\
 							"<span class='alert'>You cut out something alien from [surgeon == patient ? "yourself" : "[patient]"] with [src]!</span>",\
 							"<span class='alert'>[patient == surgeon ? "You cut" : "<b>[surgeon]</b> cuts"] out something alien from you with [src]!</span>")
-						imp.pixel_x = rand(-2, 5)
-						imp.pixel_y = rand(-6, 1)
-						imp.set_loc(get_turf(patient))
-						imp.on_remove(patient)
-						patient.implant.Remove(imp)
+						imp.cut_out()
 				return 1
 
 		/* chest op_stage description


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE] [FREEZE-EXEMPT] [CONTROVERSIAL] [FEEDBACK] [WIKI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All security officers (not assistants or detectives) get the anti-mindhack health implant currently reserved for HoSes.

Adds a new 2 TC traitor item available to traitors, spy-thieves and nuke-op custom class uplinks: implant remover.
After a 3 second public action bar and obnoxiously loud noise, the implant remover purges all non-syndicate implants from the target, dealing 10 burn damage per implant removed.

https://i.imgur.com/0qwdjA2.mp4

The sprite and sound effect are placeholder, if this looks like getting merged me or someone else can make an actual sprite for it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
One traitor immediately mindhacking the entire security team generally doesn't make for very entertaining rounds, this aims to make mindhacking security officers much more challenging but still possible if you can remove the implant. Cloned security officers will also be vulnerable to mindhacking unless they are able to recover the implant from their corpse.

Standard disclaimer that although I'm a dev, this is far from guaranteed to be merged.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)All security officers (not assistants) now receive anti-mindhack implants.
(*)New 2TC traitor item: implant remover. Removes all non-syndicate implants from a person after a short delay.
```
