### PR TITLE
Fixes #14015

### DIFF
--- a/code/obj/item/gun/russian.dm
+++ b/code/obj/item/gun/russian.dm
@@ -87,6 +87,7 @@
 	desc = "A slightly shabby looking combat revolver developed by somebody. Uses .357 caliber rounds."
 	force = MELEE_DMG_REVOLVER
 	shotsMax = 1 //griff
+	contraband = 4
 	var/fakeshots = 0
 	New()
 		fakeshots = rand(2, 7)


### PR DESCRIPTION
## About the PR 
Fixes bug where the fake revolver from tratior purchases did not have contraband level

## Why's this needed? 
Having the fake revolver be discernible from an actual revolver devalues the item
