### PR TITLE
Datumises Syndicate Agents

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -2,6 +2,7 @@
 #define ROLE_SPY_THIEF "spy_thief"
 #define ROLE_NUKEOP "nukeop"
 #define ROLE_NUKEOP_COMMANDER "nukeop_commander"
+#define ROLE_SYNDICATE_AGENT "syndicate_agent"
 #define ROLE_VAMPIRE "vampire"
 #define ROLE_GANG_LEADER "gang_leader"
 #define ROLE_WIZARD "wizard"

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2339,7 +2339,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
-		antagify(M, "Syndicate Agent", 0)
+		M.mind?.add_generic_antagonist(ROLE_SYNDICATE_AGENT, "Junior Syndicate Operative")
 
 /datum/job/special/syndicate_weak/no_ammo
 	name = "Poorly Equipped Junior Syndicate Operative"
@@ -2391,7 +2391,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-		antagify(M, "Syndicate Agent", 0)
+		M.mind?.add_generic_antagonist(ROLE_SYNDICATE_AGENT, "Syndicate Special Operative")
 		M.show_text("<b>The assault has begun! Head over to the station and kill any and all Nanotrasen personnel you encounter!</b>", "red")
 
 /datum/job/special/pirate

--- a/code/modules/antagonists/__generic_antagonist.dm
+++ b/code/modules/antagonists/__generic_antagonist.dm
@@ -23,3 +23,38 @@
 
 		. = ..()
 
+/datum/antagonist/generic/syndicate_agent
+	id = ROLE_SYNDICATE_AGENT
+	antagonist_icon = "syndicate"
+	faction = FACTION_SYNDICATE
+
+	New(datum/mind/new_owner)
+		src.owner = new_owner
+		if (istype(ticker.mode, /datum/game_mode/nuclear))
+			var/datum/game_mode/nuclear/gamemode = ticker.mode
+			if (!(src.owner in gamemode.syndicates))
+				gamemode.syndicates += src.owner
+
+		. = ..()
+
+	add_to_image_groups()
+		. = ..()
+		var/image/image = image('icons/mob/antag_overlays.dmi', icon_state = src.antagonist_icon)
+		var/datum/client_image_group/image_group = get_image_group(ROLE_NUKEOP)
+		image_group.add_mind_mob_overlay(src.owner, image)
+		image_group.add_mind(src.owner)
+
+	remove_from_image_groups()
+		. = ..()
+		var/datum/client_image_group/image_group = get_image_group(ROLE_NUKEOP)
+		image_group.remove_mind_mob_overlay(src.owner)
+		image_group.remove_mind(src.owner)
+
+	remove_self()
+		if (istype(ticker.mode, /datum/game_mode/nuclear))
+			var/datum/game_mode/nuclear/gamemode = ticker.mode
+			if (src.owner in gamemode.syndicates)
+				gamemode.syndicates -= src.owner
+
+		. = ..()
+

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -841,29 +841,6 @@ var/global/totally_random_jobs = FALSE
 
 	return
 
-// Convert mob to generic hard mode traitor or alternatively agimmick
-proc/antagify(mob/H, var/traitor_role, var/agimmick, var/do_objectives)
-	if (!(H.mind))
-		message_admins("Attempted to antagify [H] but could not find mind")
-		logTheThing(LOG_DEBUG, H, "Attempted to antagify [H] but could not find mind.")
-		return
-	if (!agimmick)
-		if (do_objectives)
-			var/list/eligible_objectives = typesof(/datum/objective/regular/) + typesof(/datum/objective/escape/) - /datum/objective/regular/
-			var/num_objectives = rand(1,3)
-			for(var/i = 0, i < num_objectives, i++)
-				var/select_objective = pick(eligible_objectives)
-				new select_objective(null, H.mind)
-				H.show_antag_popup("traitorhard")
-				ticker.mode.traitors |= H.mind
-	else
-		ticker.mode.Agimmicks |= H.mind
-		H.show_antag_popup("traitorgeneric")
-	if (traitor_role)
-		H.mind.special_role = traitor_role
-	else
-		H.mind.special_role = H.name
-
 //////////////////////////////////////////////
 // cogwerks - personalized trinkets project //
 /////////////////////////////////////////////


### PR DESCRIPTION
[Gamemodes] [Internal] [Code Quality]


## About The PR:
_This, to my knowledge, is the last antagonist datumisation; following this PR, framework for the original antagonist system will begin to be deprecated, and the new system will be cleaned up and optimised._

Syndicate Special Operatives, Junior Syndicate Agents, and Poorly Equipped Junior Syndicate Agents have been datumised under the generic antagonist role of `/datum/antagonist/generic/syndicate_agent`, permitting them to arm nuclear bombs and see fellow Syndicate Operatives.
Deprecates `/proc/antagify()`.



## Why Is This needed?
Same rationale as #9366.