### PR TITLE
Fix ideal gas law breakdown in reactor

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -60,7 +60,7 @@
 	/// INTERNAL DEBUG: tracks total stored thermal energy in the coolant
 	VAR_PRIVATE/_last_total_coolant_e = 0
 	/// INTERNAL DEBUG: set to true to output debug messages
-	VAR_PRIVATE/_debug_mode = FALSE
+	VAR_PRIVATE/_debug_mode = TRUE
 
 	New()
 		. = ..()
@@ -324,6 +324,16 @@
 			. = src.current_gas
 		if(inGas)
 			src.current_gas = inGas.remove((src.reactor_vessel_gas_volume*MIXTURE_PRESSURE(inGas))/(R_IDEAL_GAS_EQUATION*inGas.temperature))
+			if(src.current_gas && TOTAL_MOLES(src.current_gas) < 1)
+				if(istype(., /datum/gas_mixture))
+					var/datum/gas_mixture/result = .
+					result.merge(src.current_gas)
+					src.current_gas = null
+					return result
+				else
+					. = src.current_gas
+					src.current_gas = null
+					return .
 
 
 	proc/processCaseRadiation(var/rads)
@@ -650,9 +660,10 @@
 		src.component_grid[4][5] = new /obj/item/reactor_component/control_rod("bohrum")
 
 		//enable for faster debugging
-		//src.component_grid[4][2] = new /obj/item/reactor_component/fuel_rod("cerenkite")
-		//src.component_grid[4][4] = new /obj/item/reactor_component/fuel_rod("cerenkite")
-		//src.component_grid[4][6] = new /obj/item/reactor_component/fuel_rod("cerenkite")
+		if(src._debug_mode)
+			src.component_grid[4][2] = new /obj/item/reactor_component/fuel_rod("cerenkite")
+			src.component_grid[4][4] = new /obj/item/reactor_component/fuel_rod("cerenkite")
+			src.component_grid[4][6] = new /obj/item/reactor_component/fuel_rod("cerenkite")
 
 
 		..()

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -60,7 +60,7 @@
 	/// INTERNAL DEBUG: tracks total stored thermal energy in the coolant
 	VAR_PRIVATE/_last_total_coolant_e = 0
 	/// INTERNAL DEBUG: set to true to output debug messages
-	VAR_PRIVATE/_debug_mode = TRUE
+	VAR_PRIVATE/_debug_mode = FALSE
 
 	New()
 		. = ..()
@@ -297,14 +297,19 @@
 			// temperature differential
 			var/deltaT = src.temperature - src.current_gas.temperature
 			// temp differential for radiative heating
-			var/deltaTr = (src.temperature ** 4) - (src.current_gas.temperature ** 4)
+			//this is equivelant to (src.temperature ** 4) - (src.current_gas.temperature ** 4), but factored so its less likely to hit overflow
+			var/deltaTr = (src.temperature + src.current_gas.temperature)*(src.temperature - src.current_gas.temperature)*((src.temperature**2) + (src.current_gas.temperature**2))
+
 			//thermal conductivity
 			var/k = calculateHeatTransferCoefficient(null,src.material)
 			//surface area in thermal contact (m^2)
 			var/A = 1 * (MACHINE_PROC_INTERVAL*8) //multipied by process time to approximate flow rate
 
 			var/thermal_e = THERMAL_ENERGY(current_gas)
-			var/coe_check = thermal_e + src.temperature*src.thermal_mass
+
+			//commented out for later debugging purposes
+			//var/coe_check = thermal_e + src.temperature*src.thermal_mass
+
 			//okay, we're slightly abusing some things here. Notably we're using the thermal conductivity as a stand-in
 			//for the convective heat transfer coefficient(h). It's wrong, since h generally depends on flow rate, but we
 			//can assume a constant flow rate and then a dependence on the thermal conductivity of the material it's flowing over
@@ -322,9 +327,10 @@
 			//after we've transferred heat to the gas, we remove that energy from the gas channel to preserve CoE
 			src.temperature = clamp(src.temperature - (THERMAL_ENERGY(current_gas) - thermal_e)/src.thermal_mass, coldest, hottest)
 
-			var/coe2 = (THERMAL_ENERGY(current_gas) + src.temperature*src.thermal_mass)
-			if(abs(coe2 - coe_check) > 5)
-				CRASH("COE VIOLATION COMPONENT")
+			//commented out for later debugging purposes
+			//var/coe2 = (THERMAL_ENERGY(current_gas) + src.temperature*src.thermal_mass)
+			//if(abs(coe2 - coe_check) > 64)
+			//	CRASH("COE VIOLATION REACTOR")
 			if(src.current_gas.temperature < 0 || src.temperature < 0)
 				CRASH("TEMP WENT NEGATIVE")
 

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -60,7 +60,7 @@
 	/// INTERNAL DEBUG: tracks total stored thermal energy in the coolant
 	VAR_PRIVATE/_last_total_coolant_e = 0
 	/// INTERNAL DEBUG: set to true to output debug messages
-	VAR_PRIVATE/_debug_mode = TRUE
+	VAR_PRIVATE/_debug_mode = FALSE
 
 	New()
 		. = ..()

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -308,14 +308,18 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			// temperature differential
 			var/deltaT = src.temperature - src.air_contents.temperature
 			// temp differential for radiative heating
-			var/deltaTr = (src.temperature ** 4) - (src.air_contents.temperature ** 4)
+			//this is equivelant to (src.temperature ** 4) - (src.current_gas.temperature ** 4), but factored so its less likely to hit overflow
+			var/deltaTr = (src.temperature + src.air_contents.temperature)*(src.temperature - src.air_contents.temperature)*((src.temperature**2) + (src.air_contents.temperature**2))
+
 			//thermal conductivity
 			var/k = calculateHeatTransferCoefficient(null,src.material)
 			//surface area in thermal contact (m^2)
 			var/A = src.gas_thermal_cross_section * (MACHINE_PROC_INTERVAL*8) //multipied by process time to approximate flow rate
 
 			var/thermal_e = THERMAL_ENERGY(air_contents)
-			var/coe_check = thermal_e + src.temperature*src.thermal_mass
+			//commented out for later debugging purposes
+			//var/coe_check = thermal_e + src.temperature*src.thermal_mass
+
 			//okay, we're slightly abusing some things here. Notably we're using the thermal conductivity as a stand-in
 			//for the convective heat transfer coefficient(h). It's wrong, since h generally depends on flow rate, but we
 			//can assume a constant flow rate and then a dependence on the thermal conductivity of the material it's flowing over
@@ -332,9 +336,10 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			//after we've transferred heat to the gas, we remove that energy from the gas channel to preserve CoE
 			src.temperature = clamp(src.temperature - (THERMAL_ENERGY(air_contents) - thermal_e)/src.thermal_mass, coldest, hottest)
 
-			var/coe2 = (THERMAL_ENERGY(air_contents) + src.temperature*src.thermal_mass)
-			if(abs(coe2 - coe_check) > 5)
-				CRASH("COE VIOLATION COMPONENT")
+			//commented out for later debugging purposes
+			//var/coe2 = (THERMAL_ENERGY(air_contents) + src.temperature*src.thermal_mass)
+			//if(abs(coe2 - coe_check) > 64)
+			//	CRASH("COE VIOLATION COMPONENT")
 			if(src.air_contents.temperature < 0 || src.temperature < 0)
 				CRASH("TEMP WENT NEGATIVE")
 

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -341,6 +341,16 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 		if(inGas)
 			src.air_contents = inGas.remove((src.gas_volume*MIXTURE_PRESSURE(inGas))/(R_IDEAL_GAS_EQUATION*inGas.temperature))
 			src.air_contents?.volume = gas_volume
+			if(src.air_contents && TOTAL_MOLES(src.air_contents) < 1)
+				if(istype(., /datum/gas_mixture))
+					var/datum/gas_mixture/result = .
+					result.merge(src.air_contents)
+					src.air_contents = null
+					return result
+				else
+					. = src.air_contents
+					src.air_contents = null
+					return .
 
 #define SANE_COMPONENT_MATERIALS \
 		100;"gold",\

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -315,6 +315,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			var/A = src.gas_thermal_cross_section * (MACHINE_PROC_INTERVAL*8) //multipied by process time to approximate flow rate
 
 			var/thermal_e = THERMAL_ENERGY(air_contents)
+			var/coe_check = thermal_e + src.temperature*src.thermal_mass
 			//okay, we're slightly abusing some things here. Notably we're using the thermal conductivity as a stand-in
 			//for the convective heat transfer coefficient(h). It's wrong, since h generally depends on flow rate, but we
 			//can assume a constant flow rate and then a dependence on the thermal conductivity of the material it's flowing over
@@ -324,10 +325,16 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			//by clamping between hottest and coldest. It's not pretty, but it works.
 			var/hottest = max(src.air_contents.temperature, src.temperature)
 			var/coldest = min(src.air_contents.temperature, src.temperature)
-			src.air_contents.temperature = clamp(src.air_contents.temperature + ((k * A * deltaT) + (5.67037442e-8 * A * deltaTr))/HEAT_CAPACITY(src.air_contents), coldest, hottest)
+			//max limit on the energy transfered is bounded between the coldest and hottest temperature of the thermal mass, to ensure that the
+			//gas can't suck out more heat from the component than exists
+			var/max_delta_e = clamp(((k * A * deltaT) + (5.67037442e-8 * A * deltaTr)), src.temperature*src.thermal_mass - hottest*src.thermal_mass, src.temperature*src.thermal_mass - coldest*src.thermal_mass)
+			src.air_contents.temperature = clamp(src.air_contents.temperature + max_delta_e/HEAT_CAPACITY(src.air_contents), coldest, hottest)
 			//after we've transferred heat to the gas, we remove that energy from the gas channel to preserve CoE
-			src.temperature = src.temperature - (THERMAL_ENERGY(air_contents) - thermal_e)/src.thermal_mass
+			src.temperature = clamp(src.temperature - (THERMAL_ENERGY(air_contents) - thermal_e)/src.thermal_mass, coldest, hottest)
 
+			var/coe2 = (THERMAL_ENERGY(air_contents) + src.temperature*src.thermal_mass)
+			if(abs(coe2 - coe_check) > 5)
+				CRASH("COE VIOLATION COMPONENT")
 			if(src.air_contents.temperature < 0 || src.temperature < 0)
 				CRASH("TEMP WENT NEGATIVE")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out ideal gas law breaks down at super low pressures. We get around that be setting a minimum quantity of gas to operate on. Also we put an upper limit on energy transfer between components and gas to prevent very efficient cooling from violating the laws of thermodynamics. Also a neat hack to manage float precision stuff when calculating `T_c^4 - T_g^4`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13649 

