### PR TITLE
transfer typing indicator when skeletons get decapitated

### DIFF
--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -321,6 +321,12 @@
 	on_removal()
 		src.transplanted = 1
 		if (src.linked_human)
+		 	// if we're typing, attempt to seamlessly transfer it
+			if (src.linked_human.has_typing_indicator && isskeleton(src.linked_human))
+				src.linked_human.remove_typing_indicator()
+				src.linked_human.has_typing_indicator = TRUE // proc above removes it
+				src.create_typing_indicator()
+
 			src.RegisterSignal(src.linked_human, COMSIG_CREATE_TYPING, .proc/create_typing_indicator)
 			src.RegisterSignal(src.linked_human, COMSIG_REMOVE_TYPING, .proc/remove_typing_indicator)
 			src.RegisterSignal(src.linked_human, COMSIG_SPEECH_BUBBLE, .proc/speech_bubble)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes bug where skeletons decapitated mid typing would never clear their typing indicator
fixes #13979

this makes it so the typing indicator will transfer to their decapitated head when it drops to the floor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad


