### PR TITLE
Adds a bunch of blinds to Donut 3

### DIFF
--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -224,7 +224,7 @@ obj/decal/fakeobjects
 	anchored = ANCHORED
 	density = 0
 	desc = "Barber poles historically were signage used to convey that the barber would perform services such as blood letting and other medical procedures, with the red representing blood, and the white representing the bandaging. In America, long after the time when blood-letting was offered, a third colour was added to bring it in line with the colours of their national flag. This one is in space."
-	layer = OBJ_LAYER
+	layer = EFFECTS_LAYER_UNDER_2
 	plane = PLANE_DEFAULT
 
 /obj/decal/fakeobjects/oven

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -575,7 +575,7 @@
 	anchored = ANCHORED
 	density = 0
 	opacity = 0
-	layer = FLY_LAYER+1.01 // just above windows
+	layer = EFFECTS_LAYER_UNDER_3 // below lights, above windoors
 	var/base_state = "blindsH"
 	var/open = 1
 	var/id = null

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -627,7 +627,7 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/glass/reinforced)
 	has_crush = FALSE
 	health = 500
 	health_max = 500
-	layer = EFFECTS_LAYER_UNDER_1
+	layer = EFFECTS_LAYER_UNDER_4 // under lights and blinds, above pretty much everything else
 	object_flags = BOTS_DIRBLOCK | CAN_REPROGRAM_ACCESS | HAS_DIRECTIONAL_BLOCKING
 	flags = FPRINT | IS_PERSPECTIVE_FLUID | ALWAYS_SOLID_FLUID | ON_BORDER
 	event_handler_flags = USE_FLUID_ENTER
@@ -637,7 +637,7 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/glass/reinforced)
 	. = ..()
 
 /obj/machinery/door/airlock/pyro/glass/windoor/close()
-	layer = EFFECTS_LAYER_UNDER_1
+	layer = EFFECTS_LAYER_UNDER_4
 	. = ..()
 
 /obj/machinery/door/airlock/pyro/glass/windoor/bumpopen(atom/movable/AM)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2458,10 +2458,6 @@
 	dir = 1
 	},
 /area/station/science/lobby)
-"aGI" = (
-/obj/disposalpipe/segment/brig,
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/hallway/primary/east)
 "aGL" = (
 /obj/machinery/computer/ordercomp,
 /obj/disposalpipe/segment,
@@ -3223,6 +3219,13 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
+"aSv" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "aSD" = (
 /obj/machinery/light/incandescent/warm,
 /obj/decal/tile_edge/line/yellow{
@@ -3817,6 +3820,14 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"bcb" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bch" = (
 /obj/grille/catwalk/jen,
 /obj/cable{
@@ -4461,6 +4472,7 @@
 "bmd" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "bmm" = (
@@ -4626,6 +4638,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
+"bpN" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "bqb" = (
 /obj/grille/catwalk/jen,
 /obj/cable{
@@ -4977,7 +4996,12 @@
 "bul" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "buq" = (
@@ -5187,6 +5211,7 @@
 /obj/machinery/cashreg,
 /obj/access_spawn/hydro,
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/wood,
 /area/station/hydroponics/bay)
 "bwD" = (
@@ -5734,6 +5759,9 @@
 /area/station/crew_quarters/market)
 "bFX" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "bGh" = (
@@ -6152,7 +6180,12 @@
 /obj/item/storage/wall/clothingrack/dresses2{
 	dir = 4
 	},
-/obj/machinery/light_switch/east,
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 4
+	},
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
 "bMH" = (
@@ -6197,6 +6230,13 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
+"bNy" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "bNI" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -6652,9 +6692,14 @@
 	pixel_x = 10;
 	pixel_y = 1
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
@@ -7098,6 +7143,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "ccC" = (
@@ -7216,6 +7262,7 @@
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "ceA" = (
@@ -7802,19 +7849,18 @@
 	},
 /area/station/crew_quarters/courtroom)
 "cmM" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Engineering";
-	req_access = null
-	},
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	req_access = null
+	},
 /turf/simulated/floor,
-/area/station/engine/inner)
+/area/station/engine/gas)
 "cmX" = (
 /obj/table/reinforced/auto,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -7884,6 +7930,11 @@
 	dir = 8
 	},
 /area/station/bridge/customs)
+"coS" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "cpa" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -9483,6 +9534,7 @@
 "cNI" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "cNU" = (
@@ -11424,6 +11476,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
+"dto" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
 "dtM" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -12822,7 +12881,12 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/light_switch/east,
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -13485,6 +13549,7 @@
 	dir = 1
 	},
 /obj/machinery/cashreg,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating/jen,
 /area/station/ranch)
 "eag" = (
@@ -14173,6 +14238,7 @@
 	rand_pos = 1
 	},
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor,
 /area/station/ranch)
 "emJ" = (
@@ -14222,9 +14288,7 @@
 	},
 /obj/reagent_dispensers/foamtank,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/machinery/light/small/sticky{
-	dir = 2
-	},
+/obj/machinery/light/small/sticky,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "eop" = (
@@ -14541,6 +14605,13 @@
 "etV" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hallway/secondary/exit)
+"etW" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "eue" = (
 /obj/stool/chair/comfy/blue{
 	dir = 1
@@ -14987,7 +15058,12 @@
 	pixel_x = 7;
 	pixel_y = -1
 	},
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "eBb" = (
@@ -15288,9 +15364,10 @@
 /area/station/medical/cdc)
 "eGd" = (
 /obj/decal/fakeobjects/pole{
-	layer = 4
+	layer = 29
 	},
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
 "eGk" = (
@@ -16132,6 +16209,13 @@
 	icon_state = "fred1"
 	},
 /area/station/security/quarters)
+"eTQ" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/bot_storage)
 "eTU" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -16899,6 +16983,11 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"fgy" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crewquarters/fuq3)
 "fgB" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 4;
@@ -17000,6 +17089,11 @@
 "fhT" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/crew_quarters/stockex)
+"fii" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/hangar/science)
 "fiu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17584,6 +17678,9 @@
 	icon_state = "1-2"
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "fsc" = (
@@ -17704,6 +17801,13 @@
 "ftV" = (
 /turf/simulated/floor/circuit/purple,
 /area/station/crew_quarters/hor)
+"ftY" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
 "fue" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/disposalpipe/segment/food{
@@ -17830,6 +17934,13 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/barber_shop)
+"fvC" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "fvD" = (
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
@@ -18211,6 +18322,11 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"fBO" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/crewquarters/fuq3)
 "fCi" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -18830,6 +18946,13 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hallway/secondary/exit)
+"fKA" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/janitor/office)
 "fKQ" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -18872,6 +18995,13 @@
 /obj/decal/poster/wallsign/biohazard,
 /turf/simulated/wall/auto/jen/blue,
 /area/station/medical/morgue)
+"fMu" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "fMv" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -19396,6 +19526,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "fUN" = (
@@ -19422,6 +19553,7 @@
 "fUW" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/fuq3,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/fuq3)
 "fUZ" = (
@@ -21654,11 +21786,11 @@
 /area/station/security/main)
 "gEs" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8
-	},
 /obj/access_spawn/research,
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -21755,6 +21887,13 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/white,
 /area/station/security/main)
+"gFO" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "gFS" = (
 /obj/cable{
 	icon_state = "5-6"
@@ -21884,6 +22023,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/west)
+"gHR" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "gHS" = (
 /obj/cable{
 	icon_state = "4-9"
@@ -22237,6 +22383,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "gPb" = (
@@ -22751,6 +22898,7 @@
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "gWm" = (
@@ -23023,6 +23171,7 @@
 "hao" = (
 /obj/disposalpipe/segment/transport,
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "haF" = (
@@ -24676,6 +24825,9 @@
 /area/station/bridge/captain)
 "hyP" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "hyQ" = (
@@ -25231,6 +25383,11 @@
 	icon_state = "red2"
 	},
 /area/station/maintenance/outer/west)
+"hLD" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "hLE" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26187,6 +26344,7 @@
 	pixel_y = -2
 	},
 /obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/wood,
 /area/station/hydroponics/bay)
 "icX" = (
@@ -27319,6 +27477,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ivQ" = (
@@ -27368,6 +27527,7 @@
 	})
 "iwC" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "iwD" = (
@@ -31024,6 +31184,7 @@
 "jEb" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/hangar/science)
 "jEm" = (
@@ -32601,6 +32762,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "kat" = (
@@ -32646,6 +32808,11 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"kbk" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/decal/poster/wallsign/hazard_rad,
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "kbs" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -32741,6 +32908,11 @@
 /obj/access_spawn,
 /turf/simulated/floor,
 /area/station/hangar/main)
+"kcF" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/hangar/science)
 "kcG" = (
 /obj/disposaloutlet{
 	dir = 8;
@@ -33636,6 +33808,13 @@
 	},
 /turf/simulated/floor/carpet/green/standard/edge,
 /area/station/crew_quarters/quartersC)
+"kqT" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/science)
 "kqV" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail{
@@ -36534,6 +36713,9 @@
 /area/station/security/main)
 "loa" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "lob" = (
@@ -39992,6 +40174,18 @@
 /obj/storage/closet/office,
 /turf/simulated/floor/wood/six,
 /area/station/library)
+"mpP" = (
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
+/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "mpU" = (
 /turf/simulated/wall/auto/jen,
 /area/station/chapel/sanctuary)
@@ -40013,6 +40207,11 @@
 "mqx" = (
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/west)
+"mqy" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/janitor/office)
 "mqG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41262,7 +41461,7 @@
 "mMc" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
-/obj/window_blinds/cog2/middle{
+/obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -41607,6 +41806,7 @@
 /area/station/turret_protected/AIbaseoutside)
 "mSM" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "mSO" = (
@@ -41765,12 +41965,13 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "mVx" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8
-	},
 /obj/decal/mule/dropoff,
 /obj/firedoor_spawn,
 /obj/access_spawn,
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	req_access = null
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/refinery)
 "mVJ" = (
@@ -42161,6 +42362,7 @@
 	can_rupture = 0;
 	dir = 5
 	},
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "naA" = (
@@ -44722,6 +44924,7 @@
 "nSb" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "nSh" = (
@@ -45010,6 +45213,11 @@
 	icon_state = "fgreen2"
 	},
 /area/station/engine/engineering/ce)
+"nWf" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "nWh" = (
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 10;
@@ -45046,7 +45254,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn/cargo,
-/obj/machinery/door/airlock/pyro/glass/engineering,
+/obj/machinery/door/airlock/pyro/engineering,
 /turf/simulated/floor,
 /area/station/quartermaster/refinery)
 "nWy" = (
@@ -45432,6 +45640,11 @@
 "ocE" = (
 /turf/simulated/floor/black,
 /area/station/engine/inner)
+"ocF" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "ocH" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -45569,7 +45782,6 @@
 "ogm" = (
 /obj/machinery/computer/airbr{
 	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
 	id = "asyshuttle_med";
 	pixel_y = 33;
 	starts_established = 1
@@ -46150,6 +46362,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/equipment)
+"ooy" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
 "ope" = (
 /obj/disposalpipe/segment/ejection,
 /obj/machinery/door/poddoor{
@@ -46685,6 +46904,11 @@
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
+"oxF" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "oxG" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment,
@@ -48433,6 +48657,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "pcj" = (
@@ -48710,6 +48935,9 @@
 	dir = 8
 	},
 /obj/access_spawn/engineering_mechanic,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "pgC" = (
@@ -48746,6 +48974,11 @@
 	dir = 5
 	},
 /area/station/crew_quarters/hor)
+"phi" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "php" = (
 /obj/machinery/magnet_chassis{
 	dir = 1
@@ -49476,8 +49709,8 @@
 /obj/decal/mule/dropoff,
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
 	req_access = null
 	},
 /turf/simulated/floor/black/grime,
@@ -49673,9 +49906,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/medical/breakroom)
 "puI" = (
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/junction,
 /obj/machinery/light/incandescent/cool/very{
 	dir = 1
 	},
@@ -49710,6 +49941,7 @@
 "puU" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/fuq3)
 "pvc" = (
@@ -49826,6 +50058,9 @@
 "pxJ" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "pxQ" = (
@@ -50693,6 +50928,7 @@
 	})
 "pJN" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "pJQ" = (
@@ -51617,9 +51853,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/nw)
 "pZR" = (
-/obj/machinery/door/airlock/pyro/alt{
-	dir = 2
-	},
+/obj/machinery/door/airlock/pyro/alt,
 /obj/decal/mule/dropoff,
 /obj/disposalpipe/segment,
 /obj/access_spawn,
@@ -53085,12 +53319,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/inner)
 "qtl" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8;
-	req_access = null
-	},
 /obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	req_access = null
+	},
 /obj/access_spawn/eva,
 /turf/simulated/floor/darkblue,
 /area/station/ai_monitored/storage/eva)
@@ -54795,6 +55029,7 @@
 	dir = 4;
 	level = 2
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "qVn" = (
@@ -54986,6 +55221,7 @@
 "qXR" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
+/obj/blind_switch/area/west,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -55391,7 +55627,6 @@
 "rcL" = (
 /obj/machinery/computer/airbr{
 	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
 	id = "asyshuttle_viro";
 	pixel_y = 33;
 	starts_established = 1
@@ -55713,7 +55948,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ril" = (
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "riw" = (
@@ -56016,7 +56256,12 @@
 	},
 /area/shuttle/asylum/medbay)
 "rmu" = (
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "rmv" = (
@@ -56496,6 +56741,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"ruU" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/bot_storage)
 "ruY" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -56833,6 +57085,11 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"rAd" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "rAk" = (
 /obj/disposalpipe/segment,
 /obj/landmark/gps_waypoint,
@@ -57477,6 +57734,13 @@
 "rJD" = (
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"rJL" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/engineering/breakroom)
 "rJM" = (
 /obj/machinery/dispenser{
 	pltanks = 0
@@ -57574,13 +57838,19 @@
 /obj/item/chicken_carrier,
 /obj/machinery/light_switch/east{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = -4
 	},
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,
 /obj/item/satchel/hydro,
 /obj/item/clothing/mask/chicken,
 /obj/item/storage/box/clothing/rancher,
+/obj/blind_switch/east{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 4
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "rLr" = (
@@ -57675,6 +57945,9 @@
 	icon_state = "1-2"
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "rMh" = (
@@ -58553,7 +58826,12 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = -2
 	},
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/science)
 "sao" = (
@@ -59567,6 +59845,9 @@
 /area/station/hallway/primary/east)
 "sqU" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/ranch)
 "srg" = (
@@ -60370,10 +60651,12 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "sEo" = (
-/obj/decal/poster/wallsign/hazard_rad,
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/station/engine/inner)
+/area/station/engine/gas)
 "sEy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60642,6 +60925,7 @@
 /area/station/science/storage)
 "sJC" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/ranch)
 "sJD" = (
@@ -60742,14 +61026,15 @@
 	},
 /area/station/hallway/primary/west)
 "sLb" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8
-	},
 /obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "kitchen freezer pipe"
+	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	req_access = null
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
@@ -61450,6 +61735,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"sWc" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/barber_shop)
 "sWu" = (
 /obj/lattice{
 	dir = 4;
@@ -62191,12 +62481,10 @@
 /turf/simulated/floor/pool/no_animate,
 /area/spacehabitat/pool)
 "tir" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	req_access = null
-	},
 /obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
 /obj/access_spawn/eva,
+/obj/machinery/door/airlock/pyro/command,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -62878,9 +63166,7 @@
 	},
 /area/station/crew_quarters/market)
 "tur" = (
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/junction,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "tus" = (
@@ -63156,6 +63442,7 @@
 /area/station/ai_monitored/armory)
 "txZ" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "tyb" = (
@@ -63512,7 +63799,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
@@ -63695,6 +63987,7 @@
 /area/station/turret_protected/ai_upload)
 "tHb" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "tHe" = (
@@ -65257,7 +65550,12 @@
 	anchored = 1
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/light_switch/east,
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 4
+	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "uia" = (
@@ -66373,18 +66671,18 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/medical/breakroom)
 "uAZ" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8;
-	req_access = null
-	},
-/obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
-/obj/access_spawn/eva,
+/obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/access_spawn/eva,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	req_access = null
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -66568,6 +66866,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "uDt" = (
@@ -66672,7 +66973,12 @@
 /obj/machinery/coffeemaker/engineering{
 	pixel_y = 3
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
@@ -66763,6 +67069,9 @@
 "uFP" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "uFW" = (
@@ -67730,6 +68039,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "uVt" = (
@@ -67919,7 +68231,6 @@
 /area/station/medical/medbay/surgery/storage)
 "uYt" = (
 /obj/machinery/computer/power_monitor{
-	dir = 2;
 	name = "Station Power Grid Monitoring"
 	},
 /obj/machinery/power/data_terminal,
@@ -68037,6 +68348,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "vaE" = (
@@ -69770,12 +70082,12 @@
 /area/station/hallway/primary/east)
 "vBg" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/access_spawn/telesci,
+/obj/machinery/door/airlock/pyro/sci_alt,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "vBl" = (
@@ -69999,6 +70311,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
+"vFA" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/hangar/science)
 "vFH" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment{
@@ -70121,6 +70438,11 @@
 	},
 /turf/simulated/grass,
 /area/station/crew_quarters/garden)
+"vHo" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "vHp" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -70263,6 +70585,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"vIZ" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "vJd" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular,
@@ -73318,7 +73645,12 @@
 	tag = ""
 	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "wFJ" = (
@@ -73378,6 +73710,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "wGC" = (
@@ -73476,6 +73809,7 @@
 /area/station/security/detectives_office)
 "wHU" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
 "wIa" = (
@@ -73607,6 +73941,7 @@
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "wJx" = (
@@ -73878,6 +74213,9 @@
 /area/station/security/brig/north_side)
 "wML" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/breakroom)
 "wMO" = (
@@ -74064,6 +74402,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "wPR" = (
@@ -74459,6 +74798,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"wVZ" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "wWe" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/hallway/primary/west)
@@ -74682,6 +75028,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
+"wXL" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/janitor/office)
 "wXP" = (
 /obj/cable,
 /obj/cable{
@@ -76175,6 +76528,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 1
 	},
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating/jen,
 /area/station/ranch)
 "xsH" = (
@@ -76464,6 +76818,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"xww" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/janitor/office)
 "xwC" = (
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/black,
@@ -77040,6 +77401,11 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
+"xEs" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "xEu" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools/two,
@@ -77177,7 +77543,12 @@
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/east)
 "xGG" = (
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "xGU" = (
@@ -77192,9 +77563,7 @@
 /turf/simulated/floor/white,
 /area/station/science/lobby)
 "xHf" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "xHi" = (
@@ -77503,7 +77872,12 @@
 "xLQ" = (
 /obj/machinery/portable_reclaimer,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/industrial,
 /area/station/quartermaster/refinery)
 "xMe" = (
@@ -78979,6 +79353,9 @@
 /area/station/crew_quarters/sauna)
 "yhV" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/science)
 "yid" = (
@@ -115080,7 +115457,7 @@ cYk
 wax
 ogT
 uWW
-mSM
+mqy
 rdj
 rdj
 rdj
@@ -115382,7 +115759,7 @@ wjj
 ogT
 ogT
 dnh
-mSM
+mqy
 rdj
 rdj
 rdj
@@ -115456,7 +115833,7 @@ lOa
 wkT
 fyr
 wkT
-pJN
+vIZ
 nhe
 hAg
 prl
@@ -115758,7 +116135,7 @@ lOa
 ops
 fyr
 lEp
-pJN
+vIZ
 vrX
 hAg
 prl
@@ -115982,10 +116359,10 @@ teM
 rRH
 olN
 aon
-mSM
-mSM
-mSM
-mSM
+fKA
+xww
+xww
+wXL
 aon
 rdj
 rdj
@@ -116060,7 +116437,7 @@ lOa
 fyr
 fyr
 kfp
-pJN
+rAd
 olH
 hAg
 ssP
@@ -116069,12 +116446,12 @@ oPf
 oPf
 oPf
 hyr
+gFO
 loa
 loa
 loa
-loa
-pxJ
-moM
+bcb
+mpP
 pxJ
 hyr
 xof
@@ -116962,7 +117339,7 @@ oqi
 aZz
 aZz
 aZz
-pJN
+gHR
 gEs
 aZz
 aZz
@@ -122408,7 +122785,7 @@ rfc
 cpa
 ciW
 aGD
-yhV
+vFA
 iMm
 mup
 xbV
@@ -122710,7 +123087,7 @@ rfc
 cpa
 ciW
 aGD
-yhV
+fii
 xbV
 xbV
 xbV
@@ -123012,7 +123389,7 @@ rfc
 cpa
 ciW
 aGD
-yhV
+fii
 xbV
 xbV
 xbV
@@ -123314,7 +123691,7 @@ rfc
 cpa
 qWW
 aGD
-yhV
+kcF
 xbV
 nLQ
 xbV
@@ -123918,7 +124295,7 @@ rfc
 cpa
 ciW
 juJ
-yhV
+fii
 lJc
 mWo
 qYT
@@ -124825,7 +125202,7 @@ xxy
 axk
 upI
 ubq
-yhV
+kqT
 yhV
 nOL
 nOL
@@ -125321,7 +125698,7 @@ mke
 kHx
 kHx
 kHx
-txZ
+coS
 sfc
 lns
 oOt
@@ -125417,7 +125794,7 @@ gcY
 kPH
 hoG
 xfi
-cpa
+nWf
 onh
 ciW
 hAg
@@ -125602,12 +125979,12 @@ rkj
 mfs
 mfs
 mfs
-sqU
-sqU
+wVZ
+etW
 wnd
 mfs
-kyD
-kyD
+wVZ
+etW
 gug
 jxC
 aJt
@@ -126323,7 +126700,7 @@ pTF
 vTy
 eKX
 mer
-cpa
+nWf
 oGa
 ciW
 aGD
@@ -126504,7 +126881,7 @@ qjK
 lhr
 btN
 oht
-sqU
+ocF
 aSU
 mBB
 mBB
@@ -126625,7 +127002,7 @@ qef
 kPH
 hoG
 wfL
-cpa
+hLD
 onh
 ciW
 aGD
@@ -126831,7 +127208,7 @@ kHx
 mke
 mke
 inC
-txZ
+phi
 sfc
 ffS
 bTR
@@ -127531,7 +127908,7 @@ vGK
 lvY
 maP
 vtw
-cpa
+nWf
 onh
 ciW
 aGD
@@ -127833,7 +128210,7 @@ loj
 fHI
 vFt
 wIy
-cpa
+oxF
 oGa
 qOF
 hCA
@@ -128014,7 +128391,7 @@ lJg
 btN
 ePf
 gYk
-sqU
+ocF
 aSU
 mBB
 mBB
@@ -128034,7 +128411,7 @@ mfs
 wqJ
 wqJ
 mWS
-txZ
+aSv
 wqJ
 wqJ
 vhj
@@ -128135,7 +128512,7 @@ vDi
 caq
 vOr
 orj
-cpa
+hLD
 pdZ
 ciW
 aGD
@@ -128380,7 +128757,7 @@ rdj
 rdj
 dFZ
 rdj
-iwC
+xEs
 xie
 xie
 xie
@@ -128389,7 +128766,7 @@ rat
 xie
 xie
 xie
-iwC
+xEs
 rdj
 rdj
 rdj
@@ -128682,7 +129059,7 @@ rdj
 rdj
 dFZ
 rdj
-iwC
+vHo
 xie
 xie
 xie
@@ -128691,7 +129068,7 @@ rat
 xie
 xie
 xie
-iwC
+vHo
 rdj
 rdj
 rdj
@@ -128736,8 +129113,8 @@ tYp
 tuB
 vzs
 wno
-wbX
-wbX
+ruU
+eTQ
 wno
 wno
 wbX
@@ -128981,9 +129358,9 @@ mYB
 mYB
 mYB
 vYX
-iwC
+fMu
 uDr
-iwC
+bpN
 vYX
 xie
 tut
@@ -129230,11 +129607,11 @@ mfs
 mfs
 mfs
 mfs
-sqU
+fvC
 sqU
 mfs
 mfs
-sqU
+fvC
 sqU
 mfs
 pvp
@@ -130458,7 +130835,7 @@ ilz
 hsk
 wCY
 wCY
-wHU
+sWc
 nTA
 wBD
 pFu
@@ -131097,12 +131474,12 @@ uJg
 mDD
 mhe
 aaZ
-iwC
-iwC
+fMu
+bpN
 dLt
 dfS
-iwC
-iwC
+fMu
+bpN
 mhe
 mhe
 vnK
@@ -131666,7 +132043,7 @@ koB
 koB
 koB
 uwY
-xFa
+fBO
 nTA
 oVM
 gbD
@@ -131968,7 +132345,7 @@ iof
 agP
 grK
 klB
-xFa
+fgy
 wzi
 acl
 wuk
@@ -132904,9 +133281,9 @@ jHO
 sTy
 cxc
 cxc
-tHb
+ftY
 psu
-tHb
+ftY
 plQ
 nAr
 plQ
@@ -134716,9 +135093,9 @@ nkB
 xUo
 xUo
 xUo
-tHb
+ooy
 mVx
-tHb
+ooy
 xUo
 aBc
 mXg
@@ -135919,10 +136296,10 @@ asW
 rbo
 rbo
 ycH
-iLK
+bNy
 pgv
 pgv
-iLK
+dto
 tat
 chQ
 tat
@@ -135933,7 +136310,7 @@ xLg
 xLg
 xLg
 akz
-tyo
+xLg
 sKf
 xPd
 xPd
@@ -136235,7 +136612,7 @@ spT
 stt
 cWA
 cWA
-tyo
+xLg
 vkX
 xPd
 xPd
@@ -136537,7 +136914,7 @@ dlq
 dlq
 erx
 erx
-aGI
+dSg
 hHC
 qvl
 qvl
@@ -136839,7 +137216,7 @@ tQD
 xSW
 xSW
 xSW
-tyo
+xLg
 eXC
 uMR
 ihV
@@ -137141,7 +137518,7 @@ tQD
 xSW
 iGs
 bvR
-tyo
+xLg
 tyo
 dbP
 sut
@@ -137443,7 +137820,7 @@ spT
 ncR
 iGs
 wMf
-dbP
+xLg
 aZZ
 uJW
 rXi
@@ -137743,9 +138120,9 @@ ehR
 ciD
 xRU
 xLg
-dbP
-dbP
-dbP
+xLg
+xLg
+xLg
 gqe
 ykd
 lvR
@@ -138044,7 +138421,7 @@ tat
 sEo
 cmM
 sEo
-dbP
+xLg
 isQ
 lvR
 cdO
@@ -138653,13 +139030,13 @@ ocE
 ocE
 oWs
 aSs
-aSs
+kbk
 aSs
 lWj
 fEO
 lWj
 aSs
-aSs
+kbk
 aSs
 oWs
 vmV
@@ -140158,7 +140535,7 @@ xEu
 dxl
 pqD
 xVe
-aSs
+kbk
 rdj
 rdj
 rdj
@@ -140174,7 +140551,7 @@ rYX
 rdj
 rdj
 rdj
-aSs
+kbk
 iMk
 lfU
 pqD
@@ -141970,7 +142347,7 @@ ohe
 dxl
 ocE
 xVe
-aSs
+kbk
 rdj
 rdj
 rdj
@@ -141986,7 +142363,7 @@ rYX
 rdj
 rdj
 rdj
-aSs
+kbk
 iMk
 hVP
 ocE
@@ -143485,13 +143862,13 @@ ocE
 ocE
 oWs
 aSs
-aSs
+kbk
 aSs
 lWj
 fEO
 lWj
 aSs
-aSs
+kbk
 aSs
 oWs
 vOK
@@ -144704,7 +145081,7 @@ rGs
 jQq
 tXI
 aXh
-wML
+rJL
 wML
 swZ
 mAN

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6389,6 +6389,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/window_blinds/cog2/right{
+	id = "chemistry"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "bQa" = (
@@ -7370,6 +7373,9 @@
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2/middle{
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -8464,6 +8470,9 @@
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/right{
+	id = "chemistry"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "cwp" = (
@@ -10312,6 +10321,9 @@
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2/middle{
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -20242,6 +20254,10 @@
 	dir = 8
 	},
 /obj/table/reinforced/chemistry/auto,
+/obj/window_blinds/cog2/left{
+	dir = 4;
+	id = "chemistry"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "gfv" = (
@@ -22090,7 +22106,11 @@
 "gHR" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/window_blinds/cog2/middle{
-	dir = 4
+	dir = 4;
+	id = "chemistry"
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -25349,6 +25369,10 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 6;
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -49975,6 +49999,16 @@
 /obj/storage/crate/bartending,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
+"pts" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/window_blinds/cog2/left{
+	id = "chemistry"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "ptw" = (
 /obj/disposalpipe/segment/transport,
 /obj/surgery_tray/kitchen_island,
@@ -55276,6 +55310,9 @@
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/window_blinds/cog2/middle{
+	id = "chemistry"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "qWE" = (
@@ -67553,6 +67590,10 @@
 /area/station/solar/west)
 "uJx" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4;
+	id = "chemistry"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "uJI" = (
@@ -78867,6 +78908,10 @@
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/cashreg{
 	name = "Chemistry credit transfer device"
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 4;
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -120572,7 +120617,7 @@ qrR
 qgJ
 sUp
 amn
-hJh
+pts
 wTH
 tud
 nUD

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2290,6 +2290,11 @@
 /obj/grille/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"aEr" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "aEC" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -3691,6 +3696,11 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs/wide,
 /area/station/hangar/arrivals)
+"aZe" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/medical/breakroom)
 "aZs" = (
 /turf/simulated/shuttle/wall/corner{
 	dir = 1
@@ -4764,14 +4774,14 @@
 /area/station/crew_quarters/arcade/dungeon)
 "brw" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/access_spawn/medical,
+/obj/machinery/door/airlock/pyro/medical/alt{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/medical/medbooth)
 "brC" = (
@@ -6789,9 +6799,6 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "bXE" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/decal/mule/dropoff,
 /obj/firedoor_spawn,
 /obj/access_spawn/medlab,
@@ -6799,6 +6806,9 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/medical/alt{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -8344,6 +8354,9 @@
 	pixel_y = 7
 	},
 /obj/access_spawn/medical,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbooth)
 "cus" = (
@@ -10683,7 +10696,13 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/north{
+	id = genetics;
+	pixel_x = 4
+	},
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
@@ -10698,9 +10717,8 @@
 	dir = 4
 	},
 /obj/access_spawn/cargo,
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	req_access = null
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
@@ -11483,6 +11501,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"dtv" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	id = mining
+	},
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "dtM" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -12037,6 +12062,16 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/chapel/sanctuary)
+"dEq" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "dEr" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail{
@@ -12493,9 +12528,8 @@
 	icon_state = "4-8"
 	},
 /obj/access_spawn/cargo,
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	req_access = null
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
@@ -14030,6 +14064,10 @@
 /area/station/medical/medbay/pharmacy)
 "eiB" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8;
+	id = genetics
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -16215,7 +16253,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/science/bot_storage)
+/area/station/science/teleporter)
 "eTU" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -16799,6 +16837,13 @@
 /obj/storage/secure/closet/engineering/mechanic,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"fcn" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "fcp" = (
 /obj/item/clothing/suit/bedsheet,
 /obj/stool/bed,
@@ -17105,6 +17150,11 @@
 "fiB" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/north_side)
+"fiF" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "fiH" = (
 /obj/machinery/light/small/sticky{
 	dir = 4
@@ -17806,6 +17856,10 @@
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
+/obj/window_blinds/cog2/middle{
+	dir = 8;
+	id = mining
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "fue" = (
@@ -17831,6 +17885,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/medical/medbay)
+"fut" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "fuv" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -21561,6 +21622,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "gAo" = (
@@ -22535,8 +22599,13 @@
 /turf/space,
 /area/listeningpost)
 "gQV" = (
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
 /obj/reagent_dispensers/watertank/fountain,
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/medical/breakroom)
 "gQW" = (
@@ -23235,6 +23304,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/AIsat)
+"hcd" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "hcg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -25387,7 +25463,7 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/science/teleporter)
 "hLE" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25935,6 +26011,14 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"hVX" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 10;
+	id = genetics
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "hVZ" = (
 /obj/decal/floatingtiles{
 	dir = 4
@@ -26072,7 +26156,12 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/obj/machinery/light_switch/east,
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "hZl" = (
@@ -26645,6 +26734,13 @@
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/AIsat)
+"ihh" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/breakroom)
 "ihq" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
@@ -27670,6 +27766,10 @@
 	dir = 4
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8;
+	id = genetics
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -30566,6 +30666,12 @@
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/science)
 "juz" = (
@@ -31014,6 +31120,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
+"jAv" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "jAH" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -31808,11 +31921,13 @@
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "jLx" = (
-/obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
 /obj/access_spawn/rancher,
 /obj/decal/mule/dropoff,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/maintenance{
+	req_access = null
+	},
 /turf/simulated/floor,
 /area/station/ranch)
 "jLD" = (
@@ -34643,6 +34758,13 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
+"kEz" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "kEK" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -34891,6 +35013,9 @@
 	dir = 4
 	},
 /obj/access_spawn/cargo,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "kKi" = (
@@ -36065,6 +36190,9 @@
 /area/station/chapel/sanctuary)
 "lcg" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "lcq" = (
@@ -38760,7 +38888,12 @@
 "lTz" = (
 /obj/machinery/optable,
 /obj/item/reagent_containers/iv_drip/blood,
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "lTE" = (
@@ -39153,6 +39286,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
+"lYK" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 6;
+	id = genetics
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "lYL" = (
 /obj/table/auto,
 /obj/random_item_spawner/dressup/two,
@@ -40149,11 +40290,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "mpE" = (
-/obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/hydro,
 /obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/maintenance{
+	req_access = null
+	},
 /turf/simulated/floor/wood,
 /area/station/hydroponics/bay)
 "mpG" = (
@@ -40242,6 +40385,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/AIsat)
+"mqW" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	id = genetics
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "mqY" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -40929,12 +41079,18 @@
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
 	},
-/obj/machinery/light_switch/south,
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
 /obj/table/auto,
 /obj/item/plate{
 	pixel_y = 7
 	},
 /obj/random_item_spawner/snacks/one,
+/obj/blind_switch/south{
+	id = mining;
+	pixel_x = 4
+	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "mDN" = (
@@ -44926,7 +45082,7 @@
 /obj/disposalpipe/segment,
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/science/teleporter)
 "nSh" = (
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
@@ -45201,7 +45357,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass/engineering,
+/obj/machinery/door/airlock/pyro/engineering,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "nWd" = (
@@ -45217,7 +45373,7 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/science/teleporter)
 "nWh" = (
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 10;
@@ -46245,6 +46401,14 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"onb" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 9;
+	id = genetics
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "onh" = (
 /turf/simulated/floor/purpleblack{
 	dir = 1
@@ -46908,7 +47072,7 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/science/teleporter)
 "oxG" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment,
@@ -50084,6 +50248,11 @@
 	dir = 5
 	},
 /area/station/chapel/sanctuary)
+"pyf" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/medical/medbooth)
 "pyn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50838,6 +51007,9 @@
 "pIM" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/window_blinds/cog2/middle{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -56192,6 +56364,9 @@
 "rlA" = (
 /obj/disposalpipe/segment,
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	id = mining
+	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
 "rlB" = (
@@ -56747,7 +56922,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/science/bot_storage)
+/area/station/science/teleporter)
 "ruY" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -57022,6 +57197,9 @@
 /obj/machinery/cashreg{
 	pixel_x = -4;
 	pixel_y = -2
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -58826,12 +59004,6 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = -2
 	},
-/obj/machinery/light_switch/south{
-	pixel_x = -4
-	},
-/obj/blind_switch/area/south{
-	pixel_x = 4
-	},
 /turf/simulated/floor,
 /area/station/hangar/science)
 "sao" = (
@@ -59627,6 +59799,14 @@
 "smZ" = (
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
+"sna" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 5;
+	id = genetics
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "snc" = (
 /obj/table/reinforced/auto,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -60456,6 +60636,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
+"sAm" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/breakroom)
 "sAG" = (
 /turf/simulated/floor,
 /area/spacehabitat/pool)
@@ -62195,6 +62382,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
+"tfa" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/qm)
 "tfk" = (
 /obj/decal/boxingrope,
 /obj/machinery/camera{
@@ -62825,6 +63019,7 @@
 "tor" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "toz" = (
@@ -62893,6 +63088,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/visitation)
+"tpf" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/breakroom)
 "tph" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -64303,9 +64505,6 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "tMg" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/decal/mule/dropoff,
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -64313,6 +64512,9 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/medical/alt{
 	dir = 4
 	},
 /turf/simulated/floor/blue,
@@ -64361,9 +64563,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	req_access = null
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -64456,6 +64657,11 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"tOw" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "tOD" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -66016,6 +66222,9 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
+/obj/window_blinds/cog2/middle{
+	id = mining
+	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
 "uqE" = (
@@ -67210,20 +67419,22 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "uHZ" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Engineering"
-	},
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
 /obj/decal/mule/dropoff,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering/breakroom)
 "uIi" = (
 /obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left{
+	id = null
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/breakroom)
 "uIk" = (
@@ -70089,7 +70300,7 @@
 /obj/access_spawn/telesci,
 /obj/machinery/door/airlock/pyro/sci_alt,
 /turf/simulated/floor/black,
-/area/station/science/lobby)
+/area/station/science/teleporter)
 "vBl" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -71931,13 +72142,15 @@
 /area/station/bridge)
 "wcQ" = (
 /obj/decal/mule/dropoff,
-/obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/maintenance{
+	req_access = null
+	},
 /turf/simulated/floor,
 /area/station/crewquarters/fuq3)
 "wdh" = (
@@ -72090,6 +72303,9 @@
 /area/station/hangar/qm)
 "wfJ" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbooth)
 "wfL" = (
@@ -72483,9 +72699,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
-"wno" = (
-/turf/simulated/wall/auto/jen/purple,
-/area/station/science/bot_storage)
 "wns" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/external{
@@ -74198,6 +74411,9 @@
 	pixel_y = 5
 	},
 /obj/access_spawn/medical,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbooth)
 "wMI" = (
@@ -77859,6 +78075,9 @@
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/breakroom)
@@ -119428,7 +119647,7 @@ vSL
 nOU
 jrH
 pWe
-uIi
+aZe
 wHi
 nUt
 tAU
@@ -119724,12 +119943,12 @@ cmi
 bnj
 sbI
 nAi
-uIi
-uIi
-uIi
+ihh
+sAm
+tpf
 tMg
 xLt
-uIi
+tpf
 mKz
 qnp
 nIN
@@ -125492,7 +125711,7 @@ hNd
 qbv
 hNd
 sTE
-xJS
+rtr
 jvG
 uoI
 nmG
@@ -127304,7 +127523,7 @@ rtr
 tDQ
 teN
 rtr
-xJS
+rtr
 onh
 ciW
 xqT
@@ -127606,7 +127825,7 @@ qkQ
 kPH
 ukP
 sge
-xJS
+rtr
 onh
 ciW
 aGD
@@ -128814,7 +129033,7 @@ wPh
 qNW
 hoG
 miG
-xJS
+rtr
 pjd
 mzb
 sqm
@@ -129111,12 +129330,12 @@ eOq
 oCr
 tYp
 tuB
-vzs
-wno
+sTE
+rtr
 ruU
 eTQ
-wno
-wno
+rtr
+rtr
 wbX
 kIj
 wbX
@@ -130605,7 +130824,7 @@ fes
 gul
 wNz
 imF
-xDi
+mqW
 biC
 pMQ
 pMQ
@@ -130613,7 +130832,7 @@ gNA
 pMQ
 abr
 pMQ
-xDi
+mqW
 jBg
 sca
 tSw
@@ -130907,15 +131126,15 @@ fes
 ueF
 aWR
 noC
-xDi
-xDi
+hVX
+onb
 rGd
 pMQ
 hOb
 pMQ
 wKh
-xDi
-xDi
+lYK
+sna
 fPb
 jBg
 aAb
@@ -131210,13 +131429,13 @@ jIk
 aWR
 krj
 uuy
-xDi
-xDi
+jAv
+onb
 ruY
 mAl
 nNu
-xDi
-xDi
+lYK
+sna
 oDl
 jBg
 sps
@@ -131474,12 +131693,12 @@ uJg
 mDD
 mhe
 aaZ
-fMu
-bpN
+kEz
+tfa
 dLt
 dfS
-fMu
-bpN
+kEz
+tfa
 mhe
 mhe
 vnK
@@ -131517,7 +131736,7 @@ xDi
 sFY
 sFY
 sFY
-xDi
+sna
 vfS
 dCa
 qSh
@@ -131774,7 +131993,7 @@ gPi
 fLf
 fLf
 jme
-mCZ
+dtv
 fBJ
 rqF
 jwT
@@ -131784,7 +132003,7 @@ aDk
 duh
 lMS
 jnk
-qxQ
+fut
 qxQ
 fhc
 qxQ
@@ -132953,7 +133172,7 @@ puU
 nqL
 hRi
 fIF
-wfJ
+aEr
 qvc
 qIT
 cFr
@@ -133290,9 +133509,9 @@ plQ
 plQ
 plQ
 xUo
-lcg
+hcd
 tMX
-gAd
+dEq
 duN
 qxQ
 qxQ
@@ -133557,7 +133776,7 @@ svU
 srJ
 sLh
 uDq
-wfJ
+pyf
 oyi
 gcu
 lNp
@@ -133595,7 +133814,7 @@ tHb
 mHm
 mPq
 aSD
-lcg
+tOw
 oqp
 wPT
 fuT
@@ -133859,7 +134078,7 @@ svU
 tbg
 sLh
 uDq
-wfJ
+fiF
 lEs
 cjy
 ivc
@@ -134199,7 +134418,7 @@ bmd
 uWL
 lTK
 ivX
-lcg
+tOw
 ugb
 lJJ
 edW
@@ -134502,7 +134721,7 @@ pIM
 tMX
 gAd
 duN
-lcg
+fcn
 rzn
 kJX
 gAd

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -5981,6 +5981,13 @@
 	dir = 9
 	},
 /area/station/hangar/arrivals)
+"bJl" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "bJA" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -28357,6 +28364,11 @@
 /obj/stool/chair/comfy,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/medical/breakroom)
+"iGM" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "iGZ" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -35533,6 +35545,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/armory_outside)
+"kRb" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	id = "chemistry"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "kRc" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/emergency{
@@ -41701,7 +41720,12 @@
 /obj/machinery/light/incandescent/cool/very{
 	dir = 1
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -4
+	},
+/obj/blind_switch/area/north{
+	pixel_x = 4
+	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -42818,6 +42842,13 @@
 "nea" = (
 /turf/simulated/floor/carpet/blue/standard,
 /area/station/medical/medbay/cloner)
+"neb" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "ned" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -49115,6 +49146,12 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/dropper,
+/obj/blind_switch/south{
+	pixel_x = 4
+	},
+/obj/machinery/light_switch/south{
+	pixel_x = -4
+	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "pgv" = (
@@ -56301,6 +56338,7 @@
 /area/station/hallway/primary/west)
 "rki" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "rkj" = (
@@ -67592,7 +67630,7 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 4;
-	id = "chemistry"
+	id = Chemistry
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -69274,6 +69312,9 @@
 	dir = 4
 	},
 /obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "vkW" = (
@@ -76111,6 +76152,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"xjv" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "xjy" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment{
@@ -78911,7 +78959,7 @@
 	},
 /obj/window_blinds/cog2/middle{
 	dir = 4;
-	id = "chemistry"
+	id = Chemistry
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -127237,11 +127285,11 @@ bpe
 bpe
 pgO
 vkJ
-rki
+neb
 ijz
-rki
-rki
-rki
+bJl
+xjv
+neb
 pgO
 kfw
 rht
@@ -127846,7 +127894,7 @@ nAt
 uvs
 wMO
 qXC
-rki
+iGM
 fVi
 jyN
 aTA
@@ -128148,7 +128196,7 @@ wXy
 uvs
 rCl
 ohz
-rki
+iGM
 nAG
 tvK
 oEH
@@ -128450,7 +128498,7 @@ uvs
 uvs
 buf
 kLL
-rki
+kRb
 nAG
 ubw
 qnY

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -10700,7 +10700,7 @@
 	pixel_x = -4
 	},
 /obj/blind_switch/north{
-	id = genetics;
+	id = "genetics";
 	pixel_x = 4
 	},
 /turf/simulated/floor/greenblack{
@@ -11504,7 +11504,7 @@
 "dtv" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
-	id = mining
+	id = "mining"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
@@ -14066,7 +14066,7 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 8;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research{
@@ -17858,7 +17858,7 @@
 	},
 /obj/window_blinds/cog2/middle{
 	dir = 8;
-	id = mining
+	id = "mining"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
@@ -26015,7 +26015,7 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 10;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
@@ -27768,7 +27768,7 @@
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 8;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research{
@@ -39290,7 +39290,7 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 6;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
@@ -40388,7 +40388,7 @@
 "mqW" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/left{
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
@@ -41088,7 +41088,7 @@
 	},
 /obj/random_item_spawner/snacks/one,
 /obj/blind_switch/south{
-	id = mining;
+	id = "mining";
 	pixel_x = 4
 	},
 /turf/simulated/floor/black,
@@ -46405,7 +46405,7 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 9;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
@@ -56365,7 +56365,7 @@
 /obj/disposalpipe/segment,
 /obj/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
-	id = mining
+	id = "mining"
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/staff_room)
@@ -59803,7 +59803,7 @@
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
 	dir = 5;
-	id = genetics
+	id = "genetics"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
@@ -66223,7 +66223,7 @@
 /obj/access_spawn/mining,
 /obj/firedoor_spawn,
 /obj/window_blinds/cog2/middle{
-	id = mining
+	id = "mining"
 	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -67630,7 +67630,7 @@
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 4;
-	id = Chemistry
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -78959,7 +78959,7 @@
 	},
 /obj/window_blinds/cog2/middle{
 	dir = 4;
-	id = Chemistry
+	id = "chemistry"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

blinds are cool we should have more of those
adds blinds to some areas including:
- ranch
- toxins
- botany
- QM
- engi break room
- genetics
- medical break room
- mining
- refinery
- and more!

Non-blind changes:
- Changes the layer of windoors and blinds so that blinds layer above windoors but below lights
- Changes some doors to opaque where a transparent door would counteract the blinds

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
privacy (crime)

