### PR TITLE
Adds a clipboard to detective lockers

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -376,7 +376,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/pinpointer/bloodtracker,
 	/obj/item/device/flash,
 	/obj/item/camera_film,
-	/obj/item/storage/box/luminol_grenade_kit)
+	/obj/item/storage/box/luminol_grenade_kit
+	/obj/item/clipboard)
 
 /obj/storage/secure/closet/security/armory
 	name = "\improper Special Equipment locker"

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -376,7 +376,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/pinpointer/bloodtracker,
 	/obj/item/device/flash,
 	/obj/item/camera_film,
-	/obj/item/storage/box/luminol_grenade_kit
+	/obj/item/storage/box/luminol_grenade_kit,
 	/obj/item/clipboard)
 
 /obj/storage/secure/closet/security/armory


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a clipboard to the contents of all detective lockers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Having a tool to organize notes and forensic printouts would be useful for detectives, especially for RP. Having them all in one place and easily editable would be nice for putting together a case.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The detective now has a clipboard in their locker.
```
