### PR TITLE
Allows for placing cable coils on catwalks.

### DIFF
--- a/code/obj/item/cable_coil.dm
+++ b/code/obj/item/cable_coil.dm
@@ -191,6 +191,14 @@ obj/item/cable_coil/dropped(mob/user)
 		if (!C.d1 && C.d2 != ignore_dir)
 			return C
 
+/obj/item/cable_coil/proc/check_for_catwalk_in_turf(var/turf/T)
+	for(var/obj/grille/catwalk/catwalk in T)
+		if (!catwalk) continue
+		if (!istype(catwalk, /obj/grille/catwalk/)) continue
+		return TRUE
+
+	return FALSE
+
 /obj/item/cable_coil/move_callback(var/mob/living/M, var/turf/target, var/direction, var/turf/source)
 	if (!istype(M))
 		return
@@ -257,11 +265,11 @@ obj/item/cable_coil/dropped(mob/user)
 
 // Placing a cable on a turf
 /obj/item/cable_coil/proc/turf_place(turf/target, turf/source, mob/user)
-	if (target.intact)		// if floor is intact, complain
+	if (target.intact && !check_for_catwalk_in_turf(target))	// if floor is intact, complain, unless it's on a catwalk
 		return
-	if (!(istype(target,/turf/simulated/floor) || istype(target,/turf/space/fluid)))
+	if (!(istype(target,/turf/simulated/floor) || istype(target,/turf/space/fluid) || check_for_catwalk_in_turf(target)))
 		return
-	if (!(istype(source,/turf/simulated/floor) || istype(source,/turf/space/fluid)))
+	if (!(istype(source,/turf/simulated/floor) || istype(source,/turf/space/fluid) || check_for_catwalk_in_turf(source)))
 		return
 	if (GET_DIST(target, source) > 1)
 		boutput(user, "You can't lay cable at a place that far away.")
@@ -285,7 +293,7 @@ obj/item/cable_coil/dropped(mob/user)
 // called when cable_coil is clicked on an installed obj/cable or auto-laying found a stub to connect to
 /obj/item/cable_coil/proc/cable_join(obj/cable/C, turf/source, mob/user, attempt_at_source)
 	var/turf/target = C.loc
-	if (!isturf(target) || target.intact)		// sanity checks, also stop use interacting with T-scanner revealed cable
+	if (!isturf(target) || (target.intact && !check_for_catwalk_in_turf(target)))		// sanity checks, also stop use interacting with T-scanner revealed cable
 		return
 	if (GET_DIST(C, user) > 1)		// make sure it's close enough
 		boutput(user, "You can't lay cable at a place that far away.")
@@ -301,7 +309,7 @@ obj/item/cable_coil/dropped(mob/user)
 	//Okay so this code branch tries to connect C on the turf you're standing on, for when you slap an obj/cable by hand
 	//Auto-laying cable doesn't need it because that attempts to put a cable on both turfs anyway
 	if (attempt_at_source && (C.d1 == dirn || C.d2 == dirn))		// one end of the clicked cable is pointing towards us
-		if (source.intact)						// can't place a cable if the floor is complete
+		if (source.intact && !check_for_catwalk_in_turf(source))						// can't place a cable if the floor is complete
 			boutput(user, "You can't lay cable there unless the floor tiles are removed.")
 			return
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title says it all. You can now place cable coils on catwalks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

To make solars repairs actually possible, and because I'm gonna make a PR making catwalks buildable very, very soon.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Caio029
(+)Cable coils can now be placed on catwalks.
```
