### PR TITLE
Deprecates /datum/mind/var/master

### DIFF
--- a/code/datums/gamemodes/spy.dm
+++ b/code/datums/gamemodes/spy.dm
@@ -111,14 +111,14 @@
 	src.spies.Add(spymind)
 	src.spies[spymind] = leadermind
 	spymind.special_role = "spyminion"
-	spymind.master = leader.ckey
+	//spymind.master = leader.ckey
 
 	return 1
 
 /datum/game_mode/spy/proc/remove_spy(mob/living/spy)
 	src.spies.Remove(spy)
 	spy.mind.special_role = null
-	spy.mind.master = null
+	//spy.mind.master = null
 	return 1
 
 /datum/game_mode/spy/declare_completion()

--- a/code/datums/gamemodes/spy.dm
+++ b/code/datums/gamemodes/spy.dm
@@ -111,14 +111,12 @@
 	src.spies.Add(spymind)
 	src.spies[spymind] = leadermind
 	spymind.special_role = "spyminion"
-	//spymind.master = leader.ckey
 
 	return 1
 
 /datum/game_mode/spy/proc/remove_spy(mob/living/spy)
 	src.spies.Remove(spy)
 	spy.mind.special_role = null
-	//spy.mind.master = null
 	return 1
 
 /datum/game_mode/spy/declare_completion()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -37,12 +37,6 @@ datum/mind
 
 	var/list/intrinsic_verbs = list()
 
-	// For mindhack/vampthrall/spyminion master references, which are now tracked by ckey.
-	// Mob references are not very reliable and did cause trouble with automated mindhack status removal
-	// The relevant code snippets call a ckey -> mob reference lookup proc where necessary,
-	// namely ckey_to_mob(mob.mind.master) (Convair880).
-	var/master = null
-
 	var/handwriting = null
 	var/color = null
 
@@ -195,10 +189,9 @@ datum/mind
 				obj_count++
 
 		// Added (Convair880).
-		if (recipient.mind.master)
-			var/mob/mymaster = ckey_to_mob(recipient.mind.master)
-			if (mymaster)
-				output+= "<br><b>Your master:</b> [mymaster.real_name]"
+		var/datum/mind/master = recipient.mind.get_master()
+		if (master?.current)
+			output += "<br><b>Your master:</b> [master.current.real_name]"
 
 		recipient.Browse(output,"window=memory;title=Memory")
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1582,7 +1582,7 @@
 			L.help(src, M)
 
 		if (INTENT_DISARM)
-			if (M.is_mentally_dominated_by(src))
+			if (src.mind && (M.mind?.get_master() == src.mind))
 				boutput(M, "<span class='alert'>You cannot harm your master!</span>")
 				return
 
@@ -1604,7 +1604,7 @@
 			message_admin_on_attack(M, "grabs")
 
 		if (INTENT_HARM)
-			if (M.is_mentally_dominated_by(src))
+			if (src.mind && (M.mind?.get_master() == src.mind))
 				boutput(M, "<span class='alert'>You cannot harm your master!</span>")
 				return
 

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -17,7 +17,19 @@ proc/get_all_gangs()
 	for (var/datum/antagonist/gang_leader/antag_datum in get_all_antagonists(ROLE_GANG_LEADER))
 		. += antag_datum.gang
 
-	return .
+/** Returns the mind of this mind's master.
+ * If a specific antagonist role ID is provided, then the master of the antagonist datum of that ID belonging to this mind will be returned.
+ * If no antagonist role ID is provided, then the master of the newest antagonist datum will be returned.
+ */
+/datum/mind/proc/get_master(antagonist_role_id)
+	if (antagonist_role_id)
+		var/datum/antagonist/subordinate/antagonist_role = src.get_antagonist(antagonist_role_id)
+		if (antagonist_role?.master)
+			. = antagonist_role.master
+		return
+
+	for (var/datum/antagonist/subordinate/antagonist_role in src.antagonists)
+		. = antagonist_role.master // Return the master of the newest antagonist datum in `antagonists`.
 
 /// Returns the gang datum of this mob, provided they has one. Otherwise returns false.
 /mob/proc/get_gang()

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -55,10 +55,6 @@
 		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce their skin!</B></span>")
 		return FALSE
 
-	if ((target.mind && target.mind.special_role == ROLE_VAMPTHRALL) && target.is_mentally_dominated_by(M))
-		boutput(M, "<span class='alert'>You can't drink the blood of your own thralls!</span>")
-		return FALSE
-
 	if (isnpcmonkey(target))
 		boutput(M, "<span class='alert'>Drink monkey blood?! That's disgusting!</span>")
 		return FALSE
@@ -219,13 +215,6 @@
 
 	if (check_target_immunity(target) == 1)
 		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce their skin!</B></span>")
-		return 0
-
-	var/mob/master = null
-	if(src.owner.mind && src.owner.mind.master)
-		master = ckey_to_mob(src.owner.mind.master)
-	if ((target.mind && target.mind.special_role == ROLE_VAMPTHRALL) && target.is_mentally_dominated_by(master))
-		boutput(M, "<span class='alert'>You can't drink the blood of your master's thralls!</span>")
 		return 0
 
 	if (isnpcmonkey(target))

--- a/code/modules/antagonists/vampire/thrall.dm
+++ b/code/modules/antagonists/vampire/thrall.dm
@@ -14,9 +14,8 @@
 		if (istype(master, /datum/abilityHolder/vampire))
 			src.master_ability_holder = master
 
-			if (istype(src.master_ability_holder.owner, /mob))
-				src.owner = new_owner
-				src.owner.master = src.master_ability_holder.owner.ckey
+			if (istype(src.master_ability_holder.owner, /mob) && src.master_ability_holder.owner.mind)
+				src.master = src.master_ability_holder.owner.mind
 
 		. = ..()
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1175,7 +1175,7 @@
 		logTheThing(LOG_COMBAT, user, "uses [src] ([type], object name: [initial(name)]) on [constructTarget(M,"combat")]")
 		return
 
-	if (user.mind && user.mind.special_role == ROLE_VAMPTHRALL && isvampire(M) && user.is_mentally_dominated_by(M))
+	if (user.mind && M.mind && (user.mind.get_master(ROLE_VAMPTHRALL) == M.mind))
 		boutput(user, "<span class='alert'>You cannot harm your master!</span>") //This message was previously sent to the attacking item. YEP.
 		return
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -276,7 +276,7 @@ TYPEINFO(/obj/item/baton)
 				if (!src.is_active || (src.is_active && src.can_stun() == 0))
 					src.do_stun(user, M, "failed_stun", 1)
 				else
-					if (user.mind && user.mind.special_role == ROLE_VAMPTHRALL && isvampire(M) && user.is_mentally_dominated_by(M))
+					if (user.mind && M.mind && (user.mind.get_master(ROLE_VAMPTHRALL) == M.mind))
 						boutput(user, "<span class='alert'>You cannot harm your master!</span>")
 						return
 					if (M.do_dodge(user, src) || M.parry_or_dodge(user, src))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -452,17 +452,6 @@
 	return
 #undef DO_NOTHING
 
-/mob/proc/is_mentally_dominated_by(var/mob/dominator)
-	if (!dominator || !src.mind)
-		return 0
-
-	if (src.mind.master)
-		var/mob/mymaster = ckey_to_mob(src.mind.master)
-		if (mymaster && (mymaster == dominator))
-			return 1
-
-	return 0
-
 /mob/proc/violate_hippocratic_oath()
 	if(!src.mind)
 		return 0

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -152,18 +152,10 @@
 				for (var/datum/objective/specialist/werewolf/feed/O in M.objectives)
 					if (O && istype(O, /datum/objective/specialist/werewolf/feed/))
 						special = length(O.mobs_fed_on)
-			if (ROLE_VAMPTHRALL)
-				if (M.master)
-					var/mob/mymaster = ckey_to_mob(M.master)
-					if (mymaster) special = mymaster.real_name
-			if ("spyminion")
-				if (M.master)
-					var/mob/mymaster = ckey_to_mob(M.master)
-					if (mymaster) special = mymaster.real_name
-			if (ROLE_MINDHACK)
-				if (M.master)
-					var/mob/mymaster = ckey_to_mob(M.master)
-					if (mymaster) special = mymaster.real_name
+			if (ROLE_VAMPTHRALL, ROLE_MINDHACK)
+				var/datum/mind/master = M.get_master(traitor_type)
+				if (master?.current)
+					special = master.current.real_name
 			if (ROLE_FLOCKMIND)
 				var/relay_successful = FALSE
 				if (isflockmob(M.current))


### PR DESCRIPTION
[Internal] [Code Quality]


## About The PR:
Deprecates `/datum/mind/var/master` and `/proc/is_mentally_dominated_by()`, replacing them in most cases with the new `/datum/mind/proc/get_master()`.
Removes superfluous vampire thrall checks in the vampire bite ability code.



## Why Is This needed?
Removal of remnants from the old antagonist system that has been superceded by antagonist datums.