### PR TITLE
Add storage datums to tables with desk drawers

### DIFF
--- a/code/WorkInProgress/AzrunStuff.dm
+++ b/code/WorkInProgress/AzrunStuff.dm
@@ -28,21 +28,13 @@
 	item_state = "sheet";
 	name = "Strange Blueprint"
 	interesting = "There is additional detail regarding the creation of flora and fauna."
-
-/obj/item/storage/desk_drawer/azrun/
-	spawn_contents = list(	/obj/item/raw_material/molitz_beta,\
-	/obj/item/raw_material/molitz_beta,\
-	/obj/item/raw_material/plasmastone,\
-	/obj/item/organ/lung/plasmatoid/left,\
-	/obj/item/pen/crayon/red,\
-
-)
 /obj/table/wood/auto/desk/azrun
-	New()
-		..()
-		var/obj/item/storage/desk_drawer/azrun/L = new(src)
-		src.desk_drawer = L
-
+	has_drawer = TRUE
+	drawer_contents = list(/obj/item/raw_material/molitz_beta,
+							/obj/item/raw_material/molitz_beta,
+							/obj/item/raw_material/plasmastone,
+							/obj/item/organ/lung/plasmatoid/left,
+							/obj/item/pen/crayon/red)
 
 /obj/item/storage/toilet/goldentoilet/azrun
 	name = "thinking throne"

--- a/code/WorkInProgress/aloe_stuff_public.dm
+++ b/code/WorkInProgress/aloe_stuff_public.dm
@@ -81,19 +81,14 @@
 		..()
 		src.occupant = new /mob/living/critter/small_animal/cat/brixley(src)
 		src.build_icon()
-/obj/item/storage/desk_drawer/aloe
-	spawn_contents = list(/obj/item/reagent_containers/patch/LSD,
-						  /obj/item/reagent_containers/patch/lsd_bee,
-						  /obj/item/cloth/handkerchief/nt,
-						  /obj/item/aiModule/hologram_expansion/elden,
-						  /obj/item/straw/fast,
-	)
 
 /obj/table/wood/auto/desk/aloe
-	New()
-		..()
-		var/obj/item/storage/desk_drawer/aloe/drawer = new(src)
-		src.desk_drawer = drawer
+	has_drawer = TRUE
+	drawer_contents = list(/obj/item/reagent_containers/patch/LSD,
+							/obj/item/reagent_containers/patch/lsd_bee,
+							/obj/item/cloth/handkerchief/nt,
+							/obj/item/aiModule/hologram_expansion/elden,
+							/obj/item/straw/fast)
 
 /area/centcom/offices/aloe
 	name = "\proper office of aloe"

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -634,21 +634,15 @@
 		mutations_to_add = list(new /datum/mutation_orb_mutdata(id = "cow", magical = 1))
 
 //lily's office
-/obj/item/storage/desk_drawer/lily/
-	spawn_contents = list(	/obj/item/reagent_containers/food/snacks/cake,\
-	/obj/item/reagent_containers/food/snacks/cake,\
-	/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake,\
-	/obj/item/reagent_containers/food/snacks/cake/cream,\
-	/obj/item/reagent_containers/food/snacks/cake/cream,\
-	/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau,\
-	/obj/item/reagent_containers/food/snacks/cake,\
-)
-
 /obj/table/wood/auto/desk/lily
-	New()
-		..()
-		var/obj/item/storage/desk_drawer/lily/L = new(src)
-		src.desk_drawer = L
+	has_drawer = TRUE
+	drawer_contents = list(/obj/item/reagent_containers/food/snacks/cake,
+						/obj/item/reagent_containers/food/snacks/cake,
+						/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake,
+						/obj/item/reagent_containers/food/snacks/cake/cream,
+						/obj/item/reagent_containers/food/snacks/cake/cream,
+						/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau,
+						/obj/item/reagent_containers/food/snacks/cake)
 
 /obj/machinery/door/unpowered/wood/lily
 

--- a/code/modules/food_and_drink/cakes.dm
+++ b/code/modules/food_and_drink/cakes.dm
@@ -518,6 +518,8 @@
 				qdel(W)
 
 	attack_hand(mob/user)
+		if (src.stored)
+			return ..()
 		if(length(cakeActions))
 			user.showContextActions(cakeActions, src)
 		else

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -421,6 +421,10 @@
 		user.s_active = null
 		user.detach_hud(src.hud)
 
+/// if user sees the storage hud
+/datum/storage/proc/hud_shown(mob/user)
+	return user in src.hud.mobs
+
 /// emping storage emps everything inside
 /datum/storage/proc/storage_emp_act()
 	for (var/atom/A as anything in src.get_contents())

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -111,38 +111,6 @@
 	desc = "A large briefcase for experimental toxins research."
 	spawn_contents = list(/obj/item/raw_material/molitz_beta = 2, /obj/item/paper/hellburn)
 
-/obj/item/storage/desk_drawer
-	name = "desk drawer"
-	desc = "This fits into a desk and you can store stuff in it! Wow, amazing!!"
-	icon = 'icons/obj/items/storage.dmi'
-	icon_state = "desk_drawer"
-	flags = FPRINT | TABLEPASS
-	w_class = W_CLASS_BULKY
-	max_wclass = W_CLASS_SMALL
-	slots = 13 // these can't move (in theory) and they can only hold w_class 2 things so we may as well let them hold a bunch
-	mechanics_type_override = /obj/item/storage/desk_drawer
-	var/locked = 0
-	var/id = null
-
-	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/device/key/filing_cabinet))
-			var/obj/item/device/key/K = W
-			if (src.id && K.id == src.id)
-				src.locked = !src.locked
-				user.visible_message("[user] [!src.locked ? "un" : null]locks [src].")
-				playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)
-			else
-				boutput(user, "<span class='alert'>[K] doesn't seem to fit in [src]'s lock.</span>")
-			return
-		..()
-
-	mouse_drop(atom/over_object, src_location, over_location)
-		if (src.locked)
-			if (usr)
-				boutput(usr, "<span class='alert'>[src] is locked!</span>")
-			return
-		..()
-
 /obj/item/storage/rockit
 	name = "\improper Rock-It Launcher"
 	desc = "Huh..."

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -275,7 +275,7 @@ TYPEINFO_NEW(/obj/table)
 
 		else if (istype(W, /obj/item/device/key/filing_cabinet) && src.has_drawer)
 			var/obj/item/device/key/K = W
-			if (src?.lock_id == K.id)
+			if (src.lock_id && src..lock_id == K.id)
 				src.drawer_locked = !src.drawer_locked
 				user.visible_message("[user] [!src.drawer_locked ? "un" : null]locks [src].")
 				playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -275,7 +275,7 @@ TYPEINFO_NEW(/obj/table)
 
 		else if (istype(W, /obj/item/device/key/filing_cabinet) && src.has_drawer)
 			var/obj/item/device/key/K = W
-			if (src.lock_id && src..lock_id == K.id)
+			if (src.lock_id && src.lock_id == K.id)
 				src.drawer_locked = !src.drawer_locked
 				user.visible_message("[user] [!src.drawer_locked ? "un" : null]locks [src].")
 				playsound(src, 'sound/items/Screwdriver2.ogg', 50, 1)

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -323,6 +323,10 @@ TYPEINFO_NEW(/obj/table)
 				actions.start(new /datum/action/bar/icon/railing_jump/table_jump(user, src), user)
 				return
 
+		if (src.has_drawer && src.drawer_locked)
+			boutput(user, "<span class='alert'>[src]'s desk drawer is locked!</span>")
+			return
+
 		return ..()
 
 	Cross(atom/movable/mover)


### PR DESCRIPTION
[GAME OBJECTS][REWORK][CLEANLINESS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR replaces the /obj/item/storage/desk_drawer that tables are using right now for storage with a storage datum

Something that's slightly different now though is that for adding an item to a storage by clicking its HUD, it relays the click to the item. Now that tables use a storage datum on them directly, this means that in order for storage to work on them, clicking the table while the HUD is shown will now place the item in the storage rather than on the table. Table storages now show at the location of the table always though, making it hard to click the table with the HUD up anyways, so it might be fine? Not sure if that should be considered a bug or not

They visually rustle now too

Also fixes a bug where chemistry tables that were supposed to be spawning with beakers weren't spawning with them

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleanliness