### PR TITLE
Refactor door locks into procs, limit ion storm to airlocks

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -230,15 +230,15 @@ ABSTRACT_TYPE(/datum/ion_category)
 /datum/ion_category/doors
 	amount = 40
 
-	valid_instance(var/obj/machinery/door/door)
+	valid_instance(var/obj/machinery/door/airlock/door)
 		return ..() && !door.cant_emag
 
 	build_targets()
-		for_by_tcl(door, /obj/machinery/door)
+		for_by_tcl(door, /obj/machinery/door/airlock)
 			if (valid_instance(door))
 				targets += door
 
-	action(var/obj/machinery/door/door)
+	action(var/obj/machinery/door/airlock/door)
 		var/door_diceroll = rand(1,3)
 		switch(door_diceroll)
 			if(1)
@@ -247,6 +247,7 @@ ABSTRACT_TYPE(/datum/ion_category)
 			if(2)
 				door.locked = 1
 				door.UpdateIcon()
+				playsound(door, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
 				logTheThing(LOG_STATION, null, "Ion storm locked an airlock ([door.name]) at [log_loc(door)]")
 			if(3)
 				if (door.density)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -245,10 +245,9 @@ ABSTRACT_TYPE(/datum/ion_category)
 				door.secondsElectrified = -1
 				logTheThing(LOG_STATION, null, "Ion storm electrified an airlock ([door.name]) at [log_loc(door)]")
 			if(2)
-				door.locked = 1
-				door.UpdateIcon()
-				playsound(door, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
-				logTheThing(LOG_STATION, null, "Ion storm locked an airlock ([door.name]) at [log_loc(door)]")
+				if (!door.locked)
+					door.set_locked()
+					logTheThing(LOG_STATION, null, "Ion storm locked an airlock ([door.name]) at [log_loc(door)]")
 			if(3)
 				if (door.density)
 					door.open()

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1097,11 +1097,9 @@ About the new airlock wires panel:
 				src.shock(usr, 50)
 		if (AIRLOCK_WIRE_DOOR_BOLTS)
 			//Cutting this wire also drops the door bolts, and mending it does not raise them. (This is what happens now, except there are a lot more wires going to door bolts at present)
-			if (src.locked!=1)
-				src.locked = 1
-				playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
+			if (!src.locked)
+				src.set_locked()
 				logTheThing(LOG_STATION, usr, "[usr] has bolted a door at [log_loc(src)].")
-			src.UpdateIcon()
 
 		if (AIRLOCK_WIRE_BACKUP_POWER1, AIRLOCK_WIRE_BACKUP_POWER2)
 			//Cutting either one disables the backup door power (allowing it to be crowbarred open, but disabling bolts-raising), but may electocute the user.

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -984,7 +984,6 @@ About the new airlock wires panel:
 				if(src.arePowerSystemsOn()) //only can raise bolts if power's on
 					boutput(usr, "You hear a clunk from inside the door.")
 					src.set_unlocked()
-			src.UpdateIcon()
 			SPAWN(1 DECI SECOND)
 				src.shock(usr, 25)
 

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -59,14 +59,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door/airlock, proc/play_deny, proc/toggle_bo
 		boutput(user, "<span class='alert'>The door has no power - you can't raise/lower the door bolts.</span>")
 		return
 	if(src.locked)
-		src.locked = 0
-		src.UpdateIcon()
-		playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
+		src.set_unlocked()
 	else
 		logTheThing(LOG_STATION, user || usr, "[user || usr] has bolted a door at [log_loc(src)].")
-		src.locked = 1
-		src.UpdateIcon()
-		playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
+		src.set_locked()
 
 /obj/machinery/door/airlock/proc/shock_perm(mob/user)
 	if(!src.arePowerSystemsOn() || (src.status & NOPOWER))
@@ -980,16 +976,14 @@ About the new airlock wires panel:
 			//one wire for door bolts. Sending a pulse through this drops door bolts if they're not down (whether power's on or not),
 			//raises them if they are down (only if power's on)
 			if (!src.locked)
-				src.locked = 1
 				logTheThing(LOG_STATION, usr, "[usr] has bolted a door at [log_loc(src)].")
 				boutput(usr, "You hear a clunk from the bottom of the door.")
-				playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
+				src.set_locked()
 				tgui_process.update_uis(src)
 			else
 				if(src.arePowerSystemsOn()) //only can raise bolts if power's on
-					src.locked = 0
 					boutput(usr, "You hear a clunk from inside the door.")
-					playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
+					src.set_unlocked()
 			src.UpdateIcon()
 			SPAWN(1 DECI SECOND)
 				src.shock(usr, 25)
@@ -1832,16 +1826,12 @@ TYPEINFO(/obj/machinery/door/airlock)
 
 			if("unlock")
 				if(!src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS) && locked)
-					src.locked = 0
-					playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
-				src.UpdateIcon()
+					src.set_unlocked()
 				src.send_status(,senderid)
 
 			if("lock")
 				if(!src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS) && !locked)
-					src.locked = 1
-					playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
-				src.UpdateIcon()
+					src.set_locked()
 				src.send_status()
 
 			if("secure_open")
@@ -1851,18 +1841,13 @@ TYPEINFO(/obj/machinery/door/airlock)
 						send_status(,senderid)
 						return
 					if(src.locked && !src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						src.locked = 0
-						playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
-					src.UpdateIcon()
+						src.set_unlocked()
 
 					src.open(1)
 					sleep(0.5 SECONDS)
 
 					if(!src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						src.locked = 1
-						playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
-
-					src.UpdateIcon()
+						src.set_locked()
 					sleep(src.operation_time)
 					src.send_status(,senderid)
 
@@ -1873,17 +1858,13 @@ TYPEINFO(/obj/machinery/door/airlock)
 						src.send_status(,senderid)
 						return
 					if(src.locked && !src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						src.locked = 0
-						playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
+						src.set_unlocked()
 
 					src.close(1)
 					sleep(0.5 SECONDS)
 
 					if(!src.isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-						src.locked = 1
-						playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
-
-					src.UpdateIcon()
+						src.set_locked()
 					sleep(src.operation_time)
 					src.send_status(,senderid)
 
@@ -1959,6 +1940,15 @@ TYPEINFO(/obj/machinery/door/airlock)
 
 			send_status(user_name)
 			src.last_update_time = ticker.round_elapsed_ticks
+
+	set_locked()
+		. = ..()
+		playsound(src, 'sound/machines/airlock_bolt.ogg', 40, 1, -2)
+
+	set_unlocked()
+		. = ..()
+		playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, 1, -2)
+
 
 	allowed(mob/living/carbon/human/user)
 		. = ..()

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -613,6 +613,23 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 		close()
 	else return
 
+/// toggles the lock state of the door
+/obj/machinery/door/proc/toggle_locked()
+	if (locked)
+		set_unlocked()
+	else
+		set_locked()
+
+/// locks the door, aka bolt / key lock
+/obj/machinery/door/proc/set_locked()
+	src.locked = TRUE
+	src.UpdateIcon()
+
+/// unlocks the door, aka unbolt / un-key lock
+/obj/machinery/door/proc/set_unlocked()
+	src.locked = FALSE
+	src.UpdateIcon()
+
 /obj/machinery/door/proc/knockOnDoor(mob/user)
 	if(!ON_COOLDOWN(user, "knocking_cooldown", KNOCK_DELAY)) //slow the fuck down cowboy
 		attack_particle(user,src)
@@ -760,7 +777,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 			if (!(checkdir & src.lock_dir))
 				boutput(user, "<span class='alert'>[src]'s keyhole isn't on this side!</span>")
 				return
-		src.locked = !src.locked
+		src.toggle_locked()
 		src.visible_message("<span class='notice'><B>[user] [!src.locked ? "un" : null]locks [src].</B></span>")
 		return
 	else if (isscrewingtool(I) && src.locked)
@@ -770,7 +787,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 		src.visible_message("<span class='alert'><B>[user] smashes through the door!</B></span>")
 		playsound(src, 'sound/impact_sounds/Generic_Hit_Heavy_1.ogg', 50, 1)
 		src.operating = -1
-		src.locked = 0
+		src.set_unlocked()
 		open()
 		return 1
 	if (!src.locked)
@@ -808,7 +825,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 		if (!(checkdir & src.lock_dir))
 			boutput(user, "<span class='alert'>[src]'s lock isn't on this side!</span>")
 			return
-	src.locked = !src.locked
+	src.toggle_locked()
 	src.visible_message("<span class='notice'><B>[user] [!src.locked ? "un" : null]locks [src].</B></span>")
 	return
 
@@ -855,7 +872,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 
 	onEnd()
 		..()
-		src.the_door.locked = 0
+		src.the_door.set_unlocked()
 		owner.visible_message("<span class='alert'>[owner] jimmies [src.the_door]'s lock open!</span>")
 		playsound(src.the_door, 'sound/items/Screwdriver2.ogg', 50, 1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Refactors door locking and unlocking into procs
* Limits ionstorm to affecting airlocks


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Improves maintainability, locking airlocks made use of playsound and UpdateIcon procs scattered in the code. These are now bundled in.
* ionstorm could set lock state on doors that should not be lockable such as modern fire doors, resulting in invalid icon_state values and invisible blockages in doorways
* fixes minor bug where airlocks bolted by ion storms did not play the associated door bolt sound