### PR TITLE
vending now tries to put the cash directly into your hand

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -571,6 +571,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 			if (src.credit > 0)
 				var/obj/item/currency/spacecash/returned = new /obj/item/currency/spacecash
 				returned.setup(src.get_output_location(), src.credit)
+				usr.put_in_hand_or_eject(returned) // try to eject it into the users hand, if we can
 				src.credit = 0
 		if("vend")
 			if(params["target"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When taking your cash out of a vending machine it will now try and put the money in your hand, like it does with anything that you buy, instead of always dropping it on the floor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
makes vending machines more consistant with where they put your stuff.
I have been minorly inconvenienced for too long.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)zay25325
(+)vending machines put money into your hand instead of dropping it
```
