### PR TITLE
ckey() ban ckey inputs, don't prompt admins for autofill when ckey isn't included

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -274,12 +274,11 @@ var/global/list/playersSeen = list()
 		var/data[] = new()
 
 		if (!mobRef)
-			data["ckey"] = input(src, "Ckey (lowercase, only alphanumeric, no spaces, leave blank to skip)", "Ban") as null|text
-			var/auto = alert("Attempt to autofill IP and compID with most recent?","Autofill?","Yes","No")
-			if (auto == "No")
-				data["compID"] = input(src, "Computer ID", "Ban") as null|text
-				data["ip"] = input(src, "IP Address", "Ban") as null|text
-			else if (data["ckey"])
+			data["ckey"] = ckey(input(src, "Ckey, leave blank to skip)", "Ban") as null|text)
+			var/auto_fill
+			if (data["ckey"])
+				auto_fill = alert("Attempt to autofill IP and compID with most recent?","Autofill?","Yes","No")
+			if (auto_fill == "Yes")
 				var/list/response
 				try
 					response = apiHandler.queryAPI("playerInfo/get", list("ckey" = data["ckey"]), forceResponse = 1)
@@ -290,6 +289,9 @@ var/global/list/playersSeen = list()
 					boutput(src, "<span class='alert'>No data found for target, IP and/or compID will be left blank.</span>")
 				data["ip"] = response["last_ip"]
 				data["compID"] = response["last_compID"]
+			else
+				data["compID"] = input(src, "Computer ID", "Ban") as null|text
+				data["ip"] = input(src, "IP Address", "Ban") as null|text
 		else
 			data["ckey"] = M.ckey
 			data["compID"] = M.computer_id

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -274,7 +274,7 @@ var/global/list/playersSeen = list()
 		var/data[] = new()
 
 		if (!mobRef)
-			data["ckey"] = ckey(input(src, "Ckey, leave blank to skip)", "Ban") as null|text)
+			data["ckey"] = ckey(input(src, "Ckey, leave blank to skip", "Ban") as null|text)
 			var/auto_fill
 			if (data["ckey"])
 				auto_fill = alert("Attempt to autofill IP and compID with most recent?","Autofill?","Yes","No")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Runs manual ban ckey entries through `ckey()`
* No longer prompts admins about autofill is no ckey was provided to lookup in the first place

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* `ckey()`ing the inputs isn't actually required, but it does transform that data being stored in the database into a consistent form, rather than having some entires being proper ckeys, and others just keys
* Being prompted for autofill when you've left the ckey target blank is confusing for the user, even if it didn't actually do anything