### PR TITLE
Datumises Vampire Thralls

### DIFF
--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -1,25 +1,6 @@
 // Converted everything related to vampires from client procs to ability holders and used
 // the opportunity to do some clean-up as well (Convair880).
 
-/* 	/		/		/		/		/		/		Setup		/		/		/		/		/		/		/		/		*/
-/mob/proc/make_vampiric_thrall()
-	if (ishuman(src))
-		var/datum/abilityHolder/vampiric_thrall/A = src.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
-		if (A && istype(A))
-			return
-
-		var/datum/abilityHolder/vampiric_thrall/V = src.add_ability_holder(/datum/abilityHolder/vampiric_thrall)
-
-		V.addAbility(/datum/targetable/vampiric_thrall/speak)
-		V.addAbility(/datum/targetable/vampire/vampire_bite/thrall)
-
-
-		V.transferOwnership(src)
-
-		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			src.show_antag_popup("vampthrall")
-
-
 /* 	/		/		/		/		/		/		Ability Holder	/		/		/		/		/		/		/		/		*/
 
 /atom/movable/screen/ability/topBar/vampiric_thrall
@@ -67,7 +48,7 @@
 	points = 0
 
 	var/mob/vamp_isbiting = null
-	var/datum/abilityHolder/vampire/master = 0
+	var/datum/abilityHolder/vampire/master
 
 	var/last_blood_points = 0
 

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1119,14 +1119,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			..()
 
 	onDeath(gibbed)
-		var/datum/abilityHolder/vampiric_thrall/abil = src.mob.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
-		if (abil)
-			if (abil.master)
-				abil.master.remove_thrall(src.mob)
-			else
-				remove_mindhack_status(src.mob, "vthrall", "death")
-		var/datum/component/tracker_hud/vampthrall/component = src.mob.GetComponent(/datum/component/tracker_hud/vampthrall)
-		component?.RemoveComponent()
+		src.mob?.mind?.remove_antagonist(ROLE_VAMPTHRALL)
 		..()
 
 /datum/mutantrace/skeleton

--- a/code/modules/antagonists/__subordinate_antagonist.dm
+++ b/code/modules/antagonists/__subordinate_antagonist.dm
@@ -6,4 +6,7 @@ ABSTRACT_TYPE(/datum/antagonist/subordinate)
 
 	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, master)
 		src.master = master
+		// Remove mind.master when it has been superseded by subordinate antagonist roles.
+		src.owner = new_owner
+		src.owner.master = src.master.ckey
 		. = ..()

--- a/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
+++ b/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
@@ -295,12 +295,6 @@
 
 		sender.say_thrall(message, src)
 
-
-	proc/remove_thrall(var/mob/victim)
-		remove_mindhack_status(victim)
-		thralls -= victim
-		src.getAbility(/datum/targetable/vampire/enthrall)?.pointCost = 200 + 100 * length(src.thralls)
-
 	proc/make_thrall(var/mob/victim)
 		if (ishuman(victim))
 
@@ -342,29 +336,8 @@
 					owner.TakeDamage("chest", 0, 30)
 					return
 
-			if (M.mind)
-				M.mind.special_role = ROLE_VAMPTHRALL
-				if(ismob(owner))
-					M.mind.master = owner.ckey
-				else
-					M.mind.master = owner
-				if (!(M.mind in ticker.mode.Agimmicks))
-					ticker.mode.Agimmicks += M.mind
-
-			thralls += M
-			src.getAbility(/datum/targetable/vampire/enthrall)?.pointCost = 200 + 100 * length(src.thralls)
-
-			M.decomp_stage = DECOMP_STAGE_NO_ROT
-			M.set_mutantrace(/datum/mutantrace/vampiric_thrall)
-			M.make_vampiric_thrall()
-			var/datum/abilityHolder/vampiric_thrall/VZ = M.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
-			if (VZ && istype(VZ))
-				VZ.master = src
-			M.AddComponent(/datum/component/tracker_hud/vampthrall, src.owner)
-
-			boutput(M, "<span class='alert'><b>You awaken filled with purpose - you must serve your master vampire, [owner.real_name]!</B></span>")
-			M.antagonist_overlay_refresh(1)
-			owner.antagonist_overlay_refresh(1)
+			M.mind.add_subordinate_antagonist(ROLE_VAMPTHRALL, master = src.owner.mind)
+			src.owner.antagonist_overlay_refresh(TRUE, FALSE)
 
 			boutput(owner, "<span class='notice'>[M] has been revived as your thrall.</span>")
 			logTheThing(LOG_COMBAT, owner, "enthralled [constructTarget(M,"combat")] at [log_loc(owner)].")

--- a/code/modules/antagonists/vampire/thrall.dm
+++ b/code/modules/antagonists/vampire/thrall.dm
@@ -1,0 +1,57 @@
+/datum/antagonist/subordinate/thrall
+	id = ROLE_VAMPTHRALL
+	display_name = "vampire thrall"
+	remove_on_death = TRUE
+	remove_on_clone = TRUE
+
+	/// The ability holder of this vampire, containing their respective abilities. This is also used for tracking blood, at the moment.
+	var/datum/abilityHolder/vampiric_thrall/ability_holder
+
+	is_compatible_with(datum/mind/mind)
+		return ishuman(mind.current)
+
+	give_equipment()
+		if (!ishuman(src.owner.current))
+			return FALSE
+
+		var/mob/living/carbon/human/H = src.owner.current
+
+		H.decomp_stage = DECOMP_STAGE_NO_ROT
+		H.coreMR = H.mutantrace
+		H.set_mutantrace(/datum/mutantrace/vampiric_thrall)
+		H.AddComponent(/datum/component/tracker_hud/vampthrall, src.owner)
+
+		var/datum/abilityHolder/vampiric_thrall/A = H.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
+		if (!A)
+			src.ability_holder = H.add_ability_holder(/datum/abilityHolder/vampiric_thrall)
+		else
+			src.ability_holder = A
+
+		var/datum/abilityHolder/vampire/master_ability_holder = src.master.current.get_ability_holder(/datum/abilityHolder/vampire)
+		if (master_ability_holder)
+			src.ability_holder.master = master_ability_holder
+			master_ability_holder.thralls += H
+			master_ability_holder.getAbility(/datum/targetable/vampire/enthrall)?.pointCost = 200 + 100 * length(master_ability_holder.thralls)
+
+		src.ability_holder.addAbility(/datum/targetable/vampiric_thrall/speak)
+		src.ability_holder.addAbility(/datum/targetable/vampire/vampire_bite/thrall)
+
+	remove_equipment()
+		var/mob/living/carbon/human/H = src.owner.current
+
+		remove_mindhack_status(H, "vthrall", "death")
+		H.set_mutantrace(H.coreMR)
+		var/datum/component/C = H.GetComponent(/datum/component/tracker_hud/vampthrall)
+		C?.RemoveComponent(/datum/component/tracker_hud/vampthrall)
+
+		if (src.ability_holder.master)
+			src.ability_holder.master.thralls -= H
+			src.ability_holder.master.getAbility(/datum/targetable/vampire/enthrall)?.pointCost = 200 + 100 * length(src.ability_holder.master.thralls)
+
+		src.ability_holder.removeAbility(/datum/targetable/vampiric_thrall/speak)
+		src.ability_holder.removeAbility(/datum/targetable/vampire/vampire_bite/thrall)
+		H.remove_ability_holder(/datum/abilityHolder/vampiric_thrall)
+
+	announce()
+		. = ..()
+		boutput(src.owner.current, "<span class='alert'><b>You awaken filled with purpose - you must serve your master vampire, [src.master.current.real_name]!</B></span>")

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -381,7 +381,7 @@ TYPEINFO(/obj/machinery/clonepod)
 				if (success)
 					logTheThing(LOG_COMBAT, src.occupant, "Cloning pod removed [antag.display_name] antag status.")
 				else
-					logTheThing(LOG_DEBUG, src, "Cloning pod failed to remove zombie antag status from [src.occupant] with return code [success].")
+					logTheThing(LOG_DEBUG, src, "Cloning pod failed to remove [antag.display_name] antag status from [src.occupant] with return code [success].")
 
 		// Someone is having their brain zapped. 75% chance of them being de-antagged if they were one
 		//MBC todo : logging. This shouldn't be an issue thoug because the mindwipe doesn't even appear ingame (yet?)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -734,6 +734,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\antagonists\traitor\licensed_traitor.dm"
 #include "code\modules\antagonists\traitor\sleeper_agent.dm"
 #include "code\modules\antagonists\traitor\traitor.dm"
+#include "code\modules\antagonists\vampire\thrall.dm"
 #include "code\modules\antagonists\vampire\vampire.dm"
 #include "code\modules\antagonists\vampire\abilities\_vampire_ability_holder.dm"
 #include "code\modules\antagonists\vampire\abilities\blood_steal.dm"


### PR DESCRIPTION
[Gamemodes] [Internal] [Bug] [Code Quality]


## About the PR:
Vampire thralls have been fully migrated onto the new datum system, which only includes resurrected and admin-spawned vampire thralls.
Vampire thralls should now correctly remove their mutantrace, abilities, and ability holders on death or on cloning.
Fixes #12639,
Fixes #12513,
Fixes #12204, 
Fixes #11996, 
Fixes #11059,
Fixes #9959,
Fixes #9270.


## Why's this needed?
Same rationale as #9366.