### PR TITLE
Spin emote now closes the bartender's sawn off

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -2459,5 +2459,5 @@ ABSTRACT_TYPE(/obj/item/gun/survival_rifle_barrel)
 
 		playsound(user.loc, 'sound/weapons/gunload_click.ogg', 15, TRUE)
 
-		update_icon()
+		UpdateIcon()
 

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -2453,3 +2453,9 @@ ABSTRACT_TYPE(/obj/item/gun/survival_rifle_barrel)
 	alter_projectile(obj/projectile/P)
 		. = ..()
 		P.proj_data.shot_sound = 'sound/weapons/sawnoff.ogg'
+
+	on_spin_emote(mob/living/carbon/human/user)
+		if(src.broke_open)
+			src.attack_self(user)
+			user.visible_message("<span class='alert'><b>[user]</b> snaps shut [src] with a [pick("spin", "twirl")]!</span>")
+		..()

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -2423,19 +2423,7 @@ ABSTRACT_TYPE(/obj/item/gun/survival_rifle_barrel)
 		..()
 
 	attack_self(mob/user)
-		if (src.broke_open)
-			src.broke_open = FALSE
-		else
-			src.broke_open = TRUE
-			src.casings_to_eject = src.shells_to_eject
-
-			if (src.casings_to_eject > 0) //this code exists because without it the gun ejects double the amount of shells
-				src.ejectcasings()
-				src.shells_to_eject = 0
-
-		playsound(user.loc, 'sound/weapons/gunload_click.ogg', 15, TRUE)
-
-		update_icon()
+		src.toggle_action(user)
 		..()
 
 	attackby(obj/item/I, mob/user)
@@ -2455,7 +2443,21 @@ ABSTRACT_TYPE(/obj/item/gun/survival_rifle_barrel)
 		P.proj_data.shot_sound = 'sound/weapons/sawnoff.ogg'
 
 	on_spin_emote(mob/living/carbon/human/user)
-		if(src.broke_open)
-			src.attack_self(user)
+		if(src.broke_open) // Only allow spinning to close the gun, doesn't make as much sense spinning it open.
+			src.toggle_action(user)
 			user.visible_message("<span class='alert'><b>[user]</b> snaps shut [src] with a [pick("spin", "twirl")]!</span>")
 		..()
+
+	proc/toggle_action(mob/user)
+		if (!src.broke_open)
+			src.casings_to_eject = src.shells_to_eject
+
+			if (src.casings_to_eject > 0) //this code exists because without it the gun ejects double the amount of shells
+				src.ejectcasings()
+				src.shells_to_eject = 0
+		src.broke_open = !src.broke_open
+
+		playsound(user.loc, 'sound/weapons/gunload_click.ogg', 15, TRUE)
+
+		update_icon()
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][Feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows a user to use `*spin` or `*twirl` emotes to snap just the sawn off shotgun if the action is open. This also makes it so that if a user snaps the sawn off shotgun closed using these emotes, there is a chance they accidentally shoot themselves (existing gun code).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Silly flare, and increase the chance the ~bartender~ user accidentally shoots themselves trying to be cool.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Blackrep
(+) The bartender's sawn off can now be spun closed using twirl emote
```
