### PR TITLE
Fix apc text assuming I'm a borg

### DIFF
--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -107,7 +107,7 @@
 				if (jumper.positive)
 					user.visible_message("<span class='notice'>[user] transfers some of their power to [apc]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
 				else
-					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to yourself!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to itself!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
 					logTheThing(LOG_STATION, user, "drains [overspill] power from the APC [apc] now [100*apc.cell.charge/apc.cell.maxcharge]% [log_loc(apc)]")
 			else
 				donor_cell.charge -= jumper.charge_amount

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -107,7 +107,7 @@
 				if (jumper.positive)
 					user.visible_message("<span class='notice'>[user] transfers some of their power to [apc]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
 				else
-					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to itself!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to themselves!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
 					logTheThing(LOG_STATION, user, "drains [overspill] power from the APC [apc] now [100*apc.cell.charge/apc.cell.maxcharge]% [log_loc(apc)]")
 			else
 				donor_cell.charge -= jumper.charge_amount


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes https://github.com/goonstation/goonstation/issues/14098


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I am not borg. Or am I. Am I?

