### PR TITLE
New Command Traitor Item: AI Proto-Teleman module

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1003,6 +1003,16 @@ This is basically useless for anyone but miners.
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
 
+/datum/syndicate_buylist/traitor/ai_teleport
+	name = "AI Proto-Teleman Module"
+	item = /obj/item/aiModule/ability_expansion/proto_teleman
+	cost = 6
+	vr_allowed = FALSE
+	not_in_crates = TRUE
+	desc = "An AI module that upgrades any AI connected to the installed law rack access to a targeted teleport system using the on-station science teleporter"
+	job = list("Captain", "Research Director")
+	can_buy = UPLINK_TRAITOR
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new item for traitorous captains and RDs, the prototype teleporter module. This module let's AIs send things to and from the science teleporter, with some restrictions on delivery locations.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See #10922


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Adds a new command traitor item: A prototype teleporter module that costs 6 tc. Available for the captain and research director.
```
