### PR TITLE
Walls now save their girder material when built

### DIFF
--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -123,7 +123,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				var/datum/material/M = getMaterial("steel")
 				A.setMaterial(src.material ? src.material : M, copy = FALSE)
 				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
-				
+
 				var/floorname1	= src.floorname
 				var/floorintact1	= src.floorintact
 				var/floorburnt1	= src.floorburnt
@@ -159,7 +159,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "false [src.material.matname] wall"
+		src.name = "false [src.material.name] wall"
 		animate(src, time = delay, pixel_x = 25, easing = BACK_EASING)
 		SPAWN(delay)
 			//we want to return 1 without waiting for the animation to finish - the textual cue seems sloppy if it waits
@@ -181,7 +181,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "[src.material.matname] wall"
+		src.name = "[src.material.name] wall"
 		animate(src, time = delay, pixel_x = 0, easing = BACK_EASING)
 		src.set_density(1)
 		src.gas_impermeable = 1

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -120,9 +120,9 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				//a false wall turns into a sheet of metal and displaced girders
 				var/atom/A = new /obj/item/sheet(src)
 				var/atom/B = new /obj/structure/girder/displaced(src)
-				var/datum/material/M = getMaterial("steel")
-				A.setMaterial(src.material ? src.material : M, copy = FALSE)
-				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				var/datum/material/defaultMaterial = getMaterial("steel")
+				A.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 				var/floorname1	= src.floorname
 				var/floorintact1	= src.floorintact

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -135,7 +135,6 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				//a false wall turns into a sheet of metal and displaced girders
 				var/atom/A = new /obj/item/sheet(F)
 				var/atom/B = new /obj/structure/girder/displaced(F)
-
 				var/datum/material/M = getMaterial("steel")
 				A.setMaterial(src.material ? src.material : M)
 				B.setMaterial(src.girdermaterial ? src.girdermaterial : M)

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -18,7 +18,6 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 	var/can_be_auto = 1
 	var/mod = null
 	var/obj/overlay/floor_underlay = null
-	var/girdermaterial = null
 
 	temp
 		var/was_rwall = 0
@@ -117,6 +116,14 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 					boutput(user, "<span class='notice'>It was a false wall!</span>")
 				//disassemble it
 				boutput(user, "<span class='notice'>Now dismantling false wall.</span>")
+
+				//a false wall turns into a sheet of metal and displaced girders
+				var/atom/A = new /obj/item/sheet(src)
+				var/atom/B = new /obj/structure/girder/displaced(src)
+				var/datum/material/M = getMaterial("steel")
+				A.setMaterial(src.material ? src.material : M, copy = FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				
 				var/floorname1	= src.floorname
 				var/floorintact1	= src.floorintact
 				var/floorburnt1	= src.floorburnt
@@ -133,12 +140,6 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				F.icon_state = flooricon_state1
 				F.setIntact(floorintact1)
 				F.burnt = floorburnt1
-				//a false wall turns into a sheet of metal and displaced girders
-				var/atom/A = new /obj/item/sheet(F)
-				var/atom/B = new /obj/structure/girder/displaced(F)
-				var/datum/material/M = getMaterial("steel")
-				A.setMaterial(src.material ? src.material : M)
-				B.setMaterial(src.girdermaterial ? src.girdermaterial : M)
 
 				F.levelupdate()
 				logTheThing(LOG_STATION, user, "dismantles a False Wall in [user.loc.loc] ([log_loc(user)])")
@@ -158,7 +159,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "false wall"
+		src.name = "false [src.material.matname] wall"
 		animate(src, time = delay, pixel_x = 25, easing = BACK_EASING)
 		SPAWN(delay)
 			//we want to return 1 without waiting for the animation to finish - the textual cue seems sloppy if it waits
@@ -180,7 +181,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "wall"
+		src.name = "[src.material.matname] wall"
 		animate(src, time = delay, pixel_x = 0, easing = BACK_EASING)
 		src.set_density(1)
 		src.gas_impermeable = 1

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -135,13 +135,11 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				//a false wall turns into a sheet of metal and displaced girders
 				var/atom/A = new /obj/item/sheet(F)
 				var/atom/B = new /obj/structure/girder/displaced(F)
-				if(src.material)
-					A.setMaterial(src.material)
-					B.setMaterial(src.material)
-				else
-					var/datum/material/M = getMaterial("steel")
-					A.setMaterial(M)
-					B.setMaterial(M)
+
+				var/datum/material/M = getMaterial("steel")
+				A.setMaterial(src.material ? src.material : M)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : M)
+
 				F.levelupdate()
 				logTheThing(LOG_STATION, user, "dismantles a False Wall in [user.loc.loc] ([log_loc(user)])")
 				return

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -159,7 +159,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "false [src.material.name] wall"
+		src.name = src.material ? "false [src.material.name] wall" : "false wall"
 		animate(src, time = delay, pixel_x = 25, easing = BACK_EASING)
 		SPAWN(delay)
 			//we want to return 1 without waiting for the animation to finish - the textual cue seems sloppy if it waits
@@ -181,7 +181,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		if (src.operating)
 			return 0
 		src.operating = 1
-		src.name = "[src.material.name] wall"
+		src.name = src.material ? "[src.material.name] wall" : "steel wall"
 		animate(src, time = delay, pixel_x = 0, easing = BACK_EASING)
 		src.set_density(1)
 		src.gas_impermeable = 1

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -121,8 +121,8 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 				var/atom/A = new /obj/item/sheet(src)
 				var/atom/B = new /obj/structure/girder/displaced(src)
 				var/datum/material/defaultMaterial = getMaterial("steel")
-				A.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
-				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+				A.setMaterial(src.material ? src.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 				var/floorname1	= src.floorname
 				var/floorintact1	= src.floorintact

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -18,6 +18,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 	var/can_be_auto = 1
 	var/mod = null
 	var/obj/overlay/floor_underlay = null
+	var/girdermaterial = null
 
 	temp
 		var/was_rwall = 0

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -301,16 +301,16 @@ obj/structure/ex_act(severity)
 		var/FloorIntact = T.intact
 		var/FloorBurnt = T.burnt
 		var/FloorName = T.name
+		var/girdermaterial
 
 		var/target_type = S.reinforcement ? /turf/simulated/wall/false_wall/reinforced : /turf/simulated/wall/false_wall
 
 		T.ReplaceWith(target_type, FALSE, FALSE, FALSE)
 		var/atom/A = src.loc
 		var/datum/material/M = getMaterial("steel")
-
-		A.setMaterial(src.material ? src.material : M, copy = FALSE)
-
 		var/turf/simulated/wall/false_wall/FW = A
+
+		FW.setMaterial(S.material ? S.material : M, copy = FALSE)
 		FW.girdermaterial = src.material ? src.material : M
 		FW.inherit_area()
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -123,7 +123,8 @@ obj/structure/ex_act(severity)
 		else
 			if (S.material.material_flags & MATERIAL_METAL)
 				actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_PLATE, null, user), user)
-			else(boutput(user, "You cannot plate [src] with [S]!"))
+			else
+				boutput(user, "You cannot plate [src] with [S]!")
 	else
 		..()
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -73,8 +73,8 @@ obj/structure/ex_act(severity)
 				if (src.material)
 					A.setMaterial(src.material)
 				else
-					var/datum/material/M = getMaterial("steel")
-					A.setMaterial(M)
+					var/datum/material/defaultMaterial = getMaterial("steel")
+					A.setMaterial(defaultMaterial)
 				qdel(src)
 			else
 				if (prob(30))
@@ -82,8 +82,8 @@ obj/structure/ex_act(severity)
 					if (src.material)
 						A.setMaterial(src.material)
 					else
-						var/datum/material/M = getMaterial("steel")
-						A.setMaterial(M)
+						var/datum/material/defaultMaterial = getMaterial("steel")
+						A.setMaterial(defaultMaterial)
 				else
 					qdel(src)
 
@@ -214,8 +214,8 @@ obj/structure/ex_act(severity)
 				if (the_girder.material)
 					A.setMaterial(the_girder.material)
 				else
-					var/datum/material/M = getMaterial("steel")
-					A.setMaterial(M)
+					var/datum/material/defaultMaterial = getMaterial("steel")
+					A.setMaterial(defaultMaterial)
 				qdel(the_girder)
 			if (GIRDER_UNSECURESUPPORT)
 				verbens = "unsecured the support struts of"
@@ -236,8 +236,8 @@ obj/structure/ex_act(severity)
 				if (the_tool.material)
 					A.setMaterial(the_girder.material)
 				else
-					var/datum/material/M = getMaterial("steel")
-					A.setMaterial(M)
+					var/datum/material/defaultMaterial = getMaterial("steel")
+					A.setMaterial(defaultMaterial)
 				qdel(the_girder)
 			if (GIRDER_SECURE)
 				if (!istype(the_girder.loc, /turf/simulated/floor/))
@@ -253,14 +253,14 @@ obj/structure/ex_act(severity)
 				var/turf/Tsrc = get_turf(the_girder)
 				var/turf/simulated/wall/WALL
 				var/obj/item/sheet/S = the_tool
-				var/datum/material/M = getMaterial("steel")
+				var/datum/material/defaultMaterial = getMaterial("steel")
 
 				if (S.reinforcement)
 					WALL = Tsrc.ReplaceWithRWall()
 				else
 					WALL = Tsrc.ReplaceWithWall()
-				WALL.setMaterial(S.material ? S.material : M)
-				WALL.girdermaterial = the_girder.material ? the_girder.material : M
+				WALL.setMaterial(S.material ? S.material : defaultMaterial)
+				WALL.girdermaterial = the_girder.material ? the_girder.material : defaultMaterial
 
 				WALL.inherit_area()
 				S?.change_stack_amount(-2)
@@ -307,11 +307,11 @@ obj/structure/ex_act(severity)
 
 		T.ReplaceWith(target_type, FALSE, FALSE, FALSE)
 		var/atom/A = src.loc
-		var/datum/material/M = getMaterial("steel")
+		var/datum/material/defaultMaterial = getMaterial("steel")
 		var/turf/simulated/wall/false_wall/FW = A
 
-		FW.setMaterial(S.material ? S.material : M, copy = FALSE)
-		FW.girdermaterial = src.material ? src.material : M
+		FW.setMaterial(S.material ? S.material : defaultMaterial, copy = FALSE)
+		FW.girdermaterial = src.material ? src.material : defaultMaterial
 		FW.inherit_area()
 
 		FW.setFloorUnderlay(FloorIcon, FloorState, FloorIntact, 0, FloorBurnt, FloorName)
@@ -327,8 +327,8 @@ obj/structure/ex_act(severity)
 		if(src.material)
 			S.setMaterial(src.material)
 		else
-			var/datum/material/M = getMaterial("steel")
-			S.setMaterial(M)
+			var/datum/material/defaultMaterial = getMaterial("steel")
+			S.setMaterial(defaultMaterial)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 75, 1)
 		qdel(src)
 		return

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -121,7 +121,9 @@ obj/structure/ex_act(severity)
 			actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_REINFORCE, null, user), user)
 
 		else
-			actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_PLATE, null, user), user)
+			if (S.material.material_flags & MATERIAL_METAL)
+				actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_PLATE, null, user), user)
+			else(boutput(user, "You cannot plate [src] with [S]!"))
 	else
 		..()
 
@@ -257,7 +259,7 @@ obj/structure/ex_act(severity)
 				else
 					WALL = Tsrc.ReplaceWithWall()
 				WALL.setMaterial(S.material ? S.material : M)
-				A.girdermaterial = src.material ? src.material : M
+				WALL.girdermaterial = the_girder.material ? the_girder.material : M
 
 				WALL.inherit_area()
 				S?.change_stack_amount(-2)

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -301,7 +301,6 @@ obj/structure/ex_act(severity)
 		var/FloorIntact = T.intact
 		var/FloorBurnt = T.burnt
 		var/FloorName = T.name
-		var/girdermaterial
 
 		var/target_type = S.reinforcement ? /turf/simulated/wall/false_wall/reinforced : /turf/simulated/wall/false_wall
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -254,11 +254,14 @@ obj/structure/ex_act(severity)
 					WALL = Tsrc.ReplaceWithRWall()
 				else
 					WALL = Tsrc.ReplaceWithWall()
-				if (the_girder.material)
-					WALL.setMaterial(the_girder.material)
+				if (S.material)
+					WALL.setMaterial(S.material)
 				else
-					var/datum/material/M = getMaterial("steel")
-					WALL.setMaterial(M)
+					WALL.setMaterial(getMaterial("steel"))
+				if (the_girder.material)
+					WALL.girdermaterial = the_girder.material
+				else
+					WALL.girdermaterial = getMaterial("steel")
 				WALL.inherit_area()
 				S?.change_stack_amount(-2)
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -312,7 +312,7 @@ obj/structure/ex_act(severity)
 		var/datum/material/defaultMaterial = getMaterial("steel")
 		var/turf/simulated/wall/false_wall/FW = A
 
-		FW.setMaterial(S.material ? S.material : defaultMaterial, copy = FALSE)
+		FW.setMaterial(S.material ? S.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
 		FW.girdermaterial = src.material ? src.material : defaultMaterial
 		FW.inherit_area()
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -309,9 +309,9 @@ obj/structure/ex_act(severity)
 		var/datum/material/M = getMaterial("steel")
 
 		A.setMaterial(src.material ? src.material : M, copy = FALSE)
-		A.girdermaterial = src.material ? src.material : M
 
 		var/turf/simulated/wall/false_wall/FW = A
+		FW.girdermaterial = src.material ? src.material : M
 		FW.inherit_area()
 
 		FW.setFloorUnderlay(FloorIcon, FloorState, FloorIntact, 0, FloorBurnt, FloorName)

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -250,18 +250,15 @@ obj/structure/ex_act(severity)
 				var/turf/Tsrc = get_turf(the_girder)
 				var/turf/simulated/wall/WALL
 				var/obj/item/sheet/S = the_tool
+				var/datum/material/M = getMaterial("steel")
+
 				if (S.reinforcement)
 					WALL = Tsrc.ReplaceWithRWall()
 				else
 					WALL = Tsrc.ReplaceWithWall()
-				if (S.material)
-					WALL.setMaterial(S.material)
-				else
-					WALL.setMaterial(getMaterial("steel"))
-				if (the_girder.material)
-					WALL.girdermaterial = the_girder.material
-				else
-					WALL.girdermaterial = getMaterial("steel")
+				WALL.setMaterial(S.material ? S.material : M)
+				A.girdermaterial = src.material ? src.material : M
+
 				WALL.inherit_area()
 				S?.change_stack_amount(-2)
 
@@ -302,17 +299,15 @@ obj/structure/ex_act(severity)
 		var/FloorIntact = T.intact
 		var/FloorBurnt = T.burnt
 		var/FloorName = T.name
-		var/oldmat = src.material
 
 		var/target_type = S.reinforcement ? /turf/simulated/wall/false_wall/reinforced : /turf/simulated/wall/false_wall
 
 		T.ReplaceWith(target_type, FALSE, FALSE, FALSE)
 		var/atom/A = src.loc
-		if(oldmat)
-			A.setMaterial(oldmat)
-		else
-			var/datum/material/M = getMaterial("steel")
-			A.setMaterial(M)
+		var/datum/material/M = getMaterial("steel")
+
+		A.setMaterial(src.material ? src.material : M, copy = FALSE)
+		A.girdermaterial = src.material ? src.material : M
 
 		var/turf/simulated/wall/false_wall/FW = A
 		FW.inherit_area()

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -118,8 +118,10 @@ obj/structure/ex_act(severity)
 			return
 
 		if (src.icon_state != "reinforced" && S.reinforcement)
-			actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_REINFORCE, null, user), user)
-
+			if (S.material.material_flags & MATERIAL_METAL)
+				actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_REINFORCE, null, user), user)
+			else
+				boutput(user, "You cannot reinforce [src] with [S]!")
 		else
 			if (S.material.material_flags & MATERIAL_METAL)
 				actions.start(new /datum/action/bar/icon/girder_tool_interact(src, W, GIRDER_PLATE, null, user), user)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -138,23 +138,23 @@
 			var/atom/A = new /obj/structure/girder/reinforced(src)
 			var/obj/item/sheet/B = new /obj/item/sheet( src )
 
-			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
-			B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
+			B.setMaterial(src.material ? src.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
 			B.set_reinforcement(src.material)
 		else
 			if (prob(50)) // pardon all these nested probabilities, just trying to vary the damage appearance a bit
 				var/atom/A = new /obj/structure/girder/reinforced(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/B = new /obj/item/raw_material/scrap_metal
 					B.set_loc(src)
-					B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
+					B.setMaterial(src.material ? src.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 			else if( prob(50))
 				var/atom/A = new /obj/structure/girder(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 	else
 		if (!devastated)
@@ -162,26 +162,26 @@
 			var/atom/B = new /obj/item/sheet( src )
 			var/atom/C = new /obj/item/sheet( src )
 
-			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
-			B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
-			C.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
+			B.setMaterial(src.material ? src.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
+			C.setMaterial(src.material ? src.material : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 		else
 			if (prob(50))
 				var/atom/A = new /obj/structure/girder/displaced(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 
 			else if (prob(50))
 				var/atom/B = new /obj/structure/girder(src)
 
-				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/C = new /obj/item/raw_material/scrap_metal
 					C.set_loc(src)
-					C.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+					C.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = src.material ? TRUE :FALSE)
 
 
 	var/atom/D = ReplaceWithFloor()

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -132,29 +132,29 @@
 	qdel(parts)
 
 /turf/simulated/wall/proc/dismantle_wall(devastated=0, keep_material = 1)
-	var/datum/material/M = getMaterial("steel")
+	var/datum/material/defaultMaterial = getMaterial("steel")
 	if (istype(src, /turf/simulated/wall/r_wall) || istype(src, /turf/simulated/wall/auto/reinforced))
 		if (!devastated)
 			var/atom/A = new /obj/structure/girder/reinforced(src)
 			var/obj/item/sheet/B = new /obj/item/sheet( src )
 
-			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
-			B.setMaterial(src.material ? src.material : M, copy = FALSE)
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+			B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
 			B.set_reinforcement(src.material)
 		else
 			if (prob(50)) // pardon all these nested probabilities, just trying to vary the damage appearance a bit
 				var/atom/A = new /obj/structure/girder/reinforced(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/B = new /obj/item/raw_material/scrap_metal
 					B.set_loc(src)
-					B.setMaterial(src.material ? src.material : M, copy = FALSE)
+					B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
 
 			else if( prob(50))
 				var/atom/A = new /obj/structure/girder(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 	else
 		if (!devastated)
@@ -162,26 +162,26 @@
 			var/atom/B = new /obj/item/sheet( src )
 			var/atom/C = new /obj/item/sheet( src )
 
-			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
-			B.setMaterial(src.material ? src.material : M, copy = FALSE)
-			C.setMaterial(src.material ? src.material : M, copy = FALSE)
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
+			B.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
+			C.setMaterial(src.material ? src.material : defaultMaterial, copy = FALSE)
 
 		else
 			if (prob(50))
 				var/atom/A = new /obj/structure/girder/displaced(src)
-				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 
 			else if (prob(50))
 				var/atom/B = new /obj/structure/girder(src)
 
-				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/C = new /obj/item/raw_material/scrap_metal
 					C.set_loc(src)
-					C.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+					C.setMaterial(src.girdermaterial ? src.girdermaterial : defaultMaterial, copy = FALSE)
 
 
 	var/atom/D = ReplaceWithFloor()

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -185,7 +185,10 @@
 
 
 	var/atom/D = ReplaceWithFloor()
-	D.setMaterial(src.girdermaterial && keep_material ? src.girdermaterial : M, copy = FALSE)
+	if (src.material && keep_material)
+		D.setMaterial(src.material)
+	else
+		D.setMaterial(getMaterial("steel"), copy = FALSE)
 
 
 /turf/simulated/wall/burn_down()

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -138,7 +138,7 @@
 			var/obj/item/sheet/B = new /obj/item/sheet( src )
 
 			var/datum/material/M = getMaterial("steel")
-			A.setMaterial(src.girdermaterialc ? src.girdermaterial : M, copy = FALSE)
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 			B.setMaterial(src.material ? src.material : M, copy = FALSE)
 			B.set_reinforcement(src.material)
 		else
@@ -169,44 +169,32 @@
 			var/atom/A = new /obj/structure/girder(src)
 			var/atom/B = new /obj/item/sheet( src )
 			var/atom/C = new /obj/item/sheet( src )
-			if (src.material)
-				A.setMaterial(src.material)
-				B.setMaterial(src.material)
-				C.setMaterial(src.material)
-			else
-				var/datum/material/M = getMaterial("steel")
-				A.setMaterial(M, copy = FALSE)
-				B.setMaterial(M, copy = FALSE)
-				C.setMaterial(M, copy = FALSE)
+
+			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+			B.setMaterial(src.material ? src.material : M, copy = FALSE)
+			C.setMaterial(src.material ? src.material : M, copy = FALSE)
+
 		else
 			if (prob(50))
 				var/atom/A = new /obj/structure/girder/displaced(src)
-				if (src.material)
-					A.setMaterial(src.material)
-				else
-					A.setMaterial(getMaterial("steel"), copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+
 
 			else if (prob(50))
 				var/atom/B = new /obj/structure/girder(src)
 
-				if (src.material)
-					B.setMaterial(src.material)
-				else
-					B.setMaterial(getMaterial("steel"), copy = FALSE)
+				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+
 
 				if (prob(50))
 					var/atom/movable/C = new /obj/item/raw_material/scrap_metal
 					C.set_loc(src)
-					if (src.material)
-						C.setMaterial(src.material)
-					else
-						C.setMaterial(getMaterial("steel"), copy = FALSE)
+					C.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+
 
 	var/atom/D = ReplaceWithFloor()
-	if (src.material && keep_material)
-		D.setMaterial(src.material)
-	else
-		D.setMaterial(getMaterial("steel"), copy = FALSE)
+	D.setMaterial(src.girdermaterial && keep_material ? src.girdermaterial : M, copy = FALSE)
+
 
 /turf/simulated/wall/burn_down()
 	src.ReplaceWithFloor()

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -170,6 +170,7 @@
 			var/atom/B = new /obj/item/sheet( src )
 			var/atom/C = new /obj/item/sheet( src )
 
+			var/datum/material/M = getMaterial("steel")
 			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 			B.setMaterial(src.material ? src.material : M, copy = FALSE)
 			C.setMaterial(src.material ? src.material : M, copy = FALSE)
@@ -177,22 +178,26 @@
 		else
 			if (prob(50))
 				var/atom/A = new /obj/structure/girder/displaced(src)
+				var/datum/material/M = getMaterial("steel")
 				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 			else if (prob(50))
 				var/atom/B = new /obj/structure/girder(src)
 
+				var/datum/material/M = getMaterial("steel")
 				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/C = new /obj/item/raw_material/scrap_metal
 					C.set_loc(src)
+				var/datum/material/M = getMaterial("steel")
 					C.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 	var/atom/D = ReplaceWithFloor()
+	var/datum/material/M = getMaterial("steel")
 	D.setMaterial(src.girdermaterial && keep_material ? src.girdermaterial : M, copy = FALSE)
 
 

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -18,6 +18,7 @@
 	var/health = 100
 	var/list/forensic_impacts = null
 	var/last_proj_update_time = null
+	var/girdermaterial = null
 
 	New()
 		..()
@@ -135,15 +136,11 @@
 		if (!devastated)
 			var/atom/A = new /obj/structure/girder/reinforced(src)
 			var/obj/item/sheet/B = new /obj/item/sheet( src )
-			if (src.material)
-				A.setMaterial(src.material)
-				B.setMaterial(src.material)
-				B.set_reinforcement(src.material)
-			else
-				var/datum/material/M = getMaterial("steel")
-				A.setMaterial(M, copy = FALSE)
-				B.setMaterial(M, copy = FALSE)
-				B.set_reinforcement(M)
+
+			var/datum/material/M = getMaterial("steel")
+			A.setMaterial(src.girdermaterialc ? src.girdermaterial : M, copy = FALSE)
+			B.setMaterial(src.material ? src.material : M, copy = FALSE)
+			B.set_reinforcement(src.material)
 		else
 			if (prob(50)) // pardon all these nested probabilities, just trying to vary the damage appearance a bit
 				var/atom/A = new /obj/structure/girder/reinforced(src)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -132,37 +132,29 @@
 	qdel(parts)
 
 /turf/simulated/wall/proc/dismantle_wall(devastated=0, keep_material = 1)
+	var/datum/material/M = getMaterial("steel")
 	if (istype(src, /turf/simulated/wall/r_wall) || istype(src, /turf/simulated/wall/auto/reinforced))
 		if (!devastated)
 			var/atom/A = new /obj/structure/girder/reinforced(src)
 			var/obj/item/sheet/B = new /obj/item/sheet( src )
 
-			var/datum/material/M = getMaterial("steel")
 			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 			B.setMaterial(src.material ? src.material : M, copy = FALSE)
 			B.set_reinforcement(src.material)
 		else
 			if (prob(50)) // pardon all these nested probabilities, just trying to vary the damage appearance a bit
 				var/atom/A = new /obj/structure/girder/reinforced(src)
-				if (src.material)
-					A.setMaterial(src.material)
-				else
-					A.setMaterial(getMaterial("steel"), copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
+
 
 				if (prob(50))
 					var/atom/movable/B = new /obj/item/raw_material/scrap_metal
 					B.set_loc(src)
-					if (src.material)
-						B.setMaterial(src.material)
-					else
-						B.setMaterial(getMaterial("steel"), copy = FALSE)
+					B.setMaterial(src.material ? src.material : M, copy = FALSE)
 
 			else if( prob(50))
 				var/atom/A = new /obj/structure/girder(src)
-				if (src.material)
-					A.setMaterial(src.material)
-				else
-					A.setMaterial(getMaterial("steel"), copy = FALSE)
+				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 	else
 		if (!devastated)
@@ -170,7 +162,6 @@
 			var/atom/B = new /obj/item/sheet( src )
 			var/atom/C = new /obj/item/sheet( src )
 
-			var/datum/material/M = getMaterial("steel")
 			A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 			B.setMaterial(src.material ? src.material : M, copy = FALSE)
 			C.setMaterial(src.material ? src.material : M, copy = FALSE)
@@ -178,26 +169,22 @@
 		else
 			if (prob(50))
 				var/atom/A = new /obj/structure/girder/displaced(src)
-				var/datum/material/M = getMaterial("steel")
 				A.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 			else if (prob(50))
 				var/atom/B = new /obj/structure/girder(src)
 
-				var/datum/material/M = getMaterial("steel")
 				B.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 				if (prob(50))
 					var/atom/movable/C = new /obj/item/raw_material/scrap_metal
 					C.set_loc(src)
-				var/datum/material/M = getMaterial("steel")
 					C.setMaterial(src.girdermaterial ? src.girdermaterial : M, copy = FALSE)
 
 
 	var/atom/D = ReplaceWithFloor()
-	var/datum/material/M = getMaterial("steel")
 	D.setMaterial(src.girdermaterial && keep_material ? src.girdermaterial : M, copy = FALSE)
 
 
@@ -324,6 +311,7 @@
 				health *= 0.75
 			if(src.material.material_flags & MATERIAL_CRYSTAL)
 				health /= 2
+				desc += " Wait where did the girder go?"
 		return
 
 /turf/simulated/wall/r_wall/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Materials]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![Untitled-1](https://github.com/goonstation/goonstation/assets/26363708/aad5d81c-5dee-498f-ad1e-dd4db23af239)
![Untitled-2](https://github.com/goonstation/goonstation/assets/26363708/da1719eb-3a69-420d-8b8c-b778745e8e93)

Previously walls would just take on the material of whatever girder they were built on. This ended up in the girder basically eating whatever sheet was put onto it regardless of the material. Now the girder's material is stored in the wall until the wall is broken in which case a girder of the correct material spawns. Also, in order to place a sheet on a girder, the sheet has to be a metal sheet, so glass walls won't be able to be built.

Should fix:
https://github.com/goonstation/goonstation/issues/14385
https://github.com/goonstation/goonstation/issues/13870

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Girders shouldn't determine a wall's material since the plating is what is actually visible from the outside.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)monkeymilesmoo
(*)Plating on a wall can now be of a different material from the girder it was built on without being absorbed by the girder on placement.
```
