### PR TITLE
Fix stealth storage bugs with storage

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -267,6 +267,8 @@
 	New()
 		..()
 		src.cloaked = 0
+		src.create_storage(/datum/storage, prevent_holding = list(/obj/item/storage/box), max_wclass = src.max_wclass, slots = src.slots, sneaky = src.sneaky,
+			opens_if_worn = TRUE)
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes stealth storages not staying open when put in a pocket, and it fixes them being able to hold other boxes, including each other.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #14051