### PR TITLE
Limit styptic's bleed fixing potential, adjust proconvertin risks

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -900,17 +900,38 @@ datum
 			fluid_b = 224
 			transparency = 230
 			depletion_rate = 0.3
+			overdose = 10
+			threshold = THRESHOLD_INIT
+			
+			
+			cross_threshold_over()
+				if(ismob(holder?.my_atom))
+					var/mob/M = holder.my_atom
+					APPLY_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "r_proconvertin", -2)
+				..()
+
+			cross_threshold_under()
+				if(ismob(holder?.my_atom))
+					var/mob/M = holder.my_atom
+					REMOVE_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "r_proconvertin")
+				..()
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M)
 					M = holder.my_atom
 				if (isliving(M))
 					var/mob/living/H = M
-					repair_bleeding_damage(H, 90, 1 * mult)
-					if (probmult(2))
-						H.contract_disease(/datum/ailment/malady/bloodclot,null,null,1)
+					repair_bleeding_damage(H, 70, 1 * mult)
 				..()
 				return
+
+			do_overdose(var/severity, var/mob/M, var/mult = 1)
+				if (!M)
+					M = holder.my_atom
+				if (isliving(M))
+					var/mob/living/H = M
+					if (probmult(6)) // ~60% chance to get a clot from 15u
+						H.contract_disease(/datum/ailment/malady/bloodclot,null,null,1)
 
 		medical/filgrastim // used to stimulate the body to produce more white blood cells. here, it will make you make more blood. this is good if you are losing a lot of blood and bad if you already have all your blood
 			name = "filgrastim"
@@ -1241,9 +1262,8 @@ datum
 					var/mob/living/L = M
 					if (L.bleeding == 1)
 						repair_bleeding_damage(L, 50, 1)
-					else
+					else if (L.bleeding <= 3)
 						repair_bleeding_damage(L, 5, 1)
-						//H.bleeding = min(H.bleeding, rand(0,5))
 
 					M.UpdateDamageIcon()
 				else if(method == INGEST)

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -921,7 +921,7 @@ datum
 					M = holder.my_atom
 				if (isliving(M))
 					var/mob/living/H = M
-					repair_bleeding_damage(H, 70, 1 * mult)
+					repair_bleeding_damage(H, 50, 1 * mult)
 				..()
 				return
 

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -185,7 +185,13 @@
 		return 0
 
 	proc/apply_to(mob/M as mob, mob/user as mob)
-		repair_bleeding_damage(M, 25, 1)
+		if(isliving(M))
+			var/mob/living/L = M
+			if (L.bleeding <= 3)
+				repair_bleeding_damage(M, 25, 1)
+
+		else 
+			repair_bleeding_damage(M, 25, 1)
 		active = 1
 
 		if (reagents?.total_volume)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Chemistry] [Medical] [Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tested thoroughly locally, is just a couple of number adjustments and usage of pre-existing stamina mechanics. If this is still too much for change freeze feel free to close til a later date.

Proconvertin:
Makes proconvertin's downside in low volumes a stamina debuff, like your blood turning to sludge
Weakens proconvertin's effectiveness at stopping bleeding (it already lowers the amount you bleed while it's in you)
Moves the clot chance to a small overdose threshold

Styptic & Patches - no longer stop bleeds with severity 4 or 5 (if you didn't know, patches have a 25% per tick to lower bleed, regardless of contents!)

Natural regeneration can bring bleeds down from a 5, so it's still possible to survive a high tier bleed with just styptic, it's going to be a gamble, though.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Proconvertin is currently in a weird place where it's more harmful and slower than anything else. The blood clots it causes take a long time to fix as they're a malady. They're too annoying to be ignorable, and occasionally debilitating (chest/head blood clots)

The alternatives to stop bleeding are completely risk-free. Styptic is stupid good and is just brainlessly used until your subject stops dying (especially likely with how often Auto-menders call TOUCH)

I think bandages are in a good spot, as they're a niche tool that solve the issue quickly, but they require a whole inventory slot (serious bleed isnt super common)

With this change, proconvertin might actually find its way into doctors' repertoires as a slow-but-reliable bleeding fixer. It's still counted as 'unsafe' so will have to be administered via syringe.

I do have alternative solutions in mind, such as moving the clot to a strychnine-style counter if this does not spark joy in the reviewers.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Styptic Powder & patches no longer fix extreme bleeding. Cauterization and bandages still work fine.
(+)Proconvertin now reduces stamina, but doesn't cause blood clots until overdosed.
```
