### PR TITLE
Removes crit alert from health implants

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -316,7 +316,6 @@ THROWING DARTS
 		if(inafterlife(src.owner))
 			return
 		DEBUG_MESSAGE("[src] calling to report crit")
-		health_alert()
 		..()
 
 	on_death()
@@ -325,11 +324,6 @@ THROWING DARTS
 		DEBUG_MESSAGE("[src] calling to report death")
 		death_alert()
 		..()
-
-	proc/health_alert()
-		if (!src.owner)
-			return
-		src.send_message("HEALTH ALERT: [src.owner] in [get_area(src)]: [src.sensehealth()]", MGA_MEDCRIT, "HEALTH-MAILBOT")
 
 	proc/death_alert()
 		if (!src.owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [INPUT WANTED] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the crit alert from health implants.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See #13103
Sister/alternative pr to #13680


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Health implants no longer send alerts when someone is in crit.
```
