### PR TITLE
Random Room Mapping Contest: 3x3, 3x5, 5x3 submissions

### DIFF
--- a/assets/maps/random_rooms/3x3/interrogation_50.dmm
+++ b/assets/maps/random_rooms/3x3/interrogation_50.dmm
@@ -1,0 +1,79 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"c" = (
+/obj/item/device/light/floodlight/starts_on/fixed{
+	dir = 5
+	},
+/obj/item/cell/shell_cell{
+	pixel_y = -10;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"j" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/item/clothing/mask/cigarette{
+	icon_state = "cigbutt";
+	pixel_y = -8
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"k" = (
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/blood{
+	icon_state = "floor6";
+	pixel_y = 30
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"B" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/decal/cleanable/water,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 8
+	},
+/obj/machinery/light/small/broken{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"G" = (
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/stool/chair/e_chair,
+/obj/item/handcuffs{
+	pixel_y = -20
+	},
+/obj/decal/cleanable/blood{
+	icon_state = "drip2b"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+"U" = (
+/obj/decal/cleanable/blood{
+	icon_state = "drip1a"
+	},
+/turf/simulated/floor/grey/blackgrime,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+k
+U
+c
+"}
+(2,1,1) = {"
+G
+S
+a
+"}
+(3,1,1) = {"
+B
+j
+G
+"}

--- a/assets/maps/random_rooms/3x5/cabeeno_75.dmm
+++ b/assets/maps/random_rooms/3x5/cabeeno_75.dmm
@@ -1,0 +1,200 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/submachine/ATM/atm_alt{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 10
+	},
+/area/space)
+"f" = (
+/obj/item/storage/secure/ssafe/loot{
+	pixel_x = -28
+	},
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/item/stamped_bullion{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/honey{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/honey{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/honey{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/honey{
+	pixel_y = 8
+	},
+/turf/simulated/floor/black,
+/area/space)
+"g" = (
+/obj/stool/bar,
+/mob/living/critter/small_animal/bee,
+/turf/simulated/floor/carpet/red/fancy/edge,
+/area/space)
+"i" = (
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 5
+	},
+/area/space)
+"l" = (
+/obj/submachine/slot_machine/cash,
+/turf/simulated/floor/black,
+/area/space)
+"m" = (
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 8
+	},
+/area/space)
+"p" = (
+/obj/stool/bar,
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 1
+	},
+/area/space)
+"r" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/turf/simulated/floor/black,
+/area/space)
+"v" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/machinery/light/incandescent{
+	dir = 8
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/black,
+/area/space)
+"x" = (
+/obj/table/reinforced/roulette,
+/obj/item/spacecash/random/really_small{
+	pixel_y = 10
+	},
+/obj/item/dice/coin/poker_chip/v10{
+	pixel_y = -5
+	},
+/obj/machinery/light/incandescent{
+	dir = 4
+	},
+/obj/item/dice/coin/poker_chip/v25{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/dice/coin/poker_chip/v5{
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 4
+	},
+/area/space)
+"B" = (
+/obj/stool/chair/office/syndie,
+/mob/living/critter/small_animal/bee/fancy,
+/turf/simulated/floor/black,
+/area/space)
+"H" = (
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 9
+	},
+/area/space)
+"M" = (
+/obj/stool/bar,
+/mob/living/critter/small_animal/bee/small,
+/turf/simulated/floor/carpet/red/fancy/edge{
+	dir = 6
+	},
+/area/space)
+"N" = (
+/obj/table/reinforced/bar/auto{
+	name = "wooden table"
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/dice/coin/poker_chip{
+	pixel_x = 5
+	},
+/turf/simulated/floor/black,
+/area/space)
+"Z" = (
+/obj/roulette_table_w,
+/obj/item/spacecash/random/really_small,
+/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled{
+	pixel_y = 10;
+	pixel_x = -10
+	},
+/obj/item/dice/coin/poker_chip/v10,
+/obj/item/dice/coin/poker_chip/v10,
+/obj/item/dice/coin/poker_chip/v10,
+/obj/item/dice/coin/poker_chip/v10{
+	pixel_y = 1
+	},
+/obj/item/dice/coin/poker_chip/v10{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/dice/coin/poker_chip/v10{
+	pixel_x = 5
+	},
+/obj/item/dice/coin/poker_chip/v25{
+	pixel_x = -5
+	},
+/obj/item/dice/coin/poker_chip/v5{
+	pixel_y = -2
+	},
+/turf/simulated/floor/carpet/red,
+/area/space)
+
+(1,1,1) = {"
+f
+v
+H
+m
+a
+"}
+(2,1,1) = {"
+B
+r
+p
+Z
+g
+"}
+(3,1,1) = {"
+l
+N
+i
+x
+M
+"}

--- a/assets/maps/random_rooms/5x3/sandybeach.dmm
+++ b/assets/maps/random_rooms/5x3/sandybeach.dmm
@@ -1,0 +1,93 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/inner_tube/random{
+	pixel_x = 10
+	},
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"e" = (
+/obj/decal/fakeobjects/palmtree,
+/obj/item/reagent_containers/food/snacks/plant/coconut{
+	pixel_y = -10;
+	pixel_x = 6
+	},
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"n" = (
+/obj/table/endtable_classic,
+/obj/item/cocktail_stuff/drink_umbrella{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/water_wings{
+	pixel_y = -12;
+	pixel_x = 8
+	},
+/obj/item/clothing/glasses/sunglasses/tanning{
+	pixel_x = -5
+	},
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"r" = (
+/obj/stool/chair/pool,
+/obj/item/clothing/suit/bathrobe,
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"s" = (
+/obj/decal/cleanable/water,
+/obj/item/inner_tube/flamingo,
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"y" = (
+/mob/living/critter/small_animal/bird/seagull,
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"B" = (
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"M" = (
+/obj/machinery/traymachine/locking/tanning,
+/obj/machinery/computer/tanning{
+	pixel_y = 32
+	},
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"P" = (
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+"R" = (
+/obj/machinery/light/incandescent,
+/obj/item/beach_ball,
+/turf/simulated/floor/dojo/sand,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+e
+B
+R
+"}
+(2,1,1) = {"
+y
+a
+B
+"}
+(3,1,1) = {"
+B
+n
+B
+"}
+(4,1,1) = {"
+B
+r
+s
+"}
+(5,1,1) = {"
+M
+B
+P
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 3 new random rooms for the mapping contest.

3x3 (interrogation_50.dmm)
![image](https://github.com/goonstation/goonstation/assets/51779813/e1e5fa41-4f3c-4731-8725-0a45fba25695)

3x5 (cabeeno_75.dmm)
![image](https://github.com/goonstation/goonstation/assets/51779813/ac6d82ed-18f3-48c2-86b8-4f7b908ee6f2)

5x3 (sandybeach.dmm)
![image](https://github.com/goonstation/goonstation/assets/51779813/4d541f99-0631-44b9-b5ce-680815f1a8e3)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New random room gud
