### PR TITLE
Revolution Members And Subordiate Antagonists Will No Longer Clutter The Text Window

### DIFF
--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -199,9 +199,11 @@ ABSTRACT_TYPE(/datum/antagonist)
 			. += "<b>[owner.current]</b> (played by <b>[owner.displayed_key]</b>) was \a [assigned_by + display_name]!"
 		else
 			. += "<b>[owner.displayed_key]</b> (character destroyed) was \a [assigned_by + display_name]!"
-		if (length(src.objectives))
+		if (length(owner.objectives))
 			var/obj_count = 1
-			for (var/datum/objective/objective as anything in src.objectives)
+			for (var/datum/objective/objective as anything in owner.objectives)
+				if (istype(objective, /datum/objective/crew))
+					continue
 				if (objective.check_completion())
 					. += "<b>Objective #[obj_count]:</b> [objective.explanation_text] <span class='success'><b>Success!</b></span>"
 					if (log_data)
@@ -215,7 +217,7 @@ ABSTRACT_TYPE(/datum/antagonist)
 				obj_count++
 		if (src.check_success())
 			. += "<span class='success'><b>\The [src.display_name] has succeeded!</b></span>"
-			if (log_data)
+			if (log_data && length(src.objectives))
 				owner.current.unlock_medal("MISSION COMPLETE", TRUE)
 				if (!isnull(success_medal))
 					owner.current.unlock_medal(success_medal, TRUE)

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -199,11 +199,9 @@ ABSTRACT_TYPE(/datum/antagonist)
 			. += "<b>[owner.current]</b> (played by <b>[owner.displayed_key]</b>) was \a [assigned_by + display_name]!"
 		else
 			. += "<b>[owner.displayed_key]</b> (character destroyed) was \a [assigned_by + display_name]!"
-		if (length(owner.objectives))
+		if (length(src.objectives))
 			var/obj_count = 1
-			for (var/datum/objective/objective as anything in owner.objectives)
-				if (istype(objective, /datum/objective/crew))
-					continue
+			for (var/datum/objective/objective as anything in src.objectives)
 				if (objective.check_completion())
 					. += "<b>Objective #[obj_count]:</b> [objective.explanation_text] <span class='success'><b>Success!</b></span>"
 					if (log_data)

--- a/code/modules/antagonists/__subordinate_antagonist.dm
+++ b/code/modules/antagonists/__subordinate_antagonist.dm
@@ -1,6 +1,7 @@
 ABSTRACT_TYPE(/datum/antagonist/subordinate)
 /datum/antagonist/subordinate
 	mutually_exclusive = FALSE
+	display_at_round_end = FALSE
 	/// The mind of this antagonist's master, leader, and so forth.
 	var/datum/mind/master
 

--- a/code/modules/antagonists/revolutionary/revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/revolutionary.dm
@@ -1,6 +1,7 @@
 /datum/antagonist/revolutionary
 	id = ROLE_REVOLUTIONARY
 	display_name = "revolutionary"
+	display_at_round_end = FALSE
 
 	New()
 		. = ..()


### PR DESCRIPTION
[UI] [QoL]


## About the PR:
Revolutionaries and subordinate antagonists will no longer be displayed at the end of the round in the text window. They will still be displayed in the TGUI end of round credits.
Additionally fixes antagonists without objectives checking their objectives.



## Why's this needed?
Changeling hivemind members, thralls, and the myriad revolutionaries created within a round need not disarrange the end of round statistics readouts of major antagonists.