### PR TITLE
Stop vending machines from eating money

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1127,6 +1127,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 	New(vending_machine, var/Owner)
 		src.vendor = vending_machine
 		src.owner = Owner
+		src.owneraccount = FindBankAccountByName(Owner.scan.registered)
 		..()
 
 	onUpdate()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -618,6 +618,14 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 							account["current_money"] -= product.product_cost
 						else
 							src.credit -= product.product_cost
+					if (!player_list)
+						wagesystem.shipping_budget += round(product.product_cost * profit) // cogwerks - maybe money shouldn't just vanish into the aether idk						logTheThing(LOG_DEBUG, src, T.owneraccount["current_money"])
+						logTheThing(LOG_DEBUG, src, player_list)
+					else
+						//Players get 90% of profit from player vending machines QMs get 10%
+						var/obj/machinery/vending/player/T = src
+						T.owneraccount["current_money"] += round(product.product_cost * profit)
+						wagesystem.shipping_budget += round(product.product_cost * (1 - profit))
 					src.currently_vending = null
 					update_static_data(usr)
 				if(product.logged_on_vend)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -618,13 +618,13 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 							account["current_money"] -= product.product_cost
 						else
 							src.credit -= product.product_cost
-					if (!player_list)
-						wagesystem.shipping_budget += round(product.product_cost * profit) // cogwerks - maybe money shouldn't just vanish into the aether idk
-					else
-						//Players get 90% of profit from player vending machines QMs get 10%
-						var/obj/machinery/vending/player/T = src
-						T.owneraccount["current_money"] += round(product.product_cost * profit)
-						wagesystem.shipping_budget += round(product.product_cost * (1 - profit))
+						if (!player_list)
+							wagesystem.shipping_budget += round(product.product_cost * profit) // cogwerks - maybe money shouldn't just vanish into the aether idk
+						else
+							//Players get 90% of profit from player vending machines QMs get 10%
+							var/obj/machinery/vending/player/vMachine = src
+							vMachine.owneraccount["current_money"] += round(product.product_cost * profit)
+							wagesystem.shipping_budget += round(product.product_cost * (1 - profit))
 					src.currently_vending = null
 					update_static_data(usr)
 				if(product.logged_on_vend)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -495,6 +495,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 		if(!P.owner && src.scan?.registered)
 			.["owner"] = src.scan.registered
 			P.owner = src.scan.registered
+			P.owneraccount = FindBankAccountByName(src.scan.registered)
 		else
 			.["owner"] = P.owner
 		.["playerBuilt"] = TRUE
@@ -1127,7 +1128,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 	New(vending_machine, var/Owner)
 		src.vendor = vending_machine
 		src.owner = Owner
-		src.owneraccount = FindBankAccountByName(Owner.scan.registered)
 		..()
 
 	onUpdate()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -619,8 +619,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 						else
 							src.credit -= product.product_cost
 					if (!player_list)
-						wagesystem.shipping_budget += round(product.product_cost * profit) // cogwerks - maybe money shouldn't just vanish into the aether idk						logTheThing(LOG_DEBUG, src, T.owneraccount["current_money"])
-						logTheThing(LOG_DEBUG, src, player_list)
+						wagesystem.shipping_budget += round(product.product_cost * profit) // cogwerks - maybe money shouldn't just vanish into the aether idk
 					else
 						//Players get 90% of profit from player vending machines QMs get 10%
 						var/obj/machinery/vending/player/T = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes vending machines actually pay either the owner if it is a player machine or the station if not.
I have no idea when this broke since it used to work

Fixes: https://github.com/goonstation/goonstation/issues/14359


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The code for payout was already there, but it was under Topic() instead of ui_act() so it never got called


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)monkeymilesmoo
(+)Fixed vending machines not paying the owner.
```
