### PR TITLE
Splits mob AI critter attacks into ability and basic attacks

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -102,6 +102,10 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 	///If the mob has an ai, and is currently retaliating against being attacked, how long should we do that for? (deciseconds)
 	///Special values: RETALIATE_ONCE = Attack once, RETALIATE_UNTIL_INCAP = Attack until the target is incapacitated, RETALIATE_UNTIL_DEAD = Attck until the target is dead
 	var/ai_retaliate_persistence = RETALIATE_ONCE
+	///Counts the number of attacks this critter has performed without using an ability
+	var/ai_attack_count = 0
+	///The number of basic attacks this critter will perform in between using abilities
+	var/ai_attacks_per_ability = 2
 
 	blood_id = "blood"
 
@@ -1315,9 +1319,23 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 
 	/// Used for generic critter mobAI - override if your critter needs special attack behaviour. If you need super special attack behaviour, you'll want to create your own attack aiTask
 	proc/critter_attack(var/mob/target)
+		if (src.ai_attack_count >= src.ai_attacks_per_ability)
+			if (src.critter_ability_attack(target))
+				src.ai_attack_count = 0 //ability used successfully, reset the count
+				return
+		//default to a basic attack
+		if (src.critter_basic_attack(target))
+			src.ai_attack_count += 1
+
+	/// How the critter should attack normally
+	proc/critter_basic_attack(var/mob/target)
 		src.set_a_intent(INTENT_HARM)
 		src.hand_attack(target)
 		return TRUE
+
+	///How the critter should use abilities, return TRUE to indicate ability usage success
+	proc/critter_ability_attack(var/mob/target)
+		return FALSE
 
 	/// Used for generic critter mobAI - override if your critter needs special scavenge behaviour. If you need super special attack behaviour, you'll want to create your own attack aiTask
 	proc/critter_scavenge(var/mob/target)

--- a/code/mob/living/critter/bear.dm
+++ b/code/mob/living/critter/bear.dm
@@ -99,18 +99,20 @@
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_STAMINA_REGEN_BONUS, "bear", 3)
 		src.add_stam_mod_max("bear", 50)
 
-	critter_attack(mob/target)
+	critter_ability_attack(mob/target)
 		var/datum/targetable/critter/tackle = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
 		if (!tackle.disabled && tackle.cooldowncheck())
 			tackle.handleCast(target)
-		else
-			if(!ON_COOLDOWN(src, "bear_scream", 3 SECONDS))
-				src.visible_message("<b><span class='alert'>[src] roars!</span></b>")
-				if(istype(src, /mob/living/critter/bear/care))
-					playsound(src.loc, 'sound/voice/babynoise.ogg', 40, 0)
-				else
-					playsound(src.loc, 'sound/voice/MEraaargh.ogg', 40, 0)
-			return ..()
+			return TRUE
+
+	critter_basic_attack(mob/target)
+		if(!ON_COOLDOWN(src, "bear_scream", 3 SECONDS))
+			src.visible_message("<b><span class='alert'>[src] roars!</span></b>")
+			if(istype(src, /mob/living/critter/bear/care))
+				playsound(src.loc, 'sound/voice/babynoise.ogg', 40, 0)
+			else
+				playsound(src.loc, 'sound/voice/MEraaargh.ogg', 40, 0)
+		return ..()
 
 	critter_scavenge(var/mob/target)
 		src.visible_message("<span class='alert'<b>[src] nibbles [target]!</b></span>")

--- a/code/mob/living/critter/big_animal.dm
+++ b/code/mob/living/critter/big_animal.dm
@@ -53,14 +53,16 @@
 		HH.limb_name = "teeth"					// name for the dummy holder
 		HH.can_hold_items = FALSE
 
-	critter_attack(var/mob/target)
+	critter_ability_attack(var/mob/target)
 		var/datum/targetable/critter/bite = src.abilityHolder.getAbility(/datum/targetable/critter/bite/big)
 		if (!bite.disabled && bite.cooldowncheck() && prob(40))
 			bite.handleCast(target)
-		else
-			if(prob(20))
-				src.swap_hand()
-			src.hand_attack(target)
+			return TRUE
+
+	critter_basic_attack(mob/target)
+		if(prob(20))
+			src.swap_hand()
+		return ..()
 
 	critter_scavenge(var/mob/target)
 		src.visible_message("<span class='alert'<b>[src] bites a chunk out of [target]!</b></span>")

--- a/code/mob/living/critter/brullbar.dm
+++ b/code/mob/living/critter/brullbar.dm
@@ -139,15 +139,20 @@
 				if (H.decomp_stage >= 3 || H.bioHolder?.HasEffect("husk")) continue //is dead, isn't a skeleton, isn't a grody husk
 			. += M
 
-	critter_attack(var/mob/target)
+	critter_ability_attack(var/mob/target)
 		var/datum/targetable/critter/frenzy = src.abilityHolder.getAbility(/datum/targetable/critter/frenzy)
 		var/datum/targetable/critter/tackle = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
 		if (!tackle.disabled && tackle.cooldowncheck() && !is_incapacitated(target) && prob(30))
 			tackle.handleCast(target) // no return to wack people with the frenzy after the tackle sometimes
+			. = TRUE
 		if (!frenzy.disabled && frenzy.cooldowncheck() && is_incapacitated(target) && prob(30))
 			frenzy.handleCast(target)
-		else if (issilicon(target))
+			. = TRUE
+
+	critter_basic_attack(mob/target)
+		if (issilicon(target))
 			fuck_up_silicons(target)
+			return TRUE
 		else
 			return ..()
 

--- a/code/mob/living/critter/brullbar.dm
+++ b/code/mob/living/critter/brullbar.dm
@@ -144,6 +144,7 @@
 		var/datum/targetable/critter/tackle = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
 		if (!tackle.disabled && tackle.cooldowncheck() && !is_incapacitated(target) && prob(30))
 			tackle.handleCast(target) // no return to wack people with the frenzy after the tackle sometimes
+			src.ai_attack_count = src.ai_attacks_per_ability //brullbars get to be evil and frenzy right away
 			. = TRUE
 		if (!frenzy.disabled && frenzy.cooldowncheck() && is_incapacitated(target) && prob(30))
 			frenzy.handleCast(target)

--- a/code/mob/living/critter/fermid.dm
+++ b/code/mob/living/critter/fermid.dm
@@ -99,17 +99,20 @@
 				return 3
 		return ..()
 
-	critter_attack(var/mob/target)
+	critter_ability_attack(var/mob/target)
 		var/datum/targetable/critter/sting = src.abilityHolder.getAbility(/datum/targetable/critter/sting/fermid)
 		var/datum/targetable/critter/bite = src.abilityHolder.getAbility(/datum/targetable/critter/bite/fermid_bite)
 		if (!sting.disabled && sting.cooldowncheck())
 			sting.handleCast(target)
+			return TRUE
 		else if (!bite.disabled && bite.cooldowncheck())
 			bite.handleCast(target)
-		else
-			if(prob(30))
-				src.swap_hand()
-			src.hand_attack(target)
+			return TRUE
+
+	critter_basic_attack(mob/target)
+		if(prob(30))
+			src.swap_hand()
+		return ..()
 
 	death()
 		src.can_lie = FALSE

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -16,6 +16,8 @@
 	ai_retaliate_patience = 0
 	ai_retaliate_persistence = RETALIATE_UNTIL_INCAP
 	ai_retaliates = TRUE
+	//we're an ambush critter so we use all our abilities immediately
+	ai_attacks_per_ability = 0
 
 	dir_locked = TRUE //most items don't have dirstates, so don't let us change one
 	var/mutable_appearance/disguise
@@ -97,14 +99,17 @@
 
 	critter_attack(mob/target)
 		src.last_disturbed = TIME
+		..()
+
+	critter_ability_attack(mob/target)
 		var/datum/targetable/critter/sting/mimic/sting = src.abilityHolder.getAbility(/datum/targetable/critter/sting/mimic)
 		var/datum/targetable/critter/tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
 		if(!sting.disabled && sting.cooldowncheck())
 			sting.handleCast(target)
-		else if(!pounce.disabled && pounce.cooldowncheck())
+			return TRUE
+		if(!pounce.disabled && pounce.cooldowncheck())
 			pounce.handleCast(target)
-		else
-			. = ..()
+			return TRUE
 
 	seek_target(var/range = 5)
 		. = list()

--- a/code/mob/living/critter/skeleton.dm
+++ b/code/mob/living/critter/skeleton.dm
@@ -120,12 +120,11 @@
 			if (iswizard(C) && src.wizardSpawn) continue
 			. += C
 
-	critter_attack(mob/target)
+	critter_ability_attack(mob/target)
 		var/datum/targetable/critter/tackle = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
 		if (!tackle.disabled && tackle.cooldowncheck())
 			tackle.handleCast(target)
-		else
-			return ..()
+			return TRUE
 
 	death(var/gibbed)
 		if (prob(src.revivalChance))

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -214,11 +214,10 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 			return
 		. = ..()
 
-	critter_attack(var/mob/target)
+	critter_basic_attack(var/mob/target)
 		playsound(src.loc, 'sound/weapons/handcuffs.ogg', 50, 1, -1)
 		src.set_hand(2)
-		src.set_a_intent(INTENT_HARM)
-		src.hand_attack(target)
+		..()
 
 	can_critter_eat()
 		src.active_hand = 2 // mouth hand
@@ -247,9 +246,9 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 			if (istype(C, /mob/living/critter/small_animal/mouse) || istype(C, /mob/living/critter/wraith/plaguerat)) continue
 			. += C
 
-	critter_attack(var/mob/target)
-		..()
-		if(prob(30) && ishuman(target))
+	critter_basic_attack(var/mob/target)
+		. = ..()
+		if(. && prob(30) && ishuman(target))
 			var/mob/living/carbon/human/H = target
 			if(!H.clothing_protects_from_chems())
 				src.visible_message("<span class='alert'>[src] bites you hard enough to draw blood!</span>", "<span class='alert'>You bite [H] with all your might!</span>")
@@ -497,45 +496,53 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 			playsound(src.loc, 'sound/voice/animal/cat_hiss.ogg', 50, 1)
 			src.visible_message("<span class='alert'>[src] hisses!</span>")
 
-	critter_attack(var/the_target)
-		if (istype(the_target, /obj/critter))
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/pounce/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/pounce)
+		if (!pounce.disabled && pounce.cooldowncheck() && prob(50))
+			src.visible_message("<span class='combat'><B>[src]</B> pounces on [target] and trips them!</span>", "<span class='combat'>You pounce on [target]!</span>")
+			pounce.handleCast(target)
+			return TRUE
+
+		if ((src.catnip || prob(2) ) && (!ON_COOLDOWN(src, "claw_fury", 20 SECONDS)))
+			var/attackCount = rand(5, 9)
+			var/iteration = 0
+			target.setStatus("weakened", 2 SECONDS)
+			src.visible_message("<span class='combat'>[src] [pick("starts to claw the living <b>shit</b> out of ", "unleashes a flurry of claw at ")] [target]!</span>")
+			SPAWN(0)
+				while (iteration <= attackCount && (get_dist(src, target) <= 1))
+					src.set_hand(1) //claws
+					src.set_a_intent(INTENT_HARM)
+					src.hand_attack(target)
+					iteration++
+					sleep(0.3 SECONDS)
+			return TRUE
+
+	critter_basic_attack(var/the_target)
+		if (istype(the_target, /obj/critter)) //grrrr obj critters
 			var/obj/critter/C = the_target
 			if (C.health <= 0 && C.alive)
 				playsound(src.loc, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, 1, -1)
 				C.health -= 2
-		else if (istype(the_target, /mob))
-			var/mob/target = the_target
-			if(istype(target, /mob/living/critter/small_animal/mouse/weak/mentor) && prob(90))
-				src.visible_message("<span class='combat'><B>[src]</B> tries to bite [target] but \the [target] dodges [pick("nimbly", "effortlessly", "gracefully")]!</span>")
-				return
-			if ((src.catnip || prob(2) ) && (!ON_COOLDOWN(src, "claw_fury", 20 SECONDS)))
-				var/attackCount = rand(5, 9)
-				var/iteration = 0
-				target.setStatus("weakened", 2 SECONDS)
-				src.visible_message("<span class='combat'>[src] [pick("starts to claw the living <b>shit</b> out of ", "unleashes a flurry of claw at ")] [target]!</span>")
-				SPAWN(0)
-					while (iteration <= attackCount && (get_dist(src, target) <= 1))
-						src.set_hand(1) //claws
-						src.set_a_intent(INTENT_HARM)
-						src.hand_attack(target)
-						iteration++
-						sleep(0.3 SECONDS)
-			var/datum/targetable/critter/pounce/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/pounce)
-			if (!pounce.disabled && pounce.cooldowncheck() && prob(50))
-				src.visible_message("<span class='combat'><B>[src]</B> pounces on [target] and trips them!</span>", "<span class='combat'>You pounce on [target]!</span>")
-				pounce.handleCast(target)
-				return
-			if (prob(50))
-				src.set_hand(2) //mouth
-				src.set_a_intent(INTENT_HARM)
-				src.hand_attack(target)
-			else
-				src.set_hand(1) //claws
-				src.set_a_intent(INTENT_HARM)
-				src.hand_attack(target)
-				if (prob(10))
-					bleed(target, 2)
-					boutput(target, "<span class='alert'>[src] scratches you hard enough to draw some blood! [pick("Bad kitty", "Piece of shit", "Ow")]!</span>")
+				return TRUE
+			return FALSE
+		if (!ismob(the_target))
+			return
+		var/mob/target = the_target
+		if(istype(target, /mob/living/critter/small_animal/mouse/weak/mentor) && prob(90))
+			src.visible_message("<span class='combat'><B>[src]</B> tries to bite [target] but \the [target] dodges [pick("nimbly", "effortlessly", "gracefully")]!</span>")
+			return FALSE
+		if (prob(50))
+			src.set_hand(2) //mouth
+			src.set_a_intent(INTENT_HARM)
+			src.hand_attack(target)
+		else
+			src.set_hand(1) //claws
+			src.set_a_intent(INTENT_HARM)
+			src.hand_attack(target)
+			if (prob(10))
+				bleed(target, 2)
+				boutput(target, "<span class='alert'>[src] scratches you hard enough to draw some blood! [pick("Bad kitty", "Piece of shit", "Ow")]!</span>")
+		return TRUE
 
 /mob/living/critter/small_animal/cat/weak
 	add_abilities = list()
@@ -696,17 +703,16 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 		if (src.ai?.enabled && prob(1))
 			src.emote("scream", TRUE)
 
-	critter_attack(var/the_target)
-		if (istype(the_target, /mob))
-			var/mob/target = the_target
-			var/datum/targetable/critter/pounce/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/pounce)
-			if (!pounce.disabled && pounce.cooldowncheck() && prob(50))
-				src.visible_message("<span class='combat'><B>[src]</B> barrels into [target] and trips them!</span>", "<span class='combat'>You run into [target]!</span>")
-				pounce.handleCast(target)
-				return
-			src.set_hand(2) //mouth
-			src.set_a_intent(INTENT_HARM)
-			src.hand_attack(target)
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/pounce/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/pounce)
+		if (!pounce.disabled && pounce.cooldowncheck() && prob(50))
+			src.visible_message("<span class='combat'><B>[src]</B> barrels into [target] and trips them!</span>", "<span class='combat'>You run into [target]!</span>")
+			pounce.handleCast(target)
+			return TRUE
+
+	critter_basic_attack(mob/target)
+		src.set_hand(2) //mouth
+		return ..()
 
 	disposing()
 		. = ..()
@@ -1825,18 +1831,16 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 				return 2
 		return ..()
 
-	critter_attack(var/mob/target)
+	critter_ability_attack(var/mob/target)
 		var/datum/targetable/critter/wasp_sting/scorpion_sting/sting = src.abilityHolder.getAbility(/datum/targetable/critter/wasp_sting/scorpion_sting)
 		var/datum/targetable/critter/pincer_grab/pincer_grab = src.abilityHolder.getAbility(/datum/targetable/critter/pincer_grab)
 
 		if (!sting.disabled && sting.cooldowncheck() && prob(50))
 			sting.handleCast(target)
-			return
-		else if (!pincer_grab.disabled && pincer_grab.cooldowncheck() && prob(50))
+			return TRUE
+		if (!pincer_grab.disabled && pincer_grab.cooldowncheck() && prob(50))
 			pincer_grab.handleCast(target)
-			return
-		else
-			return ..()
+			return TRUE
 
 	seek_target(var/range = 8)
 		. = list()
@@ -1958,14 +1962,12 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 			return 2
 		return ..()
 
-	critter_attack(var/mob/target)
+	critter_ability_attack(var/mob/target)
 		var/datum/targetable/critter/wasp_sting/snake_bite/sting = src.abilityHolder.getAbility(/datum/targetable/critter/wasp_sting/snake_bite)
 
 		if (!sting.disabled && sting.cooldowncheck())
 			sting.handleCast(target)
-			return
-		else
-			return ..()
+			return TRUE
 
 	seek_target(var/range = 8)
 		. = list()

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -150,16 +150,15 @@
 			playsound(src.loc, 'sound/voice/animal/cat_hiss.ogg', 50, 1)
 			src.visible_message("<span class='alert'><B>[src]</B> hisses!</span>")
 
-	critter_attack(target)
-		if(ismob(target))
-			var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
-			var/datum/targetable/critter/spider_flail/flail = src.abilityHolder.getAbility(/datum/targetable/critter/spider_flail)
-			if (!flail.disabled && flail.cooldowncheck() && prob(20))
-				flail.handleCast(target)
-			else if(!bite.disabled && bite.cooldowncheck())
-				bite.handleCast(target)
-			else
-				..()
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
+		var/datum/targetable/critter/spider_flail/flail = src.abilityHolder.getAbility(/datum/targetable/critter/spider_flail)
+		if (!flail.disabled && flail.cooldowncheck() && prob(20))
+			flail.handleCast(target)
+			return TRUE
+		else if(!bite.disabled && bite.cooldowncheck())
+			bite.handleCast(target)
+			return TRUE
 
 	critter_scavenge(target)
 		var/datum/targetable/critter/spider_drain/drain = src.abilityHolder.getAbility(/datum/targetable/critter/spider_drain)
@@ -354,17 +353,15 @@
 			src.organHolder.drop_and_throw_organ("brain")
 			src.gib(1)
 
-	critter_attack(target)
-		if(ismob(target))
-			var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
-			var/datum/targetable/critter/clownspider_kick/kick = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_kick)
-			if (!kick.disabled && kick.cooldowncheck() && prob(20))
-				kick.handleCast(target)
-			else if(!bite.disabled && bite.cooldowncheck())
-				bite.handleCast(target)
-			else
-				src.set_a_intent(INTENT_HARM)
-				src.hand_attack(target)
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
+		var/datum/targetable/critter/clownspider_kick/kick = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_kick)
+		if (!kick.disabled && kick.cooldowncheck() && prob(20))
+			kick.handleCast(target)
+			return TRUE
+		else if(!bite.disabled && bite.cooldowncheck())
+			bite.handleCast(target)
+			return TRUE
 	cluwne
 		name = "cluwnespider"
 		desc = "Uhhh. That's not normal. Like, even for clownspiders."
@@ -379,17 +376,15 @@
 		item_shoes = /obj/item/clothing/shoes/cursedclown_shoes
 		item_mask = /obj/item/clothing/mask/cursedclown_hat
 
-		critter_attack(target)
-			if(ismob(target))
-				var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite/cluwne)
-				var/datum/targetable/critter/clownspider_kick/kick = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_kick/cluwne)
-				if (!kick.disabled && kick.cooldowncheck() && prob(20))
-					kick.handleCast(target)
-				else if(!bite.disabled && bite.cooldowncheck())
-					bite.handleCast(target)
-				else
-					src.set_a_intent(INTENT_HARM)
-					src.hand_attack(target)
+		critter_ability_attack(mob/target)
+			var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite/cluwne)
+			var/datum/targetable/critter/clownspider_kick/kick = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_kick/cluwne)
+			if (!kick.disabled && kick.cooldowncheck() && prob(20))
+				kick.handleCast(target)
+				return TRUE
+			else if(!bite.disabled && bite.cooldowncheck())
+				bite.handleCast(target)
+				return TRUE
 
 		critter_scavenge(target)
 			var/datum/targetable/critter/spider_drain/drain = src.abilityHolder.getAbility(/datum/targetable/critter/spider_drain/cluwne)
@@ -441,17 +436,15 @@
 		// egg_path = /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/cluwne
 		max_defensive_babies = 150
 
-		critter_attack(target)
-			if(ismob(target))
-				var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite/cluwne)
-				var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample/cluwne)
-				if (!trample.disabled && trample.cooldowncheck() && prob(20))
-					trample.handleCast(target)
-				else if(!bite.disabled && bite.cooldowncheck())
-					bite.handleCast(target)
-				else
-					src.set_a_intent(INTENT_HARM)
-					src.hand_attack(target)
+		critter_ability_attack(mob/target)
+			var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite/cluwne)
+			var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample/cluwne)
+			if (!trample.disabled && trample.cooldowncheck() && prob(20))
+				trample.handleCast(target)
+				return TRUE
+			else if(!bite.disabled && bite.cooldowncheck())
+				bite.handleCast(target)
+				return TRUE
 
 		critter_scavenge(target)
 			var/datum/targetable/critter/spider_drain/drain = src.abilityHolder.getAbility(/datum/targetable/critter/spider_drain/cluwne)
@@ -519,18 +512,16 @@
 			CS.ai.interrupt()
 			defenders++
 
-	critter_attack(target)
-		if(ismob(target))
-			var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
-			var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample)
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/spider_bite/bite = src.abilityHolder.getAbility(/datum/targetable/critter/spider_bite)
+		var/datum/targetable/critter/clownspider_trample/trample = src.abilityHolder.getAbility(/datum/targetable/critter/clownspider_trample)
 
-			if (!trample.disabled && trample.cooldowncheck() && prob(20))
-				trample.handleCast(target)
-			else if(!bite.disabled && bite.cooldowncheck())
-				bite.handleCast(target)
-			else
-				src.set_a_intent(INTENT_HARM)
-				src.hand_attack(target)
+		if (!trample.disabled && trample.cooldowncheck() && prob(20))
+			trample.handleCast(target)
+			return TRUE
+		else if(!bite.disabled && bite.cooldowncheck())
+			bite.handleCast(target)
+			return TRUE
 
 	critter_scavenge(target)
 		var/datum/targetable/critter/spider_drain/drain = src.abilityHolder.getAbility(/datum/targetable/critter/spider_drain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splits `critter_attack` into `critter_ability_attack` and `critter_basic_attack`, by default mob critters will now have to try to basic attack twice before using an ability.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mob critters currently frontload all their abilities as soon as they reach you, this should make them spread out ability usage a bit more.
