### PR TITLE
Fixes Rancher Belt Fishing Rods

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -779,14 +779,14 @@
 	item_state = "rancher"
 	can_hold = list(
 		/obj/item/chicken_carrier,
-		/obj/item/fishing_rod)
+		/obj/item/fishing_rod/basic)
 	check_wclass = 1
 
 	prepared
 		spawn_contents = list(/obj/item/chicken_carrier,
 		/obj/item/chicken_carrier,
 		/obj/item/chicken_carrier,
-		/obj/item/fishing_rod)
+		/obj/item/fishing_rod/basic)
 
 /obj/item/storage/belt/hunter
 	name = "trophy belt"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the fishing rods in the rancher belts from generic, non-functional parents to basic fishing rods.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14439 

