### PR TITLE
Fixes the Lockdown/Guard Command for AI eyes

### DIFF
--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -159,10 +159,13 @@
 				else
 					src.lockdown = 0
 				var/area/guardthis = input(usr, "Please type 'Here' or the name of an area. Capitalization matters!", "GuardTron 0.0.1a", "Here") as text
-				var/turf/summon_area = get_turf(src) // Can't use summon_turf, that's already used
-				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0) || (isAIeye(usr) && (summon_area.camera_coverage_emitters && length(summon_area.camera_coverage_emitters)))) // God damn AI eyes
+				var/turf/summon_area = get_turf(usr) // summon_turf is already used
+				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0) || isAIeye(usr))
 					if(guardthis == "Here")
-						guardthis = get_area(get_turf(src.master))
+						if(isAIeye(usr) && (summon_area.camera_coverage_emitters && length(summon_area.camera_coverage_emitters))) // God damn AI eyes
+							guardthis = get_area(get_turf(usr))
+						else
+							guardthis = get_area(get_turf(src.master))
 					else if(guardthis in stationAreas)
 						guardthis = stationAreas[guardthis]
 					else

--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -159,7 +159,8 @@
 				else
 					src.lockdown = 0
 				var/area/guardthis = input(usr, "Please type 'Here' or the name of an area. Capitalization matters!", "GuardTron 0.0.1a", "Here") as text
-				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0))
+				var/turf/summon_area = get_turf(src) // Can't use summon_turf, that's already used
+				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0) || (isAIeye(usr) && (summon_area.camera_coverage_emitters && length(summon_area.camera_coverage_emitters)))) // God damn AI eyes
 					if(guardthis == "Here")
 						guardthis = get_area(get_turf(src.master))
 					else if(guardthis in stationAreas)

--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -159,10 +159,10 @@
 				else
 					src.lockdown = 0
 				var/area/guardthis = input(usr, "Please type 'Here' or the name of an area. Capitalization matters!", "GuardTron 0.0.1a", "Here") as text
-				var/turf/summon_area = get_turf(usr) // summon_turf is already used
+				var/turf/summon_location = get_turf(usr) // summon_turf is already used
 				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0) || isAIeye(usr))
 					if(guardthis == "Here")
-						if(isAIeye(usr) && (summon_area.camera_coverage_emitters && length(summon_area.camera_coverage_emitters))) // God damn AI eyes
+						if(isAIeye(usr) && (summon_location.camera_coverage_emitters && length(summon_location.camera_coverage_emitters))) // God damn AI eyes
 							guardthis = get_area(get_turf(usr))
 						else
 							guardthis = get_area(get_turf(src.master))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so AI eyes can properly use the securitron app's lockdown/guard command.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4163


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)AIs can once again issue lockdown/guard orders using the securitron app while in Eye Mode.
```
