### PR TITLE
Adds a security ejection chute to the shuttles

### DIFF
--- a/assets/maps/shuttles/east/eastbase.dmm
+++ b/assets/maps/shuttles/east/eastbase.dmm
@@ -392,6 +392,15 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape/centcom)
+"pP" = (
+/obj/disposalpipe/trunk/regular/east,
+/obj/machinery/disposal/small/west{
+	name = "ejection chute"
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom)
 "qb" = (
 /obj/decal/fakeobjects/shuttleengine{
 	dir = 8;
@@ -543,6 +552,15 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
+"uJ" = (
+/obj/disposalpipe/trunk/regular/west,
+/obj/disposaloutlet/east{
+	pixel_x = 14
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom)
 "uY" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "delivery2"
@@ -1465,7 +1483,7 @@ ta
 eA
 CC
 fa
-Rb
+pP
 ro
 ro
 Iz
@@ -1493,7 +1511,7 @@ af
 Ya
 CC
 dW
-EF
+uJ
 EF
 DC
 EF
@@ -1521,7 +1539,7 @@ Rh
 pm
 IV
 fa
-bD
+Il
 bD
 Il
 bD

--- a/assets/maps/shuttles/east/eastbase.dmm
+++ b/assets/maps/shuttles/east/eastbase.dmm
@@ -394,8 +394,9 @@
 /area/shuttle/escape/centcom)
 "pP" = (
 /obj/disposalpipe/trunk/regular/east,
-/obj/machinery/disposal/small/west{
-	name = "ejection chute"
+/obj/machinery/disposal/brig/small/east{
+	name = "ejection chute";
+	dir = 8
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"

--- a/assets/maps/shuttles/east/eastbase.dmm
+++ b/assets/maps/shuttles/east/eastbase.dmm
@@ -396,7 +396,8 @@
 /obj/disposalpipe/trunk/regular/east,
 /obj/machinery/disposal/brig/small/east{
 	name = "ejection chute";
-	dir = 8
+	dir = 8;
+	desc = "A pneumatic delivery chute for ejecting staff assistants."
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
@@ -556,11 +557,9 @@
 "uJ" = (
 /obj/disposalpipe/trunk/regular/west,
 /obj/disposaloutlet/east{
-	pixel_x = 14
+	pixel_x = -8
 	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "uY" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -1512,7 +1511,7 @@ af
 Ya
 CC
 dW
-uJ
+EF
 EF
 DC
 EF
@@ -1540,7 +1539,7 @@ Rh
 pm
 IV
 fa
-Il
+uJ
 bD
 Il
 bD

--- a/assets/maps/shuttles/east/oshan.dmm
+++ b/assets/maps/shuttles/east/oshan.dmm
@@ -189,6 +189,12 @@
 	icon_state = "2"
 	},
 /area/shuttle/escape/centcom)
+"hJ" = (
+/obj/disposalpipe/segment/bent,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom)
 "hL" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 8;
@@ -856,6 +862,18 @@
 	icon_state = "5"
 	},
 /area/shuttle/escape/centcom)
+"Is" = (
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/disposaloutlet{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom)
 "IW" = (
 /obj/rack,
 /obj/random_item_spawner/tools/maybe_few,
@@ -922,6 +940,14 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
+"MU" = (
+/obj/disposalpipe/segment/bent{
+	dir = 1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom)
 "No" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
@@ -996,6 +1022,20 @@
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
+"QP" = (
+/obj/machinery/disposal/brig/small/east{
+	name = "ejection chute";
+	desc = "A pneumatic delivery chute for ejecting staff assistants.";
+	dir = 8
+	},
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom)
 "Rl" = (
 /turf/unsimulated/floor/shuttle{
 	dir = 8;
@@ -1414,7 +1454,7 @@ jn
 an
 uh
 yp
-uh
+QP
 an
 wm
 aS
@@ -1442,8 +1482,8 @@ Pg
 iT
 iT
 Dd
-iT
-iT
+hJ
+MU
 cn
 fc
 qW
@@ -1471,7 +1511,7 @@ Gh
 Gh
 Sp
 Gh
-Gh
+Is
 hg
 Bp
 qW

--- a/assets/maps/shuttles/north/donut3.dmm
+++ b/assets/maps/shuttles/north/donut3.dmm
@@ -292,7 +292,7 @@
 	},
 /area/shuttle/escape/centcom)
 "ik" = (
-/obj/disposalpipe/segment/regular/bent,
+/obj/disposalpipe/segment/regular,
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
 	},
@@ -752,7 +752,8 @@
 	dir = 1
 	},
 /obj/machinery/disposal/brig/small/east{
-	name = "ejection chute"
+	name = "ejection chute";
+	desc = "A pneumatic delivery chute for ejecting staff assistants."
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
@@ -777,12 +778,11 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "FI" = (
-/obj/disposalpipe/segment/regular/bent{
-	dir = 1
+/obj/disposalpipe/trunk,
+/obj/disposaloutlet/east{
+	pixel_x = -7
 	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "7"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "Gc" = (
 /obj/table/auto,
@@ -996,15 +996,6 @@
 	icon_state = "alt_heater-R"
 	},
 /turf/simulated/floor/plating/airless,
-/area/shuttle/escape/centcom)
-"PU" = (
-/obj/disposalpipe/trunk,
-/obj/disposaloutlet/east{
-	pixel_x = 14
-	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
 /area/shuttle/escape/centcom)
 "QE" = (
 /obj/indestructible/shuttle_corner{
@@ -1486,8 +1477,8 @@ mb
 mb
 mg
 mg
-PU
-FI
+lb
+pH
 lb
 lb
 ZD
@@ -1514,7 +1505,7 @@ Xp
 Xp
 uW
 mc
-Xp
+FI
 ik
 EK
 Hy

--- a/assets/maps/shuttles/north/donut3.dmm
+++ b/assets/maps/shuttles/north/donut3.dmm
@@ -291,6 +291,12 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape/centcom)
+"ik" = (
+/obj/disposalpipe/segment/regular/bent,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom)
 "is" = (
 /turf/unsimulated/floor/stairs/dark/wide{
 	dir = 5
@@ -738,13 +744,14 @@
 	},
 /area/centcom/outside)
 "EK" = (
-/obj/stool/chair/comfy/shuttle{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/small/east,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
 	},
@@ -766,6 +773,14 @@
 	dir = 8
 	},
 /turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom)
+"FI" = (
+/obj/disposalpipe/segment/regular/bent{
+	dir = 1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
 /area/shuttle/escape/centcom)
 "Gc" = (
 /obj/table/auto,
@@ -979,6 +994,15 @@
 	icon_state = "alt_heater-R"
 	},
 /turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom)
+"PU" = (
+/obj/disposalpipe/trunk,
+/obj/disposaloutlet/east{
+	pixel_x = 14
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
 /area/shuttle/escape/centcom)
 "QE" = (
 /obj/indestructible/shuttle_corner{
@@ -1460,8 +1484,8 @@ mb
 mb
 mg
 mg
-lb
-pH
+PU
+FI
 lb
 lb
 ZD
@@ -1488,8 +1512,8 @@ Xp
 Xp
 uW
 mc
-uW
-sS
+Xp
+ik
 EK
 Hy
 nh

--- a/assets/maps/shuttles/north/donut3.dmm
+++ b/assets/maps/shuttles/north/donut3.dmm
@@ -751,7 +751,9 @@
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/disposal/small/east,
+/obj/machinery/disposal/brig/small/east{
+	name = "ejection chute"
+	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
 	},

--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -140,7 +140,8 @@
 	dir = 1
 	},
 /obj/machinery/disposal/brig/small/east{
-	name = "ejection chute"
+	name = "ejection chute";
+	desc = "A pneumatic delivery chute for ejecting staff assistants."
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
@@ -681,12 +682,6 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape/centcom)
-"uy" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "7"
-	},
-/area/shuttle/escape/centcom)
 "uI" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 10;
@@ -859,12 +854,10 @@
 /area/centcom)
 "Hb" = (
 /obj/disposaloutlet/east{
-	pixel_x = 15
+	pixel_x = -8
 	},
-/obj/disposalpipe/trunk/regular/south,
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
+/obj/disposalpipe/trunk,
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "Hm" = (
 /obj/machinery/shuttle/engine/propulsion{
@@ -1270,7 +1263,7 @@
 	},
 /area/shuttle/escape/centcom)
 "WF" = (
-/obj/disposalpipe/segment/bent,
+/obj/disposalpipe/segment,
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
 	},
@@ -1483,8 +1476,8 @@ Li
 Li
 Vg
 Li
-Hb
-uy
+tt
+rR
 tt
 tt
 Rf
@@ -1511,7 +1504,7 @@ lQ
 lQ
 sU
 Ko
-sU
+Hb
 WF
 du
 MF

--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -136,8 +136,12 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/chair/comfy/shuttle/red{
+/obj/machinery/disposal/small/north{
+	name = "ejection chute";
 	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
@@ -678,6 +682,12 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape/centcom)
+"uy" = (
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom)
 "uI" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 10;
@@ -848,6 +858,15 @@
 "Gq" = (
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
+"Hb" = (
+/obj/disposaloutlet/east{
+	pixel_x = 15
+	},
+/obj/disposalpipe/trunk/regular/south,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom)
 "Hm" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
@@ -1251,6 +1270,12 @@
 	icon_state = "12"
 	},
 /area/shuttle/escape/centcom)
+"WF" = (
+/obj/disposalpipe/segment/bent,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom)
 "Xe" = (
 /obj/decal/poster/wallsign/hazard_caution,
 /turf/unsimulated/wall/auto/lead/blue,
@@ -1459,8 +1484,8 @@ Li
 Li
 Vg
 Li
-tt
-rR
+Hb
+uy
 tt
 tt
 Rf
@@ -1487,8 +1512,8 @@ lQ
 lQ
 sU
 Ko
-lQ
-Tr
+sU
+WF
 du
 MF
 bQ

--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -136,12 +136,11 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/disposal/small/north{
-	name = "ejection chute";
-	dir = 4
-	},
 /obj/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/machinery/disposal/brig/small/east{
+	name = "ejection chute"
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"

--- a/assets/maps/shuttles/south/southbase.dmm
+++ b/assets/maps/shuttles/south/southbase.dmm
@@ -768,11 +768,11 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/shuttle/escape/centcom)
 "Hv" = (
-/obj/machinery/disposal/small/north{
+/obj/disposalpipe/trunk/regular/south,
+/obj/machinery/disposal/brig/small/east{
 	name = "ejection chute";
 	dir = 8
 	},
-/obj/disposalpipe/trunk/regular/south,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
 	},

--- a/assets/maps/shuttles/south/southbase.dmm
+++ b/assets/maps/shuttles/south/southbase.dmm
@@ -344,12 +344,6 @@
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
-"pM" = (
-/obj/disposalpipe/segment/regular/bent/south,
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "11"
-	},
-/area/shuttle/escape/centcom)
 "qq" = (
 /obj/stool/chair/comfy/shuttle/brown,
 /obj/machinery/light{
@@ -509,13 +503,13 @@
 	},
 /area/shuttle/escape/centcom)
 "yu" = (
-/obj/disposalpipe/trunk/regular/north,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
 /obj/disposaloutlet/west{
-	pixel_x = -14
+	pixel_x = 8
 	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "yK" = (
 /obj/table/auto,
@@ -771,7 +765,8 @@
 /obj/disposalpipe/trunk/regular/south,
 /obj/machinery/disposal/brig/small/east{
 	name = "ejection chute";
-	dir = 8
+	dir = 8;
+	desc = "A pneumatic delivery chute for ejecting staff assistants."
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor4"
@@ -915,7 +910,7 @@
 	},
 /area/shuttle/escape/centcom)
 "Lo" = (
-/obj/disposalpipe/segment/regular/bent/north,
+/obj/disposalpipe/segment/regular/vertical,
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "12"
 	},
@@ -1789,7 +1784,7 @@ mh
 kF
 Hv
 Lo
-GM
+yu
 qq
 GM
 Nt
@@ -1816,8 +1811,8 @@ PQ
 NG
 ve
 ve
-pM
-yu
+NG
+ve
 mr
 sk
 mr

--- a/assets/maps/shuttles/south/southbase.dmm
+++ b/assets/maps/shuttles/south/southbase.dmm
@@ -344,6 +344,12 @@
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
+"pM" = (
+/obj/disposalpipe/segment/regular/bent/south,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom)
 "qq" = (
 /obj/stool/chair/comfy/shuttle/brown,
 /obj/machinery/light{
@@ -500,6 +506,15 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom)
+"yu" = (
+/obj/disposalpipe/trunk/regular/north,
+/obj/disposaloutlet/west{
+	pixel_x = -14
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
 	},
 /area/shuttle/escape/centcom)
 "yK" = (
@@ -752,6 +767,16 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/shuttle/escape/centcom)
+"Hv" = (
+/obj/machinery/disposal/small/north{
+	name = "ejection chute";
+	dir = 8
+	},
+/obj/disposalpipe/trunk/regular/south,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom)
 "HA" = (
 /obj/machinery/computer/shuttle,
 /turf/unsimulated/floor/shuttle{
@@ -887,6 +912,12 @@
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom)
+"Lo" = (
+/obj/disposalpipe/segment/regular/bent/north,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
 	},
 /area/shuttle/escape/centcom)
 "Lu" = (
@@ -1756,9 +1787,9 @@ YT
 NG
 mh
 kF
-ml
-Oc
-Nt
+Hv
+Lo
+GM
 qq
 GM
 Nt
@@ -1785,8 +1816,8 @@ PQ
 NG
 ve
 ve
-NG
-ve
+pM
+yu
 mr
 sk
 mr

--- a/assets/maps/shuttles/west/westbase.dmm
+++ b/assets/maps/shuttles/west/westbase.dmm
@@ -381,6 +381,14 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape/centcom)
+"ov" = (
+/obj/disposaloutlet{
+	dir = 8;
+	pixel_x = 8
+	},
+/obj/disposalpipe/trunk/regular/east,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom)
 "oM" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
@@ -995,7 +1003,8 @@
 /area/centcom/outside)
 "MB" = (
 /obj/machinery/disposal/brig/small/east{
-	name = "ejection chute"
+	name = "ejection chute";
+	desc = "A pneumatic delivery chute for ejecting staff assistants."
 	},
 /obj/disposalpipe/trunk/regular/west,
 /turf/unsimulated/floor/shuttle{
@@ -1009,10 +1018,7 @@
 	},
 /area/centcom)
 "Ng" = (
-/obj/disposaloutlet/west{
-	pixel_x = -14
-	},
-/obj/disposalpipe/trunk/regular/east,
+/obj/disposalpipe/segment/regular/horizontal,
 /turf/simulated/wall/auto/shuttle{
 	icon_state = "3"
 	},
@@ -1750,7 +1756,7 @@ jK
 jK
 fY
 jK
-fY
+ov
 aY
 cq
 cC

--- a/assets/maps/shuttles/west/westbase.dmm
+++ b/assets/maps/shuttles/west/westbase.dmm
@@ -993,12 +993,30 @@
 	},
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
+"MB" = (
+/obj/machinery/disposal/small/east{
+	name = "ejection chute"
+	},
+/obj/disposalpipe/trunk/regular/west,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom)
 "MI" = (
 /obj/stool/bench/blue/auto,
 /turf/unsimulated/floor/arrival{
 	dir = 4
 	},
 /area/centcom)
+"Ng" = (
+/obj/disposaloutlet/west{
+	pixel_x = -14
+	},
+/obj/disposalpipe/trunk/regular/east,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom)
 "Nm" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -1732,7 +1750,7 @@ jK
 jK
 fY
 jK
-jK
+fY
 aY
 cq
 cC
@@ -1760,7 +1778,7 @@ ez
 JX
 pj
 JX
-JX
+Ng
 IG
 SG
 ei
@@ -1788,7 +1806,7 @@ aY
 GJ
 mK
 mK
-jT
+MB
 aY
 pl
 Ab

--- a/assets/maps/shuttles/west/westbase.dmm
+++ b/assets/maps/shuttles/west/westbase.dmm
@@ -994,7 +994,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "MB" = (
-/obj/machinery/disposal/small/east{
+/obj/machinery/disposal/brig/small/east{
 	name = "ejection chute"
 	},
 /obj/disposalpipe/trunk/regular/west,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds ejection chutes that will safely kick out any staff assistants trying to squirm their way into the security room on the shuttle.
Thankfully it just goes into the main room of the shuttle, and not space.

First time trying my hand at mapping, let me know if I goofed up somehow, thanks.

![Capture](https://user-images.githubusercontent.com/87872171/235284872-bc633132-9a4c-4e91-89c2-b43142582297.PNG)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Attempting to throw out some unruly security visitors usually will only result in more flooding in through the open door. Also, this is pretty funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Jak27
(+)The security room on the shuttle now feature safer ways to boot out staff assistants.
```
