### PR TITLE
Adds printing press to chapel on all rotation maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -17011,6 +17011,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"chL" = (
+/obj/item/paper_bin,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "clr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17496,6 +17500,10 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"gxQ" = (
+/obj/machinery/printing_press,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "gBK" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -76955,7 +76963,7 @@ aaa
 aaa
 aaa
 acz
-aen
+chL
 aen
 aen
 afO
@@ -77258,7 +77266,7 @@ aaa
 aaa
 acz
 acz
-aen
+gxQ
 aen
 afO
 ahi

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7137,26 +7137,7 @@
 	name = "Chaplain's Office"
 	})
 "atC" = (
-/obj/item/device/light/candle,
-/obj/item/device/light/candle,
-/obj/item/device/light/candle,
-/obj/item/device/light/candle,
-/obj/item/device/light/candle,
-/obj/item/matchbook,
-/obj/item/matchbook,
-/obj/storage/crate,
-/obj/item/ghostboard,
-/obj/item/card_box/tarot,
-/turf/simulated/floor/carpet/grime,
-/area/station/chapel/office{
-	name = "Chaplain's Office"
-	})
-"atD" = (
-/obj/item/instrument/large/piano{
-	anchored = 0;
-	name = "old piano"
-	},
-/obj/item/screwdriver,
+/obj/machinery/printing_press,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office{
 	name = "Chaplain's Office"
@@ -9140,9 +9121,16 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "azO" = (
-/obj/machinery/light_switch/east{
-	dir = 4
-	},
+/obj/item/device/light/candle,
+/obj/item/device/light/candle,
+/obj/item/device/light/candle,
+/obj/item/device/light/candle,
+/obj/item/device/light/candle,
+/obj/item/matchbook,
+/obj/item/matchbook,
+/obj/storage/crate,
+/obj/item/ghostboard,
+/obj/item/card_box/tarot,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "azS" = (
@@ -33111,6 +33099,11 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/item/instrument/large/piano{
+	anchored = 0;
+	name = "old piano"
+	},
+/obj/item/screwdriver,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office{
 	name = "Chaplain's Office"
@@ -77083,7 +77076,7 @@ aqZ
 bZU
 arq
 asX
-atD
+auo
 aup
 auY
 avM

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -18717,14 +18717,12 @@
 /area/station/chapel/office)
 "aYM" = (
 /obj/machinery/light,
+/obj/machinery/printing_press,
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
 /area/station/chapel/office)
 "aYN" = (
-/obj/shrub{
-	dir = 4
-	},
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred2"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -5005,6 +5005,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "anc" = (
@@ -5322,11 +5323,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "aoa" = (
-/obj/shrub{
-	dir = 1;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -71591,6 +71587,10 @@
 	},
 /turf/simulated/floor/airless/caution/northsouth,
 /area/research_outpost)
+"ewI" = (
+/obj/machinery/printing_press,
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "exg" = (
 /turf/simulated/floor/yellow/side,
 /area/station/mining/staff_room)
@@ -122701,7 +122701,7 @@ aaa
 akr
 alD
 amX
-anZ
+ewI
 aph
 aqp
 aBA

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8996,6 +8996,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/item/paper_bin,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "aGO" = (
@@ -31693,6 +31694,11 @@
 	icon_state = "fred6"
 	},
 /area/station/crew_quarters/jazz)
+"hIU" = (
+/obj/machinery/light/incandescent,
+/obj/machinery/printing_press,
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/sanctuary)
 "hJj" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -90945,7 +90951,7 @@ aAq
 aEp
 oBe
 aGb
-fwf
+hIU
 aKw
 aKw
 aKw

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -31445,6 +31445,13 @@
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
+"jCz" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/machinery/printing_press,
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "jCE" = (
 /obj/machinery/r_door_control/podbay/security/new_walls/south{
 	pixel_y = -24
@@ -75694,6 +75701,7 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
@@ -113082,7 +113090,7 @@ rdj
 rdj
 pcq
 xfZ
-dmd
+jCz
 prO
 prO
 pjN

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -2801,7 +2801,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/photocopier,
+/obj/machinery/printing_press,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aiN" = (
@@ -2859,7 +2859,7 @@
 /area/station/chapel/sanctuary)
 "ajb" = (
 /obj/table/wood/auto,
-/obj/item/bible,
+/obj/machinery/light/lamp/green,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "ajc" = (
@@ -3137,16 +3137,12 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "ajK" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/pen/fancy,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/table/wood/auto,
+/obj/item/bible,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "ajL" = (
@@ -3189,8 +3185,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ajT" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/green,
 /obj/blind_switch/area/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -3252,18 +3246,17 @@
 	},
 /area/station/chapel/sanctuary)
 "ake" = (
-/obj/shrub{
-	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
-	dir = 1;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	tag = "icon-plant (NORTH)"
-	},
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
 /obj/machinery/light_switch/east,
+/obj/table/wood/auto,
+/obj/item/pen/fancy,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 6
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "akf" = (
@@ -3778,24 +3771,18 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
 /area/station/chapel/sanctuary)
-"alz" = (
-/obj/stool/chair/comfy{
-	dir = 1
-	},
-/obj/landmark/start{
-	name = "Chaplain"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/office)
 "alA" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/landmark/start{
+	name = "Chaplain"
+	},
+/obj/stool/chair/comfy{
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -120220,7 +120207,7 @@ auA
 agI
 ajO
 ajb
-alz
+akK
 eCr
 akg
 age

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7176,6 +7176,14 @@
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
 	})
+"doi" = (
+/obj/machinery/printing_press,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/lounge/starboard{
+	name = "Book Nook"
+	})
 "dok" = (
 /obj/machinery/turret,
 /turf/simulated/floor/circuit/white,
@@ -112374,7 +112382,7 @@ noM
 iqc
 gKn
 hXv
-hXv
+doi
 iqc
 qoL
 eIa

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -8514,16 +8514,6 @@
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
-"avW" = (
-/obj/shrub{
-	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
 "avX" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -40770,6 +40760,13 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"coN" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
 "cpq" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -44688,6 +44685,16 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"ppL" = (
+/obj/shrub{
+	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "prv" = (
 /obj/table/auto,
 /obj/item/sheet/steel/reinforced{
@@ -46542,6 +46549,12 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"xgl" = (
+/obj/machinery/printing_press,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "xgZ" = (
 /obj/decal/cleanable/oil,
 /obj/decal/cleanable/dirt,
@@ -82922,7 +82935,7 @@ aoz
 amX
 anO
 amX
-anO
+ppL
 axh
 ayp
 azs
@@ -85036,7 +85049,7 @@ amV
 dyW
 amX
 auH
-auG
+coN
 ahY
 bjx
 azs
@@ -85338,7 +85351,7 @@ amW
 amX
 anO
 amX
-anO
+xgl
 ahY
 ayq
 azu
@@ -85640,7 +85653,7 @@ aqP
 ama
 amX
 anO
-avW
+amX
 ahY
 ayr
 azt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Also adds a nearby paper bin where there wasn't one already.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Printing presses are cool but currently only exist in cargo crates, they also seem like something the chaplain would have.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Added a printing press in or near the chapel on all rotation maps.
```
