### PR TITLE
A few small fishing quality of life improvements.

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -243,7 +243,7 @@ Alien/mutant/other fish:
 /obj/item/fish/tiger_oscar
 	name = "tiger oscar"
 	desc = "Popular in both aquariums and kitchens, this fish was accidentally misclassified in 1831. Don't make that mistake again!"
-	icon_state = "tiger oscar"
+	icon_state = "tiger_oscar"
 	inhand_color = "#2e1306"
 	category = FISH_CATEGORY_FRESHWATER
 	value  = FISH_RARITY_UNCOMMON

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -74,7 +74,8 @@
 	onStart()
 		..()
 		if (src.rod.tier < fishing_spot.rod_tier_required)
-			user.visible_message("<span class='alert'>You need a higher tier rod to fish here!</span>")
+			//user.visible_message("<span class='alert'>You need a higher tier rod to fish here!</span>")
+			boutput(user, "<span class='notice'>You need a higher tier rod to fish here!.</span>")
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
@@ -85,7 +86,8 @@
 
 		src.duration = max(0.5 SECONDS, rod.fishing_speed + (pick(1, -1) * (rand(0,40) / 10) SECONDS)) //translates to rod duration +- (0,4) seconds, minimum of 0.5 seconds
 		playsound(src.user, 'sound/items/fishing_rod_cast.ogg', 50, 1)
-		src.user.visible_message("[src.user] starts fishing.")
+		//src.user.visible_message("[src.user] starts fishing.")
+		boutput(user, "<span class='notice'>You start fishing.</span>")
 		src.rod.is_fishing = TRUE
 		src.rod.UpdateIcon()
 		src.user.update_inhands()

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -573,7 +573,7 @@
 	name = "Basic fishing rod"
 	path = /obj/item/fishing_rod/basic
 	description = "A basic fishing rod."
-	cost = 5
+	cost = 0
 
 /datum/materiel/fishing_gear/upgraded_rod
 	name = "Upgraded fishing rod"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basic fishing rods are now free in fishing vendors.
Less log-spam when fishing around other players.
You can see the tigar oscar now. closes #14626

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Gannets
(+)Basic fishing rods are now free in fishing vendors.
(+)There's now less log-spam when fishing around other players.
```
