### PR TITLE
cleans up some bite code fixes some stuff with it

### DIFF
--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -72,7 +72,7 @@
 
 	return TRUE
 
-/datum/abilityHolder/vampire/proc/do_bite(var/mob/living/carbon/human/HH, var/mult = 1, var/thrall = 0)
+/datum/abilityHolder/vampire/proc/do_bite(var/mob/living/carbon/human/HH, var/mult = 1)
 	.= 1
 	var/mob/living/carbon/human/M = src.owner
 	var/datum/abilityHolder/vampire/H = src
@@ -82,7 +82,7 @@
 		boutput(M, "<span class='alert'>This human is completely void of blood... Wow!</span>")
 		return 0
 
-	if (HH.decomp_stage > DECOMP_STAGE_NO_ROT && thrall || isdead(HH) && !thrall)
+	if (isdead(HH))
 		if (prob(20))
 			boutput(M, "<span class='alert'>The blood of the [thrall ? "rotten" : "dead"] provides little sustenance...</span>")
 
@@ -133,26 +133,24 @@
 				HH.blood_volume = 0
 			else
 				HH.blood_volume -= 20 * mult
-			//vampires heal, thralls don't
-			if (!thrall)
-				if(istype(M))
-					M.HealDamage("All", 3, 3)
-					M.take_toxin_damage(-1)
-					M.take_oxygen_deprivation(-1)
 
-				if (mult >= 1) //mult is only 1 or greater during a pointblank true suck
-					if (HH.blood_volume < 300 && prob(15))
-						if (!HH.getStatusDuration("paralysis"))
-							boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
-						HH.changeStatus("paralysis", 10 SECONDS)
-					else
-						if (prob(65))
-							HH.changeStatus("weakened", 1 SECOND)
-							HH.stuttering = min(HH.stuttering + 3, 10)
+			//vampires heal, thralls don't
+			M.HealDamage("All", 3, 3)
+			M.take_toxin_damage(-1)
+			M.take_oxygen_deprivation(-1)
+			if (mult >= 1 && !ischangeling(HH)) //mult is only 1 or greater during a pointblank true suck
+				if (HH.blood_volume < 300 && prob(15))
+					if (!HH.getStatusDuration("paralysis"))
+						boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
+					HH.changeStatus("paralysis", 10 SECONDS)
+				else
+					if (prob(65))
+						HH.changeStatus("weakened", 1 SECOND)
+						HH.stuttering = min(HH.stuttering + 3, 10)
 
 			if (istype(H)) H.blood_tracking_output()
 
-	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90))
+	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90) && !ischangeling(HH))
 		HH.death(FALSE)
 
 	if (istype(H))
@@ -236,7 +234,7 @@
 
 	return 1
 
-/datum/abilityHolder/vampiric_thrall/proc/do_bite(var/mob/living/carbon/human/HH, var/mult = 1, var/thrall = 0)
+/datum/abilityHolder/vampiric_thrall/proc/do_bite(var/mob/living/carbon/human/HH, var/mult = 1)
 	.= 1
 	var/mob/living/carbon/human/M = src.owner
 	var/datum/abilityHolder/vampiric_thrall/H = src
@@ -246,9 +244,9 @@
 		boutput(M, "<span class='alert'>This human is completely void of blood... Wow!</span>")
 		return 0
 
-	if (isdead(HH))
+	if (HH.decomp_stage > DECOMP_STAGE_NO_ROT)
 		if (prob(20))
-			boutput(M, "<span class='alert'>The blood of the dead provides little sustenance...</span>")
+			boutput(M, "<span class='alert'>The blood of the rotten provides little sustenance...</span>")
 
 		var/bitesize = 5 * mult
 		M.change_vampire_blood(bitesize, 1)
@@ -293,23 +291,17 @@
 				HH.blood_volume = 0
 			else
 				HH.blood_volume -= 20 * mult
-			//vampires heal, thralls don't
-			if (!thrall)
-				M.HealDamage("All", 3, 3)
-				M.take_toxin_damage(-1)
-				M.take_oxygen_deprivation(-1)
+			if (mult >= 1 && !ischangeling(HH)) //mult is only 1 or greater during a pointblank true suck
+				if (HH.blood_volume < 300 && prob(15))
+					if (!HH.getStatusDuration("paralysis"))
+						boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
+					HH.changeStatus("paralysis", 10 SECONDS)
+				else
+					if (prob(65))
+						HH.changeStatus("weakened", 1 SECOND)
+						HH.stuttering = min(HH.stuttering + 3, 10)
 
-				if (mult >= 1) //mult is only 1 or greater during a pointblank true suck
-					if (HH.blood_volume < 300 && prob(15))
-						if (!HH.getStatusDuration("paralysis"))
-							boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
-						HH.changeStatus("paralysis", 10 SECONDS)
-					else
-						if (prob(65))
-							HH.changeStatus("weakened", 1 SECOND)
-							HH.stuttering = min(HH.stuttering + 3, 10)
-
-	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90))
+	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90) && !ischangeling(HH))
 		HH.death(FALSE)
 
 	eat_twitch(src.owner)
@@ -366,7 +358,6 @@
 
 /datum/targetable/vampire/vampire_bite/thrall
 	thrall = 1
-
 
 /datum/action/bar/private/icon/vamp_blood_suc
 	duration = 30

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -423,7 +423,7 @@
 			src.end()
 			return
 
-		if (!H.do_bite(HH,mult = 1.5, thrall = B.thrall))
+		if (!H.do_bite(HH,mult = 1.5))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			src.end()

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -138,7 +138,7 @@
 			M.HealDamage("All", 3, 3)
 			M.take_toxin_damage(-1)
 			M.take_oxygen_deprivation(-1)
-			if (mult >= 1 && !ischangeling(HH)) //mult is only 1 or greater during a pointblank true suck
+			if (mult >= 1) //mult is only 1 or greater during a pointblank true suck
 				if (HH.blood_volume < 300 && prob(15))
 					if (!HH.getStatusDuration("paralysis"))
 						boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
@@ -150,7 +150,8 @@
 
 			if (istype(H)) H.blood_tracking_output()
 
-	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90) && !ischangeling(HH))
+	if (!can_take_blood_from(HH) && (mult >= 1) && isunconscious(HH))
+		boutput(HH, "<span class='alert'>You feel your soul slipping away...</span>")
 		HH.death(FALSE)
 
 	if (istype(H))
@@ -291,7 +292,7 @@
 				HH.blood_volume = 0
 			else
 				HH.blood_volume -= 20 * mult
-			if (mult >= 1 && !ischangeling(HH)) //mult is only 1 or greater during a pointblank true suck
+			if (mult >= 1) //mult is only 1 or greater during a pointblank true suck
 				if (HH.blood_volume < 300 && prob(15))
 					if (!HH.getStatusDuration("paralysis"))
 						boutput(HH, "<span class='alert'>Your vision fades to blackness.</span>")
@@ -301,7 +302,8 @@
 						HH.changeStatus("weakened", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
 
-	if (!can_take_blood_from(HH) && (mult >= 1) && (isunconscious(HH) || HH.health <= 90) && !ischangeling(HH))
+	if (!can_take_blood_from(HH) && (mult >= 1) && isunconscious(HH))
+		boutput(HH, "<span class='alert'>You feel your soul slipping away...</span>")
 		HH.death(FALSE)
 
 	eat_twitch(src.owner)
@@ -313,16 +315,15 @@
 	name = "Bite Victim"
 	desc = "Bite the victim's neck to drain them of blood."
 	icon_state = "bite"
-	targeted = 1
-	target_nodamage_check = 1
+	targeted = TRUE
+	target_nodamage_check = TRUE
 	max_range = 1
 	cooldown = 0
 	pointCost = 0
-	when_stunned = 0
-	not_when_handcuffed = 1
+	when_stunned = FALSE
+	not_when_handcuffed = TRUE
 	lock_holder = FALSE
 	restricted_area_check = ABILITY_AREA_CHECK_VR_ONLY
-	var/thrall = 0
 
 	cast(mob/target)
 		if (!holder)
@@ -355,9 +356,6 @@
 		actions.start(new/datum/action/bar/private/icon/vamp_blood_suc(M,H,HH,src), M)
 
 		return 0
-
-/datum/targetable/vampire/vampire_bite/thrall
-	thrall = 1
 
 /datum/action/bar/private/icon/vamp_blood_suc
 	duration = 30

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -324,6 +324,7 @@
 	not_when_handcuffed = TRUE
 	lock_holder = FALSE
 	restricted_area_check = ABILITY_AREA_CHECK_VR_ONLY
+	var/thrall = FALSE
 
 	cast(mob/target)
 		if (!holder)
@@ -356,6 +357,9 @@
 		actions.start(new/datum/action/bar/private/icon/vamp_blood_suc(M,H,HH,src), M)
 
 		return 0
+
+/datum/targetable/vampire/vampire_bite/thrall
+	thrall = TRUE
 
 /datum/action/bar/private/icon/vamp_blood_suc
 	duration = 30

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -84,7 +84,7 @@
 
 	if (isdead(HH))
 		if (prob(20))
-			boutput(M, "<span class='alert'>The blood of the [thrall ? "rotten" : "dead"] provides little sustenance...</span>")
+			boutput(M, "<span class='alert'>The blood of the dead provides little sustenance...</span>")
 
 		var/bitesize = 5 * mult
 		H.change_vampire_blood(bitesize, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes thrall checks and such since thrall and vampire bites have their own procs.
prevents changelings from getting stunned / killed from bite.
makes the change to thrall blood and decomp work again.

gives a lil buff to thrall suck letting it stun like the vampire one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad useless code bad

