### PR TITLE
Nadir VR dungeon goggle safe for underdiner

### DIFF
--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -390,6 +390,13 @@
 /obj/machinery/vending/air_vendor,
 /turf/simulated/floor/industrial,
 /area/shuttle/sea_elevator)
+"mO" = (
+/obj/stool/bar,
+/obj/item/storage/secure/ssafe/diner_arcade{
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/red/standard/edge/west,
+/area/diner/dining)
 "mP" = (
 /obj/machinery/door/airlock/pyro,
 /turf/simulated/floor/black/grime,
@@ -3402,7 +3409,7 @@ nw
 nw
 nw
 uP
-XK
+mO
 XK
 QH
 XK


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUGFIX][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds diner_arcade VR goggles safe to Nadir's underdiner.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This goggles cabinet is apparently a standard element of diners and I did not know this, so this brings Nadir's diner up to parity.

Changelog entry included to notify users that it's no longer absent.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Nadir's diner now has a certain adventurous safe common to other diners.
```
