### PR TITLE
Bank Record computer always shows the total budget

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -492,6 +492,7 @@
 		if (src.temp)
 			dat += text("<TT>[src.temp]</TT><BR><BR><A href='?src=\ref[src];temp=1'>Clear Screen</A>")
 		else
+			var/total_funds = wagesystem.station_budget + wagesystem.research_budget + wagesystem.shipping_budget
 			dat += {"
 				<style type="text/css">
 				.l { text-align: left; }
@@ -511,25 +512,31 @@
 				<br><a href='?src=\ref[src];[src.authenticated ? "logout=1'>Log Out" : "login=1'>Log In"]</a><hr>
 				"}
 
-			if (src.authenticated)
+			dat += {"
+				<table>
+					<thead>
+						<tr><th colspan="2">Budget Status</th></tr>
+					</thead>
+					<tbody>
+						<tr><th>Payroll Budget</th><td class='r'>[num2text(round(wagesystem.station_budget),50)][CREDIT_SIGN]</td></tr>
+						<tr><th>Shipping Budget</th><td class='r'>[num2text(round(wagesystem.shipping_budget),50)][CREDIT_SIGN]</td></tr>
+						<tr><th>Research Budget</th><td class='r'>[num2text(round(wagesystem.research_budget),50)][CREDIT_SIGN]</td></tr>
+						<tr><th>Total Funds</th><th class='r'>[num2text(round(total_funds),50)][CREDIT_SIGN]</th></tr>
+					</tbody>
+				</table>
+				"}
 
-				var/total_funds = wagesystem.station_budget + wagesystem.research_budget + wagesystem.shipping_budget
+			if (src.authenticated)
 				var/payroll = 0
 				for(var/datum/db_record/R as anything in data_core.bank.records)
 					payroll += R["wage"]
 				var/surplus = round(wagesystem.payroll_stipend - payroll)
 
 				dat += {"
-			<table>
-				<thead>
-					<tr><th colspan="2">Budget Status</th></tr>
-				</thead>
-				<tbody>
-					<tr><th>Payroll Budget</th><td class='r'>[num2text(round(wagesystem.station_budget),50)][CREDIT_SIGN]</td></tr>
-					<tr><th>Shipping Budget</th><td class='r'>[num2text(round(wagesystem.shipping_budget),50)][CREDIT_SIGN]</td></tr>
-					<tr><th>Research Budget</th><td class='r'>[num2text(round(wagesystem.research_budget),50)][CREDIT_SIGN]</td></tr>
-					<tr><th>Total Funds</th><th class='r'>[num2text(round(total_funds),50)][CREDIT_SIGN]</th></tr>
-					<tr><th colspan="2" class='second'>Payroll Details</th></tr>
+				<table>
+					<thead>
+					<tr><th colspan="2" class='second'>Payroll Details</th></tr></thead>
+					<tbody>
 					<tr><th>Payroll Stipend</th><td class='r'>[num2text(round(wagesystem.payroll_stipend),50)][CREDIT_SIGN]</td></tr>
 					<tr><th>Payroll Cost</th><td class='r'>[num2text(round(payroll),50)][CREDIT_SIGN]</td></tr>
 					[surplus >= 0 ? {"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The bank records computer shows the station budget and shipping/research/payroll individual budgets without an ID. Getting detailed information about individual wages and accounts as well as the station wage stipend is still locked behind an ID.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Makes the bank records computer in cog2 cargo not useless
* Allows for crimers to scope out the station budget a bit easier
