### PR TITLE
Adds A Define Related To Testing Antags/Weapon Vendors/Uplinks

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -36,6 +36,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //////--- CONVENIENCE OPTIONS FOR TESTING ETC ---//
 //#define DEBUG_EVERYONE_GETS_CAPTAIN_ID // all IDs are captain rank, kept separate from below options to avoid disrupting access-related tests
 //#define NO_COOLDOWNS // disables all /datum/targetable cooldowns
+//#define BONUS_POINTS // gives a bunch of starting points to various abilities/uplinks/weapon vendors
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.
 
 //#define STOP_DISTRACTING_ME //All of the below

--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -41,6 +41,9 @@
 
 	var/points_last = 0
 
+#ifdef BONUS_POINTS
+	points = 99999
+#endif
 
 	New(var/mob/M)
 		..()

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -329,6 +329,9 @@ proc/broadcast_to_all_gangs(var/message)
 	var/obj/ganglocker/locker = null
 	/// The usable number of points that this gang has to spend with.
 	var/spendable_points = 0
+#ifdef BONUS_POINTS
+	spendable_points = 99999
+#endif
 	/// An associative list of the items that this gang has purchased and the quantity in which they have been purchased.
 	var/list/items_purchased = list()
 

--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -41,6 +41,16 @@
 	var/image/nucleus_overlay
 	var/total_placed = 0
 	var/next_pity_point = 100
+#ifdef BONUS_POINTS
+	bio_points = 999
+	bio_points_max = 999
+	bio_points_max_bonus = 999
+	base_gen_rate = 999
+	gen_rate_bonus = 999
+	gen_rate_used = 999
+	evo_points = 999
+#endif
+
 
 	var/datum/blob_ability/shift_power = null
 	var/datum/blob_ability/ctrl_power = null

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -106,6 +106,9 @@
 		src.abilityHolder = new /datum/abilityHolder/wraith(src)
 		AH = src.abilityHolder
 		src.abilityHolder.points = 50
+#ifdef BONUS_POINTS
+		src.abilityHolder.points = 99999
+#endif
 		if (!istype(src, /mob/living/intangible/wraith/wraith_trickster) && !istype(src, /mob/living/intangible/wraith/wraith_decay) && !istype(src, /mob/living/intangible/wraith/wraith_harbinger) && !istype(src, /mob/living/intangible/wraith/poltergeist))
 			src.addAbility(/datum/targetable/wraithAbility/specialize)
 		src.addAllBasicAbilities()

--- a/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
+++ b/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
@@ -104,6 +104,10 @@
 	points = 0 // Replaces the old vamp_blood_remaining var.
 	var/vamp_blood_tracking = 1
 	var/mob/vamp_isbiting = null
+#ifdef BONUS_POINTS
+	vamp_blood = 99999
+	points = 99999
+#endif
 
 	// Note: please use mob.get_vampire_blood() & mob.change_vampire_blood() instead of changing the numbers directly.
 

--- a/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
+++ b/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
@@ -7,6 +7,10 @@
 	var/possession_points = 0
 	/// number of souls required to evolve into a specialized wraith subclass
 	var/absorbs_to_evolve = 3
+#ifdef BONUS_POINTS
+	corpsecount = 9999
+	possession_points = 9999
+#endif
 	onAbilityStat()
 		..()
 		.= list()

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -29,6 +29,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	var/reading_synd_int = FALSE
 	var/reading_specific_synd_int = null
 	var/has_synd_int = TRUE
+#ifdef BONUS_POINTS
+	uses = 9999
+#endif
 
 	var/use_default_GUI = 0 // Use the parent's HTML interface (less repeated code).
 	var/temp = null
@@ -1149,6 +1152,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	var/datum/syndicate_buylist/reading_about = null
 	/// Bitflags for what items this uplink can buy (see `_std/defines/uplink.dm` for flags)
 	var/purchase_flags = UPLINK_NUKE_COMMANDER
+#ifdef BONUS_POINTS
+	points = 9999
+#endif
 
 	New()
 		..()
@@ -1159,6 +1165,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 				continue
 			num_players++
 		points = max(2, round(num_players / PLAYERS_PER_UPLINK_POINT))
+#ifdef BONUS_POINTS
+		points = 9999
+#endif
 		SPAWN(1 SECOND)
 			if (src && istype(src) && (!length(src.commander_buylist)))
 				src.setup()
@@ -1275,6 +1284,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	throw_range = 20
 	m_amt = 100
 	var/vr = 0
+#ifdef BONUS_POINTS
+	uses = 9999
+#endif
 
 	New(var/in_vr = 0)
 		..()

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -33,7 +33,11 @@
 
 	var/sound_token = 'sound/machines/capsulebuy.ogg'
 	var/sound_buy = 'sound/machines/spend.ogg'
+#ifdef BONUS_POINTS
+	var/list/credits = list(WEAPON_VENDOR_CATEGORY_SIDEARM = 999, WEAPON_VENDOR_CATEGORY_LOADOUT = 999, WEAPON_VENDOR_CATEGORY_UTILITY = 999, WEAPON_VENDOR_CATEGORY_AMMO = 999, WEAPON_VENDOR_CATEGORY_ASSISTANT = 999)
+#else
 	var/list/credits = list(WEAPON_VENDOR_CATEGORY_SIDEARM = 0, WEAPON_VENDOR_CATEGORY_LOADOUT = 0, WEAPON_VENDOR_CATEGORY_UTILITY = 0, WEAPON_VENDOR_CATEGORY_AMMO = 0, WEAPON_VENDOR_CATEGORY_ASSISTANT = 0)
+#endif
 	var/list/datum/materiel_stock = list()
 	var/token_accepted = /obj/item/requisition_token
 	var/log_purchase = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds a define that sets the points for various items very high. These include antag abilities, weapon vendors, uplinks, blob/wraith, and gang lockers. This does not include werewolf bodies eaten, and flock compute. I did not have these affected due to the werewolf not needing bodies eaten to use abilities, and flock compute influences the relay spawning.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes testing antags that rely on ability points much easier/faster to test, and makes testing changes to weapon vendors and uplinks easier/faster to test as well.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
