### PR TITLE
Oshan Cargo Redesign

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -140,35 +140,33 @@
 	},
 /area/station/medical/medbay/lobby)
 "aax" = (
+/obj/firedoor_spawn,
+/obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	name = "Supply Lobby"
+	name = "Quartermaster's Office"
 	},
+/obj/access_spawn/cargo,
 /obj/firedoor_spawn,
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "aay" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Supply Lobby"
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/obj/firedoor_spawn,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
 "aaz" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Supply Lobby"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/firedoor_spawn,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/decal/stripe_delivery,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -16919,11 +16917,9 @@
 /turf/space/fluid,
 /area/space)
 "aRU" = (
-/obj/machinery/conveyor/SN{
-	id = "qmout"
-	},
-/turf/simulated/floor/caution/misc,
-/area/station/quartermaster/office)
+/obj/machinery/disposal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "aRV" = (
 /obj/item/extinguisher,
 /obj/item/extinguisher,
@@ -27297,9 +27293,13 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bxx" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bxy" = (
 /obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/white/grime,
@@ -27332,9 +27332,6 @@
 	text = "NF"
 	},
 /obj/machinery/manufacturer/qm,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bxC" = (
@@ -27342,6 +27339,12 @@
 /area/station/quartermaster/office)
 "bxD" = (
 /obj/machinery/light/incandescent/warm,
+/obj/table/reinforced/auto,
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/machinery/recharger,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bxE" = (
@@ -27645,25 +27648,26 @@
 /area/station/hallway/secondary/exit)
 "byr" = (
 /obj/machinery/light/incandescent/warm,
+/obj/table/reinforced/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bys" = (
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "byt" = (
+/obj/machinery/light/small/floor/harsh,
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/yellow,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "byu" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/orangeblack,
+/obj/storage/crate/packing,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "byv" = (
 /obj/stool/chair/office/yellow{
@@ -27977,44 +27981,26 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
-"bzn" = (
-/turf/simulated/floor/yellowblack{
-	dir = 9
-	},
-/area/station/quartermaster/office)
 "bzo" = (
-/turf/simulated/floor/yellowblack{
-	dir = 1
-	},
-/area/station/quartermaster/office)
-"bzp" = (
-/turf/simulated/floor/yellowblack{
-	dir = 5
-	},
-/area/station/quartermaster/office)
-"bzq" = (
-/obj/machinery/light/incandescent/warm,
-/obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 5
-	},
-/obj/machinery/computer/chem_requester/science{
-	area_name = "Quartermaster's office";
-	dir = 8
-	},
+/obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
+"bzp" = (
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bzr" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bzs" = (
-/obj/table/reinforced/auto,
-/obj/item/wrapping_paper,
-/obj/item/wirecutters,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	autoclose = 0
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bzt" = (
@@ -28421,16 +28407,19 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bAt" = (
-/obj/machinery/manufacturer/mining,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
+	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bAu" = (
 /obj/machinery/manufacturer/hangar,
@@ -28440,12 +28429,16 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bAv" = (
-/turf/simulated/floor/yellowblack{
-	dir = 4
+/obj/machinery/manufacturer/mining,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
+/turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bAw" = (
-/obj/machinery/computer/supplycomp,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bAx" = (
@@ -28459,23 +28452,13 @@
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
-"bAz" = (
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
 "bAA" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/light/incandescent/warm,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "bAC" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/yellow/side{
@@ -28931,68 +28914,40 @@
 	icon_state = "L16"
 	},
 /area/station/hallway/secondary/exit)
-"bBI" = (
-/obj/storage/crate/packing,
-/turf/simulated/floor/yellow,
-/area/station/quartermaster/office)
 "bBJ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/yellowblack{
-	dir = 8
-	},
-/area/station/quartermaster/office)
-"bBK" = (
-/obj/machinery/manufacturer/uniform,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bBL" = (
 /obj/machinery/manufacturer/general,
 /obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bBM" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
 /obj/landmark/start{
 	name = "Quartermaster"
 	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bBN" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/item/reagent_containers/food/drinks/mug/random_color,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	autoclose = 0;
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/obj/access_spawn/cargo,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
+"bBO" = (
+/obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"bBO" = (
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
-"bBP" = (
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
 "bBQ" = (
 /obj/shrub,
 /turf/simulated/floor/yellow/corner{
@@ -29344,55 +29299,29 @@
 	},
 /area/station/hallway/secondary/exit)
 "bCT" = (
-/obj/machinery/light/incandescent/warm,
-/obj/storage/crate/wooden,
-/turf/simulated/floor/yellow,
-/area/station/quartermaster/office)
-"bCU" = (
-/obj/machinery/manufacturer/medical,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 10
-	},
-/turf/simulated/floor/black,
-/area/station/quartermaster/office)
-"bCV" = (
-/obj/machinery/manufacturer/robotics,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 6
-	},
-/turf/simulated/floor/black,
-/area/station/quartermaster/office)
-"bCW" = (
-/obj/table/reinforced/auto,
-/obj/item/hand_labeler,
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/stamp,
-/obj/item/pen,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	autoclose = 0;
+/obj/machinery/light/incandescent/netural{
 	dir = 4
 	},
-/obj/access_spawn/cargo,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
+"bCW" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bCX" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "bCY" = (
-/obj/cable{
-	icon_state = "5-10"
+/turf/simulated/floor/caution/corner/misc{
+	dir = 6
 	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon3,
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "bDa" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market{
@@ -29836,7 +29765,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/storage/crate/packing,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bEf" = (
@@ -29846,35 +29774,39 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/yellowblack{
-	dir = 10
-	},
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bEg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/yellowblack,
+/obj/machinery/firealarm{
+	dir = 1;
+	layer = 3.5;
+	pixel_y = -24
+	},
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bEh" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/yellowblack{
-	dir = 6
-	},
-/area/station/quartermaster/office)
-"bEi" = (
-/obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/storage/cart,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
+"bEi" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "bEj" = (
-/obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/machinery/computer/supplycomp{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -29883,63 +29815,60 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/landmark/start{
+	name = "Quartermaster"
+	},
+/obj/stool/chair/office/yellow{
+	dir = 8
+	},
 /turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "bEl" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/navbeacon/tour/oshan/tour8,
 /turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "bEm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "5-10"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
-"bEn" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
-"bEo" = (
-/obj/machinery/computer/ordercomp{
+/obj/machinery/computer/chem_requester/science{
+	area_name = "Quartermaster's office";
 	dir = 8
 	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"bEn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/light_switch/auto,
-/turf/simulated/floor/yellow/side{
+/obj/machinery/light_switch/south,
+/turf/simulated/floor/caution/east,
+/area/station/quartermaster/office)
+"bEo" = (
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/obj/submachine/cargopad{
+	name = "Cargo Bay Pad"
+	},
+/obj/machinery/light/incandescent/warm,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "bEp" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "bEq" = (
 /obj/disposalpipe/segment/morgue,
 /obj/disposalpipe/segment/mail{
@@ -30187,7 +30116,6 @@
 /area/space)
 "bFc" = (
 /obj/disposalpipe/segment/mail,
-/obj/storage/crate/wooden,
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
@@ -30200,62 +30128,48 @@
 /area/station/quartermaster/office)
 "bFe" = (
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/light/incandescent/warm,
+/obj/machinery/conveyor_switch{
+	id = "qmout"
+	},
+/obj/machinery/door_control{
+	id = "qm";
+	name = "QM Shutters Control";
+	pixel_x = 24
+	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bFf" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/simulated/floor/yellow,
-/area/station/quartermaster/office)
-"bFg" = (
-/obj/storage/cart,
-/turf/simulated/floor/yellow,
+/turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "bFh" = (
-/turf/simulated/floor/yellow/side,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/obj/machinery/manufacturer/medical,
+/turf/simulated/floor/black,
+/area/station/quartermaster/office)
 "bFi" = (
-/obj/cable{
-	icon_state = "2-5"
+/obj/access_spawn/cargo,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0
 	},
-/turf/simulated/floor/yellow/side,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
-"bFj" = (
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/floor/yellow/side,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/obj/table/reinforced/auto,
+/obj/item/hand_labeler,
+/obj/item/clipboard,
+/obj/item/paper_bin,
+/obj/item/stamp,
+/obj/item/pen,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "bFk" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/south{
-	pixel_z = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 6
-	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/obj/machinery/manufacturer/robotics,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor/black,
+/area/station/quartermaster/office)
 "bFl" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light_switch/auto,
@@ -30533,16 +30447,10 @@
 /turf/space/fluid,
 /area/shuttle/escape/station)
 "bFV" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/obj/storage/secure/closet/engineering/cargo,
-/obj/decal/stripe_caution,
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bFW" = (
@@ -30567,22 +30475,11 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bGa" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
-"bGb" = (
-/obj/disposalpipe/segment/morgue,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/yellow/side{
-	dir = 8
+	dir = 1
 	},
 /area/station/hallway/primary/south)
 "bGc" = (
@@ -30908,53 +30805,71 @@
 "bGS" = (
 /obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment/mail,
-/obj/storage/secure/closet/engineering/cargo,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGT" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Quartermaster's Office"
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm";
+	name = "QM Shutters";
+	opacity = 0;
+	dir = 4
 	},
-/obj/access_spawn/cargo,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
+/obj/plasticflaps,
+/obj/machinery/conveyor/WE{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "bGU" = (
-/obj/machinery/light/incandescent/netural,
+/obj/decal/stripe_delivery,
 /turf/simulated/floor/yellow/side{
-	dir = 9
+	dir = 8
 	},
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bGV" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
 "bGW" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/obj/machinery/navbeacon/tour/oshan/tour8,
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bGX" = (
-/obj/submachine/ATM{
-	pixel_y = 32
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Supply Lobby"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bGY" = (
-/obj/machinery/light/incandescent/netural,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/yellow/side{
-	dir = 1
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon3,
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bGZ" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/yellow/corner{
@@ -31293,42 +31208,48 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bHR" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
+/obj/disposalpipe/segment/bent/east,
+/obj/machinery/conveyor/WE{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "bHS" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Quartermaster's Office"
-	},
-/obj/access_spawn/cargo,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm";
+	name = "QM Shutters";
+	opacity = 0;
+	dir = 4
+	},
+/obj/plasticflaps,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/conveyor/WE{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "bHT" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/stripe_delivery,
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bHU" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -31339,12 +31260,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bHW" = (
-/obj/disposalpipe/junction/right/east,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -31624,48 +31547,68 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bIz" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
+/obj/machinery/light/incandescent/netural{
+	dir = 8
 	},
-/obj/access_spawn/cargo,
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/submachine/ATM{
+	pixel_y = 32
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bIA" = (
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "bIC" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bID" = (
-/obj/shrub{
-	dir = 1
-	},
+/obj/disposalpipe/trunk/north,
+/obj/machinery/disposal,
+/obj/decal/stripe_delivery,
 /turf/simulated/floor/yellow/side{
-	dir = 10
+	dir = 8
 	},
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bIE" = (
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/south)
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bIF" = (
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/south)
-"bIG" = (
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
+"bIG" = (
+/obj/machinery/computer/ordercomp{
+	dir = 8
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bIH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31679,6 +31622,12 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -31954,8 +31903,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bJy" = (
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/yellow,
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/hand_labeler,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bJz" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -31972,22 +31930,6 @@
 /obj/critter/walrus,
 /turf/simulated/floor/grass,
 /area/space)
-"bJC" = (
-/obj/plasticflaps,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "qm";
-	name = "QM Shutters";
-	opacity = 0
-	},
-/obj/machinery/conveyor/SN{
-	id = "qmout"
-	},
-/turf/simulated/floor/caution/misc{
-	dir = 1
-	},
-/area/station/quartermaster/office)
 "bJD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/jazz)
@@ -32177,19 +32119,12 @@
 /area/supply/sell_point)
 "bKh" = (
 /obj/machinery/light/incandescent/harsh,
-/obj/table/reinforced/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
 /turf/simulated/floor/scorched,
 /area/station/quartermaster/office)
 "bKj" = (
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bKl" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/hand_labeler,
 /obj/machinery/firealarm{
 	pixel_y = 24;
 	text = "NF"
@@ -32197,51 +32132,24 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bKm" = (
-/obj/machinery/computer/supplycomp,
-/obj/machinery/light_switch/auto,
-/turf/simulated/floor/caution/east,
-/area/station/quartermaster/office)
-"bKn" = (
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
+/obj/submachine/ATM{
+	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/obj/noticeboard/persistent{
-	name = "Cargo persistent notice board";
-	persistent_id = "cargo"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bKo" = (
-/obj/machinery/conveyor_switch{
-	id = "qmout"
-	},
-/obj/machinery/door_control{
-	id = "qm";
-	name = "QM Shutters Control";
-	pixel_y = 24
-	},
-/turf/simulated/floor/caution/west{
-	dir = 5
-	},
+/obj/machinery/disposal,
+/turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bKp" = (
 /obj/item/skull,
 /obj/item/spacecash/thousand,
 /turf/simulated/floor/grass,
 /area/space)
-"bKq" = (
-/obj/machinery/conveyor/SN{
-	id = "qmout"
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/quartermaster/office)
 "bKr" = (
 /obj/machinery/vending/pizza,
 /obj/machinery/firealarm{
@@ -32739,39 +32647,38 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bLL" = (
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/damaged2{
 	dir = 4
 	},
 /area/station/quartermaster/office)
-"bLM" = (
-/obj/decal/cleanable/generic,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"bLN" = (
-/turf/simulated/floor/caution/corner/misc{
-	dir = 5
-	},
-/area/station/quartermaster/office)
 "bLO" = (
-/turf/simulated/floor/caution/north,
-/area/station/quartermaster/office)
-"bLP" = (
-/turf/simulated/floor/caution/corner/misc{
-	dir = 9
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/quartermaster/office)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Supply Lobby"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bLQ" = (
 /obj/item/seed/grass,
 /obj/item/seed/grass,
 /turf/simulated/floor/grass,
 /area/space)
 "bLR" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/light/incandescent/harsh,
-/obj/machinery/conveyor/SN{
-	id = "qmout"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
 	},
-/turf/simulated/floor/caution/misc,
+/obj/machinery/manufacturer/uniform,
+/turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bLS" = (
 /obj/wingrille_spawn/auto,
@@ -34025,16 +33932,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "bPv" = (
+/obj/disposalpipe/segment/morgue,
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
+	dir = 5;
+	name = "autoname - Mining";
+	network = "Mining";
 	tag = ""
 	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "bPw" = (
 /obj/disposalpipe/segment/morgue,
 /obj/machinery/drone_recharger,
@@ -35239,6 +35148,7 @@
 /area/space)
 "bSu" = (
 /obj/machinery/vending/medical_public,
+/obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bSv" = (
@@ -36326,8 +36236,6 @@
 /area/station/crew_quarters/radio/lab)
 "bVu" = (
 /obj/disposalpipe/segment/mail,
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -39490,9 +39398,15 @@
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "cfd" = (
-/obj/item/spacecash/random/small,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/noticeboard/persistent{
+	name = "Cargo persistent notice board";
+	persistent_id = "cargo"
+	},
+/obj/table/reinforced/auto,
+/obj/item/wrapping_paper,
+/obj/item/wirecutters,
+/turf/simulated/floor/orangeblack,
+/area/station/quartermaster/office)
 "cfe" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
@@ -39684,13 +39598,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "cfG" = (
-/obj/decal/poster/wallsign/poster_nt{
-	pixel_y = 32
+/obj/machinery/conveyor/WE{
+	id = "qmout"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "cfH" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -40427,16 +40339,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
 "chZ" = (
-/turf/simulated/wall/auto/supernorn,
+/turf/space/fluid,
 /area/station/maintenance/southwest)
 "cia" = (
-/obj/item/reagent_containers/pill/cyberpunk,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
-"cib" = (
-/obj/item/raw_material/scrap_metal,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/storage/crate/wooden,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "cic" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating/random,
@@ -40448,43 +40357,46 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
-"cie" = (
-/obj/machinery/computer/stockexchange{
+"cif" = (
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
-"cif" = (
-/obj/stool/chair/yellow{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "cij" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/cookie/chocolate_chip,
-/obj/item/reagent_containers/food/snacks/cookie/oatmeal,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/storage/secure/closet/engineering/cargo,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "cil" = (
-/obj/table/reinforced/auto,
-/obj/item/spacecash/fifty,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/machinery/light_switch/auto,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "cim" = (
-/obj/item/rods/steel,
+/turf/simulated/floor/yellow,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/area/station/quartermaster/office)
 "cin" = (
-/obj/item/rods/steel/fullstack,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "cio" = (
 /obj/table/reinforced/auto,
 /obj/item/card_group/plain,
@@ -40499,11 +40411,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "cir" = (
-/obj/machinery/computer/ordercomp{
-	dir = 4
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/area/station/quartermaster/office)
 "cis" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -41809,17 +41721,6 @@
 "cHP" = (
 /turf/simulated/floor/caution/south,
 /area/research_outpost/hangar)
-"cId" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13";
-	pixel_y = 20
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
 "cIx" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
@@ -43191,17 +43092,6 @@
 /obj/access_spawn/rancher,
 /turf/simulated/floor,
 /area/station/ranch)
-"iHN" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/machinery/light/incandescent/harsh,
-/obj/item/device/radio/intercom/cargo,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
 "iJx" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -43301,14 +43191,6 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/hydroponics/bay)
-"iYt" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/cereal_box/roach,
-/obj/machinery/light/incandescent/warm/very{
-	dir = 1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
 "jdK" = (
 /obj/machinery/light_switch/auto,
 /turf/simulated/floor,
@@ -43705,9 +43587,7 @@
 "kST" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
 "kUZ" = (
 /obj/landmark{
 	name = "blobstart"
@@ -44564,10 +44444,9 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "oVp" = (
-/obj/item/rods/steel/fullstack,
 /obj/machinery/light/incandescent/warm/very,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "oVS" = (
 /obj/table/wood/round/auto,
 /obj/displaycase{
@@ -45557,18 +45436,11 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "tXX" = (
-/obj/shrub{
-	dir = 1
-	},
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/turf/simulated/floor/caution/south,
+/area/station/quartermaster/office)
 "tZV" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -74688,20 +74560,20 @@ brI
 brH
 brH
 aqn
-aqn
-aqn
+bCX
+bCX
+cic
 buE
-buE
-buE
-buE
-buE
-buE
-buE
-buE
-buE
-aqn
-aqn
-aqn
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bJw
+bCX
+bCX
+bCX
 aqn
 aqn
 aqn
@@ -74991,19 +74863,19 @@ brI
 brH
 aqn
 buE
-cic
-buE
-cie
-chZ
 btZ
 btZ
 gST
-chZ
-cir
-buE
-cic
-buE
-aqn
+bJw
+bys
+bys
+bys
+bys
+bys
+bys
+cim
+bys
+bCX
 aqn
 aqn
 aqn
@@ -75291,21 +75163,21 @@ boW
 btW
 buE
 buE
+chZ
 buE
-buE
-iYt
-cib
-cif
-bvr
 btZ
 btZ
 btZ
-bvr
-cif
-cim
+cir
+bys
+bys
+bys
+bys
+bys
+bys
 oVp
-buE
-buE
+bys
+bJw
 aqn
 aqn
 apc
@@ -75594,20 +75466,20 @@ btX
 buF
 buE
 chZ
-bxx
-cib
-cia
-cil
-chZ
-btZ
-btZ
-btZ
-chZ
-cId
-cin
-btZ
-cij
 buE
+btZ
+btZ
+btZ
+bJw
+byu
+bys
+bys
+bys
+bys
+bys
+bys
+cij
+bJw
 aqn
 bJw
 aJE
@@ -75895,20 +75767,20 @@ boW
 btY
 buG
 buE
-chZ
-chZ
-cid
-chZ
-chZ
-chZ
-chZ
-chZ
-chZ
-chZ
-chZ
-cid
-chZ
 buE
+buE
+buE
+cid
+buE
+bJw
+cia
+bys
+bys
+bys
+bys
+bys
+bys
+cij
 bJw
 bJw
 bJw
@@ -76201,18 +76073,18 @@ rOw
 btZ
 btZ
 btZ
-btZ
-btZ
-btZ
-btZ
-bPv
-cfd
-btZ
-btZ
-btZ
-bIz
-bJx
-bJx
+aRU
+bJw
+byu
+bys
+bys
+bys
+bys
+bys
+bys
+cij
+bJw
+bKo
 bJx
 bMO
 aGB
@@ -76505,14 +76377,14 @@ btZ
 bJw
 bJw
 bJw
-bJw
-bJw
-bJw
-bJw
-bJw
-bJw
-bJw
-bJw
+cia
+bys
+bys
+bys
+bys
+bys
+bys
+bEi
 bJw
 bJw
 bJw
@@ -76807,15 +76679,15 @@ bJw
 bJw
 bzm
 bAr
-bBI
-bCT
+bys
+bys
 bEe
 bFc
-bFV
+bVu
 bGS
 bVu
 aSy
-bJy
+bJA
 bKh
 bLI
 bMQ
@@ -77107,7 +76979,7 @@ bua
 bJw
 bJw
 byr
-bzn
+bys
 bAs
 bBJ
 bBJ
@@ -77409,17 +77281,17 @@ btZ
 bJw
 aMK
 bys
-bzo
-bAt
-bBK
-bCU
-bEg
+bys
+bys
+bys
+bys
+bAw
 bFe
 bMS
-bMS
+cfG
 bHR
 bIC
-bJy
+bJA
 bKj
 bQi
 bKj
@@ -77712,9 +77584,9 @@ bJw
 dHz
 bys
 bzo
-bAu
-bBL
-bCV
+bys
+bys
+bzo
 bEg
 bFf
 bJA
@@ -77722,7 +77594,7 @@ bGT
 bHS
 bJA
 bJA
-iHN
+bKj
 bLL
 bMS
 bKj
@@ -78013,19 +77885,19 @@ bvY
 bJw
 lxj
 bys
-bzp
-bAv
-bAv
-bAv
-bEh
 bys
+bys
+bys
+bys
+bEh
 bJA
+bIz
 bGU
 bHT
 bID
-bJA
+bDa
 bKl
-bLM
+bKj
 bMS
 bKj
 bMS
@@ -78314,20 +78186,20 @@ buL
 btZ
 bJw
 bxB
-byt
-bzq
-bAw
+bys
+bys
+bys
 bBM
 bys
-bEi
-bFg
-bJA
-bGV
-bHU
-bIE
+bEh
 bJA
 bKm
-bLN
+bAy
+bGY
+bAy
+cil
+bKj
+bKj
 bMS
 bOc
 bMS
@@ -78616,20 +78488,20 @@ buL
 btZ
 ciq
 bxC
-byu
-bJA
-bzr
-bBN
+bxC
+bAt
+bCW
+bCW
 bCW
 bEj
-bzr
-bJA
-cfG
-bHU
-bIE
-bJA
-bKn
-bLO
+bFV
+aay
+bAy
+bGW
+bAx
+bBN
+bKj
+bKj
 bMU
 bKj
 bMS
@@ -78917,21 +78789,21 @@ bqs
 buL
 bua
 bJA
+bJy
 bxC
-bxC
-bzr
-bAx
-bBO
+byt
+bFh
+bLR
 bBO
 bEk
-bFh
+bFi
 aay
-bGV
-bHU
+bAy
+cif
 bIF
-bJA
-bKo
-bLP
+bDa
+bKj
+bKj
 bKj
 bOe
 bKj
@@ -79221,19 +79093,19 @@ btZ
 bJA
 bxD
 bxC
-bzr
-bAy
-bAy
+bzs
+bAv
+bFk
 kST
 bEl
 bFi
-aaz
-bGW
-adF
-bIG
-bJC
-bKq
-aRU
+aay
+bAy
+cin
+bzp
+bDa
+bKj
+bKj
 bMV
 bOf
 bPi
@@ -79521,21 +79393,21 @@ bqs
 buL
 btZ
 bJA
-bxC
+cfd
 bxC
 bzs
-bAy
-bAy
-bCX
+bAu
+bBL
+bKj
 bEm
-bFj
-bDa
-bGX
-bHU
+bzr
+bCT
+bAy
+aaz
 bIG
-bJC
-bKq
-bLR
+bDa
+bKj
+bQj
 bMW
 bOg
 bPj
@@ -79825,17 +79697,17 @@ btZ
 bJA
 bxC
 byv
-bzr
-bAz
-bAy
+bzs
+bKj
+bKj
 bCY
 bEn
-bFh
-bDa
-bGX
-bHU
-bIE
 bJA
+bxx
+bGX
+bLO
+bIE
+bDa
 bJA
 bJA
 bJA
@@ -80127,14 +79999,14 @@ btZ
 bJA
 bxE
 byw
-bJA
 bAA
-bBP
+bKj
+bKj
 tXX
 bEo
-bFk
+bJA
 bGa
-bGY
+bII
 bHW
 bIH
 bDw
@@ -80432,11 +80304,11 @@ bxF
 bJA
 aax
 aax
-bDa
+bJA
 bEp
-bDa
-bDa
+bJA
 bGV
+bII
 bHU
 bII
 bLX
@@ -80736,9 +80608,9 @@ bAC
 bAC
 bDb
 bEq
-bAC
-bGb
+bPv
 bGZ
+bvs
 bHX
 bIJ
 bJD

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -140,7 +140,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "aax" = (
-/obj/firedoor_spawn,
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -167,7 +166,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -12886,10 +12885,6 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aGC" = (
@@ -16918,6 +16913,7 @@
 /area/space)
 "aRU" = (
 /obj/machinery/disposal,
+/obj/disposalpipe/trunk/west,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "aRV" = (
@@ -27331,7 +27327,7 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/obj/machinery/manufacturer/qm,
+/obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bxC" = (
@@ -27647,7 +27643,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "byr" = (
-/obj/machinery/light/incandescent/warm,
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
@@ -27658,10 +27653,10 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "byt" = (
-/obj/machinery/light/small/floor/harsh,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
+/obj/disposalpipe/segment,
+/obj/decal/stripe_caution,
+/obj/storage/crate,
+/obj/item/clothing/head/merchant_hat,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "byu" = (
@@ -27672,6 +27667,9 @@
 "byv" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
+	},
+/obj/landmark/start{
+	name = "Quartermaster"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
@@ -27979,6 +27977,7 @@
 "bzm" = (
 /obj/machinery/nanofab/refining,
 /obj/decal/stripe_caution,
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bzo" = (
@@ -27989,7 +27988,8 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -28401,6 +28401,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/storage/cart,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bAs" = (
@@ -28442,8 +28443,16 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bAx" = (
-/obj/reagent_dispensers/watertank/fountain,
-/turf/simulated/floor,
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -28453,10 +28462,10 @@
 	name = "Supply Lobby"
 	})
 "bAA" = (
-/obj/machinery/light/incandescent/warm,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bAC" = (
@@ -28928,26 +28937,31 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bBM" = (
-/obj/landmark/start{
-	name = "Quartermaster"
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
+/obj/decal/stripe_delivery,
+/turf/simulated/floor/yellow/side{
+	dir = 10
 	},
-/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bBN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
+/obj/access_spawn/cargo,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/item/reagent_containers/food/drinks/mug,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
+"bBO" = (
+/obj/machinery/light_switch/south,
+/obj/table/reinforced/auto,
+/obj/item/boardgame/chess,
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
-"bBO" = (
-/obj/machinery/light/small/floor/harsh,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
 "bBQ" = (
 /obj/shrub,
 /turf/simulated/floor/yellow/corner{
@@ -29299,9 +29313,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "bCT" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -29315,8 +29327,12 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bCX" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
+/area/station/quartermaster/office)
 "bCY" = (
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
@@ -29777,27 +29793,31 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bEg" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door_control{
+	id = "cargo_inbound";
+	name = "Cargo Inbound Door Control";
+	pixel_x = -24
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
+/obj/machinery/conveyor_switch{
+	id = "inbound";
+	name = "inbound conveyor switch"
 	},
-/turf/simulated/floor/yellow,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEh" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/storage/cart,
-/turf/simulated/floor/yellow,
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bEi" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/turf/simulated/floor/yellow,
+/obj/decal/stripe_delivery,
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEj" = (
 /obj/disposalpipe/segment/mail{
@@ -29827,6 +29847,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEm" = (
@@ -29844,16 +29867,13 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/south,
-/turf/simulated/floor/caution/east,
+/obj/vehicle/tug,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEo" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
-	},
-/obj/machinery/light/incandescent/warm,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
@@ -29861,6 +29881,10 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/machinery/light/incandescent/warm,
+/obj/tug_cart,
+/obj/tug_cart,
+/obj/tug_cart,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEp" = (
@@ -30116,34 +30140,35 @@
 /area/space)
 "bFc" = (
 /obj/disposalpipe/segment/mail,
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/yellow,
+/turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "bFd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/yellow,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "bFe" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/light/incandescent/warm,
-/obj/machinery/conveyor_switch{
-	id = "qmout"
-	},
-/obj/machinery/door_control{
-	id = "qm";
-	name = "QM Shutters Control";
-	pixel_x = 24
-	},
-/turf/simulated/floor/yellow,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bFf" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/plasticflaps,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm";
+	name = "QM Shutters";
+	opacity = 0
+	},
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bFh" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -30457,6 +30482,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/stripe_caution,
+/obj/machinery/navbeacon/mule/QM2_north/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bFX" = (
@@ -30803,35 +30830,28 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bGS" = (
-/obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment/mail,
-/obj/decal/stripe_caution,
+/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGT" = (
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "qm";
-	name = "QM Shutters";
-	opacity = 0;
-	dir = 4
-	},
-/obj/plasticflaps,
-/obj/machinery/conveyor/WE{
-	id = "qmout"
-	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
-"bGU" = (
-/obj/decal/stripe_delivery,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
+/area/station/quartermaster/office)
+"bGU" = (
+/obj/table/reinforced/auto,
+/obj/machinery/recharger,
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "bGV" = (
+/obj/submachine/ATM{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -31204,49 +31224,41 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bHR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/bent/east,
-/obj/machinery/conveyor/WE{
-	id = "qmout"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/caution/northsouth,
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bHS" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "qm";
-	name = "QM Shutters";
-	opacity = 0;
-	dir = 4
-	},
-/obj/plasticflaps,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/conveyor/WE{
-	id = "qmout"
+/obj/disposalpipe/junction/left/east,
+/turf/simulated/floor/yellow/side{
+	dir = 8
 	},
-/turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "bHT" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/stripe_delivery,
-/obj/disposalpipe/junction/left/east,
-/turf/simulated/floor/yellow/side{
-	dir = 8
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -31269,7 +31281,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
 /area/station/hallway/primary/south)
 "bHX" = (
 /obj/disposalpipe/segment{
@@ -31547,14 +31561,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bIz" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/obj/submachine/ATM{
-	pixel_y = 32
-	},
+/obj/decal/stripe_caution,
 /turf/simulated/floor/yellow/side{
-	dir = 9
+	dir = 1
 	},
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -31564,24 +31573,15 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "bIC" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bID" = (
-/obj/disposalpipe/trunk/north,
-/obj/machinery/disposal,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor/yellow/side{
-	dir = 8
+/obj/machinery/light/incandescent/netural,
+/obj/stool/chair/yellow{
+	dir = 4
 	},
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -31592,8 +31592,12 @@
 	name = "Supply Lobby"
 	})
 "bIF" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
+/obj/shrub{
+	dir = 8;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -31604,7 +31608,7 @@
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
 /turf/simulated/floor/yellow/side{
-	dir = 4
+	dir = 6
 	},
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -31903,9 +31907,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bJy" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/hand_labeler,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 3;
@@ -31913,6 +31914,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bJz" = (
@@ -32143,6 +32145,7 @@
 	})
 "bKo" = (
 /obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bKp" = (
@@ -32664,7 +32667,7 @@
 	name = "Supply Lobby"
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
@@ -33429,15 +33432,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bOa" = (
-/obj/machinery/computer/barcode/qm{
-	dir = 4
+/obj/disposalpipe/segment,
+/obj/stool/chair/office/yellow{
+	dir = 1
 	},
-/turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
-"bOb" = (
 /obj/landmark/start{
 	name = "Quartermaster"
 	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"bOb" = (
 /obj/stool/chair/yellow{
 	dir = 8
 	},
@@ -35956,9 +35960,6 @@
 /area/station/maintenance/east)
 "bUD" = (
 /obj/stool/chair/comfy,
-/obj/landmark/start{
-	name = "Quartermaster"
-	},
 /turf/simulated/floor/damaged4{
 	dir = 4
 	},
@@ -36236,7 +36237,9 @@
 /area/station/crew_quarters/radio/lab)
 "bVu" = (
 /obj/disposalpipe/segment/mail,
-/obj/decal/stripe_caution,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bVv" = (
@@ -39598,11 +39601,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "cfG" = (
-/obj/machinery/conveyor/WE{
-	id = "qmout"
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/southwest)
 "cfH" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -40339,8 +40343,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
 "chZ" = (
-/turf/space/fluid,
-/area/station/maintenance/southwest)
+/obj/machinery/light/incandescent/harsh,
+/obj/machinery/manufacturer/qm,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "cia" = (
 /obj/storage/crate/wooden,
 /obj/decal/stripe_caution,
@@ -40372,20 +40385,33 @@
 	name = "Supply Lobby"
 	})
 "cij" = (
-/obj/storage/secure/closet/engineering/cargo,
-/obj/decal/stripe_caution,
-/turf/simulated/floor/yellow,
+/obj/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/caution/west,
 /area/station/quartermaster/office)
 "cil" = (
-/obj/machinery/light_switch/auto,
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door_control{
+	id = "cargo_outbound";
+	name = "Cargo Outbound Door Control";
+	pixel_x = -24
+	},
+/obj/machinery/conveyor_switch{
+	id = "outbound";
+	name = "outbound conveyor switch"
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"cim" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
-"cim" = (
-/turf/simulated/floor/yellow,
-/turf/simulated/floor/plating/random,
-/area/station/quartermaster/office)
 "cin" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -41653,6 +41679,13 @@
 /obj/machinery/synthomatic,
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
+"cvP" = (
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "cwj" = (
 /obj/item/storage/secure/ssafe/diner_arcade{
 	pixel_x = -30
@@ -41700,6 +41733,15 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
+"cDW" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating/random,
+/area/station/quartermaster/office)
 "cFN" = (
 /obj/machinery/disposal/mail/small/autoname{
 	dir = 8;
@@ -41972,6 +42014,7 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/radio/intercom/cargo,
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "dIw" = (
@@ -42078,6 +42121,10 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/engine/storage)
+"ear" = (
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "edf" = (
 /obj/machinery/vending/pizza,
 /turf/simulated/floor/plating/random,
@@ -42321,6 +42368,14 @@
 /obj/machinery/lawrack,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"fgz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "fhb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42362,6 +42417,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
+"fBB" = (
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 100;
+	id = "qm_dock_out"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "cargo_outbound";
+	name = "Cargo Routing Door"
+	},
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "fCI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42817,6 +42886,12 @@
 /obj/machinery/manufacturer/engineering,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"gSK" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/hand_labeler,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "gST" = (
 /obj/landmark/random_room/size3x3,
 /turf/simulated/floor/plating/random,
@@ -42898,6 +42973,12 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
+"hyD" = (
+/obj/disposalpipe/segment,
+/obj/machinery/computer/supplycomp,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "hzx" = (
 /obj/wingrille_spawn/auto,
 /obj/barber_pole{
@@ -43010,6 +43091,16 @@
 /obj/item/device/t_scanner,
 /turf/simulated/floor,
 /area/station/storage/eeva)
+"irk" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "isQ" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/line/blue{
@@ -43019,6 +43110,10 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"iuW" = (
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "ivJ" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -43191,6 +43286,12 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/hydroponics/bay)
+"jcd" = (
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/turf/space/fluid,
+/area/space)
 "jdK" = (
 /obj/machinery/light_switch/auto,
 /turf/simulated/floor,
@@ -43528,6 +43629,13 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"kvq" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "kwr" = (
 /obj/lattice{
 	dir = 1;
@@ -43586,6 +43694,7 @@
 /area/station/crew_quarters/captain)
 "kST" = (
 /obj/landmark/gps_waypoint,
+/obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "kUZ" = (
@@ -43604,6 +43713,20 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"kWA" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "qm";
+	name = "QM Shutters Control";
+	pixel_y = -24
+	},
+/obj/machinery/conveyor_switch{
+	id = "qmout"
+	},
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "kYa" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/incandescent/netural,
@@ -43646,6 +43769,14 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
+"lio" = (
+/obj/disposalpipe/segment,
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"lis" = (
+/turf/simulated/floor/caution/east,
+/area/station/quartermaster/office)
 "ljO" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/green,
@@ -43676,6 +43807,13 @@
 /obj/access_spawn/tox,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
+"lph" = (
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/obj/plasticflaps,
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "lpD" = (
 /obj/machinery/navbeacon/mule/hydroponics_north,
 /turf/simulated/floor/grass,
@@ -44033,6 +44171,12 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
+"ncE" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "ndB" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor,
@@ -44103,11 +44247,27 @@
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"nks" = (
+/obj/disposalpipe/segment,
+/obj/machinery/light/incandescent/harsh,
+/obj/submachine/cargopad{
+	name = "Cargo Bay Pad"
+	},
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
 "nlv" = (
 /obj/machinery/light/incandescent/harsh/very,
 /obj/machinery/manufacturer/science,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
+"nqQ" = (
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/obj/machinery/computer/barcode/qm,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "nvJ" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -44280,6 +44440,17 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/garden/zen)
+"nVK" = (
+/obj/storage/crate,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/item/storage/box,
+/obj/decal/stripe_caution,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "nYa" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -44299,6 +44470,19 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
+"ohM" = (
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "cargo_inbound";
+	name = "Cargo Routing Door"
+	},
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/obj/plasticflaps,
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "oiZ" = (
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
@@ -44355,6 +44539,13 @@
 /obj/disposalpipe/trunk/mail/north,
 /turf/simulated/floor,
 /area/station/security/processing)
+"ozF" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/storage/cart,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "oDh" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
@@ -44444,8 +44635,9 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "oVp" = (
-/obj/machinery/light/incandescent/warm/very,
-/turf/simulated/floor/yellow,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 5
+	},
 /area/station/quartermaster/office)
 "oVS" = (
 /obj/table/wood/round/auto,
@@ -44617,6 +44809,13 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery/storage)
+"pAw" = (
+/turf/unsimulated/wall/trench/side,
+/area/supply/sell_point)
+"pAR" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/caution/south,
+/area/station/quartermaster/office)
 "pCE" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -44920,6 +45119,13 @@
 /obj/machinery/pathogen_manipulator,
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
+"qXQ" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "qZZ" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/storage/crate,
@@ -44988,6 +45194,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
+"rqE" = (
+/obj/disposalpipe/segment,
+/obj/decal/stripe_caution,
+/obj/storage/crate/biohazard,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "rsA" = (
 /obj/item/trench_map,
 /turf/simulated/floor/shuttlebay,
@@ -45166,6 +45378,15 @@
 /obj/machinery/networked/storage/scanner,
 /turf/simulated/floor/plating/random,
 /area/research_outpost/maint)
+"svi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/stripe_caution,
+/obj/machinery/bot/mulebot/QM1,
+/obj/machinery/navbeacon/mule/QM1_north/west,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "sxC" = (
 /obj/table/auto,
 /obj/item/device/light/flashlight,
@@ -45199,6 +45420,13 @@
 	dir = 10
 	},
 /area/space)
+"sPr" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/obj/disposalpipe/segment,
+/obj/item/device/radio/intercom/cargo,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "sRT" = (
 /obj/item/device/radio/intercom/science,
 /turf/simulated/floor/engine,
@@ -45277,11 +45505,18 @@
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)
 "tsX" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/bot/mulebot/QM1,
-/obj/machinery/navbeacon/mule/QM1_north/west,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
+/obj/plasticflaps,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm";
+	name = "QM Shutters";
+	opacity = 0
+	},
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "txj" = (
 /obj/lattice{
@@ -45303,6 +45538,14 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
+"tBk" = (
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/obj/machinery/light/incandescent/harsh,
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "tBo" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -45439,7 +45682,7 @@
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
 	},
-/turf/simulated/floor/caution/south,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "tZV" = (
 /obj/cable{
@@ -45502,6 +45745,10 @@
 /obj/tree,
 /turf/simulated/floor/grass/random,
 /area/station/garden/zen)
+"uvT" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "uxl" = (
 /turf/simulated/floor/redwhite{
 	dir = 1
@@ -45625,6 +45872,12 @@
 /obj/item/furniture_parts/office_chair/blue,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
+"vdr" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 10
+	},
+/area/station/quartermaster/office)
 "vex" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /obj/decal/poster/wallsign/framed_award/hos_medal{
@@ -45812,6 +46065,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
+"vYb" = (
+/obj/decal/stripe_caution,
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/quartermaster/office)
 "wbZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45822,9 +46081,10 @@
 /turf/simulated/shuttle/wall/flock,
 /area/space)
 "wdO" = (
-/obj/machinery/navbeacon/mule/QM2_north/west,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
+/turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "wfi" = (
 /obj/cable{
@@ -46049,6 +46309,12 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor,
 /area/research_outpost/hangar)
+"xiS" = (
+/obj/disposalpipe/segment,
+/obj/decal/stripe_caution,
+/obj/storage/secure/crate/bee/loaded,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "xkB" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/drinks/bottle/soda,
@@ -46231,6 +46497,13 @@
 	dir = 5
 	},
 /area/station/engine/elect)
+"ycy" = (
+/obj/machinery/conveyor/WE{
+	id = "inbound"
+	},
+/obj/disposalpipe/trunk/west,
+/turf/simulated/floor/caution/northsouth,
+/area/station/quartermaster/office)
 "ydh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -47385,20 +47658,20 @@ cgq
 cgq
 cgq
 cgq
-auI
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
+pAw
 bKg
 bKg
 bKg
 bKg
-bKg
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
 aqn
 aqn
 aqn
@@ -47687,20 +47960,20 @@ cgq
 auI
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
 bKg
 bKg
 bKg
 bKg
 bKg
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
 aqn
 aqn
 aqn
@@ -47989,20 +48262,20 @@ aqn
 aqn
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
 bKg
 bKg
 bKg
 bKg
 bKg
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
 aqn
 aqn
 aqn
@@ -48293,16 +48566,16 @@ aqn
 aqn
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
-aqn
 bMN
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
+aqn
 aqn
 aqn
 aqn
@@ -72755,7 +73028,7 @@ aqn
 aqn
 aqn
 aqn
-aqn
+jcd
 aqn
 aqn
 aqn
@@ -73057,7 +73330,7 @@ aqn
 aqn
 aqn
 aqn
-aqn
+jcd
 aqn
 aqn
 aqn
@@ -73359,7 +73632,7 @@ aqn
 aqn
 aqn
 aqn
-aqn
+apc
 aqn
 aqn
 aqn
@@ -73660,11 +73933,11 @@ aqn
 aqn
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
+bJw
+ohM
+bSj
+fBB
+bJw
 aqn
 aqn
 aqn
@@ -73962,11 +74235,11 @@ aqn
 aqn
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
+bJw
+cvP
+bJx
+aby
+bJw
 aqn
 aqn
 aqn
@@ -74264,11 +74537,11 @@ aqn
 aqn
 aqn
 aqn
-aqn
-aqn
-aqn
-aqn
-aqn
+bJw
+bMO
+cDW
+abz
+bJw
 aqn
 aqn
 aqn
@@ -74560,20 +74833,20 @@ brI
 brH
 brH
 aqn
-bCX
-bCX
+buE
+buE
 cic
 buE
 bJw
+bSj
 bJw
+lph
 bJw
+bPf
 bJw
-bJw
-bJw
-bJw
-bCX
-bCX
-bCX
+bSj
+bSj
+bSj
 aqn
 aqn
 aqn
@@ -74867,15 +75140,15 @@ btZ
 btZ
 gST
 bJw
-bys
-bys
-bys
-bys
-bys
-bys
-cim
-bys
-bCX
+chZ
+bEg
+bMQ
+bQj
+bPg
+cil
+bQj
+bGU
+bSj
 aqn
 aqn
 aqn
@@ -75163,24 +75436,24 @@ boW
 btW
 buE
 buE
-chZ
+aqn
 buE
 btZ
 btZ
 btZ
 cir
-bys
-bys
-bys
-bys
-bys
-bys
-oVp
-bys
-bJw
+bKj
+bKj
+bMR
+bKj
+bMR
+bKj
+bKj
+gSK
+bSj
 aqn
 aqn
-apc
+jcd
 aqn
 aqn
 aqn
@@ -75465,21 +75738,21 @@ boW
 btX
 buF
 buE
-chZ
+aqn
 buE
 btZ
 btZ
 btZ
 bJw
-byu
-bys
-bys
-bys
-bys
-bys
-bys
-cij
-bJw
+nqQ
+bKj
+bMS
+bMS
+bMS
+bMS
+bCY
+lis
+bSj
 aqn
 bJw
 aJE
@@ -75771,20 +76044,20 @@ buE
 buE
 buE
 cid
-buE
-bJw
-cia
-bys
-bys
-bys
-bys
-bys
-bys
-cij
-bJw
-bJw
-bJw
-bMO
+cfG
+bIC
+sPr
+bFe
+lio
+bFe
+bFe
+lio
+pAR
+nks
+bIC
+bIC
+bIC
+tBk
 bJw
 aby
 bJw
@@ -76071,22 +76344,22 @@ btX
 buE
 rOw
 btZ
-btZ
+bua
 btZ
 aRU
-bJw
-byu
-bys
-bys
-bys
-bys
-bys
-bys
+bCX
+hyD
+bOa
+rqE
+byt
+xiS
+nVK
+vdr
 cij
-bJw
+bIC
 bKo
 bJx
-bMO
+ycy
 aGB
 abz
 bJx
@@ -76373,17 +76646,17 @@ btX
 buE
 bbi
 btZ
-btZ
-bJw
-bJw
-bJw
-cia
-bys
-bys
-bys
-bys
-bys
-bys
+iuW
+bIC
+bIC
+kvq
+ozF
+ncE
+ncE
+oVp
+bKj
+bKj
+uvT
 bEi
 bJw
 bJw
@@ -76683,7 +76956,7 @@ bys
 bys
 bEe
 bFc
-bVu
+bGS
 bGS
 bVu
 aSy
@@ -76691,7 +76964,7 @@ bJA
 bKh
 bLI
 bMQ
-bOa
+bxC
 bPg
 bQg
 bJA
@@ -76986,9 +77259,9 @@ bBJ
 bEf
 bFd
 bFW
-bFW
+svi
 bHQ
-bKj
+bQj
 bJz
 bPh
 bxC
@@ -77281,23 +77554,23 @@ btZ
 bJw
 aMK
 bys
+bzo
 bys
 bys
-bys
-bys
-bAw
-bFe
-bMS
-cfG
+bzo
+kWA
+bJA
+bzr
+bzr
 bHR
-bIC
+bJA
 bJA
 bKj
 bQi
 bKj
 bKj
 bPh
-tsX
+bMU
 bJA
 bSn
 bTm
@@ -77583,16 +77856,16 @@ btZ
 bJw
 dHz
 bys
-bzo
+byu
+cia
 bys
-bys
-bzo
-bEg
+wdO
+bEh
 bFf
-bJA
+vYb
 bGT
 bHS
-bJA
+bBM
 bJA
 bKj
 bLL
@@ -77885,14 +78158,14 @@ bvY
 bJw
 lxj
 bys
+cia
+byu
 bys
-bys
-bys
-bys
+wdO
 bEh
-bJA
+tsX
 bIz
-bGU
+bAy
 bHT
 bID
 bDa
@@ -77901,7 +78174,7 @@ bKj
 bMS
 bKj
 bMS
-wdO
+bMS
 bJA
 aNT
 bTo
@@ -78187,17 +78460,17 @@ btZ
 bJw
 bxB
 bys
+bzo
+ear
 bys
-bys
-bBM
-bys
-bEh
+bzo
+bAw
 bJA
 bKm
 bAy
 bGY
-bAy
-cil
+bBO
+bDa
 bKj
 bKj
 bMS
@@ -78495,11 +78768,11 @@ bCW
 bCW
 bEj
 bFV
-aay
+irk
 bAy
 bGW
 bAx
-bBN
+bDa
 bKj
 bKj
 bMU
@@ -78791,10 +79064,10 @@ bua
 bJA
 bJy
 bxC
-byt
+bzs
 bFh
 bLR
-bBO
+bKj
 bEk
 bFi
 aay
@@ -79093,14 +79366,14 @@ btZ
 bJA
 bxD
 bxC
-bzs
+qXQ
 bAv
 bFk
 kST
 bEl
-bFi
+bBN
 aay
-bAy
+cim
 cin
 bzp
 bDa
@@ -79700,7 +79973,7 @@ byv
 bzs
 bKj
 bKj
-bCY
+bKj
 bEn
 bJA
 bxx
@@ -80008,7 +80281,7 @@ bJA
 bGa
 bII
 bHW
-bIH
+fgz
 bDw
 cft
 bIH

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -16887,7 +16887,7 @@
 /area/space)
 "aRU" = (
 /obj/machinery/disposal/transport,
-/obj/disposalpipe/trunk/west,
+/obj/disposalpipe/trunk,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "aRV" = (
@@ -29313,13 +29313,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"bCX" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/office)
 "bCY" = (
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
@@ -30135,10 +30128,6 @@
 	},
 /obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/caution/north,
-/area/station/quartermaster/office)
-"bFe" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bFf" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -36249,11 +36238,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
-"bVy" = (
-/obj/disposaloutlet,
-/obj/disposalpipe/trunk/north,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
 "bVz" = (
 /obj/item/wrapping_paper,
 /obj/decal/cleanable/dirt,
@@ -39585,12 +39569,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "cfG" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/southwest)
+/obj/decal/stripe_caution,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
 "cfH" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -39799,6 +39780,7 @@
 "cgs" = (
 /obj/table/round,
 /obj/item/cigarbox,
+/obj/item/matchbook,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "cgt" = (
@@ -43086,14 +43068,6 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"iuW" = (
-/obj/disposalpipe/trunk,
-/obj/disposaloutlet{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
 "ivJ" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -43609,13 +43583,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
-"kvq" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/office)
 "kwr" = (
 /obj/lattice{
 	dir = 1;
@@ -44228,7 +44195,6 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "nks" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light/incandescent/harsh,
 /obj/submachine/cargopad{
 	name = "Cargo Bay Pad"
@@ -44798,7 +44764,6 @@
 /turf/unsimulated/wall/trench/side,
 /area/supply/sell_point)
 "pAR" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/caution/south,
 /area/station/quartermaster/office)
 "pCE" = (
@@ -45180,7 +45145,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "rqE" = (
-/obj/disposalpipe/segment,
 /obj/decal/stripe_caution,
 /obj/storage/crate/biohazard,
 /turf/simulated/floor,
@@ -45407,7 +45371,6 @@
 "sPr" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
-/obj/disposalpipe/segment,
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -46295,7 +46258,6 @@
 /turf/simulated/floor,
 /area/research_outpost/hangar)
 "xiS" = (
-/obj/disposalpipe/segment,
 /obj/decal/stripe_caution,
 /obj/storage/secure/crate/bee/loaded,
 /turf/simulated/floor,
@@ -76029,18 +75991,18 @@ buE
 buE
 buE
 cid
-cfG
-bIC
+buE
+bJw
 sPr
-bFe
-lio
+bKj
+cfG
 xiS
 rqE
-lio
+cfG
 pAR
 nks
-bIC
-bVy
+bJw
+btZ
 btZ
 buE
 cic
@@ -76332,7 +76294,7 @@ btZ
 bua
 btZ
 aRU
-bCX
+bIC
 hyD
 bOa
 lio
@@ -76631,10 +76593,10 @@ btX
 buE
 bbi
 btZ
-iuW
-bIC
-bIC
-kvq
+btZ
+bJw
+bJw
+bJw
 ozF
 ncE
 ncE

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -16886,7 +16886,7 @@
 /turf/space/fluid,
 /area/space)
 "aRU" = (
-/obj/machinery/disposal,
+/obj/machinery/disposal/transport,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
@@ -31915,14 +31915,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bJz" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/firedoor_spawn,
-/obj/access_spawn/cargo,
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/stool/chair{
+	dir = 8
 	},
 /turf/simulated/floor/plating/random,
-/area/station/quartermaster/office)
+/area/station/maintenance/southwest)
 "bJA" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
@@ -32145,11 +32142,8 @@
 	name = "Supply Lobby"
 	})
 "bKo" = (
-/obj/disposalpipe/trunk/west,
-/obj/disposaloutlet{
-	dir = 4;
-	pixel_x = -8
-	},
+/obj/machinery/disposal/transport,
+/obj/disposalpipe/trunk/north,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "bKp" = (
@@ -32642,11 +32636,10 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
 "bLI" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/office)
+/obj/item/reagent_containers/pill/catdrugs,
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bLL" = (
 /obj/stool/chair{
 	dir = 4
@@ -34289,9 +34282,9 @@
 	},
 /area/station/storage/warehouse)
 "bQm" = (
-/obj/disposalpipe/segment/bent/south,
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
+/obj/item/reagent_containers/food/drinks/bottle/beer/borg,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bQn" = (
 /obj/machinery/door/unpowered/wood/pyro,
 /turf/simulated/floor/black,
@@ -35441,9 +35434,9 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "bTk" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/office)
+/obj/item/reagent_containers/pill/bathsalts,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bTl" = (
 /obj/vehicle/forklift,
 /obj/machinery/power/apc/autoname_west,
@@ -36257,8 +36250,9 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "bVy" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/disposaloutlet,
+/obj/disposalpipe/trunk/north,
+/turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "bVz" = (
 /obj/item/wrapping_paper,
@@ -39803,8 +39797,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/refinery)
 "cgs" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
+/obj/table/round,
+/obj/item/cigarbox,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "cgt" = (
@@ -42883,7 +42877,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "gST" = (
-/obj/landmark/random_room/size3x3,
+/obj/machinery/computer/stockexchange{
+	dir = 4
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "gUq" = (
@@ -44413,6 +44409,10 @@
 /mob/living/critter/small_animal/cockroach,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"nQD" = (
+/obj/item/spacecash,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "nSl" = (
 /obj/table/round/auto,
 /obj/item/hand_labeler,
@@ -75121,8 +75121,8 @@ brI
 brH
 aqn
 buE
-btZ
-btZ
+gST
+bLI
 gST
 bJw
 chZ
@@ -75423,9 +75423,9 @@ buE
 buE
 aqn
 buE
-btZ
-btZ
-btZ
+bJz
+nQD
+bTk
 cir
 bKj
 bKj
@@ -75725,9 +75725,9 @@ buF
 buE
 aqn
 buE
-btZ
-btZ
-btZ
+cgs
+bQi
+bQm
 bJw
 nqQ
 bKj
@@ -75737,10 +75737,10 @@ bKj
 bKj
 bCY
 lis
-bSj
-aqn
-aqn
-aqn
+bJw
+buE
+buE
+buE
 aqn
 aqn
 aqn
@@ -76041,7 +76041,7 @@ pAR
 nks
 bIC
 bVy
-buE
+btZ
 buE
 cic
 cic
@@ -76341,9 +76341,9 @@ nVK
 lio
 vdr
 cij
-bTk
+bIC
 bKo
-bua
+btZ
 btZ
 btZ
 btZ
@@ -76643,9 +76643,9 @@ bKj
 bKj
 uvT
 bEi
-bLI
+bJw
 btZ
-btZ
+bua
 bSl
 bSl
 bSl
@@ -76945,8 +76945,8 @@ bGS
 bGS
 bVu
 aSy
-bLI
-buE
+bJw
+btZ
 btZ
 bSl
 bSm
@@ -77247,7 +77247,7 @@ bFW
 svi
 bHQ
 bQj
-bJz
+cir
 btZ
 btZ
 bSl
@@ -77549,8 +77549,8 @@ bNZ
 bNZ
 bHR
 bJA
-bQm
-cgs
+bJA
+btZ
 bQi
 bPi
 bSo

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31584,7 +31584,7 @@
 	})
 "bIE" = (
 /obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/floor,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -11180,19 +11180,12 @@
 	},
 /area/station/medical/medbay/lobby)
 "aBP" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	drive_range = 100;
-	id = "qm_dock_out"
+/obj/item/boardgame/chess,
+/obj/table/glass/reinforced/auto,
+/turf/simulated/floor/green/side{
+	dir = 4
 	},
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 4;
-	id = "cargo_outbound";
-	name = "Cargo Routing Door"
-	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/lounge/port)
 "aBQ" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -12877,15 +12870,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aGB" = (
-/obj/machinery/light/incandescent/warm/very,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "aGC" = (
 /obj/stool/chair/wooden{
@@ -14133,17 +14119,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aJE" = (
-/obj/machinery/conveyor/WE{
-	id = "inbound"
+/obj/stool/chair/comfy{
+	dir = 1
 	},
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 4;
-	id = "cargo_inbound";
-	name = "Cargo Routing Door"
+/turf/simulated/floor/green/side{
+	dir = 4
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/lounge/port)
 "aJF" = (
 /obj/table/round,
 /obj/item/reagent_containers/food/snacks/candy/candy_cane,
@@ -15407,7 +15389,7 @@
 /obj/item/wrench,
 /obj/item/screwdriver,
 /turf/simulated/floor/plating/random,
-/area/station/quartermaster/office)
+/area/station/maintenance/southwest)
 "aNx" = (
 /turf/simulated/floor,
 /area/station/security/main)
@@ -16582,14 +16564,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"aQP" = (
-/obj/machinery/vending/snack,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-6"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "aQQ" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -17146,6 +17120,7 @@
 	mail_tag = "quartermasters' office"
 	},
 /obj/decal/stripe_delivery,
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aSz" = (
@@ -27334,7 +27309,6 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bxD" = (
-/obj/machinery/light/incandescent/warm,
 /obj/table/reinforced/auto,
 /obj/item/cargotele{
 	pixel_x = 5;
@@ -27977,7 +27951,6 @@
 "bzm" = (
 /obj/machinery/nanofab/refining,
 /obj/decal/stripe_caution,
-/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bzo" = (
@@ -27988,7 +27961,7 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
-/obj/machinery/light/incandescent/netural,
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -28462,12 +28435,20 @@
 	name = "Supply Lobby"
 	})
 "bAA" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light/incandescent/harsh,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs_wide"
+	},
+/area/station/crew_quarters/lounge/port)
 "bAC" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/yellow/side{
@@ -28940,10 +28921,13 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/north,
 /obj/decal/stripe_delivery,
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
-/area/station/quartermaster/office)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bBN" = (
 /obj/access_spawn/cargo,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -29314,6 +29298,9 @@
 /area/station/hallway/secondary/exit)
 "bCT" = (
 /obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -29868,6 +29855,7 @@
 	},
 /obj/machinery/light_switch/south,
 /obj/vehicle/tug,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bEo" = (
@@ -29881,7 +29869,6 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/light/incandescent/warm,
 /obj/tug_cart,
 /obj/tug_cart,
 /obj/tug_cart,
@@ -30158,15 +30145,15 @@
 	dir = 10
 	},
 /obj/plasticflaps,
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "qm";
 	name = "QM Shutters";
 	opacity = 0
-	},
-/obj/machinery/conveyor/NS{
-	id = "qmout"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
@@ -30502,9 +30489,7 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bGa" = (
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -30838,7 +30823,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/quartermaster/office)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bGU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -30846,6 +30833,7 @@
 	pixel_x = 5;
 	pixel_y = 8
 	},
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGV" = (
@@ -31237,6 +31225,14 @@
 	dir = 4
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm2";
+	name = "Supply Lobby Shutters";
+	opacity = 0;
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bHS" = (
@@ -31250,7 +31246,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/quartermaster/office)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "bHT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31577,7 +31575,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bID" = (
-/obj/machinery/light/incandescent/netural,
 /obj/stool/chair/yellow{
 	dir = 4
 	},
@@ -31918,12 +31915,13 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bJz" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "QM"
-	},
-/obj/access_spawn/cargo,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/firedoor_spawn,
-/turf/simulated/floor/yellow,
+/obj/access_spawn/cargo,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bJA" = (
 /turf/simulated/wall/auto/supernorn,
@@ -32120,9 +32118,14 @@
 /turf/space/fluid,
 /area/supply/sell_point)
 "bKh" = (
-/obj/machinery/light/incandescent/harsh,
-/turf/simulated/floor/scorched,
-/area/station/quartermaster/office)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bKj" = (
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -32131,12 +32134,10 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bKm" = (
-/obj/submachine/ATM{
-	pixel_y = 32
-	},
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -32144,10 +32145,13 @@
 	name = "Supply Lobby"
 	})
 "bKo" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/north,
+/obj/disposalpipe/trunk/west,
+/obj/disposaloutlet{
+	dir = 4;
+	pixel_x = -8
+	},
 /turf/simulated/floor/plating/random,
-/area/station/quartermaster/office)
+/area/station/maintenance/southwest)
 "bKp" = (
 /obj/item/skull,
 /obj/item/spacecash/thousand,
@@ -32638,23 +32642,17 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
 "bLI" = (
-/obj/machinery/conveyor_switch{
-	id = "inbound";
-	name = "inbound conveyor switch"
-	},
-/obj/machinery/door_control{
-	id = "cargo_inbound";
-	name = "Cargo Inbound Door Control";
-	pixel_x = -24
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
-"bLL" = (
-/obj/machinery/light/incandescent/harsh,
-/turf/simulated/floor/damaged2{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
+"bLL" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bLO" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -32963,12 +32961,10 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "bMP" = (
-/obj/plasticflaps,
-/obj/machinery/conveyor/WE{
-	id = "inbound"
-	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/obj/machinery/power/apc/autoname_west,
+/obj/cable,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bMQ" = (
 /obj/machinery/conveyor/WE{
 	id = "inbound"
@@ -32982,25 +32978,17 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bMS" = (
-/obj/decal/stripe_caution,
+/obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bMU" = (
-/obj/decal/cleanable/dirt,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/machinery/light/incandescent/blueish,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bMV" = (
-/obj/storage/crate,
-/obj/item/clothing/head/merchant_hat,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"bMW" = (
-/obj/storage/crate/biohazard,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge/port)
 "bMX" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -33428,8 +33416,16 @@
 /turf/simulated/floor/carpet/purple/fancy/narrow/se,
 /area/station/crew_quarters/radio/lab)
 "bNZ" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "qm2";
+	name = "Supply Lobby Shutters";
+	opacity = 0;
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "bOa" = (
 /obj/disposalpipe/segment,
@@ -33442,28 +33438,35 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bOb" = (
-/obj/stool/chair/yellow{
-	dir = 8
+/obj/storage/crate/robotparts,
+/obj/decal/xmas_lights{
+	pixel_y = 32
 	},
-/turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
+/turf/simulated/floor/plating/random,
+/area/station/storage/warehouse)
 "bOc" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/grime,
-/area/station/quartermaster/office)
+/obj/machinery/vending/standard,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/plating/scorched,
+/area/station/storage/warehouse)
 "bOe" = (
-/turf/simulated/floor/scorched2,
-/area/station/quartermaster/office)
+/obj/machinery/vending/coffee,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bOf" = (
-/obj/storage/secure/crate/bee/loaded,
-/obj/decal/stripe_caution,
+/obj/machinery/vending/cola/blue,
 /turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/lounge/port)
 "bOg" = (
-/obj/storage/crate/freezer,
-/obj/decal/stripe_caution,
+/obj/machinery/vending/snack,
 /turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/lounge/port)
 "bOh" = (
 /obj/shrub{
 	dir = 10
@@ -33813,23 +33816,29 @@
 	},
 /area/station/quartermaster/office)
 "bPh" = (
-/turf/simulated/floor/grime,
-/area/station/quartermaster/office)
+/obj/machinery/light/incandescent/netural,
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bPi" = (
-/obj/storage/crate/internals,
-/obj/decal/stripe_caution,
+/obj/machinery/door/airlock/pyro/alt{
+	name = "Central Warehouse"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/station/storage/warehouse)
 "bPj" = (
-/obj/storage/crate,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/item/storage/box,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4;
+	req_access = null
+	},
+/obj/access_spawn/cargo,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bPk" = (
 /obj/item/instrument/large/jukebox,
 /turf/simulated/floor/black,
@@ -34247,43 +34256,42 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
 "bQg" = (
-/obj/machinery/conveyor_switch{
-	id = "outbound";
-	name = "outbound conveyor switch"
-	},
-/obj/machinery/door_control{
-	id = "cargo_outbound";
-	name = "Cargo Outbound Door Control";
-	pixel_x = -24
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southwest)
 "bQi" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bQj" = (
-/obj/machinery/light/incandescent/harsh,
+/obj/machinery/door_control{
+	id = "qm2";
+	name = "Supply Lobby Shutters Control";
+	pixel_x = 24
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bQk" = (
-/obj/vehicle/tug,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"bQl" = (
-/obj/tug_cart,
-/obj/tug_cart,
-/obj/tug_cart,
-/obj/machinery/light/incandescent/harsh,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"bQm" = (
-/obj/machinery/light/incandescent/netural,
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs2_wide"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/lounge/port)
+"bQl" = (
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	name = "Central Warehouse"
+	},
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/storage/warehouse)
+"bQm" = (
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/wall/auto/supernorn,
+/area/station/quartermaster/office)
 "bQn" = (
 /obj/machinery/door/unpowered/wood/pyro,
 /turf/simulated/floor/black,
@@ -34620,33 +34628,27 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "bRe" = (
-/obj/access_spawn/cargo,
-/obj/machinery/door/airlock/pyro/alt{
-	name = "Central Warehouse"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/tug_cart,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "bRf" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
+"bRg" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 4;
+	dir = 8;
 	name = "autoname - SS13";
-	pixel_x = -10;
+	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs_wide"
+/turf/simulated/floor/green/side{
+	dir = 4
 	},
-/area/station/hallway/primary/south)
-"bRg" = (
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs2_wide"
-	},
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/lounge/port)
 "bRh" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/garden/zen)
@@ -35078,10 +35080,14 @@
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "bSk" = (
-/obj/tug_cart,
-/obj/machinery/light/incandescent/blueish,
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4;
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
-/area/station/quartermaster/office)
+/area/station/storage/warehouse)
 "bSl" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/warehouse)
@@ -35101,9 +35107,10 @@
 	},
 /area/station/storage/warehouse)
 "bSn" = (
-/obj/storage/crate/robotparts,
+/obj/tug_cart,
+/obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/plating/random,
-/area/station/storage/warehouse)
+/area/station/maintenance/southwest)
 "bSo" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/grime{
@@ -35124,25 +35131,13 @@
 	},
 /area/station/storage/warehouse)
 "bSr" = (
-/obj/machinery/vending/standard,
-/obj/decal/xmas_lights{
-	pixel_y = 32
+/obj/item/sea_ladder,
+/turf/simulated/floor/grime{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating/scorched,
 /area/station/storage/warehouse)
 "bSs" = (
-/obj/machinery/vending/cola/blue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/vending/medical_public,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bSt" = (
@@ -35151,8 +35146,9 @@
 /turf/simulated/floor/grime,
 /area/space)
 "bSu" = (
-/obj/machinery/vending/medical_public,
-/obj/decal/stripe_caution,
+/obj/stool/chair{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bSv" = (
@@ -35445,8 +35441,8 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "bTk" = (
-/obj/tug_cart,
-/turf/simulated/floor/plating/random,
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bTl" = (
 /obj/vehicle/forklift,
@@ -35503,18 +35499,15 @@
 	},
 /area/station/storage/warehouse)
 "bTr" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 4;
-	name = "Central Warehouse"
-	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grime{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/area/station/storage/warehouse)
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bTs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35522,11 +35515,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bTt" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "4-9"
+/obj/table/glass/reinforced/auto,
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant_small";
+	layer = 3;
+	pixel_x = -16;
+	pixel_y = 12
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
@@ -35972,8 +35967,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/warehouse)
 "bUF" = (
-/obj/machinery/light/incandescent/netural,
-/obj/stool/bench,
+/obj/stool/chair/comfy,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bUG" = (
@@ -35981,11 +35975,15 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bUH" = (
-/obj/stool/bench,
+/obj/stool/chair/comfy{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bUI" = (
+/obj/stool/chair/comfy,
 /obj/machinery/light_switch/auto,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -36259,8 +36257,9 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "bVy" = (
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/storage/warehouse)
+/area/station/maintenance/southwest)
 "bVz" = (
 /obj/item/wrapping_paper,
 /obj/decal/cleanable/dirt,
@@ -36289,13 +36288,7 @@
 /area/station/storage/warehouse)
 "bVE" = (
 /obj/table/glass/reinforced/auto,
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant_small";
-	layer = 3;
-	pixel_x = -16;
-	pixel_y = 14
-	},
+/obj/item/card_box/plain,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bVF" = (
@@ -36592,9 +36585,6 @@
 /turf/simulated/floor/damaged4{
 	dir = 1
 	},
-/area/station/storage/warehouse)
-"bWu" = (
-/turf/simulated/wall/false_wall,
 /area/station/storage/warehouse)
 "bWv" = (
 /obj/machinery/light/incandescent/netural,
@@ -39534,7 +39524,7 @@
 	},
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/crew_quarters/lounge/port)
 "cfu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -39658,13 +39648,16 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/inner/central)
 "cfT" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/obj/decal/cleanable/dirt,
-/obj/item/sea_ladder,
-/turf/simulated/floor/plating/random,
-/area/station/storage/warehouse)
+/obj/shrub,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "cfU" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -39810,14 +39803,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/refinery)
 "cgs" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/cargo,
-/obj/firedoor_spawn,
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/north,
 /turf/simulated/floor/plating/random,
-/area/station/storage/warehouse)
+/area/station/maintenance/southwest)
 "cgt" = (
 /turf/simulated/floor/plating/damaged1,
 /area/station/storage/warehouse)
@@ -42372,6 +42361,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -43091,16 +43081,6 @@
 /obj/item/device/t_scanner,
 /turf/simulated/floor,
 /area/station/storage/eeva)
-"irk" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market{
-	name = "Supply Lobby"
-	})
 "isQ" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/line/blue{
@@ -43112,6 +43092,10 @@
 /area/station/medical/medbay)
 "iuW" = (
 /obj/disposalpipe/trunk,
+/obj/disposaloutlet{
+	dir = 8;
+	pixel_x = 8
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "ivJ" = (
@@ -43771,7 +43755,7 @@
 	})
 "lio" = (
 /obj/disposalpipe/segment,
-/obj/machinery/light/small/floor/harsh,
+/obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "lis" = (
@@ -44635,6 +44619,7 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "oVp" = (
+/obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 5
 	},
@@ -45407,10 +45392,9 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "sEn" = (
-/obj/machinery/light/incandescent/harsh,
-/obj/decal/stripe_caution,
-/turf/simulated/floor/orangeblack,
-/area/station/quartermaster/office)
+/obj/vehicle/tug,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/southwest)
 "sGx" = (
 /obj/machinery/computer/tetris,
 /turf/simulated/floor/carpet/arcade,
@@ -45506,15 +45490,15 @@
 /area/evilreaver/bar)
 "tsX" = (
 /obj/plasticflaps,
+/obj/machinery/conveyor/NS{
+	id = "qmout"
+	},
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "qm";
 	name = "QM Shutters";
 	opacity = 0
-	},
-/obj/machinery/conveyor/NS{
-	id = "qmout"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
@@ -45539,13 +45523,12 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "tBk" = (
-/obj/machinery/conveyor/WE{
-	id = "inbound"
+/obj/machinery/vending/cards,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/green/side{
+	dir = 4
 	},
-/obj/machinery/light/incandescent/harsh,
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/area/station/crew_quarters/lounge/port)
 "tBo" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -46070,7 +46053,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
-/area/station/quartermaster/office)
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "wbZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46498,12 +46483,12 @@
 	},
 /area/station/engine/elect)
 "ycy" = (
-/obj/machinery/conveyor/WE{
-	id = "inbound"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/trunk/west,
-/turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/office)
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating/random,
+/area/station/storage/warehouse)
 "ydh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -75143,10 +75128,10 @@ bJw
 chZ
 bEg
 bMQ
-bQj
+bKj
 bPg
 cil
-bQj
+bKj
 bGU
 bSj
 aqn
@@ -75453,7 +75438,7 @@ gSK
 bSj
 aqn
 aqn
-jcd
+aqn
 aqn
 aqn
 aqn
@@ -75746,19 +75731,19 @@ btZ
 bJw
 nqQ
 bKj
+bKj
 bMS
-bMS
-bMS
-bMS
+bKj
+bKj
 bCY
 lis
 bSj
 aqn
-bJw
-aJE
-bJw
-aBP
-bJw
+aqn
+aqn
+aqn
+aqn
+aqn
 aqn
 aqn
 aqn
@@ -76049,25 +76034,25 @@ bIC
 sPr
 bFe
 lio
-bFe
-bFe
+xiS
+rqE
 lio
 pAR
 nks
 bIC
-bIC
-bIC
-tBk
-bJw
-aby
-bJw
-bJw
-bSj
-bSj
-bSj
-bJw
-bJw
-bJw
+bVy
+buE
+buE
+cic
+cic
+cic
+cic
+cic
+cic
+cic
+cic
+cic
+buE
 aqn
 aqn
 aqn
@@ -76350,26 +76335,26 @@ aRU
 bCX
 hyD
 bOa
-rqE
+lio
 byt
-xiS
 nVK
+lio
 vdr
 cij
-bIC
+bTk
 bKo
-bJx
-ycy
-aGB
-abz
-bJx
-bJx
+bua
+btZ
+btZ
+btZ
+bua
+btZ
 aNw
-bJx
-bJx
-bJx
-bJx
-bJw
+btZ
+bSn
+bRe
+bRe
+cic
 aqn
 aqn
 aqn
@@ -76641,7 +76626,7 @@ boW
 bsv
 bqS
 boW
-bua
+bMU
 btX
 buE
 bbi
@@ -76658,20 +76643,20 @@ bKj
 bKj
 uvT
 bEi
-bJw
-bJw
-bJw
-bMP
-bNZ
-bPf
-bJw
-bJw
+bLI
+btZ
+btZ
+bSl
+bSl
+bSl
+bSl
+bSl
 bSk
-bTk
-bTk
-bJx
-bJx
-bJw
+bSl
+btZ
+btZ
+sEn
+cic
 aqn
 aqn
 aqn
@@ -76960,20 +76945,20 @@ bGS
 bGS
 bVu
 aSy
-bJA
-bKh
 bLI
-bMQ
-bxC
-bPg
-bQg
-bJA
+buE
+btZ
+bSl
+bSm
+bTl
+aPS
+bSr
+bSo
 bSl
 bSl
-bSl
-bSl
-bJx
-bJw
+btZ
+btZ
+cic
 aqn
 aqn
 aqn
@@ -77263,20 +77248,20 @@ svi
 bHQ
 bQj
 bJz
-bPh
-bxC
-bMR
-bOb
-bMR
-sEn
-bJA
-bSm
-bTl
-aPS
+btZ
+btZ
 bSl
-cgs
-bJw
-aqn
+bOb
+bTm
+bUA
+bVz
+cgt
+bWY
+bSl
+bua
+btZ
+buE
+buE
 aqn
 aqn
 aqn
@@ -77560,25 +77545,25 @@ bys
 bzo
 kWA
 bJA
-bzr
-bzr
+bNZ
+bNZ
 bHR
 bJA
-bJA
-bKj
+bQm
+cgs
 bQi
-bKj
-bKj
-bPh
-bMU
-bJA
-bSn
-bTm
-bUA
-bVz
-cgt
-bVy
-bVy
+bPi
+bSo
+ycy
+bUB
+auL
+bWY
+bXn
+bSl
+btZ
+btZ
+btZ
+cic
 aqn
 aqn
 aqn
@@ -77866,21 +77851,21 @@ vYb
 bGT
 bHS
 bBM
-bJA
-bKj
-bLL
-bMS
-bKj
-bMS
-bMR
-bJA
-bSo
-cfT
-bUB
-auL
-bWY
-bXn
-bVy
+bDa
+btZ
+bua
+bSl
+aNT
+bTo
+bXF
+mAR
+bXK
+aRt
+bSl
+bSl
+btZ
+btZ
+cic
 aqn
 aqn
 aqn
@@ -78170,19 +78155,19 @@ bHT
 bID
 bDa
 bKl
-bKj
-bMS
-bKj
-bMS
-bMS
-bJA
-aNT
-bTo
-bXF
-mAR
-bXK
-aRt
-bVy
+btZ
+bSl
+bSq
+aHb
+bUD
+bVC
+bWs
+bWY
+cgW
+bSl
+btZ
+btZ
+cic
 aqn
 aqn
 aqn
@@ -78471,20 +78456,20 @@ bAy
 bGY
 bBO
 bDa
-bKj
-bKj
-bMS
+btZ
+btZ
+bSl
 bOc
-bMS
-bKj
-bRe
-bSq
-aHb
-bUD
-bVC
-bWs
-cgW
-bVy
+bTq
+bUE
+bVD
+bWt
+bWY
+aya
+bSl
+btZ
+bua
+buE
 aqn
 aqn
 aqn
@@ -78768,25 +78753,25 @@ bCW
 bCW
 bEj
 bFV
-irk
+aay
 bAy
 bGW
 bAx
 bDa
-bKj
-bKj
-bMU
-bKj
-bMS
-bQj
-bJA
-bSr
-bTq
-bUE
-bVD
-bWt
-aya
-bVy
+btZ
+btZ
+bSl
+bSl
+bQl
+bSl
+bSl
+bSl
+bSl
+bSl
+bSl
+bPj
+bQg
+buE
 ckg
 bXO
 chQ
@@ -79075,20 +79060,20 @@ bAy
 cif
 bIF
 bDa
-bKj
-bKj
-bKj
+bua
+btZ
+bMV
 bOe
-bKj
+bTs
 bPh
-bJA
-bSl
+bLL
+bLL
 bTr
-bSl
-bSl
-bWu
-bSl
-bVy
+cft
+bMP
+bXb
+cfT
+bXO
 aUp
 bXO
 bXb
@@ -79377,17 +79362,17 @@ cim
 cin
 bzp
 bDa
-bKj
-bKj
+btZ
+btZ
 bMV
 bOf
-bPi
-bQk
-bJA
-bSs
+bTs
+bUG
+bUG
+bUG
 bTs
 bUF
-bUH
+bUG
 bUH
 bXa
 bXO
@@ -79679,18 +79664,18 @@ bAy
 aaz
 bIG
 bDa
-bKj
-bQj
-bMW
+btZ
+btZ
+bMV
 bOg
-bPj
-bQl
-bJA
-aQP
 bTs
 bUG
-bUG
-bUG
+bTt
+dKK
+bTs
+bUF
+bVE
+bUH
 bXb
 bXO
 bXb
@@ -79968,7 +79953,7 @@ bqs
 buL
 btZ
 bJA
-bxC
+aGB
 byv
 bzs
 bKj
@@ -79981,18 +79966,18 @@ bGX
 bLO
 bIE
 bDa
-bJA
-bJA
-bJA
-bJA
-bJA
-bJA
-bJA
+cjd
+cjd
+bMV
+bSs
+bTs
 bSu
-bTt
-bUG
-bVE
-dKK
+bSu
+bSu
+bTs
+bXb
+bXb
+bXb
 bUp
 bXP
 bXb
@@ -80272,7 +80257,7 @@ btZ
 bJA
 bxE
 byw
-bAA
+bzs
 bKj
 bKj
 tXX
@@ -80283,18 +80268,18 @@ bII
 bHW
 fgz
 bDw
-cft
 bIH
 bIH
-bIH
-bIH
-bQm
+bAA
+bRf
+bKh
+bRf
 bRf
 bSv
 bTu
-bUH
-bUH
-bUH
+bXb
+bXb
+bXb
 bXb
 bXO
 bXb
@@ -80585,19 +80570,19 @@ bII
 bHU
 bII
 bLX
+bIR
 bII
-bII
-bII
-bII
-bII
-bII
-bRg
+bQk
 bVF
-bTv
-bUI
 bVF
 bWv
 bVF
+bRg
+bTv
+bUI
+aBP
+aJE
+tBk
 bXO
 chQ
 bXO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [QoL] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This pr completely alters the layout of the cargo area on Oshan, as well as Southwest Maints, Central Warehouse, and The Crew Lounge, all located within the southwest corner of the station. A screenshot of the changes can be found here:
https://gyazo.com/a4e2206c0f40e8956782f8a85b16b4d9

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Oshan's cargo area currently has a problem where it's far too easy for QM players to shut themselves off in the backroom and not interact with the rest of the station while they do their work. This new layout fixes this problem by making it easier for both crew and cargo to interact with each other without trying to converse through the backroom shutters.

Additionally, this PR helps to turn the crew lounge found near this end of the station in a room that "almost kinda" resembles a lounge instead of a single sad looking table and stools.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DeeDotVeeA
(*)Oshan Laboratory's Quartermasters have become so rich from reselling metal sheets to the market that they were able to purchase a brand new Cargo area. Good for them!
```
