### PR TITLE
allows bread to roll a chance after enough teleporting to turn into a mimic

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -71,6 +71,8 @@
 	#define COMSIG_MOVABLE_POST_RADIO_PACKET "mov_post_radio_packet"
 	/// when an atom hits something when being thrown (thrown_atom, hit_target, /datum/thrown_thing)
 	#define COMSIG_MOVABLE_HIT_THROWN "mov_hit_thrown"
+	/// when an AM is teleported by do_teleport
+	#define COMSIG_MOVABLE_TELEPORTED "mov_teleport"
 
 	// ---- complex ----
 

--- a/code/modules/food_and_drink/bread.dm
+++ b/code/modules/food_and_drink/bread.dm
@@ -41,7 +41,7 @@
 	proc/mutate()
 		src.teleport_count += 1
 		if (src.teleport_count > src.teleport_requirement)
-			if (prob((src.teleport_count-src.teleport_requirement) * 0.01))
+			if (prob(0.01))
 				src.become_mimic()
 
 	attackby(obj/item/W, mob/user)

--- a/code/modules/food_and_drink/bread.dm
+++ b/code/modules/food_and_drink/bread.dm
@@ -15,6 +15,19 @@
 	initial_reagents = "bread"
 	food_effects = list("food_hp_up")
 
+	/// how many times the bread has been teleported
+	var/teleport_count = 0
+	/// the number of teleports to start rolling to turn into a mimic
+	var/teleport_requirement = 100
+
+	New()
+		..()
+		src.RegisterSignal(src,COMSIG_MOVABLE_TELEPORTED,PROC_REF(mutate))
+
+	disposing()
+		src.UnregisterSignal(src,COMSIG_MOVABLE_TELEPORTED)
+		..()
+
 	attack(mob/M, mob/user, def_zone)
 		if (user == M)
 			boutput(user, "<span class='alert'>You can't just cram that in your mouth, you greedy beast!</span>")
@@ -23,6 +36,13 @@
 		else
 			user.visible_message("<span class='alert'><b>[user]</b> futilely attempts to shove [src] into [M]'s mouth!</span>")
 			return
+
+	/// rolls to turn the bread loaf into a mimic once the requirement is reached
+	proc/mutate()
+		src.teleport_count += 1
+		if (src.teleport_count > src.teleport_requirement)
+			if (prob((src.teleport_count-src.teleport_requirement) * 0.01))
+				src.become_mimic()
 
 	attackby(obj/item/W, mob/user)
 		if (iscuttingtool(W) || issawingtool(W))

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2374,7 +2374,7 @@
 			for(var/atom/movable/M in src.loc)
 				if(M == src || M.invisibility || M.anchored) continue
 				logTheThing(LOG_STATION, M, "entered [src] at [log_loc(src)] and teleported to [log_loc(picked)]")
-				M.set_loc(get_turf(picked.loc))
+				do_teleport(M,get_turf(picked.loc),FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				count_sent++
 			input.signal = count_sent
 			SPAWN(0)

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -484,7 +484,9 @@ TYPEINFO(/obj/machinery/networked/telepad)
 				logTheThing(LOG_STATION, usr, "sent [constructTarget(which,"station")] to [log_loc(target)] from [log_loc(src)] with a telepad")
 			else
 				logTheThing(LOG_STATION, usr, "sent [log_object(which)] from [log_loc(which)] to [log_loc(src)] with a telepad")
-			which.set_loc(target)
+			// teleblock checks should already be done
+			do_teleport(which,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
+
 
 		showswirl_out(src.loc)
 		leaveresidual(src.loc)
@@ -516,7 +518,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 				logTheThing(LOG_STATION, usr, "received [constructTarget(which,"station")] from [log_loc(which)] to [log_loc(src)] with a telepad")
 			else
 				logTheThing(LOG_STATION, usr, "received [log_object(which)] from [log_loc(which)] to [log_loc(src)] with a telepad")
-			which.set_loc(src.loc)
+			do_teleport(which,src.loc,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 		showswirl(src.loc)
 		leaveresidual(src.loc)
 		showswirl_out(receiveturf)
@@ -545,14 +547,14 @@ TYPEINFO(/obj/machinery/networked/telepad)
 			if(O.anchored) continue
 			receive.Add(O)
 		for(var/atom/movable/O in send)
-			O.set_loc(target)
+			do_teleport(O,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 			if(ismob(O))
 				logTheThing(LOG_STATION, usr, "sent [constructTarget(O,"station")] to [log_loc(target)] from [log_loc(src)] with a telepad")
 
 		for(var/atom/movable/O in receive)
 			if(ismob(O))
 				logTheThing(LOG_STATION, usr, "received [constructTarget(O,"station")] from [log_loc(O)] to [log_loc(src)] with a telepad")
-			O.set_loc(src.loc)
+			do_teleport(O,src.loc,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 		showswirl(src.loc)
 		showswirl(target)
 		use_power(500000)
@@ -631,7 +633,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 					for(var/atom/movable/O as obj|mob in src.loc)
 						if(O.anchored) continue
 						target = pick(turfs)
-						if(target) O.set_loc(target)
+						if(target) do_teleport(O,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				qdel(turfs)
 				return
 			if("ignite")
@@ -687,7 +689,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 					for(var/atom/movable/O as obj|mob in src.loc)
 						if(O.anchored) continue
 						target = pick(turfs)
-						if(target) O.set_loc(target)
+						if(target) do_teleport(O,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				qdel(turfs)
 				return
 			if("brute")
@@ -729,7 +731,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 					for(var/atom/movable/O as obj|mob in src.loc)
 						if(O.anchored) continue
 						target = pick(turfs)
-						if(target) O.set_loc(target)
+						if(target) do_teleport(O,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				qdel(turfs)
 				return
 			if("minorsummon")
@@ -765,7 +767,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 					turfs += T
 				var/turf = pick(turfs)
 				for(var/atom/movable/O as obj|mob in turf)
-					O.set_loc(src.loc)
+					do_teleport(O,src.loc,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				return
 			if("areascatter")
 				var/list/turfs = new
@@ -779,7 +781,7 @@ TYPEINFO(/obj/machinery/networked/telepad)
 					for(var/atom/movable/O as obj|mob in oview(src,5))
 						if(O.anchored) continue
 						target = pick(turfs)
-						if(target) O.set_loc(target)
+						if(target) do_teleport(O,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 				qdel(turfs)
 				return
 			if("majorsummon")

--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -207,6 +207,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/teleport/portal_generator, proc/engage, proc
 			return 1
 
 	M.set_loc(tmploc)
+	SEND_SIGNAL(M,COMSIG_MOVABLE_TELEPORTED)
+
 	if (sparks)
 		elecflash(M, power=3)
 	return 0

--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -66,7 +66,7 @@ var/list/special_places = list() //list of location names, which are coincidenta
 				if(ismob(M))
 					var/mob/O = M
 					O.changeStatus("stunned", 2 SECONDS)
-				SPAWN(6 DECI SECONDS) M.set_loc(target)
+				SPAWN(6 DECI SECONDS) do_teleport(M,target,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 			SPAWN(1 SECOND) busy = 0
 			return 1
 		return 0
@@ -91,7 +91,7 @@ var/list/special_places = list() //list of location names, which are coincidenta
 				if(ismob(M))
 					var/mob/O = M
 					O.changeStatus("stunned", 2 SECONDS)
-				SPAWN(6 DECI SECONDS) M.set_loc(src.loc)
+				SPAWN(6 DECI SECONDS) do_teleport(M,src.loc,FALSE,use_teleblocks=FALSE,sparks=FALSE)
 			SPAWN(1 SECOND) busy = 0
 			return 1
 		return 0


### PR DESCRIPTION
[OBJECTS] [FEATURE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- bread loaves now track how many times they've been teleported and now have a variable to determine the threshold when they start rolling to become a mimic
    - as of writing this, the threshold is 100 teleports

- adds a signal (COMSIG_MOVABLE_TELEPORTED) for when a movable atom is teleported through do_teleport
adjusts some things to use do_teleport

- makes teleporting bread after hitting the threshold roll to become a mimic
    - prob( 0.01 )

mimics are annoying sometimes so hopefully i made this annoying enough to achieve

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
funny reference


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(*)Teleporting bread excessively now rarely can cause dangerous results
