### PR TITLE
Removes sexual reference from motor neuron signal enhancement mutation

### DIFF
--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -344,7 +344,7 @@
 
 		if (src.limb_type == LIMB_IS_ARM)
 			if (probmult(5))
-				owner.visible_message("<span class='alert'>[owner.name]'s [src.limb] makes a [pick("rude", "funny", "weird", "lewd", "strange", "offensive", "cruel", "furious")] gesture!</span>")
+				owner.visible_message("<span class='alert'>[owner.name]'s [src.limb] makes a [pick("rude", "funny", "weird", "strange", "offensive", "cruel", "furious")] gesture!</span>")
 			else if (probmult(2))
 				owner.emote("slap")
 			else if (probmult(2))
@@ -360,7 +360,7 @@
 
 		else if (src.limb_type == LIMB_IS_LEG)
 			if (probmult(5))
-				owner.visible_message("<span class='alert'>[owner.name]'s [src.limb] twitches [pick("rudely", "awkwardly", "weirdly", "lewdly", "strangely", "offensively", "cruelly", "furiously")]!</span>")
+				owner.visible_message("<span class='alert'>[owner.name]'s [src.limb] twitches [pick("rudely", "awkwardly", "weirdly", "strangely", "offensively", "cruelly", "furiously")]!</span>")
 			else if (probmult(3))
 				owner.visible_message("<span class='alert'><B>[owner.name] trips over [his_or_her(owner)] own [src.limb]!</B></span>")
 				owner.changeStatus("weakened", 2 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes "lewdly" and "lewd" from the possible adjectives for involuntary muscle spasms when someone has the Motor Neuron Signal Enhancement.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having your arms do lewd gestures and your legs twitch lewdly seems out of place with what we have on Goon and the hard no sexual content rule.