### PR TITLE
Fix for tile stack count check

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1968,7 +1968,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 
 		// Don't replace with an [else]! If a prying tool is found above [intact] might become 0 and this runs too, which is how floor swapping works now! - BatElite
 		if (!intact)
-			if(T.change_stack_amount(-1))
+			if(T.amount >= 1)
 				restore_tile()
 				src.plate_mat = src.material
 				if(C.material)
@@ -1977,6 +1977,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 
 				if(!istype(src.material, /datum/material/metal/steel))
 					logTheThing(LOG_STATION, user, "constructs a floor (<b>Material:</b>: [src.material && src.material.name ? "[src.material.name]" : "*UNKNOWN*"]) at [log_loc(src)].")
+				T.change_stack_amount(-1)
 			//if(T && (--T.amount < 1))
 			//	qdel(T)
 			//	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Restructures a use of change_stack_amount in floors.dm that was depleting the last tile in a floor tile stack before its material could be used.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #8416.