### PR TITLE
Converts Medical obj/critters to mob equivalents.

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -743,16 +743,16 @@ ABSTRACT_TYPE(/datum/objective/crew/medicaldirector)
 /datum/objective/crew/medicaldirector/dr_acula
 	explanation_text = "Ensure that Dr. Acula escapes on the shuttle."
 	check_completion()
-		for (var/obj/critter/bat/doctor/Dr in by_cat[TR_CAT_PETS])
-			if (in_centcom(Dr) && Dr.alive)
+		for (var/mob/living/critter/small_animal/bat/doctor/Dr in by_cat[TR_CAT_PETS])
+			if (in_centcom(Dr) && isalive(Dr))
 				return 1
 		return 0
 
 /datum/objective/crew/medicaldirector/dr_acula_feeds
 	explanation_text = "Ensure that Dr. Acula survives and drinks 200 units of blood by the end of the shift."
 	check_completion()
-		for (var/obj/critter/bat/doctor/Dr in by_cat[TR_CAT_PETS])
-			if (Dr.blood_volume >= 200 && Dr.alive)
+		for (var/mob/living/critter/small_animal/bat/doctor/Dr in by_cat[TR_CAT_PETS])
+			if (Dr.blood_volume >= 200 && isalive(Dr))
 				return 1
 		return 0
 

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2226,6 +2226,14 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	butcherable = 0
 	health_brute = 15
 	health_burn = 15
+	health_brute_vuln = 0
+	health_burn_vuln = 0
+	can_bleed = FALSE
+	ai_retaliates = TRUE
+	ai_retaliate_persistence = RETALIATE_UNTIL_INCAP
+	ai_type = /datum/aiHolder/wanderer
+	is_npc = TRUE
+
 	pet_text = list("gently baps", "pets", "cuddles")
 	var/playing_dead = 0
 
@@ -2236,6 +2244,11 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	disposing()
 		. = ..()
 		STOP_TRACKING
+
+	// Opossums should not take TOX or OXY.
+	setup_healths()
+		add_hh_flesh(src.health_brute, src.health_brute_vuln)
+		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
 
 	setup_hands()
 		..() // both of these do no damage (in return, possums are basically immortal)

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -263,7 +263,7 @@ var/datum/score_tracker/score_tracker
 						command_pets_escaped += P
 					else if(P.is_pet)
 						pets_escaped += P
-					if (istype(P, /obj/critter/bat/doctor))
+					if (istype(P, /mob/living/critter/small_animal/bat/doctor))
 						acula_blood = P:blood_volume //this only gets populated if Dr. Acula escapes
 			else if(ismobcritter(pet))
 				var/mob/living/critter/P = pet

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -35743,7 +35743,7 @@
 	},
 /area/station/security/main)
 "nIL" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -39364,7 +39364,7 @@
 	},
 /area/station/hallway/primary/west)
 "rcG" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "rcS" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -38472,7 +38472,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "ckR" = (
@@ -53546,7 +53546,7 @@
 	},
 /area/station/engine/elect)
 "lmb" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -4374,7 +4374,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/small/autoname/chapel/north,
 /turf/simulated/floor/carpet/grime,
@@ -64959,7 +64959,7 @@
 	},
 /area/station/medical/head)
 "cZQ" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/cable{
 	icon_state = "1-4"
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11748,7 +11748,7 @@
 "aPO" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 9
@@ -13940,7 +13940,7 @@
 	name = "Autopsy Table"
 	},
 /obj/machinery/drainage,
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/random_item_spawner/organs/bloody,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -56418,7 +56418,7 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "riE" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -65778,7 +65778,7 @@
 /turf/simulated/floor/arrival,
 /area/station/hangar/arrivals)
 "tZn" = (
-/obj/critter/opossum/morty{
+/mob/living/critter/small_animal/opossum/morty{
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -40071,7 +40071,7 @@
 /turf/space,
 /area/station/mining/magnet)
 "gxS" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -19895,7 +19895,7 @@
 	},
 /area/station/medical/medbay/pharmacy)
 "iyS" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -46737,7 +46737,7 @@
 	desc = "A solid metal frame with some padding on it, useful for sleeping on. It's got wheels, and smells vaguely of fur and death.";
 	name = "Morty's roller bed"
 	},
-/obj/critter/opossum/morty{
+/mob/living/critter/small_animal/opossum/morty{
 	dir = 4
 	},
 /turf/simulated/floor/blackwhite{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1023,7 +1023,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "acl" = (
@@ -2992,7 +2992,7 @@
 	icon_state = "4-8"
 	},
 /obj/blind_switch/area/north,
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/bluegreen,
 /area/station/medical/medbay/treatment2)
 "ahu" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -2032,7 +2032,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "adi" = (
@@ -28830,7 +28830,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "bcb" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/item/device/radio/intercom/medical{
 	dir = 4
 	},

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -1292,7 +1292,7 @@
 	},
 /area/station/crew_quarters/md)
 "aeX" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
@@ -14061,7 +14061,7 @@
 	},
 /area/station/bridge)
 "bqD" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "bqN" = (

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -9536,7 +9536,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/phone/wall{
 	pixel_x = 24;
 	pixel_y = 4

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -19555,7 +19555,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "bds" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
@@ -24268,7 +24268,7 @@
 	},
 /area/station/medical/head/private)
 "boJ" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/wood/eight{
 	dir = 4
 	},

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -15808,7 +15808,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/research)
 "bhM" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/cable{
 	icon_state = "1-4"
 	},

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -12546,7 +12546,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "dsJ" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -12860,7 +12860,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "dxg" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -86067,7 +86067,7 @@
 "vJl" = (
 /obj/machinery/manufacturer/general/grody{
 	free_resource_amt = 2;
-	
+
 	},
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -12768,7 +12768,7 @@
 "aCa" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/kitchen{
 	dir = 2;
-	
+
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -14585,7 +14585,7 @@
 "aGa" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -18977,7 +18977,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 4;
-	
+
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
@@ -24469,7 +24469,7 @@
 "bbS" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo{
 	dir = 4;
-	
+
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -28945,7 +28945,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "blq" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
 	},
@@ -30405,7 +30405,7 @@
 /turf/simulated/floor/plating/damaged1,
 /area/station/maintenance/solar/west)
 "boE" = (
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "boF" = (
@@ -39940,7 +39940,7 @@
 "bKF" = (
 /obj/machinery/atmospherics/unary/vent_pump/toxlab_chamber_to_tank{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -41853,7 +41853,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 8;
-	
+
 	},
 /turf/simulated/floor/grime,
 /area/station/science/lab)
@@ -42504,7 +42504,7 @@
 	pixel_y = 1
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -43050,7 +43050,7 @@
 	pixel_y = 21
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor/plating,
@@ -43866,7 +43866,7 @@
 "bSl" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 8;
-	
+
 	},
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
@@ -44824,7 +44824,7 @@
 /area/research_outpost/hangar)
 "bUk" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
@@ -44876,7 +44876,7 @@
 /area/research_outpost)
 "bUp" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -45814,21 +45814,21 @@
 "bWr" = (
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
 "bWs" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 10;
-	
+
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -45983,7 +45983,7 @@
 "bWJ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 5;
-	
+
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -45993,7 +45993,7 @@
 "bWK" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_corners2";
@@ -46003,7 +46003,7 @@
 "bWL" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-	
+
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -46019,7 +46019,7 @@
 "bWM" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 10;
-	
+
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost)
@@ -46115,7 +46115,7 @@
 "bWZ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1;
-	
+
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost)
@@ -46230,7 +46230,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost)
@@ -46308,7 +46308,7 @@
 "bXw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost)

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -9180,7 +9180,7 @@
 "aCS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
-	
+
 	},
 /obj/machinery/light{
 	dir = 4
@@ -9710,7 +9710,7 @@
 "aEP" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
-	
+
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -12423,7 +12423,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aOz" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -7464,7 +7464,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/critter/opossum/morty,
+/mob/living/critter/small_animal/opossum/morty,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "dbb" = (
@@ -35263,7 +35263,7 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "oTz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CRITTER][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Did you know? Dr. Acula and Morty are still `obj/critter`s on all the maps. This changes them to mobs. Hopefully the objectives still work.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I want to put them in the crate.