### PR TITLE
Replaces critter gaunlet mimics with a subtype that does not sting

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -1041,7 +1041,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 		name = "Mimic"
 		point_cost = 1
 		count = 6
-		types = list(/mob/living/critter/mimic)
+		types = list(/mob/living/critter/mimic/virtual)
 
 	meaty
 		name = "Meat Thing"

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -174,3 +174,12 @@
 		HH.can_range_attack = FALSE
 		var/datum/limb/small_critter/L = HH.limb
 		L.max_wclass = W_CLASS_SMALL
+
+/mob/living/critter/mimic/virtual
+	add_abilities = list(/datum/targetable/critter/mimic, /datum/targetable/critter/tackle)
+
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
+		if(!pounce.disabled && pounce.cooldowncheck())
+			pounce.handleCast(target)
+			return TRUE

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -105,7 +105,7 @@
 	critter_ability_attack(mob/target)
 		var/datum/targetable/critter/sting/mimic/sting = src.abilityHolder.getAbility(/datum/targetable/critter/sting/mimic)
 		var/datum/targetable/critter/tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
-		if(!sting.disabled && sting.cooldowncheck())
+		if(sting != null && !sting.disabled && sting.cooldowncheck())
 			sting.handleCast(target)
 			return TRUE
 		if(!pounce.disabled && pounce.cooldowncheck())
@@ -176,10 +176,4 @@
 		L.max_wclass = W_CLASS_SMALL
 
 /mob/living/critter/mimic/virtual
-	add_abilities = list(/datum/targetable/critter/mimic, /datum/targetable/critter/tackle)
-
-	critter_ability_attack(mob/target)
-		var/datum/targetable/critter/tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
-		if(!pounce.disabled && pounce.cooldowncheck())
-			pounce.handleCast(target)
-			return TRUE
+		add_abilities = list(/datum/targetable/critter/mimic, /datum/targetable/critter/tackle)

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -105,10 +105,10 @@
 	critter_ability_attack(mob/target)
 		var/datum/targetable/critter/sting/mimic/sting = src.abilityHolder.getAbility(/datum/targetable/critter/sting/mimic)
 		var/datum/targetable/critter/tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle)
-		if(sting != null && !sting.disabled && sting.cooldowncheck())
+		if(sting && !sting.disabled && sting.cooldowncheck())
 			sting.handleCast(target)
 			return TRUE
-		if(!pounce.disabled && pounce.cooldowncheck())
+		if(pounce && !pounce.disabled && pounce.cooldowncheck())
 			pounce.handleCast(target)
 			return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds a subtype of mimics, /mob/living/critter/mimic/virtual, that is identical to the parent, but cannot sting, and replaces the critter gauntlet mimics with it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Going permablind in two stings in the critter gauntlet, and having 0 way to fix/mitigate this, is kinda dumb.

Fixes(?) #14068

