### PR TITLE
Adds A Catering Beacon to Cog2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -4888,8 +4888,8 @@
 "amQ" = (
 /obj/decal/cleanable/cobweb2,
 /obj/ladder/embed{
-	pixel_y = 32;
-	id = "smiling"
+	id = "smiling";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/north)
@@ -10862,8 +10862,8 @@
 	pixel_y = 20
 	},
 /obj/ladder/embed{
-	pixel_y = 32;
-	id = "smiling"
+	id = "smiling";
+	pixel_y = 32
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/chapel/sanctuary)
@@ -71378,6 +71378,14 @@
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
+"dDH" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay2,
+/obj/warp_beacon/catering,
+/turf/space,
+/area/space)
 "dEt" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -104001,7 +104009,7 @@ aaa
 aaa
 aaa
 aaa
-adb
+dDH
 adw
 aef
 aeP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a warp beacon to the catering hangar on cog2


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it easier to deliver stuff to the kitchen using pods.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Added a catering warp beacon to cog2
```
