### PR TITLE
Fix AI not getting turned back on with heal

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -509,10 +509,18 @@
 
 	SEND_SIGNAL(src, COMSIG_MOB_LOGIN)
 
+	if (isliving(src)) // If someone logs in to this mob its not an NPC
+		var/mob/living/L = src
+		L.is_npc = FALSE
+
 /mob/Logout()
 
 	//logTheThing(LOG_DIARY, src, "logged out", "access") <- sometimes shits itself and has been known to out traitors. Disabling for now.
 	SEND_SIGNAL(src, COMSIG_MOB_LOGOUT)
+
+	if (isliving(src)) // If someone logs out it should be what it was before
+		var/mob/living/L = src
+		L.is_npc = initial(L.is_npc)
 
 	tgui_process?.on_logout(src)
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -509,18 +509,10 @@
 
 	SEND_SIGNAL(src, COMSIG_MOB_LOGIN)
 
-	if (isliving(src)) // If someone logs in to this mob its not an NPC
-		var/mob/living/L = src
-		L.is_npc = FALSE
-
 /mob/Logout()
 
 	//logTheThing(LOG_DIARY, src, "logged out", "access") <- sometimes shits itself and has been known to out traitors. Disabling for now.
 	SEND_SIGNAL(src, COMSIG_MOB_LOGOUT)
-
-	if (isliving(src)) // If someone logs out it should be what it was before
-		var/mob/living/L = src
-		L.is_npc = initial(L.is_npc)
 
 	tgui_process?.on_logout(src)
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -279,12 +279,12 @@
 /mob/living/Logout()
 	. = ..()
 	src.UpdateOverlays(null, "speech_bubble")
-	L.is_npc = initial(L.is_npc)
+	src.is_npc = initial(L.is_npc)
 
 
 /mob/living/Login()
 	..()
-	L.is_npc = FALSE
+	src.is_npc = FALSE
 	// If...
 	// living
 	// and not (in the afterlife, and not in hell)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -279,7 +279,7 @@
 /mob/living/Logout()
 	. = ..()
 	src.UpdateOverlays(null, "speech_bubble")
-	src.is_npc = initial(L.is_npc)
+	src.is_npc = initial(src.is_npc)
 
 
 /mob/living/Login()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -279,9 +279,12 @@
 /mob/living/Logout()
 	. = ..()
 	src.UpdateOverlays(null, "speech_bubble")
+	L.is_npc = initial(L.is_npc)
+
 
 /mob/living/Login()
 	..()
+	L.is_npc = FALSE
 	// If...
 	// living
 	// and not (in the afterlife, and not in hell)

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -115,6 +115,7 @@
 
 /mob/living/full_heal()
 	. = ..()
+	if (src.ai && src.is_npc) src.ai.enable()
 	src.remove_ailments()
 	src.change_misstep_chance(-INFINITY)
 	restore_life_processes()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes npcs not getting set back to npcs when full healed and losing AI


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI critters should reserve AI when the get healed with SR or otherwise. Tested with flockdrones and normal critters and seems to work fine.

