### PR TITLE
Various atlas fixes

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -249,10 +249,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"abe" = (
-/obj/wingrille_spawn/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
-/area/space)
 "abf" = (
 /obj/storage/secure/closet/security/forensics,
 /obj/machinery/camera{
@@ -327,6 +323,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/auto,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "abu" = (
@@ -373,6 +372,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "abF" = (
@@ -408,7 +410,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/disposal/small,
-/obj/disposalpipe/trunk,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "abN" = (
@@ -499,8 +503,7 @@
 	icon_state = "1-4"
 	},
 /obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
@@ -539,6 +542,10 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -579,10 +586,6 @@
 "ach" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/northwest)
-"aci" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/detectives_office)
 "acj" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /turf/simulated/floor/plating,
@@ -590,6 +593,10 @@
 "ack" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
@@ -933,16 +940,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"adf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
 "adg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -986,12 +983,11 @@
 /turf/simulated/floor/white,
 /area/station/bridge/united_command)
 "adp" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-L"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/staff_room)
 "adq" = (
@@ -1465,6 +1461,10 @@
 	},
 /obj/access_spawn/hydro,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "aeI" = (
@@ -1900,12 +1900,11 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "agb" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-M"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/staff_room)
 "agd" = (
@@ -2556,12 +2555,6 @@
 	dir = 5
 	},
 /area/station/security/main)
-"aig" = (
-/obj/disposalpipe/junction/left{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "aii" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -2812,12 +2805,11 @@
 /turf/space,
 /area/space)
 "aiX" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-L"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southwest)
 "aiY" = (
@@ -3142,12 +3134,11 @@
 	},
 /area/station/chapel/sanctuary)
 "ajW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-M"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southwest)
 "ajX" = (
@@ -3158,12 +3149,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "ajY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-R"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southwest)
 "ajZ" = (
@@ -3476,6 +3466,14 @@
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"alc" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig/genpop)
 "ale" = (
 /obj/machinery/flasher/solitary/new_walls/west,
 /obj/item/device/radio/intercom/brig,
@@ -3633,7 +3631,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
 "alB" = (
-/obj/artifact_spawner,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "alC" = (
@@ -3775,7 +3773,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
 "ame" = (
-/obj/disposalpipe/segment,
 /obj/machinery/navbeacon/tour/atlas/tour5,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -3815,6 +3812,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "amm" = (
@@ -3824,6 +3825,10 @@
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -3943,7 +3948,6 @@
 /area/station/hallway/primary/south)
 "amN" = (
 /obj/machinery/vending/medical,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -3959,20 +3963,12 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "amR" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light/small/floor,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"amS" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "amT" = (
 /obj/table/auto,
 /obj/item/storage/box/revimp_kit,
@@ -4002,13 +3998,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/security/main)
-"amX" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "amY" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -4178,14 +4167,6 @@
 /obj/item/card_box/plain,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"anG" = (
-/obj/stool/bench/auto,
-/obj/disposalpipe/segment,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/cafeteria)
 "anH" = (
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -4207,6 +4188,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/corner,
 /area/station/security/main)
 "anS" = (
@@ -4214,12 +4198,16 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "anT" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "2-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
@@ -4304,6 +4292,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "aof" = (
@@ -4435,6 +4424,10 @@
 /area/station/crew_quarters/cafeteria)
 "aoC" = (
 /obj/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
 "aoD" = (
@@ -4459,6 +4452,9 @@
 	persistent_id = "brig";
 	pixel_x = -32;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -4516,7 +4512,9 @@
 /obj/machinery/disposal/small{
 	dir = 8
 	},
-/obj/disposalpipe/trunk,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "aoR" = (
@@ -4550,7 +4548,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
 "aoU" = (
-/obj/disposalpipe/segment,
 /mob/living/critter/small_animal/cat/jones,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
@@ -4729,6 +4726,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/storage/eva)
 "apF" = (
@@ -4751,7 +4751,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/space)
+/area/station/solar/north)
 "apK" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -4938,6 +4938,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "aqs" = (
@@ -5041,7 +5042,6 @@
 /obj/shrub/captainshrub{
 	pixel_y = 9
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "aqK" = (
@@ -5156,6 +5156,11 @@
 	pixel_y = 21
 	},
 /obj/machinery/flasher/genpop/new_walls/north,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red,
 /area/station/security/brig/genpop)
 "are" = (
@@ -5167,11 +5172,8 @@
 	},
 /obj/access_spawn/captain,
 /obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/bridge/captain)
-"arf" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/black,
 /area/station/bridge/captain)
 "ari" = (
 /obj/machinery/atmospherics/valve{
@@ -5283,16 +5285,6 @@
 	dir = 4
 	},
 /area/station/security/secwing)
-"arz" = (
-/obj/securearea{
-	desc = "";
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "barsign";
-	name = "Bar"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/cafeteria)
 "arA" = (
 /obj/table/reinforced/auto,
 /obj/item/clipboard,
@@ -5332,10 +5324,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack,
 /area/station/bridge)
 "arG" = (
-/obj/disposalpipe/segment,
 /obj/atlasplaque{
 	pixel_y = 25
 	},
@@ -5512,9 +5504,6 @@
 "asp" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_fpen,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	autoclose = 0;
@@ -5576,15 +5565,6 @@
 	dir = 4
 	},
 /area/station/turret_protected/ai)
-"asu" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/blue,
-/area/station/bridge)
 "asv" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/bar,
@@ -5632,11 +5612,8 @@
 /area/station/security/secwing)
 "asC" = (
 /obj/machinery/navbeacon/tour/atlas/tour7,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asD" = (
-/obj/disposalpipe/junction/right/east{
-	dir = 1
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -5652,6 +5629,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon/tour/atlas/tour8,
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asI" = (
@@ -5676,10 +5657,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"asM" = (
-/obj/disposalpipe/junction/middle/west,
-/turf/simulated/floor/blue,
-/area/station/bridge)
 "asN" = (
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -5687,9 +5664,6 @@
 /area/station/bridge)
 "asO" = (
 /obj/machinery/computer/card,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"
@@ -5707,7 +5681,6 @@
 /area/station/hydroponics/bay)
 "asS" = (
 /obj/health_scanner/floor,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side,
 /area/station/hallway/primary/north)
 "asT" = (
@@ -5715,13 +5688,19 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small/floor,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blue/checker{
 	dir = 8
 	},
 /area/station/hallway/primary/north)
 "asU" = (
-/obj/disposalpipe/junction/right/north,
 /obj/landmark/halloween,
+/obj/disposalpipe/junction/middle/east{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asV" = (
@@ -5759,6 +5738,9 @@
 /area/station/bridge)
 "atb" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "atc" = (
@@ -5917,6 +5899,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "atB" = (
@@ -5929,7 +5912,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment,
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/blue,
 /area/station/bridge)
@@ -6067,25 +6049,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
-"atR" = (
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"atS" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "atT" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -6096,17 +6059,20 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
 /area/station/hallway/primary/north)
 "atU" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
@@ -6217,6 +6183,14 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "auo" = (
@@ -6246,6 +6220,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "aur" = (
@@ -6256,7 +6231,6 @@
 /turf/space,
 /area/space)
 "aus" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "auv" = (
@@ -6447,13 +6421,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
 /area/station/bridge)
 "avb" = (
 /obj/machinery/light_switch/auto,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -6495,6 +6469,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/auto,
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -7024,12 +7002,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "awz" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-L"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southeast)
 "awB" = (
@@ -7051,12 +7028,11 @@
 /turf/simulated/floor/engine,
 /area/station/engine/engineering)
 "awE" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-M"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southeast)
 "awG" = (
@@ -7532,17 +7508,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fblue2"
 	},
-/area/station/bridge/customs)
-"axQ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/blue,
 /area/station/bridge/customs)
 "axT" = (
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -7590,6 +7559,10 @@
 "axY" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
 	},
 /turf/simulated/floor/blue,
 /area/station/bridge/customs)
@@ -7805,7 +7778,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -7822,6 +7795,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
 "ayO" = (
@@ -7863,6 +7839,9 @@
 /area/space)
 "ayU" = (
 /obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "ayV" = (
@@ -7969,12 +7948,11 @@
 	},
 /area/station/hallway/primary/south)
 "azp" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
@@ -8044,12 +8022,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "azz" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-L"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/hangar/main)
 "azB" = (
@@ -8161,12 +8138,11 @@
 /turf/simulated/floor/grass/random,
 /area/station/hallway/primary/east)
 "azQ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-R"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/hangar/main)
 "azR" = (
@@ -8200,7 +8176,6 @@
 "azV" = (
 /obj/table/reinforced/auto,
 /obj/health_scanner/wall,
-/obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/access_spawn/medical,
 /turf/simulated/floor/blue,
@@ -8306,12 +8281,11 @@
 	},
 /area/station/science/artifact)
 "aAn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-R"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southeast)
 "aAp" = (
@@ -8552,11 +8526,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
-"aBi" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
 "aBj" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/portables_connector{
@@ -8799,6 +8768,11 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c";
+	name = "factory pipe"
+	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "aBU" = (
@@ -8831,6 +8805,9 @@
 "aCc" = (
 /obj/landmark/start{
 	name = "Medical Doctor"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -9646,6 +9623,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aEj" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aEk" = (
@@ -10240,7 +10218,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "aFS" = (
-/obj/cable,
 /turf/unsimulated/wall/setpieces/fakewindow{
 	dir = 6
 	},
@@ -10324,14 +10301,6 @@
 	dir = 8
 	},
 /area/station/science/artifact)
-"aGh" = (
-/obj/storage/closet,
-/obj/item/clothing/under/misc/syndicate,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/listeningpost)
 "aGi" = (
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -10528,6 +10497,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aGS" = (
@@ -10543,7 +10513,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/science/lab)
@@ -10786,6 +10756,12 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
+/obj/machinery/disposal/small{
+	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -10795,6 +10771,9 @@
 	level = 2
 	},
 /mob/living/critter/small_animal/bat/doctor,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aHz" = (
@@ -10833,6 +10812,7 @@
 	},
 /obj/access_spawn/tox,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple,
 /area/station/science/lab)
 "aHD" = (
@@ -10858,6 +10838,9 @@
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/science/lab)
@@ -10892,18 +10875,17 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/space)
+/area/station/janitor/office)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/main)
 "aHO" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
@@ -10941,6 +10923,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aHV" = (
@@ -10961,15 +10947,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aHX" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost)
 "aHY" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -11070,12 +11047,11 @@
 	},
 /area/station/solar/south)
 "aIA" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
@@ -11155,10 +11131,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/storage)
 "aIR" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
-"aIS" = (
-/obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "aIT" = (
@@ -11442,18 +11414,20 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aJW" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aJX" = (
@@ -11477,7 +11451,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/listeningpost/solars)
 "aJZ" = (
 /obj/stool/chair/red{
@@ -11485,6 +11459,9 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -11771,12 +11748,11 @@
 /turf/space,
 /area/space)
 "aKY" = (
-/obj/grille/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
 /obj/machinery/light/beacon,
-/turf/space,
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "aKZ" = (
 /obj/lattice{
@@ -11844,7 +11820,7 @@
 /area/ghostdrone_factory)
 "aLk" = (
 /obj/decal/cleanable/cobweb,
-/obj/artifact_spawner,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "aLl" = (
@@ -11863,12 +11839,12 @@
 /area/ghostdrone_factory)
 "aLo" = (
 /obj/decal/cleanable/robot_debris/limb,
-/obj/artifact_spawner,
+/obj/landmark/artifact,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "aLp" = (
 /obj/item/plank,
-/obj/artifact_spawner,
+/obj/landmark/artifact,
 /turf/simulated/floor/grime,
 /area/ghostdrone_factory)
 "aLq" = (
@@ -11881,7 +11857,7 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aLs" = (
 /obj/storage/crate/packing,
@@ -11904,7 +11880,7 @@
 /area/ghostdrone_factory)
 "aLw" = (
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aLx" = (
 /obj/storage/closet/fire,
@@ -11996,16 +11972,6 @@
 	name = "solar paneling"
 	},
 /area/listeningpost/solars)
-"aLJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southeast)
 "aLK" = (
 /obj/machinery/floorflusher/industrial,
 /obj/disposalpipe/trunk{
@@ -12028,20 +11994,13 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aLN" = (
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
-/area/ghostdrone_factory)
-"aLO" = (
-/obj/grille/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aLP" = (
 /obj/machinery/door/airlock/pyro/classic{
@@ -12103,7 +12062,7 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aLY" = (
 /turf/simulated/floor/stairs/wide,
@@ -12212,13 +12171,13 @@
 "aMq" = (
 /obj/grille/catwalk,
 /obj/grille/catwalk,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aMr" = (
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/ghostdrone_factory)
 "aMs" = (
 /obj/storage/crate/packing,
@@ -12360,7 +12319,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/listeningpost/solars)
 "aMP" = (
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -12436,7 +12395,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/listeningpost/solars)
 "aNe" = (
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -12579,9 +12538,6 @@
 /area/listeningpost/power)
 "aNG" = (
 /obj/table/auto,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "aNH" = (
@@ -12593,6 +12549,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "aNK" = (
@@ -12619,6 +12579,10 @@
 /obj/machinery/computer3/terminal{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "aNP" = (
@@ -12641,16 +12605,13 @@
 	name = "glow - WHITE"
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
 /area/listeningpost)
 "aNQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
@@ -12769,16 +12730,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/airless/circuit/red,
 /area/listeningpost)
 "aOi" = (
 /obj/marker/supplymarker,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -12788,18 +12743,6 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/listeningpost)
-"aOj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
 /area/listeningpost)
 "aOk" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -12826,16 +12769,13 @@
 	dir = 8
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
 /area/listeningpost)
 "aOv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -12905,12 +12845,21 @@
 /area/station/maintenance/east)
 "aOG" = (
 /obj/stool/chair/red,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "aOH" = (
 /obj/stool/chair/red,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -12923,6 +12872,8 @@
 /obj/machinery/computer3/terminal{
 	dir = 1
 	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "aOK" = (
@@ -12930,8 +12881,10 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit/red,
 /area/listeningpost)
 "aOL" = (
@@ -12989,7 +12942,7 @@
 	},
 /obj/machinery/power/tracker/small_backup4,
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/listeningpost/solars)
 "aOZ" = (
 /obj/landmark/map{
@@ -13110,6 +13063,9 @@
 	layer = 9.1;
 	light_type = /obj/item/light/tube/reddish;
 	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -13411,6 +13367,9 @@
 	pixel_y = 21
 	},
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "aQl" = (
@@ -13427,6 +13386,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -13810,6 +13770,10 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
@@ -14203,7 +14167,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "aSA" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
 "aSB" = (
@@ -14347,6 +14310,7 @@
 /obj/machinery/door/airlock/pyro/medical/alt,
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aSU" = (
@@ -14374,6 +14338,7 @@
 	},
 /obj/access_spawn/head_of_personnel,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "aTa" = (
@@ -14599,12 +14564,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "aTH" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-R"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/staff_room)
 "aTI" = (
@@ -14643,16 +14607,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"aTM" = (
-/obj/storage/closet,
-/obj/item/clothing/under/misc/syndicate,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/listeningpost)
 "aTN" = (
 /obj/grille/catwalk{
 	dir = 10
@@ -14661,7 +14615,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/listeningpost/solars)
 "aTP" = (
 /obj/cable{
@@ -14687,14 +14641,8 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
-"aTS" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aTT" = (
 /obj/rack,
@@ -14875,13 +14823,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"aUp" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hydroponics/bay)
 "aUr" = (
 /obj/machinery/light{
 	dir = 4
@@ -14973,7 +14914,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -14983,6 +14923,7 @@
 /area/station/science/teleporter)
 "aUG" = (
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aUH" = (
@@ -15028,6 +14969,7 @@
 	pixel_x = 23;
 	pixel_y = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "aUP" = (
@@ -15072,14 +15014,14 @@
 	light_type = /obj/item/light/tube/blueish;
 	pixel_x = 10
 	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/disposal/small{
 	dir = 8
 	},
 /obj/machinery/navbeacon/mule/medbay_north/south,
 /obj/decal/mule/beacon,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -15147,13 +15089,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aVi" = (
@@ -15238,12 +15177,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/arrivals)
 "aVs" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
@@ -15352,6 +15290,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aVK" = (
@@ -15444,10 +15386,6 @@
 	dir = 9
 	},
 /area/station/mining/staff_room)
-"aVY" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
 "aVZ" = (
 /obj/stool/chair{
 	dir = 1
@@ -15583,6 +15521,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
 "aWq" = (
@@ -15647,22 +15586,12 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
-"aWB" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/black,
-/area/listeningpost)
 "aWC" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
 	icon_state = "alt_heater-M"
 	},
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/station/hangar/main)
 "aWD" = (
@@ -15734,6 +15663,10 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
@@ -15857,18 +15790,6 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/listeningpost/syndicate_teleporter)
-"aWY" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/unsimulated/wall/setpieces/fakewindow{
-	dir = 6
-	},
-/area/listeningpost)
 "aXa" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -15904,14 +15825,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/united_command)
-"aXd" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/unsimulated/wall/setpieces/fakewindow{
-	dir = 6
-	},
-/area/listeningpost)
 "aXe" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -15961,6 +15874,10 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
@@ -16246,7 +16163,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
@@ -16307,10 +16224,7 @@
 /area/station/crew_quarters/kitchen)
 "aYv" = (
 /obj/machinery/plantpot,
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "aYw" = (
@@ -16381,6 +16295,10 @@
 "aYI" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
@@ -16565,6 +16483,7 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "aZj" = (
@@ -16572,7 +16491,7 @@
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
-/area/space)
+/area/station/janitor/office)
 "aZk" = (
 /obj/machinery/neosmelter,
 /obj/machinery/light{
@@ -16590,8 +16509,7 @@
 /obj/machinery/power/tracker/west,
 /obj/cable/yellow,
 /obj/grille/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -16661,7 +16579,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "aZz" = (
-/obj/disposalpipe/segment,
 /mob/living/critter/small_animal/dog/george/orwell,
 /obj/machinery/phone/wall{
 	pixel_y = 33
@@ -16898,6 +16815,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
@@ -16921,6 +16841,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "bzI" = (
@@ -16936,35 +16860,16 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "bCz" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
 /area/station/solar/north)
-"bFu" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hallway/primary/north)
-"bJP" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig/genpop)
 "bKM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17087,10 +16992,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -17105,7 +17010,9 @@
 /area/station/mining/staff_room)
 "cPz" = (
 /obj/cable{
-	icon_state = "2-8"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig/genpop)
@@ -17137,15 +17044,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
-"dbu" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "dcx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -17155,6 +17053,9 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -17168,6 +17069,16 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"dpb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "drv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
@@ -17214,6 +17125,18 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"dLh" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig/genpop)
 "dLC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17232,6 +17155,13 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
+"dRN" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "dSE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17246,6 +17176,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
+/obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor/blue/checker{
 	dir = 8
 	},
@@ -17356,8 +17287,37 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
+"ffY" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Customs"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	pixel_x = -20
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/turf/simulated/floor/blue,
+/area/station/bridge/customs)
 "fiL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17422,6 +17382,10 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
 /turf/simulated/floor{
 	icon_state = "nt_logo"
 	},
@@ -17480,6 +17444,17 @@
 	dir = 1
 	},
 /area/station/mining/refinery)
+"gkR" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Cafeteria"
+	},
+/obj/machinery/secscanner{
+	icon_state = "scanner_off";
+	pixel_y = 10
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/crew_quarters/cafeteria)
 "gmQ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -17664,6 +17639,9 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "hzw" = (
@@ -17674,6 +17652,21 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
+"hBv" = (
+/obj/rack,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/mask/breath,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/storage/eva)
 "hQO" = (
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/red/side{
@@ -17696,6 +17689,13 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"iat" = (
+/obj/fitness/weightlifter,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig/genpop)
 "ifZ" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt,
 /obj/cable{
@@ -17786,6 +17786,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -17869,9 +17870,19 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"jfb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/heads)
 "jiT" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -17890,7 +17901,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/junction,
+/obj/disposalpipe/junction/right/south,
 /turf/simulated/floor{
 	icon_state = "nt_logo"
 	},
@@ -17930,6 +17941,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "jOg" = (
@@ -17938,6 +17953,19 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
+"jQl" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/brig/genpop)
 "jUk" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -17972,10 +18000,14 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "jZd" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
 "jZF" = (
@@ -18016,6 +18048,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/checker{
 	dir = 8
 	},
@@ -18293,6 +18326,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"mbp" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/bridge/captain)
 "mds" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -18354,16 +18397,6 @@
 /obj/machinery/navbeacon/mule/QM2_north/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"mAT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "mBj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18472,6 +18505,9 @@
 "naC" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -18663,23 +18699,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"nRb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hallway/primary/north)
 "nSa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18688,6 +18707,16 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
+"nSr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "nVn" = (
 /obj/cable/brown{
 	icon_state = "1-2"
@@ -18742,7 +18771,7 @@
 	icon_state = "0-2"
 	},
 /obj/grille/catwalk{
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -18826,6 +18855,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"pdA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/east)
 "peD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18856,6 +18895,10 @@
 	dir = 5
 	},
 /area/station/security/main)
+"prE" = (
+/obj/disposalpipe/junction,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "puA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
@@ -18920,6 +18963,17 @@
 	dir = 1
 	},
 /area/station/bridge/customs)
+"pQO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c";
+	name = "factory pipe"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "pSv" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -18985,6 +19039,13 @@
 	icon_state = "fblue2"
 	},
 /area/station/bridge)
+"qik" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/ejection{
+	dir = 8
+	},
+/turf/space,
+/area/station/engine/combustion_chamber)
 "qiA" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -18992,6 +19053,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "qiY" = (
@@ -19219,6 +19281,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"suv" = (
+/obj/machinery/disposal/small{
+	dir = 1;
+	layer = 32;
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "suD" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -19299,6 +19370,16 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
+"sUe" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "sUL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19332,6 +19413,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "tdE" = (
@@ -19349,6 +19433,12 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
+"tmb" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "tmg" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -19396,15 +19486,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
-"tAJ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/junction/left/west,
-/turf/simulated/floor/blue/checker{
-	dir = 8
-	},
-/area/station/hallway/primary/north)
 "tEj" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -19454,6 +19535,9 @@
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "udk" = (
@@ -19471,6 +19555,18 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"uhw" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
 "uiv" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -19540,12 +19636,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "uEL" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
@@ -19672,20 +19767,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
-"vIA" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "vIO" = (
 /obj/storage/crate/rcd,
 /obj/machinery/power/apc/autoname_east,
@@ -19722,8 +19803,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment,
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fblue2"
@@ -19733,18 +19817,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
-/area/station/hallway/primary/north)
-"vZM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "wdb" = (
 /obj/cable{
@@ -19773,12 +19849,29 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/plating/random,
 /area/station/engine/substation/west)
+"whg" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/north)
 "wlm" = (
 /obj/displaycase{
 	displayed = new/obj/item/captaingun()
 	},
 /turf/simulated/floor/blue,
 /area/station/bridge/captain)
+"wlT" = (
+/obj/wingrille_spawn/auto/reinforced,
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/eva)
 "wod" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19787,6 +19880,12 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/disposal/small{
+	dir = 8
+	},
+/obj/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -19801,11 +19900,14 @@
 "wAL" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/cable,
 /obj/cable{
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -19907,12 +20009,11 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "xlM" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
@@ -19957,18 +20058,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"xwS" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "xyg" = (
 /obj/shrub{
 	dir = 6
@@ -19992,20 +20081,29 @@
 /obj/landmark/start{
 	name = "Medical Doctor"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "xDr" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
 /obj/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/grille/catwalk{
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
 /area/station/solar/north)
+"xEm" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "xLn" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -20037,6 +20135,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "yaQ" = (
@@ -20045,6 +20144,15 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
+"ycw" = (
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/security/brig/genpop)
 "ycT" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -20064,11 +20172,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "yjL" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/wingrille_spawn/auto/crystal/reinforced,
-/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/genpop)
 "yln" = (
@@ -53728,7 +53835,7 @@ aEJ
 aii
 apX
 aqW
-aqW
+qik
 aqW
 ato
 aws
@@ -54424,7 +54531,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aLw
 aMr
@@ -55028,7 +55135,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aLw
 aMr
@@ -55632,7 +55739,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aLw
 aMr
@@ -60995,8 +61102,8 @@ aWy
 aVa
 aPF
 aGG
-aLJ
-aIS
+aXW
+aIR
 aGS
 aJH
 aRk
@@ -61297,7 +61404,7 @@ aDM
 aHm
 aUn
 aGG
-aCs
+aXW
 aIR
 aHE
 aJG
@@ -61599,7 +61706,7 @@ aGa
 aGJ
 aHo
 aGG
-aCs
+aXW
 aIR
 aQk
 axK
@@ -61672,7 +61779,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aLw
 aMr
@@ -61901,9 +62008,9 @@ aCj
 aIg
 agF
 aGG
-aCs
+aXW
 aIT
-aJo
+uhw
 aJJ
 aXA
 aYj
@@ -62276,7 +62383,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aLw
 aMr
@@ -62880,7 +62987,7 @@ aaa
 aLr
 aLw
 aLw
-aLO
+aLw
 aLw
 aMq
 aMr
@@ -66712,7 +66819,7 @@ anA
 auV
 aqK
 aqK
-aUp
+aqK
 avP
 aeH
 avP
@@ -67014,8 +67121,8 @@ kaC
 fiL
 jEN
 asn
-nRb
-bFu
+sUL
+jEN
 atT
 jEN
 sUL
@@ -67317,10 +67424,10 @@ aat
 aat
 afP
 amZ
-asD
-afP
 aat
-amZ
+pQO
+ahV
+dRN
 afP
 aat
 aat
@@ -68227,12 +68334,12 @@ auk
 akT
 aat
 asU
-akT
+aps
 ame
 asS
 azV
 aUC
-aTS
+ayF
 ayF
 ayF
 guq
@@ -68528,7 +68635,7 @@ awG
 lXC
 eLp
 awG
-awG
+sUe
 qiA
 iAV
 vZk
@@ -69110,7 +69217,7 @@ abp
 aCr
 abt
 acA
-add
+adg
 adF
 aUR
 aQR
@@ -69411,8 +69518,8 @@ aaQ
 afT
 aYO
 abL
-aci
-adf
+acA
+adg
 adF
 aei
 aeV
@@ -69426,12 +69533,12 @@ akt
 alk
 amc
 amR
-anG
-anG
-anG
-aqu
-arz
-aiI
+aot
+aot
+aot
+anJ
+atN
+afl
 aps
 ahV
 avY
@@ -69449,7 +69556,7 @@ aFA
 aFB
 aUo
 acF
-ayF
+tmb
 aGv
 aBx
 aIY
@@ -69727,13 +69834,13 @@ akv
 akt
 alk
 anH
-anJ
-anJ
+xEm
+aqu
 aUG
-anJ
-anJ
-aqy
-afl
+aqu
+aqu
+gkR
+aiI
 aps
 amv
 avY
@@ -69751,7 +69858,7 @@ ayg
 aFC
 aRj
 aAJ
-aAJ
+dpb
 aTR
 aST
 aWL
@@ -70056,7 +70163,7 @@ ayF
 adR
 afg
 aBx
-aIY
+pdA
 aGW
 awh
 aFD
@@ -70337,10 +70444,10 @@ aot
 aot
 anJ
 atN
-aig
-akT
-aat
-aBi
+afl
+aps
+ahV
+ayg
 amN
 ayE
 azj
@@ -71543,9 +71650,9 @@ anD
 aoD
 apx
 cPz
-bJP
+aqL
 yjL
-dbu
+afl
 iLG
 ahV
 ayh
@@ -71847,7 +71954,7 @@ anD
 ard
 arL
 jZd
-xwS
+afl
 xyg
 amv
 ayh
@@ -72145,11 +72252,11 @@ alr
 amq
 aPk
 aoE
-avu
-aqL
-arL
-jZd
-xwS
+ycw
+jQl
+iat
+dLh
+afl
 bQk
 ahV
 ayh
@@ -72450,8 +72557,8 @@ aoG
 apz
 arq
 aqL
-jZd
-xwS
+alc
+afl
 hUo
 ahV
 ayh
@@ -72753,8 +72860,8 @@ anD
 aVk
 arP
 anD
-vIA
-uHV
+aua
+aps
 ahV
 ayh
 awQ
@@ -72766,7 +72873,7 @@ aAO
 aAO
 aAO
 aDo
-aEj
+suv
 aEj
 aGO
 aJV
@@ -73664,7 +73771,7 @@ aps
 ahV
 agD
 aow
-aow
+whg
 aip
 alf
 aAS
@@ -73676,8 +73783,8 @@ aCL
 aCL
 aCL
 aXh
-aCL
-aCL
+aTm
+aTm
 aJW
 aGj
 aJc
@@ -74263,8 +74370,8 @@ akK
 aul
 afD
 ami
-amS
-mAT
+afl
+aps
 ahV
 ahV
 ahV
@@ -74565,12 +74672,12 @@ aat
 aat
 aat
 aat
-atR
+prE
 jtz
 aat
 aat
 aat
-aat
+prE
 aat
 aat
 aat
@@ -74862,12 +74969,12 @@ dLC
 vkO
 wSQ
 awG
-vZM
+awG
 awG
 awG
 liS
 mSy
-lXC
+awG
 bvy
 ltM
 mSy
@@ -75165,11 +75272,11 @@ act
 aiK
 act
 anT
-avc
-aoC
+wlT
+wlT
 aoC
 app
-amX
+amn
 amm
 amn
 ayi
@@ -75469,10 +75576,10 @@ act
 anU
 anU
 anU
-anU
-aoC
-afl
-aps
+hBv
+avc
+ahV
+nSr
 qLQ
 ayi
 ayo
@@ -75773,7 +75880,7 @@ aoL
 aSM
 apE
 tSg
-lXC
+awG
 fBL
 iEp
 ayi
@@ -76075,7 +76182,7 @@ aoL
 aoL
 vIO
 avc
-afl
+ahV
 asG
 asL
 ayi
@@ -76377,7 +76484,7 @@ aqz
 aDA
 app
 ave
-afl
+ahV
 aml
 ahV
 apT
@@ -76679,7 +76786,7 @@ amr
 amr
 amr
 anb
-tAJ
+krp
 dWW
 krp
 asT
@@ -76699,7 +76806,7 @@ aGC
 aHi
 aHJ
 aIl
-abe
+aIm
 aaa
 aaa
 aaa
@@ -76984,7 +77091,7 @@ hpN
 asp
 atH
 auo
-hpN
+ffY
 aFO
 aWz
 azt
@@ -77001,7 +77108,7 @@ aGD
 aHj
 aHK
 aPl
-abe
+aIm
 aaa
 aaa
 aaa
@@ -77303,7 +77410,7 @@ aGD
 aHk
 aHL
 aIm
-abe
+aIm
 aaa
 aaa
 aaa
@@ -77604,7 +77711,7 @@ aEu
 aGE
 aZj
 aHM
-abe
+aIm
 aaa
 aaa
 aaa
@@ -77887,7 +77994,7 @@ amu
 amu
 amu
 axM
-axQ
+ayd
 axY
 ayd
 pLJ
@@ -77904,9 +78011,9 @@ azf
 aFa
 aWH
 aFa
-abe
-abe
-abe
+aIm
+aIm
+aIm
 aaa
 aaa
 aaa
@@ -78189,7 +78296,7 @@ aoS
 izG
 amu
 asq
-atS
+asq
 aun
 asq
 asq
@@ -78486,18 +78593,18 @@ aaa
 aVi
 amY
 cTa
-aoe
+mbp
 aoe
 aqr
 are
 arF
-asu
+auq
 atA
 auq
 ava
 aSY
 aWp
-aYI
+jfb
 aYI
 aTb
 aQu
@@ -78791,13 +78898,13 @@ aob
 aoQ
 aoU
 aqH
-arf
+amu
 arG
-asM
+aus
 atC
 aus
 avb
-aVY
+aBK
 aZz
 aSA
 aYm
@@ -92515,8 +92622,8 @@ aaa
 aaa
 aaa
 agK
-aXd
-aWY
+aFS
+aFS
 aFS
 aYB
 aaa
@@ -93117,7 +93224,7 @@ aaa
 aaa
 aaa
 aaa
-aXd
+aFS
 aNG
 aNP
 aOi
@@ -93419,10 +93526,10 @@ aaa
 aaa
 aaa
 aaa
-aXd
+aFS
 aNG
 aNQ
-aOj
+aUH
 aOv
 aNG
 aFS
@@ -97041,16 +97148,16 @@ aaa
 aaa
 aaa
 aaa
-aXd
-aTM
-aHX
+aFS
+aNq
+aUH
 aNe
 aNY
 aJf
 aOB
 aNe
-aWB
-aGh
+aUH
+aOQ
 aFS
 aaa
 aaa
@@ -97343,16 +97450,16 @@ aaa
 aaa
 aaa
 aaa
-aXd
-aTM
-aHX
+aFS
+aNq
+aUH
 aNL
 aOa
 aFQ
 aOa
 aNL
-aWB
-aGh
+aUH
+aOQ
 aFS
 aaa
 aaa

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -19904,10 +19904,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/cable,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red/side{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes wires under fake object walls on the listening post.
Fixes missing catwalk supports from under certain catwalks.
Changes some disposals pipes to not go under walls and windows. Ones in engineering unchanged because I dunno Which is the worse crime: pipes under pipes or pipes under walls.
Fixes eva grilles not being fully electric.
Updates old artifact spawners to landmark spawners.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Correctness.

