### PR TITLE
Updates chameleon gear and gives it hides from examine

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -5,7 +5,7 @@
 	wear_image_icon = 'icons/mob/clothing/jumpsuits/worn_js.dmi'
 	inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js.dmi'
 	icon_state = "black"
-	uses_multiple_icon_states = 1
+	uses_multiple_icon_states = TRUE
 	item_state = "black"
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_jumpsuit_pattern
@@ -227,12 +227,6 @@
 		icon_state = "qm"
 		item_state = "qm"
 
-	rank/mechanic
-		name = "mechanic's uniform"
-		desc = "Formerly an electrician's uniform, renamed because mechanics are not electricians."
-		icon_state = "mechanic"
-		item_state = "mechanic"
-
 	rank/overalls
 		name = "miner's overalls"
 		desc = "Durable overalls for the hard worker who likes to smash rocks into little bits."
@@ -301,12 +295,12 @@
 	wear_image_icon = 'icons/mob/clothing/head.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	icon = 'icons/obj/clothing/item_hats.dmi'
-	uses_multiple_icon_states = 1
+	uses_multiple_icon_states = TRUE
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_hat_pattern
 	blocked_from_petasusaphilic = TRUE
 	item_function_flags = IMMUNE_TO_ACID
-	seal_hair = 0
+	seal_hair = FALSE
 
 	New()
 		..()
@@ -347,11 +341,12 @@
 			boutput(M, "<span class='alert'><B>Your chameleon hat malfunctions!</B></span>")
 			src.name = "hat"
 			src.desc = "A knit cap in...what the hell?"
+			src.hides_from_examine = null
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
 			src.icon_state = "psyche"
 			src.item_state = "bgloves"
-			src.seal_hair = 0
+			src.seal_hair = FALSE
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -370,6 +365,7 @@
 	proc/change_outfit(var/datum/chameleon_hat_pattern/T)
 		if (T)
 			src.current_choice = T
+			src.hides_from_examine = T.hides_from_examine
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -390,146 +386,155 @@
 	var/sprite_item = 'icons/obj/clothing/item_hats.dmi'
 	var/sprite_worn = 'icons/mob/clothing/head.dmi'
 	var/sprite_hand = 'icons/mob/inhand/hand_headgear.dmi'
-	var/seal_hair = 0
+	var/seal_hair = FALSE
+	var/hides_from_examine = null
 
 	NTberet
 		name = "Nanotrasen beret"
 		desc = "For the inner space dictator in you."
 		icon_state = "ntberet"
 		item_state = "ntberet"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	HoS_beret
 		name = "HoS Beret"
 		icon_state = "hosberet"
 		item_state = "hosberet"
 		desc = "Actually, this hat is from a fast-food restaurant, that's why it folds like it was made of paper."
-		seal_hair = 0
+		seal_hair = FALSE
 
 	HoS_hat
 		name = "HoS Hat"
 		icon_state = "hoscap"
 		item_state = "hoscap"
 		desc = "Actually, this hat is from a fast-food restaurant, that's why it folds like it was made of paper."
-		seal_hair = 0
+		seal_hair = FALSE
 
 	caphat
 		name = "Captain's hat"
 		icon_state = "captain"
 		item_state = "caphat"
 		desc = "A symbol of the captain's rank, and the source of all their power."
-		seal_hair = 0
+		seal_hair = FALSE
 
 	janiberet
 		name = "Head of Sanitation beret"
 		desc = "The Chief of Cleaning, the Superintendent of Scrubbing, whatever you call yourself, you know how to make those tiles shine. Good job."
 		icon_state = "janitorberet"
 		item_state = "janitorberet"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	janihat
 		name = "Head of Sanitation hat"
 		desc = "The Chief of Cleaning, the Superintendent of Scrubbing, whatever you call yourself, you know how to make those tiles shine. Good job."
 		icon_state = "janitorhat"
 		item_state = "janitorhat"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	hardhat
 		name = "hard hat"
 		icon_state = "hardhat0"
 		item_state = "hardhat0"
 		desc = "Protects your head from falling objects, and comes with a flashlight. Safety first!"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	security
 		name = "helmet"
 		icon_state = "helmet-sec"
 		item_state = "helmet"
 		desc = "Somewhat protects your head from being bashed in."
-		seal_hair = 0
+		seal_hair = FALSE
+		hides_from_examine = C_EARS
 
 	fancy
 		name = "fancy hat"
 		icon_state = "rank-fancy"
 		item_state = "that"
 		desc = "What do you mean this is hat isn't fancy?"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	detective
 		name = "Detective's hat"
 		desc = "Someone who wears this will look very smart."
 		icon_state = "detective"
 		item_state = "det_hat"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	space_helmet
 		name = "space helmet"
 		icon_state = "space"
 		item_state = "s_helmet"
 		desc = "Helps protect against vacuum."
-		seal_hair = 1
+		seal_hair = TRUE
+		hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 	space_helmet_emergency
 		name = "emergency hood"
 		icon_state = "emerg"
 		item_state = "emerg"
 		desc = "Helps protect from vacuum for a short period of time."
-		seal_hair = 1
+		seal_hair = TRUE
+		hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 	space_helmet_engineer
 		name = "engineering space helmet"
 		desc = "Comes equipped with a builtin flashlight."
 		icon_state = "espace0"
 		item_state = "s_helmet"
-		seal_hair = 1
+		seal_hair = TRUE
+		hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 	industrial_helmet
 		icon_state = "indus"
 		item_state = "indus"
 		name = "industrial space helmet"
 		desc = "Goes with Industrial Space Armor. Now with zesty citrus-scented visor!"
-		seal_hair = 1
+		seal_hair = TRUE
+		hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 	industrial_diving_helmet
 		icon_state = "diving_suit-industrial"
 		item_state = "diving_suit-industrial"
 		name = "industrial diving helmet"
 		desc = "Goes with Industrial Diving Suit. Now with a fresh mint-scented visor!"
+		seal_hair = TRUE
+		hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 	cowboy_hat
 		name = "cowboy hat"
 		desc = "Yeehaw!"
 		icon_state = "cowboy"
 		item_state = "cowboy"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	turban
 		name = "turban"
 		desc = "A very comfortable cotton turban."
 		icon_state = "turban"
 		item_state = "that"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	top_hat
 		name = "top hat"
 		desc = "An stylish looking hat"
 		icon_state = "tophat"
 		item_state = "that"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	chef_hat
 		name = "Chef's hat"
 		desc = "Your toque blanche, coloured as such so that your poor sanitation is obvious, and the blood shows up nice and crazy."
 		icon_state = "chef"
 		item_state = "chefhat"
-		seal_hair = 0
+		seal_hair = FALSE
 
 	bio_hood
 		name = "bio hood"
 		icon_state = "bio"
 		item_state = "bio_hood"
 		desc = "This hood protects you from harmful biological contaminants."
-		seal_hair = 1
+		seal_hair = TRUE
+		hides_from_examine = C_EARS
 
 /obj/item/clothing/suit/chameleon
 	name = "hoodie"
@@ -539,7 +544,7 @@
 	icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit.dmi'
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
-	uses_multiple_icon_states = 1
+	uses_multiple_icon_states = TRUE
 	over_hair = FALSE
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_suit_pattern
@@ -583,6 +588,7 @@
 			boutput(M, "<span class='alert'><B>Your chameleon suit malfunctions!</B></span>")
 			src.name = "hoodie"
 			src.desc = "A comfy jacket that's hard on the eyes."
+			src.hides_from_examine = null
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
 			src.icon_state = "hoodie-psyche"
@@ -608,6 +614,7 @@
 	proc/change_outfit(var/datum/chameleon_suit_pattern/T)
 		if (T)
 			src.current_choice = T
+			src.hides_from_examine = T.hides_from_examine
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -629,6 +636,7 @@
 	var/sprite_worn = 'icons/mob/clothing/overcoats/worn_suit.dmi'
 	var/sprite_hand = 'icons/mob/inhand/overcoat/hand_suit.dmi'
 	var/over_hair = FALSE
+	var/hides_from_examine = null
 
 	labcoat
 		name = "labcoat"
@@ -674,6 +682,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	fire_suit
 		name = "firesuit"
@@ -683,6 +692,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES
 
 	armor_vest
 		name = "armor vest"
@@ -701,6 +711,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_armor.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_armor.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_armor.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	hos_cape
 		name = "Head of Security's cape"
@@ -779,6 +790,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	space_suit_emergency
 		name = "emergency suit"
@@ -788,6 +800,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	space_suit_engineering
 		name = "engineering space suit"
@@ -797,6 +810,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	industrial_armor
 		name = "industrial space armor"
@@ -806,6 +820,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	industrial_diving_armor
 		name = "industrial diving suit"
@@ -815,6 +830,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	bio_suit
 		name = "bio suit"
@@ -824,6 +840,7 @@
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_hazard.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES
 
 	botanist_apron
 		name = "blue apron"
@@ -840,6 +857,7 @@
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
 		over_hair = FALSE
+		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES|C_GLASSES|C_EARS
 
 	chef_coat
 		name = "chef's coat"
@@ -1164,12 +1182,12 @@
 	icon = 'icons/obj/clothing/item_gloves.dmi'
 	wear_image_icon = 'icons/mob/clothing/hands.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_feethand.dmi'
-	uses_multiple_icon_states = 1
+	uses_multiple_icon_states = TRUE
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_gloves_pattern
 	material_prints = "black leather fibers"
-	hide_prints = 1
-	scramble_prints = 0
+	hide_prints = TRUE
+	scramble_prints = FALSE
 
 	New()
 		..()
@@ -1254,8 +1272,8 @@
 	var/sprite_worn = 'icons/mob/clothing/hands.dmi'
 	var/sprite_hand = 'icons/mob/inhand/hand_feethand.dmi'
 	var/print_type = "black leather fibers"
-	var/hide_prints = 1
-	var/scramble_prints = 0
+	var/hide_prints = TRUE
+	var/scramble_prints = FALSE
 
 	insulated
 		desc = "Tough rubber work gloves styled in a high-visibility yellow color. They are electrically insulated, and provide full protection against most shocks."
@@ -1263,23 +1281,23 @@
 		icon_state = "yellow"
 		item_state = "ygloves"
 		print_type = "insulative fibers"
-		hide_prints = 1
-		scramble_prints = 0
+		hide_prints = TRUE
+		scramble_prints = FALSE
 
 	fingerless
 		desc = "These gloves lack fingers. Good for a space biker look, but not so good for concealing your fingerprints."
 		name = "fingerless gloves"
 		icon_state = "fgloves"
 		item_state = "finger-"
-		hide_prints = 0
-		scramble_prints = 0
+		hide_prints = FALSE
+		scramble_prints = FALSE
 
 	latex
 		name = "latex gloves"
 		icon_state = "latex"
 		item_state = "lgloves"
 		desc = "Thin, disposal medical gloves used to help prevent the spread of germs."
-		scramble_prints = 1
+		scramble_prints = TRUE
 
 	boxing
 		name = "boxing gloves"
@@ -1287,8 +1305,8 @@
 		icon_state = "boxinggloves"
 		item_state = "bogloves"
 		print_type = "red leather fibers"
-		hide_prints = 1
-		scramble_prints = 0
+		hide_prints = TRUE
+		scramble_prints = FALSE
 
 	long
 		desc = "These long gloves protect your sleeves and skin from whatever dirty job you may be doing."
@@ -1296,8 +1314,8 @@
 		icon_state = "long_gloves"
 		item_state = "long_gloves"
 		print_type = "synthetic silicone rubber fibers"
-		hide_prints = 1
-		scramble_prints = 0
+		hide_prints = TRUE
+		scramble_prints = FALSE
 
 	gauntlets
 		name = "concussion gauntlets"
@@ -1305,8 +1323,8 @@
 		icon_state = "cgaunts"
 		item_state = "bgloves"
 		print_type = "industrial-grade mineral fibers"
-		hide_prints = 1
-		scramble_prints = 0
+		hide_prints = TRUE
+		scramble_prints = FALSE
 
 /obj/item/storage/belt/chameleon
 	name = "utility belt"
@@ -1316,7 +1334,7 @@
 	icon = 'icons/obj/items/belts.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	wear_image_icon = 'icons/mob/clothing/belt.dmi'
-	uses_multiple_icon_states = 1
+	uses_multiple_icon_states = TRUE
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_belt_pattern
 
@@ -1429,6 +1447,18 @@
 		desc = "Can hold various mining tools."
 		icon_state = "minerbelt"
 		item_state = "mining"
+
+	robotics
+		name = "Roboticist's belt"
+		desc = "A utility belt, in the departmental colors of someone who loves robots and surgery."
+		icon_state = "utilrobotics"
+		item_state = "robotics"
+
+	rancher
+		name = "rancher's belt"
+		desc = "A sturdy belt with hooks for chicken carriers."
+		icon_state = "rancherbelt"
+		item_state = "rancher"
 
 /obj/item/storage/backpack/chameleon
 	name = "backpack"
@@ -1865,7 +1895,7 @@
 		name = "Medical Doctor"
 		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/medical
 		hat_type = new/datum/chameleon_hat_pattern
-		suit_type = new/datum/chameleon_suit_pattern/labcoat
+		suit_type = new/datum/chameleon_suit_pattern/labcoat_medical
 		glasses_type = new/datum/chameleon_glasses_pattern/prodoc
 		shoes_type = new/datum/chameleon_shoes_pattern/red
 		gloves_type = new/datum/chameleon_gloves_pattern/latex
@@ -1880,7 +1910,7 @@
 		glasses_type = new/datum/chameleon_glasses_pattern/prodoc
 		shoes_type = new/datum/chameleon_shoes_pattern
 		gloves_type = new/datum/chameleon_gloves_pattern/latex
-		belt_type = new/datum/chameleon_belt_pattern
+		belt_type = new/datum/chameleon_belt_pattern/robotics
 		backpack_type = new/datum/chameleon_backpack_pattern/robotics
 
 	geneticist
@@ -1916,17 +1946,6 @@
 		belt_type = new/datum/chameleon_belt_pattern
 		backpack_type = new/datum/chameleon_backpack_pattern/engineer
 
-	mechanic
-		name = "Mechanic"
-		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/mechanic
-		hat_type = new/datum/chameleon_hat_pattern/hardhat
-		suit_type = new/datum/chameleon_suit_pattern/winter_coat_engineering
-		glasses_type = new/datum/chameleon_glasses_pattern/meson
-		shoes_type = new/datum/chameleon_shoes_pattern/brown
-		gloves_type = new/datum/chameleon_gloves_pattern/insulated
-		belt_type = new/datum/chameleon_belt_pattern
-		backpack_type = new/datum/chameleon_backpack_pattern/engineer
-
 	miner
 		name = "Miner"
 		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/overalls
@@ -1938,7 +1957,6 @@
 		belt_type = new/datum/chameleon_belt_pattern/miner
 		backpack_type = new/datum/chameleon_backpack_pattern/engineer
 
-
 	rancher
 		name = "Rancher"
 		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/rancher
@@ -1947,7 +1965,7 @@
 		glasses_type = new/datum/chameleon_glasses_pattern
 		shoes_type = new/datum/chameleon_shoes_pattern/brown
 		gloves_type = new/datum/chameleon_gloves_pattern
-		belt_type = new/datum/chameleon_belt_pattern
+		belt_type = new/datum/chameleon_belt_pattern/rancher
 		backpack_type = new/datum/chameleon_backpack_pattern
 
 	botanist


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates the roboticist and rancher disguise to use their own belt.
Updates the medical doctor disguise to use their labcoat.
Updates 0/1 to TRUE/FALSE.
Updates outersuit and hat to use hides from examine flags.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some disguises are currently outdated and all lack hides from examine flags which is a dead givaway on certain ones

