### PR TITLE
more power plz

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -301,7 +301,7 @@
 			//thermal conductivity
 			var/k = calculateHeatTransferCoefficient(null,src.material)
 			//surface area in thermal contact (m^2)
-			var/A = 10
+			var/A = 10 * (MACHINE_PROC_INTERVAL*8) //multipied by process time to approximate flow rate
 
 			var/thermal_e = THERMAL_ENERGY(current_gas)
 

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -40,7 +40,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	/// How much gas this component can hold, and will be processed per tick
 	var/gas_volume = 0
 	/// Thermal mass. Basically how much energy it takes to heat this up 1Kelvin
-	var/thermal_mass = 420*25//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
+	var/thermal_mass = 420*250//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
 
 
 	New(material_name="steel")
@@ -120,8 +120,8 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			var/k = calculateHeatTransferCoefficient(RC.material,src.material)
 			//surface area in thermal contact (m^2)
 			var/A = min(src.thermal_cross_section,RC.thermal_cross_section)
-			src.temperature = src.temperature - (k * A * 1/src.thermal_mass)*deltaT
-			RC.temperature = RC.temperature - (k * A * 1/RC.thermal_mass)*-deltaT
+			src.temperature = src.temperature - (k * A * (MACHINE_PROC_INTERVAL*8)/src.thermal_mass)*deltaT //8 because machines are ticked when % 8 == 0
+			RC.temperature = RC.temperature - (k * A * (MACHINE_PROC_INTERVAL*8)/RC.thermal_mass)*-deltaT
 
 			if(RC.temperature < 0 || src.temperature < 0)
 				CRASH("TEMP WENT NEGATIVE")
@@ -133,8 +133,8 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			var/deltaT = src.temperature - holder.temperature
 			var/k = calculateHeatTransferCoefficient(holder.material,src.material)
 			var/A = src.thermal_cross_section
-			src.temperature = src.temperature - (k * A * 1/src.thermal_mass)*deltaT
-			holder.temperature = holder.temperature - (k * A * 1/holder.thermal_mass)*-deltaT
+			src.temperature = src.temperature - (k * A * (MACHINE_PROC_INTERVAL*8)/src.thermal_mass)*deltaT
+			holder.temperature = holder.temperature - (k * A * (MACHINE_PROC_INTERVAL*8)/holder.thermal_mass)*-deltaT
 			if(holder.temperature < 0 || src.temperature < 0)
 				CRASH("TEMP WENT NEGATIVE")
 
@@ -233,7 +233,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	icon_state_cap = "fuel_cap"
 	neutron_cross_section = 1.0
 	thermal_cross_section = 10
-	thermal_mass = 420*100//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
+	thermal_mass = 420*1000//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
 
 	extra_info()
 		. = ..()
@@ -287,7 +287,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	var/gas_thermal_cross_section = 15
 	var/datum/gas_mixture/air_contents
 	gas_volume = 100
-	thermal_mass = 420*5//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
+	thermal_mass = 420*50//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
 
 	melt()
 		..()
@@ -312,7 +312,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			//thermal conductivity
 			var/k = calculateHeatTransferCoefficient(null,src.material)
 			//surface area in thermal contact (m^2)
-			var/A = src.gas_thermal_cross_section
+			var/A = src.gas_thermal_cross_section * (MACHINE_PROC_INTERVAL*8) //multipied by process time to approximate flow rate
 
 			var/thermal_e = THERMAL_ENERGY(air_contents)
 			//okay, we're slightly abusing some things here. Notably we're using the thermal conductivity as a stand-in


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buffs nuclear reactor power to bring it more in line with other generators.
The basic default setup now outputs about 5MW. Replacing the three cerenkite rods with plutonium boosts that to ~15MW. While melting down, the reactor produces about 1GJ of thermal energy which would work out to about 800MW.

Essentially it works out as:
- Basic setup: 5MW
- Advance setup: 20-50MW
- Ludicrous setup: 100-1000MW

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
@TobleroneSwordfish is trying to balance the PTL


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Nuclear reactor power output has been buffed.
```
