### PR TITLE
VR Antagonist Fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -258,19 +258,30 @@ datum/mind
 				return TRUE
 		return FALSE
 
-	/// Attempts to remove existing antagonist datums of ID role_id from this mind.
-	proc/remove_antagonist(role_id, source = null)
-		for (var/datum/antagonist/A as anything in src.antagonists)
-			if (A.id == role_id)
-				A.remove_self(TRUE, source)
-				src.antagonists.Remove(A)
-				if (!length(src.antagonists) && src.special_role == A.id)
-					src.special_role = null
-					ticker.mode.traitors.Remove(src)
-					ticker.mode.Agimmicks.Remove(src)
-				qdel(A)
-				return TRUE
-		return FALSE
+	/// Attempts to remove existing antagonist datums of ID `role` from this mind, or if provided, a specific instance of an antagonist datum.
+	proc/remove_antagonist(role, source = null)
+		var/datum/antagonist/antagonist_role
+		if (istype(role, /datum/antagonist))
+			antagonist_role = role
+
+		else if (istext(role))
+			for (var/datum/antagonist/A as anything in src.antagonists)
+				if (A.id == role)
+					antagonist_role = A
+					break
+
+		if (!antagonist_role)
+			return FALSE
+
+		antagonist_role.remove_self(TRUE, source)
+		src.antagonists.Remove(antagonist_role)
+		if (!length(src.antagonists) && src.special_role == antagonist_role.id)
+			src.special_role = null
+			ticker.mode.traitors.Remove(src)
+			ticker.mode.Agimmicks.Remove(src)
+		qdel(antagonist_role)
+
+		return TRUE
 
 	/// Removes ALL antagonists from this mind. Use with caution!
 	proc/wipe_antagonists()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2142,7 +2142,7 @@ var/global/noir = 0
 			if (tgui_alert(usr, "Remove the [antag.display_name] antagonist from [M.real_name] (ckey [M.ckey])?", "antagonist", list("Yes", "Cancel")) != "Yes")
 				return
 			boutput(usr, "<span class='notice'>Removing antagonist of type \"[antag.id]\" from mob [M.real_name] (ckey [M.ckey])...</span>")
-			var/success = M.mind.remove_antagonist(antag.id)
+			var/success = M.mind.remove_antagonist(antag)
 			if (success)
 				boutput(usr, "<span class='notice'>Removal successful.[length(M.mind.antagonists) ? "" : " As this was [M.real_name] (ckey [M.ckey])'s only antagonist role, their antagonist status is now fully removed."]</span>")
 			else

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -81,12 +81,14 @@ ABSTRACT_TYPE(/datum/antagonist)
 		if (take_gear)
 			src.remove_equipment()
 
-		src.remove_from_image_groups()
 		src.remove_objectives()
 
-		if (!src.silent && !src.pseudo)
-			src.announce_removal(source)
-			src.announce_objectives()
+		if (!src.pseudo)
+			src.remove_from_image_groups()
+
+			if (!src.silent)
+				src.announce_removal(source)
+				src.announce_objectives()
 
 	/// Returns TRUE if this antagonist can be assigned to the given mind, and FALSE otherwise. This is intended to be special logic, overriden by subtypes; mutual exclusivity and other selection logic is not performed here.
 	proc/is_compatible_with(datum/mind/mind)
@@ -250,7 +252,7 @@ ABSTRACT_TYPE(/datum/antagonist)
 
 	proc/on_death()
 		if (src.remove_on_death)
-			src.owner.remove_antagonist(src.id, ANTAGONIST_REMOVAL_SOURCE_DEATH)
+			src.owner.remove_antagonist(src, ANTAGONIST_REMOVAL_SOURCE_DEATH)
 
 //this is stupid, but it's more reliable than trying to keep signals attached to mobs
 /mob/death()

--- a/code/modules/antagonists/changeling/abilities/_changeling_ability_holder.dm
+++ b/code/modules/antagonists/changeling/abilities/_changeling_ability_holder.dm
@@ -125,7 +125,7 @@
 		// Remove changeling critter antagonist roles, as the mind is removed from the critter prior to death.
 		for (var/datum/antagonist/antag in mind_to_be_transferred.antagonists)
 			if (istype(antag, /datum/antagonist/subordinate/changeling_critter))
-				mind_to_be_transferred.remove_antagonist(antag.id)
+				mind_to_be_transferred.remove_antagonist(antag)
 
 		// Remove any previous hivemind member roles, and add a new one.
 		mind_to_be_transferred.remove_antagonist(ROLE_CHANGELING_HIVEMIND_MEMBER)

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -368,7 +368,7 @@ TYPEINFO(/obj/machinery/clonepod)
 			for (var/datum/antagonist/antag in src.occupant.mind.antagonists)
 				if (!antag.remove_on_clone)
 					continue
-				var/success = src.occupant.mind.remove_antagonist(antag.id)
+				var/success = src.occupant.mind.remove_antagonist(antag)
 				if (success)
 					logTheThing(LOG_COMBAT, src.occupant, "Cloning pod removed [antag.display_name] antag status.")
 				else


### PR DESCRIPTION
[Internal] [Bug]


## About The PR:
Fixes VR antagonists removing non-VR antagonist datums should a mind possess more than one datum of the same type, such as roundstart wizards using VR, opting to become a VR wizard, then being deprived of their real wizard antagonist status when they log out. This has been fixed by permitting `remove_antagonist()` to accept a reference to an antagonist datum as its `role` argument.
Additionally fixes pseudo antagonists attempting to remove their owner from client image groups that they are not registered to.