### PR TITLE
Prevents Abominations From Being Mindhacked

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -731,6 +731,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	var/custom_orders = null // ex: kill the captain, dance constantly, don't speak, etc
 
 	can_implant(var/mob/living/carbon/human/target, var/mob/user)
+		var/mob/living/carbon/human/H = target
 		if (!istype(target))
 			return FALSE
 		if (!implant_hacker)
@@ -738,8 +739,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				implant_hacker = user
 			else
 				return FALSE
+		if (isabomination(H)) //Abominations really shouldn't be mindhackable, for the aboms sake
+			if (ismob(user)) user.show_text("The implant cannot locate a mind within the mass to hack!", "red")
+			return FALSE
 		// all the stuff in here was added by Convair880, I just adjusted it to work with this can_implant() proc thing - haine
-		var/mob/living/carbon/human/H = target
 		if (!H.mind || !H.client)
 			if (ismob(user)) user.show_text("[H] is braindead!", "red")
 			return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [INPUT WANTED] [GAME OBJECTS] [MUTANTRACES]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents abominations from being mindhacked. Does not affect changelings.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Considering abominations are these massive, loud threats, being able to shut them down with 1 click is really bad. This makes it so a random sec off/traitor with a mind hack on them can't just negate an active abomination.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Abominations can no longer be mindhacked.
```
