### PR TITLE
Visible reactor neutrons for infrared vision

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -278,11 +278,13 @@
 		if(istype(proj_data))
 			src.icon = proj_data.icon
 			src.icon_state = proj_data.icon_state
+			src.invisibility = proj_data.invisibility
 			if (!proj_data.override_color)
 				src.color = proj_data.color_icon
 		else
 			src.icon = 'icons/obj/projectiles.dmi'
 			src.icon_state = null
+			src.invisibility = INVIS_NONE
 			if (!proj_data) return //ZeWaka: Fix for null.override_color
 			if (!proj_data.override_color)
 				src.color = "#ffffff"
@@ -518,6 +520,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/name = "projectile"
 	var/icon = 'icons/obj/projectiles.dmi'
 	var/icon_state = "bullet"	// A special note: the icon state, if not a point-symmetric sprite, should face NORTH by default.
+	var/invisibility = INVIS_NONE
 	var/impact_image_state = null // what kinda overlay they puke onto non-mobs when they hit
 	var/brightness = 0
 	var/color_red = 0

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -711,8 +711,11 @@
 #undef REACTOR_MELTDOWN_TEMP
 /datum/projectile/neutron //neutron projectile for radiation shooting from reactor
 	name = "neutron"
-	icon_state = ""
-	icon = null
+	icon_state = "trace"
+	icon = 'icons/obj/projectiles.dmi'
+	invisibility = INVIS_INFRA
+	override_color = TRUE
+	color_icon = "#00FF00"
 	power = 100
 	cost = 20
 //Kill/Stun ratio


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Objects][Feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that the neutrons emitted by the nuclear reactor are visible if the player has infrared vision, which is granted by mesons.

https://github.com/goonstation/goonstation/assets/6396368/193e3444-6789-4637-98ea-1170d57ec8de


I picked an icon named trace and used a green tint, if anyone has better sprite ideas I'm all eyes!



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks nice, is fun, lets engineers see how harmful the reactor actually is, and how neutrons get stopped by objects/walls.
Amy gave the idea a thumbs up


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Garash
(+)Neutrons emitted by the nuclear reactor are now visible for people with infrared vision, (which is granted by mesons amongst other means.)
```
