### PR TITLE
Prevents Non-antags from Mindhacking Players

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -711,9 +711,9 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				return 0
 		// all the stuff in here was added by Convair880, I just adjusted it to work with this can_implant() proc thing - haine
 		var/mob/living/carbon/human/H = target
-		if (!H.mind || !H.client)
-			if (ismob(user)) user.show_text("[H] is braindead!", "red")
-			return 0
+		//if (!H.mind || !H.client) // TODO: REMOVE BEFORE PRING
+		//	if (ismob(user)) user.show_text("[H] is braindead!", "red")
+		//	return 0
 		if (src.uses <= 0)
 			if (ismob(user)) user.show_text("[src] has been used up!", "red")
 			return 0
@@ -1463,7 +1463,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			boutput(user, "<span class='alert'>You are too far away from [M]!</span>")
 			return
 
-		if(!user.mind.antagonists && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
+		if(get_all_antagonists(!user) && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
 			boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
 			return
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1462,11 +1462,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if(!in_interact_range(M, user))
 			boutput(user, "<span class='alert'>You are too far away from [M]!</span>")
 			return
-
-		for(var/datum/mind/U in ticker.minds)
-			if(!U.special_role && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
-				boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
-				return
+		var/datum/mind/U = user.mind
+		if(!U.special_role && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
+			boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
+			return
 
 		if (sneaky)
 			boutput(user, "<span class='alert'>You implanted the implant into [M].</span>")

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -711,9 +711,9 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				return 0
 		// all the stuff in here was added by Convair880, I just adjusted it to work with this can_implant() proc thing - haine
 		var/mob/living/carbon/human/H = target
-		//if (!H.mind || !H.client) // TODO: REMOVE BEFORE PRING
-		//	if (ismob(user)) user.show_text("[H] is braindead!", "red")
-		//	return 0
+		if (!H.mind || !H.client)
+			if (ismob(user)) user.show_text("[H] is braindead!", "red")
+			return 0
 		if (src.uses <= 0)
 			if (ismob(user)) user.show_text("[src] has been used up!", "red")
 			return 0

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1463,9 +1463,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			boutput(user, "<span class='alert'>You are too far away from [M]!</span>")
 			return
 
-		if(get_all_antagonists(!user) && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
-			boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
-			return
+		for(var/datum/mind/U in ticker.minds)
+			if(!U.special_role && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
+				boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
+				return
 
 		if (sneaky)
 			boutput(user, "<span class='alert'>You implanted the implant into [M].</span>")

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1463,6 +1463,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			boutput(user, "<span class='alert'>You are too far away from [M]!</span>")
 			return
 
+		if(!user.mind.antagonists && (istype(src.imp, /obj/item/implanter/mindhack) || istype(src.imp, /obj/item/implanter/super_mindhack))) // prevents (mostly) crew from using mindhacks against antags, considering it's functionally a de-antager in the hands of crew.
+			boutput(user, "<span class='alert'>Your conscious prevents you from using this implant!</span>")
+			return
+
 		if (sneaky)
 			boutput(user, "<span class='alert'>You implanted the implant into [M].</span>")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [INPUT WANTED] [GAME OBJECT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr changes mindhack implants so that they can't be implanted into someone as a non-antag. Note: This is really hard to test on local, so let me know if this either breaks something, or doesn't work.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Crew, especially sec, having the ability to de-antag someone with the click of a mouse is really bad, cause at least with executing them they have the chance to roll a mid-round antag. This also stops things such as shutting down a shambler by mindhacking as sec and telling the shambler to crusher themselves.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Mindhack implants can now only be implanted by antagonists
```
