### PR TITLE
Miscellaneous map fixes

### DIFF
--- a/assets/maps/prefabs/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/prefab_customs_shuttle.dmm
@@ -16,7 +16,6 @@
 "aJ" = (
 /obj/table/regal/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_fpen/few,
-/obj/table/regal/auto,
 /obj/item/reagent_containers/food/drinks/bottle/bojackson{
 	desc = "This bottle, is Ambrosia worthy of the gods, aged using cutting edge technology  f- wha... ITS ALL GONE!";
 	initial_volume = 0;

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -50566,6 +50566,7 @@
 	pixel_x = 1;
 	pixel_y = 10
 	},
+/obj/item/clothing/mask/breath,
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "pBK" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -72210,9 +72210,6 @@
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /turf/unsimulated/floor/plating/scorched,
 /area/crater)
-"nrT" = (
-/turf/unsimulated/wall/auto/virtual,
-/area/space)
 "nrU" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/unsimulated/floor/grime,
@@ -109385,7 +109382,7 @@ jnw
 jnw
 jnw
 bKx
-nrT
+cnw
 aab
 aab
 bMw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Removes a wall from VR outside of the Solarium ship, that I suppose got misplaced.
- Fixes double stacked regal table in the HoP ship prefab.
- Adds breath masks to the suit storage in the QM podbay in Donut 3.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Polish!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Not needed.
