### PR TITLE
implement strip_prefix

### DIFF
--- a/_std/text.dm
+++ b/_std/text.dm
@@ -116,6 +116,19 @@ proc/md5_to_more_pronouncable(text)
 		. += vowels[round(num / length(consonants)) + 1]
 	. = jointext(., "")
 
+/**
+ * Removes a given prefix from a string.
+ *
+ * @return The string without the prefix if the prefix was present at the start. If not, the original string is returned.
+ *
+ * Note: Non-text inputs will be converted into a string. The procedure is case sensitive.
+ */
+proc/strip_prefix(string, prefix)
+	if (!istext(string))
+		string = "[string]"
+	if(copytext(string, 1, length(prefix) + 1) == prefix)
+		string = copytext(string, length(prefix) + 1)
+	return string
 
 proc/strip_prefix_from_list(list/L, prefix)
 	for(var/i in 1 to length(L))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Remove a specified prefix from a string
* Handling non-text inputs: Convert them into strings before processing
* If the string does not start with the prefix, the original string is returned as is
* case sensitive

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* useful proc to add to our library of string manipulation procs
