### PR TITLE
Parallax Cleanup And Bug Fixes

### DIFF
--- a/_std/map.dm
+++ b/_std/map.dm
@@ -6,9 +6,10 @@
 #define Z_LEVEL_MINING 5	//! The mining Z-level. Trench on underwater maps
 #define Z_LEVEL_DYNAMIC 6	//! The Z-level used for dynamically loaded maps. See: region_allocator
 
-/// A list of each z-level define and it's associated parallax layer types. See `code\map\map_settings.dm` for station-level parallax layers.
-var/list/z_level_parallax_settings = list(
+/// A list of each z-level define and it's default associated parallax layer types. See `code\map\map_settings.dm` for station-level parallax layers.
+var/list/default_z_level_parallax_settings = list(
 	"[Z_LEVEL_NULL]" = list(),
+	"[Z_LEVEL_STATION]" = list(),
 	"[Z_LEVEL_ADVENTURE]" = list(),
 	"[Z_LEVEL_DEBRIS]" = list(
 		/atom/movable/screen/parallax_layer/space_1,
@@ -24,6 +25,9 @@ var/list/z_level_parallax_settings = list(
 		/atom/movable/screen/parallax_layer/asteroids_near,
 		),
 	)
+
+/// A list of each z-level define and it's current associated parallax layer types.
+var/list/z_level_parallax_settings
 
 ///Map generation defines
 #define PERLIN_LAYER_HEIGHT "perlin_height"

--- a/assets/maps/prefabs/prefab_beesanctuary.dmm
+++ b/assets/maps/prefabs/prefab_beesanctuary.dmm
@@ -193,7 +193,9 @@
 /obj/decal/fakeobjects/pipe{
 	icon_state = "exposed"
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "hg" = (
 /obj/machinery/light{
@@ -235,7 +237,9 @@
 /area/prefab/bee_sanctuary)
 "jj" = (
 /obj/decal/floatingtiles,
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "jn" = (
 /obj/cable{
@@ -271,7 +275,9 @@
 /obj/decal/floatingtiles{
 	dir = 1
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "jJ" = (
 /obj/table/reinforced/chemistry/auto,
@@ -701,7 +707,9 @@
 /obj/decal/floatingtiles{
 	dir = 4
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "yW" = (
 /obj/grille/catwalk{
@@ -815,7 +823,9 @@
 	dir = 8;
 	icon_state = "floattiles6"
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "BC" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -997,7 +1007,9 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles3"
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "EY" = (
 /obj/critter/domestic_bee,
@@ -1047,11 +1059,15 @@
 /obj/decal/floatingtiles{
 	dir = 8
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "GD" = (
 /obj/critter/domestic_bee/zombee,
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "GY" = (
 /turf/unsimulated/floor/purpleblack/corner{
@@ -1395,7 +1411,9 @@
 	icon_state = "floattiles6"
 	},
 /obj/critter/domestic_bee/zombee,
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "Po" = (
 /obj/decal/cleanable/dirt/dirt2,
@@ -1440,7 +1458,9 @@
 	dir = 4;
 	icon_state = "floattiles3"
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "Qn" = (
 /obj/machinery/light{
@@ -1472,7 +1492,9 @@
 /area/prefab/bee_sanctuary)
 "QB" = (
 /obj/map/light/void,
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "QV" = (
 /obj/decal/fakeobjects/pipe{
@@ -1506,7 +1528,9 @@
 	pixel_x = -14;
 	pixel_y = 1
 	},
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "Ro" = (
 /obj/decal/fakeobjects/pipe{
@@ -1762,7 +1786,9 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/prefab/bee_sanctuary)
 "Ym" = (
-/turf/unsimulated/floor/void,
+/turf/unsimulated/floor/void{
+	plane = -110
+	},
 /area/prefab/bee_sanctuary)
 "Yp" = (
 /obj/river{

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -52,28 +52,8 @@ var/global/area/current_battle_spawn = null
 				living_battlers.Add(player.mind)
 
 	boutput(world, "<span class='notice'><h2>Preparing the [station_or_ship()]. Please be patient!</h2></span>")
-	// Stolen from /datum/terrainify/void
-	var/datum/station_zlevel_repair/station_repair = new
-	station_repair.ambient_light = new /image/ambient
-	station_repair.ambient_light.color = rgb(6.9, 4.20, 6.9)
-	station_repair.station_generator = new/datum/map_generator/void_generator
-	var/list/space = list()
-	for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
-		space += S
-	station_repair.station_generator.generate_terrain(space, flags=MAPGEN_IGNORE_FAUNA)
-	for (var/turf/S in space)
-		S.UpdateOverlays(station_repair.ambient_light, "ambient")
-	station_repair.clean_up_station_level()
+	generate_void()
 	map_settings.space_turf_replacement = /turf/simulated/floor/void
-	map_settings.parallax_layers = list(
-		/atom/movable/screen/parallax_layer/void,
-		/atom/movable/screen/parallax_layer/void/clouds_1,
-		/atom/movable/screen/parallax_layer/void/clouds_2,
-		)
-	for (var/client/client in clients)
-		if (client.parallax_controller)
-			client.parallax_controller.setup_z_level_parallax_layers()
-			client.parallax_controller.update_parallax_z()
 
 	// Dense borders to prevent leaving the station Z
 	for(var/x in 1 to world.maxx)

--- a/code/datums/special_r.dm
+++ b/code/datums/special_r.dm
@@ -241,6 +241,7 @@ datum/special_respawn
 		if(istype(T, /turf/simulated/floor))
 			var/turf/simulated/floor/F = T
 			if (was_eaten)
+				F.icon = 'icons/turf/floors.dmi'
 				F.icon_state = "bloodfloor_2"
 				F.name = "fleshy floor"
 			else

--- a/code/map.dm
+++ b/code/map.dm
@@ -72,6 +72,8 @@ var/global/list/mapNames = list(
 			if (!map_settings)
 				map_settings = new /datum/map_settings
 				CRASH("A mapName entry for '[src.name]' wasn't found!")
+
+			setup_z_level_parallax_settings()
 		..()
 
 //Setting maps to be underwater is handled in the map config file, aka [mapname].dm

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -53,18 +53,14 @@ var/datum/station_zlevel_repair/station_repair = new
 					if(!E)
 						new src.weather_effect(T)
 
-	proc/clean_up_station_level(replace_with_cars, add_sub)
+	proc/clean_up_station_level(replace_with_cars, add_sub, remove_parallax = TRUE)
 		mass_driver_fixup()
 		shipping_market_fixup()
 		land_vehicle_fixup(replace_with_cars, add_sub)
 		copy_gas_to_airless()
 		clear_around_beacons()
-		clear_parallax()
-
-	proc/clear_parallax()
-		map_settings.parallax_layers = list()
-		for (var/client/client in clients)
-			client.parallax_controller?.remove_parallax_layer(/atom/movable/screen/parallax_layer)
+		if (remove_parallax)
+			remove_all_parallax_layers(Z_LEVEL_STATION)
 
 	proc/land_vehicle_fixup(replace_with_cars, add_sub)
 		if(replace_with_cars)
@@ -279,24 +275,46 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 	convert_station_level(params, datum/tgui/ui)
 		if(..())
-			station_repair.ambient_light = new /image/ambient
-			station_repair.ambient_light.color = rgb(6.9, 4.20, 6.9)
+			generate_void()
 
-			station_repair.station_generator = new/datum/map_generator/void_generator
-
-			var/list/space = list()
-			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
-				space += S
-			convert_turfs(space)
-			for (var/turf/S in space)
-				S.UpdateOverlays(station_repair.ambient_light, "ambient")
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS)
+			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS, FALSE)
 
 			logTheThing(LOG_ADMIN, ui.user, "turned space into an THE VOID.")
 			logTheThing(LOG_DIARY, ui.user, "turned space into an THE VOID.", "admin")
 			message_admins("[key_name(ui.user)] turned space into THE VOID.")
 
+
+/proc/generate_void(all_z_levels = FALSE)
+	station_repair.ambient_light = new /image/ambient
+	station_repair.ambient_light.color = rgb(6.9, 4.20, 6.9)
+
+	station_repair.station_generator = new/datum/map_generator/void_generator
+
+	var/list/space = list()
+	for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
+		space += S
+	if (all_z_levels)
+		for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_DEBRIS), locate(world.maxx, world.maxy, Z_LEVEL_DEBRIS)))
+			space += S
+		for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_MINING), locate(world.maxx, world.maxy, Z_LEVEL_MINING)))
+			space += S
+
+	station_repair.station_generator.generate_terrain(space, flags = MAPGEN_ALLOW_VEHICLES * station_repair.allows_vehicles)
+	for (var/turf/S in space)
+		S.UpdateOverlays(station_repair.ambient_light, "ambient")
+
+	station_repair.clean_up_station_level()
+
+	var/list/void_parallax_layers = list(
+		/atom/movable/screen/parallax_layer/void,
+		/atom/movable/screen/parallax_layer/void/clouds_1,
+		/atom/movable/screen/parallax_layer/void/clouds_2,
+		)
+
+	add_global_parallax_layer(void_parallax_layers, z_level = Z_LEVEL_STATION)
+	if (all_z_levels)
+		add_global_parallax_layer(void_parallax_layers, z_level = Z_LEVEL_DEBRIS)
+		add_global_parallax_layer(void_parallax_layers, z_level = Z_LEVEL_MINING)
 
 /datum/terrainify/ice_moon
 	name = "Ice Moon Station"
@@ -353,7 +371,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 					station_repair.ambient_light.color = rgb(ambient_value,ambient_value+((rand()*1)),ambient_value+((rand()*1))) //randomly shift green&blue to reduce vertical banding
 					S.UpdateOverlays(station_repair.ambient_light, "ambient")
 			// Path to market does not need to be cleared because it was converted to ice.  Abyss will screw up everything!
-			station_repair.clear_parallax()
+			remove_all_parallax_layers(Z_LEVEL_STATION)
 			handle_mining(params, space)
 
 			logTheThing(LOG_ADMIN, ui.user, "turned space into an another outpost on Theta.")

--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -62,7 +62,8 @@
 
 			for (var/client/client in clients)
 				client.parallax_controller?.recolour_parallax_layers(src.space_color, 3 SECONDS)
-				client.parallax_controller?.add_parallax_layer(/atom/movable/screen/parallax_layer/blowout_clouds, 3 SECONDS, layer_params = params)
+
+			add_global_parallax_layer(/atom/movable/screen/parallax_layer/blowout_clouds, 3 SECONDS, layer_params = params)
 	#endif
 
 			world << siren
@@ -102,7 +103,8 @@
 	#ifndef UNDERWATER_MAP
 			for (var/client/client in clients)
 				client.parallax_controller?.recolour_parallax_layers(list(), 3 SECONDS)
-				client.parallax_controller?.remove_parallax_layer(/atom/movable/screen/parallax_layer/blowout_clouds, 3 SECONDS)
+
+			remove_global_parallax_layer(/atom/movable/screen/parallax_layer/blowout_clouds, 3 SECONDS)
 	#endif
 
 			sleep(rand(25 SECONDS,50 SECONDS))

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -136,8 +136,7 @@ var/global/meteor_shower_active = 0
 			if (scroll_angle)
 				var/list/params = list("scroll_angle" = scroll_angle)
 
-				for (var/client/client in clients)
-					client.parallax_controller?.add_parallax_layer(/atom/movable/screen/parallax_layer/meteor_shower, layer_params = params)
+				add_global_parallax_layer(/atom/movable/screen/parallax_layer/meteor_shower, layer_params = params)
 	#endif
 
 			var/start_x
@@ -200,8 +199,7 @@ var/global/meteor_shower_active = 0
 				S.UpdateIcon()
 
 	#ifndef UNDERWATER_MAP
-			for (var/client/client in clients)
-				client.parallax_controller?.remove_parallax_layer(/atom/movable/screen/parallax_layer/meteor_shower)
+			remove_global_parallax_layer(/atom/movable/screen/parallax_layer/meteor_shower)
 	#endif
 
 	admin_call(var/source)

--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -176,6 +176,7 @@ client/proc/replace_space_exclusive()
 			LAGCHECK(LAG_REALTIME)
 #endif
 
+		remove_all_parallax_layers()
 		message_admins("Finished space replace!")
 		map_currently_underwater = 1
 
@@ -209,11 +210,13 @@ client/proc/dereplace_space()
 					var/turf/orig = locate(F.x, F.y, F.z)
 					orig.ReplaceWith(/turf/space, FALSE, TRUE, FALSE, TRUE)
 				LAGCHECK(LAG_REALTIME)
+			restore_parallax_layers_to_default(Z_LEVEL_STATION)
 		else
 			for(var/turf/space/fluid/F in world)
 				var/turf/orig = locate(F.x, F.y, F.z)
 				orig.ReplaceWith(/turf/space, FALSE, TRUE, FALSE, TRUE)
 				LAGCHECK(LAG_REALTIME)
+			restore_parallax_layers_to_default()
 
 		message_admins("Finished space dereplace!")
 		map_currently_underwater = 0

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -67,19 +67,11 @@ var/global/parallax_enabled = TRUE
 		src.z_level_parallax_layers = list()
 
 		for (var/z_level in Z_LEVEL_NULL to Z_LEVEL_MINING)
-			if (z_level == Z_LEVEL_STATION)
-				var/list/atom/movable/screen/parallax_layer/station_parallax_layers = list()
-				for (var/parallax_layer_type as anything in map_settings.parallax_layers)
-					station_parallax_layers += new parallax_layer_type(null, src.owner)
+			var/list/atom/movable/screen/parallax_layer/z_parallax_layers = list()
+			for (var/parallax_layer_type as anything in z_level_parallax_settings["[z_level]"])
+				z_parallax_layers += new parallax_layer_type(null, src.owner)
 
-				src.z_level_parallax_layers["[Z_LEVEL_STATION]"] = station_parallax_layers
-
-			else
-				var/list/atom/movable/screen/parallax_layer/z_parallax_layers = list()
-				for (var/parallax_layer_type as anything in z_level_parallax_settings["[z_level]"])
-					z_parallax_layers += new parallax_layer_type(null, src.owner)
-
-				src.z_level_parallax_layers["[z_level]"] = z_parallax_layers
+			src.z_level_parallax_layers["[z_level]"] = z_parallax_layers
 
 		src.previous_turf = get_turf(src.owner.eye)
 		var/area/A = get_area(src.previous_turf)

--- a/code/modules/parallax/parallax_procs.dm
+++ b/code/modules/parallax/parallax_procs.dm
@@ -1,0 +1,53 @@
+/// Initialises `z_level_parallax_settings` by populating it with the default z-level parallax layers.
+/proc/setup_z_level_parallax_settings()
+	default_z_level_parallax_settings["[Z_LEVEL_STATION]"] = map_settings.parallax_layers
+
+	var/parallax_layers = list()
+	for (var/z_level in Z_LEVEL_NULL to Z_LEVEL_MINING)
+		var/list/z_level_parallax_layers = default_z_level_parallax_settings["[z_level]"]
+		parallax_layers["[z_level]"] = z_level_parallax_layers.Copy()
+
+	z_level_parallax_settings = parallax_layers
+
+
+/// Creates a new parallax layer of the specified type, or various layers should `parallax_layer_type_or_types` be a list, on the specified z-level for every client.
+/proc/add_global_parallax_layer(parallax_layer_type_or_types, animation_time = 0, z_level = Z_LEVEL_STATION, list/layer_params)
+	if (islist(parallax_layer_type_or_types))
+		var/list/parallax_layers = parallax_layer_type_or_types
+		parallax_layer_type_or_types = parallax_layers.Copy()
+
+	for (var/client/client in clients)
+		client.parallax_controller?.add_parallax_layer(parallax_layer_type_or_types, animation_time, z_level, layer_params)
+
+	z_level_parallax_settings["[z_level]"] += parallax_layer_type_or_types
+
+
+/// Removes all parallax layers of a specified type, or various types should `parallax_layer_type_or_types` be a list, not including children types, from a specified z-level for every client.
+/proc/remove_global_parallax_layer(parallax_layer_type_or_types, animation_time = 0, z_level = Z_LEVEL_STATION)
+	for (var/client/client in clients)
+		client.parallax_controller?.remove_parallax_layer(parallax_layer_type_or_types, animation_time, z_level)
+
+	z_level_parallax_settings["[z_level]"] -= parallax_layer_type_or_types
+
+
+/// Removes all parallax layers from a specified z-level, or all parallax layers from all z-levels if one is not specified.
+/proc/remove_all_parallax_layers(z_level)
+	if (z_level)
+		remove_global_parallax_layer(z_level_parallax_settings["[z_level]"], z_level = z_level)
+		return
+
+	for (var/z in Z_LEVEL_NULL to Z_LEVEL_MINING)
+		remove_global_parallax_layer(z_level_parallax_settings["[z]"], z_level = z)
+
+
+/// Restores a specified z-level's parallax layers to their default state, or all parallax layers from all z-levels if a z-level is not specified.
+/proc/restore_parallax_layers_to_default(z_level)
+	if (z_level)
+		remove_all_parallax_layers(z_level)
+		add_global_parallax_layer(default_z_level_parallax_settings["[z_level]"], z_level = z_level)
+		return
+
+	remove_all_parallax_layers()
+	for (var/z in default_z_level_parallax_settings)
+		add_global_parallax_layer(default_z_level_parallax_settings[z], z_level = z)
+

--- a/code/world.dm
+++ b/code/world.dm
@@ -526,14 +526,6 @@ var/global/mob/twitch_mob = 0
 	Z_LOG_DEBUG("World/Init", "Loading intraround jars...")
 	load_intraround_jars()
 
-	if (derelict_mode)
-		Z_LOG_DEBUG("World/Init", "Derelict mode stuff")
-		creepify_station()
-		voidify_world()
-		signal_loss = 80 // heh
-		bust_lights()
-		master_mode = "disaster" // heh pt. 2
-
 	//SpyStructures and caches live here
 	UPDATE_TITLE_STATUS("Updating cache")
 	Z_LOG_DEBUG("World/Init", "Building various caches...")
@@ -558,6 +550,14 @@ var/global/mob/twitch_mob = 0
 	Z_LOG_DEBUG("World/Init", "Setting up mining level...")
 	makeMiningLevel()
 	#endif
+
+	if (derelict_mode)
+		Z_LOG_DEBUG("World/Init", "Derelict mode stuff")
+		creepify_station()
+		voidify_world()
+		signal_loss = 80 // heh
+		bust_lights()
+		master_mode = "disaster" // heh pt. 2
 
 	UPDATE_TITLE_STATUS("Lighting up")
 	Z_LOG_DEBUG("World/Init", "RobustLight2 init...")

--- a/code/z_adventurezones/solarium.dm
+++ b/code/z_adventurezones/solarium.dm
@@ -181,6 +181,7 @@ proc/voidify_world()
 					space.name = "stomach acid"
 					if (space.z == Z_LEVEL_STATION)
 						new /obj/stomachacid(space)
+			remove_all_parallax_layers()
 		else
 			generate_void(TRUE)
 

--- a/code/z_adventurezones/solarium.dm
+++ b/code/z_adventurezones/solarium.dm
@@ -138,6 +138,7 @@ var/global/derelict_mode = 0
 				LAGCHECK(LAG_LOW)
 				space.icon_state = "howlingsun"
 				space.icon = 'icons/misc/worlds.dmi'
+			remove_all_parallax_layers()
 			playsound_global(world, 'sound/machines/lavamoon_plantalarm.ogg', 70)
 			SPAWN(1 DECI SECOND)
 				for(var/mob/living/carbon/human/H in mobs)
@@ -171,29 +172,24 @@ proc/voidify_world()
 	lobby_titlecard.set_pregame_html()
 
 	SPAWN(3 SECONDS)
-		for (var/turf/space/space in world)
-			LAGCHECK(LAG_LOW)
-			if(was_eaten)
+		if (was_eaten)
+			for (var/turf/space/space in world)
+				LAGCHECK(LAG_LOW)
 				if (space.icon_state != "acid_floor")
 					space.icon_state = "acid_floor"
 					space.icon = 'icons/misc/meatland.dmi'
 					space.name = "stomach acid"
-					if (space.z == 1)
+					if (space.z == Z_LEVEL_STATION)
 						new /obj/stomachacid(space)
-			else
-				if(space.icon_state != "darkvoid")
-					space.icon_state = "darkvoid"
-					space.icon = 'icons/turf/floors.dmi'
-					space.name = "void"
-		//var/obj/overlay/the_sun = locate("the_sun")
-		//if (istype(the_sun))
+		else
+			generate_void(TRUE)
+
 		if (the_sun)
 			var/obj/Sun = the_sun
 			Sun.icon_state = "sun_red"
 			Sun.desc = "Uhhh...."
-			Sun.blend_mode = 2 // heh
-		//var/obj/critter/the_automaton = locate("the_automaton")
-		//if (istype(the_automaton))
+			Sun.blend_mode = 2
+
 		if (the_automaton)
 			var/obj/critter/Automaton = the_automaton
 			Automaton.aggressive = 1

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1277,6 +1277,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\parallax\parallax_controller.dm"
 #include "code\modules\parallax\parallax_layer_parent.dm"
 #include "code\modules\parallax\parallax_layers.dm"
+#include "code\modules\parallax\parallax_procs.dm"
 #include "code\modules\power\apc.dm"
 #include "code\modules\power\cable.dm"
 #include "code\modules\power\cablecolors.dm"


### PR DESCRIPTION
[Internal] [Code Quality] [Bug]


## About The PR:
Implements various global procs to handle parallax layer operations across all clients on a server.
Implements global procs to handle the removal and restoration to default of all parallax layers on a specified z-level, or if no z-level is specified, all z-levels.
Permits parallax layer addition and removal procs to accept lists as their parallax layer types to add/remove argument.

Fixes a layering bugs with non-parallax void tiles in the bee sanctuary.
Additionally fixes #14211 and fixes #13920.