### PR TITLE
Makes it so outside armoury perimeter is unaffected by radstorms

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -3767,6 +3767,7 @@ TYPEINFO(/area/station/turret_protected/AIbaseoutside)
 /area/station/turret_protected/armory_outside
 	name = "Armory Outer Perimeter"
 	icon_state = "secext"
+	do_not_irradiate = 1
 	requires_power = FALSE
 	minimaps_to_render_on = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping] [qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the outside of the armoury is unaffected by radstorm, as it's well, outside, in space.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because it's it's inconsistent with the others outside areas, that don't get irradiated during radstorms.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Not needed in my opinion.
