### PR TITLE
Fix an issue with garrotes (Fibre Wire)

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -1018,7 +1018,7 @@ proc/Create_Tommyname()
 
 	proc/check_conditions()
 		. = 0
-		if(BOUNDS_DIST(owner, target) > 0 || !isturf(target.loc) || !target || !owner || !the_garrote || !the_garrote.wire_readied)
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !isturf(target.loc) || !owner || !the_garrote || !the_garrote.wire_readied)
 			interrupt(INTERRUPT_ALWAYS)
 			. = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX]  

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Slight one-line tweak to garrote code to fix #12955 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Garrotes/Fibre wire should not be able to grab people who enter closets, disposal units, etc. who have been selected to be grabbed, but not yet grabbed.