### PR TITLE
SecHUD flag no longer shows up if target has SecHUDs

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -121,7 +121,8 @@
 				. += "<br><span class='notice'>[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(src.wear_id:ID_card)] [src.wear_id:ID_card:name] in it.</span>"
 
 	if (src.arrestIcon?.icon_state)
-		if(locate(usr) in global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount) // anyone that can see arrest status can see the flag too
+		var/mob/user = usr
+		if(locate(user) in global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount) // anyone that can see arrest status can see the flag too
 			var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
 			if(sec_record)
 				var/sechud_flag = sec_record["sec_flag"]

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -121,8 +121,7 @@
 				. += "<br><span class='notice'>[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(src.wear_id:ID_card)] [src.wear_id:ID_card:name] in it.</span>"
 
 	if (src.arrestIcon?.icon_state)
-		var/mob/user = usr
-		if(locate(user) in global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount) // anyone that can see arrest status can see the flag too
+		if(global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount[usr]) // are you in the list of people who can see arrest icons??
 			var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
 			if(sec_record)
 				var/sechud_flag = sec_record["sec_flag"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#13424 introduced a bug where if the target had SecHUDs, it would show up in examine for anyone that examined them. This fixed that by not using ``usr``, oops. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13444, sorry for introducing bug :(

