### PR TITLE
Makes monster burgers take much longer to eat

### DIFF
--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -471,8 +471,8 @@
 	name = "THE MONSTER"
 	desc = "There are no words to describe the sheer unhealthiness of this abomination."
 	icon_state = "giantburger"
-	bites_left = 1
-	heal_amt = 50
+	bites_left = 20
+	heal_amt = 3
 	throwforce = 10
 	initial_volume = 330
 	initial_reagents = list("cholesterol"=200)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [CATERING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the amount of bites it takes to eat a monster burger from 1 to 20. Also changes the heal_amt to compensate.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is meant to be a sister pr to #13538


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)MONSTER burgers now take about 20 bites to eat.
```
