### PR TITLE
Fix storage removal not updating tooltip

### DIFF
--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -82,6 +82,10 @@
 	qdel(src.hud)
 	src.hud = null
 
+	if (istype(src.linked_item, /obj/item))
+		var/obj/item/I = src.linked_item
+		I.tooltip_rebuild = TRUE
+
 	src.linked_item = null
 	src.stored_items = null
 


### PR DESCRIPTION
[GAME OBJECTS][BUG][MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a small bug where the stored contents tooltip wasn't updated for when removing a storage from an atom


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix