### PR TITLE
Fix over-inserting control rods

### DIFF
--- a/code/obj/nuclearreactor/reactorcontrol.dm
+++ b/code/obj/nuclearreactor/reactorcontrol.dm
@@ -181,12 +181,8 @@
 		switch(action)
 			if("adjustCR")
 				logTheThing(LOG_STATION, src, "[src.reactor_handle] control rod insertion configured to [params["crvalue"]]% by [ui.user]")
-				for(var/x=1 to length(src.reactor_handle.component_grid))
-					for(var/y=1 to length(src.reactor_handle.component_grid[1]))
-						if(src.reactor_handle.component_grid[x][y])
-							if(istype(src.reactor_handle.component_grid[x][y],/obj/item/reactor_component/control_rod))
-								var/obj/item/reactor_component/control_rod/CR = src.reactor_handle.component_grid[x][y]
-								CR.configured_insertion_level = text2num(params["crvalue"])/100
+				src.reactor_handle.set_control_rods(text2num(params["crvalue"]))
+
 			if("slot")
 				var/x = params["x"]
 				var/y = params["y"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I fixed this already, but forgot to apply it to the control computer. Whoops


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14601 

