### PR TITLE
Minor empty storage fixes

### DIFF
--- a/code/modules/storage/no_hud.dm
+++ b/code/modules/storage/no_hud.dm
@@ -33,6 +33,10 @@
 		var/obj/item/I = src.linked_item
 		I.inventory_counter_enabled = TRUE
 		I.create_inventory_counter()
+		if (!src.show_count)
+			I.inventory_counter.update_percent(0, 100)
+		else
+			I.inventory_counter.update_number(0)
 
 /datum/storage/no_hud/disposing()
 	if (src.use_inventory_counter && istype(src.linked_item, /obj/item))

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -63,6 +63,10 @@
 	src.sneaky = sneaky
 	src.opens_if_worn = opens_if_worn
 
+	if (istype(src.linked_item, /obj/item))
+		var/obj/item/I = src.linked_item
+		I.tooltip_rebuild = TRUE
+
 	RegisterSignal(src.linked_item, COMSIG_ITEM_DROPPED, PROC_REF(storage_item_on_drop))
 
 	if (length(spawn_contents))


### PR DESCRIPTION
[GAME OBJECTS][BUG][MINOR] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes storages created without any items afterwards not having their tooltips updated, and ones using /datum/storage/no_hud not having a zero inventory counter shown


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes