### PR TITLE
Changes gang member popup headset info

### DIFF
--- a/browserassets/html/traitorTips/gang_member_added.html
+++ b/browserassets/html/traitorTips/gang_member_added.html
@@ -16,7 +16,7 @@
 		</li>
 	</ul>
 
-	<p>2. You have a special radio channel accessible on your headset! Occassionally you'll hear an announcement over this channel about priority areas - make sure to tag them when you can.</p>
+	<p>2. Use the prefix :z to speak on your gang's radio frequency! Occassionally you'll hear an announcement over this channel about priority areas - make sure to tag them when you can.</p>
 
  	<p>3. <em>Don't attack fellow gang members and listen to your leader!</em> You can identify them by the G icon. Blue is your leader, red are your fellow henchmen.</p>
 

--- a/browserassets/html/traitorTips/gang_member_added.html
+++ b/browserassets/html/traitorTips/gang_member_added.html
@@ -16,7 +16,7 @@
 		</li>
 	</ul>
 
-	<p>2. Use :g to communicate with your gang! Occassionally you'll hear an announcement over this channel about priority areas - make sure to tag them when you can.</p>
+	<p>2. You have a special radio channel accessible on your headset! Occassionally you'll hear an announcement over this channel about priority areas - make sure to tag them when you can.</p>
 
  	<p>3. <em>Don't attack fellow gang members and listen to your leader!</em> You can identify them by the G icon. Blue is your leader, red are your fellow henchmen.</p>
 

--- a/code/modules/antagonists/gang/gang_leader.dm
+++ b/code/modules/antagonists/gang/gang_leader.dm
@@ -70,7 +70,7 @@
 
 	announce()
 		. = ..()
-		boutput(src.owner.current, "<span class='alert'>Your headset has been tuned to your gang's frequency. Prefix a message with :g to communicate on this channel.</span>")
+		boutput(src.owner.current, "<span class='alert'>Your headset has been tuned to your gang's frequency. Prefix a message with :z to communicate on this channel.</span>")
 		boutput(src.owner.current, "<span class='alert'>You must recruit people to your gang and compete for wealth and territory!</span>")
 		boutput(src.owner.current, "<span class='alert'>You can harm whoever you want, but be careful - the crew can harm gang members too!</span>")
 		boutput(src.owner.current, "<span class='alert'>To set your gang's home turf and spawn your locker, use the Set Gang Base ability in the top left. Make sure to pick somewhere safe, as your locker can be broken into and looted. You can only do this once!</span>")

--- a/code/modules/antagonists/gang/gang_member.dm
+++ b/code/modules/antagonists/gang/gang_member.dm
@@ -57,7 +57,7 @@
 	announce()
 		. = ..()
 		boutput(src.owner.current, "<span class='alert'>You are now a member of [src.gang.gang_name]!</span>")
-		boutput(src.owner.current, "<span class='alert'>Your headset has been tuned to your gang's frequency. Prefix a message with :g to communicate on this channel.</span>")
+		boutput(src.owner.current, "<span class='alert'>Your headset has been tuned to your gang's frequency. Prefix a message with :z to communicate on this channel.</span>")
 		boutput(src.owner.current, "<span class='alert'>Your boss is denoted by the blue G and your fellow gang members are denoted by the red G! Work together and do some crime!</span>")
 		boutput(src.owner.current, "<span class='alert'>You are free to harm anyone who isn't in your gang, but be careful, they can do the same to you!</span>")
 		boutput(src.owner.current, "<span class='alert'>You should only use bombs if you have a good reason to, and also run any bombings past your gang!</span>")


### PR DESCRIPTION
[Bug][gamemode]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes tip that ":g" prefix can be used by gang members to talk to their gang to ":z"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13815 

Added a changelog since lots of new folks playing gang on RP who might've otherwise thought the prefix is broken.

## Changelog
```
(u)mona
(+)The gang radio prefix is :z! Documentation updated.
```