### PR TITLE
Makes pocket O2 tanks not fit on your back.

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -454,6 +454,7 @@ TYPEINFO(/obj/item/tank/jetpack/micro)
 	name = "pocket oxygen tank"
 	icon_state = "pocket_oxtank"
 	flags = FPRINT | TABLEPASS | CONDUCT
+	c_flags = null
 	health = 5
 	w_class = W_CLASS_TINY
 	force = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[minor] [game-objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the ONBACK flag from the pocket O2 tank that it inherited which  I don't think it was intended to do that. This should make handling these things just a touch less annoying!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I press v to put it away and it decides it should replace my backpack >:(