### PR TITLE
Don't hit mechcomp on edit custom signal

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -367,6 +367,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 					//must be a custom config specific to the device, so let the device handle it
 					var/path = src.configs[selected_config]
 					call(parent, path)(W, user)
+					return FALSE
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/compatible()

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -367,7 +367,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 					//must be a custom config specific to the device, so let the device handle it
 					var/path = src.configs[selected_config]
 					call(parent, path)(W, user)
-					return FALSE
+					return TRUE
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/compatible()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes hitting mechcomp with multitool when you edit a custom signal


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stop being clumsy and smacking your mechcomp!

