### PR TITLE
Wingrille spawner colour update

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1087,17 +1087,19 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 			name = "reinforced autowindow grille spawner"
 			win_path = "/obj/window/auto/reinforced"
 			icon_state = "r-wingrille_new"
+			color = "#72c8fd"
 
 		crystal
 			name = "crystal autowindow grille spawner"
 			win_path = "/obj/window/auto/crystal"
 			icon_state = "wingrille_new"
-			color = "#A114FF"
+			color = "#9e53cf"
 
 			reinforced
 				name = "reinforced crystal autowindow grille spawner"
 				win_path = "/obj/window/auto/crystal/reinforced"
 				icon_state = "r-wingrille_new"
+				color = "#8713d4"
 
 		tuff
 			name = "tuff stuff reinforced autowindow grille spawner"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates new wingrille spawner sprites with colour differentiation like the previous sprites.

![image](https://github.com/goonstation/goonstation/assets/113442598/d5517c28-2e7e-46c6-a659-df9c9766ab9b)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The sprite difference between the two currently may be hard to see without zooming in. This should make it easy to tell whats reinforced and whats not.

