### PR TITLE
Allows Cargo to order Wooden Sheets.

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -164,6 +164,26 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Glass Sheets Crate - 50 pack"
 
+/datum/supply_packs/wood10
+	name = "10 Wooden Sheets"
+	desc = "x10 Wooden Sheets"
+	category = "Basic Materials"
+	contains = list(/obj/item/sheet/wood)
+	amount = 10
+	cost = 500
+	containertype = /obj/storage/crate
+	containername = "Wooden Sheets Crate - 10 pack"
+
+/datum/supply_packs/wood50
+	name = "50 Wooden Sheets"
+	desc = "x50 Wooden Sheets"
+	category = "Basic Materials"
+	contains = list(/obj/item/sheet/wood)
+	amount = 50
+	cost = 2500
+	containertype = /obj/storage/crate
+	containername = "Wooden Sheets Crate - 10 pack"
+
 /datum/supply_packs/dryfoods
 	name = "Catering: Dry Goods Crate"
 	desc = "x25 Assorted Cooking Ingredients"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -171,7 +171,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	contains = list(/obj/item/sheet/wood)
 	amount = 10
 	cost = 500
-	containertype = /obj/storage/crate
+	containertype = /obj/storage/crate/wooden
 	containername = "Wooden Sheets Crate - 10 pack"
 
 /datum/supply_packs/wood50
@@ -181,8 +181,8 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	contains = list(/obj/item/sheet/wood)
 	amount = 50
 	cost = 2500
-	containertype = /obj/storage/crate
-	containername = "Wooden Sheets Crate - 10 pack"
+	containertype = /obj/storage/crate/wooden
+	containername = "Wooden Sheets Crate - 50 pack"
 
 /datum/supply_packs/dryfoods
 	name = "Catering: Dry Goods Crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds two new order selections to Cargo: 10x Wooden Sheets (for 500 credits) and 50x Wooden sheets (for 2500 credits).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, there are only two ways to obtain wooden sheets: begging Hydroponics to grow a tree for 10 minutes or scavenging whatever wooden sheets spawns in the station you are in. This PR aims to add a new quick source of wood for player projects.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Caio029
(*)Cargo can now order wooden sheets in two new selections: x10 Wooden Sheets (for 500 credits) and x50 Wooden Sheets (for 2500 credits).
```
