### PR TITLE
Add carbon nanofiber as the default material for surplus vests

### DIFF
--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -451,6 +451,8 @@ TYPEINFO(/obj/item/clothing/suit/armor/vest)
 		..()
 		src.AddComponent(/datum/component/toggle_coat, coat_style = "[src.coat_style]", buttoned = FALSE)
 
+TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
+	mat_appearances_to_ignore = list("carbonfibre")
 /obj/item/clothing/suit/armor/NT_alt
 	name = "old armored vest"
 	desc = "A grungy surplus armored vest. Smelly and not very clean."
@@ -458,6 +460,8 @@ TYPEINFO(/obj/item/clothing/suit/armor/vest)
 	item_state = "nt2armor"
 	body_parts_covered = TORSO
 	hides_from_examine = 0
+	default_material = "carbonfibre"
+
 	setupProperties()
 		..()
 		setProperty("meleeprot", 6)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Clothing][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR sets the default material of the surplus vests obtainable from Sketchy D-5 as carbon nanofiber, which is consistent with the material of security's armored vests.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the only way to obtain carbon nanofiber is to either:
1. Ask / steal an armored vest from security (sec will likely refuse / requires antag actions)
2. Order & open a security crate which contains an armored vest from cargo (sec will likely refuse / requires antag actions)
3. Mine & kill nanites, which mining tends not to do due to the risk to themselves / the station (also sec will likely yell at you)

It would be nice to have easier access to carbon nanofiber & dyneema (which requires carbon nanofiber), without having to commit several crimes / relying on security to give you gear.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Blackrep
(+)Surplus vests from Sketchy D-5 are now made of carbon nanofiber.
```
