### PR TITLE
Fixes A Parallax Runtime

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1504,7 +1504,6 @@
 	var/mob/new_player/M = new()
 
 	M.key = usr.client.key
-	M.Login()
 	return
 
 /mob/verb/show_preferences()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -5257,7 +5257,6 @@ var/global/noir = 0
 	var/mob/new_player/M = new()
 
 	M.key = usr.client.key
-	M.Login()
 
 	usr.remove()
 


### PR DESCRIPTION
[Internal] [Runtime]


## About the PR:
Fixes a runtime resulting from `/client/proc/respawn_self()` calling `Login()` twice on a mob, resulting in the parallax signals attempting to be registered twice.