### PR TITLE
Adds a Cargo Teleporter, Hand Labeler, and Recharging Station to Cog1 Artlab

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -30937,8 +30937,7 @@
 	pixel_y = 2
 	},
 /obj/item/cargotele{
-	pixel_x = 4;
-	pixel_y = 10
+	pixel_x = 4
 	},
 /obj/item/wrench{
 	pixel_x = 5;
@@ -39016,8 +39015,7 @@
 "cfc" = (
 /obj/table/auto,
 /obj/machinery/recharger{
-	pixel_x = -5;
-	pixel_y = 6
+	pixel_x = 5
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -41093,14 +41091,27 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/simulated/floor,
-/area/station/science/artifact)
-"ckw" = (
 /obj/stool/chair/office{
 	dir = 8
 	},
+/turf/simulated/floor,
+/area/station/science/artifact)
+"ckw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
+	},
+/obj/table/auto,
+/obj/item/hand_labeler{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/cargotele{
+	pixel_x = -5;
+	pixel_y = -2
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -30937,7 +30937,8 @@
 	pixel_y = 2
 	},
 /obj/item/cargotele{
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 10
 	},
 /obj/item/wrench{
 	pixel_x = 5;
@@ -39015,7 +39016,8 @@
 "cfc" = (
 /obj/table/auto,
 /obj/machinery/recharger{
-	pixel_x = 5
+	pixel_x = -5;
+	pixel_y = 6
 	},
 /obj/machinery/light{
 	dir = 8;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds another table to cogmap1's artlab containing a hand labeler, a cargo teleporter, and a recharging station.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parity change, these items were already present in the artlabs of other maps such as Donut3.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
