### PR TITLE
Fixes beepsky's lockdown behaviour

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -825,7 +825,7 @@
 					var/obj/item/card/id/perp_id = H.equipped()
 					if (!istype(perp_id))
 						perp_id = H.wear_id
-					if(!perp_id || (perp_id && !(perp_id.access & src.lockdown_permit)))
+					if(!perp_id || (perp_id && !length(perp_id.access & src.lockdown_permit)))
 						src.threatlevel += 4
 			if (src.threatlevel >= 4)
 				src.EngageTarget(C)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes beepsky not enforcing lockdown detainments against people without head/sec access.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #13412 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Securitrons will now properly arrest unauthorized people when on lockdown.
```
