### PR TITLE
Transception pad trapped mob ejection

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -888,6 +888,7 @@ TYPEINFO(/obj/machinery/transception_pad)
 				use_power(200)
 				telefrag(M)
 				src.is_transceiving = FALSE
+			break
 
 
 /obj/machinery/computer/transception

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -633,10 +633,11 @@ TYPEINFO(/obj/machinery/transception_pad)
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "neopad"
 	name = "\proper transception pad"
+	desc = "A sophisticated cargo pad capable of utilizing the station's transception antenna when connected by cable. Keep clear during operation."
 	anchored = 1
 	density = 0
 	layer = FLOOR_EQUIP_LAYER1
-	desc = "A sophisticated cargo pad capable of utilizing the station's transception antenna when connected by cable. Keep clear during operation."
+	processing_tier = PROCESSING_32TH //processes infrequently to check for stuck mobs
 	var/is_transceiving = FALSE
 	var/frequency = FREQ_TRANSCEPTION_SYS
 	var/net_id
@@ -870,6 +871,24 @@ TYPEINFO(/obj/machinery/transception_pad)
 			M.emote("scream")
 			M.changeStatus("stunned", 5 SECONDS)
 			M.changeStatus("weakened", 5 SECONDS)
+
+	//if anyone gets stuck inside, eject them. (violently. you got stuck in a prototype teleporter)
+	process()
+		..()
+		for(var/mob/M in src.contents)
+			if(!src.is_transceiving)
+				src.is_transceiving = TRUE
+				src.visible_message("<span class='alert'><B>[src]</B> emits a buffer error alert!</span>")
+				playsound(src.loc, 'sound/machines/pod_alarm.ogg', 30, 0)
+				flick("neopad_activate",src)
+				SPAWN(0.4 SECONDS)
+					M.set_loc(src.loc)
+					showswirl(src.loc)
+					use_power(200)
+					telefrag(M)
+					src.is_transceiving = FALSE
+				break
+
 
 /obj/machinery/computer/transception
 	name = "\improper Transception Interlink"

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -875,19 +875,19 @@ TYPEINFO(/obj/machinery/transception_pad)
 	//if anyone gets stuck inside, eject them. (violently. you got stuck in a prototype teleporter)
 	process()
 		..()
+		if(src.is_transceiving)
+			return
 		for(var/mob/M in src.contents)
-			if(!src.is_transceiving)
-				src.is_transceiving = TRUE
-				src.visible_message("<span class='alert'><B>[src]</B> emits a buffer error alert!</span>")
-				playsound(src.loc, 'sound/machines/pod_alarm.ogg', 30, 0)
-				flick("neopad_activate",src)
-				SPAWN(0.4 SECONDS)
-					M.set_loc(src.loc)
-					showswirl(src.loc)
-					use_power(200)
-					telefrag(M)
-					src.is_transceiving = FALSE
-				break
+			src.is_transceiving = TRUE
+			src.visible_message("<span class='alert'><B>[src]</B> emits a buffer error alert!</span>")
+			playsound(src.loc, 'sound/machines/pod_alarm.ogg', 30, 0)
+			flick("neopad_activate",src)
+			SPAWN(0.4 SECONDS)
+				M.set_loc(src.loc)
+				showswirl(src.loc)
+				use_power(200)
+				telefrag(M)
+				src.is_transceiving = FALSE
 
 
 /obj/machinery/computer/transception

--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -877,7 +877,8 @@ TYPEINFO(/obj/machinery/transception_pad)
 		..()
 		if(src.is_transceiving)
 			return
-		for(var/mob/M in src.contents)
+		var/mob/M = locate() in src.contents
+		if(M)
 			src.is_transceiving = TRUE
 			src.visible_message("<span class='alert'><B>[src]</B> emits a buffer error alert!</span>")
 			playsound(src.loc, 'sound/machines/pod_alarm.ogg', 30, 0)
@@ -888,8 +889,6 @@ TYPEINFO(/obj/machinery/transception_pad)
 				use_power(200)
 				telefrag(M)
 				src.is_transceiving = FALSE
-			break
-
 
 /obj/machinery/computer/transception
 	name = "\improper Transception Interlink"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a procedure to transception pads where they periodically self-test for mobs trapped inside their "buffer", at a slow processing interval. Any mobs found are quickly and violently ejected back into corporeality if the transception pad is not currently in use.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should fix #13403; tested locally with manual set_loc of self into the pad.
