### PR TITLE
More cyborg interaction range fixes and tool jankiness fixes

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -847,6 +847,7 @@ TYPEINFO(/obj/machinery/power/stomper)
 	icon_state = "stomper0"
 	density = 1
 	anchored = 0
+	status = REQ_PHYSICAL_ACCESS
 
 	var/power_up_realtime = 30
 	var/const/power_cell_usage = 4
@@ -894,7 +895,7 @@ TYPEINFO(/obj/machinery/power/stomper)
 		src.add_fingerprint(user)
 
 		if(open)
-			if(cell && !user.equipped())
+			if(cell && !user.equipped() && in_interact_range(src, user))
 				cell.UpdateIcon()
 				user.put_in_hand_or_drop(cell)
 

--- a/code/obj/item/clothing/trash_bags.dm
+++ b/code/obj/item/clothing/trash_bags.dm
@@ -44,7 +44,7 @@
 		if(W.w_class > W_CLASS_NORMAL)
 			boutput(user, "<span class='alert'>\The [W] is too big to fit inside [src]!</span>")
 			return
-		if (W.cant_self_remove)
+		if (W.cant_self_remove || W.cant_drop)
 			boutput(user, "<span class='alert'>You can't get [W] to come off of you!</span>")
 			return
 		if (istype(W, /obj/item/clothing/under/trash_bag))

--- a/code/obj/machinery/tripod.dm
+++ b/code/obj/machinery/tripod.dm
@@ -4,12 +4,13 @@
 	icon_state = "tripod"
 	density = 1
 	anchored = 1
+	status = REQ_PHYSICAL_ACCESS
 
 	machine_registry_idx = MACHINES_MISC
 	var/obj/item/tripod_bulb/bulb = null
 
 	attack_hand(mob/user)
-		if (can_reach(user,src))
+		if (in_interact_range(src, user))
 			if (bulb)
 				bulb.removed(src)
 				user.put_in_hand_or_drop(bulb)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Trash bags now check for ``cant_drop`` as well, so ghostdrones and cyborgs can't put their stuff into them
Power stompers and tripods require physical access for removing power cell or tripod bulb


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9156, #13426, half of #13425, silicon jank bad

