### PR TITLE
Removes every mail booth

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -19030,13 +19030,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/sanctuary)
-"qAK" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mail_booth,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
 "qCC" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -66088,7 +66081,7 @@ agu
 agz
 ahG
 axq
-qAK
+aca
 alU
 akM
 aqo

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -33602,7 +33602,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/mail_booth,
 /turf/unsimulated/floor/orangeblack/side{
 	dir = 9
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -895,7 +895,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "adv" = (
-/obj/mail_booth,
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -73965,15 +73965,6 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/science)
-"mcz" = (
-/obj/mail_booth,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
 "mde" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -141447,7 +141438,7 @@ arJ
 aaa
 aaa
 aKm
-mcz
+aOn
 aOn
 aFz
 aIP

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -35762,7 +35762,6 @@
 /area/station/security/detectives_office)
 "lcr" = (
 /obj/machinery/light/incandescent,
-/obj/mail_booth,
 /turf/simulated/floor/escape{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -58194,15 +58194,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"rLK" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/obj/mail_booth,
-/turf/simulated/floor/arrival{
-	dir = 1
-	},
-/area/station/hangar/arrivals)
 "rLN" = (
 /obj/machinery/neosmelter,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -105260,7 +105251,7 @@ stQ
 vBJ
 rdj
 dne
-rLK
+dCV
 jUI
 czv
 sGu

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44204,12 +44204,6 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"kpI" = (
-/obj/mail_booth,
-/turf/simulated/floor/neutral/side{
-	dir = 1
-	},
-/area/station/hallway/primary/north)
 "kqg" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -120858,7 +120852,7 @@ woB
 rtj
 izx
 twQ
-kpI
+aUG
 bDT
 aKX
 aMc

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2487,14 +2487,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
-"bgC" = (
-/obj/mail_booth,
-/turf/simulated/floor/blackwhite{
-	dir = 10
-	},
-/area/station/hallway/secondary/entry{
-	name = "Arrival Shuttle Hallway"
-	})
 "bgG" = (
 /turf/simulated/floor/purpleblack{
 	dir = 8
@@ -82821,7 +82813,7 @@ rJg
 fDm
 gfS
 aiq
-bgC
+hxY
 eMn
 jQa
 aiq

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -44471,12 +44471,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/research_outpost)
-"oHI" = (
-/obj/mail_booth,
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/crew_quarters/market)
 "oID" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -102010,7 +102004,7 @@ buv
 btM
 bvO
 bwu
-oHI
+bxh
 byd
 ady
 bzU

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -73613,10 +73613,6 @@
 	temperature = 313.15
 	},
 /area/iomoon)
-"pIi" = (
-/obj/mail_booth,
-/turf/unsimulated/floor/wood,
-/area/afterlife/bar/sanctuary)
 "pJw" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater"
@@ -98554,7 +98550,7 @@ crf
 cpq
 aaa
 daM
-pIi
+daZ
 daZ
 daM
 daM


### PR DESCRIPTION
## About the PR
See title
## Why's this needed?
It said it was closing friday, but didn't say which friday. Well, i decree it to be removed now.
## Changelog
```changelog
(u)Tyrant
(+)Mail booths are now gone. No more penpals.  Should've been removed a while ago actually.
```