### PR TITLE
refactored some mob part and limb code

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -7,14 +7,18 @@
 
 /datum/limb
 	var/obj/item/parts/holder = null
-	///used for ON_COOLDOWN stuff
+	/// used for ON_COOLDOWN stuff
 	var/cooldowns
 	var/special_next = 0
-	var/datum/item_special/disarm_special = null //Contains the datum which executes the items special, if it has one, when used beyond melee range.
-	var/datum/item_special/harm_special = null //Contains the datum which executes the items special, if it has one, when used beyond melee range.
+	/// Contains the datum which executes the items special, if it has one, when used beyond melee range.
+	var/datum/item_special/disarm_special = null
+	/// Contains the datum which executes the items special, if it has one, when used beyond melee range.
+	var/datum/item_special/harm_special = null
 	var/can_pickup_item = TRUE
-	var/attack_strength_modifier = 1 // scale from 0 to 1 on how well this limb can attack/hit things with items
-	var/can_gun_grab = TRUE // if the limb can gun grab with a held gun
+	/// scale from 0 to 1 on how well this limb can attack/hit things with items
+	var/attack_strength_modifier = 1
+	/// if the limb can gun grab with a held gun
+	var/can_gun_grab = TRUE
 
 	New(var/obj/item/parts/holder)
 		..()
@@ -276,7 +280,7 @@
 	harm(mob/living/target, mob/living/user)
 		src.point_blank(target, user)
 
-	//despite the name, this means reloading
+	/// despite the name, this means reloading
 	is_on_cooldown(var/mob/user)
 		return GET_COOLDOWN(user, "\ref[src] reload")
 
@@ -411,10 +415,8 @@
 		user.lastattacked = target
 		ON_COOLDOWN(src, "limb_cooldown", COMBAT_CLICK_DELAY)
 
-
-
-
-/datum/limb/mouth/small // for cats/mice/etc
+/// for cats/mice/etc
+/datum/limb/mouth/small
 	sound_attack = 'sound/impact_sounds/Flesh_Tear_1.ogg'
 	dam_low = 1
 	dam_high = 3
@@ -778,7 +780,7 @@
 	log_name = "severed werewolf limb"
 	quality = 1
 
-// Currently used by the High Fever disease which is obtainable from the "Too Much" chem which only shows up in sickly pears, which are currently commented out. Go there to make use of this.
+/// Currently used by the High Fever disease which is obtainable from the "Too Much" chem which only shows up in sickly pears, which are currently commented out. Go there to make use of this.
 /datum/limb/hot //because
 	attack_hand(atom/target, var/mob/living/user, var/reach, params, location, control)
 		if (!holder)
@@ -1371,7 +1373,7 @@
 		user.lastattacked = target
 
 
-//little critters with teeth, like mice! can pick up small items only.
+/// little critters with teeth, like mice! can pick up small items only.
 /datum/limb/small_critter
 	var/max_wclass = W_CLASS_TINY // biggest thing we can carry
 	var/dam_low = 1
@@ -1476,7 +1478,8 @@
 					return
 		..()
 
-/datum/limb/small_critter/med //same as the previous, but can pick up some heavier shit
+/// same as the parent, but can pick up some heavier shit
+/datum/limb/small_critter/med
 	max_wclass = W_CLASS_SMALL
 	stam_damage_mult = 0.5
 
@@ -1528,14 +1531,14 @@
 			logTheThing(LOG_COMBAT, user, "slashes [constructTarget(target,"combat")] with dash arms at [log_loc(user)].")
 		..()
 
-//test for crab attack thing
+/// test for crab attack thing
 /datum/limb/swipe_quake
 	New(var/obj/item/parts/holder)
 		..()
 		src.setDisarmSpecial (/datum/item_special/slam/no_item_attack)
 		src.setHarmSpecial (/datum/item_special/swipe/limb)
 
-//I wanted a claw-like limb but without the random item pickup fail
+/// I wanted a claw-like limb but without the random item pickup fail
 /datum/limb/tentacle
 	harm(mob/target, var/mob/living/user)
 		if(check_target_immunity( target ))

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -75,7 +75,7 @@ ABSTRACT_TYPE(/obj/item/parts)
 	var/partDecompIcon = 'icons/mob/human_decomp.dmi'
 	/// Used by getHandIconState to determine the attached-to-mob-sprite hand sprite
 	var/handlistPart
-	/// Used by getHandIconState to determine the attached-to-mob-sprite hand sprite, but for foot sprites, presumably
+	/// Used by getPartIconState to determine the attached-to-mob-sprite non-hand sprite
 	var/partlistPart
 	/// for medical crap
 	var/datum/bone/bones = null

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -9,18 +9,28 @@ ABSTRACT_TYPE(/obj/item/parts)
 	c_flags = ONBELT
 	override_attack_hand = 0
 	var/skin_tone = "#FFFFFF"
-	var/slot = null // which part of the person or robot suit does it go on???????
-	var/streak_decal = /obj/decal/cleanable/blood // what streaks everywhere when it's cut off?
-	var/streak_descriptor = "bloody" //bloody, oily, etc
-	var/datum/limb/limb_data = null // used by arms for attack_hand overrides
-	var/limb_type = /datum/limb // the type of limb_data
-	var/obj/item/remove_object = null //set to create an item when severed rather than removing the arm itself
-	var/side = "left" //used for streak direction
-	var/remove_stage = 0 //2 will fall off, 3 is removed
-	var/no_icon = 0 //if the only icon is above the clothes layer ie. in the handlistPart list
-	var/skintoned = 1 // is this affected by human skin tones? Also if the severed limb uses a separate bloody-stump icon layered on top
+	/// which part of the person or robot suit does it go on???????
+	var/slot = null
+	/// what streaks everywhere when it's cut off?
+	var/streak_decal = /obj/decal/cleanable/blood
+	/// bloody, oily, etc
+	var/streak_descriptor = "bloody"
+	/// used by arms for attack_hand overrides
+	var/datum/limb/limb_data = null
+	/// the type of limb_data
+	var/limb_type = /datum/limb
+	/// set to create an item when severed rather than removing the arm itself
+	var/obj/item/remove_object = null
+	/// used for streak direction
+	var/side = "left"
+	/// 2 will fall off, 3 is removed. This should use defines honestly but eh.
+	var/remove_stage = 0
+	///if the only icon is above the clothes layer ie. in the handlistPart list
+	var/no_icon = FALSE
+	/// is this affected by human skin tones? Also if the severed limb uses a separate bloody-stump icon layered on top
+	var/skintoned = TRUE
 
-	/// Gets overlaid onto the severed limb, under the stump if the limb is skintoned
+	// Gets overlaid onto the severed limb, under the stump if the limb is skintoned
 	/// The icon of this overlay
 	var/severed_overlay_1_icon
 	/// The state of this overlay
@@ -46,28 +56,39 @@ ABSTRACT_TYPE(/obj/item/parts)
 	/// The color reference. null for uncolored("#ffffff"), CUST_1/2/3 for one of the mob's haircolors, SKIN_TONE for the mob's skintone
 	var/handfoot_overlay_1_color
 
-	var/easy_attach = 0 //Attachable without surgery?
+	///Attachable without surgery?
+	var/easy_attach = FALSE
 
-	var/decomp_affected = 1 // set to 1 if this limb has decomposition icons
+	/// set to true if this limb has decomposition icons
+	var/decomp_affected = TRUE
 	var/current_decomp_stage_l = -1
 	var/current_decomp_stage_s = -1
 
 	var/mob/living/holder = null
 
-	var/image/standImage	// Used by getMobIcon to pass off to update_body. Typically holds image(the_limb's_icon, "[src.slot]")
-	var/image/lyingImage	// Appears to be unused, since we just rotate the sprite through animagic
-	var/partIcon = 'icons/mob/human.dmi'	// The icon the mob sprite uses when attached, change if the limb's icon isnt in 'icons/mob/human.dmi'
+	/// Used by getMobIcon to pass off to update_body. Typically holds image(the_limb's_icon, "[src.slot]")
+	var/image/standImage
+	/// Appears to be unused, since we just rotate the sprite through animagic
+	var/image/lyingImage
+	/// The icon the mob sprite uses when attached, change if the limb's icon isnt in 'icons/mob/human.dmi'
+	var/partIcon = 'icons/mob/human.dmi'
 	var/partDecompIcon = 'icons/mob/human_decomp.dmi'
-	var/handlistPart	// Used by getHandIconState to determine the attached-to-mob-sprite hand sprite
-	var/partlistPart	// Ditto, but for foot sprites, presumably
-	var/datum/bone/bones = null // for medical crap
+	/// Used by getHandIconState to determine the attached-to-mob-sprite hand sprite
+	var/handlistPart
+	/// Used by getHandIconState to determine the attached-to-mob-sprite hand sprite, but for foot sprites, presumably
+	var/partlistPart
+	/// for medical crap
+	var/datum/bone/bones = null
 	var/brute_dam = 0
 	var/burn_dam = 0
 	var/tox_dam = 0
 	var/siemens_coefficient = 1
-	var/step_image_state = null // for legs, we leave footprints in this style (located in blood.dmi)
-	var/accepts_normal_human_overlays = 1 //for avoiding istype in update icon
-	var/datum/movement_modifier/movement_modifier // When attached, applies this movement modifier
+	/// for legs, we leave footprints in this style (located in blood.dmi)
+	var/step_image_state = null
+	/// for avoiding istype in update icon
+	var/accepts_normal_human_overlays = TRUE
+	/// When attached, applies this movement modifier
+	var/datum/movement_modifier/movement_modifier
 	/// If TRUE, it'll resist mutantraces trying to change them
 	var/limb_is_unnatural = FALSE
 	/// Limb is not attached to its original owner
@@ -75,7 +96,7 @@ ABSTRACT_TYPE(/obj/item/parts)
 	/// What kind of limb is this? So we dont have to do dozens of typechecks. is bitflags, check defines/item.dm
 	var/kind_of_limb
 	/// Can we roll this limb as a random limb?
-	var/random_limb_blacklisted = 0
+	var/random_limb_blacklisted = FALSE
 
 	New(atom/new_holder)
 		..()

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -15,7 +15,7 @@
 	hitsound = 'sound/impact_sounds/meat_smack.ogg'
 	var/original_DNA = null
 	var/original_fprints = null
-	var/show_on_examine = 0
+	var/show_on_examine = FALSE
 
 	take_damage(brute, burn, tox, damage_type, disallow_limb_loss)
 		if (brute <= 0 && burn <= 0)// && tox <= 0)
@@ -318,7 +318,7 @@
 	override_attack_hand = 0 //to hit with an item instead of hand when used empty handed
 	can_hold_items = 1
 	var/rebelliousness = 0
-	var/strangling = 0
+	var/strangling = FALSE
 
 	on_holder_examine()
 		if (src.show_on_examine)
@@ -328,11 +328,11 @@
 		if(rebelliousness < 10 && prob(20))
 			rebelliousness += 1
 
-		if(strangling == 1)
+		if(strangling)
 			if(holder.losebreath < 5) holder.losebreath = 5
 			if(prob(20-rebelliousness))
 				holder.visible_message("<span class='alert'>[holder.name] stops trying to strangle themself.</span>", "<span class='alert'>You manage to pull your [src.name] away from your throat!</span>")
-				strangling = 0
+				strangling = FALSE
 				holder.losebreath -= 5
 			return
 
@@ -349,7 +349,7 @@
 			holder.visible_message("<span class='alert'>[holder.name] tries to strangle themself with their [src.name].</span>", "<span class='alert'>Your [src.name] tries to strangle you!</span>")
 			holder.emote("gasp")
 			holder.losebreath = 5
-			strangling = 1
+			strangling = TRUE
 
 	sever(mob/user)
 		if(holder?.handcuffs)
@@ -459,8 +459,8 @@
 	name = "left item arm"
 	decomp_affected = FALSE
 	limb_type = /datum/limb/item
-	streak_decal = /obj/decal/cleanable/oil // what streaks everywhere when it's cut off?
-	streak_descriptor = "oily" //bloody, oily, etc
+	streak_decal = /obj/decal/cleanable/oil
+	streak_descriptor = "oily"
 	override_attack_hand = 1
 	can_hold_items = 0
 	remove_object = null
@@ -469,6 +469,7 @@
 	no_icon = TRUE
 	skintoned = FALSE
 	var/special_icons = 'icons/mob/human.dmi'
+	/// uses defines and flags to determine if you can drop or remove it.
 	var/original_flags = 0
 	var/image/handimage = 0
 	random_limb_blacklisted = TRUE
@@ -618,6 +619,7 @@
 	partlistPart = null
 	no_icon = TRUE
 	skintoned = FALSE
+	/// uses defines and flags to determine if you can drop or remove it.
 	var/original_flags = 0
 	var/image/handimage = 0
 	var/special_icons = 'icons/mob/human.dmi'
@@ -746,7 +748,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
 	handlistPart = "l_hand_brullbar"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	/// Brullbar are pretty unnatural, and most people'd miss em if they suddenly turned into a lizard arm
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BRULLBAR)
@@ -779,7 +781,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
 	handlistPart = "r_hand_brullbar"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	/// If you went through the trouble to get yourself a wendy arm, you should keep it no matter how inhuman you become
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BRULLBAR)
@@ -812,7 +814,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_left"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_HOT)
 
@@ -832,7 +834,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_right"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_HOT)
 
@@ -854,7 +856,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/bear
 	handlistPart = "l_hand_bear"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BEAR)
 
@@ -883,7 +885,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/bear
 	handlistPart = "r_hand_bear"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BEAR)
 
@@ -910,7 +912,7 @@
 	skintoned = FALSE
 	handlistPart = "l_hand_plant"
 	var/name_thing = "plant"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	easy_attach = TRUE
 	/// Plants are pretty unnatural
 	limb_is_unnatural = TRUE
@@ -938,7 +940,7 @@
 	skintoned = FALSE
 	handlistPart = "r_hand_plant"
 	var/name_thing = "plant"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
@@ -965,7 +967,7 @@
 	skintoned = FALSE
 	partlistPart = "l_foot_plant"
 	var/name_thing = "plant"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
@@ -992,7 +994,7 @@
 	skintoned = FALSE
 	partlistPart = "r_foot_plant"
 	var/name_thing = "plant"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
@@ -1046,7 +1048,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "l_hand_abomination"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	/// About as unnatural as it gets
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ABOM)
@@ -1092,7 +1094,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "r_hand_abomination"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ABOM)
 
@@ -1184,7 +1186,7 @@
 	limb_type = /datum/limb/claw
 	handlistPart = "l_hand_brullbar"
 	siemens_coefficient = 0
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BRULLBAR)
 
@@ -1212,7 +1214,7 @@
 	limb_type = /datum/limb/claw
 	handlistPart = "r_hand_brullbar"
 	siemens_coefficient = 0
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_BRULLBAR)
 
@@ -1238,7 +1240,7 @@
 	skintoned = FALSE
 	handlistPart = "r_hand_stone"
 	var/name_thing = "stone"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_STONE)
 
@@ -1264,7 +1266,7 @@
 	skintoned = FALSE
 	handlistPart = "l_hand_stone"
 	var/name_thing = "stone"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_STONE)
 
@@ -1290,7 +1292,7 @@
 	skintoned = FALSE
 	partlistPart = "l_foot_stone"
 	var/name_thing = "stone"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_STONE)
 
@@ -1316,7 +1318,7 @@
 	skintoned = FALSE
 	partlistPart = "r_foot_stone"
 	var/name_thing = "stone"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_STONE)
 
@@ -1762,7 +1764,7 @@
 	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
-	show_on_examine = 1
+	show_on_examine = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -1781,7 +1783,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
 	handlistPart = "hand_right"
-	show_on_examine = 1
+	show_on_examine = TRUE
 
 	New(var/atom/holder)
 		if (holder != null)
@@ -2126,7 +2128,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_left"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)
@@ -2145,7 +2147,7 @@
 	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_right"
-	show_on_examine = 1
+	show_on_examine = TRUE
 	limb_is_unnatural = TRUE
 
 	New(var/atom/holder)

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -11,7 +11,7 @@
 	stamina_damage = 40
 	stamina_cost = 23
 	stamina_crit_chance = 5
-	skintoned = 1
+	skintoned = TRUE
 	hitsound = 'sound/impact_sounds/meat_smack.ogg'
 	var/original_DNA = null
 	var/original_fprints = null
@@ -457,7 +457,7 @@
 
 /obj/item/parts/human_parts/arm/left/item
 	name = "left item arm"
-	decomp_affected = 0
+	decomp_affected = FALSE
 	limb_type = /datum/limb/item
 	streak_decal = /obj/decal/cleanable/oil // what streaks everywhere when it's cut off?
 	streak_descriptor = "oily" //bloody, oily, etc
@@ -466,12 +466,12 @@
 	remove_object = null
 	handlistPart = null
 	partlistPart = null
-	no_icon = 1
-	skintoned = 0
+	no_icon = TRUE
+	skintoned = FALSE
 	var/special_icons = 'icons/mob/human.dmi'
 	var/original_flags = 0
 	var/image/handimage = 0
-	random_limb_blacklisted = 1
+	random_limb_blacklisted = TRUE
 	/// No more yee eating csaber arms
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ITEM)
@@ -607,7 +607,7 @@
 
 /obj/item/parts/human_parts/arm/right/item
 	name = "right item arm"
-	decomp_affected = 0
+	decomp_affected = FALSE
 	limb_type = /datum/limb/item
 	streak_decal = /obj/decal/cleanable/oil // what streaks everywhere when it's cut off?
 	streak_descriptor = "oily" //bloody, oily, etc
@@ -616,12 +616,12 @@
 	remove_object = null
 	handlistPart = null
 	partlistPart = null
-	no_icon = 1
-	skintoned = 0
+	no_icon = TRUE
+	skintoned = FALSE
 	var/original_flags = 0
 	var/image/handimage = 0
 	var/special_icons = 'icons/mob/human.dmi'
-	random_limb_blacklisted = 1
+	random_limb_blacklisted = TRUE
 	/// Also, item arms are supposedly junk jammed into a severed limb's socket
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ITEM)
@@ -740,8 +740,8 @@
 	icon_state = "arm_left_brullbar"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "eerie"
 	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
@@ -773,8 +773,8 @@
 	icon_state = "arm_right_brullbar"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "eerie"
 	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
@@ -806,8 +806,8 @@
 	icon_state = "arm_left"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "bloody"
 	override_attack_hand = 1
 	limb_type = /datum/limb/hot
@@ -826,8 +826,8 @@
 	icon_state = "arm_right"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "bloody"
 	override_attack_hand = 1
 	limb_type = /datum/limb/hot
@@ -848,8 +848,8 @@
 	icon_state = "arm_left_bear"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "bearly"
 	override_attack_hand = 1
 	limb_type = /datum/limb/bear
@@ -877,8 +877,8 @@
 	icon_state = "arm_right_bear"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "bearly"
 	override_attack_hand = 1
 	limb_type = /datum/limb/bear
@@ -906,12 +906,12 @@
 	icon_state = "arm_left_plant"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	handlistPart = "l_hand_plant"
 	var/name_thing = "plant"
 	show_on_examine = 1
-	easy_attach = 1
+	easy_attach = TRUE
 	/// Plants are pretty unnatural
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
@@ -934,12 +934,12 @@
 	icon_state = "arm_right_plant"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	handlistPart = "r_hand_plant"
 	var/name_thing = "plant"
 	show_on_examine = 1
-	easy_attach = 1
+	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
 
@@ -961,12 +961,12 @@
 	icon_state = "leg_left_plant"
 	slot = "l_leg"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	partlistPart = "l_foot_plant"
 	var/name_thing = "plant"
 	show_on_examine = 1
-	easy_attach = 1
+	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
 
@@ -988,12 +988,12 @@
 	icon_state = "leg_right_plant"
 	slot = "r_leg"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	partlistPart = "r_foot_plant"
 	var/name_thing = "plant"
 	show_on_examine = 1
-	easy_attach = 1
+	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
 
@@ -1041,8 +1041,8 @@
 	icon_state = "arm_left_abomination"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "l_hand_abomination"
@@ -1087,8 +1087,8 @@
 	icon_state = "arm_right_abomination"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "r_hand_abomination"
@@ -1133,11 +1133,11 @@
 	partIcon = 'icons/mob/vampiric_thrall.dmi'
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
+	decomp_affected = FALSE
 	override_attack_hand = 1
 	can_hold_items = 0
 	limb_type = /datum/limb/zombie //Basically zombie arms am I right?
-	skintoned = 1
+	skintoned = TRUE
 	streak_descriptor = "undeadly"
 	override_attack_hand = 1
 	/// Supernatural if not abnormally gross
@@ -1156,11 +1156,11 @@
 	partIcon = 'icons/mob/vampiric_thrall.dmi'
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
+	decomp_affected = FALSE
 	override_attack_hand = 1
 	can_hold_items = 0
 	limb_type = /datum/limb/zombie //Basically zombie arms am I right?
-	skintoned = 1
+	skintoned = TRUE
 	streak_descriptor = "undeadly"
 	override_attack_hand = 1
 	limb_is_unnatural = TRUE
@@ -1177,8 +1177,8 @@
 	icon_state = "arm_left_brullbar"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "eerie"
 	override_attack_hand = 1
 	limb_type = /datum/limb/claw
@@ -1205,8 +1205,8 @@
 	icon_state = "arm_right_brullbar"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	streak_descriptor = "eerie"
 	override_attack_hand = 1
 	limb_type = /datum/limb/claw
@@ -1234,8 +1234,8 @@
 	icon_state = "arm_right_stone"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	handlistPart = "r_hand_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
@@ -1260,8 +1260,8 @@
 	icon_state = "arm_left_stone"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	handlistPart = "l_hand_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
@@ -1286,8 +1286,8 @@
 	icon_state = "leg_left_stone"
 	slot = "l_leg"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	partlistPart = "l_foot_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
@@ -1312,8 +1312,8 @@
 	icon_state = "leg_right_stone"
 	slot = "r_leg"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	partlistPart = "r_foot_stone"
 	var/name_thing = "stone"
 	show_on_examine = 1
@@ -1343,7 +1343,7 @@
 	slot = "l_arm"
 	side = "left"
 	handlistPart = "hand_left"
-	skintoned = 0
+	skintoned = FALSE
 	kind_of_limb = (LIMB_MUTANT)
 
 	New(var/atom/holder)
@@ -1361,7 +1361,7 @@
 	side = "left"
 	partlistPart = "foot_left"
 	step_image_state = "footprintsL"
-	skintoned = 0
+	skintoned = FALSE
 	kind_of_limb = (LIMB_MUTANT)
 
 	New(var/atom/holder)
@@ -1380,7 +1380,7 @@
 	icon = 'icons/mob/cow.dmi'
 	partIcon = 'icons/mob/cow.dmi'
 	limb_hit_bonus = 4
-	skintoned = 1
+	skintoned = TRUE
 	handfoot_overlay_1_icon = 'icons/mob/cow.dmi'
 	handfoot_overlay_1_state = null
 	handfoot_overlay_1_color = CUST_2
@@ -1479,12 +1479,12 @@
 /obj/item/parts/human_parts/arm/mutant/lizard
 	icon = 'icons/mob/lizard.dmi'
 	partIcon = 'icons/mob/lizard.dmi'
-	skintoned = 1
+	skintoned = TRUE
 
 /obj/item/parts/human_parts/leg/mutant/lizard
 	icon = 'icons/mob/lizard.dmi'
 	partIcon = 'icons/mob/lizard.dmi'
-	skintoned = 1
+	skintoned = TRUE
 
 ////// ACTUAL LIZARD LIMBS //////
 /obj/item/parts/human_parts/arm/mutant/lizard/left
@@ -1619,12 +1619,12 @@
 /obj/item/parts/human_parts/arm/mutant/roach
 	icon = 'icons/mob/roach.dmi'
 	partIcon = 'icons/mob/roach.dmi'
-	skintoned = 1
+	skintoned = TRUE
 
 /obj/item/parts/human_parts/leg/mutant/roach
 	icon = 'icons/mob/roach.dmi'
 	partIcon = 'icons/mob/roach.dmi'
-	skintoned = 1
+	skintoned = TRUE
 
 ////// ACTUAL ROACH LIMBS //////
 /obj/item/parts/human_parts/arm/mutant/roach/left
@@ -1758,8 +1758,8 @@
 	slot = "l_arm"
 	side = "left"
 	handlistPart = "hand_left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
 	show_on_examine = 1
@@ -1776,8 +1776,8 @@
 	icon_state = "arm_right"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
 	handlistPart = "hand_right"
@@ -1842,7 +1842,7 @@
 /obj/item/parts/human_parts/arm/mutant/skeleton
 	icon = 'icons/mob/skeleton.dmi'
 	partIcon = 'icons/mob/skeleton.dmi'
-	easy_attach = 1 // Its just a bone... full of meat. Kind of.
+	easy_attach = TRUE // Its just a bone... full of meat. Kind of.
 	kind_of_limb = (LIMB_MUTANT | LIMB_SKELLY)
 	force = 10
 	throw_return = TRUE
@@ -1850,7 +1850,7 @@
 /obj/item/parts/human_parts/leg/mutant/skeleton
 	icon = 'icons/mob/skeleton.dmi'
 	partIcon = 'icons/mob/skeleton.dmi'
-	easy_attach = 1
+	easy_attach = TRUE
 	kind_of_limb = (LIMB_MUTANT | LIMB_SKELLY)
 	force = 10
 	throw_return = TRUE
@@ -2032,14 +2032,14 @@
 /obj/item/parts/human_parts/arm/mutant/kudzu
 	icon = 'icons/obj/items/human_parts.dmi'
 	partIcon = 'icons/mob/human.dmi'
-	skintoned = 1
+	skintoned = TRUE
 	limb_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	handfoot_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	severed_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	limb_overlay_1_color = null
 	handfoot_overlay_1_color = null
 	severed_overlay_1_color = null
-	easy_attach = 1 // These plants really like humanoid flesh
+	easy_attach = TRUE // These plants really like humanoid flesh
 	kind_of_limb = (LIMB_MUTANT | LIMB_PLANT)
 
 	New()
@@ -2051,14 +2051,14 @@
 /obj/item/parts/human_parts/leg/mutant/kudzu
 	icon = 'icons/obj/items/human_parts.dmi'
 	partIcon = 'icons/mob/human.dmi'
-	skintoned = 1
+	skintoned = TRUE
 	limb_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	handfoot_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	severed_overlay_1_icon = 'icons/mob/kudzu.dmi'
 	limb_overlay_1_color = null
 	handfoot_overlay_1_color = null
 	severed_overlay_1_color = null
-	easy_attach = 1
+	easy_attach = TRUE
 	kind_of_limb = (LIMB_MUTANT | LIMB_PLANT)
 
 	New()
@@ -2121,8 +2121,8 @@
 	icon_state = "arm_left"
 	slot = "l_arm"
 	side = "left"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_left"
@@ -2140,8 +2140,8 @@
 	icon_state = "arm_right"
 	slot = "r_arm"
 	side = "right"
-	decomp_affected = 0
-	skintoned = 0
+	decomp_affected = FALSE
+	skintoned = FALSE
 	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_right"

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -10,13 +10,13 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts)
 	streak_descriptor = "oily"
 	var/appearanceString = "generic"
 	var/icon_state_base = ""
-	accepts_normal_human_overlays = 0
-	skintoned = 0
+	accepts_normal_human_overlays = FALSE
+	skintoned = FALSE
 	/// Robot limbs shouldn't get replaced through mutant race changes
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ROBOT)
 
-	decomp_affected = 0
+	decomp_affected = FALSE
 	var/robot_movement_modifier
 
 	var/max_health = 100
@@ -498,7 +498,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 	desc = "A metal arm for a cyborg. It won't be able to use as many tools without it!"
 	max_health = 60
 	can_hold_items = 1
-	accepts_normal_human_overlays = 1
+	accepts_normal_human_overlays = TRUE
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
 		if(!ismob(M))

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -22,8 +22,10 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts)
 	var/max_health = 100
 	var/dmg_blunt = 0
 	var/dmg_burns = 0
-	var/weight = 0     // for calculating speed modifiers
-	var/powerdrain = 0 // does this part consume any extra power
+	/// for calculating speed modifiers
+	var/weight = 0
+	/// does this part consume any extra power
+	var/powerdrain = 0
 
 	force = 6
 	stamina_damage = 40
@@ -171,9 +173,9 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 	var/obj/item/organ/brain/brain = null
 	var/obj/item/ai_interface/ai_interface = null
 	var/visible_eyes = 1
-
-		// Screen head specific
-	var/mode = "lod" // lod (light-on-dark) or dol (dark-on-light)
+	// Screen head specific
+	/// lod (light-on-dark) or dol (dark-on-light)
+	var/mode = "lod"
 	var/face = "happy"
 
 	examine()
@@ -394,7 +396,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/chest)
 	icon_state_base = "body"
 	icon_state = "body-generic"
 	slot = "chest"
-	//These vars track the wiring/cell that the chest needs before you can stuff it on a frame
+	// These vars track the wiring/cell that the chest needs before you can stuff it on a frame
 	var/wires = 0
 	var/obj/item/cell/cell = null
 
@@ -886,7 +888,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 	name = "robot frame"
 	icon_state = "robo_suit"
 	max_health = 5000
-	var/syndicate = 0 ///This will make the borg a syndie one
+	/// This will make the borg a syndie one
+	var/syndicate = FALSE
 	var/emagged = 0
 	var/obj/item/parts/robot_parts/head/head = null
 	var/obj/item/parts/robot_parts/chest/chest = null
@@ -1211,7 +1214,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 		return
 
 /obj/item/parts/robot_parts/robot_frame/syndicate
-	syndicate = 1
+	syndicate = TRUE
 
 // UPGRADES
 // Cyborg

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -12,7 +12,7 @@
 	var/color_r = 1 // same as glasses/helmets/masks/etc, used for vision color modifications, see human/handle_regular_hud_updates()
 	var/color_g = 1
 	var/color_b = 1
-	var/show_on_examine = 0 // do we get mentioned when our donor is examined?
+	var/show_on_examine = FALSE // do we get mentioned when our donor is examined?
 
 	New()
 		..()
@@ -119,7 +119,7 @@ TYPEINFO(/obj/item/organ/eye/cyber)
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	made_from = "pharosium"
-	show_on_examine = 1
+	show_on_examine = TRUE
 
 	emp_act()
 		..()


### PR DESCRIPTION
[CODE QUALITY] [INTERNAL]
## About the PR
Cleans up some doc comments, and changes some binary vars to use `TRUE` and `FALSE` defines properly.
## Why's this needed?
Cleaner code is a cleaner mental state. I was reading through the vars and i couldn't tell if the 1s and 0s being declared were an ints or bools, which is bad if there's tons to read through. The find replace probably didn't catch everything but at the very least the doc comments and default values should clear it up for future minor refactors.
Thought this should have been atomized out, so i atomized it out.