### PR TITLE
Adds AI intercoms to Atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -3708,7 +3708,10 @@
 "alR" = (
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon6,
-/obj/machinery/light_switch/auto,
+/obj/item/device/radio/intercom/AI{
+	dir = 8;
+	broadcasting = 0
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "alS" = (
@@ -5549,9 +5552,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch/auto,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
+	},
+/obj/item/device/radio/intercom/AI{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
@@ -13850,6 +13855,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "aRs" = (
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0
+	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "aRv" = (
@@ -15418,6 +15426,7 @@
 	light_type = /obj/item/light/tube/blueish
 	},
 /obj/table/auto,
+/obj/machinery/light_switch/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aVO" = (
@@ -18460,6 +18469,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/item/device/radio/intercom/AI{
+	broadcasting = 0
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "mSy" = (
@@ -20084,6 +20096,14 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
+"ylU" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment,
+/obj/machinery/light_switch/auto,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 
 (1,1,1) = {"
 aaa
@@ -60071,7 +60091,7 @@ axo
 puT
 opJ
 alt
-aWF
+ylU
 aWF
 aWF
 mxP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds four AI intercoms to Atlas. One on the bridge and three around the core, similar to all other stations.
![AtlasIntercom1](https://user-images.githubusercontent.com/109899867/233428133-db34dcc2-4f6b-469c-913f-6c16959f7149.png)
![AtlasIntercom2](https://user-images.githubusercontent.com/109899867/233428152-647d68ba-e98c-4fda-8338-4343ff71c4f4.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes Atlas more similar to other maps by giving it AI intercoms, previously closing the shutters for safety would mean an AI couldn't communicate with anyone in the room.



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Piesuu
(+)The NCS Atlas has been equipped with AI intercoms
```
