### PR TITLE
exploration tools random room

### DIFF
--- a/assets/maps/random_rooms/3x5/exploration_tools_50.dmm
+++ b/assets/maps/random_rooms/3x5/exploration_tools_50.dmm
@@ -1,0 +1,88 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/airless/caution/corner/sw,
+/area/dmm_suite/clear_area)
+"c" = (
+/turf/simulated/floor/airless/caution/east,
+/area/dmm_suite/clear_area)
+"q" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/airless/caution/corner/ne,
+/area/dmm_suite/clear_area)
+"u" = (
+/obj/item/furniture_parts/rack,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/shoes/magnetic,
+/obj/item/tank/emergency_oxygen,
+/obj/item/clothing/gloves/yellow,
+/turf/simulated/floor/airless/caution,
+/area/dmm_suite/clear_area)
+"v" = (
+/turf/simulated/floor/airless/caution/south,
+/area/dmm_suite/clear_area)
+"w" = (
+/obj/item/furniture_parts/rack,
+/obj/item/crowbar,
+/obj/item/wrench{
+	pixel_x = 5
+	},
+/obj/item/wirecutters{
+	pixel_x = -5
+	},
+/obj/item/device/multitool,
+/obj/item/screwdriver{
+	pixel_x = 10
+	},
+/obj/item/weldingtool,
+/turf/simulated/floor/airless/caution,
+/area/dmm_suite/clear_area)
+"x" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/airless/caution/corner/nw,
+/area/dmm_suite/clear_area)
+"C" = (
+/turf/simulated/floor/airless/caution/north,
+/area/dmm_suite/clear_area)
+"Q" = (
+/obj/item/furniture_parts/rack,
+/obj/item/storage/belt/utility,
+/obj/item/device/light/flashlight,
+/obj/item/extinguisher,
+/obj/item/kitchen/utensil/knife,
+/obj/item/ammo/power_cell/higher_power,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
+/turf/simulated/floor/airless/caution,
+/area/dmm_suite/clear_area)
+"T" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/airless/caution/corner/se,
+/area/dmm_suite/clear_area)
+"X" = (
+/turf/simulated/floor/airless/caution/west,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+x
+X
+X
+X
+a
+"}
+(2,1,1) = {"
+C
+w
+Q
+u
+v
+"}
+(3,1,1) = {"
+q
+c
+c
+c
+T
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a random room which contains all the tools needed for exploration/adventuring. Contains a full toolset, a space suit/helmet, insulated gloves and magnetic boots, brute/fire/toxin medkits, a toolbelt, a flashlight and a fire extinguisher. The spawn weight is 50.
<img width="126" alt="Schermafbeelding 2023-05-01 180659" src="https://user-images.githubusercontent.com/120601289/235493274-7f9719aa-22e7-45e3-954e-68b3d29dcf5e.png">


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adds more variation to random rooms, which encourages more players to look for random rooms.