### PR TITLE
fixes typo in withdrawals

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -691,7 +691,7 @@ This is basically useless for anyone but miners.
 	name = "Stimulants"
 	item = /obj/item/storage/box/stimulants
 	cost = 6
-	desc = "When top agents need energy, they turn to our new line of X-Cite 500 stimulants. This 3-pack of all-natural* and worry-free** blend accelerates perception, endurance, and reaction time to superhuman levels! Shrug off even the cruelest of blows without a scratch! <br><br><font size=-1>*Contains less than 0.5 grams unnatural material per 0.49 gram serving.<br>**May cause dizziness, blurred vision, heart failure, renal compaction, adenoid calcification, or death. Users are recommended to take only a single dose at a time, and let withdrawl symptoms play out naturally.</font>"
+	desc = "When top agents need energy, they turn to our new line of X-Cite 500 stimulants. This 3-pack of all-natural* and worry-free** blend accelerates perception, endurance, and reaction time to superhuman levels! Shrug off even the cruelest of blows without a scratch! <br><br><font size=-1>*Contains less than 0.5 grams unnatural material per 0.49 gram serving.<br>**May cause dizziness, blurred vision, heart failure, renal compaction, adenoid calcification, or death. Users are recommended to take only a single dose at a time, and let withdrawal symptoms play out naturally.</font>"
 	job = list("Medical Doctor","Medical Director","Scientist","Geneticist","Pathologist","Research Director")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -683,7 +683,7 @@
 
 	simpledot/stimulant_withdrawl
 		id = "stimulant_withdrawl"
-		name = "Stimulant withdrawl"
+		name = "Stimulant withdrawal"
 		icon_state = "janktank-w"
 		desc = "You feel AWFUL!"
 		tickSpacing = 3 SECONDS
@@ -1346,8 +1346,8 @@
 
 	gang_drug_withdrawl
 		id = "janktank_withdrawl"
-		name = "janktank withdrawl"
-		desc = "You're going through withrawl of Janktank"
+		name = "Janktank withdrawal"
+		desc = "You're going through withdrawal of Janktank"
 		icon_state = "janktank-w"
 		duration = 9 MINUTES
 		maxDuration = 18 MINUTES

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1897,7 +1897,7 @@ TYPEINFO(/obj/item/implantpad)
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> Tracking Beacon<BR>
 <b>Zone:</b> Spinal Column> 2-5 vertebrae<BR>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<BR>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<BR>
 <b>Life:</b> 10 minutes after death of host<BR>
 <b>Important Notes:</b> None<BR>
 <HR>
@@ -1944,7 +1944,7 @@ No Implant Specifics"}
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> T.U.R.D.S. Weapon Auth Implant<BR>
 <b>Zone:</b> Spinal Column> 2-5 vertebrae<BR>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<BR>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<BR>
 <b>Life:</b> 10 minutes after death of host<BR>
 <b>Important Notes:</b> Allows access to weapons equip with M.W.L. (Martian Weapon Lock) devices<BR>
 <HR>
@@ -1964,35 +1964,35 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> Counter-Revolutionary Implant<BR>
 <b>Zone:</b> Spinal Column> 5-7 vertebrae<BR>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<BR>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<BR>
 <b>Important Notes:</b> Will make the crewmember loyal to the command staff and prevent thoughts of rebelling.<BR>"}
 			else if (istype(src.case.imp, /obj/item/implant/revenge/microbomb))
 				dat += {"
 <b>Implant Specifications:</b><br>
 <b>Name:</b> Microbomb Implant<br>
 <b>Zone:</b> Base of Skull<br>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<br>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<br>
 <b>Important Notes: <font color='red'>Illegal</font></b><BR><HR>"}
 			else if (istype(src.case.imp, /obj/item/implant/robotalk))
 				dat += {"
 <b>Implant Specifications:</b><br>
 <b>Name:</b> Machine Language Translator<br>
 <b>Zone:</b> Cerebral Cortex<br>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<br>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<br>
 <b>Important Notes:</b> Enables the host to transmit, receive and understand digital transmissions used by most mechanoids.<BR>"}
 			else if (istype(src.case.imp, /obj/item/implant/bloodmonitor))
 				dat += {"
 <b>Implant Specifications:</b><br>
 <b>Name:</b> Blood Monitor<br>
 <b>Zone:</b> Jugular Vein<br>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<br>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<br>
 <b>Important Notes:</b> Warns the host of any detected infections or foreign substances in the bloodstream.<BR>"}
 			else if (istype(src.case.imp, /obj/item/implant/mindhack))
 				dat += {"
 <b>Implant Specifications:</b><br>
 <b>Name:</b> Mind Hack<br>
 <b>Zone:</b> Brain Stem<br>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<br>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<br>
 <b>Important Notes:</b> Injects an electrical signal directly into the brain that compels obedience in human subjects for a short time. Most minds fight off the effects after approx. 25 minutes.<BR>"}
 			else if (istype(src.case.imp, /obj/item/implant/emote_triggered/signaler))
 				var/obj/item/implant/emote_triggered/signaler/implant = src.case.imp
@@ -2000,7 +2000,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 <b>Implant Specifications:</b><br>
 <b>Name:</b> Remote Signaler<br>
 <b>Zone:</b> Left hand near wrist<br>
-<b>Power Source:</b> Nervous System Ion Withdrawl Gradient<br>
+<b>Power Source:</b> Nervous System Ion Withdrawal Gradient<br>
 <HR>
 <b>Implant Details:</b> <BR>
 <b>Function:</b> Transmits a radio signal on a configurable frequency.


### PR DESCRIPTION
[Bug][status effects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

changes spelling of withdrawal in the status effects.dm

withdrawl/withrawl-->withdrawal

im not a prescriptivist, but...

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13669 
