### PR TITLE
Stops pulling chair you are sitting on

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1126,6 +1126,11 @@
 	if(!can_reach(src, A) || src.restrained())
 		return
 
+	if(istype(A, /obj/stool))
+		var/obj/stool/C = A
+		if(C?.buckled_guy == src)
+			return
+
 	src.pulling = A
 
 	if(ismob(src.pulling))

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -107,6 +107,9 @@
 		if (!can_buckle(to_buckle,user))
 			return FALSE
 
+		if (to_buckle.pulling == src)
+			to_buckle.remove_pulling()
+
 		if (to_buckle == user)
 			user.visible_message("<span class='notice'><b>[to_buckle]</b> buckles in!</span>", "<span class='notice'>You buckle yourself in.</span>")
 		else
@@ -379,6 +382,10 @@
 			return FALSE
 		if (!can_buckle(to_buckle,user))
 			return FALSE
+
+		if (to_buckle.pulling == src)
+			to_buckle.remove_pulling()
+
 
 		if (to_buckle == user)
 			user.visible_message("<span class='notice'><b>[to_buckle]</b> lies down on [src], fastening the buckles!</span>", "<span class='notice'>You lie down and buckle yourself in.</span>")
@@ -706,6 +713,9 @@
 	buckle_in(mob/living/to_buckle, mob/living/user, var/stand = 0)
 		if (!can_buckle(to_buckle,user))
 			return FALSE
+
+		if (to_buckle.pulling == src)
+			to_buckle.remove_pulling()
 
 		if(stand && ishuman(to_buckle))
 			if(ON_COOLDOWN(to_buckle, "chair_stand", 1 SECOND))


### PR DESCRIPTION
[Bug] [Player-Actions]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes https://github.com/goonstation/goonstation/issues/13726
Stops people from being able to pull the chair that they are sitting on, more specifically to the bug, wheelchairs.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No more gmod prop surfing


![1285770302993](https://user-images.githubusercontent.com/26363708/234122352-3917615a-0d29-4f95-a250-8715038ebc03.jpg)