### PR TITLE
Allows portable aquariums to be emptied out into the fish research terminal

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -281,18 +281,32 @@ TYPEINFO(/obj/item/fish_portal)
 		if (src.working)
 			boutput(user, "<span class='alert'>The terminal is busy!</span>")
 			return
-		var/proceed = FALSE
-		for(var/check_path in src.allowed)
-			if(istype(W, check_path))
-				proceed = TRUE
-				break
-		if (!proceed)
-			boutput(user, "<span class='alert'>You can't put that in the upload terminal!</span>")
+		if (istype(W, /obj/item/storage/fish_box))
+			var/obj/item/storage/fish_box/S = W
+			if (S.contents.len < 1) boutput(user, "<span class='alert'>There's no fish in the portable aquarium!</span>")
+			else
+				user.visible_message("<span class='notice'>[user] loads [S]'s contents into [src]!</span>")
+				var/amtload = 0
+				for (var/obj/item/fish/F in S.contents)
+					F.set_loc(src)
+					amtload++
+				S.UpdateIcon()
+				boutput(user, "<span class='notice'>[amtload] fish loaded from the portable aquarium!</span>")
+				S.tooltip_rebuild = 1
 			return
-		user.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>")
-		user.u_equip(W)
-		W.set_loc(src)
-		W.dropped(user)
+		else
+			var/proceed = FALSE
+			for(var/check_path in src.allowed)
+				if(istype(W, check_path))
+					proceed = TRUE
+					break
+			if (!proceed)
+				boutput(user, "<span class='alert'>You can't put that in the upload terminal!</span>")
+				return
+			user.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>")
+			user.u_equip(W)
+			W.set_loc(src)
+			W.dropped(user)
 
 /obj/submachine/fishing_upload_terminal/portable
 	anchored = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can now dump fish out of your aquariums in to the research terminal.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I played exactly one round of Angler on live and realised it felt like garbage having to manually load fish in one at a time.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Gannets
(+)You can now empty out portable aquariums in to the fishing research terminal. This saves you 6 whole clicks!
```
