### PR TITLE
Changes a "2053" to "[CURRENT_SPACE_YEAR]" in rubber stamps.

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -242,7 +242,7 @@
 	var/obj/O = user.equipped()
 	var/time_type = istype(O, /obj/item/stamp/clown) ? "HONK O'CLOCK" : "SHIFT TIME"
 	var/T = ""
-	T = time_type + ": [time2text(world.timeofday, "DD MMM 2053, hh:mm:ss")]"
+	T = time_type + ": [time2text(world.timeofday, "DD MMM [CURRENT_SPACE_YEAR], hh:mm:ss")]"
 
 	// TODO: change this awful array name & stampAssetType
 	var/stamp_assets = list(


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CLEANLINESS][OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces an instance of the year 2053 in rubber stamp code to instead use the global `CURRENT_SPACE_YEAR` define, which at present is a macro for 2053.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hear me out, as silly as it might sound. What if it *wasn't* 2053? Our stamps would be hilaaaariously out of date!