### PR TITLE
Repath walls

### DIFF
--- a/assets/maps/allocated/blob_tutorial.dmm
+++ b/assets/maps/allocated/blob_tutorial.dmm
@@ -14,7 +14,7 @@
 /turf/simulated/floor,
 /area/tutorial/blob)
 "V" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "v-space"

--- a/assets/maps/shuttles/east/east_disaster.dmm
+++ b/assets/maps/shuttles/east/east_disaster.dmm
@@ -724,7 +724,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1419,7 +1419,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/east_martian.dmm
+++ b/assets/maps/shuttles/east/east_martian.dmm
@@ -583,7 +583,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1110,7 +1110,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/east_medships.dmm
+++ b/assets/maps/shuttles/east/east_medships.dmm
@@ -554,7 +554,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -966,7 +966,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/east_royal.dmm
+++ b/assets/maps/shuttles/east/east_royal.dmm
@@ -1009,7 +1009,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1944,7 +1944,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/east_syndicate.dmm
+++ b/assets/maps/shuttles/east/east_syndicate.dmm
@@ -566,7 +566,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1102,7 +1102,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/east_wrestle.dmm
+++ b/assets/maps/shuttles/east/east_wrestle.dmm
@@ -745,7 +745,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1395,7 +1395,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/eastbase.dmm
+++ b/assets/maps/shuttles/east/eastbase.dmm
@@ -631,7 +631,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "zj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1179,7 +1179,7 @@
 	},
 /area/centcom)
 "XO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/empty.dmm
+++ b/assets/maps/shuttles/east/empty.dmm
@@ -14,7 +14,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -35,7 +35,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/east/oshan.dmm
+++ b/assets/maps/shuttles/east/oshan.dmm
@@ -320,7 +320,7 @@
 	},
 /area/shuttle/escape/centcom)
 "mL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -900,7 +900,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/centcom)
 "Mx" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/east/oshan_disaster.dmm
+++ b/assets/maps/shuttles/east/oshan_disaster.dmm
@@ -335,7 +335,7 @@
 	},
 /area/shuttle/escape/centcom)
 "mL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -966,7 +966,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "Mx" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/east/oshan_meat.dmm
+++ b/assets/maps/shuttles/east/oshan_meat.dmm
@@ -343,7 +343,7 @@
 /turf/unsimulated/floor/setpieces/bloodfloor/stomach,
 /area/shuttle/escape/centcom)
 "mL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -910,7 +910,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/centcom)
 "Mx" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/east/oshan_minisubs.dmm
+++ b/assets/maps/shuttles/east/oshan_minisubs.dmm
@@ -245,7 +245,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/shuttle/escape/centcom)
 "mL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -732,7 +732,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/centcom)
 "Mx" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/east/oshan_royal.dmm
+++ b/assets/maps/shuttles/east/oshan_royal.dmm
@@ -439,7 +439,7 @@
 	},
 /area/shuttle/escape/centcom)
 "mL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1289,7 +1289,7 @@
 	},
 /area/shuttle/escape/centcom)
 "Mx" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3.dmm
+++ b/assets/maps/shuttles/north/donut3.dmm
@@ -226,7 +226,7 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1267,7 +1267,7 @@
 	},
 /area/shuttle/escape/centcom)
 "ZQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3_cave.dmm
+++ b/assets/maps/shuttles/north/donut3_cave.dmm
@@ -192,7 +192,7 @@
 /turf/unsimulated/floor/cave,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1024,7 +1024,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "ZQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3_disaster.dmm
+++ b/assets/maps/shuttles/north/donut3_disaster.dmm
@@ -278,7 +278,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1495,7 +1495,7 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "ZQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3_royal.dmm
+++ b/assets/maps/shuttles/north/donut3_royal.dmm
@@ -315,7 +315,7 @@
 	},
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -2070,7 +2070,7 @@
 	},
 /area/shuttle/escape/centcom)
 "ZQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3_syndicate.dmm
+++ b/assets/maps/shuttles/north/donut3_syndicate.dmm
@@ -226,7 +226,7 @@
 /turf/unsimulated/floor/black,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1197,7 +1197,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "ZQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/donut3_wrestle.dmm
+++ b/assets/maps/shuttles/north/donut3_wrestle.dmm
@@ -956,7 +956,7 @@
 	},
 /area/centcom/outside)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1253,7 +1253,7 @@
 /turf/unsimulated/floor/carpet/green/fancy/edge/nw,
 /area/shuttle/escape/centcom)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/empty.dmm
+++ b/assets/maps/shuttles/north/empty.dmm
@@ -3,7 +3,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -26,7 +26,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/manta.dmm
+++ b/assets/maps/shuttles/north/manta.dmm
@@ -344,7 +344,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "vo" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -921,7 +921,7 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "WR" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/manta_disaster.dmm
+++ b/assets/maps/shuttles/north/manta_disaster.dmm
@@ -445,7 +445,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "vo" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1120,7 +1120,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "WR" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/north/north_disaster.dmm
+++ b/assets/maps/shuttles/north/north_disaster.dmm
@@ -929,7 +929,7 @@
 	},
 /area/centcom/outside)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1217,7 +1217,7 @@
 	},
 /area/shuttle/escape/centcom)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/north_martian.dmm
+++ b/assets/maps/shuttles/north/north_martian.dmm
@@ -792,7 +792,7 @@
 	},
 /area/centcom/outside)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1008,7 +1008,7 @@
 	},
 /area/centcom/outside)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/north_wrestle.dmm
+++ b/assets/maps/shuttles/north/north_wrestle.dmm
@@ -951,7 +951,7 @@
 	},
 /area/centcom/outside)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1248,7 +1248,7 @@
 /turf/unsimulated/floor/carpet/green/fancy/edge/nw,
 /area/shuttle/escape/centcom)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -869,7 +869,7 @@
 	},
 /area/centcom/outside)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1121,7 +1121,7 @@
 	},
 /area/shuttle/escape/centcom)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/north/small/manta_default.dmm
+++ b/assets/maps/shuttles/north/small/manta_default.dmm
@@ -9,7 +9,7 @@
 	},
 /area/shuttle/escape/centcom)
 "fu" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -249,7 +249,7 @@
 /turf/space/fluid,
 /area/shuttle/escape/centcom)
 "RD" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwall"
 	},

--- a/assets/maps/shuttles/north/small/manta_disaster.dmm
+++ b/assets/maps/shuttles/north/small/manta_disaster.dmm
@@ -57,7 +57,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "fu" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -431,7 +431,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "RD" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwall"
 	},

--- a/assets/maps/shuttles/north/small/manta_royal.dmm
+++ b/assets/maps/shuttles/north/small/manta_royal.dmm
@@ -80,7 +80,7 @@
 /turf/unsimulated/floor/carpet/regalcarpet/border,
 /area/shuttle/escape/centcom)
 "fu" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -703,7 +703,7 @@
 /turf/unsimulated/floor/marble/black,
 /area/shuttle/escape/centcom)
 "RD" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwall"
 	},

--- a/assets/maps/shuttles/south/empty.dmm
+++ b/assets/maps/shuttles/south/empty.dmm
@@ -3,7 +3,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -26,7 +26,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_disaster.dmm
+++ b/assets/maps/shuttles/south/south_disaster.dmm
@@ -486,7 +486,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -942,7 +942,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_martian.dmm
+++ b/assets/maps/shuttles/south/south_martian.dmm
@@ -339,7 +339,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -686,7 +686,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_medships.dmm
+++ b/assets/maps/shuttles/south/south_medships.dmm
@@ -240,7 +240,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -583,7 +583,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_miniships.dmm
+++ b/assets/maps/shuttles/south/south_miniships.dmm
@@ -242,7 +242,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -530,7 +530,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_royal.dmm
+++ b/assets/maps/shuttles/south/south_royal.dmm
@@ -633,7 +633,7 @@
 /turf/unsimulated/floor/carpet/regalcarpet/innercorner,
 /area/shuttle/escape/centcom)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -1240,7 +1240,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_syndicate.dmm
+++ b/assets/maps/shuttles/south/south_syndicate.dmm
@@ -300,7 +300,7 @@
 /turf/unsimulated/floor/red,
 /area/shuttle/escape/centcom)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -640,7 +640,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/south_wrestle.dmm
+++ b/assets/maps/shuttles/south/south_wrestle.dmm
@@ -435,7 +435,7 @@
 	},
 /area/shuttle/escape/centcom)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -928,7 +928,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/south/southbase.dmm
+++ b/assets/maps/shuttles/south/southbase.dmm
@@ -353,7 +353,7 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "qO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -709,7 +709,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "Gm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/west/empty.dmm
+++ b/assets/maps/shuttles/west/empty.dmm
@@ -14,7 +14,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
 "HA" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -35,7 +35,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "Rs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";

--- a/assets/maps/shuttles/west/small/donut2_default.dmm
+++ b/assets/maps/shuttles/west/small/donut2_default.dmm
@@ -58,7 +58,7 @@
 	},
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
@@ -261,7 +261,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/escape/centcom)
 "Io" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},

--- a/assets/maps/shuttles/west/small/donut2_disaster.dmm
+++ b/assets/maps/shuttles/west/small/donut2_disaster.dmm
@@ -59,7 +59,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
@@ -294,7 +294,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/escape/centcom)
 "Io" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},

--- a/assets/maps/shuttles/west/small/donut2_royal.dmm
+++ b/assets/maps/shuttles/west/small/donut2_royal.dmm
@@ -97,7 +97,7 @@
 	},
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
@@ -453,7 +453,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/escape/centcom)
 "Io" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},

--- a/assets/maps/shuttles/west/small/donut2_syndicate.dmm
+++ b/assets/maps/shuttles/west/small/donut2_syndicate.dmm
@@ -67,7 +67,7 @@
 /turf/unsimulated/floor/black,
 /area/shuttle/escape/centcom)
 "gI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
@@ -327,7 +327,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/escape/centcom)
 "Io" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},

--- a/assets/maps/shuttles/west/west_disaster.dmm
+++ b/assets/maps/shuttles/west/west_disaster.dmm
@@ -664,7 +664,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "vp" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1318,7 +1318,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "Qs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/west/west_martian.dmm
+++ b/assets/maps/shuttles/west/west_martian.dmm
@@ -465,7 +465,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "vp" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -974,7 +974,7 @@
 	},
 /area/shuttle/escape/centcom)
 "Qs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/assets/maps/shuttles/west/westbase.dmm
+++ b/assets/maps/shuttles/west/westbase.dmm
@@ -578,7 +578,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "vp" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -1095,7 +1095,7 @@
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)
 "Qs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -987,6 +987,8 @@ proc/generate_space_color()
 	plane = PLANE_FLOOR
 #endif
 
+/turf/unsimulated/wall/generic
+
 /turf/unsimulated/wall/solidcolor
 	name = "invisible solid turf"
 	desc = "A solid... nothing? Is that even a thing?"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -13931,7 +13931,7 @@
 	},
 /area/shuttle/arrival/station)
 "aIR" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "wall";
 	opacity = 0
@@ -14454,7 +14454,7 @@
 	},
 /area/shuttle/arrival/station)
 "aKs" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/effects/160x160.dmi';
 	icon_state = "shuttlecock";
 	layer = 30;

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -634,7 +634,7 @@
 	},
 /area/space)
 "bQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},
@@ -1172,7 +1172,7 @@
 	},
 /area/space)
 "dv" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -274,7 +274,7 @@
 /turf/unsimulated/floor/void/channel,
 /area/adventure/channel/teleport)
 "abj" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "cloaking field"
@@ -976,7 +976,7 @@
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "diagonalWall"
@@ -1017,7 +1017,7 @@
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "diagonalWall"
 	},
@@ -1028,7 +1028,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/unsimulated/floor/void/channel,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 8;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "diagonalWall"
@@ -1060,7 +1060,7 @@
 	},
 /area/hospital/samostrel)
 "adP" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1141,7 +1141,7 @@
 	},
 /area/hospital/samostrel)
 "aeb" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1339,7 +1339,7 @@
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 8;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "diagonalWall"
@@ -3855,7 +3855,7 @@
 /turf/unsimulated/floor/carpet/office,
 /area/hospital)
 "amQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/sovblastdoor.dmi';
@@ -4182,7 +4182,7 @@
 	},
 /area/hospital/samostrel)
 "anT" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4495,7 +4495,7 @@
 /turf/unsimulated/floor/caution/east,
 /area/hospital/samostrel)
 "aoL" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4768,7 +4768,7 @@
 	},
 /area/hospital/samostrel)
 "apD" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -7934,7 +7934,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "ayY" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -8112,7 +8112,7 @@
 	},
 /area/moon/museum)
 "azK" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -8287,7 +8287,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "aAy" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -8296,7 +8296,7 @@
 	},
 /area/hospital)
 "aAz" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -9152,7 +9152,7 @@
 	},
 /area/centcom)
 "aDB" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorsingle1";
@@ -9399,7 +9399,7 @@
 	},
 /area/moon/museum)
 "aEp" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -21031,7 +21031,7 @@
 /turf/unsimulated/floor/caution/east,
 /area/drone/office)
 "bmZ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It won't budge.";
 	dir = 1;
 	icon = 'icons/obj/doors/Door1.dmi';
@@ -21585,7 +21585,7 @@
 	},
 /area/drone)
 "bod" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It won't budge.";
 	dir = 1;
 	icon = 'icons/obj/doors/Door1.dmi';
@@ -21733,7 +21733,7 @@
 /turf/unsimulated/floor/engine,
 /area/drone/assembly)
 "bow" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "They're sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -21804,7 +21804,7 @@
 	},
 /area/drone/assembly)
 "boN" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "They're sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -21902,7 +21902,7 @@
 /turf/unsimulated/floor/engine,
 /area/drone/assembly)
 "bpm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "They're sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -26327,7 +26327,7 @@
 /turf/unsimulated/floor/lava,
 /area/iomoon)
 "bDN" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -31165,7 +31165,7 @@
 /turf/unsimulated/floor/grass/random,
 /area/afterlife/heaven/hydroponics)
 "bTY" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "Wall"
@@ -34590,7 +34590,7 @@
 	},
 /area/meat_derelict/entry)
 "cfz" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -34764,7 +34764,7 @@
 	},
 /area/meat_derelict/entry)
 "cfX" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -35056,7 +35056,7 @@
 	},
 /area/meat_derelict/entry)
 "cgF" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -35731,7 +35731,7 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/racing_entry)
 "ciz" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "v-space"
@@ -35814,7 +35814,7 @@
 	icon_state = "blue"
 	})
 "ciO" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/beach.dmi';
 	icon_state = "sand";
 	name = "sand"
@@ -37258,7 +37258,7 @@
 	},
 /area/sim/racing_entry)
 "cmy" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/beach2.dmi';
 	icon_state = "sandwater";
 	name = "water"
@@ -37354,7 +37354,7 @@
 	},
 /area/sim/racing_entry)
 "cmN" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/beach.dmi';
 	icon_state = "water"
 	},
@@ -41567,7 +41567,7 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/owlery/staffhall)
 "czo" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -41578,7 +41578,7 @@
 /area/owlery/staffhall)
 "czp" = (
 /obj/decal/cleanable/dirt,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -51276,7 +51276,7 @@
 /turf/unsimulated/floor/plating,
 /area/owlery/Owlmait2)
 "cWl" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorsingle1";
@@ -51681,7 +51681,7 @@
 /turf/unsimulated/floor/white,
 /area/owlery/owleryhall)
 "cWZ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -51730,7 +51730,7 @@
 /turf/unsimulated/floor/green,
 /area/owlery/owleryhall)
 "cXe" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -51759,7 +51759,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/syndicate/minerva5/command)
 "cXi" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -57181,7 +57181,7 @@
 /turf/unsimulated/floor/orangeblack/side,
 /area/centcom)
 "dmy" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -57195,7 +57195,7 @@
 	},
 /area/centcom)
 "dns" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -57226,7 +57226,7 @@
 	},
 /area/centcom)
 "dnI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -58052,7 +58052,7 @@
 	},
 /area/shuttle/merchant_shuttle/right_centcom/cogmap)
 "dun" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -58241,7 +58241,7 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/hospital/underground)
 "duQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -58708,7 +58708,7 @@
 	},
 /area/centcom/offices/zewaka)
 "dwu" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -60493,7 +60493,7 @@
 	icon_state = "blue"
 	})
 "dCy" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -60667,7 +60667,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/flourish)
 "dEd" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -60919,7 +60919,7 @@
 	icon_state = "blue"
 	})
 "dEY" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadcap"
 	},
@@ -61003,7 +61003,7 @@
 	})
 "dFk" = (
 /obj/window_blinds/left,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -61265,7 +61265,7 @@
 	},
 /area/centcom/lounge)
 "dGe" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -61321,7 +61321,7 @@
 	},
 /area/centcom/lounge)
 "dGl" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -61505,7 +61505,7 @@
 	},
 /area/centcom/lounge)
 "dGI" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -62216,7 +62216,7 @@
 /turf/unsimulated/floor/wood,
 /area/centcom/lounge)
 "dIQ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 1;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -63160,7 +63160,7 @@
 /area/centcom/lobby)
 "dLi" = (
 /obj/window_blinds,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -63186,7 +63186,7 @@
 /area/centcom/lobby)
 "dLo" = (
 /obj/window_blinds,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -63196,7 +63196,7 @@
 /area/centcom/lobby)
 "dLp" = (
 /obj/window_blinds/left,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -63206,7 +63206,7 @@
 /area/centcom/lobby)
 "dLq" = (
 /obj/window_blinds/middle,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -63216,7 +63216,7 @@
 /area/centcom/lobby)
 "dLr" = (
 /obj/window_blinds/right,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -63537,7 +63537,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -63558,7 +63558,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -63734,7 +63734,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -63929,7 +63929,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -63987,7 +63987,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -64296,7 +64296,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -64829,7 +64829,7 @@
 	},
 /area/centcom/lobby)
 "dPc" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
 	name = "window";
@@ -66261,7 +66261,7 @@
 	},
 /area/crypt/sigma/mainhall)
 "dTY" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It won't budge.";
 	dir = 1;
 	icon = 'icons/obj/doors/Door1.dmi';
@@ -67365,7 +67365,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/kyle)
 "fDK" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/doors/shuttle.dmi';
 	icon_state = "door1";
 	name = "broken door"
@@ -69220,7 +69220,7 @@
 	anchored = 1;
 	pixel_x = 11
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
@@ -71412,7 +71412,7 @@
 /turf/unsimulated/outdoors/grass,
 /area/diner/cow)
 "mAm" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "cloaking field"
@@ -71899,7 +71899,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/kyle)
 "niP" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -73422,7 +73422,7 @@
 	},
 /area/meat_derelict/guts)
 "pvh" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/doors/shuttle.dmi';
 	icon_state = "door1";
 	name = "broken door"
@@ -75100,7 +75100,7 @@
 	},
 /area/centcom/offices/varshie)
 "rYJ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "cloaking field"
@@ -75135,7 +75135,7 @@
 /turf/unsimulated/floor,
 /area/iomoon/base)
 "sbg" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "A double black security door. Looks pretty tough. I wouldn't take this door on in a fight.";
 	icon = 'icons/obj/doors/destiny.dmi';
 	icon_state = "fmorg_closed";
@@ -76313,7 +76313,7 @@
 /turf/unsimulated/floor/void,
 /area/diner/cow)
 "uhn" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -76846,7 +76846,7 @@
 /turf/unsimulated/floor,
 /area/iomoon/base/underground)
 "uXp" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_1";
 	name = "window";
@@ -76855,7 +76855,7 @@
 /area/centcom/gallery)
 "uYi" = (
 /obj/map/light/yellow,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 4;
 	icon = 'icons/misc/worlds.dmi';
 	icon_state = "leadwindow_2";
@@ -77361,7 +77361,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/mbc)
 "vJH" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 8;
 	icon = 'icons/misc/worlds.dmi';
 	icon_old = null;
@@ -78884,7 +78884,7 @@
 /area/centcom/offices/katzen)
 "ydb" = (
 /obj/machinery/light/small/floor,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	dir = 8;
 	icon = 'icons/misc/worlds.dmi';
 	icon_old = null;

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -17,7 +17,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -118,7 +118,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -221,7 +221,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -1003,7 +1003,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -1905,7 +1905,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -2219,7 +2219,7 @@
 	icon_state = "wall_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -4764,7 +4764,7 @@
 	dir = 8;
 	icon_state = "diagonalWall3"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5221,7 +5221,7 @@
 	dir = 8;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5247,7 +5247,7 @@
 	dir = 10;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5258,7 +5258,7 @@
 	dir = 6;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5289,7 +5289,7 @@
 	dir = 9;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5304,7 +5304,7 @@
 	dir = 6;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5315,7 +5315,7 @@
 	dir = 1;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5612,7 +5612,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -5623,7 +5623,7 @@
 	dir = 4;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -6470,7 +6470,7 @@
 	dir = 8;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -6493,7 +6493,7 @@
 	dir = 1;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -6661,7 +6661,7 @@
 	dir = 10;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -6823,7 +6823,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -7699,7 +7699,7 @@
 	dir = 4;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -10828,7 +10828,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -10842,7 +10842,7 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11293,7 +11293,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11311,7 +11311,7 @@
 	dir = 4;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11470,7 +11470,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11485,7 +11485,7 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11721,7 +11721,7 @@
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "wall3_space_end"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11934,7 +11934,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11945,7 +11945,7 @@
 	dir = 4;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -11956,7 +11956,7 @@
 	dir = 9;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -12745,7 +12745,7 @@
 	dir = 10;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -14601,7 +14601,7 @@
 	dir = 6;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -16994,7 +16994,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -17700,7 +17700,7 @@
 	dir = 4;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -18254,7 +18254,7 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -18507,7 +18507,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -18813,7 +18813,7 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -19165,7 +19165,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -19945,7 +19945,7 @@
 /turf/simulated/floor/grime,
 /area/diner/hallway)
 "kqJ" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/doors/shuttle.dmi';
 	icon_state = "door1";
 	name = "broken door"
@@ -20070,7 +20070,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -20098,7 +20098,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -20467,7 +20467,7 @@
 	dir = 4;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -21063,7 +21063,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -21224,7 +21224,7 @@
 	dir = 8;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -21406,7 +21406,7 @@
 	dir = 1;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -21691,7 +21691,7 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -22342,7 +22342,7 @@
 /obj/decal/fakeobjects/shuttleengine{
 	icon_state = "alt_heater-L"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -22353,7 +22353,7 @@
 	dir = 5;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -22518,7 +22518,7 @@
 	icon_state = "wall3_trans"
 	},
 /turf/space,
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -23133,7 +23133,7 @@
 	dir = 5;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -24358,7 +24358,7 @@
 	dir = 4;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -24550,7 +24550,7 @@
 /obj/indestructible/shuttle_corner{
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -24600,7 +24600,7 @@
 	dir = 5;
 	icon_state = "wall_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -24855,7 +24855,7 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"
@@ -24869,7 +24869,7 @@
 /obj/decal/fakeobjects/shuttleengine{
 	icon_state = "alt_heater-R"
 	},
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/turf/space.dmi';
 	icon_state = "1";
 	name = "space"

--- a/maps/z4_blank.dmm
+++ b/maps/z4_blank.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "b" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "outer forcefield"
@@ -12,7 +12,7 @@
 	name = "Penalty Box"
 	})
 "c" = (
-/turf/unsimulated/wall{
+/turf/unsimulated/wall/generic{
 	icon = 'icons/obj/singularity.dmi';
 	icon_state = "TheSingMain";
 	name = "forcefield";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* #14234 abstracted unsimulated walls which were used all over. This repaths all of them (minus secret and unused maps) into a generic subtype


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Abstract type violation crash correction
