### PR TITLE
Fix mimics having invisible ghosts and nametags

### DIFF
--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -1,7 +1,8 @@
 /mob/living/critter/mimic
-	name = "mechanical toolbox"
+	name = "Mimic"
 	desc = null
-	icon_state = null
+	icon = 'icons/misc/critter.dmi'
+	icon_state = "mimicface"
 	is_npc = TRUE
 	ai_type = /datum/aiHolder/mimic
 	can_lie = FALSE
@@ -65,12 +66,17 @@
 		src.appearance = src.disguise
 		src.overlay_refs = target.overlay_refs?.Copy() //this is necessary to preserve overlay management metadata
 		src.is_hiding = TRUE
+		qdel(src.name_tag)
+		src.name_tag = null
 		src.UpdateIcon()
 
 
 	proc/stop_hiding()
 		if(src.is_hiding)
 			src.is_hiding = FALSE
+			src.name_tag = new()
+			src.update_name_tag()
+			src.vis_contents += src.name_tag
 			src.UpdateIcon()
 			src.visible_message("[src] suddenly opens eyes that weren't there and sprouts teeth!")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes mimics have visible ghosts and hides their nametag while they're disguised.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sneaky mimics. Too sneaky when dead.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Mimic nametags are now invisible when they're disguised.
```
