### PR TITLE
Allow equip hotkey to auto-sheathe swords

### DIFF
--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -390,7 +390,7 @@
 			if ("equip")
 				var/obj/item/I = master.equipped()
 				if (I)
-					if (I.try_specific_equip())
+					if (I.try_specific_equip(user))
 						return
 
 					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !(master.var_name && master.var_name.cant_self_remove)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -307,6 +307,9 @@
 			if ("invtoggle")
 				var/obj/item/I = master.equipped()
 				if (I)
+					if (I.try_specific_equip(user))
+						return
+
 					// this doesnt unequip the original item because that'd cause all the items to drop if you swapped your jumpsuit, I expect this to cause problems though
 					// ^-- You don't say.
 					// you can write multiline macros with \, please god don't write 400 character macros on one line
@@ -387,6 +390,9 @@
 			if ("equip")
 				var/obj/item/I = master.equipped()
 				if (I)
+					if (I.try_specific_equip())
+						return
+
 					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !(master.var_name && master.var_name.cant_self_remove)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }
 					autoequip_slot(slot_shoes, shoes)
 					autoequip_slot(slot_gloves, gloves)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1598,3 +1598,7 @@
 
 /obj/item/proc/can_pickup(mob/user)
 	return !src.anchored
+
+/// attempt unique functionality when item is held in hand and and using the equip hotkey
+/obj/item/proc/try_specific_equip(mob/user)
+	return FALSE

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1158,6 +1158,17 @@ TYPEINFO(/obj/item/bat)
 		else if(target.organHolder?.butt)
 			target.organHolder.drop_and_throw_organ("butt", dist = 5, speed = 1, showtext = 1)
 
+/obj/item/swords/try_specific_equip(mob/living/carbon/human/user)
+	. = FALSE
+	if (!istype(user))
+		return
+	if (!istype(user.belt, /obj/item/swords_sheaths))
+		return
+	var/obj/item/swords_sheaths/sheath = user.belt
+	if (!sheath.sword_inside && sheath.sword_path == src.type && !src.cant_drop)
+		sheath.Attackby(src, user)
+		return TRUE
+
 //PS the description can be shortened if you find it annoying and you are a jerk.
 TYPEINFO(/obj/item/swords/katana)
 	mats = list("MET-3"=20, "FAB-1"=5)


### PR DESCRIPTION
[GAME OBJECTS][PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows using the equip hotkey while having a sword in hand to auto-sheathe it

Also implements it in a generic way that allows you to do similar things for other items.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Faster, otherwise you have to manually click the sheath to sheathe the sword which is annoying


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(+)Swords will now auto-sheathe if using the equip hotkey while they're held in hand.
```
