### PR TITLE
Datumises Flocktraces

### DIFF
--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -177,7 +177,7 @@
 	return O
 
 
-/mob/living/intangible/flock/flockmind/proc/partition(free = FALSE)
+/mob/living/intangible/flock/flockmind/proc/partition(antagonist_source = ANTAGONIST_SOURCE_SUMMONED)
 	boutput(src, "<span class='flocksay'>Partitioning initiated. Stand by.</span>")
 
 	var/ghost_confirmation_delay = 30 SECONDS
@@ -201,7 +201,7 @@
 		boutput(src, "<span class='flocksay'>Partition failure: unable to coalesce sentience.</span>")
 		return TRUE
 
-	if (!free && !src.abilityHolder.pointCheck(FLOCKTRACE_COMPUTE_COST))
+	if ((antagonist_source == ANTAGONIST_SOURCE_SUMMONED) && !src.abilityHolder.pointCheck(FLOCKTRACE_COMPUTE_COST))
 		message_admins("A Flocktrace offer from [src.real_name] was sent but failed due to lack of compute.")
 		logTheThing(LOG_ADMIN, null, "Flocktrace offer from [src.real_name] failed due to lack of compute.")
 		boutput(src, "<span class='flocksay'>Partition failure: Compute required unavailable.</span>")
@@ -212,7 +212,7 @@
 	message_admins("[picked.key] respawned as a Flocktrace under [src.real_name].")
 	log_respawn_event(picked.mind, "Flocktrace", src.real_name)
 
-	picked.make_flocktrace(get_turf(src), src.flock, free)
+	picked.mind?.add_subordinate_antagonist(ROLE_FLOCKTRACE, source = antagonist_source, master = src.mind)
 
 // old code for flocktrace respawns
 /datum/ghost_notification/respawn/flockdrone
@@ -235,7 +235,8 @@
 	// pick a random ghost
 	var/mob/dead/observer/winner = valid_ghosts[rand(1, valid_ghosts.len)]
 	if(winner) // probably a paranoid check
-		var/mob/living/trace = winner.make_flocktrace(get_turf(src), src.flock)
+		winner.mind?.add_subordinate_antagonist(ROLE_FLOCKTRACE, master = src.mind)
+		var/mob/living/trace = winner.mind.current
 		message_admins("[key_name(src)] made [key_name(trace)] a flocktrace via ghost volunteer respawn.")
 		logTheThing(LOG_ADMIN, src, "made [key_name(trace)] a flocktrace via ghost volunteer respawn.")
 		flock_speak(null, "Trace partition \[ [trace.real_name] \] has been instantiated.", src.flock)

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -792,54 +792,19 @@ var/respawn_arena_enabled = 0
 
 /mob/proc/flockerize(var/datum/flock/flock) // this will not host your web apps for you
 	if (src.mind || src.client)
+		var/datum/mind/flockmind_mind = src.mind
 		if(flock == null)
 			// no flocks given, make flockmind
-			var/datum/mind/flockmind_mind = src.mind
 			message_admins("[key_name(usr)] made [key_name(src)] a flockmind ([src.real_name]).")
 			logTheThing(LOG_ADMIN, usr, "made [constructTarget(src,"admin")] a flockmind ([src.real_name]).")
 			flockmind_mind.add_antagonist(ROLE_FLOCKMIND)
-			if (isflockmob(flockmind_mind.current))
-				return flockmind_mind.current
 		else
 			// make flocktrace of existing flock
 			message_admins("[key_name(usr)] made [key_name(src)] a flocktrace of flock [flock.name].")
 			logTheThing(LOG_ADMIN, usr, "made [constructTarget(src,"admin")] a flocktrace ([flock.name]).")
-			return make_flocktrace(get_turf(src), flock)
-	return null
+			flockmind_mind.add_subordinate_antagonist(ROLE_FLOCKTRACE, master = flock.flockmind_mind)
 
-// flocktraces are made by flockminds
-/mob/proc/make_flocktrace(var/atom/spawnloc, var/datum/flock/flock, var/free = FALSE)
-	if (src.mind || src.client)
-		if(!spawnloc)
-			spawnloc = get_turf(src)
-		if(!flock)
-			flock = new/datum/flock()
+		if (isflockmob(flockmind_mind.current))
+			return flockmind_mind.current
 
-		var/mob/living/intangible/flock/trace/O = new/mob/living/intangible/flock/trace(spawnloc, flock, free)
-		if (src.mind)
-			src.mind.transfer_to(O)
-			flock.trace_minds[O.name] = O.mind
-		else
-			var/key = src.client.key
-			if (src.client)
-				src.client.mob = O
-			O.mind = new /datum/mind()
-			O.mind.ckey = ckey
-			O.mind.key = key
-			O.mind.current = O
-			ticker.minds += O.mind
-		ticker.mode.Agimmicks |= O.mind
-		if (!O.mind.special_role) // Preserve existing antag role (if any).
-			O.mind.special_role = ROLE_FLOCKTRACE
-		qdel(src)
-
-		boutput(O, "<span class='bold'>You are a Flocktrace, a partition of the Flock's collective computation!</span>")
-		boutput(O, "<span class='bold'>Your loyalty is to the Flock of [flock.flockmind.real_name]. Spread drones, convert the station, and aid in the construction of the Relay.</span>")
-		boutput(O, "<span class='bold'>In this form, you cannot be harmed, but you can't do anything to the world at large.</span>")
-		boutput(O, "<span class='italic'>Tip: Click-drag yourself onto unoccupied drones to take direct control of them.</span>")
-		boutput(O, "<span class='notice'>You are part of the <span class='bold'>[flock.name]</span> flock.</span>")
-		O.show_antag_popup("flocktrace")
-		flock_speak(null, "Trace partition [O.real_name] has been instantiated.", flock)
-
-		return O
 	return null

--- a/code/modules/antagonists/flockmind/flocktrace.dm
+++ b/code/modules/antagonists/flockmind/flocktrace.dm
@@ -1,0 +1,59 @@
+/datum/antagonist/subordinate/flocktrace
+	id = ROLE_FLOCKTRACE
+	display_name = "flocktrace"
+
+	/// The flock that this flocktrace belongs to.
+	var/datum/flock/flock
+
+	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, master)
+		src.master = master
+		if (!isflockmob(src.master.current))
+			return
+
+		var/mob/living/intangible/flock/flockmob = src.master.current
+		src.flock = flockmob.flock
+
+		. = ..()
+
+	give_equipment()
+		var/free = TRUE
+		if (src.assigned_by == ANTAGONIST_SOURCE_SUMMONED)
+			free = FALSE
+
+		var/mob/current_mob = src.owner.current
+		var/mob/living/intangible/flock/trace/flocktrace_mob = new/mob/living/intangible/flock/trace(get_turf(current_mob), src.flock, free)
+		src.owner.transfer_to(flocktrace_mob)
+		qdel(current_mob)
+
+		src.flock.trace_minds[flocktrace_mob.name] = src.owner
+
+	remove_equipment()
+		src.flock.traces -= src.owner.current
+		src.flock.trace_minds -= src.owner.current.name
+
+		var/mob/current_mob = src.owner.current
+		src.owner.current.ghostize()
+		qdel(current_mob)
+
+	relocate()
+		var/turf/T = get_turf(src.master.current)
+		if (!(T && isturf(T)) || (T.z != Z_LEVEL_STATION))
+			var/spawn_loc = pick_landmark(LANDMARK_LATEJOIN, locate(1, 1, Z_LEVEL_STATION))
+			if (spawn_loc)
+				src.owner.current.set_loc(spawn_loc)
+			else
+				src.owner.current.z = Z_LEVEL_STATION
+		else
+			src.owner.current.set_loc(T)
+
+	assign_objectives()
+		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/flock, src)
+
+	announce()
+		. = ..()
+		boutput(src.owner.current, "<span class='bold'>You are a Flocktrace, a partition of the Flock's collective computation!</span>")
+		boutput(src.owner.current, "<span class='bold'>Your loyalty is to the Flock of [src.flock.flockmind.real_name]. Spread drones, convert the station, and aid in the construction of the Relay.</span>")
+		boutput(src.owner.current, "<span class='bold'>In this form, you cannot be harmed, but you can't do anything to the world at large.</span>")
+		boutput(src.owner.current, "<span class='italic'>Tip: Click-drag yourself onto unoccupied drones to take direct control of them.</span>")
+		boutput(src.owner.current, "<span class='notice'>You are part of the <span class='bold'>[flock.name]</span> flock.</span>")
+		flock_speak(null, "Trace partition [src.owner.current.real_name] has been instantiated.", src.flock)

--- a/code/modules/antagonists/flockmind/flocktrace.dm
+++ b/code/modules/antagonists/flockmind/flocktrace.dm
@@ -17,6 +17,9 @@
 
 	give_equipment()
 		var/free = TRUE
+		// If this flocktrace has been created by a flockmind, ensure that the flocktrace is not free.
+		// Late spawning flockminds will receive a free flocktrace as part of the latejoin or random event.
+		// Likewise, Admin spawned flocktraces will also be free.
 		if (src.assigned_by == ANTAGONIST_SOURCE_SUMMONED)
 			free = FALSE
 

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -229,7 +229,7 @@
 						var/mob/living/intangible/flock/flockmind/F = mind.current
 						if (istype(F) && (alive_player_count() > 40)) // Flockmind can have a free trace, as a treat.
 							SPAWN(1)
-								F.partition(TRUE)
+								F.partition(ANTAGONIST_SOURCE_RANDOM_EVENT)
 					else
 						failed = 1
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -709,6 +709,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\antagonists\changeling\abilities\transform.dm"
 #include "code\modules\antagonists\conspirator\conspirator.dm"
 #include "code\modules\antagonists\flockmind\flockmind.dm"
+#include "code\modules\antagonists\flockmind\flocktrace.dm"
 #include "code\modules\antagonists\flockmind\abilities\_flockmind_ability_holder.dm"
 #include "code\modules\antagonists\flockmind\abilities\control_panel.dm"
 #include "code\modules\antagonists\flockmind\abilities\create_structure.dm"


### PR DESCRIPTION
[Gamemodes] [Internal] [Code Quality]


## About the PR:
Flocktraces have been fully migrated onto the new datum system, including partitioned and admin-spawned flocktraces.



## Why's this needed?
Same rationale as #9366.