### PR TITLE
Allow rev flash to convert through sunglasses

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -424,9 +424,9 @@ TYPEINFO(/obj/item/device/flash/turbo)
 		return
 
 	attack(mob/living/M, mob/user)
-		flash_mob(M, user, 1)
+		flash_mob(M, user)
 
-	flash_mob(mob/living/M as mob, mob/user as mob, var/convert = 1)
+	flash_mob(mob/living/M as mob, mob/user as mob)
 		if (user.mind && !(user.mind.get_antagonist(ROLE_HEAD_REVOLUTIONARY)))
 			..()
 			return

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -434,7 +434,6 @@ TYPEINFO(/obj/item/device/flash/turbo)
 			user.show_text("[src] refuses to flash!", "red")
 			return
 		else
-			message_admins("is a head rev smile")
 			playsound(src, 'sound/weapons/rev_flash_startup.ogg', 30, 1 , 0, 0.6)
 			var/convert_result = convert(M,user)
 			if (convert_result == REV_FLASH_IMPLANT)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows revolutionary flash to convert (NOT BLIND) through eye protection.
Refactors some of the rev flash code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Head revolutionaries would attempt to convert normal crew without being aware of sunglasses or miss them due to gas masks.
I do not feel there is much gameplay reason to almost randomly have crew members who were immune, either due to looting the map glasses or starting with a trinket.
Key jobs are already protected from conversion and are unaffected.

I could not identify any reason for convert(M,user) to exist in the parent level flash_mob().
Took more advantage of calling the flash_mob() parent to handle things instead of doing it elsewhere.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(*)Revolutionary flash can now convert through eye protection. This does not change the blinding behavior.
```
