### PR TITLE
Default mutantrace

### DIFF
--- a/code/datums/abilities/lizard.dm
+++ b/code/datums/abilities/lizard.dm
@@ -83,7 +83,7 @@
 		if (..())
 			return 1
 
-		if (L.mutantrace && !istype(L.mutantrace, /datum/mutantrace/lizard) || !L.organHolder)
+		if (!istype(L.mutantrace, /datum/mutantrace/lizard) || !L.organHolder)
 			boutput(L, "<span class='notice'>You don't have any chromatophores.</span>")
 			return 1
 
@@ -114,7 +114,7 @@
 		if (..())
 			return 1
 
-		if (L.mutantrace && !istype(L.mutantrace, /datum/mutantrace/lizard))
+		if (!istype(L.mutantrace, /datum/mutantrace/lizard))
 			boutput(L, "<span class='notice'>You don't have any chromatophores.</span>")
 			return 1
 
@@ -144,7 +144,7 @@
 		if (..())
 			return 1
 
-		if (L.mutantrace && !istype(L.mutantrace, /datum/mutantrace/lizard))
+		if (!istype(L.mutantrace, /datum/mutantrace/lizard))
 			boutput(L, "<span class='notice'>You're fresh out of chromatophores.</span>")
 			return 1
 

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -285,8 +285,8 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 											"[user] slides [his_or_her(user)] razor across [isAI(M) ? "your screen" : "the front of your head"].",\
 									"You shave off a small patch of [isAI(M) ? "dust stuck to [M]'s screen" : "rust on [M]'s face"].")
 		return 0 // runtimes violate law 1, probably
-	else if(!M.mutantrace || M.hair_override)
-		return 1 // is human or mutant forced to be hairy, should be fine
+	else if((M.mutantrace.mutant_appearance_flags & HAS_HUMAN_HAIR) || M.hair_override)
+		return 1 // has human hair or mutant forced to be hairy, should be fine
 	else
 		var/datum/mutantrace/mutant = M.mutantrace.name
 		var/datum/mutantrace/mutant_us = "human"

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -312,7 +312,7 @@
 				mob_type = "Monkey"
 			else if (ishuman(src))
 				var/mob/living/carbon/human/H = src
-				if (H.mutantrace && !H.mutantrace.human_compatible)
+				if (!H.mutantrace.human_compatible)
 					mob_type = capitalize(H.mutantrace.name)
 				else
 					mob_type = "Human"

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -296,7 +296,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 	disposing()
 		if (src.mob)
-			src.mob.mutantrace = null
 			src.mob.set_face_icon_dirty()
 			src.mob.set_body_icon_dirty()
 

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -30,7 +30,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	*
 	* (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | HAS_NO_HEAD | USES_STATIC_ICON)
 	*
-	* NOT_DIMORPHIC tells the sprite builder not to use any female sprites or vars. If you remove this, make sure there's a torso_f and groin_f in the mutant's DMI!
+	* NOT_DIMORPHIC tells the sprite builder not to use any female sprites or vars. If you remove this, make sure there's a chest_f and groin_f in the mutant's DMI!
 	*
 	* HAS_NO_SKINTONE, HAS_NO_EYES, HAS_NO_HEAD each prevent the renderer from trying to colorize the player's body or apply hair / eyes. They tend to be baked in.
 	*
@@ -127,12 +127,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	var/l_limb_arm_type_mutantrace_f = null
 	var/r_limb_leg_type_mutantrace_f = null
 	var/l_limb_leg_type_mutantrace_f = null
-
-	//This stuff is for robot_parts, the stuff above is for human_parts
-	var/r_robolimb_arm_type_mutantrace = null // Should we get custom arms? Dispose() replaces them with normal human arms.
-	var/l_robolimb_arm_type_mutantrace = null
-	var/r_robolimb_leg_type_mutantrace = null
-	var/l_robolimb_leg_type_mutantrace = null
 
 	///If true, normal limbs use custom icons for this mutantrace
 	var/override_limb_icons = FALSE
@@ -675,6 +669,15 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			if(src.detail_oversuit_1_color_f)
 				src.detail_oversuit_1_color = src.detail_oversuit_1_color_f
 
+/datum/mutantrace/human
+	name = "human"
+	icon = 'icons/mob/human.dmi'
+	mutant_folder = 'icons/mob/human.dmi'
+	icon_state = "blank"
+	human_compatible = TRUE
+	mutant_appearance_flags = HUMAN_APPEARANCE_FLAGS
+	dna_mutagen_banned = FALSE
+	
 /datum/mutantrace/blob // podrick's july assjam submission, it's pretty cute
 	name = "blob"
 	icon = 'icons/mob/blob_ambassador.dmi'

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -14,7 +14,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	/// The mutant's own appearanceholder, modified to suit our target appearance
 	var/datum/appearanceHolder/AH
 	/// The mutant's original appearanceholder, from before they were a mutant, to restore their old appearance
-	var/datum/appearanceHolder/origAH
 	var/override_eyes = 1
 	var/override_hair = 1
 	var/override_beard = 1
@@ -321,7 +320,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 						W.layer = initial(W.layer)
 			if (ishuman(src.mob))
 				var/mob/living/carbon/human/H = src.mob
-				AppearanceSetter(H, "reset")
 				MutateMutant(H, "reset")
 				organ_mutator(H, "reset")
 				LimbSetter(H, "reset")
@@ -348,109 +346,77 @@ ABSTRACT_TYPE(/datum/mutantrace)
 		if(!ishuman(H) || !(H?.bioHolder?.mobAppearance) || !src.AH)
 			return // please dont call set_mutantrace on a non-human non-appearanceholder
 
-		switch(mode)
-			if("set")	// upload everything, the appearance flags'll determine what gets used
-				src.origAH = new/datum/appearanceHolder
-				src.origAH.CopyOther(AH) // backup the old appearanceholder
+		AH.mob_appearance_flags = src.mutant_appearance_flags
+		AH.customization_first_offset_y = src.head_offset
+		AH.customization_second_offset_y = src.head_offset
+		AH.customization_third_offset_y = src.head_offset
 
-				AH.mob_appearance_flags = src.mutant_appearance_flags
-				AH.customization_first_offset_y = src.head_offset
-				AH.customization_second_offset_y = src.head_offset
-				AH.customization_third_offset_y = src.head_offset
+		var/typeinfo/datum/mutantrace/typeinfo = src.get_typeinfo()
+		if(typeinfo.special_styles)
+			if (!AH.special_style || !typeinfo.special_styles[AH.special_style]) // missing or invalid style
+				AH.special_style = pick(typeinfo.special_styles)
+			src.special_style = AH.special_style
+			src.mutant_folder = typeinfo.special_styles[AH.special_style]
 
-				var/typeinfo/datum/mutantrace/typeinfo = src.get_typeinfo()
-				if(typeinfo.special_styles)
-					if (!AH.special_style || !typeinfo.special_styles[AH.special_style]) // missing or invalid style
-						AH.special_style = pick(typeinfo.special_styles)
-					src.special_style = AH.special_style
-					src.mutant_folder = typeinfo.special_styles[AH.special_style]
+		AH.special_hair_1_icon = src.special_hair_1_icon
+		AH.special_hair_1_state = src.special_hair_1_state
+		AH.special_hair_1_color_ref = src.special_hair_1_color
+		AH.special_hair_1_layer = src.special_hair_1_layer
+		AH.special_hair_1_offset_y = src.head_offset
 
-				AH.special_hair_1_icon = src.special_hair_1_icon
-				AH.special_hair_1_state = src.special_hair_1_state
-				AH.special_hair_1_color_ref = src.special_hair_1_color
-				AH.special_hair_1_layer = src.special_hair_1_layer
-				AH.special_hair_1_offset_y = src.head_offset
+		AH.special_hair_2_icon = src.special_hair_2_icon
+		AH.special_hair_2_state = src.special_hair_2_state
+		AH.special_hair_2_color_ref = src.special_hair_2_color
+		AH.special_hair_2_layer = src.special_hair_2_layer
+		AH.special_hair_2_offset_y = src.head_offset
 
-				AH.special_hair_2_icon = src.special_hair_2_icon
-				AH.special_hair_2_state = src.special_hair_2_state
-				AH.special_hair_2_color_ref = src.special_hair_2_color
-				AH.special_hair_2_layer = src.special_hair_2_layer
-				AH.special_hair_2_offset_y = src.head_offset
+		AH.special_hair_3_icon = src.special_hair_3_icon
+		AH.special_hair_3_state = src.special_hair_3_state
+		AH.special_hair_3_color_ref = src.special_hair_3_color
+		AH.special_hair_3_layer = src.special_hair_1_layer
+		AH.special_hair_3_offset_y = src.head_offset
 
-				AH.special_hair_3_icon = src.special_hair_3_icon
-				AH.special_hair_3_state = src.special_hair_3_state
-				AH.special_hair_3_color_ref = src.special_hair_3_color
-				AH.special_hair_3_layer = src.special_hair_1_layer
-				AH.special_hair_3_offset_y = src.head_offset
+		AH.mob_detail_1_icon = src.detail_1_icon
+		AH.mob_detail_1_state = src.detail_1_state
+		AH.mob_detail_1_color_ref = src.detail_1_color
+		AH.mob_detail_1_offset_y = src.body_offset
 
-				AH.mob_detail_1_icon = src.detail_1_icon
-				AH.mob_detail_1_state = src.detail_1_state
-				AH.mob_detail_1_color_ref = src.detail_1_color
-				AH.mob_detail_1_offset_y = src.body_offset
+		AH.mob_oversuit_1_icon = src.detail_oversuit_1_icon
+		AH.mob_oversuit_1_state = src.detail_oversuit_1_state
+		AH.mob_oversuit_1_color_ref = src.detail_oversuit_1_color
+		AH.mob_oversuit_1_offset_y = src.body_offset
 
-				AH.mob_oversuit_1_icon = src.detail_oversuit_1_icon
-				AH.mob_oversuit_1_state = src.detail_oversuit_1_state
-				AH.mob_oversuit_1_color_ref = src.detail_oversuit_1_color
-				AH.mob_oversuit_1_offset_y = src.body_offset
+		AH.mob_head_offset = src.head_offset
+		AH.mob_hand_offset = src.hand_offset
+		AH.mob_body_offset = src.body_offset
+		AH.mob_leg_offset = src.leg_offset
+		AH.mob_arm_offset = src.arm_offset
 
-				AH.mob_head_offset = src.head_offset
-				AH.mob_hand_offset = src.hand_offset
-				AH.mob_body_offset = src.body_offset
-				AH.mob_leg_offset = src.leg_offset
-				AH.mob_arm_offset = src.arm_offset
+		if (src.mutant_appearance_flags & FIX_COLORS)	// mods the special colors so it doesnt mess things up if we stop being special
+			AH.customization_first_color = fix_colors(AH.customization_first_color)
+			AH.customization_second_color = fix_colors(AH.customization_second_color)
+			AH.customization_third_color = fix_colors(AH.customization_third_color)
 
-				if (src.mutant_appearance_flags & FIX_COLORS)	// mods the special colors so it doesnt mess things up if we stop being special
-					AH.customization_first_color = fix_colors(AH.customization_first_color)
-					AH.customization_second_color = fix_colors(AH.customization_second_color)
-					AH.customization_third_color = fix_colors(AH.customization_third_color)
+		AH.s_tone_original = AH.s_tone
+		if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_1)
+			AH.s_tone = AH.customization_first_color
+		else if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_2)
+			AH.s_tone = AH.customization_second_color
+		else if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_3)
+			AH.s_tone = AH.customization_third_color
+		else
+			AH.s_tone = AH.s_tone_original
 
-				AH.s_tone_original = AH.s_tone
-				if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_1)
-					AH.s_tone = AH.customization_first_color
-				else if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_2)
-					AH.s_tone = AH.customization_second_color
-				else if(src.mutant_appearance_flags & SKINTONE_USES_PREF_COLOR_3)
-					AH.s_tone = AH.customization_third_color
-				else
-					AH.s_tone = AH.s_tone_original
+		AH.mutant_race = src
+		if (!src.dna_mutagen_banned)
+			AH.original_mutant_race = src
+		AH.body_icon = src.mutant_folder
+		AH.body_icon_state = src.icon_state
+		AH.e_icon = src.eye_icon
+		AH.e_state = src.eye_state
+		AH.e_offset_y = src.eye_offset ? src.eye_offset : src.head_offset
 
-				AH.mutant_race = src
-				if (!src.dna_mutagen_banned)
-					AH.original_mutant_race = src
-				AH.body_icon = src.mutant_folder
-				AH.body_icon_state = src.icon_state
-				AH.e_icon = src.eye_icon
-				AH.e_state = src.eye_state
-				AH.e_offset_y = src.eye_offset ? src.eye_offset : src.head_offset
-
-				AH.UpdateMob()
-			if("reset")
-				var/still_should_have_this_funky_skintone = null // Hulk and such still require us to be a funky color
-				if(H.bioHolder.HasOneOfTheseEffects("hulk", "albinism", "blankman", "melanism", "achromia"))
-					still_should_have_this_funky_skintone = AH.s_tone
-				AH.CopyOther(src.origAH)
-				if(still_should_have_this_funky_skintone)
-					AH.s_tone = still_should_have_this_funky_skintone
-				AH.mob_appearance_flags = HUMAN_APPEARANCE_FLAGS
-				AH.body_icon = 'icons/mob/human.dmi'
-				AH.mutant_race = null
-				AH.customization_first_offset_y = 0
-				AH.customization_second_offset_y = 0
-				AH.customization_third_offset_y = 0
-				AH.mob_head_offset = 0
-				AH.mob_hand_offset = 0
-				AH.mob_body_offset = 0
-				AH.mob_arm_offset = 0
-				AH.mob_leg_offset = 0
-				AH.e_offset_y = 0 // Fun fact, monkey eyes are right at nipple height
-				AH.mob_oversuit_1_offset_y = 0
-				AH.mob_detail_1_offset_y = 0
-				AH.special_hair_3_offset_y = 0
-				AH.special_hair_2_offset_y = 0
-				AH.special_hair_1_offset_y = 0
-				AH.UpdateMob()
-				qdel(origAH)
-
+		AH.UpdateMob()
 
 	proc/LimbSetter(var/mob/living/carbon/human/L, var/mode as text)
 		if(!ishuman(L) || !L.organHolder || !L.limbs)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -639,7 +639,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	name = "human"
 	icon = 'icons/mob/human.dmi'
 	mutant_folder = 'icons/mob/human.dmi'
-	icon_state = "blank"
+	icon_state = "body_m"
 	human_compatible = TRUE
 	mutant_appearance_flags = HUMAN_APPEARANCE_FLAGS
 	dna_mutagen_banned = FALSE

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1768,7 +1768,7 @@ datum/preferences
 
 		if (ishuman(character))
 			var/mob/living/carbon/human/H = character
-			if (H.mutantrace.voice_override)
+			if (H.mutantrace?.voice_override) //yass TODO: find different way of handling this
 				H.voice_type = H.mutantrace.voice_override
 
 	proc/apply_post_new_stuff(mob/living/character)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1768,7 +1768,7 @@ datum/preferences
 
 		if (ishuman(character))
 			var/mob/living/carbon/human/H = character
-			if (H.mutantrace && H.mutantrace.voice_override)
+			if (H.mutantrace.voice_override)
 				H.voice_type = H.mutantrace.voice_override
 
 	proc/apply_post_new_stuff(mob/living/character)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -1061,7 +1061,7 @@ datum/preferences
 			logTheThing(LOG_DEBUG, usr ? usr : null, null, "a preference datum's appearence holder is null!")
 			return
 
-		var/datum/mutantrace/mutantRace = null
+		var/datum/mutantrace/mutantRace = /datum/mutantrace/human
 		for (var/ID in traitPreferences.traits_selected)
 			var/datum/trait/T = getTraitById(ID)
 			if (T?.mutantRace)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -203,7 +203,6 @@
 	proc/onAdd(var/mob/owner)
 		if(mutantRace && ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			H.mutantrace?.origAH.CopyOther(H.bioHolder.mobAppearance)
 			H.set_mutantrace(mutantRace)
 		return
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -203,6 +203,7 @@
 	proc/onAdd(var/mob/owner)
 		if(mutantRace && ishuman(owner))
 			var/mob/living/carbon/human/H = owner
+			H.default_mutantrace = mutantRace
 			H.set_mutantrace(mutantRace)
 		return
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -627,7 +627,7 @@
 		return
 
 	//Zombies just rise again (after a delay)! Oh my!
-	if (src.mutantrace && src.mutantrace.onDeath(gibbed))
+	if (src.mutantrace.onDeath(gibbed))
 		return
 
 	if (src.bioHolder && src.bioHolder.HasEffect("revenant"))
@@ -710,7 +710,7 @@
 	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 	emote("deathgasp") //let the world KNOW WE ARE DEAD
 
-	if (!src.mutantrace || inafterlife(src)) // wow fucking racist
+	if (!inafterlife(src))
 		modify_christmas_cheer(-7)
 
 	src.canmove = 0
@@ -1425,16 +1425,10 @@
 		return 1*/
 
 /mob/living/carbon/human/say_quote(var/text)
-	var/sayverb = null
-	if (src.mutantrace)
-		if (src.mutantrace.voice_message)
-			src.voice_name = src.mutantrace.voice_name
-			src.voice_message = src.mutantrace.voice_message
-		sayverb = src.mutantrace.say_verb()
-	else
-		src.voice_name = initial(src.voice_name)
-		src.voice_message = initial(src.voice_message)
-
+	if (src.mutantrace.voice_message)
+		src.voice_name = src.mutantrace.voice_name
+		src.voice_message = src.mutantrace.voice_message
+	var/sayverb = src.mutantrace.say_verb()
 	var/special = 0
 	if (src.stamina < STAMINA_WINDED_SPEAK_MIN)
 		special = "gasp_whisper"
@@ -3110,9 +3104,7 @@
 		.= 4 * (src.hand ? 1 : -1) * (src.dir & WEST ? 1 : -1)
 
 /mob/living/carbon/human/get_hand_pixel_y()
-	.= -5
-	if (src.mutantrace)
-		.+= src.mutantrace.hand_offset
+	.= -5 + src.mutantrace.hand_offset
 
 /mob/living/carbon/human/verb/show_inventory()
 	set name = "Show Inventory"

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -168,6 +168,8 @@
 
 	var/datum/humanInventory/inventory = null
 
+	var/default_mutantrace = /datum/mutantrace/human
+
 /mob/living/carbon/human/New(loc, datum/appearanceHolder/AH_passthru, datum/preferences/init_preferences, ignore_randomizer=FALSE)
 	. = ..()
 
@@ -233,6 +235,7 @@
 			MB.power = microbombs_4_everyone
 
 	src.text = "<font color=#[random_hex(3)]>@"
+	src.set_mutantrace(src.default_mutantrace)
 	src.update_colorful_parts()
 
 	init_preferences?.apply_post_new_stuff(src)
@@ -2944,6 +2947,8 @@
 
 /mob/living/carbon/human/set_mutantrace(var/datum/mutantrace/mutantrace_type)
 
+	if(!mutantrace_type)
+		mutantrace_type = src.default_mutantrace
 	if(src.mutantrace)
 		qdel(src.mutantrace) // so that disposing() runs and removes mutant traits
 		. = 1

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2953,7 +2953,7 @@
 	if(ispath(mutantrace_type, /datum/mutantrace) )	//Set a new mutantrace only if passed one
 		src.mutantrace = new mutantrace_type(src)
 		src.mutantrace.MutateMutant(src, "set")
-		src.mutantrace.on_attach() // Mutant race initalization, to avoid issues with abstract representation in New()
+		src.mutantrace.on_attach(src) // Mutant race initalization, to avoid issues with abstract representation in New()
 		. = 1
 
 	if(.)

--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -248,6 +248,7 @@ mob/living/carbon/human/cluwne/satan/megasatan //someone can totally use this fo
 	New()
 		..()
 		src.bioHolder.AddEffect("cow")
+		src.default_mutantrace = /datum/mutantrace/cow
 
 	initializeBioholder()
 		. = ..()
@@ -694,6 +695,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 	New()
 		..()
 		src.bioHolder.AddEffect("cow")
+		src.default_mutantrace = /datum/mutantrace/cow
 
 
 // merchant
@@ -848,6 +850,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 	New()
 		..()
 		src.bioHolder.AddEffect("cow")
+		src.default_mutantrace = /datum/mutantrace/cow
 
 
 /mob/living/carbon/human/tommy

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -12,12 +12,12 @@
 #ifdef IN_MAP_EDITOR
 	icon_state = "monkey"
 #endif
+	default_mutantrace = /datum/mutantrace/monkey
 
 	New()
 		..()
 		SPAWN(0.5 SECONDS)
 			if (!src.disposed)
-				src.bioHolder.AddEffect("monkey")
 				if (src.name == "monkey" || !src.name)
 					src.name = pick_string_autokey("names/monkey.txt")
 				src.real_name = src.name
@@ -197,13 +197,13 @@
 	var/list/shitlist = list()
 	var/ai_aggression_timeout = 600
 	var/ai_poke_thing_chance = 1
+	default_mutantrace = /datum/mutantrace/monkey
 
 	New()
 		..()
 		START_TRACKING
 		if (!src.disposed)
 			src.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-			src.bioHolder.AddEffect("monkey")
 			if (src.name == "monkey" || !src.name)
 				src.name = pick_string_autokey("names/monkey.txt")
 			src.real_name = src.name
@@ -630,12 +630,12 @@
 	name = "sea monkey"
 	max_health = 150
 	ai_useitems = FALSE // or they eat all the floor pills and die before anyone visits
+	default_mutantrace = /datum/mutantrace/monkey/seamonkey
 
 	New()
 		..()
 		SPAWN(0.5 SECONDS)
 			if (!src.disposed)
-				src.bioHolder.AddEffect("seamonkey")
 				if (src.name == "sea monkey" || !src.name)
 					src.name = pick_string_autokey("names/monkey.txt")
 				src.real_name = src.name

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -328,20 +328,19 @@
 	if(src.traitHolder?.hasTrait("athletic"))
 		brute *=1.33
 
-	if (src.mutantrace)
-		var/typemult
-		if(islist(src.mutantrace.typevulns))
-			typemult = src.mutantrace.typevulns[DAMAGE_TYPE_TO_STRING(damage_type)]
-		if(!typemult)
-			typemult = 1
-		if(damage_type == DAMAGE_BURN)
-			burn *= typemult
-		else
-			brute *= typemult
+	var/typemult
+	if(islist(src.mutantrace.typevulns))
+		typemult = src.mutantrace.typevulns[DAMAGE_TYPE_TO_STRING(damage_type)]
+	if(!typemult)
+		typemult = 1
+	if(damage_type == DAMAGE_BURN)
+		burn *= typemult
+	else
+		brute *= typemult
 
-		brute *= src.mutantrace.brutevuln
-		burn *= src.mutantrace.firevuln
-		tox *= src.mutantrace.toxvuln
+	brute *= src.mutantrace.brutevuln
+	burn *= src.mutantrace.firevuln
+	tox *= src.mutantrace.toxvuln
 
 
 	//if (src.bioHolder && src.bioHolder.HasEffect("resist_toxic"))

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -33,15 +33,16 @@
 
 	var/maptext_out = 0
 	var/message = null
-	if (src.mutantrace)
-		var/list/mutantrace_emote_stuff = src.mutantrace.emote(act, voluntary)
-		if(!islist(mutantrace_emote_stuff))
-			message = mutantrace_emote_stuff
-		else
-			if(length(mutantrace_emote_stuff) >= 1)
-				message = mutantrace_emote_stuff[1]
-			if(length(mutantrace_emote_stuff) >= 2)
-				maptext_out = mutantrace_emote_stuff[2]
+
+	var/list/mutantrace_emote_stuff = src.mutantrace.emote(act, voluntary)
+	if(!islist(mutantrace_emote_stuff))
+		message = mutantrace_emote_stuff
+	else
+		if(length(mutantrace_emote_stuff) >= 1)
+			message = mutantrace_emote_stuff[1]
+		if(length(mutantrace_emote_stuff) >= 2)
+			maptext_out = mutantrace_emote_stuff[2]
+
 	if (!message)
 		switch (lowertext(act))
 			// most commonly used emotes first for minor performance improvements

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -806,7 +806,7 @@
 	var/image/i_r_hand = null
 	var/image/i_l_hand = null
 
-	var/hand_offset = src.mutantrace.hand_offset
+	var/hand_offset = src.mutantrace?.hand_offset
 
 	if (src.limbs)
 		if(src.l_hand && src.r_hand && src.l_hand == src.r_hand && src.l_hand.two_handed)

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -11,14 +11,9 @@
 		blood_image = image('icons/effects/blood.dmi')
 
 	// lol
-	var/head_offset = 0
-	var/hand_offset = 0
-	var/body_offset = 0
-
-	if (src.mutantrace)
-		head_offset = src.mutantrace.head_offset
-		hand_offset = src.mutantrace.hand_offset
-		body_offset = src.mutantrace.body_offset
+	var/head_offset = src.mutantrace.head_offset
+	var/hand_offset = src.mutantrace.hand_offset
+	var/body_offset = src.mutantrace.body_offset
 
 	src.update_lying()
 
@@ -811,9 +806,7 @@
 	var/image/i_r_hand = null
 	var/image/i_l_hand = null
 
-	var/hand_offset = 0
-	if (src.mutantrace)
-		hand_offset = src.mutantrace.hand_offset
+	var/hand_offset = src.mutantrace.hand_offset
 
 	if (src.limbs)
 		if(src.l_hand && src.r_hand && src.l_hand == src.r_hand && src.l_hand.two_handed)

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -243,7 +243,7 @@
 	say_understands(var/other)
 		if (ishuman(other))
 			var/mob/living/carbon/human/H = other
-			if (!H.mutantrace || !H.mutantrace.exclusive_language)
+			if (!H.mutantrace.exclusive_language)
 				return 1
 		if (isrobot(other))
 			return 1

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -316,6 +316,8 @@
 		return 1
 
 	var/mult = (max(tick_spacing, TIME - last_human_life_tick) / tick_spacing)
+	
+	src.mutantrace.onLife(mult)
 
 	if (farty_party)
 		src.emote("fart")
@@ -338,9 +340,6 @@
 			var/obj/item/parts/human_parts/leg/D = src.limbs.r_leg
 			if(D.original_holder && src != D.original_holder)
 				D.foreign_limb_effect()
-
-	if (src.mutantrace)
-		src.mutantrace.onLife(mult)
 
 	if (!isdead(src)) // Marq was here, breaking everything.
 

--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -14,7 +14,7 @@
 			if (!isrestrictedz(T.z) && H.loc == T && T.temp_flags & HAS_KUDZU) //only infect if on the floor
 				H.infect_kudzu()
 
-			if (H.mutantrace && !H.mutantrace.decomposes)
+			if (!H.mutantrace.decomposes)
 				return ..()
 
 			var/suspend_rot = \

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -49,7 +49,7 @@
 
 		if (ishuman(other))
 			var/mob/living/carbon/human/H = other
-			if (!H.mutantrace || !H.mutantrace.exclusive_language)
+			if (!H.mutantrace.exclusive_language)
 				return 1
 			else
 				return 0

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1398,7 +1398,7 @@ var/global/list/ai_emotions = list("Happy" = "ai_happy", \
 /mob/living/silicon/ai/say_understands(var/other)
 	if (ishuman(other))
 		var/mob/living/carbon/human/H = other
-		if(!H.mutantrace || !H.mutantrace.exclusive_language)
+		if(!H.mutantrace.exclusive_language)
 			return 1
 	if (isrobot(other))
 		return 1

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -820,7 +820,7 @@ Frequency:
 		return TRUE
 	if (ishuman(other))
 		var/mob/living/carbon/human/H = other
-		if (!H.mutantrace || !H.mutantrace.exclusive_language)
+		if (!H.mutantrace.exclusive_language)
 			return TRUE
 		else
 			return ..()

--- a/code/mob/living/silicon/hivebot/mainframe.dm
+++ b/code/mob/living/silicon/hivebot/mainframe.dm
@@ -61,7 +61,7 @@
 /mob/living/silicon/hive_mainframe/say_understands(var/other)
 	if (ishuman(other))
 		var/mob/living/carbon/human/H = other
-		if(!H.mutantrace || !H.mutantrace.exclusive_language)
+		if(!H.mutantrace.exclusive_language)
 			return 1
 	if (isrobot(other))
 		return 1

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1829,7 +1829,7 @@
 		if (isAI(other)) return 1
 		if (ishuman(other))
 			var/mob/living/carbon/human/H = other
-			if(!H.mutantrace || !H.mutantrace.exclusive_language)
+			if(!H.mutantrace.exclusive_language)
 				return 1
 		if (ishivebot(other)) return 1
 		return ..()

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -518,8 +518,6 @@ var/global/debug_messages = 0
 	if (!race)
 		return
 
-	if(H.mutantrace)
-		qdel(H.mutantrace)
 	H.set_mutantrace(race)
 	H.set_face_icon_dirty()
 	H.set_body_icon_dirty()

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -865,8 +865,7 @@
 
 		src.hair_override = H.hair_override
 
-		if(H.mutantrace)
-			src.mutantrace = new H.mutantrace.type
+		src.mutantrace = new H.mutantrace.type
 		return
 
 	proc/update_menu()
@@ -936,8 +935,7 @@
 		if(src.update_wearid && target_mob.wear_id)
 			target_mob.choose_name(1,1,target_mob.real_name, force_instead = 1)
 
-		if(src.mutantrace)
-			target_mob.set_mutantrace(src.mutantrace.type)
+		target_mob.set_mutantrace(src.mutantrace.type)
 
 		switch(src.cinematic)
 			if("Changeling") //Heh
@@ -1024,10 +1022,7 @@
 		else
 			g = "f"
 
-		if(src.mutantrace)
-			src.preview_icon = new /icon(src.mutantrace.icon, src.mutantrace.icon_state)
-		else
-			src.preview_icon = new /icon('icons/mob/human.dmi', "body_[g]")
+		src.preview_icon = new /icon(src.mutantrace.icon, src.mutantrace.icon_state) //todo: #14465
 
 		if(!src.mutantrace?.override_skintone)
 			// Skin tone

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1016,12 +1016,6 @@
 		var/customization_second_r = null
 		var/customization_third_r = null
 
-		var/g = "m"
-		if (src.tf_holder.mobAppearance.gender == MALE)
-			g = "m"
-		else
-			g = "f"
-
 		src.preview_icon = new /icon(src.mutantrace.icon, src.mutantrace.icon_state) //todo: #14465
 
 		if(!src.mutantrace?.override_skintone)

--- a/code/modules/antagonists/changeling/abilities/transform.dm
+++ b/code/modules/antagonists/changeling/abilities/transform.dm
@@ -20,8 +20,8 @@
 		var/mob/living/carbon/human/H = holder.owner
 		if(!istype(H))
 			return 1
-		if (H.mutantrace)
-			if (ismonkey(H))
+		if (ismonkey(H))
+			if (!istype(H.default_mutantrace, /datum/mutantrace/monkey))
 				if (tgui_alert(H,"Are we sure?","Exit this lesser form?",list("Yes","No")) != "Yes")
 					return 1
 				doCooldown()
@@ -50,11 +50,8 @@
 				H.abilityHolder.updateButtons()
 				logTheThing(LOG_COMBAT, H, "leaves lesser form as a changeling, [log_loc(H)].")
 				return 0
-			else if (isabomination(H))
-				boutput(H, "We cannot transform in this form.")
-				return 1
 			else
-				boutput(H, "We cannot transform in this form.")
+				boutput(H, "We cannot leave this form in this way.")
 				return 1
 		else
 			if (tgui_alert(H,"Are we sure?","Assume lesser form?",list("Yes","No")) != "Yes")

--- a/code/modules/antagonists/hunter/hunter.dm
+++ b/code/modules/antagonists/hunter/hunter.dm
@@ -351,8 +351,6 @@
 		src.handcuffs.destroy_handcuffs(src)
 	src.buckled = null
 
-	if (src.mutantrace)
-		qdel(src.mutantrace)
 	src.set_mutantrace(/datum/mutantrace/hunter)
 
 	var/datum/abilityHolder/hunter/A = src.get_ability_holder(/datum/abilityHolder/hunter)

--- a/code/modules/antagonists/werewolf/abilities/_werewolf_ability_holder.dm
+++ b/code/modules/antagonists/werewolf/abilities/_werewolf_ability_holder.dm
@@ -43,7 +43,7 @@
 
 			playsound(M.loc, 'sound/impact_sounds/Slimy_Hit_4.ogg', 50, 1, -1)
 			SPAWN(0.5 SECONDS)
-				if (M?.mutantrace && istype(M.mutantrace, /datum/mutantrace/werewolf))
+				if (istype(M?.mutantrace, /datum/mutantrace/werewolf))
 					M.emote("howl")
 
 			M.visible_message("<span class='alert'><B>[M] [pick("metamorphizes", "transforms", "changes")] into a werewolf! Holy shit!</B></span>")

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -900,7 +900,7 @@ datum
 				if(!ishuman(holder?.my_atom))
 					return
 				var/mob/living/carbon/human/M = holder.my_atom
-				if(M.mutantrace && !src.orig_mutantrace)
+				if(!src.orig_mutantrace)
 					src.orig_mutantrace = M.mutantrace.type
 
 			on_mob_life_complete(var/mob/living/carbon/human/M)
@@ -1620,10 +1620,8 @@ datum
 				..()
 
 			on_mob_life_complete(var/mob/living/carbon/human/M)
-				if(M && istype(M))
-					if (!M.mutantrace)
-						if(M.bioHolder)
-							M.bioHolder.AddEffect("roach",0,bioeffect_length) //length of bioeffect proportionate to length grasshopper was in human
+				if(istype(M))
+					M.bioHolder?.AddEffect("roach",0,bioeffect_length) //length of bioeffect proportionate to length grasshopper was in human
 
 		fooddrink/alcoholic/freeze
 			name = "Freeze"

--- a/code/modules/medical/genetics/bioEffects/mutantrace.dm
+++ b/code/modules/medical/genetics/bioEffects/mutantrace.dm
@@ -92,7 +92,7 @@
 	research_level = EFFECT_RESEARCH_ACTIVATED
 	msgGain = "You become human."
 	msgLose = "ook."
-	icon_state  = "monkey"
+	icon_state  = "blank"
 	probability = 0
 	occur_in_genepools = FALSE
 

--- a/code/modules/medical/genetics/bioEffects/mutantrace.dm
+++ b/code/modules/medical/genetics/bioEffects/mutantrace.dm
@@ -83,6 +83,19 @@
 	msgLose = "You shed your roachy skin!"
 	icon_state  = "roach"
 
+/datum/bioEffect/mutantrace/human
+	name = "Less Primal Genetics"
+	desc = "Makes one into a boring-old human being. YOU SHOULD NOT SEE THIS"
+	id = "human"
+	mutantrace_option = "Human"
+	mutantrace_path = /datum/mutantrace/human
+	research_level = EFFECT_RESEARCH_ACTIVATED
+	msgGain = "You become human."
+	msgLose = "ook."
+	icon_state  = "monkey"
+	probability = 0
+	occur_in_genepools = FALSE
+
 /datum/bioEffect/mutantrace/monkey
 	name = "Primal Genetics"
 	desc = "Enables and exaggerates vestigal ape traits."

--- a/code/modules/medical/genetics/bioEffects/mutantrace.dm
+++ b/code/modules/medical/genetics/bioEffects/mutantrace.dm
@@ -4,7 +4,6 @@
 	id = "lizard"
 	mutantrace_option = "Lizard"
 	effectType = EFFECT_TYPE_MUTANTRACE
-	effect_group = "mutantrace"
 	probability = 33
 	msgGain = "Your skin feels oddly dry."
 	msgLose = "Your scales fall off."
@@ -22,18 +21,18 @@
 		..() // caaaaaaall yooooooour paaaareeeeents
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
+			if (!istype(H.mutantrace, src.mutantrace_path))
+				H.set_mutantrace(src.mutantrace_path)
 			for (var/ID in H.bioHolder.effects)
 				// clear away any existing mutantraces first
 				if (istype(H.bioHolder.GetEffect(ID), /datum/bioEffect/mutantrace) && ID != src.id)
 					H.bioHolder.RemoveEffect(ID)
-			if (!istype(H.mutantrace, src.mutantrace_path))
-				H.set_mutantrace(src.mutantrace_path)
 
 	OnRemove()
 		..()
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
-			if (istype(H.mutantrace,src.mutantrace_path))
+			if (istype(H.mutantrace,src.mutantrace_path) && !istype(H.default_mutantrace, src.mutantrace_path))
 				H.set_mutantrace(null)
 
 	OnLife()

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -340,7 +340,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			H.sound_fart = fartsounds[fartsound || "default"] || fartsounds["default"]
 			H.voice_type = voicetype || RANDOM_HUMAN_VOICE
 
-			if (H.mutantrace && H.mutantrace.voice_override)
+			if (H.mutantrace.voice_override)
 				H.voice_type = H.mutantrace.voice_override
 
 			H.update_name_tag()

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -506,7 +506,7 @@
 			if (!istype(H) || isprematureclone(H))
 				return
 			var/datum/bioEffect/mutantrace/BE = locate(params["ref"])
-			if (H.mutantrace && !H.mutantrace?.genetics_removable)
+			if (!H.mutantrace?.genetics_removable)
 				//this should probably be a UI notification but I'm not touching that code with a ten foot pole
 				scanner_alert(ui.user, "Unable to purge corrupt genotype.")
 				return

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -1079,7 +1079,7 @@
 					"precisionEmitter" = genResearch.isResearched(/datum/geneticsResearchEntry/rad_precision),
 					"materialMax" = genResearch.max_material,
 					"mutantRaces" = list(list(
-						"name" = "Human",
+						"name" = "Clear Mutantrace",
 						"icon" = "template",
 						"ref" = "\ref[null]",
 						)),

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3199,7 +3199,7 @@ TYPEINFO(/obj/item/device/guardbot_module)
 						if (!has_contraband_permit)
 							. += perp.back.get_contraband() * 0.5
 
-				if(perp.mutantrace && perp.mutantrace.jerk)
+				if(perp.mutantrace.jerk)
 //					if(istype(perp.mutantrace, /datum/mutantrace/zombie))
 //						return 5 //Zombies are bad news!
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1386,11 +1386,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 												/datum/mutantrace/monkey, /datum/mutantrace/roach, /datum/mutantrace/cow,
 										 		/datum/mutantrace/pug)
 
-	implanted(mob/M, mob/I)
-		..()
-		if (ishuman(src.owner))
-			var/mob/living/carbon/human/H = owner
-
 	do_process(var/mult = 1)
 		if (ishuman(src.owner) && !active)
 			active = TRUE

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1382,7 +1382,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		..()
 
 /obj/item/implant/artifact/wizard/wizard_gimmick
-	var/datum/mutantrace/original_mutantrace = null
 	var/static/list/possible_mutantraces = list(null, /datum/mutantrace/lizard, /datum/mutantrace/skeleton, /datum/mutantrace/ithillid,
 												/datum/mutantrace/monkey, /datum/mutantrace/roach, /datum/mutantrace/cow,
 										 		/datum/mutantrace/pug)
@@ -1391,7 +1390,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		..()
 		if (ishuman(src.owner))
 			var/mob/living/carbon/human/H = owner
-			original_mutantrace = H.mutantrace
 
 	do_process(var/mult = 1)
 		if (ishuman(src.owner) && !active)
@@ -1411,9 +1409,9 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	on_remove()
 		if (ishuman(src.owner))
 			var/mob/living/carbon/human/H = owner
-			if (H.mutantrace != original_mutantrace)
+			if (H.mutantrace != H.default_mutantrace)
 				gibs(get_turf(H), null, H.bioHolder.Uid, H.bioHolder.bloodType, 0)
-			H.set_mutantrace(original_mutantrace)
+			H.set_mutantrace(null)
 		..()
 
 /obj/item/implant/artifact/wizard/wizard_bad

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -535,10 +535,7 @@
 				state = I.item_state ? I.item_state + "-L" : (I.icon_state ? I.icon_state + "-L" : "L")
 			handimage.icon_state = state
 
-			if (H.mutantrace)
-				handimage.pixel_y = H.mutantrace.hand_offset + 6
-			else
-				handimage.pixel_y = 6
+			handimage.pixel_y = H.mutantrace.hand_offset + 6
 
 			if (H)
 				//H.update_clothing()
@@ -668,11 +665,7 @@
 			if(!(state in icon_states(I.inhand_image_icon)))
 				state = I.item_state ? I.item_state + "-R" : (I.icon_state ? I.icon_state + "-R" : "R")
 
-			handimage.icon_state = state
-			if (H.mutantrace)
-				handimage.pixel_y = H.mutantrace.hand_offset + 6
-			else
-				handimage.pixel_y = 6
+			handimage.pixel_y = H.mutantrace.hand_offset + 6
 
 			if (H)
 				H.update_clothing()

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -237,9 +237,9 @@ TYPEINFO(/obj/machinery/clonepod)
 
 		if (istype(oldholder))
 			oldholder.clone_generation++
+			src.occupant.bioHolder.CopyOther(oldholder, copyActiveEffects = connected?.gen_analysis)
 			src.occupant?.set_mutantrace(oldholder?.mobAppearance?.mutant_race?.type)
 			src.occupant?.set_mutantrace(oldholder?.mobAppearance?.original_mutant_race?.type)
-			src.occupant.bioHolder.CopyOther(oldholder, copyActiveEffects = connected?.gen_analysis)
 			oldholder.mobAppearance?.mutant_race = oldholder.mobAppearance?.original_mutant_race
 			if(ishuman(src.occupant))
 				var/mob/living/carbon/human/H = src.occupant

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -183,15 +183,15 @@ TYPEINFO(/obj/machinery/secscanner)
 
 		var/mob/living/carbon/human/perp = target
 
-		if (perp.mutantrace)
-			if (istype(perp.mutantrace, /datum/mutantrace/abomination))
-				threatcount += 8
-			else if (istype(perp.mutantrace, /datum/mutantrace/zombie))
-				threatcount += 6
-			else if (istype(perp.mutantrace, /datum/mutantrace/werewolf) || istype(perp.mutantrace, /datum/mutantrace/hunter))
-				threatcount += 4
-			else if (istype(perp.mutantrace, /datum/mutantrace/cat))
-				threatcount += 3
+		//yass TODO: move this to a var on mutantrace
+		if (istype(perp.mutantrace, /datum/mutantrace/abomination))
+			threatcount += 8
+		else if (istype(perp.mutantrace, /datum/mutantrace/zombie))
+			threatcount += 6
+		else if (istype(perp.mutantrace, /datum/mutantrace/werewolf) || istype(perp.mutantrace, /datum/mutantrace/hunter))
+			threatcount += 4
+		else if (istype(perp.mutantrace, /datum/mutantrace/cat))
+			threatcount += 3
 
 		if(perp.traitHolder.hasTrait("stowaway") && perp.traitHolder.hasTrait("jailbird"))
 			if(isnull(data_core.security.find_record("name", perp.name)))

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -204,7 +204,7 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals/posters.dmi', "wa
 
 /mob/living/carbon/human/build_flat_icon(var/direction)
 	var/icon/return_icon
-	if (src.mutantrace)
+	if (src.mutantrace) //TODO: #14465
 		return_icon = icon(src.mutantrace.icon, src.mutantrace.icon_state, direction ? direction : null)
 	else
 		return_icon = icon('icons/mob/human.dmi', "body_[src.gender == MALE ? "m" : "f"]", direction ? direction : null)

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -74,7 +74,7 @@
 		if (!has_fluid_move_gear)
 			if (ishuman(A))
 				var/mob/living/carbon/human/H = A
-				if (H.mutantrace && H.mutantrace.aquatic)
+				if (H.mutantrace.aquatic)
 					has_fluid_move_gear = 1
 
 		if (!has_fluid_move_gear)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -324,7 +324,7 @@ var/list/stinkThingies = list("ass","armpit","excretions","leftovers","administr
 			message = say_gurgle(message)
 			messageEffects += "Gurgle"
 
-	if(H.mutantrace && !isdead(H))
+	if(!isdead(H))
 		message = H.mutantrace.say_filter(message)
 		messageEffects += "[H.mutantrace] say_filter()"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a `human` mutantrace, and adds handling for default mutantraces for `mob/.../human`s

TODO:
- [x] Bioeffect for human mutantrace
- [x] Mutantrace traits set default mutantrace
- [x] Misc NPCs (void diner guys etc.)
- [x] fix bugs? 😭
- [x] Strip out all the code paths that are only for `null` mutantrace


fixes #14430

Also cleans out a few unused vars off of mutantraces

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
First step(s) in moving to a world in which code can assume all `/mob/.../human`s have a valid mutantrace, instead being if-elsed everywhere


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Tarmunora
(*)"Human" is now a mutantrace. This will probably cause some bugs. Please report any mutantrace-related weirdness
```
