### PR TITLE
Quantum Telescope return to usable state after window is closed

### DIFF
--- a/code/modules/telescience/telescope/quantumTelescope.dm
+++ b/code/modules/telescience/telescope/quantumTelescope.dm
@@ -22,7 +22,8 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 			rebuildEventList(using)
 
 	proc/boot_if_away()
-		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using)))
+		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using) || !isAI(using) && !(GET_DIST(src, using) <= ((WIDE_TILE_WIDTH - 1)/ 2)))) // copied last bit from default.dm tgui code
+			src.remove_dialog(using)
 			using.Browse(null, "window=qtelescope;override_setting=1")
 			using = null
 		return
@@ -43,7 +44,7 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 
 		user.Browse(grabResource("html/telescope.html"), "window=qtelescope;size=974x560;title=Quantum Telescope;can_resize=0", 1)
 
-		onclose(user, "telescope", src)
+		onclose(user, "qtelescope", src)
 
 		SPAWN(1 SECOND)
 			callJsFunc(user, "setRef", list("\ref[src]")) //This is shit but without it, it calls the JS before the window is open and doesn't work. (Is this still true?!?!)

--- a/code/modules/telescience/telescope/quantumTelescope.dm
+++ b/code/modules/telescience/telescope/quantumTelescope.dm
@@ -22,7 +22,7 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 			rebuildEventList(using)
 
 	proc/boot_if_away()
-		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using) || !isAI(using) && !(GET_DIST(src, using) <= ((WIDE_TILE_WIDTH - 1)/ 2)))) // copied last bit from default.dm tgui code
+		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using) || (!isAI(using) && !(GET_DIST(src, using) <= ((WIDE_TILE_WIDTH - 1)/ 2))))) // copied last bit from default.dm tgui code
 			src.remove_dialog(using)
 			using.Browse(null, "window=qtelescope;override_setting=1")
 			using = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Typo ``onclose(user, "telescope", src)`` meant that anytime the window was closed, due to being closed or the individual dying, the console would remain inoperable because it wouldn't null ``using``, ever.
Added a check for if people are in view range of the console, so that Cyborgs can't interact with it from anywhere, including other Z levels. When they try to interact with the window, it'll close.
There's an annoying bug where if the Cyborg moves far away with the window open and never clicks on it, and someone else starts using the console, the Cyborg will be able to interact with the console via their window and two player the telescope. I haven't had a good time trying to fix it or force the window to close in any way that I've tried 😭 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13272, #13425, #12348, #10911
