### PR TITLE
Material scrap and shard fixes

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -503,8 +503,8 @@
 	New()
 		..()
 		icon_state += "[rand(1,5)]"
-	steel
-		material_name = "Steel"
+/obj/item/raw_material/scrap_metal/steel
+	material_name = "Steel"
 
 /obj/item/raw_material/shard
 	// same deal here

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -498,12 +498,11 @@
 	stack_type = /obj/item/raw_material/scrap_metal
 	burn_possible = 0
 	set_name = TRUE
+	material_name = "Steel"
 
 	New()
 		..()
 		icon_state += "[rand(1,5)]"
-		if(!src.material)
-			src.setMaterial(getMaterial("steel"))
 	steel
 		material_name = "Steel"
 
@@ -531,6 +530,7 @@
 	burn_possible = 0
 	event_handler_flags = USE_FLUID_ENTER
 	material_amt = 0.1
+	material_name = "Glass"
 	set_name = TRUE
 	var/sound_stepped = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
 
@@ -538,8 +538,6 @@
 		..()
 		icon_state += "[rand(1,3)]"
 		src.setItemSpecial(/datum/item_special/double)
-		if(!src.material)
-			src.setMaterial(getMaterial("glass"))
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
 		if(!scalpel_surgery(M,user)) return ..()

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -546,7 +546,9 @@
 		else return
 
 	Crossed(atom/movable/AM as mob|obj)
-		walked_over(AM) // check if we need to hurt they feeties
+		if(ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			walked_over(H) // check if we need to hurt they feeties
 		..()
 
 	custom_suicide = 1

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -547,8 +547,7 @@
 
 	Crossed(atom/movable/AM as mob|obj)
 		if(ishuman(AM))
-			var/mob/living/carbon/human/H = AM
-			walked_over(H) // check if we need to hurt they feeties
+			walked_over(AM) // check if we need to hurt they feeties
 		..()
 
 	custom_suicide = 1

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -543,24 +543,7 @@
 		else return
 
 	Crossed(atom/movable/AM as mob|obj)
-		if(ishuman(AM))
-			var/mob/living/carbon/human/H = AM
-			if(ON_COOLDOWN(H, "shard_Crossed", 7 SECONDS) || H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
-				return
-			if(isabomination(H))
-				return
-			if(H.lying)
-				boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
-				step_on(H)
-			else
-				//Can't step on stuff if you have no legs, and it can't hurt if they're protected or not human parts.
-				if (H.mutantrace?.can_walk_on_shards)
-					return
-				if (!istype(H.limbs?.l_leg, /obj/item/parts/human_parts) && !istype(H.limbs?.r_leg, /obj/item/parts/human_parts))
-					return
-				if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 7))
-					boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
-					step_on(H)
+		walked_over(AM) // check if we need to hurt they feeties
 		..()
 
 	custom_suicide = 1
@@ -580,6 +563,24 @@
 		material_name = "Glass"
 	plasmacrystal
 		material_name = "Plasmaglass"
+
+/obj/item/raw_material/shard/proc/walked_over(mob/living/carbon/human/H as mob)
+	if(ON_COOLDOWN(H, "shard_Crossed", 7 SECONDS) || H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
+		return
+	if(isabomination(H))
+		return
+	if(H.lying)
+		boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
+		step_on(H)
+	else
+		//Can't step on stuff if you have no legs, and it can't hurt if they're protected or not human parts.
+		if (H.mutantrace?.can_walk_on_shards)
+			return
+		if (!istype(H.limbs?.l_leg, /obj/item/parts/human_parts) && !istype(H.limbs?.r_leg, /obj/item/parts/human_parts))
+			return
+		if(!H.shoes || (src.material && src.material.hasProperty("hard") && src.material.getProperty("hard") >= 7))
+			boutput(H, "<span class='alert'><B>You step on [src]! Ouch!</B></span>")
+			step_on(H)
 
 /obj/item/raw_material/shard/proc/step_on(mob/living/carbon/human/H as mob)
 	playsound(src.loc, src.sound_stepped, 50, 1)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -33,7 +33,8 @@
 
 	_update_stack_appearance()
 		if(material)
-			name = "[amount] [initial(src.name)][amount > 1 ? "s":""]"
+			UpdateName(src) // get the name in order so it has whatever it needs
+			name = "[amount] [src.name][amount > 1 ? "s":""]"
 		return
 
 	attackby(obj/item/W, mob/user)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -495,13 +495,15 @@
 	desc = "Some twisted and ruined metal. It could probably be smelted down into something more useful."
 	icon_state = "scrap"
 	burn_possible = 0
+	set_name = TRUE
 
 	New()
 		..()
 		icon_state += "[rand(1,5)]"
-
-/obj/item/raw_material/scrap_metal/steel
-	material_name = "Steel"
+		if(!src.material)
+			src.setMaterial(getMaterial("steel"))
+	steel
+		material_name = "Steel"
 
 /obj/item/raw_material/shard
 	// same deal here
@@ -533,6 +535,8 @@
 		..()
 		icon_state += "[rand(1,3)]"
 		src.setItemSpecial(/datum/item_special/double)
+		if(!src.material)
+			src.setMaterial(getMaterial("glass"))
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
 		if(!scalpel_surgery(M,user)) return ..()

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -37,7 +37,7 @@
 		return
 
 	attackby(obj/item/W, mob/user)
-		if(W.type == src.type)
+		if(check_valid_stack(W))
 			stack_item(W)
 			if(!user.is_in_hands(src))
 				user.put_in_hand(src)
@@ -494,6 +494,7 @@
 	name = "scrap"
 	desc = "Some twisted and ruined metal. It could probably be smelted down into something more useful."
 	icon_state = "scrap"
+	stack_type = /obj/item/raw_material/scrap_metal
 	burn_possible = 0
 	set_name = TRUE
 
@@ -512,6 +513,7 @@
 	icon_state = "shard"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "shard-glass"
+	stack_type = /obj/item/raw_material/shard
 	flags = TABLEPASS | FPRINT
 	object_flags = NO_GHOSTCRITTER
 	tool_flags = TOOL_CUTTING

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -503,6 +503,7 @@
 	New()
 		..()
 		icon_state += "[rand(1,5)]"
+
 /obj/item/raw_material/scrap_metal/steel
 	material_name = "Steel"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A few changes to make shards and scrap metal work more intuitively and cause less issues.

``/obj/item/raw_material/scrap_metal`` and ``/obj/item/raw_material/shard`` now apply a default material just in case there isn't a material at all. Yeah I know they're parent objects but I figured this is probably better than going through every single instance of the parent objects in every map and code file and applying a material. 
_This should prevent scraps and shards without a material existing and causing issues._

``/obj/item/raw_material/shard/Crossed`` code has been moved into its own proc ``walked_over`` to avoid early returns skipping the parent Crossed proc from running. _Walking over glass shards with a ore scoop will now actually pick them up instead of early returning all the time! Salvagers can actually break the solars and walk over with an ore scoop and collect all the shards, amazing!_

``/obj/item/raw_material/scrap_metal`` and ``/obj/item/raw_material/shard`` now have a stacktype, so any subtypes will attempt to stack using ``check_valid_stack`` and if they're the same material and everything checks out, they'll stack! 
_So it doesn't matter if its the subtype or parent type with a material applied, they'll stack, It Just Works™_

Changed ``_update_stack_appearance`` to call ``UpdateName`` before changing the item name. ``UpdateName`` handles all cases I've tested just fine and makes sure the material prefix in place.
_This should prevent stacking things to just change to (amount) (item) and skipping material prefix. Stacking a bunch of glass shards will now give you 20 glass shards instead of 20 shards._


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13467 and #13413, makes them a whole lot less jank and weird. They're still kind of weird, but vastly better now!
