### PR TITLE
Fix incorrect window spawner on radio prefab

### DIFF
--- a/assets/maps/prefabs/prefab_ksol.dmm
+++ b/assets/maps/prefabs/prefab_ksol.dmm
@@ -1177,7 +1177,7 @@
 /turf/variableTurf/floor,
 /area/noGenerate)
 "cW" = (
-/obj/wingrille_spawn/reinforced/full,
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/airless/plating,
 /area/noGenerate)
 "cX" = (
@@ -1211,6 +1211,10 @@
 	icon_state = "floattiles4"
 	},
 /turf/variableTurf/clear,
+/area/noGenerate)
+"dz" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/variableTurf/floor,
 /area/noGenerate)
 "QJ" = (
 /obj/machinery/light/incandescent/broken{
@@ -1874,7 +1878,7 @@ ae
 ae
 aq
 as
-as
+dz
 aN
 bb
 bq


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
was not perspective window


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
perspective window

