### PR TITLE
Adds a missing security scanner to Atlas bridge

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6490,26 +6490,6 @@
 /obj/submachine/ATM,
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/eva)
-"avf" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Customs"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/access_spawn/heads,
-/obj/firedoor_spawn,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/blue,
-/area/station/bridge/customs)
 "avg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -76991,7 +76971,7 @@ hpN
 asp
 atH
 auo
-avf
+hpN
 aFO
 aWz
 azt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, one of the two doors leading to the bridge from HoP desk had a security scanner while the other did not. This adds a scanner to the other door so that no evildoer can hide from the law or whatever.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Symmetry Good!!!!!!! :D 
Oversight Bad!!!!!!! >:(



