### PR TITLE
Remove Werewolves Scooby Doo Speech

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -641,7 +641,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	mutant_appearance_flags = HUMAN_APPEARANCE_FLAGS
 	dna_mutagen_banned = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/human
-	
+
 /datum/mutantrace/blob // podrick's july assjam submission, it's pretty cute
 	name = "blob"
 	icon = 'icons/mob/blob_ambassador.dmi'
@@ -1343,7 +1343,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			src.mob.UpdateName()
 
 			src.mob.bioHolder.AddEffect("protanopia", null, null, 0, 1)
-			src.mob.bioHolder.AddEffect("accent_scoob_nerf", null, null, 0, 1)
 			src.mob.bioHolder.AddEffect("regenerator_wolf", null, null, 0, 1)
 
 	disposing()
@@ -1360,7 +1359,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			src.mob.max_health -= 50
 			health_update_queue |= src.mob
 			src.mob.bioHolder.RemoveEffect("protanopia")
-			src.mob.bioHolder.RemoveEffect("accent_scoob_nerf")
 			src.mob.bioHolder.RemoveEffect("regenerator_wolf")
 
 			if (!isnull(src.original_name))


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows werewolves to speak coherantly without having to shift out of their wolf form. Accents can be very hard to read through for some people and can often result in attempts to communicate being brushed off. Players can do their own funny little voice modifications if they want, and not worry about actual speaking attempts being ignored.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Werewolves were given the Scooby Doo accent a while ago, which was a funny gag for them for a while. However, the accent makes communication incredibly difficult, and seeing as they were recently given some weight to spawn on mixed rp rounds, that.. Isn't the best. QoL should come before a gimmick. The accent is still accessible via genetics, so I don't see much harm in its removal from wolves.

(i also have no idea if i coded this correctly, but it worked fine on local)
![Screenshot (147)](https://github.com/goonstation/goonstation/assets/73998720/136fae07-fd02-4b6e-a046-3bb9ff647987)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)Werewolves will now speak normally again.
```
