### PR TITLE
Adds doorway from engineering core to mechanics on donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -25896,10 +25896,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
-"hMu" = (
-/obj/table/auto,
-/turf/simulated/floor/yellow,
-/area/station/engine/elect)
 "hMC" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -26818,6 +26814,14 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/clown)
+"icB" = (
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 1;
+	req_access = null
+	},
+/obj/access_spawn/engineering_mechanic,
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
 "icO" = (
 /obj/table/reinforced/auto,
 /obj/access_spawn/hydro,
@@ -31714,6 +31718,17 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
+"jCq" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decoration/vent/vent2{
+	pixel_y = 32
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 1
+	},
+/area/station/engine/inner)
 "jCs" = (
 /obj/machinery/disposal/mail/small/autoname/bridge/east,
 /obj/cable{
@@ -140229,7 +140244,7 @@ tat
 svo
 nTr
 toH
-dbP
+tat
 sEo
 cmM
 sEo
@@ -140531,7 +140546,7 @@ tat
 wGr
 iLK
 iLK
-dbP
+tat
 pIf
 nZo
 vuP
@@ -140833,7 +140848,7 @@ mTe
 tAo
 ewz
 pEh
-dbP
+tat
 tmO
 pqD
 ocE
@@ -141134,9 +141149,9 @@ ewz
 ewz
 bUH
 ewz
-hMu
-dbP
-gew
+ewz
+icB
+vVK
 pqD
 ocE
 xVe
@@ -141437,7 +141452,7 @@ oLB
 tAo
 ewz
 xqx
-dbP
+tat
 oXX
 pqD
 ocE
@@ -141738,9 +141753,9 @@ tat
 tat
 pIN
 tat
-dbP
-dbP
-vVK
+tat
+tat
+jCq
 pqD
 ocE
 oWs

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -26815,10 +26815,7 @@
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/clown)
 "icB" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 1;
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/engineering,
 /obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -75437,11 +75434,10 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "wGr" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	req_access = null
-	},
 /obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4
+	},
 /obj/access_spawn/engineering_mechanic,
 /obj/cable{
 	icon_state = "4-8"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds a shortcut to donut3 to get to mechanics faster
![image](https://user-images.githubusercontent.com/73148980/233749669-8160c4fb-09be-4243-8585-416ac3a6ca6b.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mechanics and engineering has been merged, maps should act like that as well.



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Not really needed tbh