### PR TITLE
Zoldorf clickdragging now works again

### DIFF
--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -389,8 +389,9 @@
 		return make_zoldorf()
 	return null
 
-/client/MouseDrop(var/over_object, var/src_location, var/over_location, mob/user as mob) //handling click dragging of items within one tile of a zoldorf booth.
+/client/MouseDrop(var/over_object, var/src_location, var/over_location) //handling click dragging of items within one tile of a zoldorf booth.
 	..()
+	var/mob/zoldorf/user = usr
 	if(!istype(user,/mob/zoldorf))
 		return
 	var/turf/Tb = get_turf(over_location)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
MouseDrop doesn't pass user so the whole clickdragging breaks, so I just did a bandaid fix that solves it. If I can do it in a better way, feel free to complain, but I'd rather not refactor zoldorf...


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13437, multiple people have mentorhelped about it recently and we should probably have it working even if zoldorf is a mess
