### PR TITLE
allow headless humans to be poured with an agressive grab

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -137,6 +137,15 @@
 
 		UpdateIcon()
 
+	afterattack(atom/target, mob/user, reach, params)
+		. = ..()
+		if (state >= GRAB_AGGRESSIVE && !istype(target,/turf))
+			if (src.affecting?.is_open_container() && src.affecting?.reagents && target.is_open_container())
+				logTheThing(LOG_CHEMISTRY, user, "transfers chemicals from [src.affecting] [log_reagents(src.affecting)] to [target] at [log_loc(user)].")
+				var/trans = src.affecting.reagents.trans_to(target, 10)
+				if (trans)
+					boutput(user, "<span class='notice'>You dump [trans] units of the solution from [src.affecting] to [target].</span>")
+
 	attack(atom/target, mob/user)
 		if (check())
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[PLAYER ACTIONS] [FEATURE] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
allows aggressive grabs to transfer the reagents of mobs that are also open containers 10 u at a time

unsure if this is a good idea

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
currently you can pour chems into a headless skeleton, but cant get the chems out of them by pouring them

makes mixing chemicals using a skeleton more viable


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(+)Headless skeletons can now have their contents poured into open containers with an aggressive grab
```
