### PR TITLE
Cyborg cells no longer disappear on death

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -278,6 +278,12 @@
 			var/turf/T = get_turf(src)
 			for(var/obj/item/parts/robot_parts/R in src.contents)
 				R.set_loc(T)
+				if (istype(R, /obj/item/parts/robot_parts/chest))
+					var/obj/item/parts/robot_parts/chest/chest = R
+					chest.wires = 1
+					if (src.cell)
+						chest.cell = src.cell
+
 			var/obj/item/parts/robot_parts/robot_frame/frame =  new(T)
 			frame.emagged = is_emagged
 			frame.syndicate = is_syndicate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SILICONS] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The chest dropped by cyborgs upon death will now contain it's cell and a piece of wire. If the chest was destroyed, the cell will be lost too.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the cell will disappear if a roboticist removes the cyborg's head. This does not make sense and is annoying and confusing. I think this behavior is a bug.