### PR TITLE
Menu For Picking Pug Fur Color

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -664,8 +664,7 @@ datum/preferences
 					tgui_alert(usr, "No usable special styles detected for this mutantrace.", "Error")
 					return
 				var/list/style_list = typeinfo.special_styles
-				var/current_index = style_list.Find(AH.special_style) // do they already have a special style in their prefs
-				var/new_style = style_list[current_index + 1 > length(style_list) ? 1 : current_index + 1]
+				var/new_style = tgui_input_list(usr, "Select a style pattern", "Special Style", style_list)
 				if (new_style)
 					AH.special_style = new_style
 					update_preview_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives you a little tgui menu when you change pug fur color instead of picking the next one in the list when you click it.


![](https://cdn.discordapp.com/attachments/1041726307584704532/1105867944698859631/image.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Probably a lot more intuitive of a way to pick something like this, shows you all the options possible, generally better UX imo. Plus I want it *personally*! Since I like to play pug when I play and use this sometimes