### PR TITLE
Gives non secass sec anti mindhack, makes low hp disable anti mindhack implants

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -447,7 +447,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	allow_spy_theft = 0
 	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
-	receives_implant = /obj/item/implant/health/security
+	receives_implant = /obj/item/implant/health/security/anti_mindhack
 	receives_disk = 1
 	receives_security_disk = 1
 	receives_badge = 1
@@ -478,6 +478,7 @@ ABSTRACT_TYPE(/datum/job/security)
 		name = "Security Assistant"
 		limit = 3
 		cant_spawn_as_con = 1
+		receives_implant = /obj/item/implant/health/security
 		wages = PAY_UNTRAINED
 		slot_back = list(/obj/item/storage/backpack/security)
 		slot_jump = list(/obj/item/clothing/under/rank/security/assistant)
@@ -2461,7 +2462,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	receives_miranda = 1
-	receives_implant = /obj/item/implant/health/security
+	receives_implant = /obj/item/implant/health/security/anti_mindhack
 	slot_back = list(/obj/item/storage/backpack/NT)
 	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
 	slot_jump = list(/obj/item/clothing/under/misc/turds)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -749,6 +749,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		M.reagents.add_reagent("synaptizine", 10)
 		M.reagents.add_reagent("saline", 10)
 		M.reagents.add_reagent("salbutamol", 10)
+		M.reagents.add_reagent("anti_rad", 20)
 
 		if(M == I)
 			boutput(M, "<span class='alert'>You feel utterly strengthened in your resolve! You are the most important person in the universe!</span>")

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -356,7 +356,7 @@ THROWING DARTS
 		mailgroups.Add(MGD_SECURITY)
 		..()
 
-/obj/item/implant/health/security/anti_mindhack //HoS implant
+/obj/item/implant/health/security/anti_mindhack //Security w/o ass implant
 	name = "mind protection health implant"
 	icon_state = "implant-b"
 	impcolor = "b"
@@ -717,8 +717,8 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if (src.uses <= 0)
 			if (ismob(user)) user.show_text("[src] has been used up!", "red")
 			return 0
-		for(var/obj/item/implant/health/security/anti_mindhack/AM in H.implant)
-			boutput(user, "<span class='alert'>[H] is protected from mindhacking by \an [AM.name]!</span>")
+		if((locate(/obj/item/implant/health/security/anti_mindhack) in H.implant) && H.health >= 30)
+			boutput(user, "<span class='alert'>[H]'s fortitude is too strong and is protected from mindhacking by an Anti-Mindhack implant! They need to be highly weakened first.</span>")
 			return 0
 		// It might happen, okay. I don't want to have to adapt the override code to take every possible scenario (no matter how unlikely) into considertion.
 		if (H.mind && ((H.mind.special_role == ROLE_VAMPTHRALL) || (H.mind.special_role == "spyminion")))
@@ -744,9 +744,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if (!ishuman(M) || (src.uses <= 0))
 			return
 
-		boutput(M, "<span class='alert'>A stunning pain shoots through your brain!</span>")
-		M.changeStatus("stunned", 10 SECONDS)
-		M.changeStatus("weakened", 10 SECONDS)
+		boutput(M, "<span class='alert'>A bolt of a new found purpose curves through your veins!</span>")
+		M.reagents.add_reagent("omnizine",15)
+		M.reagents.add_reagent("synaptizine", 10)
+		M.reagents.add_reagent("saline", 10)
+		M.reagents.add_reagent("salbutamol", 10)
 
 		if(M == I)
 			boutput(M, "<span class='alert'>You feel utterly strengthened in your resolve! You are the most important person in the universe!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Alternate to #13365. Like #13365, every security member except secasses now recieves an anti mindhack implant. Unlike #13365 however, getting someone with an anti mindhack implant below 30 hp will allow you to mindhack them. This pr does two other changes to smooth this out as well.

People with anti mindhack implants that are above 30 hp will be unable to be implanted, this prevents you from wasting an implant on them. Getting implanted with a mindhack implant also injects you with cocktail of 15 omnizine, 10 synaptzine, 10 saline 10 salbutamol and 20 potassium iodide. This means that the secoff you just got into crit wont be in crit for much longer (this also intentionally adds a tactical element to mindhacks).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think this is a much more interesting approach then #13365. This makes mindhacks synergize with traitors stealth and combat items much better as they make it easier to mindhack people. This also makes higher value target harder to mindhack because theyre harder to attack.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Nanotrasen has increased security by giving every security member whose not a security assistant an anti mindhack implant. To compensate the syndicate has updated their mindhacks to override anti mindhack implants when a person is under 30 health, and given them the ability to inject a healing mixture (15 omnizine, 10 synaptzine, 10 saline, 10 salbutamol and 20 potassium iodide) when injected into someone.
```
