### PR TITLE
Fix mimics getting a FIXME icon when they get dizzy

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1187,7 +1187,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 				if (canmove || isdead(src))
 					src.UpdateOverlays(null, "dizzy")
 					return
-				else
+				else if(src.is_valid_icon_state("dizzy",src.icon))
 					var/image/dizzyStars = src.SafeGetOverlayImage("dizzy", src.icon, "dizzy", MOB_OVERLAY_BASE+20) // why such a big boost? because the critter could have a bunch of overlays, that's why
 					if (dizzyStars)
 						src.UpdateOverlays(dizzyStars, "dizzy")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Checks for a valid icon state in the icon file when trying to add a dizzy overlay.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![image](https://github.com/goonstation/goonstation/assets/3855802/f74d5e97-77d3-489a-a32d-dfb64f23e55e)



