### PR TITLE
area_that_kills_you roundstart deletion check

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -1915,7 +1915,7 @@ Returns:
 	name = "nothing"
 	icon = 'icons/obj/decals/misc.dmi'
 	icon_state = "blank"
-	anchored = ANCHORED
+	anchored = ANCHORED_ALWAYS
 	density = 0
 	opacity = 0
 	plane = PLANE_ABOVE_LIGHTING

--- a/code/area.dm
+++ b/code/area.dm
@@ -573,6 +573,10 @@ TYPEINFO(/area)
 			jerk.remove()
 
 		else if (isobj(O) && !(istype(O, /obj/overlay/tile_effect) || O.anchored == 2 || istype(O, /obj/landmark)))
+			#ifdef CHECK_MORE_RUNTIMES
+			if(current_state <= GAME_STATE_WORLD_NEW)
+				CRASH("[identify_object(O)] got deleted by area_that_kills_you_if_you_enter_it at [O.x],[O.y],[O.z] ([O.loc.loc] [O.loc.type]) during world initialization")
+			#endif
 			qdel(O)
 		. = ..()
 /area/battle_royale_spawn //People entering VR or exiting VR with stupid exploits are jerks.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
copies the cordon round-start deletion check onto the area_that_kills_you_if_you_enter_it

gives ANCHORED_ALWAYS to /obj/decal/nothing so it shouldn't get deleted roundstart
haven't tested if it actually prevents it, but it should


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://github.com/goonstation/goonstation/assets/64938519/411af383-1e15-49f0-bc04-96b3ccc8d606)
also decals nuking themselves roundstart in the afterlife bar bad


