### PR TITLE
Fix molitz beta and enable it to work in reactor components

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -372,41 +372,51 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 /datum/materialProc/molitz_temp
 	max_generations = 1
 	execute(var/atom/owner, var/temp, var/agent_b=FALSE)
-		if(!istype(owner.material, /datum/material/crystal/molitz))
-			return
+		if(temp < 500) return //less than reaction temp
+
 		var/datum/material/crystal/molitz/molitz = owner.material
-		var/turf/target = get_turf(owner)
+		if(!istype(molitz)) CRASH("Molitz_temp material proc applied to non-molitz thing") //somehow applied to non-molitz
+
 		if(molitz.iterations <= 0) return
+
+		var/datum/gas_mixture/air
+		if(hasvar(owner, "air_contents"))
+			air = owner:air_contents
+		if(!air && hasvar(owner.loc, "air_contents"))
+			air = owner.loc:air_contents
+		if(!air)
+			var/turf/target = get_turf(owner)
+			air = target?.return_air()
+
+		if(!air) return //all air finding has failed, so stop
+
+		//okay, now we've passed all the conditions for gas generation - do that
 		if(ON_COOLDOWN(owner, "molitz_gas_generate", 30 SECONDS)) return
 
-		var/datum/gas_mixture/air = target?.return_air()
-		if(!air) return
-
 		var/datum/gas_mixture/payload = new /datum/gas_mixture
-		payload.temperature = T20C
-		payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 
-		if(agent_b && air.temperature > 500 && air.toxins > MINIMUM_REACT_QUANTITY )
+		if(agent_b && air.toxins > MINIMUM_REACT_QUANTITY)
 			var/datum/gas/oxygen_agent_b/trace_gas = payload.get_or_add_trace_gas_by_type(/datum/gas/oxygen_agent_b)
-			payload.temperature = T0C
+			trace_gas.moles += 0.18 * owner.material_amt //set payload's trace_gas datum
+			payload.oxygen = 15 * owner.material_amt
+			payload.temperature = T0C //reduced temp is supposeed to represent endothermic reaction
+			air.merge(payload) //add it to the target air
 
+			//sparkles
 			animate_flash_color_fill_inherit(owner,"#ff0000",4, 2 SECONDS)
 			playsound(owner, 'sound/effects/leakagentb.ogg', 50, 1, 8)
 			if(!particleMaster.CheckSystemExists(/datum/particleSystem/sparklesagentb, owner))
 				particleMaster.SpawnSystem(new /datum/particleSystem/sparklesagentb(owner))
-			trace_gas.moles += 0.18 * owner.material_amt
-			molitz.iterations -= 1
-			payload.oxygen = 15 * owner.material_amt
-
-			target.assume_air(payload)
-		else
+		else //no plasma present, or this is just normal molitz - you get just plain oxygen
+			payload.oxygen = 80 * owner.material_amt
+			payload.temperature = temp
+			air.merge(payload) //add it to the target air
+			//blue sparkles
 			animate_flash_color_fill_inherit(owner,"#0000FF",4, 2 SECONDS)
 			playsound(owner, 'sound/effects/leakoxygen.ogg', 50, 1, 5)
-			payload.oxygen = 80 * owner.material_amt
-			molitz.iterations -= 1
 
-			target.assume_air(payload)
 
+		molitz.iterations -= 1
 
 
 /datum/materialProc/molitz_temp/agent_b

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -382,17 +382,17 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/datum/gas_mixture/air
 		if(hasvar(owner, "air_contents"))
 			air = owner:air_contents
-		if(!air && hasvar(owner.loc, "air_contents"))
+		if(!istype(air) && hasvar(owner.loc, "air_contents"))
 			air = owner.loc:air_contents
-		if(!air)
+		if(!istype(air))
 			var/turf/target = get_turf(owner)
 			air = target?.return_air()
 
-		if(!air) return //all air finding has failed, so stop
+		if(!istype(air)) return //all air finding has failed, so stop
 
-		//okay, now we've passed all the conditions for gas generation - do that
 		if(ON_COOLDOWN(owner, "molitz_gas_generate", 30 SECONDS)) return
 
+		//okay, now we've passed all the conditions for gas generation - do that
 		var/datum/gas_mixture/payload = new /datum/gas_mixture
 
 		if(agent_b && air.toxins > MINIMUM_REACT_QUANTITY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Molitz beta was a little broken, basically off-gassing whenever `tempTrigger()` was called and only producing oxy b if temperature was above 500K and plasma was present, otherwise producing oxygen if temp was too low or plasma wasn't present.

Now it only off-gasses if temperature is above 500K, and only produces oxy b in the presence of plasma, otherwise it produces oxygen. A subtle but important difference.

Also, if the molitz is inside something that can contain air, the resultant gas is produced inside the thing - notably this enables the use of molitz components in the nuclear reactor to output gas directly into the cooling loop.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using the nuclear reactor to harvest oxy b sounds badass.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Fixed a minor bug with molitz beta, and enabled it to produce gas inside the nuclear reactor (and other things)
```
