### PR TITLE
Further oshan cabling fixes

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1669,34 +1669,50 @@
 "adH" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "adI" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "adJ" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "adK" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "adL" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "adM" = (
@@ -26109,6 +26125,9 @@
 /area/station/bridge)
 "but" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "buu" = (
@@ -42370,7 +42389,6 @@
 /obj/item/aiModule/notHuman,
 /obj/item/aiModule/oneHuman,
 /obj/random_item_spawner/ai_experimental,
-/obj/cable,
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
@@ -45198,6 +45216,13 @@
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"rQU" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/bridge)
 "rUH" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
@@ -46210,6 +46235,9 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/ai_upload)
@@ -91546,7 +91574,7 @@ cjV
 bsI
 bts
 bts
-but
+rQU
 buV
 bvC
 bwj


### PR DESCRIPTION
[BUG] [MAPPING] [MINOR]
## About the PR
fixed three other bits of miscabling. At this rate, i'm going to get a reputation for being the cabling guy
![image](https://user-images.githubusercontent.com/51260013/228433479-d587aa9d-267c-48c9-becd-ab070e87112d.png)
![image](https://user-images.githubusercontent.com/51260013/228433489-ba602044-ba1a-4564-8fe3-afa87aa4fa0e.png)
the EVA cables are fixed in  #13480 , as i foolishly didn't check for further cabling errors before publishing that pr
## Why's this needed?
Grilles were not electrified, and a cable was doing nothing. Bugs are bad, squish em with hydraulic presses.