### PR TITLE
The selection of nukie commanders prioritizes those who have won nukie rounds previously

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -178,13 +178,12 @@
 
 /datum/game_mode/nuclear/proc/pick_leader()
 	RETURN_TYPE(/datum/mind)
-	var/list/datum/mind/possible_medal_leaders = list()
 	var/list/datum/mind/possible_leaders = list()
 	for(var/datum/mind/mind in syndicates)
 		if(mind.current.client.preferences.be_syndicate_commander && mind.current.has_medal("Manhattan Project"))
-			possible_medal_leaders += mind
-	if(length(possible_medal_leaders))
-		return pick(possible_medal_leaders)
+			possible_leaders += mind
+	if(length(possible_leaders))
+		return pick(possible_leaders)
 	else
 		for(var/datum/mind/mind in syndicates)
 			if(mind.current.client.preferences.be_syndicate_commander)

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -178,10 +178,17 @@
 
 /datum/game_mode/nuclear/proc/pick_leader()
 	RETURN_TYPE(/datum/mind)
+	var/list/datum/mind/possible_medal_leaders = list()
 	var/list/datum/mind/possible_leaders = list()
 	for(var/datum/mind/mind in syndicates)
-		if(mind.current.client.preferences.be_syndicate_commander)
-			possible_leaders += mind
+		if(mind.current.client.preferences.be_syndicate_commander && mind.current.has_medal("Manhattan Project"))
+			possible_medal_leaders += mind
+	if(length(possible_medal_leaders))
+		return pick(possible_medal_leaders)
+	else
+		for(var/datum/mind/mind in syndicates)
+			if(mind.current.client.preferences.be_syndicate_commander)
+				possible_leaders += mind
 	if(length(possible_leaders))
 		return pick(possible_leaders)
 	return pick(syndicates)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr changes the way nukie commander is rolled. If someone has won a former nukie round and has syndicate commander ticked, they will be put onto a list to where commanders could be pulled from. If that list is empty, the game will then make a list of anyone with syndicate commander ticked, if that list is still empty the game will pull from any nukie.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This helps to ensure that nuclear commanders have a baseline of knowledge regarding nuclear rounds. This should mean that nukie commanders are on average more qualified to lead nukies.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)The game will priotize selecting those who have previously won nuclear rounds as nukies to be nuclear commander
```
