### PR TITLE
Breath masks can be attached to clown masks

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -379,6 +379,15 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 			src.item_state = "clown_hat"
 			user.show_text("You untuck the wig from the [src].")
 
+	attackby(obj/item/W, mob/user)
+		if(istype(W, /obj/item/clothing/mask/breath) && !(src.c_flags & MASKINTERNALS))
+			src.c_flags |= MASKINTERNALS
+			boutput(user, "You shove [W] under the [src]")
+			src.desc += " There seems to be a breathing mask stuck under the nose."
+			qdel(W)
+			return
+		..()
+
 /obj/item/clothing/mask/gas/syndie_clown
 	name = "clown wig and mask"
 	desc = "I AM THE ONE WHO HONKS."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets people shove a breath mask underneath their clown mask in order to breathe while performing funny business.
All it does is add the flag MASKINTERNALS to the clown mask so it can connect to an oxygen tank.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Even clowns deserve oxygen.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)monkeymilesmoo
(+)Clicking on a clown mask with a breath mask now shoves the breath mask inside, allowing for clowns to breathe without having to break character.
```

