### PR TITLE
I made a camera that turns creatures into StG cards. Want it as an admin-only item? 

### DIFF
--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -424,7 +424,7 @@ TYPEINFO(/obj/item/camera/large)
 				stg_area_table += list(/area/station/crew_quarters/cafeteria, /datum/playing_card/griffening/area/cafeteria)
 				stg_area_table += list(/area/shuttle/escape, /datum/playing_card/griffening/area/shuttle)
 				stg_area_table += list(/area/station/maintenance, /datum/playing_card/griffening/effect/disarm) // surprisingly no maint area card!
-				stg_area_table += list(/area/station/science, /datum/playing_card/griffening/effect/) // or a sci card
+				stg_area_table += list(/area/station/science, /datum/playing_card/griffening/effect/Telescientist) // or a sci card
 				stg_area_table += list(/area/station, /datum/playing_card/griffening/effect/abandoned_crate) // Atleast you're still on station right?
 
 				for(var/list/compare_area in stg_area_table)

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -219,7 +219,6 @@ TYPEINFO(/obj/item/camera/large)
 			card.name += " [atk]/[def]"
 			card.desc = card_data_creature.card_data
 			card.desc += " ATK [atk] | DEF [def]"
-			// good thing these aren't undef'd! dont wanna have to dupe the defines
 			switch(victim.gender)
 				if(MALE)
 					icon_state_num = rand(1,STGCARD_NUMBER_F)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a magic camera under the `/obj/item/camera/stg` path that turns people photographed by it into talking _Spaceman: The Griffening_ cards. Critters and creatures can also be made into cards. 
People without a respective antag or job mob card or critters without a corresponding friend card get turned into random generic cards that are noted to be "not tournament legal". If you miss and photograph the floor, you get an area or effect card corresponding to the location, and if you somehow fail at doing that, you get rewarded the expensive card for your **total misplay**.
This is obviously a big reference to a game i really like. But, well, this game runs primarily on cool references. And it is admin only.
Also, cameras can have varying costs of film to them now. Default 1, the magic camera uses 10.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I made this to prove that it could be done. Now I have nothing left to do but to put it into master, so you can have it too.
I was also told that it was "cool" and "neeeeerdy" and "pretty sick" and "amazing" and "i love this, i would want to become a trading card if it was added" when posting videos on discord, so i am further encouraged by warm reception.

## Short demonstrations

https://github.com/goonstation/goonstation/assets/25937686/f909c5c0-c834-4283-a0ab-b9f4fee3523f

https://github.com/goonstation/goonstation/assets/25937686/0e41ca75-57e9-4075-8f7e-fe7e233e81d4