### PR TITLE
E-Gun component can now fire again

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2948,8 +2948,7 @@
 		return
 
 	fire(var/datum/mechanicsMessage/input)
-		if(charging || level == 2) return
-		if(ON_COOLDOWN(src, SEND_COOLDOWN_ID, src.cooldown_time)) return
+		if(charging) return
 		return ..()
 
 	update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
E-Gun component never calls parent proc to actually fire the gun. This fixes that. I assume its because duplicate cooldown checks somehow broke it, but I just debugged and remove code until it worked. 😎 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13487, woo energy gun traps
