### PR TITLE
allows ice cubes to stop decomposition of corpses

### DIFF
--- a/code/mob/living/critter/bee.dm
+++ b/code/mob/living/critter/bee.dm
@@ -547,6 +547,8 @@
 			SPAWN(2 SECONDS)
 				var/obj/icecube/honeycube = new /obj/icecube(src)
 				MT.set_loc(honeycube)
+				honeycube.melttemp = T20C
+				honeycube.cooltemp = T20C
 				honeycube.name = "block of honey"
 				honeycube.desc = "It's a block of honey. I guess there's someone trapped inside? Is it Han Solo?"
 				honeycube.steam_on_death = 0

--- a/code/mob/living/life/bodytemp.dm
+++ b/code/mob/living/life/bodytemp.dm
@@ -28,6 +28,13 @@
 		else if (istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 			var/obj/machinery/atmospherics/unary/cryo_cell/C = owner.loc
 			loc_temp = C.air_contents.temperature
+		else if (istype(owner.loc,/obj/icecube))
+			var/obj/icecube/ice = owner.loc
+			loc_temp = ice.cooltemp// ice go brrrrrrrrr
+			if (owner.bodytemperature > ice.melttemp)
+				ice.takeDamage(1 * mult)
+			else if (environment.temperature > ice.melttemp)
+				ice.takeDamage(0.5 * mult)
 		else
 			loc_temp = environment.temperature
 

--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -21,7 +21,8 @@
 					istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell) || \
 					istype(owner.loc, /obj/item/reagent_containers/food/snacks/shell) || \
 					owner.reagents?.has_reagent("formaldehyde") || \
-					owner.reagents?.has_reagent("miasmosa")
+					owner.reagents?.has_reagent("miasmosa") || \
+					istype(owner.loc, /obj/icecube)
 
 			if (istype(owner.loc, /obj/machinery/traymachine/morgue)) //Morgues require power now
 				var/obj/machinery/traymachine/morgue/stinkbox = owner.loc

--- a/code/modules/antagonists/wizard/abilities/iceburst.dm
+++ b/code/modules/antagonists/wizard/abilities/iceburst.dm
@@ -98,6 +98,11 @@
 	var/steam_on_death = 1
 	var/add_underlay = 1
 
+	/// the temperature the cube will try to cool you to. changing this allows you to more aggressively cool
+	var/cooltemp = T0C
+	/// the temperature the cube will start taking damage at
+	var/melttemp = T0C
+
 	New(loc, mob/iced as mob)
 		..()
 		if(iced && !isAI(iced) && !isblob(iced) && !iswraith(iced))
@@ -117,7 +122,8 @@
 		src.health *= (rand(10,20)/10)
 
 		for(var/mob/M in src)
-			src.RegisterSignal(M, COMSIG_LIVING_LIFE_TICK, PROC_REF(PassiveCool))
+			if (!ishuman(M)) // bodytemp loop handles it for humans
+				src.RegisterSignal(M, COMSIG_LIVING_LIFE_TICK, PROC_REF(PassiveCool))
 
 	disposing()
 		processing_items.Remove(src)
@@ -163,8 +169,9 @@
 			src.pixel_y = 0
 
 	proc/PassiveCool(var/mob/M, mult)
-		if(M.bodytemperature >= 0)
-			M.bodytemperature = max(M.bodytemperature - (20 * mult),0)
+		if(M.bodytemperature >= src.cooltemp)
+			M.bodytemperature = max(M.bodytemperature - (20 * mult),src.cooltemp)
+		if(M.bodytemperature > src.melttemp)
 			takeDamage(1 * mult)
 
 	attack_hand(mob/user)


### PR DESCRIPTION
[OBJECTS] [BALANCE] [FEATURE]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- allows ice cubes to halt decomposition of a corpse

- ice cubes now also take damage from the air if its warmer than their melting temperature variable and its not melting due to body heat
(melting temperature is set to 0 C for regular ice cubes instead of being 0 K like before)
  - the temperature used to cool the occupant of the cube is a seperate variable incase that should be left at 0 K
  - damage from air temp seemed to be too fast so i slapped a 50% chance on there

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i remember one time i tried freezing a corpse until i could revive them
i realized: they still melted the ice cube even with no body heat
they also still rotted


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(*)Freezing people in ice and keeping the ice cold is now a valid way to delay corpses rotting.
