### PR TITLE
Standardizes Donut3 Hangar Beacon Names

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1700,8 +1700,8 @@
 /area/station/science/lab)
 "awc" = (
 /obj/blind_switch/south{
-	pixel_x = 4;
-	id = "chemistry"
+	id = "chemistry";
+	pixel_x = 4
 	},
 /obj/machinery/light_switch/south{
 	pixel_x = -4
@@ -25585,8 +25585,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "hNX" = (
-/obj/warp_beacon{
-	name = "Security Beacon"
+/obj/warp_beacon/security{
+	name = "Security Hangar Beacon"
 	},
 /obj/lattice,
 /turf/space,
@@ -29384,8 +29384,8 @@
 /area/station/science/lab)
 "iWp" = (
 /obj/lattice,
-/obj/warp_beacon/qm{
-	name = "Public hangar beacon"
+/obj/warp_beacon/mainpod1{
+	name = "Main Hangar Beacon"
 	},
 /turf/space,
 /area/space)
@@ -69006,10 +69006,10 @@
 	},
 /area/station/solar/west)
 "vbS" = (
-/obj/warp_beacon{
-	name = "Science Hangar Beacon"
-	},
 /obj/lattice,
+/obj/warp_beacon/research{
+	name = "Research Hangar Beacon"
+	},
 /turf/space,
 /area/space)
 "vca" = (
@@ -72246,7 +72246,9 @@
 /area/station/maintenance/inner/north)
 "vYk" = (
 /obj/lattice,
-/obj/warp_beacon/qm,
+/obj/warp_beacon/qm{
+	name = "QM Hangar Beacon"
+	},
 /turf/space,
 /area/space)
 "vYl" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the names of various hangar beacons on donut3 to match that with other maps.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes portal travel less confusing across maps.

