### PR TITLE
Reworks /proc/get_all_antagonists()

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -178,16 +178,14 @@ ABSTRACT_TYPE(/datum/game_mode)
 		catch(var/exception/e)
 			logTheThing(LOG_DEBUG, null, "kyle|former-antag-runtime: [e.file]:[e.line] - [e.name] - [e.desc]")
 
-	// Display all antagonist datums. We arrange them like this so that each antagonist is bundled together by type
-	for (var/V in concrete_typesof(/datum/antagonist))
-		var/datum/antagonist/dummy = V
-		for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists(initial(dummy.id)))
-			#ifdef DATA_LOGGER
-			game_stats.Increment(antagonist_role.check_completion() ? "traitorwin" : "traitorloss")
-			#endif
-			var/antag_dat = antagonist_role.handle_round_end(TRUE)
-			if (antagonist_role.display_at_round_end && length(antag_dat))
-				stuff_to_output.Add(antag_dat)
+	// Display all antagonist datums.
+	for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists())
+		#ifdef DATA_LOGGER
+		game_stats.Increment(antagonist_role.check_completion() ? "traitorwin" : "traitorloss")
+		#endif
+		var/antag_dat = antagonist_role.handle_round_end(TRUE)
+		if (antagonist_role.display_at_round_end && length(antag_dat))
+			stuff_to_output.Add(antag_dat)
 
 	boutput(world, stuff_to_output.Join("<br>"))
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -181,7 +181,8 @@ ABSTRACT_TYPE(/datum/game_mode)
 	// Display all antagonist datums. We arrange them like this so that each antagonist is bundled together by type
 	for (var/V in concrete_typesof(/datum/antagonist))
 		var/datum/antagonist/dummy = V
-		for (var/datum/antagonist/A as anything in get_all_antagonists(initial(dummy.id)))
+		for (var/datum/mind/mind as anything in get_all_antagonists(initial(dummy.id)))
+			var/datum/antagonist/A = mind.get_antagonist(initial(dummy.id))
 			#ifdef DATA_LOGGER
 			game_stats.Increment(A.check_completion() ? "traitorwin" : "traitorloss")
 			#endif

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -181,13 +181,12 @@ ABSTRACT_TYPE(/datum/game_mode)
 	// Display all antagonist datums. We arrange them like this so that each antagonist is bundled together by type
 	for (var/V in concrete_typesof(/datum/antagonist))
 		var/datum/antagonist/dummy = V
-		for (var/datum/mind/mind as anything in get_all_antagonists(initial(dummy.id)))
-			var/datum/antagonist/A = mind.get_antagonist(initial(dummy.id))
+		for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists(initial(dummy.id)))
 			#ifdef DATA_LOGGER
-			game_stats.Increment(A.check_completion() ? "traitorwin" : "traitorloss")
+			game_stats.Increment(antagonist_role.check_completion() ? "traitorwin" : "traitorloss")
 			#endif
-			var/antag_dat = A.handle_round_end(TRUE)
-			if (A.display_at_round_end && length(antag_dat))
+			var/antag_dat = antagonist_role.handle_round_end(TRUE)
+			if (antagonist_role.display_at_round_end && length(antag_dat))
 				stuff_to_output.Add(antag_dat)
 
 	boutput(world, stuff_to_output.Join("<br>"))

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -760,11 +760,11 @@ proc/create_fluff(datum/mind/target)
 		if (!owner.current || isdead(owner.current))
 			return FALSE
 
-		for (var/datum/mind/mindCheck in get_all_antagonists(ROLE_GANG_LEADER))
-			if (mindCheck == owner)
+		for (var/datum/mind/mind as anything in get_all_antagonists(ROLE_GANG_LEADER))
+			if (mind == owner)
 				continue
 
-			if (mindCheck?.current && !isdead(mindCheck.current))
+			if (mind?.current && !isdead(mind.current))
 				return FALSE
 
 		return TRUE

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -760,11 +760,11 @@ proc/create_fluff(datum/mind/target)
 		if (!owner.current || isdead(owner.current))
 			return FALSE
 
-		for (var/datum/mind/mind as anything in get_all_antagonists(ROLE_GANG_LEADER))
-			if (mind == owner)
+		for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists(ROLE_GANG_LEADER))
+			if (antagonist_role.owner == owner)
 				continue
 
-			if (mind?.current && !isdead(mind.current))
+			if (antagonist_role.owner.current && !isdead(antagonist_role.owner.current))
 				return FALSE
 
 		return TRUE

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -880,11 +880,11 @@ client/proc/toggle_ghost_respawns()
 	antagonists_see_each_other = !antagonists_see_each_other
 
 	var/datum/client_image_group/antagonist_image_group = get_image_group(CLIENT_IMAGE_GROUP_ALL_ANTAGONISTS)
-	for (var/datum/mind/mind as anything in get_all_antagonists())
+	for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists())
 		if (antagonists_see_each_other)
-			antagonist_image_group.add_mind(mind)
+			antagonist_image_group.add_mind(antagonist_role.owner)
 		else
-			antagonist_image_group.remove_mind(mind)
+			antagonist_image_group.remove_mind(antagonist_role.owner)
 
 	if (antagonists_see_each_other)
 		boutput(world, "<B>Antagonists can now see each other.</B>")

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -880,13 +880,11 @@ client/proc/toggle_ghost_respawns()
 	antagonists_see_each_other = !antagonists_see_each_other
 
 	var/datum/client_image_group/antagonist_image_group = get_image_group(CLIENT_IMAGE_GROUP_ALL_ANTAGONISTS)
-	for (var/antagonist_type in concrete_typesof(/datum/antagonist))
-		var/datum/antagonist/A = antagonist_type
-		for (var/datum/antagonist/antagonist_datum in get_all_antagonists(initial(A.id)))
-			if (antagonists_see_each_other)
-				antagonist_image_group.add_mind(antagonist_datum.owner)
-			else
-				antagonist_image_group.remove_mind(antagonist_datum.owner)
+	for (var/datum/mind/mind as anything in get_all_antagonists())
+		if (antagonists_see_each_other)
+			antagonist_image_group.add_mind(mind)
+		else
+			antagonist_image_group.remove_mind(mind)
 
 	if (antagonists_see_each_other)
 		boutput(world, "<B>Antagonists can now see each other.</B>")

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -72,9 +72,11 @@ ABSTRACT_TYPE(/datum/antagonist)
 			return FALSE
 		src.owner.antagonists.Add(src)
 
-	Del()
+	disposing()
 		if (owner && !src.pseudo)
-			antagonists["[src.id]"] -= src
+			LAZYLISTREMOVE(antagonists["[src.id]"], src)
+			if (isnull(antagonists["[src.id]"]))
+				antagonists -= "[src.id]"
 
 			owner.former_antagonist_roles.Add(owner.special_role)
 			owner.special_role = null // this isn't ideal, since the system should support multiple antagonists. once special_role is worked around, this won't be an issue

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -53,7 +53,7 @@ ABSTRACT_TYPE(/datum/antagonist)
 		if (!do_pseudo && !do_vr) // there is a special place in code hell for mind.special_role
 			if (!islist(antagonists["[src.id]"]))
 				antagonists["[src.id]"] = list()
-			antagonists["[src.id]"] += src.owner
+			antagonists["[src.id]"] += src
 
 			new_owner.special_role = id
 			if (source == ANTAGONIST_SOURCE_ADMIN)
@@ -76,7 +76,7 @@ ABSTRACT_TYPE(/datum/antagonist)
 
 	Del()
 		if (owner && !src.pseudo)
-			antagonists["[src.id]"] -= src.owner
+			antagonists["[src.id]"] -= src
 
 			owner.former_antagonist_roles.Add(owner.special_role)
 			owner.special_role = null // this isn't ideal, since the system should support multiple antagonists. once special_role is worked around, this won't be an issue

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -51,6 +51,10 @@ ABSTRACT_TYPE(/datum/antagonist)
 		src.pseudo = do_pseudo
 		src.vr = do_vr
 		if (!do_pseudo && !do_vr) // there is a special place in code hell for mind.special_role
+			if (!islist(antagonists["[src.id]"]))
+				antagonists["[src.id]"] = list()
+			antagonists["[src.id]"] += src.owner
+
 			new_owner.special_role = id
 			if (source == ANTAGONIST_SOURCE_ADMIN)
 				ticker.mode.Agimmicks |= new_owner
@@ -72,6 +76,8 @@ ABSTRACT_TYPE(/datum/antagonist)
 
 	Del()
 		if (owner && !src.pseudo)
+			antagonists["[src.id]"] -= src.owner
+
 			owner.former_antagonist_roles.Add(owner.special_role)
 			owner.special_role = null // this isn't ideal, since the system should support multiple antagonists. once special_role is worked around, this won't be an issue
 			if (src.assigned_by == ANTAGONIST_SOURCE_ADMIN)

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -11,11 +11,8 @@ var/list/antagonists = list()
 	if (antagonist_role_id)
 		return antagonists["[antagonist_role_id]"]
 
-	for (var/antagonist_type in concrete_typesof(/datum/antagonist))
-		var/datum/antagonist/A = antagonist_type
-		var/list/datum/antagonist/antagonist_roles = antagonists["[initial(A.id)]"]
-		if (length(antagonist_roles))
-			. += antagonist_roles
+	for (var/antagonist_type in antagonists)
+		. += antagonists[antagonist_type]
 
 /// Returns a list of all gang datums.
 proc/get_all_gangs()

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -1,7 +1,7 @@
 var/list/antagonists = list()
 /**
  * Gets a list of all antagonists of ID role_id, or of all IDs if no ID is specified.
- * Returns a list of minds if any datums are present, or null if none are.
+ * Returns a list of all antagonist minds. If no antagonist minds can be found, returns a empty list.
  */
 /proc/get_all_antagonists(antagonist_role_id)
 	. = list()

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -1,25 +1,32 @@
+var/list/antagonists = list()
 /**
- * Gets a list of all antagonists of ID role_id.
- * Returns a list if any datums are present, or null if none are.
+ * Gets a list of all antagonists of ID role_id, or of all IDs if no ID is specified.
+ * Returns a list of minds if any datums are present, or null if none are.
  */
-/proc/get_all_antagonists(role_id, include_pseudo = FALSE)
+/proc/get_all_antagonists(antagonist_role_id)
 	. = list()
-	for (var/datum/mind/mind in ticker.minds)
-		for (var/datum/antagonist/antag in mind.antagonists)
-			if (antag.id == role_id && (!antag.pseudo || include_pseudo))
-				. += antag
-				break
+
+	if (antagonist_role_id)
+		return antagonists["[antagonist_role_id]"]
+
+	for (var/antagonist_type in concrete_typesof(/datum/antagonist))
+		var/datum/antagonist/A = antagonist_type
+		var/list/datum/mind/antagonist_minds = antagonists["[initial(A.id)]"]
+		if (length(antagonist_minds))
+			. += antagonist_minds
 
 /// Returns a list of all gang datums.
 proc/get_all_gangs()
 	. = list()
 
-	for (var/datum/antagonist/gang_leader/antag_datum in get_all_antagonists(ROLE_GANG_LEADER))
-		. += antag_datum.gang
+	for (var/datum/mind/gang_leader as anything in get_all_antagonists(ROLE_GANG_LEADER))
+		var/datum/antagonist/gang_leader/antagonist_role = gang_leader.get_antagonist(ROLE_GANG_LEADER)
+		if (antagonist_role?.gang)
+			. += antagonist_role.gang
 
 	return .
 
-/// Returns the gang datum of this mob, provided they has one. Otherwise returns false.
+/// Returns the gang datum of this mob, provided they have one. Otherwise returns false.
 /mob/proc/get_gang()
 	var/datum/gang/gang
 	var/datum/antagonist/gang_leader/gang_leader_antagonist_role = src.mind?.get_antagonist(ROLE_GANG_LEADER)

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -1,7 +1,9 @@
+/// An associative list of all antagonist IDs, associated with a list of all antagonist datums of that ID.
 var/list/antagonists = list()
+
 /**
- * Gets a list of all antagonists of ID role_id, or of all IDs if no ID is specified.
- * Returns a list of all antagonist minds. If no antagonist minds can be found, returns a empty list.
+ * Gets a list of all antagonist datums of ID role_id, or of all IDs if no ID is specified.
+ * Returns a list of all antagonist datums. If no antagonist datums could be found, returns an empty list.
  */
 /proc/get_all_antagonists(antagonist_role_id)
 	. = list()
@@ -11,16 +13,15 @@ var/list/antagonists = list()
 
 	for (var/antagonist_type in concrete_typesof(/datum/antagonist))
 		var/datum/antagonist/A = antagonist_type
-		var/list/datum/mind/antagonist_minds = antagonists["[initial(A.id)]"]
-		if (length(antagonist_minds))
-			. += antagonist_minds
+		var/list/datum/antagonist/antagonist_roles = antagonists["[initial(A.id)]"]
+		if (length(antagonist_roles))
+			. += antagonist_roles
 
 /// Returns a list of all gang datums.
 proc/get_all_gangs()
 	. = list()
 
-	for (var/datum/mind/gang_leader as anything in get_all_antagonists(ROLE_GANG_LEADER))
-		var/datum/antagonist/gang_leader/antagonist_role = gang_leader.get_antagonist(ROLE_GANG_LEADER)
+	for (var/datum/antagonist/gang_leader/antagonist_role as anything in get_all_antagonists(ROLE_GANG_LEADER))
 		if (antagonist_role?.gang)
 			. += antagonist_role.gang
 

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -1,5 +1,5 @@
 /// An associative list of all antagonist IDs, associated with a list of all antagonist datums of that ID.
-var/list/antagonists = list()
+var/list/list/antagonists = list()
 
 /**
  * Gets a list of all antagonist datums of ID role_id, or of all IDs if no ID is specified.

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1344,60 +1344,6 @@ proc/outermost_movable(atom/movable/target)
 	var/stringtarget = copytext(stringtype, 1, parentend ? parentend : 0)
 	. = text2path(stringtarget)
 
-//Returns a list of minds that are some type of antagonist role
-//This may be a stop gap until a better solution can be figured out
-/proc/get_all_enemies()
-	if(ticker?.mode && current_state >= GAME_STATE_PLAYING)
-		var/datum/mind/enemies[] = new()
-		var/datum/mind/someEnemies[] = new()
-
-		//We gotta loop through the modes because someone thought it was a good idea to create new lists for all of them
-		if (istype(ticker.mode, /datum/game_mode/revolution))
-			someEnemies = ticker.mode:head_revolutionaries
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-			someEnemies = ticker.mode:revolutionaries
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-			someEnemies = ticker.mode:get_all_heads()
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-		else if (istype(ticker.mode, /datum/game_mode/nuclear))
-			someEnemies = ticker.mode:syndicates
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-		else if (istype(ticker.mode, /datum/game_mode/spy))
-			someEnemies = ticker.mode:spies
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-			someEnemies = ticker.mode:leaders
-			for(var/datum/mind/M in someEnemies)
-				if (M.current)
-					enemies += M
-
-		//Lists we grab regardless of game type
-		//Traitors list is populated during traitor or mixed rounds, however it is created along with the game_mode datum unlike the rest of the lists
-		someEnemies = ticker.mode.traitors
-		for(var/datum/mind/M in someEnemies)
-			if (M.current)
-				enemies += M
-
-		//Sometimes admins assign traitors, this contains those dudes
-		someEnemies = ticker.mode.Agimmicks
-		for(var/datum/mind/M in someEnemies)
-			if (M.current)
-				enemies += M
-
-		return enemies
-
-	else
-		return 0
-
 /proc/GetRedPart(hex)
     hex = uppertext(hex)
     var/hi = text2ascii(hex, 2)

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -97,7 +97,8 @@
 
 //Called in gameticker.dm in proc/declare_completion
 /proc/statlog_traitors()
-	for (var/datum/mind/M as anything in get_all_antagonists())
+	for (var/datum/antagonist/antagonist_role as anything in get_all_antagonists())
+		var/datum/mind/M = antagonist_role.owner
 		var/message[] = new()
 		message["data_type"] = "traitors"
 		message["data_status"] = "insert"

--- a/code/procs/stat_logging.dm
+++ b/code/procs/stat_logging.dm
@@ -97,9 +97,7 @@
 
 //Called in gameticker.dm in proc/declare_completion
 /proc/statlog_traitors()
-	var/list/datum/mind/traitors = get_all_enemies()
-
-	for (var/datum/mind/M in traitors)
+	for (var/datum/mind/M as anything in get_all_antagonists())
 		var/message[] = new()
 		message["data_type"] = "traitors"
 		message["data_status"] = "insert"

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,4 +1,9 @@
 
+(t)thu jun 08 23
+(u)DisturbHerb + Sunkiisu
+(p)14245
+(e)🆕🎨📦|C-Feature, C-Sprites, A-Game-Objects
+(*)Adds pet carriers to the game. These bulky carriers can hold a single small animal.
 (t)wed jun 07 23
 (u)Glamurio (Ryou)
 (p)14397


### PR DESCRIPTION
[Internal] [Code Quality]


## About The PR:
Reworks `/proc/get_all_antagonists()` to iterate through a new `antagonists` global list, as opposed to iterating through every mind datum.
The `antagonists` global list will contain all antagonist datums sorted by role ID; i.e. all traitor datums will be filed under `antagonists["[ROLE_TRAITOR]"]`.

`/datum/game_mode/var/traitors` and `/datum/game_mode/var/Agimmicks` will eventually be superceded by `get_all_antagonists()`.
Deprecates `/proc/get_all_enemies()`.



## Why Is This needed?
Optimisation of the new system and removal of remnants from the old antagonist system that has been superceded by antagonist datums.