### PR TITLE
Fix storage on disposed atoms not dropping contents

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -197,8 +197,6 @@ TYPEINFO(/atom)
 		atom_properties = null
 		if(!ismob(src)) // I want centcom cloner to look good, sue me
 			ClearAllOverlays()
-
-		src.remove_storage()
 		..()
 
 	proc/Turn(var/rot)
@@ -508,6 +506,8 @@ TYPEINFO(/atom)
 
 	src.attached_objs?.Cut()
 	src.attached_objs = null
+
+	src.remove_storage()
 
 	src.vis_locs = null // cleans up vis_contents of visual holders of this too
 

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -73,6 +73,7 @@
 		src.make_my_stuff(spawn_contents)
 
 /datum/storage/disposing()
+	// content removal only works for storages on /atom/movable right now
 	for (var/obj/item/I as anything in src.get_contents())
 		src.transfer_stored_item(I, get_turf(src.linked_item))
 


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where items with storages on them weren't dropping their contents when the item was being qdel()'d

This will only work for /atom/movable right now, which can be added to any /atom when that's done for the first time

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix