### PR TITLE
Partial materials refactor

### DIFF
--- a/assets/maps/random_rooms/5x3/laundromat.dmm
+++ b/assets/maps/random_rooms/5x3/laundromat.dmm
@@ -36,7 +36,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/raw_material/scrap_metal/steel,
+/obj/item/raw_material/scrap_metal,
 /turf/simulated/floor/airless/plating,
 /area/dmm_suite/clear_area)
 "R" = (

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -189,7 +189,6 @@
 	name = "frozen fart"
 	desc = "Remarkable! The cold temperatures in the freezer have frozen the fart in mid-air."
 	amount = 5
-	generic_name = FALSE
 	default_material = "frozenfart"
 	mat_changename = FALSE
 	uses_material_appearance = FALSE

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -439,7 +439,7 @@
 /obj/item/material_piece/neutronium
 	desc = "Neutrons condensed into a solid form."
 	icon_state = "bar"
-	default_material = "neutronium""
+	default_material = "neutronium"
 	uses_material_appearance = TRUE
 	mat_changename = TRUE
 

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -6,9 +6,10 @@
 	icon_state = "bar"
 	max_stack = INFINITY
 	stack_type = /obj/item/material_piece
-	var/generic_name = TRUE //Does this NOT have a unique name? Should prevent stacks being named things like "frozen fart frozen farts"
 	/// used for prefab bars
 	default_material = null
+	uses_material_appearance = TRUE
+	mat_changename = TRUE //TRUE for generic names such as Bar or Wad.
 
 	New()
 		..()
@@ -19,7 +20,7 @@
 
 	_update_stack_appearance()
 		if(material)
-			name = "[amount] [generic_name ? material.name : ""] [initial(src.name)][amount > 1 ? "s":""]"
+			name = "[amount] [mat_changename ? material.name : ""] [initial(src.name)][amount > 1 ? "s":""]"
 		return
 
 	split_stack(var/toRemove)
@@ -136,6 +137,7 @@
 		blob
 			name = "chunk of blob"
 			default_material = "blob"
+			mat_changename = FALSE
 
 	sphere
 		// energy
@@ -189,38 +191,30 @@
 	amount = 5
 	generic_name = FALSE
 	default_material = "frozenfart"
+	mat_changename = FALSE
+	uses_material_appearance = FALSE
 
 /obj/item/material_piece/steel
 	desc = "A processed bar of Steel, a common metal."
 	default_material = "steel"
 	icon_state = "bar"
 	default_material = "steel"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
-
 
 /obj/item/material_piece/hamburgris
 	name = "clump"
 	desc = "A big clump of petrified mince, with a horriffic smell."
 	default_material = "hamburgris"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 	icon_state = "wad"
 
 /obj/item/material_piece/glass
 	desc = "A cut block of glass, a common crystalline substance."
 	default_material = "glass"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 	icon_state = "block"
 
 /obj/item/material_piece/copper
 	desc = "A processed bar of copper, a conductive metal."
 	default_material = "copper"
 	icon_state = "bar"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
-
 
 /obj/item/material_piece/iridiumalloy
 	icon_state = "iridium"
@@ -228,15 +222,12 @@
 	desc = "A chunk of some sort of iridium alloy plating."
 	default_material = "iridiumalloy"
 	uses_material_appearance = FALSE
-	mat_changename = TRUE
 	amount = 5
 
 /obj/item/material_piece/spacelag
 	icon_state = "bar"
 	desc = "Yep. There it is. You've done it. I hope you're happy now."
 	default_material = "spacelag"
-	uses_material_appearance = FALSE
-	mat_changename = TRUE
 	amount = 1
 
 /obj/item/material_piece/slag
@@ -244,17 +235,13 @@
 	name = "slag"
 	desc = "By-product of smelting"
 	default_material = "slag"
-	uses_material_appearance = FALSE
-	mat_changename = TRUE
-	generic_name = FALSE
+	mat_changename = FALSE
 
 /obj/item/material_piece/rubber/latex
 	name = "sheet"
 	desc = "A sheet of latex."
 	icon_state = "latex"
 	default_material = "latex"
-	uses_material_appearance = FALSE
-	mat_changename = TRUE
 
 	setup_material()
 		src.create_reagents(10)
@@ -268,7 +255,6 @@
 	default_material = "wood"
 	uses_material_appearance = FALSE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 	attackby(obj/item/W, mob/user)
 		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
@@ -308,40 +294,32 @@
 	default_material = "spidersilk"
 	uses_material_appearance = FALSE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/cloth/leather
 	name = "leather"
 	desc = "leather made from the skin of some sort of space critter."
 	icon_state = "fabric"
 	default_material = "leather"
-	uses_material_appearance = TRUE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/cloth/synthleather
 	name = "synthleather"
 	desc = "A type of artificial leather."
 	icon_state = "fabric"
 	default_material = "synthleather"
-	uses_material_appearance = TRUE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/cloth/cottonfabric
 	name = "fabric"
 	desc = "A type of natural fabric."
 	icon_state = "fabric"
 	default_material = "cotton"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/jean
 	name = "jean textile"
 	desc = "A type of a sturdy textile."
 	icon_state = "fabric"
 	default_material = "jean"
-	uses_material_appearance = TRUE
 	mat_changename = FALSE
 
 /obj/item/material_piece/cloth/brullbarhide
@@ -349,58 +327,44 @@
 	desc = "The hide of a brullbar."
 	icon_state = "fabric"
 	default_material = "brullbarhide"
-	uses_material_appearance = TRUE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/cloth/kingbrullbarhide
 	name = "king brullbar hide"
 	desc = "The hide of a king brullbar."
 	icon_state = "fabric"
 	default_material = "kingbrullbarhide"
-	uses_material_appearance = FALSE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/cloth/carbon
 	name = "fabric"
 	desc = "carbon based hi-tech material."
 	icon_state = "fabric"
 	default_material = "carbonfibre"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/dyneema
 	name = "fabric"
 	desc = "carbon nanofibres and space spider silk!"
 	icon_state = "fabric"
 	default_material = "dyneema"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/hauntium
 	name = "fabric"
 	desc = "This cloth seems almost alive."
 	icon_state = "fabric"
 	default_material = "hauntium"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/beewool
 	name = "bee wool"
 	desc = "Some bee wool."
 	icon_state = "fabric"
 	default_material = "beewool"
-	uses_material_appearance = TRUE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/soulsteel
 	desc = "A bar of soulsteel. Metal made from souls."
 	icon_state = "bar"
 	default_material = "soulsteel"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/bone
 	name = "bits of bone"
@@ -409,24 +373,18 @@
 	default_material = "bone"
 	uses_material_appearance = FALSE
 	mat_changename = FALSE
-	generic_name = FALSE
 
 /obj/item/material_piece/gnesis
 	name = "wafer"
 	desc = "A warm, pulsing block of weird alien computer crystal stuff."
 	icon_state = "bar"
 	default_material = "gnesis"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/gnesisglass
 	name = "wafer"
 	desc = "A shimmering, transclucent block of weird alien computer crystal stuff."
 	icon_state = "bar"
 	default_material = "gnesisglass"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
-	generic_name = FALSE
 
 /obj/item/material_piece/coral
 	name = "chunk"
@@ -434,27 +392,19 @@
 	icon_state = "coral"
 	default_material = "coral"
 	uses_material_appearance = FALSE
-	mat_changename = TRUE
 
 /obj/item/material_piece/neutronium
 	desc = "Neutrons condensed into a solid form."
 	icon_state = "bar"
 	default_material = "neutronium"
-	uses_material_appearance = TRUE
-	mat_changename = TRUE
 
 /obj/item/material_piece/plutonium
 	desc = "Reprocessed nuclear fuel, refined into fissile isotopes."
 	icon_state = "bar"
 	default_material = "plutonium"
-	uses_material_appearance = FALSE
-	mat_changename = FALSE
 
 /obj/item/material_piece/foolsfoolsgold
 	name = "fool's pyrite bar"
 	desc = "It's gold that isn't. Except it is. MINDFUCK"
 	icon_state = "bar"
 	default_material = "gold"
-	uses_material_appearance = FALSE
-	mat_changename = FALSE
-	generic_name = FALSE

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -420,7 +420,7 @@
 	mat_changename = TRUE
 
 /obj/item/material_piece/gnesisglass
-	name = "gnesisglass wafer"
+	name = "wafer"
 	desc = "A shimmering, transclucent block of weird alien computer crystal stuff."
 	icon_state = "bar"
 	default_material = "gnesisglass"

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -8,13 +8,10 @@
 	stack_type = /obj/item/material_piece
 	var/generic_name = TRUE //Does this NOT have a unique name? Should prevent stacks being named things like "frozen fart frozen farts"
 	/// used for prefab bars
-	var/default_material = null
+	default_material = null
 
 	New()
 		..()
-		if (istext(default_material))
-			var/datum/material/M = getMaterial(default_material)
-			src.setMaterial(M)
 		setup_material()
 
 	proc/setup_material()
@@ -138,10 +135,7 @@
 
 		blob
 			name = "chunk of blob"
-
-			setup_material()
-				src.setMaterial(getMaterial("blob"), setname = 0)
-				..()
+			default_material = "blob"
 
 	sphere
 		// energy
@@ -194,80 +188,75 @@
 	desc = "Remarkable! The cold temperatures in the freezer have frozen the fart in mid-air."
 	amount = 5
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("frozenfart"), appearance = FALSE, setname = FALSE)
-		..()
+	default_material = "frozenfart"
 
 /obj/item/material_piece/steel
 	desc = "A processed bar of Steel, a common metal."
 	default_material = "steel"
 	icon_state = "bar"
+	default_material = "steel"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
-	setup_material()
-		src.setMaterial(getMaterial("steel"), appearance = TRUE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/hamburgris
 	name = "clump"
 	desc = "A big clump of petrified mince, with a horriffic smell."
 	default_material = "hamburgris"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 	icon_state = "wad"
-
-	setup_material()
-		src.setMaterial(getMaterial("hamburgris"), appearance = TRUE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/glass
 	desc = "A cut block of glass, a common crystalline substance."
 	default_material = "glass"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 	icon_state = "block"
-
-	setup_material()
-		src.setMaterial(getMaterial("glass"), appearance = TRUE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/copper
 	desc = "A processed bar of copper, a conductive metal."
 	default_material = "copper"
 	icon_state = "bar"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
-	setup_material()
-		src.setMaterial(getMaterial("copper"), appearance = TRUE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/iridiumalloy
 	icon_state = "iridium"
 	name = "plate"
 	desc = "A chunk of some sort of iridium alloy plating."
+	default_material = "iridiumalloy"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 	amount = 5
-	setup_material()
-		src.setMaterial(getMaterial("iridiumalloy"), appearance = FALSE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/spacelag
 	icon_state = "bar"
 	desc = "Yep. There it is. You've done it. I hope you're happy now."
+	default_material = "spacelag"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 	amount = 1
-	setup_material()
-		src.setMaterial(getMaterial("spacelag"), appearance = TRUE, setname = TRUE)
-		..()
 
 /obj/item/material_piece/slag
 	icon_state = "wad"
 	name = "slag"
 	desc = "By-product of smelting"
+	default_material = "slag"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("slag"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/rubber/latex
 	name = "sheet"
 	desc = "A sheet of latex."
 	icon_state = "latex"
+	default_material = "latex"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 
 	setup_material()
-		src.setMaterial(getMaterial("latex"), appearance = FALSE, setname = TRUE)
 		src.create_reagents(10)
 		reagents.add_reagent("rubber", 10)
 		return ..()
@@ -276,10 +265,11 @@
 	name = "wooden log"
 	desc = "Years of genetic engineering mean timber always comes in mostly perfectly shaped cylindrical logs."
 	icon_state = "log"
+	default_material = "wood"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("wood"), appearance = FALSE, setname = FALSE)
-		..()
+
 	attackby(obj/item/W, mob/user)
 		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
 			user.visible_message("[user] cuts a plank from the [src].", "You cut a plank from the [src].")
@@ -295,9 +285,10 @@
 	name = "stalk"
 	desc = "Keep away from Space Pandas."
 	icon_state = "bamboo"
-	setup_material()
-		src.setMaterial(getMaterial("bamboo"), appearance = FALSE, setname = TRUE)
-		..()
+	default_material = "bamboo"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
+
 	attackby(obj/item/W, mob/user)
 		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
 			user.visible_message("[user] carefully extracts a shoot from [src].", "You carefully cut a shoot from [src], leaving behind some usable building material.")
@@ -314,158 +305,156 @@
 	name = "space spider silk"
 	desc = "space silk produced by space dwelling space spiders. space."
 	icon_state = "spidersilk"
+	default_material = "spidersilk"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("spidersilk"), appearance = FALSE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/cloth/leather
 	name = "leather"
 	desc = "leather made from the skin of some sort of space critter."
 	icon_state = "fabric"
+	default_material = "leather"
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("leather"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/cloth/synthleather
 	name = "synthleather"
 	desc = "A type of artificial leather."
 	icon_state = "fabric"
+	default_material = "synthleather"
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("synthleather"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/cloth/cottonfabric
 	name = "fabric"
 	desc = "A type of natural fabric."
 	icon_state = "fabric"
-	setup_material()
-		src.setMaterial(getMaterial("cotton"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "cotton"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/jean
 	name = "jean textile"
 	desc = "A type of a sturdy textile."
 	icon_state = "fabric"
-	setup_material()
-		src.setMaterial(getMaterial("jean"), appearance = TRUE, setname = FALSE)
-		..()
+	default_material = "jean"
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
 
 /obj/item/material_piece/cloth/brullbarhide
 	name = "brullbar hide"
 	desc = "The hide of a brullbar."
 	icon_state = "fabric"
+	default_material = "brullbarhide"
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("brullbarhide"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/cloth/kingbrullbarhide
 	name = "king brullbar hide"
 	desc = "The hide of a king brullbar."
 	icon_state = "fabric"
+	default_material = "kingbrullbarhide"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("kingbrullbarhide"), appearance = FALSE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/cloth/carbon
 	name = "fabric"
 	desc = "carbon based hi-tech material."
 	icon_state = "fabric"
-	setup_material()
-		src.setMaterial(getMaterial("carbonfibre"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "carbonfibre"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/dyneema
 	name = "fabric"
 	desc = "carbon nanofibres and space spider silk!"
 	icon_state = "fabric"
-	setup_material()
-		src.setMaterial(getMaterial("dyneema"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "dyneema"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/hauntium
 	name = "fabric"
 	desc = "This cloth seems almost alive."
 	icon_state = "fabric"
-
-	setup_material()
-		src.setMaterial(getMaterial("hauntium"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "hauntium"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/cloth/beewool
 	name = "bee wool"
 	desc = "Some bee wool."
 	icon_state = "fabric"
+	default_material = "beewool"
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("beewool"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/soulsteel
 	desc = "A bar of soulsteel. Metal made from souls."
 	icon_state = "bar"
-	setup_material()
-		src.setMaterial(getMaterial("soulsteel"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "soulsteel"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/bone
 	name = "bits of bone"
 	desc = "some bits and pieces of bones."
 	icon_state = "scrap3"
+	default_material = "bone"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("bone"), appearance = FALSE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/gnesis
 	name = "wafer"
 	desc = "A warm, pulsing block of weird alien computer crystal stuff."
 	icon_state = "bar"
-	setup_material()
-		src.setMaterial(getMaterial("gnesis"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "gnesis"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/gnesisglass
 	name = "gnesisglass wafer"
 	desc = "A shimmering, transclucent block of weird alien computer crystal stuff."
 	icon_state = "bar"
+	default_material = "gnesisglass"
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 	generic_name = FALSE
-	setup_material()
-		src.setMaterial(getMaterial("gnesisglass"), appearance = TRUE, setname = FALSE)
-		..()
 
 /obj/item/material_piece/coral
 	name = "chunk"
 	desc = "A piece of coral. Nice!"
 	icon_state = "coral"
-	setup_material()
-		src.setMaterial(getMaterial("coral"), appearance = FALSE, setname = TRUE)
-		..()
+	default_material = "coral"
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 
 /obj/item/material_piece/neutronium
 	desc = "Neutrons condensed into a solid form."
 	icon_state = "bar"
-	setup_material()
-		src.setMaterial(getMaterial("neutronium"), appearance = TRUE, setname = TRUE)
-		..()
+	default_material = "neutronium""
+	uses_material_appearance = TRUE
+	mat_changename = TRUE
 
 /obj/item/material_piece/plutonium
 	desc = "Reprocessed nuclear fuel, refined into fissile isotopes."
 	icon_state = "bar"
-	setup_material()
-		src.setMaterial(getMaterial("plutonium"), appearance = 0, setname = 0)
-		..()
+	default_material = "plutonium"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 
 /obj/item/material_piece/foolsfoolsgold
 	name = "fool's pyrite bar"
 	desc = "It's gold that isn't. Except it is. MINDFUCK"
 	icon_state = "bar"
+	default_material = "gold"
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
 	generic_name = FALSE
-
-	setup_material()
-		src.setMaterial(getMaterial("gold"), appearance = TRUE, setname = FALSE)
-		..()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -14,6 +14,11 @@
 	var/move_triggered = 0
 	var/object_flags = 0
 
+	/// Material of this object as a string, set on New()
+	var/default_material = null
+	/// Does this object use appearance from the material?
+	var/uses_material_appearance = FALSE
+
 	animate_movement = 2
 //	desc = "<span class='alert'>HI THIS OBJECT DOESN'T HAVE A DESCRIPTION MAYBE IT SHOULD???</span>"
 //heh no not really
@@ -27,6 +32,9 @@
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
 		src.update_access_from_txt()
+		// Lets stop having 5 implementations of this that all do it differently
+		if (!src.material && default_material)
+			src.setMaterial(getMaterial(default_material), src.uses_material_appearance, src.mat_changename, copy = FALSE)
 
 	Move(NewLoc, direct)
 		if(usr==0) usr = null

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -14,7 +14,7 @@
 	var/move_triggered = 0
 	var/object_flags = 0
 
-	/// Material of this object as a string, set on New()
+	/// Material id of this object as a lowercase string, set on New()
 	var/default_material = null
 	/// Does this object use appearance from the material?
 	var/uses_material_appearance = FALSE

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -56,13 +56,8 @@
 			O?.UpdateIcon() //now that we are in nullspace tell them to update
 
 	steel
-#ifdef IN_MAP_EDITOR
 		icon_state = "grille1-0"
-#endif
-		New()
-			..()
-			var/datum/material/M = getMaterial("steel")
-			src.setMaterial(M, copy=FALSE)
+		default_material = "steel"
 
 	steel/broken
 		desc = "Looks like its been in this sorry state for quite some time."
@@ -89,11 +84,9 @@
 		var/catwalk_type = "C" // Short for "Catwalk"
 		var/connects_to = list(/obj/grille/catwalk, /obj/machinery/door) // We're working differently from grilles. We don't check a list and then another, we check all possible atoms to connect to.
 		event_handler_flags = 0
-
-		New()
-			..()
-			var/datum/material/M = getMaterial("steel")
-			src.setMaterial(M, appearance = FALSE, setname = FALSE, copy = FALSE)
+		default_material = "steel"
+		uses_material_appearance = FALSE
+		mat_changename = FALSE
 
 		update_icon(special_icon_state, override_parent = TRUE)
 			if (ruined)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -61,7 +61,7 @@ MATERIAL
 	rand_pos = 1
 	inventory_counter_enabled = 1
 	default_material = "steel"
-	uses_material_appearance = FALSE
+	uses_material_appearance = TRUE
 
 	New()
 		..()

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -41,6 +41,7 @@ MATERIAL
 
 /obj/item/sheet
 	name = "sheet"
+	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon = 'icons/obj/metal.dmi'
 	icon_state = "sheet-m_5"
 	//Used to determine the right icon_state: combined with suffixes for material/reinforcement in update_appearance and one for amount in change_stack_appearance
@@ -56,12 +57,16 @@ MATERIAL
 	stamina_cost = 23
 	stamina_crit_chance = 10
 	material_amt = 0.1
-	var/datum/material/reinforcement = null
+	var/reinforcement = null
 	rand_pos = 1
 	inventory_counter_enabled = 1
+	default_material = "steel"
+	uses_material_appearance = FALSE
 
 	New()
 		..()
+		if (src.reinforcement)
+			src.set_reinforcement(getMaterial(src.reinforcement))
 		SPAWN(0)
 			update_appearance()
 		create_inventory_counter()
@@ -100,8 +105,8 @@ MATERIAL
 			else
 				src.icon_state_base += "-m"
 			src.name = "[material.name] " + src.name
-			if (istype(reinforcement))
-				src.name = "[reinforcement.name]-reinforced " + src.name
+			if (reinforcement)
+				src.name = "[reinforcement]-reinforced " + src.name
 				src.icon_state_base += "-r"
 			src.color = src.material.color
 			src.alpha = src.material.alpha
@@ -245,10 +250,10 @@ MATERIAL
 			//boutput(world, "check valid stack check 4 failed")
 			return 0
 		if (src.reinforcement && S.reinforcement)
-			if (src.reinforcement.type != S.reinforcement.type)
+			if (src.reinforcement != S.reinforcement)
 				//boutput(world, "check valid stack check 5 failed")
 				return 0
-			if (!isSameMaterial(S.reinforcement, src.reinforcement))
+			if (!isSameMaterial(getMaterial(S.reinforcement), getMaterial(src.reinforcement)))
 				//boutput(world, "check valid stack check 6 failed")
 				return 0
 		return 1
@@ -275,7 +280,7 @@ MATERIAL
 
 		var/list/availableRecipes = list()
 		if (src?.material?.material_flags & MATERIAL_METAL)
-			if (istype(src.reinforcement))
+			if (src.reinforcement)
 				for(var/recipePath in concrete_typesof(/datum/sheet_crafting_recipe/reinforced_metal))
 					availableRecipes.Add(sheet_crafting_recipe_get_ui_data(recipePath))
 
@@ -286,7 +291,7 @@ MATERIAL
 		if (src?.material?.material_flags & MATERIAL_CRYSTAL)
 			for(var/recipePath in concrete_typesof(/datum/sheet_crafting_recipe/glass))
 				availableRecipes.Add(sheet_crafting_recipe_get_ui_data(recipePath))
-			if (istype(src.reinforcement))
+			if (src.reinforcement)
 				availableRecipes.Add(sheet_crafting_recipe_get_ui_data(/datum/sheet_crafting_recipe/remetal/glass))
 		if (src?.material?.mat_id == "cardboard")
 			for(var/recipePath in concrete_typesof(/datum/sheet_crafting_recipe/cardboard))
@@ -443,75 +448,60 @@ MATERIAL
 		return
 
 /obj/item/sheet/steel
-
-	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "sheet-metal"
-
-	New()
-		..()
-		var/datum/material/M = getMaterial("steel")
-		src.setMaterial(M)
+	default_material = "steel"
+	color = "#8C8C8C"
 
 	reinforced
 		icon_state = "sheet-m-r_5"
-		New()
-			..()
-			var/datum/material/M = getMaterial("steel")
-			src.set_reinforcement(M)
+		reinforcement = "steel"
 
 /obj/item/sheet/glass
-
 	icon_state = "sheet-g_5" //overriden in-game but shows up in map editors
-	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "sheet-glass"
-
-	New()
-		..()
-		var/datum/material/M = getMaterial("glass")
-		src.setMaterial(M)
+	default_material = "glass"
+	color = "#A3DCFF"
 
 	reinforced
 		icon_state = "sheet-g-r_5"
-		New()
-			..()
-			var/datum/material/M = getMaterial("steel")
-			src.set_reinforcement(M)
+		reinforcement = "steel"
 
 	crystal
-
-		New()
-			..()
-			var/datum/material/M = getMaterial("plasmaglass")
-			src.setMaterial(M)
+		default_material = "plasmaglass"
+		color = "#A114FF"
 
 		reinforced
 			icon_state = "sheet-g-r_5"
-			New()
-				..()
-				var/datum/material/M = getMaterial("steel")
-				src.set_reinforcement(M)
+			reinforcement = "steel"
 
 /obj/item/sheet/wood
-
-	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "sheet-metal"
+	icon_state = "sheet-m_5$wood"
+	default_material = "wood"
 	amount = 10
-
-	New()
-		..()
-		var/datum/material/M = getMaterial("wood")
-		src.setMaterial(M)
 
 /obj/item/sheet/bamboo
-
-	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "sheet-metal"
+	icon_state = "sheet-m_5$$bamboo"
+	default_material = "bamboo"
 	amount = 10
 
-	New()
-		..()
-		var/datum/material/M = getMaterial("bamboo")
-		src.setMaterial(M)
+/obj/item/sheet/mauxite
+	item_state = "sheet-metal"
+	icon_state = "sheet-m_5$$mauxite"
+	default_material = "mauxite"
+	amount = 10
+
+/obj/item/sheet/electrum
+	default_material = "electrum"
+	color = "#44ACAC"
+
+	change_stack_amount(var/use_amount)
+		if (!isnum(use_amount))
+			return
+		if (isrobot(usr))
+			var/mob/living/silicon/robot/R = usr
+			R.cell.use(use_amount * 200)
 
 // RODS
 /obj/item/rods
@@ -864,11 +854,13 @@ MATERIAL
 
 
 /obj/item/rods/steel
+	color = "#8C8C8C"
+	default_material = "steel"
 
-	New()
-		..()
-		var/datum/material/M = getMaterial("steel")
-		src.setMaterial(M)
+/obj/item/rods/mauxite
+	icon_state = "rods_5$$mauxite"
+	default_material = "mauxite"
+	amount = 10
 
 // TILES
 
@@ -1029,32 +1021,14 @@ MATERIAL
 #endif
 
 /obj/item/tile/steel
-
-	New()
-		..()
-		var/datum/material/M = getMaterial("steel")
-		src.setMaterial(M)
+	default_material = "steel"
+	color = "#8C8C8C"
 
 /obj/item/tile/cardboard // for drones
 	desc = "They keep the floor in a good and walkable condition. At least, they would if they were actually made of steel."
 	force = 0
-	New()
-		..()
-		var/datum/material/M = getMaterial("cardboard")
-
-		src.setMaterial(M)
-
-/obj/item/sheet/electrum
-	New()
-		..()
-		setMaterial(getMaterial("electrum"))
-
-	change_stack_amount(var/use_amount)
-		if (!isnum(use_amount))
-			return
-		if (isrobot(usr))
-			var/mob/living/silicon/robot/R = usr
-			R.cell.use(use_amount * 200)
+	default_material = "cardboard"
+	color = "#d3b173"
 
 // kinda needed for some stuff I'm making - haine
 /obj/item/sheet/steel/fullstack

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -287,7 +287,7 @@
 	name = "pharosium ore"
 	desc = "A chunk of Pharosium, a conductive metal."
 	material_name = "Pharosium"
-	default_material = "pharosium
+	default_material = "pharosium"
 	metal = 1
 	conductor = 1
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -551,7 +551,7 @@
 	icon_state = "scrap"
 	stack_type = /obj/item/raw_material/scrap_metal
 	burn_possible = 0
-	set_name = TRUE
+	mat_changename = TRUE
 	material_name = "Steel"
 	default_material = "steel"
 
@@ -585,7 +585,7 @@
 	material_amt = 0.1
 	material_name = "Glass"
 	default_material = "glass"
-	set_name = TRUE
+	mat_changename = TRUE
 	var/sound_stepped = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
 
 	New()

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -17,8 +17,10 @@
 	var/wiggle = 6 // how much we want the sprite to be deviated fron center
 	max_stack = INFINITY
 	event_handler_flags = USE_FLUID_ENTER
-	///Does the raw material item get its name set by setMaterial()?
-	var/set_name = FALSE
+	/// Does the raw material item get its name set?
+	mat_changename = FALSE
+	uses_material_appearance = TRUE
+	default_material = null
 
 	New()
 		..()
@@ -28,8 +30,8 @@
 		if(src.material?.name)
 			initial_material_name = src.material.name
 
-	proc/setup_material()
-		src.setMaterial(getMaterial(lowertext(src.material_name)), appearance = TRUE, setname = src.set_name)
+	proc/setup_material() // Overwrite for ore specific setup
+		return
 
 	_update_stack_appearance()
 		if(material)
@@ -215,6 +217,7 @@
 	throwforce = 10
 	scoopable = 0
 	material_name = "Rock"
+	default_material = "rock"
 
 	setup_material()
 		..()
@@ -224,12 +227,14 @@
 	name = "mauxite ore"
 	desc = "A chunk of Mauxite, a sturdy common metal."
 	material_name = "Mauxite"
+	default_material = "mauxite"
 	metal = 2
 
 /obj/item/raw_material/molitz
 	name = "molitz crystal"
 	desc = "A crystal of Molitz, a common crystalline substance."
 	material_name = "Molitz"
+	default_material = "moltiz"
 	crystal = 1
 
 	get_desc()
@@ -254,11 +259,11 @@
 	desc = "An unusual crystal of Molitz."
 	icon_state = "ore$$molitz_b"
 	material_name = "Molitz Beta"
+	default_material = "molitz_b"
 	crystal = 1
 
 	setup_material()
 		. = ..()
-		src.setMaterial(getMaterial("molitz_b"), appearance = TRUE, setname = FALSE)
 		src.pressure_resistance = INFINITY //has to be after material setup. REASONS
 
 	get_desc()
@@ -282,38 +287,40 @@
 	name = "pharosium ore"
 	desc = "A chunk of Pharosium, a conductive metal."
 	material_name = "Pharosium"
+	default_material = "pharosium
 	metal = 1
 	conductor = 1
-
 
 /obj/item/raw_material/cobryl // relate this to precursors
 	name = "cobryl ore"
 	desc = "A chunk of Cobryl, a somewhat valuable metal."
 	material_name = "Cobryl"
+	default_material = "cobryl"
 	metal = 1
 
 /obj/item/raw_material/char
 	name = "char ore"
 	desc = "A heap of Char, a fossil energy source similar to coal."
 	material_name = "Char"
+	default_material = "char"
 	//cogwerks - burn vars
 	burn_point = 450
 	burn_output = 1600
 	burn_possible = 2
 	health = 20
 
-
 /obj/item/raw_material/claretine // relate this to wizardry somehow
 	name = "claretine ore"
 	desc = "A heap of Claretine, a highly conductive salt."
 	material_name = "Claretine"
+	default_material = "claretine"
 	conductor = 2
-
 
 /obj/item/raw_material/bohrum
 	name = "bohrum ore"
 	desc = "A chunk of Bohrum, a heavy and highly durable metal."
 	material_name = "Bohrum"
+	default_material = "bohrum"
 	metal = 3
 	dense = 1
 
@@ -321,16 +328,16 @@
 	name = "syreline ore"
 	desc = "A chunk of Syreline, an extremely valuable and coveted metal."
 	material_name = "Syreline"
+	default_material = "syreline"
 	metal = 1
-
 
 /obj/item/raw_material/erebite
 	name = "erebite ore"
 	desc = "A chunk of Erebite, an extremely volatile high-energy mineral."
 	var/exploded = 0
 	material_name = "Erebite"
+	default_material = "erebite"
 	powersource = 2
-
 
 	ex_act(severity)
 		if(exploded)
@@ -383,14 +390,15 @@
 	name = "cerenkite ore"
 	desc = "A chunk of Cerenkite, a highly radioactive mineral."
 	material_name = "Cerenkite"
+	default_material = "cerenkite"
 	metal = 1
 	powersource = 1
-
 
 /obj/item/raw_material/plasmastone
 	name = "plasmastone"
 	desc = "A piece of plasma in its solid state."
 	material_name = "Plasmastone"
+	default_material = "plasmastone"
 	//cogwerks - burn vars
 	burn_point = 1000
 	burn_output = 10000
@@ -405,6 +413,7 @@
 	desc = "A gemstone. It's probably pretty valuable!"
 	icon_state = "gem1"
 	material_name = "Gem"
+	default_material = null
 	force = 1
 	throwforce = 3
 	crystal = 1
@@ -430,17 +439,20 @@
 	name = "uqill nugget"
 	desc = "A nugget of Uqill, a rare and very dense stone."
 	material_name = "Uqill"
+	default_material = "uqill"
 	dense = 2
 
 /obj/item/raw_material/fibrilith
 	name = "fibrilith chunk"
 	desc = "A compressed chunk of Fibrilith, an odd mineral known for its high tensile strength."
 	material_name = "Fibrilith"
+	default_material = "fibrilith"
 
 /obj/item/raw_material/telecrystal
 	name = "telecrystal"
 	desc = "A large unprocessed telecrystal, a gemstone with space-warping properties."
 	material_name = "Telecrystal"
+	default_material = "telecrystal"
 	crystal = 1
 	powersource = 2
 
@@ -467,30 +479,32 @@
 		desc = "[desc] It's all shiny and blue now."
 		return TRUE
 
-
 /obj/item/raw_material/miracle
 	name = "miracle matter"
 	desc = "Miracle Matter is a bizarre substance known to metamorphosise into other minerals when processed."
 	material_name = "Miracle"
+	default_material = "miracle"
 
 /obj/item/raw_material/starstone
 	name = "starstone"
 	desc = "An extremely rare jewel. Highly prized by collectors and lithovores."
 	material_name = "Starstone"
+	default_material = "starstone"
 	crystal = 1
 
 /obj/item/raw_material/eldritch
 	name = "koshmarite ore"
 	desc = "An unusual dense pulsating stone. You feel uneasy just looking at it."
 	material_name = "Koshmarite"
+	default_material = "koshmarite"
 	crystal = 1
 	dense = 2
-
 
 /obj/item/raw_material/martian
 	name = "viscerite lump"
 	desc = "A disgusting flesh-like material. Ugh. What the hell is this?"
 	material_name = "Viscerite"
+	default_material = "viscerite"
 	dense = 2
 
 	setup_material()
@@ -502,8 +516,8 @@
 	name = "gold nugget"
 	desc = "A chunk of pure gold. Damn son."
 	material_name = "Gold"
+	default_material = "gold"
 	dense = 2
-
 
 // Misc building material
 
@@ -512,6 +526,7 @@
 	desc = "Some spun cloth. Useful if you want to make clothing."
 	icon_state = "fabric"
 	material_name = "Fabric"
+	default_material = "fabric"
 	scoopable = 0
 
 /obj/item/raw_material/cotton/
@@ -519,11 +534,13 @@
 	desc = "It's a big puffy white thing. Most likely not a cloud though."
 	icon_state = "cotton"
 	material_name = "Cotton"
+	default_material = "cotton"
 
 /obj/item/raw_material/ice
 	name = "ice chunk"
 	desc = "A chunk of ice. It's pretty cold."
 	material_name = "Ice"
+	default_material = "ice"
 	crystal = 1
 	scoopable = 0
 
@@ -536,13 +553,11 @@
 	burn_possible = 0
 	set_name = TRUE
 	material_name = "Steel"
+	default_material = "steel"
 
 	New()
 		..()
 		icon_state += "[rand(1,5)]"
-
-/obj/item/raw_material/scrap_metal/steel
-	material_name = "Steel"
 
 /obj/item/raw_material/shard
 	// same deal here
@@ -569,6 +584,7 @@
 	event_handler_flags = USE_FLUID_ENTER
 	material_amt = 0.1
 	material_name = "Glass"
+	default_material = "glass"
 	set_name = TRUE
 	var/sound_stepped = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
 
@@ -598,11 +614,13 @@
 				user.suiciding = 0
 		return 1
 
-
 	glass
 		material_name = "Glass"
+		default_material = "glass"
+
 	plasmacrystal
 		material_name = "Plasmaglass"
+		default_material = "plasmaglass"
 
 /obj/item/raw_material/shard/proc/walked_over(mob/living/carbon/human/H as mob)
 	if(ON_COOLDOWN(H, "shard_Crossed", 7 SECONDS) || H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
@@ -633,6 +651,7 @@
 	name = "chitin chunk"
 	desc = "A chunk of chitin."
 	material_name = "Chitin"
+	default_material = "chitin"
 	metal = 3
 	dense = 1
 

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -140,6 +140,7 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 	icon = 'icons/obj/furniture/table_wood.dmi'
 	furniture_type = /obj/table/wood/auto
 	furniture_name = "wooden table"
+	default_material = "wood"
 	mat_appearances_to_ignore = list("wood")
 	mat_changename = TRUE
 

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -145,7 +145,7 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 	constructed //no "wood wood table"
 		name = "table parts"
 		furniture_name = "table"
-		furniture_type = /obj/table/wood/constructed
+		//furniture_type = /obj/table/wood/constructed
 
 /obj/item/furniture_parts/table/wood/round
 	name = "round wood table parts"
@@ -220,14 +220,8 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 	furniture_name = "glass table"
 	density_check = FALSE //FOR NOW
 	var/has_glass = 1
-	var/default_material = "glass"
+	default_material = "glass"
 
-	New()
-		..()
-		if (!src.material && default_material)
-			var/datum/material/M
-			M = getMaterial(default_material)
-			src.setMaterial(M)
 
 	UpdateName()
 		if (!src.has_glass)

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -135,26 +135,22 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 	furniture_name = "desk"
 
 /obj/item/furniture_parts/table/wood
-	name = "wood table parts"
+	name = "table parts"
 	desc = "A collection of parts that can be used to make a wooden table."
 	icon = 'icons/obj/furniture/table_wood.dmi'
 	furniture_type = /obj/table/wood/auto
 	furniture_name = "wooden table"
 	mat_appearances_to_ignore = list("wood")
-
-	constructed //no "wood wood table"
-		name = "table parts"
-		furniture_name = "table"
-		//furniture_type = /obj/table/wood/constructed
+	mat_changename = TRUE
 
 /obj/item/furniture_parts/table/wood/round
-	name = "round wood table parts"
+	name = "round table parts"
 	desc = "A collection of parts that can be used to make a round wooden table."
 	icon = 'icons/obj/furniture/table_wood_round.dmi'
 	furniture_type = /obj/table/wood/round/auto
 
 /obj/item/furniture_parts/table/wood/desk
-	name = "wood desk parts"
+	name = "desk parts"
 	desc = "A collection of parts that can be used to make a wooden desk."
 	icon = 'icons/obj/furniture/table_wood_desk.dmi'
 	furniture_type = /obj/table/wood/auto/desk

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -26,6 +26,8 @@
 	throwforce = 10
 	pressure_resistance = 3*ONE_ATMOSPHERE
 	layer = STORAGE_LAYER //dumb
+	default_material = "steel"
+	uses_material_appearance = FALSE
 	var/allow_unbuckle = 1
 	var/mob/living/buckled_guy = null
 	var/deconstructable = 1
@@ -873,6 +875,23 @@
 			src.visible_message("<span class='alert'>[src] trips [AM]!</span>", "<span class='alert'>You hear someone fall.</span>")
 			AM.changeStatus("weakened", 2 SECONDS)
 		return
+
+/* ======================================================= */
+/* -------------------- Material Chairs ------------------ */
+/* ======================================================= */
+
+/obj/stool/chair/material
+	name = "material chair"
+	desc = "A chair made from a material"
+	uses_material_appearance = TRUE
+	comfort_value = 4
+
+	mauxite
+		name = "mauxite chair"
+		icon_state = "chair$$mauxite"
+		desc = "A sturdy chair made from mauxite. It doesn't look very comfortable..."
+		comfort_value = -2
+		default_material = "mauxite"
 
 /* ======================================================= */
 /* -------------------- Folded Chairs -------------------- */

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -889,7 +889,7 @@
 /obj/stool/chair/material/mauxite
 	name = "chair"
 	icon_state = "chair$$mauxite"
-	desc = "A sturdy chair made from mauxite. It doesn't look very comfortable..."
+	desc = "A sturdy chair. It doesn't look very comfortable..."
 	comfort_value = -2
 	default_material = "mauxite"
 

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -880,18 +880,19 @@
 /* -------------------- Material Chairs ------------------ */
 /* ======================================================= */
 
+ABSTRACT_TYPE(/obj/stool/chair/material)
 /obj/stool/chair/material
 	name = "material chair"
 	desc = "A chair made from a material"
 	uses_material_appearance = TRUE
-	comfort_value = 4
+	mat_changename = TRUE
 
-	mauxite
-		name = "mauxite chair"
-		icon_state = "chair$$mauxite"
-		desc = "A sturdy chair made from mauxite. It doesn't look very comfortable..."
-		comfort_value = -2
-		default_material = "mauxite"
+/obj/stool/chair/material/mauxite
+	name = "chair"
+	icon_state = "chair$$mauxite"
+	desc = "A sturdy chair made from mauxite. It doesn't look very comfortable..."
+	comfort_value = -2
+	default_material = "mauxite"
 
 /* ======================================================= */
 /* -------------------- Folded Chairs -------------------- */

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -880,7 +880,6 @@
 /* -------------------- Material Chairs ------------------ */
 /* ======================================================= */
 
-ABSTRACT_TYPE(/obj/stool/chair/material)
 /obj/stool/chair/material
 	name = "material chair"
 	desc = "A chair made from a material"

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -540,13 +540,12 @@ TYPEINFO_NEW(/obj/table/mauxite)
 	. = ..()
 	smooth_list = typecacheof(/obj/table/mauxite/auto)
 /obj/table/mauxite
-	name = "mauxite table"
+	name = "table"
 	icon = 'icons/obj/furniture/table.dmi'
 	icon_state = "0$$mauxite"
 	desc = "A table made of dense mauxite"
-	mat_appearances_to_ignore = list("mauxite")
-	uses_material_appearance = TRUE
-	mat_changename = FALSE
+	uses_material_appearance = FALSE
+	mat_changename = TRUE
 	default_material = "mauxite"
 
 	auto

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -543,7 +543,6 @@ TYPEINFO_NEW(/obj/table/mauxite)
 	name = "table"
 	icon = 'icons/obj/furniture/table.dmi'
 	icon_state = "0$$mauxite"
-	desc = "A table made of dense mauxite"
 	uses_material_appearance = FALSE
 	mat_changename = TRUE
 	default_material = "mauxite"

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -20,6 +20,8 @@ TYPEINFO_NEW(/obj/table)
 	mechanics_interaction = MECHANICS_INTERACTION_SKIP_IF_FAIL
 	material_amt = 0.2
 	var/parts_type = /obj/item/furniture_parts/table
+	default_material = null
+	uses_material_appearance = FALSE
 	var/auto = 0
 	var/status = null //1=weak|welded, 2=strong|unwelded
 	var/image/working_image = null
@@ -456,11 +458,12 @@ TYPEINFO_NEW(/obj/table/wood)
 	icon = 'icons/obj/furniture/table_wood.dmi'
 	parts_type = /obj/item/furniture_parts/table/wood
 	mat_appearances_to_ignore = list("wood")
+	uses_material_appearance = FALSE
+	mat_changename = FALSE
+	default_material = "wood"
 
 	auto
 		auto = 1
-	constructed //no "wood wood table"
-		name = "table"
 
 /obj/table/wood/auto/desk
 	name = "wooden desk"
@@ -531,6 +534,23 @@ TYPEINFO_NEW(/obj/table/scrap)
 
 	auto
 		auto = 1
+
+TYPEINFO(/obj/table/mauxite)
+TYPEINFO_NEW(/obj/table/mauxite)
+	. = ..()
+	smooth_list = typecacheof(/obj/table/mauxite/auto)
+/obj/table/mauxite
+	name = "mauxite table"
+	icon = 'icons/obj/furniture/table.dmi'
+	icon_state = "0$$mauxite"
+	desc = "A table made of dense mauxite"
+	mat_appearances_to_ignore = list("mauxite")
+	uses_material_appearance = TRUE
+	mat_changename = FALSE
+	default_material = "mauxite"
+
+	auto
+		auto = TRUE
 
 /obj/table/folding
 	name = "folding table"
@@ -776,10 +796,10 @@ TYPEINFO_NEW(/obj/table/glass)
 	desc = "A table made of glass. It looks like it might shatter if you set something down on it too hard."
 	icon = 'icons/obj/furniture/table_glass.dmi'
 	mat_appearances_to_ignore = list("glass")
+	default_material = "glass"
 	parts_type = /obj/item/furniture_parts/table/glass
 	var/glass_broken = GLASS_INTACT
 	var/reinforced = 0
-	var/default_material = "glass"
 
 	auto
 		auto = 1
@@ -800,11 +820,6 @@ TYPEINFO_NEW(/obj/table/glass)
 
 		auto
 			auto = 1
-
-	New()
-		..()
-		if (!src.material && default_material)
-			src.setMaterial(getMaterial(default_material), copy = FALSE)
 
 	UpdateName()
 		if (src.glass_broken)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -26,12 +26,14 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 	var/stab_resist = 0
 	var/corrode_resist = 0
 	var/temp_resist = 0
-	var/default_material = "glass"
 	var/default_reinforcement = null
 	var/reinf = 0 // cant figure out how to remove this without the map crying aaaaa - ISN
 	var/deconstruct_time = 1 SECOND
 	var/image/connect_image = null
 	var/image/damage_image = null
+	default_material = "glass"
+	mat_changename = TRUE
+	uses_material_appearance = TRUE
 	pressure_resistance = 4*ONE_ATMOSPHERE
 	gas_impermeable = TRUE
 	anchored = ANCHORED
@@ -44,8 +46,6 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		..()
 		src.ini_dir = src.dir
 		update_nearby_tiles(need_rebuild=1,selfnotify=1) // self notify to stop fluid jankness
-		if (default_material)
-			src.setMaterial(getMaterial(default_material), copy = FALSE)
 		if (default_reinforcement)
 			src.reinforcement = getMaterial(default_reinforcement)
 		onMaterialChanged()

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -17,7 +17,7 @@
 	var/burnt = 0
 	var/has_material = TRUE
 	/// Set to instantiated material datum ([getMaterial()]) for custom material floors
-	var/plate_mat = null
+	var/plate_mat = "steel" // As a string
 	var/reinforced = FALSE
 	//Stuff for the floor & wall planner undo mode that initial() doesn't resolve.
 	var/tmp/roundstart_icon_state
@@ -29,8 +29,8 @@
 		..()
 		if (has_material)
 			if (isnull(plate_mat))
-				plate_mat = getMaterial("steel")
-			setMaterial(plate_mat, copy = FALSE)
+				plate_mat = "steel"
+			setMaterial(getMaterial(plate_mat), copy = FALSE)
 		roundstart_icon_state = icon_state
 		roundstart_dir = dir
 		#ifdef XMAS
@@ -656,7 +656,7 @@
 	step_priority = STEP_PRIORITY_MED
 
 	New()
-		plate_mat = getMaterial("pharosium")
+		plate_mat = "pharosium"
 		. = ..()
 
 /turf/simulated/floor/circuit/green
@@ -707,7 +707,7 @@
 	mat_changename = 0
 
 	New()
-		plate_mat = getMaterial("cotton")
+		plate_mat = "cotton"
 		. = ..()
 
 /turf/simulated/floor/carpet/grime
@@ -917,7 +917,7 @@ DEFINE_FLOORS(marble/border_wb,
 		#endif
 		I.plane = PLANE_SPACE
 		src.underlays += I
-		plate_mat = getMaterial("glass")
+		plate_mat = "glass"
 		..()
 
 /turf/simulated/floor/glassblock/transparent/cyan
@@ -1110,7 +1110,7 @@ DEFINE_FLOORS(minitiles/black,
 	step_priority = STEP_PRIORITY_MED
 
 	New()
-		plate_mat = getMaterial("wood")
+		plate_mat = "wood"
 		. = ..()
 
 /turf/simulated/floor/wood/two
@@ -1436,7 +1436,7 @@ DEFINE_FLOORS(techfloor/green,
 			src.ReplaceWith(/turf/simulated/floor/snow/snowball, keep_old_material=FALSE, handle_air = FALSE)
 			return
 		#endif
-		plate_mat = getMaterial("synthrubber")
+		plate_mat = "synthrubber"
 		..()
 
 /turf/proc/grassify()
@@ -1521,7 +1521,7 @@ DEFINE_FLOORS(techfloor/green,
 	mat_changedesc = 0
 
 	New()
-		plate_mat = getMaterial("rock")
+		plate_mat = "rock"
 		..()
 
 /////////////////////////////////////////
@@ -1621,7 +1621,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 	allows_vehicles = 1
 
 	New()
-		plate_mat = getMaterial("blob")
+		plate_mat = "blob"
 		..()
 
 	proc/setOvermind(var/mob/living/intangible/blob_overmind/O)
@@ -1789,7 +1789,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 	broken = 0
 	burnt = 0
 	if(plate_mat)
-		src.setMaterial(plate_mat, copy = FALSE)
+		src.setMaterial(getMaterial(plate_mat), copy = FALSE)
 	else
 		src.setMaterial(getMaterial("steel"), copy = FALSE)
 	levelupdate()
@@ -1970,7 +1970,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 		if (!intact)
 			if(T.amount >= 1)
 				restore_tile()
-				src.plate_mat = src.material
+				src.plate_mat = getMaterial(src.material)
 
 				// if we have a special icon state and it doesn't have a material variant
 				// and at the same time the base floor icon state does have a material variant
@@ -2504,7 +2504,7 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 	mat_appearances_to_ignore = list("ice")
 
 	New()
-		plate_mat = getMaterial("ice")
+		plate_mat = "ice"
 		..()
 		name = initial(name)
 
@@ -2606,3 +2606,15 @@ DEFINE_FLOORS_SIMMED_UNSIMMED(racing/rainbow_road,
 	New()
 		..()
 		src.set_dir(pick(NORTH,SOUTH))
+
+// Material flooring
+
+DEFINE_FLOORS(mauxite,
+	icon = 'icons/turf/floors.dmi';\
+	icon_state = "floor$$mauxite";\
+	plate_mat = "mauxite")
+
+DEFINE_FLOORS(bamboo,
+	icon = 'icons/turf/floors.dmi';\
+	icon_state = "floor$$bamboo";\
+	plate_mat = "bamboo")

--- a/code/turf/floors_unsimulated.dm
+++ b/code/turf/floors_unsimulated.dm
@@ -180,7 +180,7 @@
 			/obj/decal/cleanable/molten_item, /obj/decal/cleanable/machine_debris, /obj/decal/cleanable/oil, /obj/decal/cleanable/rust)
 			make_cleanable( C ,src)
 		else if ((locate(/obj) in src) && prob(3))
-			var/obj/C = pick(/obj/item/cable_coil/cut/small, /obj/item/brick, /obj/item/cigbutt, /obj/item/scrap, /obj/item/raw_material/scrap_metal/steel,\
+			var/obj/C = pick(/obj/item/cable_coil/cut/small, /obj/item/brick, /obj/item/cigbutt, /obj/item/scrap, /obj/item/raw_material/scrap_metal,\
 			/obj/item/spacecash, /obj/item/tile/steel, /obj/item/weldingtool, /obj/item/screwdriver, /obj/item/wrench, /obj/item/wirecutters, /obj/item/crowbar)
 			new C (src)
 		else if (prob(1) && prob(2)) // really rare. not "three space things spawn on destiny during first test with just prob(1)" rare.

--- a/code/turf/floors_unsimulated.dm
+++ b/code/turf/floors_unsimulated.dm
@@ -10,6 +10,7 @@
 	icon_state = "floor"
 	thermal_conductivity = 0.04
 	heat_capacity = 225000
+	var/plate_mat = null // Stop making the macro crash
 
 
 /turf/unsimulated/floor/attackby(obj/item/C, mob/user, params)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -48260,7 +48260,7 @@
 /area/station/security/brig)
 "veC" = (
 /obj/structure/girder/reinforced,
-/obj/item/raw_material/scrap_metal/steel,
+/obj/item/raw_material/scrap_metal,
 /turf/simulated/floor,
 /area/pasiphae/bridge)
 "veU" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I needed material stuff for a prefab, ended up making furniture use the same material set call instead of 5 different implentations across all the things. Now for objects its set for everything on New() on the base object type.

Fixes wooden tables and the like giving you steel sheets probably.

Test merge this since it touches a lot of material stuff, I tested it myself but can't be sure nothing broke.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency is good. Easier to make new material stuff.
