### PR TITLE
Allow putting a Camera on Space Suit Helmet

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -46,6 +46,7 @@
 		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.has_camera == FALSE)
 			boutput(user, "You hastily shove the [C] onto the [src].")
 			src.name = "[src.name] with a camera"
+			src.desc = "[src.desc] It has a camera screwed on top."
 			if(src.camera_tag == initial(src.camera_tag))
 				src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
 				camera_counter++
@@ -58,6 +59,7 @@
 		else if (istype(C, /obj/item/screwdriver) && src.has_camera == TRUE)
 			boutput(user, "You detach the camera from the helmet and it drops to the floor.")
 			src.name = copytext("[src.name]",1,-14)
+			src.desc = copytext("[src.desc]",1,-32)
 			new /obj/item/clothing/head/helmet/camera(get_turf(src))
 			camera_counter--
 			src.camera_network = "Zeta"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -694,7 +694,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 	New()
 		..()
 		if(src.camera_tag == initial(src.camera_tag))
-			src.camera_tag = "Built [src.camera_tag] [src.camera_counter]"
+			src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
 			camera_counter++
 		src.camera = new /obj/machinery/camera (src)
 		src.camera.c_tag = src.camera_tag

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -37,6 +37,17 @@
 		setProperty("space_movespeed", 0.2)
 		setProperty("radprot", 5)
 
+	attackby(var/obj/item/C, mob/user as mob)
+		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.type == /obj/item/clothing/head/helmet/space)
+			boutput(user, "You hastily shove the [C] onto the [src]")
+			new /obj/item/(get_turf(src))
+			qdel(T)
+			qdel(src)
+			return
+		else
+			..()
+
+
 	oldish
 		icon_state = "space-OLD"
 		desc = "A relic of the past."
@@ -657,7 +668,6 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 	name = "camera helmet"
 	desc = "A helmet with a built in camera."
 	icon_state = "camhat"
-	item_state = "camhat"
 	var/obj/machinery/camera/camera = null
 	var/camera_tag = "Helmet Cam"
 	var/camera_network = "Zeta"
@@ -671,6 +681,26 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 		src.camera = new /obj/machinery/camera (src)
 		src.camera.c_tag = src.camera_tag
 		src.camera.network = src.camera_network
+
+
+/obj/item/clothing/head/helmet/suitcamera
+	name = "Suit helmet with Camera"
+	desc = "A Space suit with a camera attached to the top"
+	icon_state = "espace0"
+	var/obj/machinery/camera/camera = null
+	var/camera_tag = "Helmet Cam"
+	var/camera_network = "Zeta"
+	var/static/camera_counter = 0
+	New()
+		..()
+		if(src.camera_tag == initial(src.camera_tag))
+			src.camera_tag = "Built [src.camera_tag] [src.camera_counter]"
+			camera_counter++
+		src.camera = new /obj/machinery/camera (src)
+		src.camera.c_tag = src.camera_tag
+		src.camera.network = src.camera_network
+
+
 
 /obj/item/clothing/head/helmet/camera/security
 	name = "security camera helmet"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -40,8 +40,8 @@
 	attackby(var/obj/item/C, mob/user as mob)
 		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.type == /obj/item/clothing/head/helmet/space)
 			boutput(user, "You hastily shove the [C] onto the [src]")
-			new /obj/item/(get_turf(src))
-			qdel(T)
+			new /obj/item/clothing/head/helmet/space/camera(get_turf(src))
+			qdel(C)
 			qdel(src)
 			return
 		else
@@ -683,7 +683,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 		src.camera.network = src.camera_network
 
 
-/obj/item/clothing/head/helmet/suitcamera
+/obj/item/clothing/head/helmet/space/camera
 	name = "Suit helmet with Camera"
 	desc = "A Space suit with a camera attached to the top"
 	icon_state = "espace0"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -45,8 +45,8 @@
 	attackby(var/obj/item/C, mob/user as mob)
 		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.has_camera == FALSE)
 			boutput(user, "You hastily shove the [C] onto the [src].")
-			src.name = "[src] with a camera"
-			src.desc = "A [src] with a camera stuck to the top. It looks like it can be unscrewed."
+			src.name = "[src.name] with a camera"
+			src.desc = "[src] It has a camera screwed on top."
 			if(src.camera_tag == initial(src.camera_tag))
 				src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
 				camera_counter++
@@ -59,7 +59,7 @@
 		else if (istype(C, /obj/item/screwdriver) && src.has_camera == TRUE)
 			boutput(user, "You detach the camera from the helmet and it drops to the floor.")
 			src.name = copytext("[src.name]",1,-14)
-			src.desc = "A space helmet"
+			src.desc = copytext("[src]",1,-32)
 			new /obj/item/clothing/head/helmet/camera(get_turf(src))
 			camera_counter--
 			src.camera_network = "Zeta"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -46,7 +46,6 @@
 		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.has_camera == FALSE)
 			boutput(user, "You hastily shove the [C] onto the [src].")
 			src.name = "[src.name] with a camera"
-			src.desc = "[src] It has a camera screwed on top."
 			if(src.camera_tag == initial(src.camera_tag))
 				src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
 				camera_counter++
@@ -59,7 +58,6 @@
 		else if (istype(C, /obj/item/screwdriver) && src.has_camera == TRUE)
 			boutput(user, "You detach the camera from the helmet and it drops to the floor.")
 			src.name = copytext("[src.name]",1,-14)
-			src.desc = copytext("[src]",1,-32)
 			new /obj/item/clothing/head/helmet/camera(get_turf(src))
 			camera_counter--
 			src.camera_network = "Zeta"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -25,6 +25,11 @@
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
 	seal_hair = 1
 	path_prot = 0
+	var/camera_network = "Zeta"
+	var/camera_tag = "Helmet Cam"
+	var/static/camera_counter = 0
+	var/obj/machinery/camera/camera = null
+	var/has_camera = FALSE
 
 	setupProperties()
 		..()
@@ -38,11 +43,31 @@
 		setProperty("radprot", 5)
 
 	attackby(var/obj/item/C, mob/user as mob)
-		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.type == /obj/item/clothing/head/helmet/space)
-			boutput(user, "You hastily shove the [C] onto the [src]")
-			new /obj/item/clothing/head/helmet/space/camera(get_turf(src))
+		if (istype(C, /obj/item/clothing/head/helmet/camera) && src.has_camera == FALSE)
+			boutput(user, "You hastily shove the [C] onto the [src].")
+			src.name = "[src] with a camera"
+			src.desc = "A [src] with a camera stuck to the top. It looks like it can be unscrewed."
+			if(src.camera_tag == initial(src.camera_tag))
+				src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
+				camera_counter++
+			src.camera = new /obj/machinery/camera (src)
+			src.camera.c_tag = src.camera_tag
+			src.camera.network = src.camera_network
+			src.has_camera = TRUE
 			qdel(C)
-			qdel(src)
+			return
+		else if (istype(C, /obj/item/screwdriver) && src.has_camera == TRUE)
+			boutput(user, "You detach the camera from the helmet and it drops to the floor.")
+			src.name = copytext("[src.name]",1,-14)
+			src.desc = "A space helmet"
+			new /obj/item/clothing/head/helmet/camera(get_turf(src))
+			camera_counter--
+			src.camera_network = "Zeta"
+			src.camera_tag = "Helmet Cam"
+			src.camera = null
+			src.has_camera = FALSE
+
+
 			return
 		else
 			..()
@@ -681,25 +706,6 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 		src.camera = new /obj/machinery/camera (src)
 		src.camera.c_tag = src.camera_tag
 		src.camera.network = src.camera_network
-
-
-/obj/item/clothing/head/helmet/space/camera
-	name = "Suit helmet with Camera"
-	desc = "A Space suit with a camera attached to the top"
-	icon_state = "espace0"
-	var/obj/machinery/camera/camera = null
-	var/camera_tag = "Helmet Cam"
-	var/camera_network = "Zeta"
-	var/static/camera_counter = 0
-	New()
-		..()
-		if(src.camera_tag == initial(src.camera_tag))
-			src.camera_tag = "Space Suit [src.camera_tag] [src.camera_counter]"
-			camera_counter++
-		src.camera = new /obj/machinery/camera (src)
-		src.camera.c_tag = src.camera_tag
-		src.camera.network = src.camera_network
-
 
 
 /obj/item/clothing/head/helmet/camera/security


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability to combine a camera helmet onto a space suit helmet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for test subjects in telesci to actually wear a space suit and also be able to have the scientist watch where they go at the same time without needing to go through the process of getting a camera eye.

