### PR TITLE
Fishing fixes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1667,7 +1667,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_head = list(/obj/item/clothing/head/black)
 	slot_foot = list(/obj/item/clothing/shoes/galoshes/waders)
 	slot_glov = list(/obj/item/clothing/gloves/black)
-	slot_poc2 = list(/obj/item/device/pda2/botanist)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	items_in_backpack = list(/obj/item/fishing_rod/basic)
 

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -220,7 +220,7 @@ TYPEINFO(/obj/item/fish_portal)
 	icon_state = "uploadterminal_open"
 	anchored = ANCHORED
 	density = 1
-	layer = 3
+	layer = MOB_LAYER + 0.1
 	var/working = FALSE
 	var/allowed = list(/obj/item/fish)
 
@@ -245,23 +245,23 @@ TYPEINFO(/obj/item/fish_portal)
 			else
 				switch( P.value )
 					if (FISH_RARITY_COMMON)
-						new/obj/item/requisition_token/fishing/common(src.loc, src.layer + 0.1)
+						new/obj/item/requisition_token/fishing/common(src.loc)
 						JOB_XP(user, "Angler", 1)
 						qdel( P )
 					if (FISH_RARITY_UNCOMMON)
-						new/obj/item/requisition_token/fishing/uncommon(src.loc, src.layer + 0.1)
+						new/obj/item/requisition_token/fishing/uncommon(src.loc)
 						JOB_XP(user, "Angler", 2)
 						qdel( P )
 					if (FISH_RARITY_RARE)
-						new/obj/item/requisition_token/fishing/rare(src.loc, src.layer + 0.1)
+						new/obj/item/requisition_token/fishing/rare(src.loc)
 						JOB_XP(user, "Angler", 3)
 						qdel( P )
 					if (FISH_RARITY_EPIC)
-						new/obj/item/requisition_token/fishing/epic(src.loc, src.layer + 0.1)
+						new/obj/item/requisition_token/fishing/epic(src.loc)
 						JOB_XP(user, "Angler", 4)
 						qdel( P )
 					if (FISH_RARITY_LEGENDARY)
-						new/obj/item/requisition_token/fishing/legendary(src.loc, src.layer + 0.1)
+						new/obj/item/requisition_token/fishing/legendary(src.loc)
 						JOB_XP(user, "Angler", 5)
 						qdel( P )
 		if (found_blacklisted_fish)
@@ -271,7 +271,7 @@ TYPEINFO(/obj/item/fish_portal)
 		for(var/obj/item/S in src)
 			S.set_loc(get_turf(src))
 		src.working = FALSE
-		src.icon_state = "upload_terminal_0"
+		src.icon_state = "uploadterminal_open"
 		playsound(src.loc, 'sound/machines/ding.ogg', 100, 1)
 
 	attack_ai(var/mob/user as mob)

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -9,6 +9,7 @@
 	icon_state = "fishing_rod-inactive"
 	inhand_image_icon = 'icons/mob/inhand/hand_fishing.dmi'
 	item_state = "fishing_rod-inactive"
+	c_flags = ONBELT
 	/// average time to fish up something, in seconds - will vary on the upper and lower bounds by a maximum of 4 seconds, with a minimum time of 0.5 seconds.
 	var/fishing_speed = 8 SECONDS
 	/// how long to wait between casts in seconds - mainly so sounds dont overlap

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -47,7 +47,8 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	user.visible_message("[user] [pick("reels in", "catches", "pulls in", "fishes up")] a \
 	[pick("big", "wriggly", "fat", "slimy", "fishy", "large", "high-quality", "nasty", "chompy", "real", "wily")] \
 	[prob(80) ? "[fish.name]" : pick("one", "catch", "chomper", "wriggler", "sunovagun", "sucker")]!")
-	fish.set_loc(get_turf(user))
+	user.put_in_hand_or_drop(fish)
+	//fish.set_loc(get_turf(user))
 	playsound(user, 'sound/items/fishing_rod_reel.ogg', 50, 1)
 	fishing_rod.last_fished = TIME //set the last fished time
 	return 1

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -649,6 +649,7 @@
 
 /obj/item/requisition_token/fishing
 	icon_state = "fish_common"
+	layer = 4.5
 
 	common
 		name = "common research ticket"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Fishing rods now fit on the belt slot.
- Caught fish now try to be placed in your empty hand, if there's no room they land on your tile.
- Fixed the upload terminal layering under players.
- Fixed the upload terminal looking closed after it's finished processing fish.