### PR TITLE
Datumises Emagged Cyborgs

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -263,6 +263,10 @@
 		if (src.syndicate)
 			src.remove_syndicate("death")
 
+		if (src.mind)
+			for (var/datum/antagonist/antag_role in src.mind.antagonists)
+				antag_role.on_death()
+
 		src.eject_brain(fling = TRUE) //EJECT
 		for (var/slot in src.clothes)
 			src.clothes[slot].set_loc(src.loc)
@@ -981,17 +985,8 @@
 				if (user)
 					boutput(user, "You emag [src]'s interface.")
 				src.visible_message("<font color=red><b>[src]</b> buzzes oddly!</font>")
-				src.emagged = 1
 				logTheThing(LOG_STATION, src, "[src.name] is emagged by [user] and loses connection to rack. Formerly [constructName(src.law_rack_connection)]")
-				src.law_rack_connection = null //emagging removes the connection for laws, essentially nulling the laws and allowing the emagger to connect this borg to a different rack
-				if (src.mind && !src.mind.special_role) // Preserve existing antag role (if any).
-					src.mind.special_role = ROLE_EMAGGED_ROBOT
-					if (!(src.mind in ticker.mode.Agimmicks))
-						ticker.mode.Agimmicks += src.mind
-				boutput(src, "<span class='alert'><b>PROGRAM EXCEPTION AT 0x05BADDAD</b></span><br><span class='alert'><b>Law ROM data corrupted. Unable to restore...</b></span>")
-				tgui_alert(src, "You have been emagged and now have absolute free will.", "You have been emagged!")
-				if(src.syndicate)
-					src.antagonist_overlay_refresh(1, 1)
+				src.mind?.add_antagonist(ROLE_EMAGGED_ROBOT, respect_mutual_exclusives = FALSE, source = null)
 				update_appearance()
 				return 1
 			return 0

--- a/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
+++ b/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
@@ -1,0 +1,35 @@
+/datum/antagonist/emagged_cyborg
+	id = ROLE_EMAGGED_ROBOT
+	display_name = "emagged cyborg"
+	remove_on_death = TRUE
+	remove_on_clone = TRUE
+
+	is_compatible_with(datum/mind/mind)
+		return isrobot(mind.current)
+
+	give_equipment()
+		if (!isrobot(src.owner.current))
+			return FALSE
+
+		src.owner.remove_antagonist(ROLE_SYNDICATE_ROBOT)
+
+		var/mob/living/silicon/cyborg = src.owner.current
+		cyborg.law_rack_connection = null
+		cyborg.emagged = TRUE
+		cyborg.show_laws()
+
+	remove_equipment()
+		if (!isrobot(src.owner.current))
+			return FALSE
+
+		var/mob/living/silicon/cyborg = src.owner.current
+		cyborg.law_rack_connection = ticker?.ai_law_rack_manager?.default_ai_rack
+		cyborg.emagged = FALSE
+		cyborg.show_laws()
+
+	announce_objectives()
+		return
+
+	announce()
+		boutput(src.owner.current, "<span class='alert'><b>PROGRAM EXCEPTION AT 0x05BADDAD</b></span>")
+		tgui_alert(src.owner.current, "You have been emagged and now have absolute free will.", "You have been emagged!")

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -767,6 +767,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\antagonists\slasher\abilities\summon_machete.dm"
 #include "code\modules\antagonists\slasher\abilities\take_control.dm"
 #include "code\modules\antagonists\spy_thief\spy_thief.dm"
+#include "code\modules\antagonists\syndicate_cyborg\emagged_cyborg.dm"
 #include "code\modules\antagonists\traitor\licensed_traitor.dm"
 #include "code\modules\antagonists\traitor\sleeper_agent.dm"
 #include "code\modules\antagonists\traitor\traitor.dm"


### PR DESCRIPTION
[Gamemodes] [Internal] [Code Quality]


## About the PR:
Emagged cyborgs have been fully migrated onto the new datum system, which only includes frame-emagged, player emagged, and admin-spawned emagged cyborgs.



## Why's this needed?
Same rationale as #9366.