### PR TITLE
Cargo appraiser requisition support

### DIFF
--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -399,7 +399,7 @@ ABSTRACT_TYPE(/datum/req_contract)
 	proc/assess_sale(obj/storage/crate/sell_crate)
 		var/contents_index = list() ///Registry of everything in crate, including contents of item containers within it
 		var/eval_message = "<font color=#FF9900>Contents insufficient for marked requisition" ///Message returned on failed evaluation, appended later
-		var/successes_needed = length(src.rc_entries) //Decremented with each successful fulfillment, reach 0 to win
+		var/successes_needed = length(src.rc_entries) ///Decremented with each successful fulfillment, reach 0 to win
 
 		contents_index += sell_crate.contents
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -1037,8 +1037,8 @@ TYPEINFO(/obj/item/device/appraisal)
 					if(C.delivery_destination == "REQ_THIRDPARTY")
 						out_text = "<strong>Cannot evaluate third-party sales.</strong><br>"
 					else if (RC.req_code == C.delivery_destination)
-						var/evaluated = RC.assess_sale(C)
-						if(evaluated == "Contracts sufficient for marked requisition.")
+						var/evaluated = RC.requisify(C,TRUE)
+						if(evaluated == "Contents sufficient for marked requisition.")
 							sell_value = RC.payout
 						out_text = "<strong>[evaluated]</strong><br>"
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -1034,7 +1034,7 @@ TYPEINFO(/obj/item/device/appraisal)
 						sell_value = shippingmarket.appraise_value(C.contents, T.goods_buy, sell = 0)
 						out_text = "<strong>Prices from [T.name]</strong><br>"
 				for (var/datum/req_contract/RC in shippingmarket.req_contracts)
-					if(C.req_code == "REQ_THIRDPARTY")
+					if(C.delivery_destination == "REQ_THIRDPARTY")
 						out_text = "<strong>Cannot evaluate third-party sales.</strong><br>"
 					else if (RC.req_code == C.delivery_destination)
 						var/evaluated = RC.assess_sale(C)

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -1033,6 +1033,14 @@ TYPEINFO(/obj/item/device/appraisal)
 					if (T.crate_tag == C.delivery_destination)
 						sell_value = shippingmarket.appraise_value(C.contents, T.goods_buy, sell = 0)
 						out_text = "<strong>Prices from [T.name]</strong><br>"
+				for (var/datum/req_contract/RC in shippingmarket.req_contracts)
+					if(C.req_code == "REQ_THIRDPARTY")
+						out_text = "<strong>Cannot evaluate third-party sales.</strong><br>"
+					else if (RC.req_code == C.delivery_destination)
+						var/evaluated = RC.assess_sale(C)
+						if(evaluated == "Contracts sufficient for marked requisition.")
+							sell_value = RC.payout
+						out_text = "<strong>[evaluated]</strong><br>"
 
 			if (sell_value == -1)
 				// no trader on the crate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds support for the cargo appraiser to properly analyze crates bar-coded for market requisitions, returning a success or failure message, and in the latter case an itemized list of all entries that have not been adequately satisfied by current crate contents (and the extent to which they haven't been satisfied).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Significantly improves gameplay for quartermasters fulfilling market requisitions, as you no longer need to send out a crate to find out whether its contents were valid, and should make any incorrect evaluation behavior a lot easier for users to diagnose and report.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Cargo appraisers can now evaluate market requisition fulfillment by scanning a crate with an appropriate bar code applied.
```
