### PR TITLE
Gives the RD and MDir labcoats a little more chemprot

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -581,6 +581,10 @@
 	item_state = "MDlonglabcoat"
 	coat_style = "MDlonglabcoat"
 
+	setupProperties()
+		. = ..()
+		setProperty("chemprot", 30)
+
 	april_fools
 		icon_state = "MDlonglabcoat-alt"
 		item_state = "MDlonglabcoat-alt"
@@ -592,6 +596,10 @@
 	icon_state = "RDlabcoat"
 	item_state = "RDlabcoat"
 	coat_style = "RDlabcoat"
+
+	setupProperties()
+		. = ..()
+		setProperty("chemprot", 30)
 
 	get_desc(var/dist, var/mob/user)
 		if (user.mind?.assigned_role == "Research Director")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the chemprot for the MDir and RD labcoats by 5%. This would make these items slightly more unique statistically and more desired over other labcoats.  


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They visually are longer, therefore should be more protective from chems. It makes sense.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DimWhat
(+)Made the MDir and RD labcoats slightly more chemical resistant
```
