### PR TITLE
Re-enable ocean pathfinding

### DIFF
--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -266,7 +266,12 @@ var/list/ai_move_scheduled = list()
 			for(var/atom/A as anything in targets)
 				var/score = src.score_target(A)
 				if(score > best_score)
-					var/tmp_best_path = get_path_to(holder.owner, A, max_dist*2, can_be_adjacent_to_target, null, !move_through_space)
+					var/simulated_only = !move_through_space
+#ifdef UNDERWATER_MAP
+					//fucking unsimulated ocean tiles fuck
+					simulated_only = FALSE
+#endif
+					var/tmp_best_path = get_path_to(holder.owner, A, max_dist*2, can_be_adjacent_to_target, null, simulated_only)
 					if(length(tmp_best_path))
 						best_score = score
 						best_path = tmp_best_path

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -20,7 +20,7 @@
 	icon = 'icons/turf/outdoors.dmi'
 	icon_state = "sand_other"
 	color = OCEAN_COLOR
-	pathable = 0
+	pathable = 1
 	mat_changename = 0
 	mat_changedesc = 0
 	fullbright = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[EXPERIMENTAL] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Did you know that all pathfinding on ocean tiles, including the trench has just been turned off for months? Well apparently it has, this PR is to test what happens when we turn it back on.