### PR TITLE
Makes all silicons incapable of recalling the shuttle

### DIFF
--- a/code/modules/networks/computer3/communication.dm
+++ b/code/modules/networks/computer3/communication.dm
@@ -120,7 +120,7 @@
 							src.master.add_fingerprint(usr)
 							return
 
-						if(isAI(usr) || src.authenticated == "AIUSR")
+						if(issilicon(usr) || src.authenticated == "AIUSR")
 							src.print_text("<b>Error:</b> Shuttle recall from AIUSR blocked by Central Command.")
 							return
 


### PR DESCRIPTION
[SILICONS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #13769 by changing `isAI()` to `issilicon()`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If the Ai isn't supposed to recall shuttles, other sillicons shouldn't be able to either.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Piesuu
(+)Cyborgs can no longer recall the emergency shuttle
```
