### PR TITLE
corpses in reclaimers no longer produce miasma

### DIFF
--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -30,7 +30,7 @@
 			if (H.decomp_stage >= DECOMP_STAGE_SKELETONIZED)
 				return ..()
 
-			if (!(suspend_rot || istype(owner.loc, /obj/item/body_bag) || (istype(owner.loc, /obj/storage) && owner.loc:welded) || istype(owner.loc, /obj/statue)))
+			if (!(suspend_rot || istype(owner.loc, /obj/item/body_bag) || (istype(owner.loc, /obj/storage) && owner.loc:welded) || istype(owner.loc, /obj/statue) || istype(owner.loc, /obj/machinery/clonegrinder)))
 				icky_icky_miasma(T)
 
 			var/env_temp = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [QOL][MEDICAL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rotting corpses inside of the enzymatic reclaimer no longer produce miasma.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The cloner should not be filled with miasma because people keep forgetting to turn the reclaimer on.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ZWRh3
(+) Corpses inside enzymatic reclaimers do not produce miasma.
```
