### PR TITLE
Makes the mop clean tracked blood again

### DIFF
--- a/code/modules/fluids/fluid_procs.dm
+++ b/code/modules/fluids/fluid_procs.dm
@@ -131,11 +131,11 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 		if (istype(T) && T.messy > 0)
 			var/found_cleanable = 0
 			for (var/obj/decal/cleanable/C in T)
-				if (istype(T) && !T.cleanable_fluid_react(C, 1)) // Some cleanables need special treatment
+				if (istype(T) && !T.cleanable_fluid_react(C, TRUE)) // Some cleanables need special treatment
 					found_cleanable = 1 //there exists a cleanable without a special case
 					break
 			if (found_cleanable)
-				T.cleanable_fluid_react(0,1)
+				T.cleanable_fluid_react(null,TRUE)
 
 	F.trigger_fluid_enter()
 
@@ -200,11 +200,11 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 		if (istype(T) && T.messy > 0)
 			var/found_cleanable = 0
 			for (var/obj/decal/cleanable/C in T)
-				if (istype(T) && !T.cleanable_fluid_react(C, 1))
+				if (istype(T) && !T.cleanable_fluid_react(C, TRUE))
 					found_cleanable = 1
 					break
 			if (found_cleanable)
-				T.cleanable_fluid_react(0,1)
+				T.cleanable_fluid_react(null,TRUE)
 
 	F.trigger_fluid_enter()
 
@@ -215,14 +215,14 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 	if (src.messy <= 0) return //hey this is CLEAN so don't even bother looping through contents, thanks!!
 	var/found_cleanable = 0
 	for (var/obj/decal/cleanable/C in src)
-		if (!src.cleanable_fluid_react(C, 1)) // Some cleanables need special treatment
+		if (!src.cleanable_fluid_react(C, TRUE)) // Some cleanables need special treatment
 			found_cleanable = 1 //there exists a cleanable without a special case
 	if (found_cleanable)
-		src.cleanable_fluid_react(0,1)
+		src.cleanable_fluid_react(null,TRUE)
 
 //called whenever a cleanable is spawned. Returns 1 on success
 //grab_any_amount will be True when a fluid spreads onto a tile that may have cleanables on it
-/turf/simulated/proc/cleanable_fluid_react(var/obj/decal/cleanable/possible_cleanable = 0, var/grab_any_amount = 0)
+/turf/simulated/proc/cleanable_fluid_react(var/obj/decal/cleanable/possible_cleanable, var/grab_any_amount = FALSE)
 	if (!IS_VALID_FLUIDREACT_TURF(src)) return
 	//if possible_cleanable has a value, handle exclusively this decal. don't search thru the turf.
 	if (possible_cleanable)
@@ -232,7 +232,7 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 			var/blood_dna = blood.blood_DNA
 			var/blood_type = blood.blood_type
 			var/is_tracks = istype(possible_cleanable,/obj/decal/cleanable/blood/dynamic/tracks)
-			if(is_tracks)
+			if(is_tracks && !grab_any_amount)
 				return 0
 			if (blood.reagents && blood.reagents.total_volume >= 13 || src.active_liquid || grab_any_amount)
 				if (blood.reagents)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CODE QUALITY][BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes all usages of `cleanable_fluid_react()` to use nulls and TRUE/FALSE

This PR makes bloody footprints get cleaned up when a fluid passes over them. They will still remain if another blood decal gets place on their tile. This allows mops to clean them once more.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

e1fee89 changed blood tracks to not get absorbed when somebody bled on them but also made them unmoppable. This change keeps that while making them moppable like before.
Fixes #12597 and the very similar #12875

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Bloody footprints are moppable again.
```
