### PR TITLE
Replaces 2 tables at Clarion escape with auto tables

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2832,7 +2832,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "ahZ" = (
-/obj/table,
+/obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
 /turf/simulated/floor/bluegreen/side{
 	dir = 8
@@ -2935,7 +2935,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "aiw" = (
-/obj/table,
+/obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
 /turf/simulated/floor/bluegreen/side{
 	dir = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Auto Tables Good, Fixes #14206

