### PR TITLE
Actually makes sylvester not dense

### DIFF
--- a/code/obj/critter/turtle.dm
+++ b/code/obj/critter/turtle.dm
@@ -17,6 +17,7 @@
 	atk_text = "headbutts"
 	chase_text = "charges into"
 	crit_text = "rams really hard into"
+	density = 0
 	var/shell_count = 0		//Count down to 0. Measured in process cycles. If they are in their shell when this is 0, exit.
 	var/wandering_count = 0		//Make them move less frequently when wandering... They're slow.
 	var/rigged = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Turns out density is set to 1 for critters by default, whoops

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fix

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Not needed