### PR TITLE
Remove items from hand when they're put on a cargo tug cart

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -96,10 +96,16 @@ TYPEINFO(/obj/tug_cart)
 		if (BOUNDS_DIST(C, src) > 0 || load)
 			return
 
-		// if a create, close before loading
+		// if a crate, close before loading
 		var/obj/storage/crate/crate = C
 		if (istype(crate))
 			crate.close()
+
+		// if an item, ensure any mob holding it isn't anymore
+		var/obj/item/holdable = C
+		if (istype(holdable))
+			holdable.force_drop()
+
 		C.set_loc(src.loc)
 		SPAWN(0.2 SECONDS)
 			if (C && C.loc == src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When loading an atom onto a tug cart, if it's an item, it will now have force_drop called on it before being loaded, preventing it from remaining in hand while also being on the cart.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13679.