### PR TITLE
Fishing fixes

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -300,7 +300,7 @@ Alien/mutant/other fish:
 /obj/item/fish/bc_angelfish
 	name = "bicolor angelfish"
 	desc = "It's like two fish in one! Apparently they don't get along with other fish though, at least they have each other."
-	icon_state = "bc_angelfish"
+	icon_state = "bc_angel"
 	inhand_color = "#3005f0"
 	category = FISH_CATEGORY_AQUARIUM
 	value  = FISH_RARITY_UNCOMMON

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -198,6 +198,15 @@ TYPEINFO(/obj/item/fish_portal)
 /obj/fishing_pool/portable
 	anchored = 0
 
+	attackby(obj/item/W, mob/user)
+		if (istool(W, TOOL_SCREWING | TOOL_WRENCHING))
+			user.visible_message("<b>[user]</b> [src.anchored ? "unanchors" : "anchors"] the [src].")
+			playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
+			src.anchored = !(src.anchored)
+			return
+		else
+			return ..()
+
 // Gannets new fishing gear
 
 /obj/submachine/fishing_upload_terminal
@@ -274,6 +283,15 @@ TYPEINFO(/obj/item/fish_portal)
 
 /obj/submachine/fishing_upload_terminal/portable
 	anchored = 0
+
+	attackby(obj/item/W, mob/user)
+		if (istool(W, TOOL_SCREWING | TOOL_WRENCHING))
+			user.visible_message("<b>[user]</b> [src.anchored ? "unanchors" : "anchors"] the [src].")
+			playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
+			src.anchored = !(src.anchored)
+			return
+		else
+			return ..()
 
 /obj/item/storage/fish_box
 	name = 	"Portable aquarium"

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -235,15 +235,15 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/fluid // covers pool, aquariums and uh all other standing pools of fluid.
 	fishing_atom_type = /obj/fluid
 	rod_tier_required = 1
-	fish_available = list(/obj/item/fish/clownfish = 40,\
-	/obj/item/fish/damselfish = 30,\
-	/obj/item/fish/green_chromis = 20,\
-	/obj/item/fish/cardinalfish = 15,\
+	fish_available = list(/obj/item/fish/clownfish = 15,\
+	/obj/item/fish/damselfish = 10,\
+	/obj/item/fish/green_chromis = 10,\
+	/obj/item/fish/cardinalfish = 5,\
 	/obj/item/fish/royal_gramma = 10,\
-	/obj/item/fish/bc_angelfish = 10,\
+	/obj/item/fish/bc_angelfish = 5,\
 	/obj/item/fish/blue_tang = 15,\
 	/obj/item/fish/firefish = 5,\
-	/obj/item/fish/yellow_tang = 15,\
+	/obj/item/fish/yellow_tang = 10,\
 	/obj/item/fish/mandarin_fish = 5)
 
 /datum/fishing_spot/water_cooler

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -202,12 +202,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/fish/bass = 30,\
 	/obj/item/fish/salmon = 20,\
 	/obj/item/fish/herring = 15,\
-	/obj/item/fish/red_herring = 5,\
-	/obj/item/fish/tuna = 10,\
-	/obj/item/fish/cod = 15,\
-	/obj/item/fish/flounder = 10,\
-	/obj/item/fish/mahimahi = 10,\
-	/obj/item/fish/shrimp = 15,\
 	/obj/item/fish/sardine = 20)
 
 	// test pools
@@ -222,6 +216,21 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	master
 		fishing_atom_type = /obj/fishing_pool/master
 		rod_tier_required = 3
+
+/datum/fishing_spot/fishing_pool_portable
+	fishing_atom_type = /obj/fishing_pool/portable
+	rod_tier_required = 1
+	fish_available = list(/obj/item/fish/goldfish = 30,\
+	/obj/item/fish/bass = 20,\
+	/obj/item/fish/salmon = 20,\
+	/obj/item/fish/carp = 15,\
+	/obj/item/fish/rainbow_trout = 10,\
+	/obj/item/fish/chub = 10,\
+	/obj/item/fish/carp = 40,\
+	/obj/item/fish/bass = 30,\
+	/obj/item/fish/salmon = 20,\
+	/obj/item/fish/herring = 15,\
+	/obj/item/fish/sardine = 20)
 
 /datum/fishing_spot/fluid // covers pool, aquariums and uh all other standing pools of fluid.
 	fishing_atom_type = /obj/fluid

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -274,6 +274,15 @@
 /obj/submachine/weapon_vendor/fishing/portable
 	anchored = 0
 
+	attackby(obj/item/W, mob/user)
+		if (istool(W, TOOL_SCREWING | TOOL_WRENCHING))
+			user.visible_message("<b>[user]</b> [src.anchored ? "unanchors" : "anchors"] the [src].")
+			playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
+			src.anchored = !(src.anchored)
+			return
+		else
+			return ..()
+
 // Materiel avaliable for purchase:
 
 /datum/materiel

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6843,7 +6843,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -33793,7 +33793,7 @@
 	},
 /obj/item/paper/ranch_guide,
 /obj/item/storage/box/clothing/rancher,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/clothing/mask/chicken,
 /obj/cable{
@@ -48105,7 +48105,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -20801,7 +20801,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/machinery/light_switch/east{
 	dir = 4;

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -37100,7 +37100,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -52254,7 +52254,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -6808,7 +6808,7 @@
 	name = "rancher supply closet"
 	},
 /obj/item/paper/ranch_guide,
-/obj/item/fishing_rod,
+/obj/item/fishing_rod/basic,
 /obj/item/chicken_carrier,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Couple of things I missed.

- You can now wrench/screwdriver the portable fishing equipment to secure it.
- The Angler crate now comes with the correct fishing pool.
- Fixes rancher supply closets spawning with broken rods.
- Missing icon for bc angelfish.
- Rebalance some fish lists and probablilities.
