### PR TITLE
Make gas sharing transfer enough gas in order to attempt to equalize in one step

### DIFF
--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -271,7 +271,7 @@ What are the archived variables for?
 /datum/gas_mixture/proc/check_gas_mixture(datum/gas_mixture/sharer)
 	if (!sharer)
 		return SELF_CHECK_FAIL
-	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (GAS - sharer.GAS)/5;
+	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (GAS + sharer.GAS) / 2 - sharer.GAS;
 	APPLY_TO_ARCHIVED_GASES(_DELTA_GAS)
 	#undef _DELTA_GAS
 
@@ -295,7 +295,7 @@ What are the archived variables for?
 /// * Checks if the turf is valid for air group processing.
 /// * Returns: FALSE if self-check failed or TRUE if check passes
 /datum/gas_mixture/proc/check_turf(turf/model)
-	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (ARCHIVED(GAS) - model.GAS)/5;
+	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (ARCHIVED(GAS) + model.GAS) / 2 - model.GAS
 	APPLY_TO_GASES(_DELTA_GAS)
 	#undef _DELTA_GAS
 
@@ -315,7 +315,7 @@ What are the archived variables for?
 /datum/gas_mixture/proc/share(datum/gas_mixture/sharer)
 	if(!sharer)
 		return
-	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = QUANTIZE(src.ARCHIVED(GAS) - sharer.ARCHIVED(GAS))/5;
+	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = QUANTIZE((src.ARCHIVED(GAS) + sharer.ARCHIVED(GAS)) / 2 - sharer.ARCHIVED(GAS));
 	APPLY_TO_GASES(_DELTA_GAS)
 	#undef _DELTA_GAS
 
@@ -370,7 +370,7 @@ What are the archived variables for?
 /// * Similar to [/datum/gas_mixture/proc/share], except the model is not modified.
 /// * Return: Moles of gas exchanged.
 /datum/gas_mixture/proc/mimic(turf/model, border_multiplier = 1)
-	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = QUANTIZE(((src.ARCHIVED(GAS) - model.GAS)/5)*border_multiplier/src.group_multiplier);
+	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = QUANTIZE(((src.ARCHIVED(GAS) + model.GAS) / 2 - model.GAS)*border_multiplier/src.group_multiplier);
 	APPLY_TO_GASES(_DELTA_GAS)
 	#undef _DELTA_GAS
 

--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -295,7 +295,7 @@ What are the archived variables for?
 /// * Checks if the turf is valid for air group processing.
 /// * Returns: FALSE if self-check failed or TRUE if check passes
 /datum/gas_mixture/proc/check_turf(turf/model)
-	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (ARCHIVED(GAS) + model.GAS) / 2 - model.GAS
+	#define _DELTA_GAS(GAS, ...) var/delta_##GAS = (ARCHIVED(GAS) + model.GAS) / 2 - model.GAS;
 	APPLY_TO_GASES(_DELTA_GAS)
 	#undef _DELTA_GAS
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before this PR gas amount transferred was the difference between the two gas mixtures divided by 5.
This PR makes it so enough gas is transferred that (ignoring other effects and gas transfers happening on the same tick) the two gas mixtures become equalized immediately. In practice this means that repressurization is faster but might also have various other side effects.

Making this PR largely to testmerge it and for people to post feedback on the change here.

(With the addition of this PR we *might* need to re-enable gas archiving because the directional artifacts can get a bit silly now. Shouldn't be a large performance impact.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Repressurization being slow kinda sucks and the /5 constant looks pretty pulled out of someone's ass so changing it doesn't seem horrible. This should give feel of faster atmos.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)pali
(*)The ratio at which gas gets transferred in atmos got increased. This should make repressurization faster. Let me know if you see any positive or negative impacts of this experiment while it's being tested.
```
