### PR TITLE
Glass Recycler QoL update

### DIFF
--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -165,7 +165,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 		product_list += new /datum/glass_product("flute", /obj/item/reagent_containers/food/drinks/drinkingglass/flute, 1)
 		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)
 
-	proc/create(var/type)
+	proc/create(var/type, mob/user)
 		var/datum/glass_product/target_product = null
 		for (var/datum/glass_product/product in product_list)
 			if(product.product_type == type)
@@ -185,7 +185,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 
 		src.visible_message("<span class='notice'>[src] manufactures \a [G]!</span>")
 		playsound(src.loc, 'sound/machines/vending_dispense_small.ogg', 40, 0, 0.1)
-		usr.put_in_hand_or_eject(G)
+		user?.put_in_hand_or_eject(G)
 		use_power(20 WATTS)
 
 	ui_interact(mob/user, datum/tgui/ui)
@@ -222,7 +222,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 		switch(action)
 			if("create")
 				var/product_type = params["type"]
-				create(product_type)
+				create(product_type, usr)
 				. = TRUE
 
 

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -135,6 +135,8 @@ TYPEINFO(/obj/machinery/glass_recycler)
 			user.u_equip(W)
 			qdel(W)
 			ui_interact(user)
+			var/sound = pick('sound/impact_sounds/Glass_Shatter_1.ogg', 'sound/impact_sounds/Glass_Shatter_2.ogg', 'sound/impact_sounds/Glass_Shatter_3.ogg')
+			playsound(src.loc, sound, 40, 0, 0.1)
 			return TRUE
 		else
 			boutput(user, "<span class='alert'>You cannot put [W] into [src]!</span>")
@@ -175,12 +177,15 @@ TYPEINFO(/obj/machinery/glass_recycler)
 
 		if (src.glass_amt < target_product.product_cost)
 			src.visible_message("<span class='alert'>[src] doesn't have enough glass to make that!</span>")
+			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 40, 0, 0.1)
 			return
 
 		var/obj/item/G = new target_product.product_path(get_turf(src))
 		src.glass_amt -= target_product.product_cost
 
 		src.visible_message("<span class='notice'>[src] manufactures \a [G]!</span>")
+		playsound(src.loc, 'sound/machines/vending_dispense_small.ogg', 40, 0, 0.1)
+		usr.put_in_hand_or_eject(G)
 		use_power(20 WATTS)
 
 	ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Objects][QoL][Sounds]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If successful, putting objects into the Glass Recycler(GR) plays one out of three glass-breaking sounds at random; If unsuccessful, no sound is played.
Creating an object in the GR makes an output sound and if the creation is rejected for not having enough glass, an error sound is played. (As far as I could tell, not having enough glass shouldn't normally happen, because then the button to create in the UI shouldn't be enabled in that case. However, I'm sure there are weird moments when two players try to interact with it at the same time.)

Additionally, creating glassware in the GR will put that item directly into one of the player's free hands if possible.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This aligns the functionality of the GR with most other machines that create objects.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nelamil
(+)Glass Recyclers play sounds when used and put created glassware in user's hands if possible.
```
