### PR TITLE
Prevent breaching charges from activating on handheld objects

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1189,7 +1189,7 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (user.equipped() == src)
 			if (!src.armed)
-				if (istype(target, /obj/item/storage)) // no blowing yourself up if you have full backpack
+				if (!src.check_placeable_target(target))
 					return
 				if (user.bioHolder && user.bioHolder.HasEffect("clumsy"))
 					boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
@@ -1273,6 +1273,13 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 		qdel(src)
 		return
 
+	proc/check_placeable_target(atom/A)
+		if (!istype(A, /obj/item))
+			return TRUE
+		if (istype(A, /obj/item/storage))// no blowing yourself up if you have full backpack
+			return FALSE
+		return A.density
+
 /obj/item/breaching_charge/NT
 	name = "NanoTrasen Experimental EDF-7 Breaching Charge"
 	expl_devas = 0
@@ -1295,7 +1302,7 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (user.equipped() == src)
 			if (!src.armed)
-				if (istype(target, /obj/item/storage)) // no blowing yourself up if you have full backpack
+				if (!src.check_placeable_target(target))
 					return
 				if (user.bioHolder && user.bioHolder.HasEffect("clumsy"))
 					boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1276,7 +1276,7 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 	proc/check_placeable_target(atom/A)
 		if (!istype(A, /obj/item))
 			return TRUE
-		if (istype(A, /obj/item/storage))// no blowing yourself up if you have full backpack
+		if (istype(A, /obj/item/storage)) // no blowing yourself up if you have full backpack
 			return FALSE
 		return A.density
 

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1780,7 +1780,7 @@ TYPEINFO(/obj/item/mining_tool/drill)
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (user.equipped() == src)
 			if (!src.armed)
-				if (istype(target, /obj/item/storage)) // no blowing yourself up if you have full backpack
+				if (!src.check_placeable_target(target))
 					return
 				if(user.bioHolder.HasEffect("clumsy") || src.emagged)
 					if(src.emagged)


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents breaching charges from being activated when clicking an object that can be handheld with them, unless it has density for any reason.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes it's easy to misclick an item, ex. an item on the rack that breaching charges are found on, and have a breaching charge go off when you didn't want that to happen.