### PR TITLE
Nadir AI hardware adjustments

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -3441,16 +3441,6 @@
 /area/station/quartermaster/cargobay{
 	name = "Cargo Primary Endpoint"
 	})
-"bxP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "byf" = (
 /obj/decal/tile_edge{
 	icon = 'icons/obj/decals/stencils.dmi';
@@ -10525,19 +10515,6 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
-"eIz" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/black/grime,
-/area/station/hallway/secondary/construction{
-	name = "The Warrens"
-	})
 "eIK" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -10609,18 +10586,6 @@
 /turf/simulated/floor/engine/caution/north,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
-	})
-"eLp" = (
-/obj/random_item_spawner/junk/some,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/hallway/secondary/construction{
-	name = "The Warrens"
 	})
 "eLE" = (
 /obj/machinery/drainage,
@@ -14603,13 +14568,6 @@
 "gwB" = (
 /obj/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -21357,18 +21315,6 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
-"joN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/black/grime,
-/area/station/maintenance/storage{
-	icon_state = "crewquarters";
-	name = "Warrens Hall"
-	})
 "joW" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -25830,6 +25776,19 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
+"lfY" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "lgg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28211,6 +28170,13 @@
 "mfc" = (
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/storage{
@@ -84254,7 +84220,7 @@ ugi
 wWe
 dqY
 nQY
-bxP
+vKn
 vKn
 lyg
 cNf
@@ -104513,7 +104479,7 @@ erp
 lcu
 bSC
 hQo
-joN
+erp
 eRD
 uJB
 eRD
@@ -106921,7 +106887,7 @@ gYR
 gYR
 gYR
 gYR
-eIz
+txY
 qlx
 pRb
 pRb
@@ -108654,11 +108620,11 @@ mIG
 mIG
 mIG
 gFY
-pSO
-pSO
 avC
 pSO
 pSO
+pSO
+avC
 aDn
 mIG
 nYt
@@ -109897,7 +109863,7 @@ iww
 qxv
 xnE
 cHd
-eIK
+lfY
 oZp
 hXx
 oZp
@@ -112356,7 +112322,7 @@ ksc
 niC
 giN
 lFx
-eLp
+itp
 cBV
 cBV
 neB

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1771,6 +1771,19 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"aQc" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/machinery/power/apc/autoname_north/nopoweralert,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "aQs" = (
 /obj/machinery/door_control{
 	id = "cargogaming";
@@ -19027,18 +19040,6 @@
 /turf/simulated/floor/black,
 /area/station/medical/research{
 	name = "Genetic Research"
-	})
-"ilj" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north/nopoweralert,
-/turf/simulated/floor/black/grime,
-/area/station/hallway/secondary/construction{
-	name = "The Warrens"
 	})
 "ilO" = (
 /obj/machinery/drainage,
@@ -109000,8 +109001,8 @@ eGi
 hET
 pCL
 kRh
-pTT
-giN
+aQc
+aef
 kRh
 tkJ
 ayE
@@ -111114,8 +111115,8 @@ dsv
 qmH
 ppQ
 kRh
-ilj
-aef
+niC
+giN
 ntr
 cBV
 cBV


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts Nadir's AI upload turrets a bit to not have them blast the AI when its shutters are open and turrets are on lethal mode. Also reduces camera coverage in a few maintenance areas around the station, most notably the Warrens, and relocates the Warrens APC to remain within camera coverage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13011. Reduces camera coverage to facilitate crime gaming.
