### PR TITLE
Adds a couple mimic-themed random rooms, enable items to be mimics

### DIFF
--- a/assets/maps/random_rooms/3x3/toolbox.dmm
+++ b/assets/maps/random_rooms/3x3/toolbox.dmm
@@ -1,0 +1,100 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/floor/caution/south,
+/area/dmm_suite/clear_area)
+"b" = (
+/turf/simulated/floor/caution/west,
+/area/dmm_suite/clear_area)
+"c" = (
+/obj/rack,
+/obj/item/storage/toolbox/electrical{
+	mimic_chance = 10;
+	pixel_x = 5
+	},
+/obj/item/storage/toolbox/electrical{
+	mimic_chance = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/electrical{
+	mimic_chance = 10;
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/dmm_suite/clear_area)
+"e" = (
+/obj/rack,
+/obj/item/storage/toolbox/mechanical{
+	mimic_chance = 10;
+	pixel_x = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	mimic_chance = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/mechanical{
+	mimic_chance = 10;
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/turf/simulated/floor/caution/corner/sw,
+/area/dmm_suite/clear_area)
+"q" = (
+/obj/rack,
+/obj/item/storage/toolbox/emergency{
+	mimic_chance = 10;
+	pixel_x = 5
+	},
+/obj/item/storage/toolbox/emergency{
+	mimic_chance = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/emergency{
+	mimic_chance = 10;
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/turf/simulated/floor/caution/corner/nw,
+/area/dmm_suite/clear_area)
+"s" = (
+/turf/simulated/floor/damaged2,
+/area/dmm_suite/clear_area)
+"w" = (
+/turf/simulated/floor/caution/east,
+/area/dmm_suite/clear_area)
+"z" = (
+/turf/simulated/floor/caution/north,
+/area/dmm_suite/clear_area)
+"T" = (
+/obj/rack,
+/obj/item/storage/toolbox/artistic{
+	mimic_chance = 10;
+	pixel_x = 5
+	},
+/obj/item/storage/toolbox/artistic{
+	mimic_chance = 10;
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/artistic{
+	mimic_chance = 10;
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/turf/simulated/floor/caution/corner/se,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+q
+b
+e
+"}
+(2,1,1) = {"
+z
+s
+a
+"}
+(3,1,1) = {"
+c
+w
+T
+"}

--- a/assets/maps/random_rooms/5x3/notamimic.dmm
+++ b/assets/maps/random_rooms/5x3/notamimic.dmm
@@ -1,0 +1,204 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/carafe/research{
+	pixel_y = 4;
+	mimic_chance = 5
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/dmm_suite/clear_area)
+"e" = (
+/obj/table/auto,
+/obj/item/beach_ball{
+	pixel_y = 9;
+	mimic_chance = 10
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC"
+	},
+/turf/simulated/floor/purple/side,
+/area/dmm_suite/clear_area)
+"g" = (
+/obj/table/auto,
+/obj/item/cigpacket{
+	pixel_x = -3;
+	mimic_chance = 5
+	},
+/obj/item/clothing/mask/cigarette{
+	pixel_y = 10;
+	pixel_x = 2;
+	mimic_chance = 5
+	},
+/obj/item/clothing/mask/cigarette{
+	pixel_y = 9;
+	mimic_chance = 5
+	},
+/turf/simulated/floor/purple/side{
+	dir = 6
+	},
+/area/dmm_suite/clear_area)
+"s" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/bottle,
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 10
+	},
+/area/dmm_suite/clear_area)
+"x" = (
+/obj/stool/chair/office{
+	dir = 1
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/dmm_suite/clear_area)
+"C" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 9;
+	pixel_x = -6;
+	mimic_chance = 100
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 7;
+	pixel_y = 8;
+	mimic_chance = 15
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC";
+	pixel_y = -2
+	},
+/turf/simulated/floor/purple/side{
+	dir = 5
+	},
+/area/dmm_suite/clear_area)
+"M" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/paper_cup{
+	pixel_x = 4;
+	mimic_chance = 50
+	},
+/obj/item/clothing/glasses/regular{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/paper_cup{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC";
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC";
+	pixel_y = 8;
+	pixel_x = 5
+	},
+/turf/simulated/floor/purple/side,
+/area/dmm_suite/clear_area)
+"N" = (
+/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/item/clothing/suit/labcoat/science{
+	pixel_y = -4
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 7
+	},
+/obj/item/paper{
+	info = "oh god, the notes, they do nothing!";
+	pixel_y = -10;
+	pixel_x = -14
+	},
+/turf/simulated/floor,
+/area/dmm_suite/clear_area)
+"Q" = (
+/turf/simulated/floor/purple/side{
+	dir = 8
+	},
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/table/auto,
+/obj/item/clipboard{
+	pixel_y = 3;
+	pixel_x = 9
+	},
+/obj/item/item_box/postit{
+	pixel_x = -7
+	},
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/dmm_suite/clear_area)
+"U" = (
+/turf/simulated/floor/purple/side,
+/area/dmm_suite/clear_area)
+"W" = (
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/dmm_suite/clear_area)
+"Y" = (
+/turf/simulated/floor,
+/area/dmm_suite/clear_area)
+"Z" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 13;
+	mimic_chance = 10
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -4;
+	pixel_y = 4;
+	mimic_chance = 5
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC";
+	pixel_y = 3
+	},
+/obj/item/sticker/postit{
+	words = "NOT A MIMIC";
+	pixel_y = -4;
+	pixel_x = 16
+	},
+/turf/simulated/floor/purple/side{
+	dir = 9
+	},
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+Z
+Q
+s
+"}
+(2,1,1) = {"
+a
+Y
+M
+"}
+(3,1,1) = {"
+W
+Y
+U
+"}
+(4,1,1) = {"
+S
+N
+e
+"}
+(5,1,1) = {"
+C
+x
+g
+"}

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -562,3 +562,8 @@ TYPEINFO(/obj)
 			src.throw_at(get_edge_target_turf(src,get_dir(AM, src)), 10, 1)
 		else if(AM.throwforce >= 80 && !isrestrictedz(src.z))
 			src.meteorhit(AM)
+
+/obj/proc/become_mimic()
+	var/mob/living/critter/mimic/replacer = new(get_turf(src.loc))
+	replacer.disguise_as(src)
+	qdel(src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -310,9 +310,7 @@
 	..()
 	if(prob(src.mimic_chance))
 		SPAWN(10 SECONDS)
-			var/mob/living/critter/mimic/replacer = new(get_turf(src.loc))
-			replacer.disguise_as(src)
-			qdel(src)
+			src.become_mimic()
 
 /obj/item/set_loc(var/newloc as turf|mob|obj in world)
 	if (src.temp_flags & IS_LIMB_ITEM)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -118,7 +118,8 @@
 	var/override_attack_hand = 1 //when used as an arm, attack with item rather than using attack_hand
 	var/limb_hit_bonus = 0 // attack bonus for when you have this item as a limb and hit someone with it
 	var/can_hold_items = 0 //when used as an arm, can it hold things?
-
+	/// Chance for this item to be replaced by a mimic disguised as it - note, setting this high here is a *really* bad idea
+	var/mimic_chance = 0
 	var/rand_pos = 0
 	var/obj/item/holding = null
 	var/rarity = ITEM_RARITY_COMMON // Just a little thing to indicate item rarity. RPG fluff.
@@ -307,6 +308,11 @@
 	if (isnull(initial(src.health))) // if not overridden
 		src.health = get_initial_item_health(src.type)
 	..()
+	if(prob(src.mimic_chance))
+		SPAWN(10 SECONDS)
+			var/mob/living/critter/mimic/replacer = new(get_turf(src.loc))
+			replacer.disguise_as(src)
+			qdel(src)
 
 /obj/item/set_loc(var/newloc as turf|mob|obj in world)
 	if (src.temp_flags & IS_LIMB_ITEM)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a var to `/obj/item` that gives a chance for that item to be replaced by a mimic. Defaults to 0. It is inadvisable to set it on `/obj/item`, but good for a laugh if you set it to 1. Peoples organs pop out and attack them, it's great.

Adds two random rooms. 
NotAMimic:
![image](https://user-images.githubusercontent.com/3855802/232232118-c919df13-d07c-43f8-abb5-188612c9d80b.png)
Has a bunch of research themed items, with sticky notes with "NOT A MIMIC" stuck to them. They each have a small chance to be a mimic. Major loot: a pair of thermal goggles.

Toolbox Storage:
![image](https://user-images.githubusercontent.com/3855802/232232267-8ad15823-07f1-451e-939d-03791a837c17.png)

Toolboxes of each type, each with a small chance to be a mimic.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More random rooms are good, especially dangerous ones.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Added a couple of mimic themed random rooms.
```
