### PR TITLE
Fix a typo and a tiny logic error on the reactor computers

### DIFF
--- a/code/obj/nuclearreactor/reactorcontrol.dm
+++ b/code/obj/nuclearreactor/reactorcontrol.dm
@@ -48,13 +48,13 @@
 		if (status & (NOPOWER|BROKEN))
 			return
 
-		if(turbine_handle.overspeed & src.icon_state != "engine1")
+		if(turbine_handle.overspeed && src.icon_state != "engine1")
 			src.icon_state = "engine1"
 			src.UpdateIcon()
-		else if(turbine_handle.stalling & src.icon_state != "engine2")
+		else if(turbine_handle.stalling && src.icon_state != "engine2")
 			src.icon_state = "engine2"
 			src.UpdateIcon()
-		else if(!turbine_handle.overspeed & !turbine_handle.stalling & src.icon_state != "engine")
+		else if(!turbine_handle.overspeed && !turbine_handle.stalling && src.icon_state != "engine")
 			src.icon_state = "engine"
 			src.UpdateIcon()
 

--- a/code/obj/nuclearreactor/reactorcontrol.dm
+++ b/code/obj/nuclearreactor/reactorcontrol.dm
@@ -54,7 +54,7 @@
 		else if(turbine_handle.stalling & src.icon_state != "engine2")
 			src.icon_state = "engine2"
 			src.UpdateIcon()
-		else if(src.icon_state != "engine")
+		else if(!turbine_handle.overspeed & !turbine_handle.stalling & src.icon_state != "engine")
 			src.icon_state = "engine"
 			src.UpdateIcon()
 
@@ -105,7 +105,7 @@
 
 /obj/machinery/power/nuclear/reactor_control
 	name = "Reactor Control Computer"
-	desc = "A computer for configuring and monitoring the a nuclear reactor."
+	desc = "A computer for configuring and monitoring a nuclear reactor."
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "reactor_stats"
 	density = TRUE

--- a/strings/books/nuclear_engineering.txt
+++ b/strings/books/nuclear_engineering.txt
@@ -26,7 +26,7 @@
 <p>Thermal conductivity is critical for moving heat from the reactor components into the coolant gas, and should be maximised where possible.</p>
 
 <h2>Spent Fuel Reclamation</h2>
-<p>When fuel rods degrade to unnaceptable levels of radioactivity in the reactor, they will be filled with Plutonium. Place a spent fuel rod into the provided centrifuges will extract that Plutonium for refinement into more powerful fuel rods.</p>
+<p>When fuel rods degrade to unnaceptable levels of radioactivity in the reactor, they will be filled with Plutonium. Place a spent fuel rod into the provided centrifuges to extract that Plutonium for refinement into more powerful fuel rods.</p>
 </body>
 </HTML>
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Typo: "the a" -> "a"
Logic fix: icon state should only change to default state when nothing is wrong. 


