### PR TITLE
Interdictor activation threshold adjustment

### DIFF
--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -130,7 +130,7 @@
 					src.connected = 1
 					boutput(user, "You activate the interdictor's magnetic lock.")
 					playsound(src.loc, src.sound_togglebolts, 50, 0)
-					if(intcap.charge == intcap.maxcharge && !src.canInterdict)
+					if(intcap.charge >= (intcap.maxcharge * 0.7) && !src.canInterdict)
 						src.start_interdicting()
 				else
 					boutput(user, "<span class='alert'>An interdictor is already active within range.</span>")
@@ -169,7 +169,7 @@
 						src.connected = 1
 						boutput(user, "You activate the interdictor's magnetic lock.")
 						playsound(src.loc, src.sound_togglebolts, 50, 0)
-						if(intcap.charge == intcap.maxcharge && !src.canInterdict)
+						if(intcap.charge >= (intcap.maxcharge * 0.7) && !src.canInterdict)
 							src.start_interdicting()
 					else
 						boutput(user, "<span class='alert'>Cannot activate interdictor - another field is already active within operating bounds.</span>")
@@ -274,7 +274,7 @@
 				if(!src.canInterdict)
 					playsound(src.loc, src.sound_interdict_run, 5, 0, 0, 0.8)
 				use_power(added / CELLRATE)
-		if(intcap.charge == intcap.maxcharge && !src.canInterdict)
+		if(intcap.charge >= (intcap.maxcharge * 0.7) && !src.canInterdict)
 			doupdateicon = 0
 			src.start_interdicting()
 		if(src.canInterdict)

--- a/strings/books/interdictor_guide.txt
+++ b/strings/books/interdictor_guide.txt
@@ -100,7 +100,7 @@
 	Due to the advanced technologies incorporated into the Spatial Interdictor's mainboard, it will automatically begin operating when conditions are suitable.
 	<br>
 	<br>
-	Suitable conditions are: Adequate internal cell charge, presence of an area power controller, and active magnetic anchoring.
+	Suitable conditions are: Adequate internal cell charge (70% of capacity or greater), presence of an area power controller, and active magnetic anchoring.
 	<br>
 	<br>
 	For charging or operation, activate magnetic anchoring by touching the control pad located on the front side of the rectangular regulator unit.

--- a/strings/books/interdictor_guide.txt
+++ b/strings/books/interdictor_guide.txt
@@ -117,7 +117,7 @@
 	The Spatial Interdictor is equipped with three distinct indicators, each representing a different aspect of its functionality:
 	<br>
 	<br>
-	- The charge meter, located on the side of the interdiction pillar. This represents the current capacity of the buffer cell, and <b>must be full for interdiction to begin.</b>
+	- The charge meter, located on the side of the interdiction pillar. This represents the current capacity of the buffer cell; while all three segments are illuminated, the interdictor is ready to operate.
 	<br>
 	<br>
 	- The interdiction emitter, located on the top of the interdiction pillar. While illuminated, the Interdictor is currently active and protecting its surroundings.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the required internal capacitor fullness for interdictors to activate, from 100% of capacity to 70%. Also updates ingame documentation of this threshold.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13865 in a manner that also improves general interdictor QoL.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Spatial interdictors can now initialize at 70% or higher charge, instead of requiring completely full charge.
```
