### PR TITLE
skeleton head speech related QOL / bugfixes

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1124,9 +1124,15 @@
 
 		if(chat_text)
 			chat_text.measure(src.client)
-			for(var/image/chat_maptext/I in src.chat_text.lines)
-				if(I != chat_text)
-					I.bump_up(chat_text.measured_height)
+			var/obj/chat_maptext_holder/holder = src.chat_text
+			if (is_decapitated_skeleton) // for skeleton heads
+				var/mob/living/carbon/human/H = src
+				var/datum/mutantrace/skeleton/S = H.mutantrace
+				holder = S.head_tracker?.chat_text
+			if (holder)
+				for(var/image/chat_maptext/I in holder.lines)
+					if(I != chat_text)
+						I.bump_up(chat_text.measured_height)
 
 	var/rendered = null
 	if (length(heard_a))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1063,7 +1063,8 @@
 				for(var/mob/M in olocs[olocs.len])
 					listening |= M
 				for(var/obj/item/organ/head/H in say_location.loc)
-					listening |= H.linked_human
+					if (H.linked_human)
+						listening |= H.linked_human
 
 				listening |= olocs[olocs.len]
 			else

--- a/code/modules/speech/floating_chat.dm
+++ b/code/modules/speech/floating_chat.dm
@@ -75,16 +75,30 @@ proc/make_chat_maptext(atom/target, msg, style = "", alpha = 255, force = 0, tim
 	else
 		// force whatever it is to be shown. for not chat tings. honk.
 		text.maptext = msg
-	if(istype(target, /atom/movable) && target.chat_text)
+
+	var/obj/chat_maptext_holder/holder = target.chat_text
+
+	if (istype(target,/obj/item/organ/head)) // skeleton speech scrolling bandaid fix
+		var/obj/item/organ/head/head = target
+		holder = head.linked_human.chat_text
+		text.loc = head
+		text.layer = head.layer+1 // dont layer under the hud k thanks bye
+
+	else if(istype(target, /atom/movable))
 		var/atom/movable/L = target
-		text.loc = L.chat_text
-		if(length(L.chat_text.lines) && L.chat_text.lines[length(L.chat_text.lines)].maptext == text.maptext)
-			L.chat_text.lines[length(L.chat_text.lines)].transform *= 1.05
-			qdel(text)
-			return null
-		L.chat_text.lines.Add(text)
-	else // hmm?
+		holder = L.chat_text
+		text.loc = holder
+
+	else
 		text.loc = target
+
+	if(length(holder.lines) && holder.lines[length(holder.lines)].maptext == text.maptext)
+		holder.lines[length(holder.lines)].transform *= 1.05
+		qdel(text)
+		return null
+
+	holder.lines.Add(text)
+
 	animate(text, alpha = alpha, maptext_y = 34, time = 4, flags = ANIMATION_END_NOW)
 	var/text_id = text.unique_id
 	SPAWN(time)

--- a/code/modules/speech/floating_chat.dm
+++ b/code/modules/speech/floating_chat.dm
@@ -35,11 +35,6 @@
 		if(istype(src.loc, /obj/chat_maptext_holder))
 			var/obj/chat_maptext_holder/holder = src.loc
 			holder.lines -= src
-		if(istype(src.loc, /obj/item/organ/head))
-			var/obj/item/organ/head/head =  src.loc
-			var/obj/chat_maptext_holder/holder = head.linked_human?.chat_text
-			if(holder)
-				holder.lines -= src
 		for(var/client/C in src.visible_to)
 			C.images -= src
 		src.loc = null
@@ -83,17 +78,12 @@ proc/make_chat_maptext(atom/target, msg, style = "", alpha = 255, force = 0, tim
 
 	var/obj/chat_maptext_holder/holder = target.chat_text
 
-	if (istype(target,/obj/item/organ/head)) // skeleton speech scrolling bandaid fix
-		var/obj/item/organ/head/head = target
-		holder = head.linked_human?.chat_text
-		text.loc = head
-		text.layer = head.layer+1 // dont layer under the hud k thanks bye
-
-	else if(istype(target, /atom/movable) && holder)
+	if(istype(target, /atom/movable) && holder)
 		var/atom/movable/L = target
 		holder = L.chat_text
 		text.loc = holder
-
+		if (target.layer > HUD_LAYER)
+			text.layer = target.layer+1
 	else
 		text.loc = target
 

--- a/code/modules/speech/floating_chat.dm
+++ b/code/modules/speech/floating_chat.dm
@@ -35,6 +35,11 @@
 		if(istype(src.loc, /obj/chat_maptext_holder))
 			var/obj/chat_maptext_holder/holder = src.loc
 			holder.lines -= src
+		if(istype(src.loc, /obj/item/organ/head))
+			var/obj/item/organ/head/head =  src.loc
+			var/obj/chat_maptext_holder/holder = head.linked_human?.chat_text
+			if(holder)
+				holder.lines -= src
 		for(var/client/C in src.visible_to)
 			C.images -= src
 		src.loc = null
@@ -80,11 +85,11 @@ proc/make_chat_maptext(atom/target, msg, style = "", alpha = 255, force = 0, tim
 
 	if (istype(target,/obj/item/organ/head)) // skeleton speech scrolling bandaid fix
 		var/obj/item/organ/head/head = target
-		holder = head.linked_human.chat_text
+		holder = head.linked_human?.chat_text
 		text.loc = head
 		text.layer = head.layer+1 // dont layer under the hud k thanks bye
 
-	else if(istype(target, /atom/movable))
+	else if(istype(target, /atom/movable) && holder)
 		var/atom/movable/L = target
 		holder = L.chat_text
 		text.loc = holder
@@ -92,12 +97,13 @@ proc/make_chat_maptext(atom/target, msg, style = "", alpha = 255, force = 0, tim
 	else
 		text.loc = target
 
-	if(length(holder.lines) && holder.lines[length(holder.lines)].maptext == text.maptext)
-		holder.lines[length(holder.lines)].transform *= 1.05
-		qdel(text)
-		return null
+	if (holder)
+		if(length(holder.lines) && holder.lines[length(holder.lines)].maptext == text.maptext)
+			holder.lines[length(holder.lines)].transform *= 1.05
+			qdel(text)
+			return null
 
-	holder.lines.Add(text)
+		holder.lines.Add(text)
 
 	animate(text, alpha = alpha, maptext_y = 34, time = 4, flags = ANIMATION_END_NOW)
 	var/text_id = text.unique_id

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -728,6 +728,9 @@ MATERIAL
 			head.pixel_x = rand(-8,8)
 			head.pixel_y = rand(-8,8)
 			heads -= head
+			if (head in src.vis_contents)
+				vis_contents -= head
+				head.anchored = FALSE
 
 			if(!length(heads))
 				head_offset = 0
@@ -772,10 +775,11 @@ MATERIAL
 		return
 
 	proc/update()
-		src.overlays = null
 
 		if((length(heads) < 3 && head_offset > 0) || length(heads) == 0)
-			src.overlays += image('icons/obj/metal.dmi',"head_spike_blood")
+			src.UpdateOverlays(image('icons/obj/metal.dmi',"head_spike_blood"),"blood")
+		else
+			src.UpdateOverlays(null,"blood")
 
 		switch(length(heads)) //fuck it
 			if(0)
@@ -807,16 +811,22 @@ MATERIAL
 		if(length(heads) > 0)
 			var/pixely = 8 - 8*head_offset - 8*length(heads)
 			for(var/obj/item/organ/head/H in heads)
+				if (H in vis_contents) continue
 				H.pixel_x = 0
 				H.pixel_y = pixely
 				pixely += 8
 				H.set_dir(SOUTH)
-				src.overlays += H
+				src.vis_contents += H
+				H.anchored = ANCHORED
 
-			src.overlays += image('icons/obj/metal.dmi',"head_spike_flies")
+			src.UpdateOverlays(image('icons/obj/metal.dmi',"head_spike_flies"),"flies")
+		else
+			src.UpdateOverlays(null,"flies")
 
 		if(anchored)
-			src.overlays += image('icons/obj/metal.dmi',"head_spike_weld")
+			src.UpdateOverlays(image('icons/obj/metal.dmi',"head_spike_weld"),"weld")
+		else
+			src.UpdateOverlays(null,"weld")
 
 
 	proc/has_space()

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -730,7 +730,7 @@ MATERIAL
 			heads -= head
 			if (head in src.vis_contents)
 				vis_contents -= head
-				head.anchored = FALSE
+				head.vis_flags &= ~VIS_INHERIT_ID
 
 			if(!length(heads))
 				head_offset = 0
@@ -817,7 +817,7 @@ MATERIAL
 				pixely += 8
 				H.set_dir(SOUTH)
 				src.vis_contents += H
-				H.anchored = ANCHORED
+				H.vis_flags |= VIS_INHERIT_ID
 
 			src.UpdateOverlays(image('icons/obj/metal.dmi',"head_spike_flies"),"flies")
 		else

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -55,6 +55,8 @@
 	var/obj/item/clothing/mask/wear_mask = null
 	var/obj/item/clothing/glasses/glasses = null
 
+	appearance_flags = KEEP_TOGETHER
+
 	New()
 		..()
 		SPAWN(0)
@@ -73,6 +75,9 @@
 					src.donor.set_eye(null)
 			else
 				src.UpdateIcon(/*makeshitup*/ 1)
+			if (!src.chat_text)
+				src.chat_text = new
+			src.vis_contents += src.chat_text
 
 	disposing()
 		if (src.linked_human)
@@ -97,6 +102,7 @@
 		wear_mask = null
 		glasses = null
 		linked_human = null
+		chat_text = null
 
 		..()
 

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -480,7 +480,6 @@
 			return ..()
 
 	attach_organ(var/mob/living/carbon/M as mob, var/mob/user as mob)
-		if (src.anchored) return // prevent bugs with heads on spikes vis_contents
 		/* Overrides parent function to handle special case for attaching heads. */
 		if (src.linked_human)
 			src.UnregisterSignal(src.linked_human, COMSIG_CREATE_TYPING)

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -480,6 +480,7 @@
 			return ..()
 
 	attach_organ(var/mob/living/carbon/M as mob, var/mob/user as mob)
+		if (src.anchored) return // prevent bugs with heads on spikes vis_contents
 		/* Overrides parent function to handle special case for attaching heads. */
 		if (src.linked_human)
 			src.UnregisterSignal(src.linked_human, COMSIG_CREATE_TYPING)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -1094,8 +1094,18 @@
 	var/rendered = "<span class='game say'>[my_name] <span class='message'>[message_a]</span></span>"
 
 	var/rendered_outside = null
-	if (olocs.len)
-		var/atom/movable/OL = olocs[olocs.len]
+	if (length(olocs))
+		var/atom/movable/OL = olocs[length(olocs)]
+
+		var/obj/head_on_spike/H = locate() in olocs
+		if (H)
+			OL = H
+			thickness = -1 // override because we're the head on the spike
+		else if (ismob(OL) && length(olocs) > 1)
+			var/atom/I = olocs[length(olocs)-1]
+			if (istype(I,/obj))
+				OL = I
+
 		if (thickness < 0)
 			rendered_outside = rendered
 		else if (thickness == 0)
@@ -1111,7 +1121,7 @@
 		processed += M
 		var/thisR = rendered
 
-		if (olocs.len && !(M.loc in olocs))
+		if (olocs.len && !(M.loc in olocs) && (M != src))
 			if (rendered_outside)
 				thisR = rendered_outside
 			else

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -1095,25 +1095,26 @@
 
 	var/rendered_outside = null
 	if (length(olocs))
-		var/atom/movable/OL = olocs[length(olocs)]
+		/// outermost atom before it hits turf
+		var/atom/movable/AM = olocs[length(olocs)]
 
-		var/obj/head_on_spike/H = locate() in olocs
-		if (H)
-			OL = H
+		var/obj/head_on_spike/O = locate() in olocs
+		if (O)
+			AM = O
 			thickness = -1 // override because we're the head on the spike
-		else if (ismob(OL) && length(olocs) > 1)
-			var/atom/I = olocs[length(olocs)-1]
-			if (istype(I,/obj))
-				OL = I
+		else if (ismob(AM) && length(olocs) > 1)
+			var/atom/A = olocs[length(olocs)-1]
+			if (istype(A,/obj))
+				AM = A
 
 		if (thickness < 0)
 			rendered_outside = rendered
 		else if (thickness == 0)
-			rendered_outside = "<span class='game say'>[my_name] (on [bicon(OL)] [OL]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>[my_name] (on [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
 		else if (thickness < 10)
-			rendered_outside = "<span class='game say'>[my_name] (inside [bicon(OL)] [OL]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>[my_name] (inside [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
 		else if (thickness < 20)
-			rendered_outside = "<span class='game say'>muffled <span class='name' data-ctx='\ref[src.mind]'>[src.voice_name]</span> (inside [bicon(OL)] [OL]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>muffled <span class='name' data-ctx='\ref[src.mind]'>[src.voice_name]</span> (inside [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
 
 	for (var/mob/M in heard)
 		if (M in processed)
@@ -1121,7 +1122,7 @@
 		processed += M
 		var/thisR = rendered
 
-		if (olocs.len && !(M.loc in olocs) && (M != src))
+		if (olocs.len && !(M.loc in olocs))
 			if (rendered_outside)
 				thisR = rendered_outside
 			else

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -1095,26 +1095,28 @@
 
 	var/rendered_outside = null
 	if (length(olocs))
-		/// outermost atom before it hits turf
-		var/atom/movable/AM = olocs[length(olocs)]
+		/// outermost movable atom in the chain our mob is in, used to determine how text will look
+		var/atom/movable/outermost = olocs[length(olocs)]
 
-		var/obj/head_on_spike/O = locate() in olocs
-		if (O)
-			AM = O
-			thickness = -1 // override because we're the head on the spike
-		else if (ismob(AM) && length(olocs) > 1)
-			var/atom/A = olocs[length(olocs)-1]
-			if (istype(A,/obj))
-				AM = A
+		/// determines if we're located on a spike for special handling
+		var/obj/head_on_spike/spike = locate() in olocs
+		if (spike)
+			outermost = spike
+			thickness = -1 // dont muffle at all for heads on spikes
+		else
+			/// determine if we're atleast in an item held by a mob, such as a backpack
+			for (var/obj/item/I in olocs)
+				if (ismob(I.loc))
+					outermost = I // set it so it appears as what we're in when talking
 
 		if (thickness < 0)
 			rendered_outside = rendered
 		else if (thickness == 0)
-			rendered_outside = "<span class='game say'>[my_name] (on [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>[my_name] (on [bicon(outermost)] [outermost]) <span class='message'>[message_a]</span></span>"
 		else if (thickness < 10)
-			rendered_outside = "<span class='game say'>[my_name] (inside [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>[my_name] (inside [bicon(outermost)] [outermost]) <span class='message'>[message_a]</span></span>"
 		else if (thickness < 20)
-			rendered_outside = "<span class='game say'>muffled <span class='name' data-ctx='\ref[src.mind]'>[src.voice_name]</span> (inside [bicon(AM)] [AM]) <span class='message'>[message_a]</span></span>"
+			rendered_outside = "<span class='game say'>muffled <span class='name' data-ctx='\ref[src.mind]'>[src.voice_name]</span> (inside [bicon(outermost)] [outermost]) <span class='message'>[message_a]</span></span>"
 
 	for (var/mob/M in heard)
 		if (M in processed)

--- a/code/procs/mobprocs/typing_indicator.dm
+++ b/code/procs/mobprocs/typing_indicator.dm
@@ -110,7 +110,6 @@ The say/whisper/me wrappers and cancel_typing remove the typing indicator.
 // -- Human Typing Indicators -- //
 /mob/living/create_typing_indicator()
 	if(!src.has_typing_indicator && isalive(src) && !src.bioHolder?.HasEffect("mute")) //Prevents sticky overlays and typing while in any state besides conscious
-		src.UpdateOverlays(living_typing_bubble, TYPING_OVERLAY_KEY)
 		src.has_typing_indicator = TRUE
 		if(SEND_SIGNAL(src, COMSIG_CREATE_TYPING))
 			return
@@ -125,7 +124,6 @@ The say/whisper/me wrappers and cancel_typing remove the typing indicator.
 
 /mob/living/create_emote_typing_indicator()
 	if(!src.has_typing_indicator && isalive(src))
-		src.UpdateOverlays(living_emote_typing_bubble, TYPING_OVERLAY_KEY)
 		src.has_typing_indicator = TRUE
 		if(SEND_SIGNAL(src, COMSIG_CREATE_TYPING))
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes up some hearing / speech / skeleton mutantrace code a bit
![image](https://user-images.githubusercontent.com/64938519/235553511-43d0f789-fcf3-4ff4-a552-eba90cbd3ada.png)
![image](https://user-images.githubusercontent.com/64938519/235553513-e9dec81a-719d-47e8-b0b4-d758ec088f35.png)

- speaking inside a backpack or other equipped items as a skull lets the person hear you and it shows in chat as a human inside the backpack instead of inside the mob

- If you talk inside someone's backpack as a skull they can now hear you and see your maptext properly

- Heads on spikes now use vis_contents/updateoverlays and display maptext properly as a result, fixes #13929 

- typing overlays for skeletons are nolonger added before the check to see where it should be added

did some basic testing with observers, a possessed clown while i forced the skeleton to speak, etc.
it works, but i still probably made dumb mistakes somewhere



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
improves quality of life for skeleton mutantrace users

bugs bad


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(*)Severed skeleton heads can now speak inside backpacks and while on spikes
```
