### PR TITLE
Generic Antagonist Datums

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -19,6 +19,7 @@
 #define ROLE_FLOCKMIND "flockmind"
 #define ROLE_FLOCKTRACE "flocktrace"
 #define ROLE_SALVAGER "salvager"
+#define ROLE_ANTAGONIST_CRITTER "antagonist_critter"
 #define ROLE_MISC "misc"
 
 // special antagonist roles

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -258,6 +258,29 @@ datum/mind
 				return TRUE
 		return FALSE
 
+	proc/add_generic_antagonist(role_id, display_name, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_ROUND_START, respect_mutual_exclusives = TRUE, do_pseudo = FALSE, do_vr = FALSE, late_setup = FALSE)
+		if (!role_id || !display_name)
+			return FALSE
+		// Check for mutual exclusivity for real antagonists.
+		if (respect_mutual_exclusives && !do_pseudo && !do_vr && length(src.antagonists))
+			for (var/datum/antagonist/A as anything in src.antagonists)
+				if (A.mutually_exclusive)
+					return FALSE
+		// Refuse to add multiple types of the same antagonist.
+		if (!isnull(src.get_antagonist(role_id)) && !do_vr)
+			return FALSE
+		for (var/V in concrete_typesof(/datum/antagonist/generic))
+			var/datum/antagonist/generic/A = V
+			if (initial(A.id) == role_id)
+				var/datum/antagonist/generic/new_datum = new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, role_id, display_name)
+				if (!new_datum || QDELETED(new_datum))
+					return FALSE
+				return TRUE
+		var/datum/antagonist/generic/new_datum = new /datum/antagonist/generic(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, role_id, display_name)
+		if (!QDELETED(new_datum))
+			return TRUE
+		return FALSE
+
 	/// Attempts to remove existing antagonist datums of ID `role` from this mind, or if provided, a specific instance of an antagonist datum.
 	proc/remove_antagonist(role, source = null)
 		var/datum/antagonist/antagonist_role

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1875,7 +1875,7 @@ var/global/noir = 0
 			if (!M?.mind)
 				return
 			var/list/antag_options = list()
-			var/list/eligible_antagonist_types = concrete_typesof(/datum/antagonist) - concrete_typesof(/datum/antagonist/subordinate)
+			var/list/eligible_antagonist_types = concrete_typesof(/datum/antagonist) - (concrete_typesof(/datum/antagonist/subordinate) + concrete_typesof(/datum/antagonist/generic))
 			for (var/V as anything in eligible_antagonist_types)
 				var/datum/antagonist/A = V
 				if (!M.mind.get_antagonist(initial(A.id)))

--- a/code/modules/admin/custom_spawn_event.dm
+++ b/code/modules/admin/custom_spawn_event.dm
@@ -86,15 +86,11 @@
 
 			mind.transfer_to(new_mob)
 
-			if (src.antag_role == "antagonist") //no datum, but we still want them to be a generic antag
-				antagify(new_mob, agimmick = TRUE, do_objectives = FALSE)
-			else if (src.antag_role)
-				mind.add_antagonist(src.antag_role, do_relocate = FALSE, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN, do_equip = src.equip_antag, respect_mutual_exclusives = FALSE)
-				if (!mind.get_antagonist(src.antag_role)) //incompatible antag type, fall back to generic antag
-					antagify(new_mob, agimmick = TRUE, do_objectives = FALSE)
+			if (src.antag_role && !(mind.add_antagonist(src.antag_role, do_equip = src.equip_antag, do_objectives = FALSE, do_relocate = FALSE, source = ANTAGONIST_SOURCE_ADMIN, respect_mutual_exclusives = FALSE)))
+				mind.add_generic_antagonist("generic_antagonist", new_mob.real_name, do_equip = src.equip_antag, do_objectives = FALSE, do_relocate = FALSE, source = ANTAGONIST_SOURCE_ADMIN, respect_mutual_exclusives = FALSE)
+
 			else
-				remove_antag(new_mob, usr, TRUE, TRUE)
-				mind = new_mob.mind
+				mind.wipe_antagonists()
 
 			if (length(src.objective_text))
 				if (src.antag_role)

--- a/code/modules/antagonists/__generic_antagonist.dm
+++ b/code/modules/antagonists/__generic_antagonist.dm
@@ -1,0 +1,25 @@
+/datum/antagonist/generic
+
+	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, id, display_name)
+		if (!src.id)
+			src.id = id
+		if (!src.display_name)
+			src.display_name = display_name
+
+		. = ..()
+
+	do_popup(override)
+		if (!override)
+			override = "traitorgeneric"
+
+		..(override)
+
+/datum/antagonist/generic/antagonist_critter
+	id = ROLE_ANTAGONIST_CRITTER
+	display_name = "antagonist critter"
+
+	New(datum/mind/new_owner, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, do_vr, late_setup, id, display_name)
+		src.display_name = "[initial(src.display_name)] [display_name]"
+
+		. = ..()
+

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -245,7 +245,7 @@
 					new /obj/item/implant/access/infinite/assistant(M.current)
 					if (src.custom_spawn_turf)
 						M.current.set_loc(src.custom_spawn_turf)
-					antagify(M.current, null, 1)
+					M.add_generic_antagonist(ROLE_ANTAGONIST_CRITTER, "[M.current.real_name]", source = ANTAGONIST_SOURCE_RANDOM_EVENT)
 				candidates -= M
 
 			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter", alert_origin = ALERT_GENERAL)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -688,6 +688,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\admin\viewvariables\reference_tracking.dm"
 #include "code\modules\animation\AnimationLibrary.dm"
 #include "code\modules\antagonists\__antagonist.dm"
+#include "code\modules\antagonists\__generic_antagonist.dm"
 #include "code\modules\antagonists\__intangible_antagonist.dm"
 #include "code\modules\antagonists\__mob_antagonist.dm"
 #include "code\modules\antagonists\__subordinate_antagonist.dm"


### PR DESCRIPTION
[Gamemodes] [Internal] [Code Quality]


## About The PR:
Implements a new generic antagonist datum subtype to accommodate for non-specific antagonists, such as antagonists originating from random event critter spawns and Admin spawn events.
A specified `role_id` and `display_name` should be assigned to the datum through the `add_generic_antagonist()` proc on `/datum/mind`.



## Why Is This needed?
Same rationale as #9366.