### PR TITLE
[APRIL FOOLS] Random Oceans on Oshan and Nadir

### DIFF
--- a/code/datums/controllers/process/fluid_spawner.dm
+++ b/code/datums/controllers/process/fluid_spawner.dm
@@ -47,6 +47,39 @@ var/global/obj/fluid/ocean_fluid_obj = null
 		schedule_interval = 5 SECONDS
 
 		src.processing_fluid_turfs = global.processing_fluid_turfs
+		// wacky reagent randomization here: taken from oceanization admin verb and ice cream (thanks)
+#ifdef UNDERWATER_MAP
+		message_admins("Ocean shenanigans now begin.")
+
+		//ocean_fluid_obj?.group?.reagents?.clear_reagents() // idk???
+
+		var/chosenReagent = null
+		if (all_functional_reagent_ids.len > 1)
+			chosenReagent = pick(all_functional_reagent_ids)
+		else
+			message_admins("Wait, this isn't supposed to happen. The functional reagents list is empty! Defaulting to water. Call coders pls")
+			chosenReagent = "water"
+		ocean_reagent_id = chosenReagent
+		var/datum/reagents/R = new /datum/reagents(100)
+		R.add_reagent(chosenReagent, 100)
+
+		var/master_reagent_name = R.get_master_reagent_name()
+		if(master_reagent_name == "water")
+			ocean_name = "ocean floor" //normal ocean
+		else
+			ocean_name = master_reagent_name + " ocean floor"
+
+		ocean_color = R.get_average_color().to_rgb()
+		qdel(R)
+		message_admins("Replacing...")
+		for(var/turf/space/fluid/S in world)
+			if (S.z != 1 || istype(S, /turf/space/fluid/warp_z5)) continue
+			var/turf/orig = locate(S.x, S.y, S.z)
+			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
+			T.name = ocean_name
+			T.color = ocean_color
+		message_admins("Ocean is now set to [reagent_id_to_name(chosenReagent)] ([chosenReagent]), good luck!!")
+#endif
 
 		SPAWN(20 SECONDS)
 			if (total_clients() >= OSHAN_LIGHT_OVERLOAD)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE]
# TESTMERGE THIS: IT IS AN APRIL FOOLS JOKE!
I'm a bit early but it's 1 am rn so after i sleep everyone else will be in with *their* jokes so might as well do it now and be the first to be jolly and jesting like a silly old fool.
i am sooo shaking with anxiety rn. hopefully this is good enough to make it in. i'm terrified.
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Underwater maps (Oshan & Nadir) get their ocean turned into a random reagent at roundstart. 
The pool taken from is `all_functional_reagent_ids` which is the same one used by random ice cream.
That's it. There's nothing else to it. It just randomizes the ocean.
It's told to admins when it's done, so if something very problematic pops up, it can be oceanify'd into something else.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
**April Fools!** Silly little individual prank that'll make some laughs.
Fun fact: when i first tested this, the ocean happened to roll vampire serum LOL