### PR TITLE
Adds angler equipment to most maps

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45874,7 +45874,7 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "emu" = (
-/obj/wingrille_spawn/auto/reinforced,
+/obj/fishing_pool/portable,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "emz" = (
@@ -46981,8 +46981,6 @@
 /turf/simulated/floor/plating,
 /area/station/routing/engine)
 "flp" = (
-/obj/table/auto,
-/obj/machinery/recharger,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -49926,10 +49924,10 @@
 /area/station/engine/power)
 "hRW" = (
 /obj/item/toy/plush/small{
+	desc = "You found a new friend! A faded tag on his foot says \"For Paige\".";
 	layer = 3.1;
-	pixel_y = 4;
 	name = "Paul";
-	desc = "You found a new friend! A faded tag on his foot says \"For Paige\"."
+	pixel_y = 4
 	},
 /obj/stool/chair/comfy,
 /obj/cable{
@@ -51473,7 +51471,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/storage/crate,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "jsu" = (
@@ -52206,7 +52203,7 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "jYd" = (
-/obj/storage/secure/closet/civilian/hydro,
+/obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "jYz" = (
@@ -53129,8 +53126,8 @@
 	},
 /obj/machinery/power/stats_meter{
 	name = "Hot Loop Inlet Meter";
-	tag = "Hot Loop Inlet Meter";
-	pixel_x = -12
+	pixel_x = -12;
+	tag = "Hot Loop Inlet Meter"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -53898,6 +53895,10 @@
 /obj/machinery/light/small/warm/very,
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
+"lRw" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grime,
+/area/space)
 "lSg" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/fakeobjects/skeleton/decomposed_corpse{
@@ -54912,8 +54913,8 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Inlet Meter";
-	tag = "Cold Loop Inlet Meter";
-	pixel_x = 12
+	pixel_x = 12;
+	tag = "Cold Loop Inlet Meter"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -55408,8 +55409,8 @@
 "ntQ" = (
 /obj/machinery/atmospherics/mixer/flipped{
 	dir = 1;
-	id_tag = "engine_combust";
 	frequency = 1225;
+	id_tag = "engine_combust";
 	master_id = "engine_combust_control"
 	},
 /turf/simulated/floor/red,
@@ -55418,8 +55419,8 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/power/stats_meter{
 	name = "Hot Loop Outlet Meter";
-	tag = "Hot Loop Outlet Meter";
-	pixel_x = -12
+	pixel_x = -12;
+	tag = "Hot Loop Outlet Meter"
 	},
 /obj/cable{
 	d1 = 4;
@@ -61492,14 +61493,13 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "sTC" = (
-/obj/rack,
-/obj/item/storage/toolbox/emergency,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "sUG" = (
@@ -62816,6 +62816,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/storage/cart,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "ugY" = (
@@ -64850,11 +64851,12 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "wfn" = (
-/obj/storage/crate,
-/obj/decal/cleanable/cobweb2,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/table/auto,
+/obj/machinery/recharger,
+/obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "wft" = (
@@ -66139,6 +66141,10 @@
 	dir = 6
 	},
 /area/station/medical/medbay/psychiatrist)
+"xla" = (
+/obj/submachine/fishing_upload_terminal/portable,
+/turf/simulated/floor/grime,
+/area/station/storage/hydroponics)
 "xmb" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -66604,8 +66610,8 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Outlet Meter";
-	tag = "Cold Loop Outlet Meter";
-	pixel_x = 12
+	pixel_x = 12;
+	tag = "Cold Loop Outlet Meter"
 	},
 /obj/cable{
 	d1 = 4;
@@ -66928,7 +66934,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ybI" = (
-/obj/storage/cart,
+/obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "ycE" = (
@@ -127064,7 +127070,7 @@ auq
 fxZ
 oFJ
 eiP
-jYd
+xla
 fqB
 adC
 aaj
@@ -127669,7 +127675,7 @@ auq
 nVt
 auq
 fqB
-aaG
+lRw
 adC
 adC
 adC

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -4848,8 +4848,8 @@
 "amQ" = (
 /obj/decal/cleanable/cobweb2,
 /obj/ladder/embed{
-	pixel_y = 32;
-	id = "smiling"
+	id = "smiling";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/north)
@@ -8986,6 +8986,9 @@
 /turf/space,
 /area/space)
 "axu" = (
+/obj/storage/crate,
+/obj/item/bee_egg_carton,
+/obj/item/bee_egg_carton,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -10800,8 +10803,8 @@
 	pixel_y = 20
 	},
 /obj/ladder/embed{
-	pixel_y = 32;
-	id = "smiling"
+	id = "smiling";
+	pixel_y = 32
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/chapel/sanctuary)
@@ -15999,10 +16002,7 @@
 	},
 /area/shuttle/arrival/station)
 "aOo" = (
-/obj/item/storage/box/beakerbox,
-/obj/storage/crate,
-/obj/item/paper/book/from_file/hydroponicsguide,
-/obj/item/paper/book/from_file/hydroponicsguide,
+/obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -16502,9 +16502,7 @@
 	},
 /area/station/hydroponics/bay)
 "aPB" = (
-/obj/storage/crate,
-/obj/item/bee_egg_carton,
-/obj/item/bee_egg_carton,
+/obj/submachine/fishing_upload_terminal/portable,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -17064,16 +17062,6 @@
 	},
 /area/station/hydroponics/bay)
 "aQW" = (
-/obj/stool/chair/comfy/blue{
-	desc = "It's all ripped and grimy. Gross.";
-	dir = 4;
-	name = "grody blue chair"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
-"aQX" = (
 /obj/table/wood/auto,
 /obj/item/device/reagentscanner,
 /obj/item/reagent_containers/glass/bottle/weedkiller,
@@ -17082,7 +17070,7 @@
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
-"aQY" = (
+"aQX" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/glass/bottle/fruitful,
 /obj/item/reagent_containers/glass/bottle/topcrop,
@@ -17094,17 +17082,17 @@
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
-"aQZ" = (
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 5
-	},
+"aQY" = (
+/obj/item/storage/box/beakerbox,
 /obj/storage/crate,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 5
+/obj/item/paper/book/from_file/hydroponicsguide,
+/obj/item/paper/book/from_file/hydroponicsguide,
+/turf/simulated/floor/grass{
+	name = "astroturf"
 	},
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 5
-	},
+/area/station/hydroponics/bay)
+"aQZ" = (
+/obj/fishing_pool/portable,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -75137,6 +75125,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"qNC" = (
+/obj/wingrille_spawn/auto,
+/obj/storage/cart,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "qNE" = (
 /obj/table/reinforced/auto,
 /obj/decal/stripe_delivery,
@@ -75339,6 +75332,16 @@
 	name = "reinforced plating"
 	},
 /area/station/quartermaster/refinery)
+"rqR" = (
+/obj/stool/chair/comfy/blue{
+	desc = "It's all ripped and grimy. Gross.";
+	dir = 4;
+	name = "grody blue chair"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "rsm" = (
 /obj/lattice{
 	dir = 8;
@@ -75718,6 +75721,21 @@
 	icon_state = "fpurple2"
 	},
 /area/station/crew_quarters/hor)
+"sFE" = (
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 5
+	},
+/obj/storage/crate,
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 5
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "sFU" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /obj/machinery/atmospherics/binary/valve/notify_admins{
@@ -101011,7 +101029,7 @@ aFD
 aHq
 aIU
 azn
-azn
+sFE
 aKt
 aCc
 aKu
@@ -102827,7 +102845,7 @@ axz
 azn
 azn
 azn
-azn
+rqR
 hFn
 aTk
 aXB
@@ -103121,7 +103139,7 @@ azn
 aCd
 aDl
 qlm
-awf
+qNC
 awf
 awf
 qlm

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6138,19 +6138,11 @@
 	},
 /area/station/crew_quarters/kitchen)
 "bKP" = (
-/obj/stool/chair/couch/green{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/landmark/start{
-	name = "Botanist"
-	},
-/obj/item/device/radio/intercom/botany,
-/turf/simulated/floor/wood/five,
-/area/station/hydroponics/bay)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "bKQ" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -13186,18 +13178,16 @@
 /turf/simulated/floor/circuit/red,
 /area/station/security/hos)
 "dVF" = (
-/obj/table/wood/round/auto,
-/obj/item/decoration/ashtray{
-	pixel_x = 7;
-	pixel_y = 7
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
 	},
-/obj/item/device/light/zippo{
-	pixel_x = -5;
-	pixel_y = 2
+/obj/stool/chair/couch/green,
+/obj/machinery/light/incandescent/netural{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/water_pipe{
-	pixel_x = 3;
-	pixel_y = 6
+/obj/landmark/start{
+	name = "Botanist"
 	},
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
@@ -14311,7 +14301,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/storage/crate,
+/obj/decorative_pot,
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
 "eoB" = (
@@ -16527,6 +16517,19 @@
 	},
 /area/station/security/hos)
 "eYZ" = (
+/obj/table/wood/round/auto,
+/obj/item/decoration/ashtray{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/device/light/zippo{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/water_pipe{
+	pixel_x = 3;
+	pixel_y = 6
+	},
 /obj/disposalpipe/segment{
 	dir = 8
 	},
@@ -18420,6 +18423,23 @@
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/maintenance)
 "fDl" = (
+/obj/decal/tile_edge/line/green{
+	dir = 9;
+	icon_state = "line2"
+	},
+/obj/stool/chair/couch/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/obj/landmark/start{
+	name = "Botanist"
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 10
+	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -31716,7 +31736,6 @@
 "jES" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/dirt/jen,
-/obj/storage/closet/fire,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "jEZ" = (
@@ -32189,6 +32208,17 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "jKL" = (
+/obj/stool/chair/couch/green{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/landmark/start{
+	name = "Botanist"
+	},
+/obj/item/device/radio/intercom/botany,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -38069,6 +38099,10 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hangar/arrivals)
+"lEi" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/ne)
 "lEk" = (
 /obj/table/wood/auto,
 /obj/bedsheetbin,
@@ -44599,7 +44633,6 @@
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/lobby)
 "nDB" = (
-/obj/machinery/light/incandescent/netural,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -48259,13 +48292,11 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "oLn" = (
-/obj/decal/tile_edge/line/green{
-	dir = 5;
-	icon_state = "line2"
+/obj/disposalpipe/segment{
+	dir = 8
 	},
-/obj/decorative_pot,
-/turf/simulated/floor/wood/five,
-/area/station/hydroponics/bay)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "oLv" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -54622,19 +54653,10 @@
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "qHk" = (
-/obj/decal/tile_edge/line/green{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/stool/chair/couch/green,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/obj/landmark/start{
-	name = "Botanist"
-	},
-/turf/simulated/floor/wood/five,
-/area/station/hydroponics/bay)
+/obj/machinery/light/incandescent/netural,
+/obj/submachine/weapon_vendor/fishing/portable,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "qHn" = (
 /obj/railing/orange,
 /turf/simulated/floor/plating/jen,
@@ -58342,25 +58364,9 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "rLj" = (
-/obj/decal/tile_edge/line/green{
-	dir = 9;
-	icon_state = "line2"
-	},
-/obj/stool/chair/couch/green{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
-/obj/landmark/start{
-	name = "Botanist"
-	},
-/obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 10
-	},
-/turf/simulated/floor/wood/five,
-/area/station/hydroponics/bay)
+/obj/submachine/fishing_upload_terminal/portable,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "rLr" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen/blue,
@@ -71972,6 +71978,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/tile_edge/line/green{
+	dir = 1;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
 "vTk" = (
@@ -74913,6 +74923,10 @@
 "wMg" = (
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
+"wMh" = (
+/obj/fishing_pool/portable,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "wMm" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -128439,7 +128453,7 @@ sSb
 vzA
 vzA
 vzA
-vzA
+bKP
 eVk
 jyt
 lMh
@@ -128741,7 +128755,7 @@ vra
 vzA
 vzA
 vzA
-vzA
+oLn
 dou
 mfs
 ssO
@@ -129347,7 +129361,7 @@ jRn
 ibv
 oJO
 nDB
-mfs
+qHk
 wqJ
 rGw
 eoq
@@ -129649,8 +129663,8 @@ ebZ
 pgL
 oJP
 leI
-mfs
 rLj
+wqJ
 fDl
 ssI
 tqD
@@ -129951,8 +129965,8 @@ lGJ
 fKp
 aSY
 qyZ
-mfs
-qHk
+wMh
+wqJ
 dVF
 eYZ
 smZ
@@ -130254,7 +130268,7 @@ sOz
 mfs
 pvp
 mfs
-bKP
+wqJ
 jKL
 tFA
 azp
@@ -130555,8 +130569,8 @@ jem
 tWQ
 gfu
 uQt
+lEi
 wqJ
-oLn
 vTd
 pZO
 smZ
@@ -130857,7 +130871,7 @@ vET
 aRA
 jxj
 hYv
-wqJ
+ofw
 wqJ
 hyh
 gwE

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20738,11 +20738,11 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "bvR" = (
-/obj/storage/secure/closet/civilian/hydro,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/fishing_pool/portable,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "bvT" = (
@@ -38423,6 +38423,11 @@
 "fpw" = (
 /obj/disposalpipe/segment/food,
 /obj/reagent_dispensers/watertank/big,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -39646,8 +39651,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
-/obj/storage/secure/closet/civilian/hydro,
 /obj/decal/cleanable/dirt,
+/obj/submachine/fishing_upload_terminal/portable,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "gpl" = (
@@ -40070,6 +40075,10 @@
 	dir = 4
 	},
 /area/station/quartermaster/cargobay)
+"gGB" = (
+/obj/submachine/weapon_vendor/fishing/portable,
+/turf/simulated/floor/grey,
+/area/station/hydroponics/bay)
 "gGT" = (
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -47242,12 +47251,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "nbL" = (
-/obj/machinery/plantpot,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
 /obj/machinery/light_switch/north,
+/obj/stool/chair/green{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Botanist"
+	},
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "nbR" = (
@@ -50691,12 +50705,6 @@
 	},
 /area/station/security/secwing)
 "qdQ" = (
-/obj/stool/chair/green{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Botanist"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -50708,6 +50716,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "qea" = (
@@ -54269,12 +54278,10 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "tkn" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Hydroponics"
-	},
-/obj/access_spawn/hydro,
-/obj/firedoor_spawn,
+/obj/item/reagent_containers/glass/bottle/ammonia/large,
+/obj/item/reagent_containers/glass/bottle/ammonia/large,
+/obj/decal/cleanable/dirt,
+/obj/storage/crate/bloody,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "tkE" = (
@@ -57192,14 +57199,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "vPo" = (
-/obj/disposalpipe/segment/food,
-/obj/reagent_dispensers/compostbin,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Hydroponics"
 	},
-/turf/simulated/floor,
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "vPw" = (
 /turf/simulated/floor/neutral/corner{
@@ -58436,14 +58442,11 @@
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "wSh" = (
-/obj/item/reagent_containers/glass/bottle/ammonia/large,
-/obj/item/reagent_containers/glass/bottle/ammonia/large,
-/obj/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/storage/crate/bloody,
+/obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "wTx" = (
@@ -59612,8 +59615,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "xLO" = (
-/obj/machinery/plantpot,
 /obj/decal/cleanable/dirt,
+/obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "xLW" = (
@@ -114272,7 +114275,7 @@ bkw
 blE
 bmT
 vIY
-pUl
+tkn
 kAy
 evU
 bpC
@@ -114576,7 +114579,7 @@ nbR
 boo
 wSh
 pUl
-pUl
+gGB
 gpc
 bvR
 boo
@@ -114877,8 +114880,8 @@ wCK
 bmV
 boo
 boo
+vPo
 boo
-tkn
 boo
 boo
 boo
@@ -115179,7 +115182,7 @@ blJ
 viJ
 pyB
 fpw
-vPo
+leU
 leU
 wmT
 buR

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2037,7 +2037,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aWy" = (
-/obj/machinery/vending/hydroponics,
+/obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "aWz" = (
@@ -3892,9 +3892,9 @@
 /area/station/crew_quarters/kitchen)
 "bIs" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -10;
+	id = "nadirstall_e3";
 	pixel_x = 10;
-	id = "nadirstall_e3"
+	pixel_y = -10
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -4463,7 +4463,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
 "bVY" = (
-/obj/machinery/plantpot,
+/obj/machinery/hydro_growlamp,
 /turf/simulated/floor/black/grime,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
@@ -9062,8 +9062,8 @@
 	},
 /obj/machinery/drainage,
 /obj/sign_switch/north{
-	pixel_y = 22;
-	id = "nadirstall_sci"
+	id = "nadirstall_sci";
+	pixel_y = 22
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/science/lobby{
@@ -9789,7 +9789,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "etS" = (
-/obj/machinery/plantpot,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -10320,14 +10319,14 @@
 /area/station/engine/core/nuclear)
 "eEC" = (
 /obj/machinery/illuminated_sign/occupancy{
+	id = "nadirstall_shw2";
 	pixel_x = 11;
-	pixel_y = -6;
-	id = "nadirstall_shw2"
+	pixel_y = -6
 	},
 /obj/machinery/illuminated_sign/occupancy{
+	id = "nadirstall_shw1";
 	pixel_x = 11;
-	pixel_y = 8;
-	id = "nadirstall_shw1"
+	pixel_y = 8
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -12291,7 +12290,6 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "fvZ" = (
-/obj/machinery/plantpot,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/plating,
 /area/station/hydroponics{
@@ -14303,9 +14301,9 @@
 /area/station/crew_quarters/courtroom)
 "gpK" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -10;
+	id = "nadirstall_e1";
 	pixel_x = 10;
-	id = "nadirstall_e1"
+	pixel_y = -10
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -17721,14 +17719,14 @@
 /area/station/hallway/primary/southeast)
 "hFq" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -10;
+	id = "nadirstall_nw1";
 	pixel_x = -10;
-	id = "nadirstall_nw1"
+	pixel_y = -10
 	},
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -10;
+	id = "nadirstall_nw2";
 	pixel_x = 10;
-	id = "nadirstall_nw2"
+	pixel_y = -10
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/showers)
@@ -18143,7 +18141,7 @@
 	},
 /area/station/bridge)
 "hQc" = (
-/obj/machinery/hydro_growlamp,
+/obj/fishing_pool/portable,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "hQg" = (
@@ -20024,8 +20022,8 @@
 /area/station/crew_quarters/barber_shop)
 "iAU" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_x = -11;
-	id = "nadirstall_sec2"
+	id = "nadirstall_sec2";
+	pixel_x = -11
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
@@ -21395,9 +21393,9 @@
 	})
 "jiW" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -10;
+	id = "nadirstall_e2";
 	pixel_x = 10;
-	id = "nadirstall_e2"
+	pixel_y = -10
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_east)
@@ -24245,7 +24243,6 @@
 	},
 /area/station/crew_quarters/quarters_east)
 "kry" = (
-/obj/machinery/plantpot,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -26601,10 +26598,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/eva)
-"loU" = (
-/obj/machinery/plantpot,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "lpa" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/cable{
@@ -27856,9 +27849,9 @@
 /obj/machinery/power/data_terminal,
 /obj/item/storage/wall{
 	name = "bath cabinet";
+	pixel_x = 7;
 	pixel_y = 32;
-	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel);
-	pixel_x = 7
+	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
 /turf/simulated/floor/sanitary,
 /area/station/bridge/captain)
@@ -34590,9 +34583,9 @@
 /area/station/hallway/secondary/exit)
 "oNZ" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_y = -4;
 	id = "nadirstall_sci";
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = -4
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/lobby{
@@ -35694,8 +35687,8 @@
 /area/station/hallway/primary/northeast)
 "poP" = (
 /obj/machinery/illuminated_sign/occupancy{
-	pixel_x = 11;
-	id = "nadirstall_sec1"
+	id = "nadirstall_sec1";
+	pixel_x = 11
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
@@ -37114,8 +37107,8 @@
 	pixel_x = -12
 	},
 /obj/sign_switch/north{
-	pixel_x = 11;
-	id = "nadirstall_shw2"
+	id = "nadirstall_shw2";
+	pixel_x = 11
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -41390,8 +41383,8 @@
 	pixel_x = -12
 	},
 /obj/sign_switch/north{
-	pixel_x = 11;
-	id = "nadirstall_shw1"
+	id = "nadirstall_shw1";
+	pixel_x = 11
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -50757,8 +50750,8 @@
 	pixel_y = 21
 	},
 /obj/sign_switch/west{
-	pixel_x = -21;
-	id = "nadirstall_sec2"
+	id = "nadirstall_sec2";
+	pixel_x = -21
 	},
 /turf/simulated/floor/sanitary,
 /area/station/security/equipment)
@@ -51859,12 +51852,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "wJP" = (
-/obj/machinery/plantpot,
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/submachine/fishing_upload_terminal/portable,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "wJT" = (
@@ -53376,8 +53369,8 @@
 	dir = 4
 	},
 /obj/sign_switch/north{
-	pixel_x = 14;
-	id = "nadirstall_sec1"
+	id = "nadirstall_sec1";
+	pixel_x = 14
 	},
 /obj/decoration/toiletholder{
 	pixel_y = 32
@@ -93885,8 +93878,8 @@ hOK
 ajV
 ajV
 ajV
-loU
-loU
+ajV
+ajV
 kry
 irP
 jdK

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13719,10 +13719,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"aJP" = (
-/obj/stool/chair,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
 "aJR" = (
 /obj/vehicle/floorbuffer{
 	dir = 8
@@ -13987,10 +13983,8 @@
 	},
 /area/station/hallway/primary/west)
 "aKE" = (
-/obj/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/plating/random,
+/obj/fishing_pool/portable,
+/turf/simulated/floor/green,
 /area/station/maintenance/northwest)
 "aKF" = (
 /obj/storage/secure/closet/security/equipment,
@@ -14137,8 +14131,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/inner)
 "aLb" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
+/obj/machinery/plantpot,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
 "aLc" = (
@@ -38441,7 +38434,21 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "cfW" = (
-/obj/machinery/plantpot,
+/obj/table/round/auto,
+/obj/item/seed/cannabis,
+/obj/item/caution{
+	desc = "Caution! Construction Zone!";
+	name = "caution sign";
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/item/storage/pill_bottle/cyberpunk{
+	pixel_x = -8;
+	pixel_y = 7
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
 "cfX" = (
@@ -40532,6 +40539,21 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"cOT" = (
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	name = "Hydroponics"
+	},
+/obj/access_spawn/hydro,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/green,
+/area/station/maintenance/northwest)
 "cSE" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	req_access_txt = "1"
@@ -41638,22 +41660,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "fRB" = (
-/obj/table/round/auto,
-/obj/item/seed/cannabis,
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign";
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/station/maintenance/northwest)
 "fTt" = (
 /obj/machinery/incubator{
@@ -41661,6 +41668,12 @@
 	},
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
+"fTM" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "fUm" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating/random,
@@ -41819,6 +41832,11 @@
 	},
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
+"gim" = (
+/obj/cable,
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "giE" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "mining_podbay"
@@ -45564,6 +45582,10 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
+"sQS" = (
+/obj/machinery/light/incandescent/blueish,
+/turf/simulated/floor,
+/area/station/maintenance/northwest)
 "sRT" = (
 /obj/item/device/radio/intercom/science,
 /turf/simulated/floor/engine,
@@ -45683,6 +45705,10 @@
 	},
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)
+"tqH" = (
+/obj/submachine/fishing_upload_terminal/portable,
+/turf/simulated/floor/green,
+/area/station/maintenance/northwest)
 "tst" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4
@@ -46420,6 +46446,10 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
+"wbx" = (
+/obj/stool/chair,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "wbZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46893,6 +46923,10 @@
 	dir = 9
 	},
 /area/evilreaver/security)
+"xCx" = (
+/obj/submachine/weapon_vendor/fishing/portable,
+/turf/simulated/floor/green,
+/area/station/maintenance/northwest)
 "xED" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
@@ -77757,11 +77791,11 @@ aLK
 iUC
 bWp
 agY
-agY
-agY
-agY
+aLb
+aLb
+wbx
 cfW
-cfW
+fTM
 aLL
 nkh
 aMf
@@ -78362,10 +78396,10 @@ aUD
 bWp
 agY
 agY
-agY
-cfB
-agY
-agY
+aia
+sQS
+fRB
+xCx
 ubH
 aLF
 aMf
@@ -78664,10 +78698,10 @@ aIb
 bWp
 agY
 agY
-agY
-agY
-agY
-agY
+aia
+fRB
+fRB
+tqH
 ubH
 aLF
 aMf
@@ -78965,9 +78999,9 @@ aBo
 bWP
 aIc
 nFR
-nFR
-aLb
-aJP
+gim
+aia
+fRB
 fRB
 aKE
 ubH
@@ -79270,7 +79304,7 @@ aia
 aia
 aia
 aLD
-aLD
+cOT
 aLD
 aLL
 aLL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds angler equipment to most active maps.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So anglers don't have to order gear every round.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Gannets
(*)A fishing pool, research terminal and fishing supplies vendor has been added to most in-rotation maps. You'll find them in hydroponics, hydroponics storage or the ranch.
```
