### PR TITLE
Gene Booth Speedup Research

### DIFF
--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -51,6 +51,7 @@ TYPEINFO(/obj/machinery/genetics_booth)
 	var/letgo_hp = 50
 	var/mob/living/carbon/human/occupant = null
 	var/process_time = 20 SECONDS
+	var/static/process_speedup = 0 // static since the genetek upgrade is universal
 	var/damage_per_tick = 1
 
 	var/image/screenoverlay = null
@@ -239,7 +240,8 @@ TYPEINFO(/obj/machinery/genetics_booth)
 				UpdateOverlays(screenoverlay, "screen", 0, 1)
 				animate_shake(src,5,3,2, return_x = -3)
 				playsound(src.loc, 'sound/impact_sounds/Metal_Clang_1.ogg', 30, 1, pitch = 1.4)
-				if (entry_time + process_time < TIME)
+				var/adjusted_time = process_time - (process_time * process_speedup)
+				if (entry_time + adjusted_time < TIME)
 					eject_occupant()
 			else
 				UpdateOverlays(abilityoverlay, "abil", 0, 1)

--- a/code/modules/medical/genetics/geneticsResearch.dm
+++ b/code/modules/medical/genetics/geneticsResearch.dm
@@ -321,9 +321,9 @@ var/datum/geneticsResearchManager/genResearch = new()
 	requiredResearch = list(/datum/geneticsResearchEntry/genebooth)
 
 	onFinish()
-		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
-		_type.process_speedup += 0.25
-		_type = "byond shut the hell up" // we get warned about _type being defined but unused otherwise
+		var/obj/machinery/genetics_booth/type = /obj/machinery/genetics_booth
+		type.process_speedup += 0.25
+		. = type // we get warned about type being defined but unused and idk how else to make byond shut up
 		..()
 
 // TIER TWO
@@ -374,9 +374,9 @@ var/datum/geneticsResearchManager/genResearch = new()
 	requiredResearch = list(/datum/geneticsResearchEntry/genebooth)
 
 	onFinish()
-		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
-		_type.process_speedup += 0.25
-		_type = "byond shut the hell up"
+		var/obj/machinery/genetics_booth/type = /obj/machinery/genetics_booth
+		type.process_speedup += 0.25
+		. = type
 		..()
 
 // TIER THREE
@@ -437,9 +437,9 @@ var/datum/geneticsResearchManager/genResearch = new()
 	requiredResearch = list(/datum/geneticsResearchEntry/genebooth, /datum/geneticsResearchEntry/gene_booth_speedup)
 
 	onFinish()
-		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
-		_type.process_speedup += 0.25
-		_type = "byond shut the hell up"
+		var/obj/machinery/genetics_booth/type = /obj/machinery/genetics_booth
+		type.process_speedup += 0.25
+		. = type
 		..()
 
 // TIER FOUR

--- a/code/modules/medical/genetics/geneticsResearch.dm
+++ b/code/modules/medical/genetics/geneticsResearch.dm
@@ -311,6 +311,21 @@ var/datum/geneticsResearchManager/genResearch = new()
 		genResearch.max_material += 50
 		..()
 
+/datum/geneticsResearchEntry/gene_booth_speedup_complex
+	name = "Complex Gene Booth Acceleration"
+	desc = "Increases the working speed of the Gene Booth by an additional +25%."
+	researchTime = 1200
+	researchCost = 150
+	tier = 2
+	requiredMutRes = list("early_secret_access")
+	requiredResearch = list(/datum/geneticsResearchEntry/genebooth)
+
+	onFinish()
+		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
+		_type.process_speedup += 0.25
+		_type = "byond shut the hell up" // we get warned about _type being defined but unused otherwise
+		..()
+
 // TIER TWO
 
 /datum/geneticsResearchEntry/reclaimer
@@ -349,6 +364,20 @@ var/datum/geneticsResearchManager/genResearch = new()
 	researchCost = 120
 	tier = 2
 	requiredResearch = list(/datum/geneticsResearchEntry/rademitter)
+
+/datum/geneticsResearchEntry/gene_booth_speedup
+	name = "Gene Booth Injection Speedup"
+	desc = "Increases the working speed of the Gene Booth by 25%."
+	researchTime = 1200
+	researchCost = 75
+	tier = 2
+	requiredResearch = list(/datum/geneticsResearchEntry/genebooth)
+
+	onFinish()
+		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
+		_type.process_speedup += 0.25
+		_type = "byond shut the hell up"
+		..()
 
 // TIER THREE
 
@@ -396,6 +425,21 @@ var/datum/geneticsResearchManager/genResearch = new()
 
 	onFinish()
 		genResearch.emitter_radiation -= 30
+		..()
+
+
+/datum/geneticsResearchEntry/gene_booth_speedup_biotic
+	name = "Biotic Gene Booth Injection"
+	desc = "Increases the working speed of the Gene Booth by an additional +25%."
+	researchTime = 1800
+	researchCost = 100
+	tier = 3
+	requiredResearch = list(/datum/geneticsResearchEntry/genebooth, /datum/geneticsResearchEntry/gene_booth_speedup)
+
+	onFinish()
+		var/obj/machinery/genetics_booth/_type = /obj/machinery/genetics_booth
+		_type.process_speedup += 0.25
+		_type = "byond shut the hell up"
 		..()
 
 // TIER FOUR


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds 3 new researches to the GeneTek console, which each add +25% to the Gene Booth's working speed. Each one subsequently reduces the waiting time by approximately 5 seconds (usually a bit lower due to it relying on Process()), down to ~5 seconds. This is done by giving the gene booth a new static var, `process_speedup`, and using that in the Process() check.

Below is a screenshot of the new researches.

![image](https://github.com/goonstation/goonstation/assets/28785926/17eca0e3-6c7d-41f7-87fd-77f4c0d0be36)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The gene booth takes too damn long to work - 20 seconds per gene! And with dozens of people in a server and potentially half a dozen or more genes in the booth, that'll take a WHILE. This makes it at least bearable.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(*)Gene Booths can now be upgraded with GeneTek research to work faster by up to 75% (~5 seconds per gene).
```
