### PR TITLE
Vampires no longer take starlight damage from fluid "space" turfs

### DIFF
--- a/code/mob/living/life/disability.dm
+++ b/code/mob/living/life/disability.dm
@@ -20,13 +20,22 @@
 			owner.dizziness = max(0, owner.dizziness - 2*mult)
 			owner.jitteriness = max(0, owner.jitteriness - 2*mult)
 
+		// Vampire damage from holy sources in area
 		if (owner.mind && isvampire(owner) || isvampiricthrall(owner))
+			// Holy ground damage (inflicted in chapel)
 			if (istype(get_area(owner), /area/station/chapel) && owner.check_vampire_power(3) != 1 && !(owner.job == "Chaplain"))
 				if (prob(33))
 					boutput(owner, "<span class='alert'>The holy ground burns you!</span>")
 				owner.TakeDamage("chest", 0, 5 * mult, 0, DAMAGE_BURN)
 				owner.change_vampire_blood(-5 * mult)
-			if (owner.loc && istype(owner.loc, /turf/space) || (istype(owner.loc, /obj/dummy/spell_batpoof) && istype(get_turf(owner.loc), /turf/space)))
+
+			// Starlight damage (inflicted on non-fluid space turfs)
+			var/turf/vamp_location
+			if (istype(owner.loc, /obj/dummy/spell_batpoof))
+				vamp_location = get_turf(owner.loc)
+			else
+				vamp_location = owner.loc
+			if (istype(vamp_location,/turf/space) && !istype(vamp_location,/turf/space/fluid))
 				if (prob(33))
 					boutput(owner, "<span class='alert'>The starlight burns you!</span>")
 				owner.TakeDamage("chest", 0, 2.5 * mult, 0, DAMAGE_BURN)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts vampires' starlight damage check on /turf/space variants to not apply in the case of /turf/space/fluid variants. Also improved comments in the surroundings a bit.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes vampires not take space-based damage from what isn't space; the sunlight that still pierces through is arguably starlight, but at low enough intensity that it shouldn't be of significant harm.

Gameplay-wise, this is most relevant to vampires on Nadir, as secluded spaces are relatively hard to come by and this will significantly improve their freedom of movement.

Opted for a major changelog entry at time of posting since it significantly influences the gameplay possibilities of an antagonist, if circumstantially.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Vampires no longer take starlight damage from fluid "space" turfs.
```
