### PR TITLE
Fix Kondaru botany door having wrong access

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20020,8 +20020,8 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/obj/access_spawn/rancher,
 /obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A botany door connected to the hallway is restricted to ranch access instead of botany access.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13659
