### PR TITLE
Change how items that can fit on your back are equipped through the equip hotkey

### DIFF
--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -341,7 +341,11 @@
 					autoequip_slot(slot_ears, ears)
 					autoequip_slot(slot_wear_mask, wear_mask)
 					autoequip_slot(slot_head, head)
-					autoequip_slot(slot_back, back)
+
+					if (!istype(master.back, /obj/item/storage) || istype(I, /obj/item/storage))
+						autoequip_slot(slot_back, back)
+						if (master.equipped() != I)
+							return
 
 					if (!istype(master.belt,/obj/item/storage) || istype(I,/obj/item/storage)) // belt BEFORE trying storages, and only swap if its not a storage swap
 						autoequip_slot(slot_belt, belt)
@@ -403,7 +407,11 @@
 					autoequip_slot(slot_ears, ears)
 					autoequip_slot(slot_wear_mask, wear_mask)
 					autoequip_slot(slot_head, head)
-					autoequip_slot(slot_back, back)
+
+					if (!istype(master.back, /obj/item/storage) || istype(I, /obj/item/storage))
+						autoequip_slot(slot_back, back)
+						if (master.equipped() != I)
+							return
 
 					if (!istype(master.belt,/obj/item/storage) || istype(I,/obj/item/storage)) // belt BEFORE trying storages, and only swap if its not a storage swap
 						autoequip_slot(slot_belt, belt)


### PR DESCRIPTION
[PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that using the equip hotkey with an item that can fit on your back, while wearing a backpack, will no longer swap them, but the item will be added to the backpack storage instead if you have the storage hud open.

This is how belts work too.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change is mostly aimed at guns that can be held on your back, but figured the change can be done for other items that can do that too.

It's still common that people are expecting guns that fit on your back to be added to your backpack when using the equip hotkey, but its unexpectedly swapped with your backpack instead.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(+)Items that can fit on your back will no longer auto-swap with worn backpacks when using the equip hotkey.
```
