### PR TITLE
SecHUD flags now visibly to anyone that can see SecHUD arrest icons

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -120,10 +120,8 @@
 			else
 				. += "<br><span class='notice'>[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(src.wear_id:ID_card)] [src.wear_id:ID_card:name] in it.</span>"
 
-	if (src.arrestIcon?.icon_state && ishuman(usr))
-		var/mob/living/carbon/human/H = usr
-
-		if (istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+	if (src.arrestIcon?.icon_state)
+		if(locate(usr) in global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount) // anyone that can see arrest status can see the flag too
 			var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
 			if(sec_record)
 				var/sechud_flag = sec_record["sec_flag"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of only humans with secHUDs being able to see secHUD flags, now anyone that can see arrest status can see the flag on examine as well thanks to client image groups.

Initially tried a bunch of ishuman and isrobot but forgot ghosts can toggle arrest status and I'm sure there's more edge cases, so this is clean and works for everything but I don't know if it destroys performance or not. 👍 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13386, makes sense to couple them and it'll work if we give AI arrest status sight or something

