### PR TITLE
Security implants only send out health alerts to security upon death

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -352,9 +352,13 @@ THROWING DARTS
 /obj/item/implant/health/security
 	name = "health implant - security issue"
 
-	New()
+	on_death()
 		mailgroups.Add(MGD_SECURITY)
 		..()
+
+	death_alert()
+		..()
+		mailgroups.Remove(MGD_SECURITY)
 
 /obj/item/implant/health/security/anti_mindhack //HoS implant
 	name = "mind protection health implant"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -352,11 +352,8 @@ THROWING DARTS
 /obj/item/implant/health/security
 	name = "health implant - security issue"
 
-	on_death()
-		mailgroups.Add(MGD_SECURITY)
-		..()
-
 	death_alert()
+		mailgroups.Add(MGD_SECURITY)
 		..()
 		mailgroups.Remove(MGD_SECURITY)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
**This pr does not effect the behavior of norrmal health implants**
This pr is an alt pr to #13103 and a step sibling pr to #13367, this pr makes it to where security only gets alerted of a secoffs health when they enter crit. Security implants still send out a message to medical pda's when a secoff enter crit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Security already has loads of methods when it comes to contacting there team, this makes it more forgiving for antags when it comes to the completely passive one.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Secoffs only send out a health alert to security upon death. Secoffs will still send a health alert upon crit to medical as normal however.
```
