### PR TITLE
Fixes #13778

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -200,9 +200,10 @@ datum
 					var/perpname = H.name
 					if(H:wear_id && H:wear_id:registered)
 						perpname = H:wear_id:registered
+					var/datum/db_record/gen_record = data_core.general.find_record("name", perpname)
 					var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-					if(sec_record && sec_record["age"] < 21 && sec_record["criminal"] != "*Arrest*")
 					// Yes. Its 21. This is Space America. That is canon now.
+					if(gen_record && sec_record && gen_record["age"] < 21 && sec_record["criminal"] != "*Arrest*")
 						sec_record["criminal"] = "*Arrest*"
 						sec_record["mi_crim"] = "Underage drinking."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fuck.
Apparently sec records do not contain age and NULL is inferior to 21. 
Fixes #13778

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad, me dumb, Pali smart.