### PR TITLE
[Random Room Contest] [5x3] Adds the donut kitchen random room

### DIFF
--- a/assets/maps/random_rooms/5x3/donutkitchen.dmm
+++ b/assets/maps/random_rooms/5x3/donutkitchen.dmm
@@ -1,0 +1,99 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/ingredient/dough,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"c" = (
+/obj/submachine/chef_sink,
+/obj/machinery/light{
+	dir = 1;
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"f" = (
+/obj/submachine/chef_oven,
+/obj/landmark{
+	name = "shitty_bill_respawn"
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"j" = (
+/obj/machinery/chem_dispenser/chef,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"v" = (
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"z" = (
+/obj/table/auto,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"B" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/ingredient/dough_circle{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/dough_circle{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	tag = ""
+	},
+/obj/item/kitchen/utensil/knife{
+	pixel_x = -8
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"R" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/donut/custom/frosted,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+"X" = (
+/obj/item/reagent_containers/food/snacks/ingredient/sugar,
+/obj/item/reagent_containers/food/snacks/ingredient/sugar,
+/obj/item/reagent_containers/food/snacks/ingredient/sugar,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/item/reagent_containers/food/snacks/ingredient/flour,
+/obj/storage/crate,
+/obj/item/reagent_containers/food/snacks/plant/coconutmeat,
+/obj/item/reagent_containers/food/snacks/plant/coconutmeat,
+/obj/item/reagent_containers/food/snacks/plant/coconutmeat,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+X
+v
+a
+"}
+(2,1,1) = {"
+f
+v
+B
+"}
+(3,1,1) = {"
+v
+v
+v
+"}
+(4,1,1) = {"
+c
+v
+z
+"}
+(5,1,1) = {"
+j
+v
+R
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping] [contest] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a donut kitchen 5x3 random room. This is a small food preparation area with all the tools and devices you need to make some donuts and decorate them to your heart's content. Includes a kitchen dispenser for making edible icings in various colors. The crate holds 3 bags of flour, sugar, and a few pieces of coconut meat.

![image](https://github.com/goonstation/goonstation/assets/22460970/c884469f-5f4f-4ede-91b5-93ae37864adf)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Custom donut decorating is something that has been in the game for awhile, but I rarely see used. Having a room setup to encourage it could hopefully lead to a few more space station donut stands.

