### PR TITLE
Rockbox sales pay the CE and Miners instead of the CE and Engineers

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -848,7 +848,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 							var/list/accounts = \
 								data_core.bank.find_records("job", "Chief Engineer") + \
 								data_core.bank.find_records("job", "Chief Engineer") + \
-								data_core.bank.find_records("job", "Engineer")
+								data_core.bank.find_records("job", "Miner")
 
 
 							var/datum/signal/minerSignal = get_free_signal()


### PR DESCRIPTION
[OBJECTS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #13805  because Miners should be paid for their work


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The Rockbox payment code is a copy paste of the PTL code. Engineers don't have anything to do with rockbox sales, miners do. 