### PR TITLE
Add a security hangar beacon on Cogmap 1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -65979,6 +65979,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"xXO" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon{
+	name = "Security Beacon"
+	},
+/turf/space,
+/area/space)
 "xXP" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
@@ -90859,7 +90869,7 @@ adC
 adC
 adC
 aam
-aap
+aaq
 aaq
 aaq
 aaq
@@ -91161,7 +91171,7 @@ adC
 adC
 adC
 adC
-aii
+adC
 adC
 adC
 adC
@@ -91463,7 +91473,7 @@ adC
 adC
 adC
 adC
-aah
+xXO
 adC
 adC
 adC


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a security hangar beacon for Security on Cogmap 1


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's frustrating every time that you need to go to the Security hangar you need to go to the public hangar beacon instead, when Security has a built in hangar


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(+)Added a warp beacon for the Cogmap 1 security hangar.
```
