### PR TITLE
Fix upgrading cyborg arms in storages

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -581,8 +581,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 				M.change_stack_amount(-2)
 				if (M.amount < 1)
 					user.drop_item()
-					del(M)
-				del(src)
+					qdel(M)
+				qdel(src)
 				return
 			else
 				boutput(user, "<span class='alert'>You need at least two metal sheets to reinforce this component.</span>")
@@ -609,8 +609,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 				M.change_stack_amount(-2)
 				if (M.amount < 1)
 					user.drop_item()
-					del(M)
-				del(src)
+					qdel(M)
+				qdel(src)
 				return
 			else
 				boutput(user, "<span class='alert'>You need at least two reinforced metal sheets to reinforce this component.</span>")
@@ -655,8 +655,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/right)
 				M.change_stack_amount(-2)
 				if (M.amount < 1)
 					user.drop_item()
-					del(M)
-				del(src)
+					qdel(M)
+				qdel(src)
 				return
 			else
 				boutput(user, "<span class='alert'>You need at least two metal sheets to reinforce this component.</span>")
@@ -683,8 +683,8 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/right)
 				M.change_stack_amount(-2)
 				if (M.amount < 1)
 					user.drop_item()
-					del(M)
-				del(src)
+					qdel(M)
+				qdel(src)
 				return
 			else
 				boutput(user, "<span class='alert'>You need at least two reinforced metal sheets to reinforce this component.</span>")


### PR DESCRIPTION
[GAME OBJECTS][RUNTIME]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes cyborg arms being upgraded to heavy or stronger while in a storage breaking it and causing runtimes

Note, there's another del() in this file that I didn't change, since I didn't test it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #13990