### PR TITLE
More prefab fixes

### DIFF
--- a/assets/maps/prefabs/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/prefab_customs_shuttle.dmm
@@ -21,11 +21,9 @@
 	name = "Ancient Blue Label Scotch";
 	pixel_x = 9
 	},
-/obj/machinery/light{
-	layer = 3
-	},
 /obj/item/paper/cruiser_bought,
 /obj/table/regal/auto,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/purple/standard/edge/sw,
 /area/prefab/crashed_hop_shuttle)
 "aX" = (
@@ -41,9 +39,7 @@
 /turf/variableTurf/floor,
 /area/noGenerate)
 "bY" = (
-/turf/simulated/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
+/turf/simulated/floor/airless/plating/damaged2,
 /area/noGenerate)
 "cu" = (
 /obj/stool/chair/comfy{
@@ -110,7 +106,7 @@
 /obj/stool/chair/comfy{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/regalcarpet/border{
@@ -176,8 +172,10 @@
 	opacity = 1
 	})
 "iR" = (
-/obj/machinery/door/airlock/gannets/command/alt,
 /obj/access_spawn/head_of_personnel,
+/obj/machinery/door/airlock/pyro/command/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/prefab/crashed_hop_shuttle)
 "jd" = (
@@ -208,11 +206,11 @@
 /turf/variableTurf/clear,
 /area/prefab/crashed_hop_shuttle)
 "lh" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/stool/chair/comfy{
 	dir = 8
+	},
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/regalcarpet/border{
 	dir = 6
@@ -241,7 +239,7 @@
 /turf/variableTurf/floor,
 /area/noGenerate)
 "nE" = (
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -258,7 +256,7 @@
 	dir = 8;
 	pixel_x = 5
 	},
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -326,9 +324,6 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/prefab/crashed_hop_shuttle)
 "tD" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/stool/bee_bed{
 	desc = "A soft little bed the general size and shape of a corgi.";
 	name = "dog bed"
@@ -338,11 +333,14 @@
 	dir = 4;
 	name = "Liam"
 	},
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/purple/standard/edge/ne,
 /area/prefab/crashed_hop_shuttle)
 "tO" = (
 /obj/stool/bar,
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
@@ -431,6 +429,11 @@
 "yI" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/damaged5,
+/area/prefab/crashed_hop_shuttle)
+"zh" = (
+/obj/access_spawn/head_of_personnel,
+/obj/machinery/door/airlock/pyro/command/syndicate,
+/turf/simulated/floor/airless,
 /area/prefab/crashed_hop_shuttle)
 "zB" = (
 /obj/machinery/computer/card/portable,
@@ -522,6 +525,7 @@
 "Ge" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/prefab/crashed_hop_shuttle)
 "GG" = (
@@ -595,9 +599,7 @@
 /turf/simulated/floor/sand,
 /area/prefab/crashed_hop_shuttle)
 "Kl" = (
-/turf/simulated/floor/airless{
-	icon_state = "damaged4"
-	},
+/turf/simulated/floor/airless/plating/scorched,
 /area/noGenerate)
 "Lh" = (
 /obj/decal/fakeobjects/shuttleengine{
@@ -623,15 +625,15 @@
 /area/prefab/crashed_hop_shuttle)
 "MU" = (
 /obj/rack,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/coin{
 	pixel_x = 4;
 	pixel_y = 11
 	},
 /obj/item/spacecash/bag,
 /obj/item/stamped_bullion,
+/obj/machinery/light/incandescent{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fgreen2"
@@ -662,9 +664,7 @@
 	},
 /area/prefab/crashed_hop_shuttle)
 "OQ" = (
-/turf/simulated/floor/plating/airless{
-	icon_state = "platingdmg3"
-	},
+/turf/simulated/floor/airless/plating/damaged1,
 /area/prefab/crashed_hop_shuttle)
 "Pa" = (
 /obj/table/reinforced/bar/auto,
@@ -688,7 +688,6 @@
 /area/prefab/crashed_hop_shuttle)
 "PP" = (
 /obj/machinery/vending/alcohol,
-/obj/machinery/light,
 /turf/simulated/floor,
 /area/prefab/crashed_hop_shuttle)
 "PZ" = (
@@ -1115,7 +1114,7 @@ OE
 sH
 Zs
 Bt
-iR
+zh
 hG
 dg
 Op

--- a/assets/maps/prefabs/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/prefab_customs_shuttle.dmm
@@ -173,7 +173,7 @@
 	})
 "iR" = (
 /obj/access_spawn/head_of_personnel,
-/obj/machinery/door/airlock/pyro/command/syndicate{
+/obj/machinery/door/airlock/pyro/command{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -432,7 +432,7 @@
 /area/prefab/crashed_hop_shuttle)
 "zh" = (
 /obj/access_spawn/head_of_personnel,
-/obj/machinery/door/airlock/pyro/command/syndicate,
+/obj/machinery/door/airlock/pyro/command,
 /turf/simulated/floor/airless,
 /area/prefab/crashed_hop_shuttle)
 "zB" = (

--- a/assets/maps/prefabs/prefab_drug_den.dmm
+++ b/assets/maps/prefabs/prefab_drug_den.dmm
@@ -90,7 +90,7 @@
 	icon_state = "lattice-dir";
 	tag = "icon-lattice-dir (EAST)"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "eN" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -121,7 +121,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/prefab/drug_den)
 "hC" = (
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "ii" = (
 /obj/lattice{
@@ -129,7 +129,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "iW" = (
 /obj/item/device/light/glowstick/green_on{
@@ -159,7 +159,7 @@
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "kT" = (
 /obj/item/reagent_containers/syringe{
@@ -196,7 +196,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/prefab/drug_den)
 "mb" = (
-/turf/space,
+/turf/variableTurf/clear,
 /area/allowGenerate)
 "mE" = (
 /obj/grille/catwalk,
@@ -293,7 +293,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "tp" = (
 /obj/machinery/deep_fryer{
@@ -309,7 +309,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "ub" = (
 /obj/machinery/light/incandescent/blueish{
@@ -346,7 +346,7 @@
 /obj/item/sponge{
 	pixel_y = 7
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "xK" = (
 /obj/item/reagent_containers/glass/beaker{
@@ -382,7 +382,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "Ad" = (
 /obj/disposalpipe/segment{
@@ -399,7 +399,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "Bd" = (
 /obj/decal/poster/wallsign/testsubject,
@@ -590,7 +590,7 @@
 	tag = "icon-lattice-dir (EAST)"
 	},
 /obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "Kw" = (
 /obj/table/reinforced/auto,
@@ -639,7 +639,7 @@
 	dir = 5;
 	icon_state = "lattice-dir-b"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "LQ" = (
 /obj/cable{
@@ -670,7 +670,7 @@
 	dir = 10;
 	icon_state = "lattice-dir-b"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "NW" = (
 /obj/rack,
@@ -688,7 +688,7 @@
 	dir = 1;
 	icon_state = "lattice-dir-b"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "OO" = (
 /mob/living/critter/small_animal/mouse/mad,
@@ -707,7 +707,7 @@
 	pixel_x = 4;
 	pixel_y = -7
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "Qa" = (
 /obj/item/reagent_containers/food/snacks/donkpocket{
@@ -756,7 +756,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir-b"
 	},
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "Rf" = (
 /obj/machinery/light/incandescent/netural{
@@ -796,7 +796,7 @@
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "TA" = (
 /obj/lattice{
@@ -804,7 +804,7 @@
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light/delay5,
-/turf/space,
+/turf/variableTurf/clear,
 /area/noGenerate)
 "TN" = (
 /obj/cable{

--- a/assets/maps/prefabs/prefab_janitor.dmm
+++ b/assets/maps/prefabs/prefab_janitor.dmm
@@ -306,7 +306,7 @@
 /turf/simulated/floor,
 /area/janitor_setpiece)
 "aU" = (
-/obj/wingrille_spawn/full,
+/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/janitor_setpiece)
 "aV" = (
@@ -425,10 +425,6 @@
 /obj/machinery/r_door_control/podbay{
 	id = "jani_outpost";
 	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
 	},
 /turf/variableTurf/clear,
 /area/noGenerate)
@@ -704,8 +700,8 @@ aA
 aj
 aj
 aj
-aA
-aA
-aA
+aj
+aj
+aj
 aa
 "}

--- a/assets/maps/prefabs/prefab_planet_angry_birds.dmm
+++ b/assets/maps/prefabs/prefab_planet_angry_birds.dmm
@@ -39,7 +39,7 @@
 /area/noGenerate)
 "s" = (
 /obj/submachine/chicken_incubator,
-/obj/machinery/light/small/broken{
+/obj/machinery/light/small/sticky/broken{
 	dir = 4
 	},
 /turf/unsimulated/floor/greenblack/corner{
@@ -50,7 +50,7 @@
 /turf/unsimulated/floor/green,
 /area/noGenerate)
 "y" = (
-/obj/machinery/light/small/broken,
+/obj/machinery/light/small/sticky/broken,
 /turf/unsimulated/floor/greenblack{
 	dir = 1
 	},

--- a/assets/maps/prefabs/prefab_ranch.dmm
+++ b/assets/maps/prefabs/prefab_ranch.dmm
@@ -109,11 +109,11 @@
 /area/prefab/ranch)
 "G" = (
 /obj/rack,
-/obj/item/fishing_rod,
 /obj/item/fish_portal{
 	pixel_x = 5;
 	pixel_y = -1
 	},
+/obj/item/fishing_rod/upgraded,
 /turf/simulated/floor/green,
 /area/prefab/ranch)
 "H" = (

--- a/assets/maps/prefabs/prefab_ranch.dmm
+++ b/assets/maps/prefabs/prefab_ranch.dmm
@@ -25,13 +25,13 @@
 /obj/shrub{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/grass/leafy,
 /area/prefab/ranch)
 "m" = (
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/green/side{
@@ -46,7 +46,7 @@
 /turf/simulated/floor/dirt,
 /area/prefab/ranch)
 "p" = (
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 4
 	},
 /turf/simulated/floor/green/side{
@@ -57,13 +57,13 @@
 /obj/shrub{
 	dir = 6
 	},
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 4
 	},
 /turf/simulated/floor/grass/leafy,
 /area/prefab/ranch)
 "s" = (
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
@@ -142,7 +142,7 @@
 	dir = 4
 	},
 /obj/item/clothing/mask/chicken,
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/grass/leafy,
@@ -155,7 +155,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/prefab/ranch)
 "T" = (
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 8
 	},
 /turf/simulated/floor/shuttlebay,
@@ -167,7 +167,7 @@
 /obj/shrub{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/incandescent{
 	dir = 4
 	},
 /turf/simulated/floor/grass/leafy,

--- a/assets/maps/prefabs/prefab_safehouse.dmm
+++ b/assets/maps/prefabs/prefab_safehouse.dmm
@@ -26,12 +26,8 @@
 /obj/item/implanter{
 	pixel_x = -5
 	},
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 4;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = 10
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -136,7 +132,8 @@
 	layer = 3
 	},
 /obj/machinery/light/emergencyflashing{
-	dir = 4
+	dir = 4;
+	pixel_x = 10
 	},
 /obj/item/storage/briefcase/safehouse{
 	layer = 3.1
@@ -258,7 +255,8 @@
 	pixel_y = 9
 	},
 /obj/machinery/light/emergencyflashing{
-	dir = 8
+	dir = 8;
+	pixel_x = -10
 	},
 /turf/unsimulated/floor/circuit/vintage/vintage_CO2,
 /area/prefab/safehouse)
@@ -319,12 +317,8 @@
 /area/prefab/safehouse)
 "kB" = (
 /obj/decal/cleanable/dirt/dirt2,
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 1;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_y = 14
+/obj/machinery/light/incandescent{
+	dir = 1
 	},
 /turf/simulated/floor/neutral,
 /area/prefab/safehouse)
@@ -395,12 +389,8 @@
 	pixel_y = 11
 	},
 /obj/item/clothing/suit/bedsheet/royal,
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 4;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = 10
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/prefab/safehouse)
@@ -424,14 +414,10 @@
 /area/noGenerate)
 "my" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 1;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_y = 14
-	},
 /obj/submachine/chef_sink,
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/prefab/safehouse)
 "mB" = (
@@ -533,12 +519,8 @@
 /turf/simulated/floor/wood,
 /area/prefab/safehouse)
 "oY" = (
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 8;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = -10
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 10
@@ -653,12 +635,8 @@
 /turf/simulated/floor/carpet/red/fancy/narrow/ne,
 /area/prefab/safehouse)
 "wp" = (
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 8;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = -10
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
 /turf/simulated/floor/shuttlebay,
 /area/prefab/safehouse)
@@ -679,12 +657,8 @@
 /area/prefab/safehouse)
 "wI" = (
 /obj/decal/cleanable/oil/streak,
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 4;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = 10
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
 /area/prefab/safehouse)
@@ -706,12 +680,8 @@
 /area/prefab/safehouse)
 "yx" = (
 /obj/decal/cleanable/dirt,
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 1;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_y = 14
+/obj/machinery/light/incandescent{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/prefab/safehouse)
@@ -746,12 +716,8 @@
 /obj/item/clothing/mask/cigarette/cigar{
 	pixel_y = 6
 	},
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 4;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = 10
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_east,
 /area/prefab/safehouse)
@@ -897,9 +863,8 @@
 /obj/item/storage/toilet{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/light/small/sticky{
+	dir = 1
 	},
 /turf/simulated/floor/blue,
 /area/prefab/safehouse)
@@ -988,12 +953,8 @@
 /obj/decal/fakeobjects/recordplayer{
 	pixel_y = 4
 	},
-/obj/machinery/light{
-	brightness = 1.4;
-	dir = 8;
-	layer = 9.1;
-	name = "worn light fixture";
-	pixel_x = -10
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/red/decal/outercross,
 /area/prefab/safehouse)
@@ -1029,11 +990,10 @@
 /obj/ladder{
 	id = "safehouse_storage"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/decal/cleanable/dirt,
+/obj/machinery/light/small/sticky{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/prefab/safehouse)
 "Yq" = (

--- a/assets/maps/prefabs/prefab_water_crashed.dmm
+++ b/assets/maps/prefabs/prefab_water_crashed.dmm
@@ -159,12 +159,10 @@
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/turret_protected/sea_crashed)
 "aP" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "aQ" = (
@@ -184,12 +182,10 @@
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "aS" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/sea_crashed)
 "aT" = (
@@ -244,7 +240,7 @@
 /area/station/turret_protected/sea_crashed)
 "ba" = (
 /obj/decal/fakeobjects/firealarm_broken{
-	dir = 8;
+	dir = 4;
 	icon_state = "firex";
 	pixel_x = -24
 	},
@@ -348,8 +344,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/sea_crashed)
 "bq" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/pyro/command/alt,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "br" = (
@@ -377,16 +373,14 @@
 /area/station/turret_protected/sea_crashed)
 "bv" = (
 /obj/decal/fakeobjects/firealarm_broken{
-	dir = 1;
 	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "bx" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+/obj/machinery/light/incandescent{
+	dir = 1
 	},
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
@@ -578,7 +572,7 @@
 /turf/simulated/floor/caution/corner/se,
 /area/station/turret_protected/sea_crashed)
 "cp" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "cq" = (
@@ -666,9 +660,8 @@
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "cB" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
 /turf/simulated/floor/red,
 /area/station/turret_protected/sea_crashed)
@@ -769,12 +762,10 @@
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "cR" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "cS" = (
@@ -805,11 +796,6 @@
 	icon_state = "showerhead";
 	pixel_y = 6
 	},
-/obj/decal/fakeobjects{
-	icon = 'icons/obj/decals/misc.dmi';
-	icon_state = "drain";
-	name = "drain"
-	},
 /obj/window/cubicle{
 	desc = "A panel designed to separate bathroom stalls, turning one gross room into many.";
 	dir = 2;
@@ -817,6 +803,7 @@
 	name = "stall panel";
 	tag = ""
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -884,11 +871,7 @@
 	icon_state = "showerhead";
 	pixel_y = 6
 	},
-/obj/decal/fakeobjects{
-	icon = 'icons/obj/decals/misc.dmi';
-	icon_state = "drain";
-	name = "drain"
-	},
+/obj/machinery/drainage,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -914,7 +897,7 @@
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "di" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "dj" = (
@@ -922,12 +905,11 @@
 /turf/simulated/floor/neutral,
 /area/station/turret_protected/sea_crashed)
 "dk" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "floor6"
+	},
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
 /turf/simulated/floor/red,
 /area/station/turret_protected/sea_crashed)
@@ -937,8 +919,8 @@
 /turf/variableTurf/floor,
 /area/noGenerate)
 "dm" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/pyro/security/alt,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/turret_protected/sea_crashed)
 "dn" = (
@@ -1144,12 +1126,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/sea_crashed)
 "dF" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/sea_crashed)
 "dG" = (
@@ -1255,15 +1235,6 @@
 	icon_state = "alt_heater-R"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/turret_protected/sea_crashed)
-"dM" = (
-/obj/decal/fakeobjects/firelock_broken{
-	dir = 8;
-	icon_state = "door0"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/pyro/security/alt,
-/turf/simulated/floor/red,
 /area/station/turret_protected/sea_crashed)
 "dN" = (
 /obj/machinery/shuttle/engine/propulsion{
@@ -1768,7 +1739,7 @@ cC
 dm
 cC
 cC
-dM
+dm
 ee
 ee
 vj

--- a/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
+++ b/assets/maps/prefabs/prefab_water_miraclium_survey.dmm
@@ -9,58 +9,58 @@
 	name = "surveyors' stripe"
 	},
 /obj/machinery/tripod,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "i" = (
 /obj/item/device/audio_log/miraclium_survey,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "o" = (
 /obj/random_item_spawner/tools/one,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "s" = (
 /obj/decal/cleanable/machine_debris{
 	desc = "A pile that was probably a machine at some point."
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "A" = (
 /obj/item/mining_tool/drill,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "C" = (
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "D" = (
 /obj/item/breaching_charge/mining,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "E" = (
 /obj/decal/cleanable/dirt/dirt2,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "F" = (
 /obj/decal/fakeobjects/beacon{
 	desc = "A small tracking beacon in fairly poor condition. Nothing in the surroundings should have disturbed it - what broke it?"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "K" = (
 /obj/item/tripod,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "O" = (
 /obj/item/raw_material/miracle,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "Q" = (
 /obj/item/device/t_scanner,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "R" = (
 /obj/item/device/gps,
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 
 (1,1,1) = {"

--- a/assets/maps/prefabs/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/prefab_water_nadirelevator.dmm
@@ -27,21 +27,11 @@
 	name = "siphon shaft wall"
 	},
 /area/noGenerate)
-"aV" = (
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 9
-	},
-/area/shuttle/sea_elevator)
 "bd" = (
 /obj/machinery/light/small/floor/netural,
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/engine/caution/west,
 /area/diner/dining)
-"bn" = (
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 4
-	},
-/area/shuttle/sea_elevator)
 "bt" = (
 /turf/unsimulated/wall/setpieces/leadwall{
 	name = "siphon shaft wall"
@@ -138,11 +128,6 @@
 /area/tech_outpost{
 	name = "The Recluse"
 	})
-"et" = (
-/turf/unsimulated/wall/setpieces/leadwall/junction{
-	dir = 8
-	},
-/area/shuttle/sea_elevator)
 "ey" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/black,
@@ -221,7 +206,7 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "gL" = (
 /obj/forcefield/energyshield/perma/doorlink,
@@ -264,6 +249,9 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/shuttle/sea_elevator)
+"iJ" = (
+/turf/space/fluid/acid/clear,
+/area/noGenerate)
 "ji" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/fire{
@@ -283,9 +271,7 @@
 /turf/simulated/floor/engine,
 /area/shuttle/sea_elevator)
 "kv" = (
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 10
-	},
+/turf/unsimulated/wall/auto/lead/blue,
 /area/shuttle/sea_elevator)
 "kx" = (
 /obj/lattice,
@@ -293,7 +279,7 @@
 /obj/warp_beacon{
 	name = "Subsurface Bay"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "kD" = (
 /obj/item/crowbar,
@@ -317,17 +303,12 @@
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "lZ" = (
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/black/grime,
 /area/diner/dining)
-"ma" = (
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 6
-	},
-/area/shuttle/sea_elevator)
 "mb" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine,
@@ -473,9 +454,6 @@
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
-"qX" = (
-/turf/unsimulated/wall/setpieces/leadwall,
-/area/shuttle/sea_elevator)
 "rp" = (
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
@@ -612,11 +590,6 @@
 "uP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/dining)
-"va" = (
-/turf/unsimulated/wall/setpieces/leadwall{
-	dir = 5
-	},
-/area/shuttle/sea_elevator)
 "vg" = (
 /obj/decal/cleanable/dirt,
 /obj/item/device/light/glowstick,
@@ -634,7 +607,7 @@
 	dir = 1;
 	icon_state = "lattice-dir-b"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "wk" = (
 /obj/item/cell/charged{
@@ -770,9 +743,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/skeleton_trader)
-"Af" = (
-/turf/unsimulated/wall/setpieces/leadwall/junction,
-/area/shuttle/sea_elevator)
 "An" = (
 /obj/table/wood/auto,
 /obj/item/instrument/saxophone,
@@ -1039,11 +1009,6 @@
 "JT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/bathroom)
-"Kf" = (
-/turf/unsimulated/wall/setpieces/leadwall/cap{
-	dir = 4
-	},
-/area/shuttle/sea_elevator)
 "Kj" = (
 /obj/decal/poster/wallsign/biohazard{
 	desc = "A warning sign which reads 'ACID HAZARD'.";
@@ -1378,11 +1343,6 @@
 /area/tech_outpost{
 	name = "The Recluse"
 	})
-"TC" = (
-/turf/unsimulated/wall/setpieces/leadwall/junction{
-	dir = 1
-	},
-/area/shuttle/sea_elevator)
 "TP" = (
 /obj/npc/trader/bee{
 	name = "Bambini"
@@ -1464,9 +1424,7 @@
 /obj/machinery/r_door_control{
 	id = "nadir_minebot"
 	},
-/turf/unsimulated/wall/setpieces/leadwall/junction{
-	dir = 1
-	},
+/turf/unsimulated/wall/auto/lead/blue,
 /area/shuttle/sea_elevator)
 "VR" = (
 /obj/decal/cleanable/dirt/dirt2,
@@ -1645,7 +1603,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/turf/variableTurf/clear,
+/turf/space/fluid/acid/clear,
 /area/noGenerate)
 "Zp" = (
 /obj/table/auto,
@@ -2537,10 +2495,10 @@ nw
 nw
 nw
 nw
-aV
-qX
-qX
-qX
+kv
+kv
+kv
+kv
 kv
 nw
 nw
@@ -2585,12 +2543,12 @@ nw
 nw
 nw
 nw
-aV
-ma
+kv
+kv
 bx
 bx
 bx
-va
+kv
 kv
 XP
 XP
@@ -2650,9 +2608,9 @@ XP
 XP
 XP
 Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 XP
 XP
 XP
@@ -2678,31 +2636,31 @@ XP
 XP
 "}
 (21,1,1) = {"
-aV
-qX
-qX
-qX
-qX
-TC
+kv
+kv
+kv
+kv
+kv
+kv
 Ap
 Ap
 Ap
 Ap
 Ap
-bn
+kv
 XP
 Nl
 Nl
 Nl
 XP
 XP
+iJ
 Nl
+iJ
+iJ
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
 XP
 XP
 nw
@@ -2732,28 +2690,28 @@ mH
 xh
 xK
 jy
-Kf
+kv
 fy
 gh
-aV
+kv
 dt
 dt
-TC
+kv
+Nl
+iJ
 Nl
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 nw
 nw
 nw
@@ -2776,7 +2734,7 @@ XP
 XP
 "}
 (23,1,1) = {"
-bn
+kv
 ji
 tC
 ob
@@ -2788,26 +2746,26 @@ xI
 Ap
 Ap
 vs
+iJ
+iJ
 Nl
+iJ
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
 nw
 nw
 nw
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 Ol
 bd
 Sp
@@ -2837,26 +2795,26 @@ xI
 Vo
 Ap
 vs
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 nw
 nw
 nw
 nw
 nw
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 yh
 Iw
 LT
@@ -2874,26 +2832,26 @@ XP
 XP
 "}
 (25,1,1) = {"
-Af
-qX
+kv
+kv
 ii
 ii
-qX
+kv
 kv
 ob
 ob
-bn
+kv
 qu
 qu
-bn
+kv
 Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 nw
 nw
 nw
@@ -2923,25 +2881,25 @@ XP
 XP
 "}
 (26,1,1) = {"
-bn
+kv
 ru
 ob
 ob
 mG
-Af
+kv
 se
 se
-et
-qX
-qX
+kv
+kv
+kv
 VJ
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 XP
 nw
 nw
@@ -2972,25 +2930,25 @@ XP
 XP
 "}
 (27,1,1) = {"
-bn
+kv
 pk
 ob
 tC
 lB
-bn
+kv
 oG
 fE
 sF
 OT
 oQ
 fG
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 XP
 XP
 nw
@@ -3021,25 +2979,25 @@ XP
 XP
 "}
 (28,1,1) = {"
-va
+kv
 kv
 dd
 dd
-aV
-ma
+kv
+kv
 AG
 kD
 Be
 qu
 dC
 gL
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 gv
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 XP
 XP
 XP
@@ -3071,10 +3029,10 @@ XP
 "}
 (29,1,1) = {"
 XP
-bn
+kv
 dd
 dd
-bn
+kv
 wr
 Ou
 nJ
@@ -3087,8 +3045,8 @@ Zf
 Zf
 kx
 vX
-Nl
-Nl
+iJ
+iJ
 XP
 XP
 XP
@@ -3120,10 +3078,10 @@ XP
 "}
 (30,1,1) = {"
 XP
-va
-qX
-qX
-TC
+kv
+kv
+kv
+kv
 Lv
 fv
 ZZ
@@ -3131,13 +3089,13 @@ Fp
 Fp
 eT
 gL
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 lW
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 XP
 XP
 nw
@@ -3172,7 +3130,7 @@ XP
 XP
 XP
 XP
-bn
+kv
 Fi
 fv
 zv
@@ -3180,13 +3138,13 @@ sF
 oQ
 ON
 gL
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 XP
 XP
 nw
@@ -3221,7 +3179,7 @@ XP
 XP
 XP
 XP
-bn
+kv
 ey
 xX
 Xr
@@ -3229,12 +3187,12 @@ Be
 qu
 qu
 tA
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
+iJ
+iJ
+iJ
 XP
 XP
 nw
@@ -3270,18 +3228,18 @@ XP
 XP
 XP
 XP
-va
+kv
 wX
-qX
+kv
 wX
-qX
-qX
-qX
-ma
+kv
+kv
+kv
+kv
 Nl
-Nl
-Nl
-Nl
+iJ
+iJ
+iJ
 Nl
 XP
 XP
@@ -3327,10 +3285,10 @@ XP
 XP
 XP
 XP
+iJ
+iJ
 Nl
-Nl
-Nl
-Nl
+iJ
 Nl
 XP
 XP
@@ -3379,8 +3337,8 @@ XP
 XP
 Nl
 Nl
-Nl
-Nl
+iJ
+iJ
 XP
 XP
 XP
@@ -3428,7 +3386,7 @@ XP
 XP
 XP
 Nl
-Nl
+iJ
 XP
 XP
 XP
@@ -3699,8 +3657,8 @@ Ug
 EL
 Ck
 dw
-Nl
-Nl
+iJ
+iJ
 Wr
 Wr
 Wr
@@ -3935,7 +3893,7 @@ nw
 nw
 nw
 nw
-Nl
+iJ
 nw
 Wr
 UM
@@ -3984,7 +3942,7 @@ XP
 XP
 nw
 nw
-Nl
+iJ
 nw
 Wr
 Wr


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes stuff I missed with the first PR and a few mistakes such as wrong windows on the janitor prefab.
Mainly fixing more old sprites and non-perspective lights and replacing the nadir prefab turfs I removed with acid/clear turfs since apparently fauna ignores noGenerate areas.

Fixes  #14440
Fixes  #14453 by replacing parent rod with an upgraded one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map fixes


