### PR TITLE
Fix 8688 - AIs getting disconnected when accessing the same shell/cyborg

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -82,10 +82,17 @@ datum/mind
 				message_admins("Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to qdel'd mob [new_character] (\ref[new_character]) God damnit. Un-qdeling the mob and praying (this will probably fuck up).")
 				new_character.disposed = 0
 			else
-				message_admins("Tried to transfer mind [src] (\ref[src]) to qdel'd mob [new_character] (\ref[new_character]) FIX THIS SHIT")
+				message_admins("Tried to transfer mind [src] to qdel'd mob [new_character].")
 
-			Z_LOG_ERROR("Mind/TransferTo", "Trying to transfer to a mob that's in the delete queue! Jesus fucking christ.")
+			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to qdel'd mob [new_character] (\ref[new_character]).")
+			return
 			//CRASH("Trying to transfer to a mob that's in the delete queue!")
+
+		if (new_character.client)
+			boutput(current, "You were about to be transferred into another body, but that body was occupied!")
+			message_admins("Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to mob with an existing client [new_character] (\ref[new_character])")
+			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind of mob [current] [key_name(current)]) to mob with an existing client [new_character] [key_name(new_character)])")
+			return
 
 		if (current)
 			if(current.client)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -82,16 +82,19 @@ datum/mind
 				message_admins("Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to qdel'd mob [new_character] (\ref[new_character]) God damnit. Un-qdeling the mob and praying (this will probably fuck up).")
 				new_character.disposed = 0
 			else
-				message_admins("Tried to transfer mind [src] to qdel'd mob [new_character].")
+				message_admins("Tried to transfer mind [src] to qdel'd mob [new_character] (\ref[new_character]).")
 
-			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to qdel'd mob [new_character] (\ref[new_character]).")
+			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind [(current ? "of mob " + key_name(current) : src)] to qdel'd mob [new_character].")
 			return
 			//CRASH("Trying to transfer to a mob that's in the delete queue!")
 
 		if (new_character.client)
-			boutput(current, "You were about to be transferred into another body, but that body was occupied!")
-			message_admins("Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to mob with an existing client [new_character] (\ref[new_character])")
-			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind of mob [current] [key_name(current)]) to mob with an existing client [new_character] [key_name(new_character)])")
+			if (current)
+				boutput(current, "You were about to be transferred into another body, but that body was occupied!")
+				message_admins("Tried to transfer mind of mob [current] (\ref[current], [key_name(current)]) to mob with an existing client [new_character] (\ref[new_character])")
+			else
+				message_admins("Tried to transfer mind [src] to mob with an existing client [new_character] (\ref[new_character]).")
+			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind [(current ? "of mob " + key_name(current) : src)] to mob with an existing client [new_character] [key_name(new_character)])")
 			return
 
 		if (current)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8688
Adds more detail to the logging 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If multiple AIs exist it is relatively easy for them to deploy to the same shell/cyborg and crash due to lack of checks on transfer_to(). Presumably this would be crashing in any situation where this occurred.

I have no idea if this check is going to cause issues, if we don't clean client vars effectively it could prevent mind transfers that previously worked.
