### PR TITLE
Using equip hotkey with Vega flamethrower will add it to the fuel tank on your back

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -326,6 +326,13 @@ A Flamethrower in various states of assembly
 			B.linkedflamer = null
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		..()
+
+	try_specific_equip(mob/user)
+		. = FALSE
+		if (istype(user.back, /obj/item/tank/jetpack/backtank))
+			user.back.attackby(src, user)
+			return TRUE
+
 /obj/item/gun/flamethrower/backtank/napalm
 	New()
 		..()


### PR DESCRIPTION
[PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that using the equip hotkey when holding the Vega flamethrower will add it to the fuel tank on your back if it's there.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for quick storage