### PR TITLE
LogTheThing calls cleanup and bad arg fixes

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -139,7 +139,7 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 		// technically not disposing but it really should be here for feature parity
 		SEND_SIGNAL(src, COMSIG_PARENT_PRE_DISPOSING)
 	catch(var/exception/E)
-		logTheThing("debug", src, "caught [E] in /client/Del() signal stuff.")
+		logTheThing(LOG_DEBUG, src, "caught [E] in /client/Del() signal stuff.")
 
 	src.mob?.move_dir = 0
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -540,7 +540,7 @@ var/list/special_pa_observing_verbs = list(
 */
 /client/proc/update_admins(var/rank)
 	if(src.player.tempmin && src.player.perm_admin)
-		logTheThing("debug", src, null, "is somehow both tempminned and permadminned. This is a bug.")
+		logTheThing(LOG_DEBUG, src, "is somehow both tempminned and permadminned. This is a bug.")
 		stack_trace("[src] is somehow both tempminned and permadminned. This is a bug.")
 
 	// The idea is that player.tempmin and player.perm_admin are set when the given player

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -64,7 +64,7 @@
 		var/obj/whitehole/whitehole = new (T, grow_duration, duration, source_location, TRUE)
 		whitehole.activity_modifier = activity_modifier
 		message_admins("White Hole anomaly with origin [whitehole.source_location] spawning in [log_loc(T)]")
-		logTheThing("admin", usr, null, "Spawned a white hole anomaly with origin [whitehole.source_location] at [log_loc(T)]")
+		logTheThing(LOG_ADMIN, usr, "Spawned a white hole anomaly with origin [whitehole.source_location] at [log_loc(T)]")
 
 
 /obj/whitehole

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -720,7 +720,7 @@ proc/compare_ornament_score(list/a, list/b)
 						empty_index = i
 						break
 				src.place_ornament(ornament, empty_index || rand(1, length(src.placed_ornaments)))
-				logTheThing("station", user, null, "placed an ornament with name '[ornament.name]' on the Spacemas tree.")
+				logTheThing(LOG_STATION, user, "placed an ornament with name '[ornament.name]' on the Spacemas tree.")
 				boutput(user, "<span class='notice'>You hang \the [ornament.name] on the tree.</span>")
 				LAZYLISTADD(src.ckeys_placed_this_round, user.ckey)
 		else
@@ -1404,7 +1404,7 @@ proc/get_spacemas_ornaments(only_if_loaded=FALSE)
 				if(tgui_alert(usr, "Are you sure you want to remove \the [src] not only from the tree but also from the ornament database?", "Remove ornament", list("Yes", "No")) != "Yes")
 					return
 				get_spacemas_ornaments().Remove(src.name)
-				logTheThing("admin", usr, null, "Removed ornament '[src.name]' from the tree and the ornament database.")
+				logTheThing(LOG_ADMIN, usr, "Removed ornament '[src.name]' from the tree and the ornament database.")
 				qdel(src)
 				boutput(usr, "<span class='alert'>You removed \the [src] from the tree and the ornament database.</span>")
 			return

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -225,25 +225,25 @@
 			if(!src.GetParticles("overheat_smoke"))
 				src.UpdateParticles(new/particles/nuke_overheat_smoke(get_turf(src)),"overheat_smoke")
 				src.visible_message("<span class='alert'><b>The [src] begins to smoke!</b></span>")
-				logTheThing("station", src, "[src] is at [temperature]K and may meltdown")
+				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and may meltdown")
 				if(!ON_COOLDOWN(src, "pda_temp_alert", 30 SECONDS)) //prevent spam when it's on the edge
 					src.alertPDA("ALERT: [src] has reached a dangerous temperature. Intervene immediately to prevent meltdown.")
 			if(temperature >= REACTOR_ON_FIRE_TEMP && !src.GetParticles("overheat_fire"))
 				src.UpdateParticles(new/particles/nuke_overheat_fire(get_turf(src)),"overheat_fire")
 				src.visible_message("<span class='alert'><b>The [src] begins to burn!</b></span>")
-				logTheThing("station", src, "[src] is at [temperature]K and is likely to meltdown")
+				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and is likely to meltdown")
 				if(!ON_COOLDOWN(src, "pda_temp_alert_critical", 30 SECONDS)) //prevent spam when it's on the edge
 					src.alertPDA("ALERT: [src] has reached CRITICAL temperature. MELTDOWN IMMINENT.", crisis = TRUE)
 			else if(temperature < REACTOR_ON_FIRE_TEMP && src.GetParticles("overheat_fire"))
 				src.visible_message("<span class='alert'><b>The [src] stops burning.</b></span>")
-				logTheThing("station", src, "[src] is cooling from 2500K")
+				logTheThing(LOG_STATION, src, "[src] is cooling from 2500K")
 				src.ClearSpecificParticles("overheat_fire")
 				if(!ON_COOLDOWN(src, "pda_temp_alert_critical", 30 SECONDS)) //prevent spam when it's on the edge
 					src.alertPDA("ALERT: [src] has cooled below critical temperature. Meltdown averted. Have a nice day.", crisis = TRUE)
 		else
 			if(src.GetParticles("overheat_smoke"))
 				src.visible_message("<span class='alert'><b>The [src] stops smoking.</b></span>")
-				logTheThing("station", src, "[src] is cooling from [temperature]K")
+				logTheThing(LOG_STATION, src, "[src] is cooling from [temperature]K")
 				src.ClearSpecificParticles("overheat_smoke")
 				if(!ON_COOLDOWN(src, "pda_temp_alert", 30 SECONDS)) //prevent spam when it's on the edge
 					src.alertPDA("ALERT: [src] has cooled below dangerous temperature. Have a nice day.")
@@ -347,7 +347,7 @@
 		world << alarm //ew
 		command_alert("A nuclear reactor aboard the station has catastrophically overloaded. Radioactive debris, nuclear fallout, and coolant fires are likely. Immediate evacuation of the surrounding area is strongly advised.", "NUCLEAR MELTDOWN")
 
-		logTheThing("station", src, "[src] CATASTROPHICALLY OVERLOADS (this is bad)")
+		logTheThing(LOG_STATION, src, "[src] CATASTROPHICALLY OVERLOADS (this is bad)")
 		//explode, throw radioactive components everywhere, dump rad gas, throw radioactive debris everywhere
 		src.melted = TRUE
 		if(!src.current_gas)
@@ -502,7 +502,7 @@
 		user.u_equip(equipped)
 		equipped.set_loc(src)
 		playsound(src, 'sound/machines/law_insert.ogg', 80)
-		logTheThing("station", user, "[constructName(user)] <b>inserts</b> component into nuclear reactor([src]): [equipped] at slot [x],[y]")
+		logTheThing(LOG_STATION, user, "[constructName(user)] <b>inserts</b> component into nuclear reactor([src]): [equipped] at slot [x],[y]")
 		user.visible_message("<span class='alert'>[user] slides \a [equipped] into the reactor</span>", "<span class='alert'>You slide the [equipped] into the reactor.</span>")
 		tgui_process.update_uis(src)
 		_comp_grid_overlay_update = TRUE
@@ -510,7 +510,7 @@
 
 	proc/remove_comp_callback(var/x,var/y,var/mob/user)
 		playsound(src, 'sound/machines/law_remove.ogg', 80)
-		logTheThing("station", user, "[constructName(user)] <b>removes</b> component from nuclear reactor([src]): [src.component_grid[x][y]] at slot [x],[y]")
+		logTheThing(LOG_STATION, user, "[constructName(user)] <b>removes</b> component from nuclear reactor([src]): [src.component_grid[x][y]] at slot [x],[y]")
 		user.visible_message("<span class='alert'>[user] slides \a [src.component_grid[x][y]] out of the reactor</span>", "<span class='alert'>You slide the [src.component_grid[x][y]] out of the reactor.</span>")
 		user.put_in_hand_or_drop(src.component_grid[x][y])
 		src.component_grid[x][y] = null
@@ -540,14 +540,14 @@
 				comp_throw_prob = 25
 			if(1.0)
 				comp_throw_prob = 100
-				logTheThing("station", src, "[src] has been destroyed in an explosion!")
+				logTheThing(LOG_STATION, src, "[src] has been destroyed in an explosion!")
 
 		var/turf/epicentre = get_turf(src)
 		for(var/x=1 to REACTOR_GRID_WIDTH)
 			for(var/y=1 to REACTOR_GRID_HEIGHT)
 				if(src.component_grid[x][y] && prob(comp_throw_prob))
 					if(severity > 1)
-						logTheThing("station", src, "a [src.component_grid[x][y]] has been removed from the [src] by an explosion")
+						logTheThing(LOG_STATION, src, "a [src.component_grid[x][y]] has been removed from the [src] by an explosion")
 						_comp_grid_overlay_update = TRUE
 					if(prob(50))
 						var/obj/item/reactor_component/throwcomp = src.component_grid[x][y]

--- a/code/obj/nuclearreactor/reactorcontrol.dm
+++ b/code/obj/nuclearreactor/reactorcontrol.dm
@@ -95,11 +95,11 @@
 			if("loadChange")
 				var/x = params["newVal"]
 				src.turbine_handle.stator_load = min(max(x,1),10e30)
-				logTheThing("station", src, null, "[src.turbine_handle] stator load configured to [x] by [ui.user]")
+				logTheThing(LOG_STATION, src, "[src.turbine_handle] stator load configured to [x] by [ui.user]")
 			if("volChange")
 				var/x = params["newVal"]
 				src.turbine_handle.flow_rate = min(max(x,1),10e5)
-				logTheThing("station", src, null, "[src.turbine_handle] flow rate configured to [x] by [ui.user]")
+				logTheThing(LOG_STATION, src, "[src.turbine_handle] flow rate configured to [x] by [ui.user]")
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -180,7 +180,7 @@
 
 		switch(action)
 			if("adjustCR")
-				logTheThing("station", src, null, "[src.reactor_handle] control rod insertion configured to [params["crvalue"]]% by [ui.user]")
+				logTheThing(LOG_STATION, src, "[src.reactor_handle] control rod insertion configured to [params["crvalue"]]% by [ui.user]")
 				for(var/x=1 to length(src.reactor_handle.component_grid))
 					for(var/y=1 to length(src.reactor_handle.component_grid[1]))
 						if(src.reactor_handle.component_grid[x][y])
@@ -193,4 +193,4 @@
 				if(istype(src.reactor_handle.component_grid[x][y],/obj/item/reactor_component/control_rod))
 					var/obj/item/reactor_component/control_rod/CR = src.reactor_handle.component_grid[x][y]
 					CR.configured_insertion_level = !CR.configured_insertion_level
-					logTheThing("station", src, null, "[src.reactor_handle] control rod at [x],[y] insertion configured to [CR.configured_insertion_level*100]% by [ui.user]")
+					logTheThing(LOG_STATION, src, "[src.reactor_handle] control rod at [x],[y] insertion configured to [CR.configured_insertion_level*100]% by [ui.user]")

--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -284,8 +284,8 @@
 			if("loadChange")
 				var/x = params["newVal"]
 				src.stator_load = min(max(x,1),10e30)
-				logTheThing("station", src, null, "[src] stator load configured to [x] by [ui.user]")
+				logTheThing(LOG_STATION, src, "[src] stator load configured to [x] by [ui.user]")
 			if("volChange")
 				var/x = params["newVal"]
 				src.flow_rate = min(max(x,1),10e5)
-				logTheThing("station", src, null, "[src] flow rate configured to [x] by [ui.user]")
+				logTheThing(LOG_STATION, src, "[src] flow rate configured to [x] by [ui.user]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Updates several LogTheThing calls to use defines rather than explicit strings in their log type arg
* Removes extra arg from various calls left over from calling an older version of this proc


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* better maintainability
* extra arg is causing several LogTheThing calls to pass the log message as diary type