### PR TITLE
No space footprints

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -295,6 +295,8 @@
 	if (HAS_ATOM_PROPERTY(src, PROP_ATOM_FLOATING))
 		return
 	var/turf/T = get_turf(src)
+	if(istype_exact(T, /turf/space)) //can't smear blood on space
+		return
 	var/obj/decal/cleanable/blood/dynamic/tracks/B = null
 	if (T.messy > 0)
 		B = locate(/obj/decal/cleanable/blood/dynamic) in T

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1766,6 +1766,8 @@
 
 	proc/track_paint(mob/living/M, oldLoc, direct)
 		var/turf/T = get_turf(M)
+		if(istype_exact(T, /turf/space)) //can't smear paint on space
+			return
 		var/obj/decal/cleanable/paint/P
 		if (T.messy > 0)
 			P = locate(/obj/decal/cleanable/paint) in T


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Can't track bloody/painty footprints onto space turfs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bad:
![image](https://user-images.githubusercontent.com/3855802/234716981-5f7930f3-193e-4104-9b5b-ff75a8247e83.png)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Blood & paint footprints will no longer track onto space tiles.
```
