### PR TITLE
Makes Signifer II stun mode fully automatic.

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1669,7 +1669,6 @@ TYPEINFO(/obj/item/gun/energy/wasp)
 	New()
 		set_current_projectile(new/datum/projectile/energy_bolt/signifer_tase)
 		projectiles = list(current_projectile,new/datum/projectile/laser/signifer_lethal)
-		..()
 		AddComponent(/datum/component/holdertargeting/fullauto, 1.5, 1.5, 1)
 		..()
 

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1670,15 +1670,18 @@ TYPEINFO(/obj/item/gun/energy/wasp)
 		set_current_projectile(new/datum/projectile/energy_bolt/signifer_tase)
 		projectiles = list(current_projectile,new/datum/projectile/laser/signifer_lethal)
 		..()
+		AddComponent(/datum/component/holdertargeting/fullauto, 1.5, 1.5, 1)
+		..()
 
 	update_icon()
 		..()
 		if(!src.two_handed)// && current_projectile.type == /datum/projectile/energy_bolt)
+			src.current_projectile.fullauto_valid = TRUE
 			src.icon_state = "signifer_2"
 			src.item_state = "signifer_2"
 			muzzle_flash = "muzzle_flash_elec"
 			shoot_delay = 2
-			spread_angle = 0
+			spread_angle = 8
 			force = 9
 			w_class = W_CLASS_NORMAL
 		else //if (current_projectile.type == /datum/projectile/laser)


### PR DESCRIPTION
[A-Game-Objects] [C-Balance] [C-QoL] [E-Input-Wanted]

## About the PR 
Makes Signifer II handgun mode full auto and makes in less pain to use in general. Gives it a bit more spread angle as well.

## Why's this needed? 
Signifer II stun mode was in general very painful to use because of the spam click it required. Some HoS players say it's very uncomfortable to use and that it would be better as a full auto gun.
Signifier II stun mode on full auto drains energy pretty quickly, has decent spread angle and doesn't stun for that long so it seems good in terms of balance.

## Changelog 

```changelog
(u)Sian
(+)Makes Signifer II stun mode fully automatic.
```
