### PR TITLE
prevents cyborgs from deconstructng the robotics control console

### DIFF
--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -4,11 +4,12 @@
 	icon_state = "robotics"
 	req_access = list(access_robotics)
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
+	deconstruct_flags = DECON_NOBORG
 	desc = "A computer that allows an authorized user to have an overview of the cyborgs on the station."
 	power_usage = 500
 	circuit_type = /obj/item/circuitboard/robotics
 	id = 0
-	var/perma = 0
+	var/perma = 1
 
 	light_r =0.85
 	light_g = 0.86


### PR DESCRIPTION
[game objects][balance][controversial]

## About the PR 
this prevents silicons from deconstructing the robotics control console by using the `NO_BORG` deconstruction flag. however, to achieve no-borg interaction, it is also now not possible to deconstruct the console with tools (`perma` value set to `1`). what this means is if someone wanted to remove the robotics control console, they must have a.) a deconstruction tool, and b.) sufficient access to use the console.

i'm not super happy with my implementation, but if anyone has any ideas of how to build a check for the interaction with the screwing tool to discount specifically any use of a silicon omnitool, i'd be happy to hear. 


## Why's this needed? 
idea from: https://forum.ss13.co/showthread.php?tid=21138
can help with unkillable silicons powergaming their rogue-ness.


## Changelog 
```changelog
(u)mona
(+)To remove the robotics control console, you now need a deconstruction tool and sufficient access permissions
(+)Silicons can no longer remove the robotics control console with their tools
```
