### PR TITLE
fix light fixture build dir getting lost

### DIFF
--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -128,7 +128,7 @@
 	newlight.status = 1 // LIGHT_EMPTY
 	if (istype(src,/turf/simulated/wall/auto))
 		newlight.nostick = 0
-		newlight.autoposition()
+		newlight.autoposition(light_dir)
 	newlight.add_fingerprint(user)
 	src.add_fingerprint(user)
 	user.u_equip(parts)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
currently, when you build light fixtures, the light_dir var isn't passed into src.autoposition() when building fixtures

this results in your dir being ignored when building a light fixture, 
making it impossible in some cases to attach a fixture to a wall

and in most other cases, you will not be able to control where the fixture is placed


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, especially ones i caused
