### PR TITLE
Add clearer instructions to the nuclear reactor coolers

### DIFF
--- a/code/modules/atmospherics/machinery/unary/freezer.dm
+++ b/code/modules/atmospherics/machinery/unary/freezer.dm
@@ -17,6 +17,12 @@
 		current_temperature = 150
 		on = 1
 
+	emergency
+		name = "emergency cooler"
+		current_temperature = 73.15
+		desc = "Emergency cooling for the reactor. Only for use in meltdown scenarios."
+
+
 	New()
 		..()
 		pipe_direction = src.dir

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -560,3 +560,9 @@ all for the love of you.</tt>"}
 	desc = "A guide to designing and operating nuclear reactors. Should idiots be doing that?"
 	icon_state = "nuclearguide"
 	file_path = "strings/books/nuclear_engineering.txt"
+
+/obj/item/paper/emergencycooler
+	name = "Emergency Cooler Instructions"
+	info = {"<h3>These coolers are for emergency use only</h3></br>
+			In the event of a meltdown scenario, activate the coolers and ensure the gas loop is pressurised.<br>
+			Use of these coolers outside of an emergency scenario will result in a loss of reactor efficiency and stalling of the turbine."}

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -26792,7 +26792,8 @@
 /obj/decal/poster/wallsign/no_smoking{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/obj/machinery/atmospherics/unary/cold_sink/freezer/emergency,
+/obj/item/paper/emergencycooler,
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "chJ" = (
@@ -40617,7 +40618,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/obj/machinery/atmospherics/unary/cold_sink/freezer/emergency,
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "qih" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -40790,7 +40790,8 @@
 /turf/simulated/floor/black,
 /area/pasiphae)
 "scP" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/obj/machinery/atmospherics/unary/cold_sink/freezer/emergency,
+/obj/item/paper/emergencycooler,
 /turf/simulated/floor/engine/caution/east,
 /area/station/engine/core/nuclear)
 "scW" = (
@@ -43988,7 +43989,7 @@
 	},
 /area/station/medical/medbay/lobby)
 "ttQ" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer,
+/obj/machinery/atmospherics/unary/cold_sink/freezer/emergency,
 /turf/simulated/floor/engine/caution/west,
 /area/station/engine/core/nuclear)
 "ttW" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a subtype of the cooler with the name and description of "emergency cooling", adds a note to nadir and clarion on top of the coolers which indicates that using them outside of an emergency is wrong.

![image](https://user-images.githubusercontent.com/3855802/230791200-dbd12720-5fd8-4bde-9edc-9164d3ff2531.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It causes me physical pain every time I see someone wondering why the turbine won't spin as they cool the gas to -100C before putting it into the reactor. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Adds clearer signage to the emergency coolers for the nuclear reactor. They are for emergencies only. You should not use them in normal operation.
```
