### PR TITLE
Melt doors open with a C saber

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1594,23 +1594,22 @@ About the new airlock wires panel:
 		return src.Attackhand(user)
 	else if (ispryingtool(C))
 		src.unpowered_open_close()
-	else if (C.type == /obj/item/sword && user.a_intent == INTENT_HELP && !( src.operating ))
+	else if (istype(C, /obj/item/sword) && (user.a_intent == INTENT_HELP) && !src.operating)
 		var/obj/item/sword/S = C
 		if (!S.active)
-			boutput(user, "<span class='alert'>[S] needs to be on to melt the [src]</span>")
+			boutput(user, "<span class='alert'>[S] needs to be on to melt the [src]!</span>")
 			return
 		if (src.cant_emag)
 			boutput(user, "<span class='alert'>[src] is too resistant to melt from the saber!</span>")
 			return
-		else if (!src.density)
+		if (!src.density)
 			boutput(user, "<span class='alert'>You don't need to break open [src], as it's already open!</span>")
 			return
-		else
-			var/positions = src.get_welding_positions(user)
-			user.visible_message("<span class='alert'>[user] begins melting [src] open with [S]!</span>",\
-				"<span class='alert'>You begin melting [src] open with your [S.name]!</span>")
-			playsound(user.loc, 'sound/items/Welder2.ogg', 40, 1)
-			actions.start(new /datum/action/bar/private/welding(user, src, 10 SECONDS, /obj/machinery/door/airlock/proc/sword_open, null, null, positions[1], positions[2]),user)
+		var/positions = src.get_welding_positions(user)
+		user.visible_message("<span class='alert'>[user] begins melting [src] open with [S]!</span>",\
+			"<span class='alert'>You begin melting [src] open with your [S.name]!</span>")
+		playsound(user.loc, 'sound/items/Welder2.ogg', 40, 1)
+		actions.start(new /datum/action/bar/private/welding(user, src, src.health/45 SECONDS, /obj/machinery/door/airlock/proc/sword_open, null, null, positions[1], positions[2]),user)
 	else
 		..()
 	return

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1594,7 +1594,11 @@ About the new airlock wires panel:
 		return src.Attackhand(user)
 	else if (ispryingtool(C))
 		src.unpowered_open_close()
-	else if (C.type == /obj/item/sword && C:can_reflect() && user.a_intent == INTENT_HELP && !( src.operating ))
+	else if (C.type == /obj/item/sword && user.a_intent == INTENT_HELP && !( src.operating ))
+		var/obj/item/sword/S = C
+		if (!S.active)
+			boutput(user, "<span class='alert'>[S] needs to be on to melt the [src]</span>")
+			return
 		if (src.cant_emag)
 			boutput(user, "<span class='alert'>[src] is too resistant to melt from the saber!</span>")
 			return
@@ -1603,8 +1607,8 @@ About the new airlock wires panel:
 			return
 		else
 			var/positions = src.get_welding_positions(user)
-			user.visible_message("<span class='alert'>[user] is melting [src] open with a cyalume saber!</span>",\
-				"<span class='alert'>You are melting [src] open with your cyalume saber!</span>")
+			user.visible_message("<span class='alert'>[user] begins melting [src] open with [S]!</span>",\
+				"<span class='alert'>You begin melting [src] open with your [S.name]!</span>")
 			playsound(user.loc, 'sound/items/Welder2.ogg', 40, 1)
 			actions.start(new /datum/action/bar/private/welding(user, src, 10 SECONDS, /obj/machinery/door/airlock/proc/sword_open, null, null, positions[1], positions[2]),user)
 	else
@@ -1626,8 +1630,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/sword_open()
 	src.operating = -1
 	playsound(src, 'sound/machines/airlock_break_very_temp.ogg', 40, 1)
-	var/obj/item/scrap/S = new /obj/item/scrap
-	S.set_loc(src.loc)
+	new /obj/item/scrap(src.loc)
 	play_animation("opening")
 	src.UpdateIcon(1)
 	src.set_density(0)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1630,15 +1630,7 @@ About the new airlock wires panel:
 	src.operating = -1
 	playsound(src, 'sound/machines/airlock_break_very_temp.ogg', 40, 1)
 	new /obj/item/scrap(src.loc)
-	play_animation("opening")
-	src.UpdateIcon(1)
-	src.set_density(0)
-	if (!istype(src, /obj/machinery/door/airlock/glass))
-		if (ignore_light_or_cam_opacity)
-			src.set_opacity(0)
-		else
-			src.RL_SetOpacity(0)
-	src.UpdateIcon()
+	open(TRUE)
 
 /obj/machinery/door/airlock/proc/unpowered_open_close()
 	if (!src || !istype(src))
@@ -1696,8 +1688,8 @@ About the new airlock wires panel:
 
 	return
 
-/obj/machinery/door/airlock/open()
-	if (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
+/obj/machinery/door/airlock/open(force = FALSE) //force bypasses doors being welded, bolted, etc
+	if (force == FALSE && (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR)))
 		return 0
 	src.use_power(OPEN_CLOSE_POWER_USAGE)
 	if (src.linked_forcefield)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1594,6 +1594,19 @@ About the new airlock wires panel:
 		return src.Attackhand(user)
 	else if (ispryingtool(C))
 		src.unpowered_open_close()
+	else if (C.type == /obj/item/sword && user.a_intent == INTENT_HELP)
+		if (src.cant_emag)
+			boutput(user, "<span class='alert'>[src] is too resistant to melt from the saber!</span>")
+			return
+		else if (!src.density)
+			boutput(user, "<span class='alert'>You don't need to break open [src], as it's already open!</span>")
+			return
+		else
+			var/positions = src.get_welding_positions(user)
+			user.visible_message("<span class='alert'>[user] is melting [src] open with a cyalume saber!</span>",\
+				"<span class='alert'>You are melting [src] open with your cyalume saber!</span>")
+			playsound(user.loc, 'sound/items/Welder2.ogg', 40, 1)
+			actions.start(new /datum/action/bar/private/welding(user, src, 10 SECONDS, /obj/machinery/door/airlock/proc/sword_open, null, null, positions[1], positions[2]),user)
 	else
 		..()
 	return
@@ -1608,6 +1621,21 @@ About the new airlock wires panel:
 	else
 		logTheThing(LOG_STATION, user, "un-welded [name] at [log_loc(user)].")
 		src.welded = null
+	src.UpdateIcon()
+
+/obj/machinery/door/airlock/proc/sword_open()
+	src.operating = -1
+	playsound(src, 'sound/machines/airlock_break_very_temp.ogg', 40, 1)
+	var/obj/item/scrap/S = new /obj/item/scrap
+	S.set_loc(src.loc)
+	play_animation("opening")
+	src.UpdateIcon(1)
+	src.set_density(0)
+	if (!istype(src, /obj/machinery/door/airlock/glass))
+		if (ignore_light_or_cam_opacity)
+			src.set_opacity(0)
+		else
+			src.RL_SetOpacity(0)
 	src.UpdateIcon()
 
 /obj/machinery/door/airlock/proc/unpowered_open_close()

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1594,7 +1594,7 @@ About the new airlock wires panel:
 		return src.Attackhand(user)
 	else if (ispryingtool(C))
 		src.unpowered_open_close()
-	else if (C.type == /obj/item/sword && user.a_intent == INTENT_HELP)
+	else if (C.type == /obj/item/sword && C:can_reflect() && user.a_intent == INTENT_HELP && !( src.operating ))
 		if (src.cant_emag)
 			boutput(user, "<span class='alert'>[src] is too resistant to melt from the saber!</span>")
 			return

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1689,7 +1689,7 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/open(force = FALSE) //force bypasses doors being welded, bolted, etc
-	if (force == FALSE && (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR)))
+	if (!force && (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR)))
 		return 0
 	src.use_power(OPEN_CLOSE_POWER_USAGE)
 	if (src.linked_forcefield)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1594,7 +1594,7 @@ About the new airlock wires panel:
 		return src.Attackhand(user)
 	else if (ispryingtool(C))
 		src.unpowered_open_close()
-	else if (istype(C, /obj/item/sword) && (user.a_intent == INTENT_HELP) && !src.operating)
+	else if ((C.type == /obj/item/sword) && (user.a_intent == INTENT_HELP) && !src.operating)
 		var/obj/item/sword/S = C
 		if (!S.active)
 			boutput(user, "<span class='alert'>[S] needs to be on to melt the [src]!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so you can melt airlocks open with a c saber on help intent.
Melted airlocks are forced open and disabled forever (similarly to the emag).
For the melting to be done, there is an actionbar during which you cannot move or attack.
The duration of the action bar scales with door HP and matches the give or take time needed to bash the door open normally. 
Airlocks that are not hackable or emaggable (azones, listening post, ...) are immune to this.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's very cool and badass and a little bit of a buff to the c saber (bashing the door open takes about 20 seconds currently).
https://www.youtube.com/watch?v=K48M2S7bkSA&t=22s

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(*) Powered cyalume sabers on help intent are now able to melt doors open, like the cool guys do it in movies.
```
