### PR TITLE
Cogmap1 cargo bay belt hell / conveyor niceties

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -24441,7 +24441,7 @@
 /area/station/routing/depot)
 "boP" = (
 /obj/machinery/mass_driver{
-	drive_range = 50;
+	drive_range = 15;
 	id = "qm_in"
 	},
 /turf/simulated/floor/plating,
@@ -24468,7 +24468,7 @@
 /area/station/maintenance/east)
 "boW" = (
 /obj/machinery/mass_driver{
-	drive_range = 50;
+	drive_range = 15;
 	id = "qm_in"
 	},
 /obj/machinery/door/poddoor/pyro{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -30817,7 +30817,8 @@
 "bIK" = (
 /obj/machinery/conveyor_switch{
 	id = "qmin";
-	layer = 4
+	layer = 4;
+	last_pos = 1
 	},
 /obj/machinery/door_control{
 	id = "cargodock_in";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the range on two belt-hell mass-drivers that launch into the cargo bay to land at the entryway, instead of across the room.

Changes the last set direction on the market intake conveyor belt.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
[QOL] fixes for cog1 cargo :)

The mass-drive change should stop people from being sideswiped within cargo by people using station routing as intended. If the intake backs up (and it has a higher chance of doing so with this change) the crates/artifacts/etc. will still fling across cargo.

From round start you only need to use the market intake switch once to get the conveyor moving in the correct direction, like most other cargo conveyors across all maps.