### PR TITLE
apply materials to deployed frames if they dont have one

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -226,6 +226,8 @@
 		light_color = list(0, 179, 255, 255)
 
 		attack_hand(mob/user)
+			if (istype(user,/mob/living/object) && user == src.loc) // prevent wacky nullspace bug
+				return
 			if(src.loc==user)
 				src.set_loc(get_turf(src))
 				user.drop_item()
@@ -233,6 +235,8 @@
 			return mouse_drop(user)
 
 		attack_self(mob/user as mob)
+			if (istype(user,/mob/living/object) && user == src.loc)
+				return
 			src.set_loc(get_turf(user))
 			user.drop_item()
 			return

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -296,11 +296,19 @@
 		O.set_loc(T)
 		O.set_dir(src.dir)
 		O.was_built_from_frame(user, 0)
+
+		// if we have a material, give it to the object if the object doesn't have one
+		if (src.material && !O.material)
+			O.setMaterial(src.material)
 	else
 		O = new store_type(T)
 		O.set_dir(src.dir)
 		if(istype(O))
 			O.was_built_from_frame(user, 1)
+
+		if (src.material && !O.material)
+			O.setMaterial(src.material)
+
 	if(istype(O))
 		O.deconstruct_flags |= DECON_BUILT
 	qdel(src)


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
allows soulsteel frames to create soulsteel objects if the object doesnt have a material

add some safety checks to prevent soulsteel mechcomp cabinets from ceasing to exist when attacking themselves

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
soulsteel mechcomp cabinet go brrr


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(+)Arcplated electronics frames will now create arcplated devices if they could be arcplated
