### PR TITLE
Add locked table random room

### DIFF
--- a/assets/maps/random_rooms/5x3/lockedtable_75.dmm
+++ b/assets/maps/random_rooms/5x3/lockedtable_75.dmm
@@ -1,0 +1,74 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/floor/airless/grime,
+/area/dmm_suite/clear_area)
+"f" = (
+/obj/table/wood/auto/desk{
+	drawer_locked = 1;
+	has_drawer = 1;
+	lock_id = "locked_table_random_room"
+	},
+/obj/machinery/light/lamp/black{
+	pixel_x = -6;
+	pixel_y = 9;
+	switchon = 1
+	},
+/turf/simulated/floor/airless/grime,
+/area/dmm_suite/clear_area)
+"h" = (
+/obj/table/wood/auto/desk{
+	drawer_contents = list(/obj/item/device/key/filing_cabinet/locked_table_random_room, /obj/item/clothing/lanyard, /obj/item/reagent_containers/food/snacks/chips = 3);
+	drawer_locked = 1;
+	has_drawer = 1;
+	lock_id = "locked_table_random_room"
+	},
+/obj/item/paper/locked_table_random_room{
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/airless/grime,
+/area/dmm_suite/clear_area)
+"j" = (
+/obj/table/wood/auto/desk{
+	drawer_locked = 1;
+	has_drawer = 1;
+	lock_id = "locked_table_random_room"
+	},
+/obj/item/device/light/lava_lamp/activated{
+	pixel_x = 4;
+	pixel_y = 13
+	},
+/turf/simulated/floor/airless/grime,
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/stool/chair/wooden{
+	dir = 1
+	},
+/turf/simulated/floor/airless/grime,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+f
+a
+"}
+(3,1,1) = {"
+a
+h
+S
+"}
+(4,1,1) = {"
+a
+j
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+"}

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -572,4 +572,4 @@ all for the love of you.</tt>"}
 	info = {"Alright, so get this... I get these nice tables, with these nice locks... I set them up in this place where I can do my work in peace.
 			I heard something scary, so I leave for a few minutes, leaving my key behind. I come back. AND THEY'RE LOCKED... WITH A NOTE ON THE TABLE
 			SAYING THE KEY'S INSIDE ONE OF THEM. WHY??? I kicked the table, and YES, there is something metal in there. Well... what am I going to do
-			now?}
+			now?"}

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -566,3 +566,10 @@ all for the love of you.</tt>"}
 	info = {"<h3>These coolers are for emergency use only</h3></br>
 			In the event of a meltdown scenario, activate the coolers and ensure the gas loop is pressurised.<br>
 			Use of these coolers outside of an emergency scenario will result in a loss of reactor efficiency and stalling of the turbine."}
+
+/obj/item/paper/locked_table_random_room
+	name = "dusty note"
+	info = {"Alright, so get this... I get these nice tables, with these nice locks... I set them up in this place where I can do my work in peace.
+			I heard something scary, so I leave for a few minutes, leaving my key behind. I come back. AND THEY'RE LOCKED... WITH A NOTE ON THE TABLE
+			SAYING THE KEY'S INSIDE ONE OF THEM. WHY??? I kicked the table, and YES, there is something metal in there. Well... what am I going to do
+			now?}

--- a/code/obj/item/keys.dm
+++ b/code/obj/item/keys.dm
@@ -180,3 +180,7 @@ ABSTRACT_TYPE(/obj/item/device/key)
 	name = "tubular key"
 	desc = "One of those cylinder keys that you see on vending machines and stuff."
 	icon_state = "key_round"
+
+/obj/item/device/key/filing_cabinet/locked_table_random_room
+	desc = "A key for locking desk drawers. Cool."
+	id = "locked_table_random_room"

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -34,7 +34,7 @@ TYPEINFO_NEW(/obj/table)
 	/// whether the storage can be accessed or not
 	var/drawer_locked = FALSE
 	/// id for key checks, keys with the same id can lock it
-	var/lock_id = FALSE
+	var/lock_id = null
 	HELP_MESSAGE_OVERRIDE({"You can use a <b>wrench</b> on <span class='harm'>harm</span> intent to disassemble it."})
 
 	New(loc)


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new random room, which contains three locked tables, with a note on them.

![image](https://github.com/goonstation/goonstation/assets/53062374/5989560f-6f8e-4c9f-a503-ac0c050917b6)

Idea here is that the tables are locked, but if you lockpick them, you get access to their contents, which includes a lanyard, and a key that can unlock/lock the tables, which you can move to another location


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New random room, thought it would be fun to add tables that be unlocked/locked since it's not really used that much