### PR TITLE
Swaps Out Capsaicin Grenades In the Sec Vendor For Flashbangs

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -123,6 +123,9 @@
 	icon_state = "flashbang"
 	spawn_contents = list(/obj/item/chem_grenade/flashbang = 7)
 
+/obj/item/storage/box/flashbang_kit/vendor //Smaller amount for the sec vendor
+	spawn_contents = list(/obj/item/chem_grenade/flashbang = 4)
+
 /obj/item/storage/box/emp_kit
 	name = "\improper EMP grenade box"
 	desc = "A box with 5 EMP grenades."

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -118,7 +118,7 @@
 		materiel_stock += new/datum/materiel/loadout/justabaton
 		materiel_stock += new/datum/materiel/utility/morphineinjectors
 		materiel_stock += new/datum/materiel/utility/donuts
-		materiel_stock += new/datum/materiel/utility/crowdgrenades
+		materiel_stock += new/datum/materiel/utility/flashbangs
 		materiel_stock += new/datum/materiel/utility/detscanner
 		materiel_stock += new/datum/materiel/utility/nightvisionsechudgoggles
 		materiel_stock += new/datum/materiel/utility/markerrounds
@@ -314,10 +314,10 @@
 	path = /obj/item/storage/lunchbox/robustdonuts
 	description = "One Robust Donut and one Robusted Donut, which are loaded with helpful chemicals that help you resist stuns and heal you!"
 
-/datum/materiel/utility/crowdgrenades
-	name = "Crowd Dispersal Grenades"
-	path = /obj/item/storage/box/crowdgrenades
-	description = "Four 'Crowd Dispersal' pepper gas grenades, capable of clearing out riots. Also seasons food quite well!"
+/datum/materiel/utility/flashbangs
+	name = "Flashbang Grenades"
+	path = /obj/item/storage/box/flashbang_kit/vendor
+	description = "Four flash bangs, capable of inhibiting riots."
 
 /datum/materiel/utility/detscanner
 	name = "Forensics Scanner"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [INPUT WANTED] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr swaps out the capsaicin grenades in the sec weapons vendor for flashbangs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Since I reworked the protection for capsaicin, capsaicin grenades have become incredibly strong for how abundant they can be. This keeps the strength of the grenades, but limits them to the armory to keep them from being so abundant. I replaced them with flashbangs due to them not being nearly as strong, but still having some utility.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Replaced the capsaicin grenades in the security weapon vendor with flashbangs.
```
