### PR TITLE
Laying down, throwing and dropping items will now interrupt actionbars

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2420,6 +2420,7 @@
 /mob/proc/throw_item(atom/target, list/params)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOB_THROW_ITEM, target, params)
+	actions.interrupt(src, INTERRUPT_ACT)
 
 /mob/throw_impact(atom/hit, datum/thrown_thing/thr)
 	if (thr.throw_type & THROW_PEEL_SLIP)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1267,6 +1267,7 @@
 	if (!W) //only pass W if you KNOW that the mob has it
 		W = src.equipped()
 	if (istype(W))
+		actions.interrupt(src, INTERRUPT_ACT)
 		var/obj/item/magtractor/origW
 		if (W.useInnerItem && W.contents.len > 0)
 			if (istype(W, /obj/item/magtractor))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1455,6 +1455,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		src.lying_old = src.lying
 		src.animate_lying(src.lying)
 		src.p_class = initial(src.p_class) + src.lying // 2 while standing, 3 while lying
+		actions.interrupt(src, INTERRUPT_ACT) // interrupt actions
 
 /mob/living/proc/animate_lying(lying)
 	animate_rest(src, !lying)

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -540,6 +540,8 @@
 		if (L)
 			L.Process()
 
+		actions.interrupt(src, INTERRUPT_ACT)
+
 		if (src.client)
 			updateOverlaysClient(src.client)
 		if (length(src.observers))

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -540,8 +540,6 @@
 		if (L)
 			L.Process()
 
-		actions.interrupt(src, INTERRUPT_ACT)
-
 		if (src.client)
 			updateOverlaysClient(src.client)
 		if (length(src.observers))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added a few interrupt calls for ``INTERRUPT_ACT``.
One under ``throw_item``, one under ``drop_item`` and one under ``force_laydown_standup``.
Anything that has that flag will now be interrupted by items being thrown, dropped, the user resting and even the user being disarmed. I've tested most actions and it makes sense for them to be interrupted. 
Might impact semiconductor actionbar with materials that cause dropping, but I've confirmed it to be possible to install it locally anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9345. Prevents some really nonsensical behavior that shouldn't be possible.

[6e5ddf321f[1].webm](https://user-images.githubusercontent.com/111906440/229681809-f7410176-2edc-4117-a172-81fdc585d0bd.webm)

[2023-04-04_04-28-45.webm](https://user-images.githubusercontent.com/111906440/229681882-2d776e37-1125-4718-9528-862c5ede8d56.webm)

