### PR TITLE
undoubled a door in oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42506,7 +42506,7 @@
 /obj/machinery/door/airlock/pyro/medical/alt{
 	name = "Cloning Room";
 	id = "cloning_door";
-	req_access_text = "5"
+	req_access_txt = "5"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42497,18 +42497,15 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "hRy" = (
-/obj/machinery/door/airlock/pyro/glass{
-	id = "cloning_door";
-	name = "Cloning Room";
-	req_access_txt = "5"
-	},
 /obj/access_spawn/medical,
 /obj/disposalpipe/segment/produce{
 	dir = 4
 	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/pyro/medical/alt,
+/obj/machinery/door/airlock/pyro/medical/alt{
+	name = "Cloning Room"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "hXh" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42504,7 +42504,9 @@
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/medical/alt{
-	name = "Cloning Room"
+	name = "Cloning Room";
+	id = "cloning_door";
+	req_access_text = "5"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42508,7 +42508,6 @@
 	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/pyro/medical/alt,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "hXh" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42508,6 +42508,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/medical/alt,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "hXh" = (


### PR DESCRIPTION
[BUG]
## About the PR
The public access door to cloning in oshan had both a medical pyro door, and a medical glass pyro door. I removed the glass one and var edited the medical airlock to match the previous.

Worryingly, a lot of doors in that general area lack names and probably further information. Might need to be looked into, but that's out of scope here.
## Why's this needed?
Fixes #14164