### PR TITLE
Adds Delay to Health Implants Sending Crit/Death Alerts

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -317,7 +317,7 @@ THROWING DARTS
 			return
 		DEBUG_MESSAGE("[src] calling to report crit")
 		SPAWN(rand(15, 25) SECONDS)
-		health_alert()
+			health_alert()
 		..()
 
 	on_death()
@@ -325,7 +325,7 @@ THROWING DARTS
 			return
 		DEBUG_MESSAGE("[src] calling to report death")
 		SPAWN(rand(15, 25) SECONDS)
-		death_alert()
+			death_alert()
 		..()
 
 	proc/health_alert()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -316,7 +316,7 @@ THROWING DARTS
 		if(inafterlife(src.owner))
 			return
 		DEBUG_MESSAGE("[src] calling to report crit")
-		SPAWN(15 SECONDS)
+		SPAWN(rand(15, 25) SECONDS)
 		health_alert()
 		..()
 
@@ -324,7 +324,7 @@ THROWING DARTS
 		if(inafterlife(src.owner))
 			return
 		DEBUG_MESSAGE("[src] calling to report death")
-		SPAWN(15 SECONDS)
+		SPAWN(rand(15, 25) SECONDS)
 		death_alert()
 		..()
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -316,6 +316,7 @@ THROWING DARTS
 		if(inafterlife(src.owner))
 			return
 		DEBUG_MESSAGE("[src] calling to report crit")
+		SPAWN(15 SECONDS)
 		health_alert()
 		..()
 
@@ -323,16 +324,21 @@ THROWING DARTS
 		if(inafterlife(src.owner))
 			return
 		DEBUG_MESSAGE("[src] calling to report death")
+		SPAWN(15 SECONDS)
 		death_alert()
 		..()
 
 	proc/health_alert()
 		if (!src.owner)
 			return
+		if (!src)
+			return
 		src.send_message("HEALTH ALERT: [src.owner] in [get_area(src)]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
 
 	proc/death_alert()
 		if (!src.owner)
+			return
+		if (!src)
 			return
 		var/myarea = get_area(src)
 		var/list/cloner_areas = list()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -331,14 +331,10 @@ THROWING DARTS
 	proc/health_alert()
 		if (!src.owner)
 			return
-		if (!src)
-			return
 		src.send_message("HEALTH ALERT: [src.owner] in [get_area(src)]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
 
 	proc/death_alert()
 		if (!src.owner)
-			return
-		if (!src)
 			return
 		var/myarea = get_area(src)
 		var/list/cloner_areas = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [INPUT WANTED] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds random 15-25 second delay to the crit alert and death alerts sent from health implants.

https://user-images.githubusercontent.com/87689371/232355086-ddf11023-dc50-4823-b03b-e496346da56b.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See #13103 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Health Implants now have a 15-25 second delay before sending crit/death alerts
```
