### PR TITLE
Differentiate dark mode colors for medical, command, and intercom radio channels

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -517,12 +517,12 @@ body.theme-dark .fatalError {background: rgb(192, 0, 0); color: white;}
 body.theme-dark .connectionClosed.restored {background: green;}
 
 body.theme-dark .rstandard {color: #3fcc3f;}
-body.theme-dark .rintercom {color: #4dc1c9;}
-body.theme-dark .rcommand {color: #7ca6d6;}
+body.theme-dark .rintercom {color: #58dfe9;}
+body.theme-dark .rcommand {color: #7397c0;}
 body.theme-dark .rsecurity {color: #e43535;}
 body.theme-dark .rdetective {color: #af4242;}
 body.theme-dark .rengineering {color: #dda448;}
-body.theme-dark .rmedical {color: #51DBCB;}
+body.theme-dark .rmedical {color: #00b3c3;}
 body.theme-dark .rresearch {color: #bf83e2;}
 body.theme-dark .rcivilian {color: #ce45b2;}
 body.theme-dark .rsyndicate {color: #cf5757;}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the colors of the medical, command and intercom colors on dark mode to make them stand out from each other better.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently these channels can blend into each other a lot, this should increase visibility of them.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)The colors for the command, medical, and intercom channels for radio headsets have been changed to make them stand out more from each other.
```
