### PR TITLE
Ghostdrones not allowed to lie down anymore

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -131,6 +131,10 @@
 			src.setFace(faceType, faceColor)
 			src.UpdateOverlays(null, "dizzy")
 
+	clamp_values()
+		..()
+		src.lying = 0
+
 	death(gibbed)
 		logTheThing(LOG_COMBAT, src, "was destroyed at [log_loc(src)].")
 		setdead(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Or at least, ghostdrones now get their `lying` set back to `0`.
Wasn't sure how to implement this, so I just copied what cyborgs have with `clamp_values`. Not sure if there's anything else that needs to be clamped, so just that for now.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9534, permanently floor ghostdrone is bad