### PR TITLE
Add contraband levels to syndicate & salvager industrial combat armor

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1494,6 +1494,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
 	name = "\improper Syndicate command armor"
 	desc = "An armored space suit, not for your average expendable chumps. No sir."
 	is_syndicate = TRUE
+	contraband = 3
 	icon_state = "indusred"
 	item_state = "indusred"
 
@@ -1525,6 +1526,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	desc = "A heavily modified industrial mining suit, it's been retrofitted for greater protection in firefights."
 	icon_state = "salvager-heavy"
 	item_state = "salvager-heavy"
+	contraband = 3
 	item_function_flags = IMMUNE_TO_ACID
 
 	setupProperties()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Clothing][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The syndicate & salvager industrial combat armors don't currently have contraband levels. This PR changes it so that they both have contraband levels of 3, consistent with all other nukie spacesuits:
https://github.com/goonstation/goonstation/blob/8964248d322734ae1f8628512fbfe13f2d14a199/code/obj/item/clothing/suits.dm#L1140-L1145


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Likely an oversight that the nukie heavy armor doesn't have a contraband level when the rest does. And I based the Salvager combat armor off it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Blackrep
(+) Syndicate command, specialist heavy operative combat and salvager juggernaut combat armors are now flagged as contraband.
```
