### PR TITLE
Makes it so underage drinking relies on sec records and not true age

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -195,16 +195,16 @@ datum
 				if(!istype(holder) || !istype(holder.my_atom) || !ishuman(holder.my_atom))
 					return
 				var/mob/living/carbon/human/H = holder.my_atom
-				if(H.bioHolder.age < 21) // Yes. Its 21. This is Space America. That is canon now.
-					if(seen_by_camera(H))
-						// determine the name of the perp (goes by ID if wearing one)
-						var/perpname = H.name
-						if(H:wear_id && H:wear_id:registered)
-							perpname = H:wear_id:registered
-						var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-						if(sec_record && sec_record["criminal"] != "*Arrest*")
-							sec_record["criminal"] = "*Arrest*"
-							sec_record["mi_crim"] = "Underage drinking."
+				if(seen_by_camera(H))
+					// determine the name of the perp (goes by ID if wearing one)
+					var/perpname = H.name
+					if(H:wear_id && H:wear_id:registered)
+						perpname = H:wear_id:registered
+					var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
+					if(sec_record && sec_record["age"] < 21 && sec_record["criminal"] != "*Arrest*")
+					// Yes. Its 21. This is Space America. That is canon now.
+						sec_record["criminal"] = "*Arrest*"
+						sec_record["mi_crim"] = "Underage drinking."
 
 		fooddrink/alcoholic/hard_punch
 			name = "hard punch"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically makes it check sec records for the age of a person, istead of checking the bioholder age.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because it makes no sense cameras know how old that stoaway is, also lets security twist records a little bit if an underage drinking problem becomes excessive.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

None needed