### PR TITLE
Fix /turf/unsimulated/floor using the plating sprite and associated floors

### DIFF
--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -968,13 +968,6 @@ TYPEINFO(/turf/simulated)
 	stops_space_move = 1
 	text = "<font color=#aaa>."
 
-/turf/unsimulated/floor
-	name = "floor"
-	icon = 'icons/turf/floors.dmi'
-	icon_state = "plating"
-	text = "<font color=#aaa>."
-	plane = PLANE_FLOOR
-
 /turf/unsimulated/wall
 	name = "wall"
 	icon = 'icons/turf/walls.dmi'

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -11496,7 +11496,11 @@
 /area/lower_arctic/lower)
 "aNt" = (
 /obj/machinery/light/runway_light/delay4,
-/turf/unsimulated/floor/airless,
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
 /area/space)
 "aNu" = (
 /mob/living/critter/small_animal/wasp,
@@ -41856,7 +41860,11 @@
 /area/owlery/gangzone)
 "cCj" = (
 /obj/machinery/light/runway_light/delay5,
-/turf/unsimulated/floor/airless,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
 /area/space)
 "cCk" = (
 /obj/decal/fakeobjects{
@@ -66826,6 +66834,11 @@
 "gGM" = (
 /turf/unsimulated/floor/void/channel,
 /area/adventure/channel/teleport)
+"gGU" = (
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice,
+/turf/space,
+/area/space)
 "gHt" = (
 /obj/grille/steel,
 /turf/unsimulated/floor/plating,
@@ -70718,6 +70731,14 @@
 	dir = 4
 	},
 /area/centcom)
+"mHf" = (
+/obj/machinery/light/runway_light/delay4,
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "mIm" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -75976,6 +75997,13 @@
 	},
 /turf/unsimulated/iomoon/plating,
 /area/iomoon)
+"ueq" = (
+/obj/machinery/light/runway_light/delay5,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "uex" = (
 /obj/machinery/light{
 	dir = 8
@@ -79972,7 +80000,7 @@ cnw
 cnw
 cnw
 aEN
-cCj
+gGU
 cCS
 cCS
 cCj
@@ -81177,7 +81205,7 @@ cnw
 cnw
 cnw
 aEN
-cCj
+ueq
 cCS
 cCS
 cBB
@@ -95957,7 +95985,7 @@ aaa
 aaa
 axy
 aEN
-aNt
+mHf
 bCx
 bNa
 cdh

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -130,14 +130,14 @@
 	icon = 'icons/turf/walls_iomoon.dmi';
 	name = "silicate crust"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "aay" = (
 /obj/indestructible/shuttle_corner{
 	icon = 'icons/turf/walls_iomoon.dmi';
 	name = "silicate crust"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "aaz" = (
 /obj/map/light/lava,
@@ -633,9 +633,7 @@
 /obj/ladder{
 	id = "hospital1"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "acz" = (
 /turf/unsimulated/floor/plating/scorched,
@@ -671,9 +669,7 @@
 	icon_state = "grey_target_prism";
 	name = "ship turret"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/adventure/channel/flingy)
 "acK" = (
 /obj/lattice{
@@ -809,9 +805,7 @@
 /area/hospital)
 "adp" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "adq" = (
 /obj/decal/fakeobjects{
@@ -1325,9 +1319,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aeK" = (
 /obj/window/cubicle{
@@ -1482,15 +1474,11 @@
 /turf/unsimulated/floor/plating/damaged1,
 /area/hospital)
 "afb" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "afc" = (
 /obj/storage/closet/wardrobe/white/medical,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "afd" = (
 /obj/item/plank,
@@ -1499,9 +1487,7 @@
 /obj/item/plank,
 /obj/item/plank,
 /obj/storage/crate,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "afe" = (
 /turf/unsimulated/wall/setpieces/hospital{
@@ -1593,9 +1579,7 @@
 /area/hospital)
 "afs" = (
 /obj/decal/fakeobjects/pipe,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aft" = (
 /obj/submachine/chef_sink/chem_sink{
@@ -1884,15 +1868,11 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "agf" = (
 /obj/machinery/light/small/iomoon,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "agg" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -1904,9 +1884,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "agh" = (
 /obj/machinery/door/airlock/pyro{
@@ -2061,18 +2039,14 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agA" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agB" = (
 /obj/decal/fakeobjects/skeleton{
@@ -2081,9 +2055,7 @@
 	icon_state = "body9";
 	name = "corpse"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agC" = (
 /obj/decal/fakeobjects/pipe{
@@ -2093,9 +2065,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agE" = (
 /obj/machinery/door_control{
@@ -2163,9 +2133,7 @@
 	name = "Reactor Control";
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agJ" = (
 /obj/trigger/spooky_emote,
@@ -2215,9 +2183,7 @@
 /obj/item/clothing/suit/space/soviet{
 	desc = "A bulky space suit used by the current Soviet space program. "
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "agP" = (
 /obj/decal/fakeobjects/pipe{
@@ -2299,9 +2265,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "agX" = (
 /obj/decal/fakeobjects/pipe{
@@ -2319,9 +2283,7 @@
 	tag = "icon-conduit (EAST)"
 	},
 /obj/table/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "agY" = (
 /obj/table/auto,
@@ -2647,9 +2609,7 @@
 /area/hospital)
 "ahN" = (
 /obj/table/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "ahO" = (
 /turf/unsimulated/floor/black,
@@ -3019,7 +2979,7 @@
 	req_access_txt = "37"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "ajo" = (
 /obj/reagent_dispensers/watertank/fountain,
@@ -3397,7 +3357,7 @@
 	name = "sealed airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "alg" = (
 /obj/decal/cleanable/oil,
@@ -3960,7 +3920,7 @@
 /turf/unsimulated/floor/lunar,
 /area/moon)
 "anm" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "ann" = (
 /obj/storage/crate,
@@ -4007,18 +3967,14 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "anD" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 5;
 	tag = "icon-intact (NORTHEAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "anE" = (
 /turf/unsimulated/floor/caution/corner/nw,
@@ -4223,9 +4179,7 @@
 	name = "storage tank";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aou" = (
 /obj/decal/fakeobjects/lightbulb_broken{
@@ -4242,9 +4196,7 @@
 	desc = "Probably shouldn't drink the water here.";
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aow" = (
 /turf/unsimulated/floor/caution/west,
@@ -4494,7 +4446,7 @@
 	name = "inactive light bulb";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aoX" = (
 /obj/decal/fakeobjects/pipe{
@@ -4507,7 +4459,7 @@
 	name = "grimy pipe"
 	},
 /obj/item/sponge,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aoY" = (
 /obj/cable{
@@ -4522,7 +4474,7 @@
 	name = "inactive light bulb";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "apk" = (
 /obj/decal/fakeobjects{
@@ -4549,9 +4501,7 @@
 	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi';
 	icon_state = "manifold"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "app" = (
 /obj/decal/fakeobjects/pipe{
@@ -4559,26 +4509,20 @@
 	name = "grimy pipe";
 	tag = "icon-intact (NORTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "apq" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "apr" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4;
 	tag = "icon-intact-f (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aps" = (
 /turf/unsimulated/floor/caution/corner/sw,
@@ -4695,7 +4639,7 @@
 	},
 /area/moon/museum/west)
 "apG" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "apI" = (
 /obj/machinery/navbeacon/lunar/tour7,
@@ -4761,7 +4705,7 @@
 	dir = 4;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "apQ" = (
 /obj/decal/fakeobjects/pipe{
@@ -4777,7 +4721,7 @@
 	dir = 4;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "apR" = (
 /obj/decal/fakeobjects/pipe{
@@ -4789,7 +4733,7 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "apS" = (
 /obj/cable{
@@ -4806,7 +4750,7 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "apT" = (
 /obj/decal/fakeobjects/pipe{
@@ -4827,7 +4771,7 @@
 	name = "sealed airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aqh" = (
 /obj/shrub{
@@ -4913,18 +4857,14 @@
 	name = "rusted vent";
 	tag = "icon-vent (NORTH)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aqv" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Atmospheric Processing";
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "aqw" = (
 /obj/machinery/door/poddoor/blast{
@@ -5003,17 +4943,17 @@
 	icon_state = "vent";
 	name = "grimy vent"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "aqJ" = (
 /obj/machinery/navbeacon/lunar/tour8,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "aqK" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "aqL" = (
 /turf/unsimulated/wall/auto/adventure/old,
@@ -5039,7 +4979,7 @@
 	dir = 6;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aqP" = (
 /obj/decal/fakeobjects/pipe{
@@ -5052,7 +4992,7 @@
 	name = "custodial sink";
 	pixel_x = 2
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aqQ" = (
 /obj/cable{
@@ -5065,7 +5005,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aqZ" = (
 /obj/machinery/light,
@@ -5112,15 +5052,11 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "ari" = (
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "arj" = (
 /obj/rack,
@@ -5249,7 +5185,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "arE" = (
 /obj/machinery/door/airlock/pyro{
@@ -5267,7 +5203,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "arI" = (
 /obj/cable{
@@ -5275,7 +5211,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "arP" = (
 /obj/machinery/door/poddoor/blast/lunar{
@@ -5327,9 +5263,7 @@
 "arW" = (
 /obj/rack,
 /obj/random_item_spawner/tools,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "arX" = (
 /obj/storage/closet,
@@ -5439,27 +5373,21 @@
 /turf/unsimulated/floor/caution/east,
 /area/hospital/samostrel)
 "ask" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "asl" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 6;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "asm" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "asp" = (
 /obj/decal/fakeobjects{
@@ -5471,9 +5399,7 @@
 	icon_state = "sovmachine1";
 	name = "broken computer"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "asr" = (
 /obj/decal/fakeobjects/pipe{
@@ -5554,7 +5480,7 @@
 /area/moon/museum/west)
 "asw" = (
 /obj/trigger/critter,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "asx" = (
 /turf/unsimulated/floor{
@@ -5567,7 +5493,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = "777"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "asA" = (
 /obj/storage/closet/emergency{
@@ -5575,7 +5501,7 @@
 	desc = "A closet of EVA gear for the tour.  Maybe.  There is a teeny tiny little chance that they aren't stocked during renovations.";
 	name = "tour eva gear closet"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asB" = (
 /obj/decal/fakeobjects/pipe{
@@ -5587,7 +5513,7 @@
 	desc = "A closet of EVA gear for the tour.  Maybe.  There is a teeny tiny little chance that they aren't stocked during renovations.";
 	name = "tour eva gear closet"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asC" = (
 /obj/decal/fakeobjects/pipe{
@@ -5599,7 +5525,7 @@
 	desc = "A closet of EVA gear for the tour.  Maybe.  There is a teeny tiny little chance that they aren't stocked during renovations.";
 	name = "tour eva gear closet"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asD" = (
 /obj/securearea{
@@ -5633,14 +5559,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asH" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 1;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asI" = (
 /obj/cable{
@@ -5656,7 +5582,7 @@
 	name = "grimy pipe";
 	pixel_x = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asJ" = (
 /obj/cable{
@@ -5664,7 +5590,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asK" = (
 /obj/cable{
@@ -5677,7 +5603,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "asT" = (
 /obj/decal/fakeobjects{
@@ -5821,9 +5747,7 @@
 	icon_state = "manifold";
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "atj" = (
 /obj/decal/fakeobjects/pipe{
@@ -5831,9 +5755,7 @@
 	name = "grimy pipe";
 	tag = "icon-intact (NORTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "atk" = (
 /obj/decal/fakeobjects{
@@ -5914,7 +5836,7 @@
 	dir = 6;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "atp" = (
 /obj/critter/mannequin{
@@ -5973,7 +5895,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "att" = (
 /obj/decal/fakeobjects/moonrock,
@@ -5983,7 +5905,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atv" = (
 /obj/decal/fakeobjects/pipe{
@@ -5991,7 +5913,7 @@
 	name = "grimy pipe"
 	},
 /obj/machinery/navbeacon/lunar/tour6,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atw" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -6020,7 +5942,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atz" = (
 /obj/decal/fakeobjects/pipe{
@@ -6030,7 +5952,7 @@
 	icon_state = "manifold";
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atA" = (
 /obj/cable{
@@ -6051,7 +5973,7 @@
 	name = "grimy pipe";
 	pixel_x = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atH" = (
 /obj/machinery/light/worn{
@@ -6133,9 +6055,7 @@
 	name = "Compartment Access";
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "atT" = (
 /obj/decal/glow{
@@ -6164,14 +6084,14 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "atV" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "atW" = (
 /turf/unsimulated/wall/setpieces/leadwindow/white{
@@ -6189,7 +6109,7 @@
 	pixel_x = -4;
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "atY" = (
 /obj/decal/fakeobjects/pipe{
@@ -6201,7 +6121,7 @@
 	name = "grimy pipe";
 	pixel_x = -4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aua" = (
 /obj/decal/fakeobjects{
@@ -6226,7 +6146,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "auc" = (
 /obj/grille/steel,
@@ -6240,7 +6160,7 @@
 	name = "grimy pipe";
 	pixel_x = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aud" = (
 /obj/grille/steel,
@@ -6248,7 +6168,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aun" = (
 /obj/shrub/dead{
@@ -6353,7 +6273,7 @@
 	dir = 1;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auA" = (
 /obj/decal/fakeobjects/pipe,
@@ -6367,7 +6287,7 @@
 	name = "grimy pipe";
 	pixel_x = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auB" = (
 /obj/cable{
@@ -6375,7 +6295,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auC" = (
 /obj/cable{
@@ -6383,7 +6303,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auD" = (
 /obj/cable{
@@ -6396,7 +6316,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auE" = (
 /obj/decal/fakeobjects/pipe{
@@ -6408,7 +6328,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auF" = (
 /obj/cable{
@@ -6416,7 +6336,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auG" = (
 /obj/cable{
@@ -6428,7 +6348,7 @@
 	dir = 4;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auH" = (
 /obj/cable{
@@ -6436,7 +6356,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auI" = (
 /obj/decal/fakeobjects/pipe{
@@ -6446,7 +6366,7 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auJ" = (
 /obj/decal/fakeobjects/pipe{
@@ -6457,7 +6377,7 @@
 	name = "airlock storage tank";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "auK" = (
 /obj/stool/bench/blue/auto,
@@ -6481,7 +6401,7 @@
 	dir = 4;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "auP" = (
 /obj/decal/fakeobjects/pipe{
@@ -6489,7 +6409,7 @@
 	name = "grimy pipe";
 	pixel_x = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "auQ" = (
 /obj/cable{
@@ -6500,7 +6420,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "auX" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -6512,9 +6432,7 @@
 /area/hospital)
 "auY" = (
 /obj/item/tank/oxygen,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "auZ" = (
 /obj/decal/fakeobjects{
@@ -6564,14 +6482,14 @@
 	dir = 5;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avg" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 10;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avh" = (
 /obj/decal/fakeobjects/pipe,
@@ -6589,7 +6507,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avi" = (
 /obj/decal/fakeobjects/pipe{
@@ -6599,14 +6517,14 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avj" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avk" = (
 /obj/decal/fakeobjects/pipe{
@@ -6623,7 +6541,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avl" = (
 /obj/decal/fakeobjects/pipe{
@@ -6639,7 +6557,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avm" = (
 /obj/decal/fakeobjects/pipe{
@@ -6647,7 +6565,7 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avn" = (
 /obj/machinery/navbeacon/lunar/tour5,
@@ -6731,7 +6649,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "avv" = (
 /obj/decal/fakeobjects/pipe{
@@ -6740,7 +6658,7 @@
 	pixel_x = 6
 	},
 /obj/item/tripod_bulb/light,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "avw" = (
 /obj/cable,
@@ -6748,7 +6666,7 @@
 	dir = 6;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "avD" = (
 /obj/machinery/door/airlock/pyro{
@@ -6770,26 +6688,20 @@
 	tag = "icon-intact-f (EAST)"
 	},
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "avG" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9;
 	tag = "icon-intact-f (NORTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "avH" = (
 /obj/ladder{
 	id = "hospital2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "avI" = (
 /obj/machinery/door/airlock/pyro{
@@ -6802,9 +6714,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "avK" = (
 /obj/decal/fakeobjects{
@@ -6856,9 +6766,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "avP" = (
 /obj/decal/fakeobjects/pipe{
@@ -6866,11 +6774,11 @@
 	name = "grimy pipe"
 	},
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avQ" = (
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "avS" = (
 /turf/unsimulated/floor/grey/side{
@@ -6881,7 +6789,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "avU" = (
 /obj/decal/fakeobjects/pipe{
@@ -6891,7 +6799,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "awd" = (
 /obj/submachine/chef_sink/chem_sink{
@@ -6932,9 +6840,7 @@
 	dir = 4;
 	pixel_y = -10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "awi" = (
 /obj/table/auto,
@@ -6955,9 +6861,7 @@
 "awp" = (
 /obj/rack,
 /obj/item/clothing/head/helmet/space/soviet,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "awq" = (
 /obj/decal/fakeobjects/pipe,
@@ -6976,7 +6880,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "awr" = (
 /obj/decal/fakeobjects/pipe{
@@ -6993,7 +6897,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "aws" = (
 /obj/decal/fakeobjects/pipe{
@@ -7001,7 +6905,7 @@
 	name = "grimy pipe"
 	},
 /obj/item/device/multitool,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "awt" = (
 /turf/unsimulated/floor/grey/side,
@@ -7084,7 +6988,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "awB" = (
 /obj/decal/fakeobjects/pipe{
@@ -7094,7 +6998,7 @@
 	icon_state = "intact_off";
 	name = "pump"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "awC" = (
 /obj/grille/steel,
@@ -7102,7 +7006,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "awD" = (
 /obj/decal/fakeobjects/pipe{
@@ -7126,7 +7030,7 @@
 	desc = "A heavy bag, used for sleeping in.  Hence the name.  Wait, does this mean somebody was sleeping in the maintenance tunnels?  Who??";
 	name = "sleeping bag"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "awK" = (
 /obj/decal/cleanable/dirt,
@@ -7164,9 +7068,6 @@
 	icon_state = "floor"
 	},
 /area/hospital)
-"awR" = (
-/turf/unsimulated/floor/damaged3,
-/area/hospital)
 "awS" = (
 /obj/decal/cleanable/cobweb2,
 /obj/decal/fakeobjects{
@@ -7192,9 +7093,7 @@
 	dir = 4;
 	pixel_y = 10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "awU" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -7271,7 +7170,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "axf" = (
 /obj/decal/fakeobjects/pipe,
@@ -7290,7 +7189,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "axg" = (
 /obj/cable{
@@ -7303,7 +7202,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "axh" = (
 /turf/unsimulated/floor/stairs{
@@ -7317,11 +7216,11 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "axj" = (
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "axk" = (
 /obj/decal/fakeobjects/pipe{
@@ -7338,7 +7237,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "axn" = (
 /obj/decal/poster/wallsign/hazard_exheat,
@@ -7382,9 +7281,7 @@
 	dir = 4;
 	pixel_y = -10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "axC" = (
 /obj/decal/fakeobjects{
@@ -7548,7 +7445,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "axW" = (
 /obj/cable{
@@ -7566,7 +7463,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "axY" = (
 /obj/decal/fakeobjects/pipe{
@@ -7576,7 +7473,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "ayu" = (
 /obj/machinery/light/small/iomoon{
@@ -7610,9 +7507,7 @@
 /area/hospital)
 "ayy" = (
 /obj/item/clothing/mask/gas/emergency,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "ayA" = (
 /obj/decal/fakeobjects{
@@ -7828,7 +7723,7 @@
 	dir = 1;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "azn" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -7845,9 +7740,7 @@
 	dir = 4;
 	pixel_y = 10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "azp" = (
 /obj/decal/fakeobjects/pipe{
@@ -7859,9 +7752,7 @@
 	desc = "A big rolling laundry cart.";
 	name = "laundry cart"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "azq" = (
 /obj/landmark{
@@ -8156,14 +8047,14 @@
 	name = "grimy vent";
 	tag = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aAr" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9;
 	name = "grimy pipe"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aAA" = (
 /obj/decal/fakeobjects/pipe{
@@ -8189,7 +8080,7 @@
 	name = "sealed airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/west)
 "aAF" = (
 /obj/machinery/navbeacon/lunar/tour12,
@@ -8260,7 +8151,7 @@
 	pixel_x = 24;
 	setup_string = "lunar_rightroom,EAST HALL DOOR;giftshopinner,GIFT ACCESS;giftshopouter,WEST HALL DOOR;lunar_storage,ACC STORAGE;lunar_terror2,ACTOR 28"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aAR" = (
 /obj/shrub{
@@ -8348,7 +8239,7 @@
 	icon_state = "camerax";
 	name = "security camera"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aBx" = (
 /obj/decal/cleanable/cobweb,
@@ -8614,7 +8505,7 @@
 /area/moon/museum)
 "aCk" = (
 /obj/item/wirecutters,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aCo" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -8707,9 +8598,7 @@
 	id = "hospital1";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCG" = (
 /obj/indestructible/shuttle_corner{
@@ -8740,14 +8629,10 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTH)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCK" = (
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCL" = (
 /turf/unsimulated/floor/purpleblack{
@@ -8819,16 +8704,12 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTH)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCX" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCY" = (
 /obj/table/auto,
@@ -8837,9 +8718,7 @@
 	desc = "TODO: Fix leaky sink in command section.";
 	pixel_y = 26
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aCZ" = (
 /obj/landmark/viscontents_spawn{
@@ -8851,15 +8730,11 @@
 	})
 "aDb" = (
 /obj/storage/secure/closet/engineering/engineer,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aDc" = (
 /obj/machinery/portable_reclaimer,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aDk" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -8870,7 +8745,7 @@
 	name = "sealed airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum/giftshop)
 "aDm" = (
 /obj/machinery/door/poddoor/blast/lunar/tour{
@@ -9019,9 +8894,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aDE" = (
 /obj/landmark/viscontents_spawn{
@@ -9105,9 +8978,7 @@
 	dir = 8
 	},
 /obj/decal/cleanable/ash,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEa" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -9118,9 +8989,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEb" = (
 /obj/decal/fakeobjects/pipe{
@@ -9144,9 +9013,7 @@
 	dir = 4;
 	pixel_y = -10
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEd" = (
 /obj/decal/fakeobjects/pipe{
@@ -9168,9 +9035,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTH)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEg" = (
 /obj/storage/secure/closet/engineering/electrical,
@@ -9283,9 +9148,7 @@
 	name = "Maintenance Office";
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEF" = (
 /obj/machinery/light/small/iomoon{
@@ -9354,9 +9217,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEV" = (
 /obj/decal/fakeobjects/teleport_pad,
@@ -9391,9 +9252,7 @@
 	icon_state = "fdoor0";
 	tag = "icon-door0 (WEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aEZ" = (
 /obj/decal/fakeobjects{
@@ -9406,9 +9265,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aFc" = (
 /turf/unsimulated/floor/red/side{
@@ -9514,9 +9371,7 @@
 	name = "inactive light bulb";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aFA" = (
 /obj/decal/fakeobjects{
@@ -9529,9 +9384,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aFC" = (
 /obj/overlay{
@@ -9641,7 +9494,7 @@
 "aFT" = (
 /obj/machinery/door/airlock/pyro,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aFU" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -9660,7 +9513,7 @@
 	req_access_txt = "255"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aFW" = (
 /obj/stool/chair/office/red{
@@ -9795,9 +9648,7 @@
 	icon_state = "camerax";
 	name = "security camera"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aGQ" = (
 /obj/decal/fakeobjects{
@@ -9810,9 +9661,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (SOUTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aGR" = (
 /obj/decal/fakeobjects{
@@ -9835,9 +9684,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aGS" = (
 /obj/decal/fakeobjects{
@@ -9849,9 +9696,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTHEAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aGT" = (
 /obj/decal/fakeobjects{
@@ -9870,9 +9715,7 @@
 	icon_state = "fdoor0";
 	tag = "icon-door0 (WEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aGU" = (
 /obj/decal/fakeobjects{
@@ -9884,9 +9727,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (SOUTHEAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aGV" = (
 /turf/unsimulated/floor/caution/west,
@@ -9903,9 +9744,7 @@
 	desc = "<i>Moonmopper</i> was the worst James Bond movie.";
 	name = "moon mop"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aGY" = (
 /obj/decal/fakeobjects/pipe{
@@ -9913,9 +9752,7 @@
 	name = "grimy pipe"
 	},
 /obj/mopbucket,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/moon/museum)
 "aGZ" = (
 /obj/machinery/door/poddoor/blast/single{
@@ -9959,9 +9796,7 @@
 /obj/decal/fakeobjects/pipe{
 	icon = 'icons/obj/atmospherics/pipe_vent.dmi'
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aHr" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -9982,9 +9817,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (NORTH)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aHs" = (
 /obj/storage/crate/bin{
@@ -9992,9 +9825,7 @@
 	name = "Trash bin"
 	},
 /obj/item/device/audio_log/hospital_02,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aHt" = (
 /obj/decal/fakeobjects{
@@ -10011,9 +9842,7 @@
 	name = "maintenance light";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "aHu" = (
 /obj/machinery/light/small,
@@ -10209,7 +10038,7 @@
 	layer = 9;
 	name = "Blast Door"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost/vault)
 "aIQ" = (
 /turf/unsimulated/floor/black,
@@ -10257,7 +10086,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aIU" = (
 /obj/grille/steel,
@@ -10290,7 +10119,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aIV" = (
 /obj/machinery/light/worn{
@@ -11310,7 +11139,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aMn" = (
 /obj/machinery/light{
@@ -12042,7 +11871,7 @@
 	dir = 4
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod2)
 "aOB" = (
 /obj/cable{
@@ -12090,7 +11919,7 @@
 	locked = 1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod2)
 "aOG" = (
 /obj/decal/cleanable/blood/tracks{
@@ -12727,7 +12556,7 @@
 	name = "iceelefall"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/lower_arctic/mining)
 "aQo" = (
 /obj/machinery/computer/icebase_elevator,
@@ -12882,7 +12711,7 @@
 /obj/decal/cleanable/blood/tracks,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod2)
 "aQS" = (
 /obj/lattice{
@@ -13226,7 +13055,7 @@
 	name = "Biodome"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "aSb" = (
 /obj/window/cubicle{
@@ -13275,14 +13104,14 @@
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/maint)
 "aSk" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Biodome"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/maint)
 "aSm" = (
 /obj/table/wood/auto,
@@ -13765,7 +13594,7 @@
 	name = "Crew Quarters"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "aTT" = (
 /obj/machinery/light{
@@ -13814,7 +13643,7 @@
 	name = "Break Room"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/maint)
 "aUb" = (
 /obj/decal/mushrooms/type2,
@@ -13888,7 +13717,7 @@
 	dir = 4
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/hall)
 "aUn" = (
 /obj/cable{
@@ -13917,7 +13746,7 @@
 /area/shuttle/biodome_elevator/lower)
 "aUs" = (
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "aUt" = (
 /turf/unsimulated/floor/caution/east,
@@ -13929,7 +13758,7 @@
 /area/crater/biodome/crew)
 "aUw" = (
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "aUx" = (
 /obj/machinery/power/apc{
@@ -14456,7 +14285,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aVK" = (
 /obj/rack,
@@ -14557,19 +14386,19 @@
 	name = "Restroom"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "aVZ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aWd" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Furnace Room"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/maint)
 "aWf" = (
 /obj/item/raw_material/char,
@@ -14776,12 +14605,12 @@
 "aWK" = (
 /obj/machinery/chem_master,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aWL" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aWM" = (
 /turf/unsimulated/floor/caution/west,
@@ -14940,7 +14769,7 @@
 /obj/decal/cleanable/blood/tracks,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aXn" = (
 /obj/lattice{
@@ -15314,7 +15143,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aYl" = (
 /obj/rack,
@@ -15336,7 +15165,7 @@
 	},
 /obj/item/device/light/flashlight,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aYm" = (
 /obj/machinery/field_generator{
@@ -15445,14 +15274,14 @@
 "aYz" = (
 /obj/machinery/chem_heater,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aYA" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aYB" = (
 /obj/machinery/vending/hydroponics,
@@ -15552,7 +15381,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aYO" = (
 /obj/lattice{
@@ -15675,7 +15504,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aZj" = (
 /obj/decal/icefloor,
@@ -15773,18 +15602,18 @@
 "aZy" = (
 /obj/machinery/plantpot,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aZz" = (
 /obj/machinery/light,
 /obj/machinery/plantpot,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aZA" = (
 /obj/reagent_dispensers/watertank/big,
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "aZB" = (
 /obj/cable{
@@ -15829,7 +15658,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aZG" = (
 /obj/grille/steel,
@@ -15852,7 +15681,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "aZH" = (
 /obj/decal/fakeobjects{
@@ -15908,7 +15737,7 @@
 	dir = 4
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aZM" = (
 /obj/cable{
@@ -15967,10 +15796,10 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aZS" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "aZT" = (
 /obj/grille/catwalk{
@@ -16137,7 +15966,7 @@
 /area/upper_arctic/pod1)
 "bas" = (
 /obj/machinery/light/small,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "bat" = (
 /turf/unsimulated/floor/arctic/plating{
@@ -16366,7 +16195,7 @@
 "bbc" = (
 /obj/storage/closet/emergency,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "bbd" = (
 /obj/cable{
@@ -16381,7 +16210,7 @@
 /obj/item/paper/printout/group1,
 /obj/item/device/light/flashlight,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/pod1)
 "bbe" = (
 /obj/machinery/field_generator{
@@ -16733,7 +16562,7 @@
 /area/upper_arctic/mining)
 "bcj" = (
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/upper_arctic/mining)
 "bck" = (
 /obj/machinery/computer/icebase_elevator,
@@ -16906,7 +16735,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/icebase_elevator/upper)
 "bcA" = (
 /obj/grille/catwalk{
@@ -16914,7 +16743,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/icebase_elevator/upper)
 "bcB" = (
 /obj/lattice{
@@ -17098,7 +16927,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/icebase_elevator/upper)
 "bda" = (
 /obj/grille/catwalk{
@@ -17106,7 +16935,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/icebase_elevator/upper)
 "bdb" = (
 /obj/grille/catwalk{
@@ -17124,7 +16953,7 @@
 	name = "Biodome"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/south)
 "bde" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -17137,7 +16966,7 @@
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/south)
 "bdg" = (
 /obj/decal/mushrooms/type1,
@@ -17377,7 +17206,7 @@
 	secondsElectrified = -1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/entry)
 "bdW" = (
 /turf/unsimulated/floor/plating/scorched,
@@ -17873,7 +17702,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bfs" = (
 /obj/decal/cleanable/dirt,
@@ -18027,7 +17856,7 @@
 	layer = 8;
 	name = "window"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bfM" = (
 /obj/decal/cleanable/fungus,
@@ -18620,7 +18449,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bhI" = (
 /obj/decal/fakeobjects/robot{
@@ -18631,7 +18460,7 @@
 	},
 /obj/decal/cleanable/oil,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bhJ" = (
 /obj/decal/fakeobjects/robot{
@@ -18651,7 +18480,7 @@
 	name = "window"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bhK" = (
 /obj/decal/fakeobjects/apc_broken{
@@ -18897,7 +18726,7 @@
 	},
 /obj/machinery/light/worn,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "biq" = (
 /obj/table/auto,
@@ -18914,7 +18743,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bis" = (
 /obj/decal/fakeobjects/robot{
@@ -18935,7 +18764,7 @@
 	name = "window"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bit" = (
 /obj/table/wood/auto,
@@ -19773,7 +19602,7 @@
 	name = "Crew Quarters"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/crew_quarters)
 "bkt" = (
 /turf/unsimulated/floor/stairs{
@@ -20158,7 +19987,7 @@
 	name = "Engineering"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone)
 "blt" = (
 /obj/window/cubicle{
@@ -20596,7 +20425,7 @@
 	name = "Design Office"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone)
 "bmH" = (
 /turf/unsimulated/floor/red/side{
@@ -20823,7 +20652,7 @@
 /area/marsoutpost)
 "bnn" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/marsoutpost)
 "bno" = (
 /obj/machinery/light/small{
@@ -21099,7 +20928,7 @@
 	icon_state = "grinder-o1";
 	name = "assembly machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/office)
 "bnM" = (
 /obj/overlay{
@@ -21109,7 +20938,7 @@
 	icon_state = "grinder-b1";
 	name = "assembly machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/office)
 "bnN" = (
 /obj/overlay{
@@ -21119,7 +20948,7 @@
 	icon_state = "separator-AO1";
 	name = "assembly machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/office)
 "bnP" = (
 /obj/critter/ancient_thing,
@@ -21435,7 +21264,7 @@
 	name = "Assembly Floor"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone)
 "boM" = (
 /turf/unsimulated/floor/red/side{
@@ -21633,18 +21462,10 @@
 	name = "airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon)
 "bpC" = (
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon)
 "bpD" = (
 /turf/unsimulated/iomoon/floor,
@@ -21977,7 +21798,7 @@
 /area/iomoon)
 "bqy" = (
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bqz" = (
 /obj/landmark{
@@ -21988,7 +21809,7 @@
 	id = "iomoon";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bqA" = (
 /obj/decal/tile_edge/line/blue{
@@ -21999,7 +21820,7 @@
 	},
 /area/shuttle/john/owlery)
 "bqB" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bqC" = (
 /obj/decal/fakeobjects/pipe{
@@ -22009,7 +21830,7 @@
 	icon_state = "intact_off";
 	name = "pump"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bqD" = (
 /turf/unsimulated/floor/circuit,
@@ -22162,7 +21983,7 @@
 	dir = 5
 	},
 /obj/item/device/light/flashlight,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "brb" = (
 /obj/machinery/light/small{
@@ -22181,7 +22002,7 @@
 	name = "Drone Assembly Outpost"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone)
 "bre" = (
 /turf/unsimulated/floor{
@@ -22403,7 +22224,7 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "brM" = (
 /obj/machinery/vending/cola/red,
@@ -22611,52 +22432,10 @@
 	dir = 4;
 	name = "Surface Airlock"
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bsn" = (
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
-/area/iomoon/base)
-"bso" = (
-/obj/decal/fakeobjects/pipe{
-	dir = 6
-	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
-/area/iomoon/base)
-"bsp" = (
-/obj/decal/fakeobjects/pipe{
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
-/area/iomoon/base)
-"bsq" = (
-/obj/decal/fakeobjects/pipe{
-	desc = "It won't budge.";
-	dir = 4;
-	icon = 'icons/obj/pipe-item.dmi';
-	icon_state = "valve";
-	name = "rusted valve"
-	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bsr" = (
 /obj/decal/fakeobjects/pipe{
@@ -22670,11 +22449,7 @@
 	layer = 3.1;
 	name = "peculiar machine"
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bsw" = (
 /obj/trigger/critter,
@@ -22802,7 +22577,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bsN" = (
 /obj/decal/cleanable/blood,
@@ -22970,7 +22745,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "btp" = (
 /obj/item/sea_ladder,
@@ -22988,7 +22763,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bts" = (
 /obj/table/auto,
@@ -23017,7 +22792,7 @@
 	name = "broken door";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bty" = (
 /obj/decal/icefloor,
@@ -23102,16 +22877,13 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "btL" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9
 	},
-/turf/unsimulated/floor,
-/area/iomoon/base)
-"btM" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "btO" = (
 /obj/landmark/spawner/loot,
@@ -23157,25 +22929,21 @@
 /obj/machinery/door/airlock/pyro/external{
 	name = "Surface Airlock"
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "btT" = (
 /obj/decal/fakeobjects/pipe,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "btU" = (
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "btV" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "btW" = (
 /obj/decal/cleanable/blood,
@@ -23238,11 +23006,11 @@
 	icon_state = "circ2-broken";
 	name = "old gas turbine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "buj" = (
 /obj/railing/yellow/reinforced,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "buk" = (
 /obj/lattice{
@@ -23290,14 +23058,14 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bus" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "but" = (
 /obj/decal/cleanable/dirt,
@@ -23319,7 +23087,7 @@
 	icon_state = "circ1-broken";
 	name = "old gas circulator"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buv" = (
 /obj/decal/fakeobjects{
@@ -23330,7 +23098,7 @@
 	icon_state = "teg-broken";
 	name = "broken generator"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buw" = (
 /obj/decal/fakeobjects{
@@ -23341,7 +23109,7 @@
 	icon_state = "circ2-broken";
 	name = "old gas circulator"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buy" = (
 /obj/decal/cleanable/blood,
@@ -23466,7 +23234,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/cobweb,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buS" = (
 /obj/decal/fakeobjects{
@@ -23476,7 +23244,7 @@
 	icon_state = "conduit";
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buT" = (
 /obj/decal/fakeobjects{
@@ -23487,7 +23255,7 @@
 	icon_state = "intact";
 	name = "defunct vent"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "buX" = (
 /turf/unsimulated/floor/stairs/dark{
@@ -23659,7 +23427,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bvA" = (
 /obj/surgery_tray,
@@ -23690,7 +23458,7 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bvC" = (
 /obj/decal/fakeobjects/pipe{
@@ -23699,7 +23467,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bvE" = (
 /obj/juggleplaque{
@@ -23752,13 +23520,13 @@
 	dir = 5
 	},
 /obj/item/cell/supercell/charged,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bvO" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bvR" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -23845,14 +23613,14 @@
 	icon_state = "circ1-broken";
 	name = "old gas turbine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bwi" = (
 /obj/item/rods/steel,
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib7"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bwk" = (
 /obj/decal/cleanable/blood,
@@ -23996,7 +23764,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bwO" = (
 /turf/unsimulated/floor{
@@ -24023,7 +23791,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bwS" = (
 /obj/decal/fakeobjects/pipe{
@@ -24038,7 +23806,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bwU" = (
 /turf/unsimulated/iomoon/floor{
@@ -24138,13 +23906,13 @@
 	icon_state = "meter";
 	name = "meter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bxB" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bxE" = (
 /turf/unsimulated/wall/auto/adventure/iomoon/interior,
@@ -24291,13 +24059,13 @@
 "byn" = (
 /obj/decal/fakeobjects/tallsmes,
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "byo" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 5
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "byp" = (
 /obj/decal/fakeobjects/pipe{
@@ -24432,11 +24200,11 @@
 	anchored = 1;
 	state = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "byX" = (
 /obj/stool,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "byZ" = (
 /obj/critter/lavacrab{
@@ -24525,7 +24293,7 @@
 /area/iomoon/base)
 "bzp" = (
 /obj/machinery/door/airlock/pyro/maintenance,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bzs" = (
 /obj/decal/cleanable/ash,
@@ -24554,7 +24322,7 @@
 	icon_state = "conduit";
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bzz" = (
 /obj/decal/fakeobjects/lightbulb_broken{
@@ -24570,7 +24338,7 @@
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bzD" = (
 /obj/map/light/lava,
@@ -24702,7 +24470,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAg" = (
 /obj/decal/fakeobjects/pipe{
@@ -24724,7 +24492,7 @@
 	layer = 3.1;
 	name = "peculiar machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAh" = (
 /obj/computer3frame/terminal{
@@ -24732,7 +24500,7 @@
 	state = 1
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAm" = (
 /obj/structure/girder/displaced,
@@ -24895,11 +24663,11 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 10
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAP" = (
 /obj/item/reagent_containers/glass/oilcan,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAQ" = (
 /obj/overlay{
@@ -24910,7 +24678,7 @@
 	name = "broken databank"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bAW" = (
 /obj/item/reagent_containers/food/snacks/yuckburn,
@@ -25072,7 +24840,7 @@
 	name = "broken databank"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bBr" = (
 /obj/cable,
@@ -25085,7 +24853,7 @@
 	setup_os_string = "IOMOON_MAINFRAME"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bBs" = (
 /obj/decal/fakeobjects/firelock_broken,
@@ -25172,7 +24940,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bBE" = (
 /obj/decal/fakeobjects{
@@ -25194,13 +24962,13 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bBH" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Supplies"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bBJ" = (
 /obj/decal/fakeobjects/pipe{
@@ -25338,7 +25106,7 @@
 /obj/machinery/light/small/iomoon{
 	dir = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bCk" = (
 /obj/decal/fakeobjects/azarakrocks/rock3,
@@ -25355,7 +25123,7 @@
 	icon_state = "lavamachine_10";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCn" = (
 /obj/overlay{
@@ -25365,7 +25133,7 @@
 	icon_state = "lavamachine_11";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCo" = (
 /obj/overlay{
@@ -25375,7 +25143,7 @@
 	icon_state = "lavamachine_12";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCp" = (
 /obj/overlay{
@@ -25387,7 +25155,7 @@
 	name = "peculiar machine"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCq" = (
 /obj/table/auto,
@@ -25413,7 +25181,7 @@
 	name = "downed server"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCt" = (
 /obj/decal/fakeobjects/pipe{
@@ -25428,7 +25196,7 @@
 	pixel_y = -6
 	},
 /obj/item/storage/firstaid/toxin,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bCx" = (
 /obj/lattice{
@@ -25711,7 +25479,7 @@
 	icon_state = "lavamachine_00";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bDh" = (
 /obj/overlay{
@@ -25732,7 +25500,7 @@
 	icon_state = "lavamachine_02";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bDo" = (
 /obj/lattice{
@@ -25782,7 +25550,7 @@
 	print_id = "Control0"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bDw" = (
 /obj/machinery/light/small/iomoon,
@@ -25806,7 +25574,7 @@
 	bank_id = "LOGS"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bDA" = (
 /obj/table/auto,
@@ -25982,7 +25750,7 @@
 	icon_state = "wallterm0";
 	name = "broken computer"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bDR" = (
 /obj/decal/fakeobjects{
@@ -25994,7 +25762,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "bDT" = (
 /obj/decal/fakeobjects/pipe{
@@ -26035,7 +25803,7 @@
 	name = "downed server"
 	},
 /obj/decal/stripe_caution,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bDY" = (
 /obj/machinery/power/data_terminal,
@@ -26044,7 +25812,7 @@
 	tag = "IOMOON_MAINFRAME"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bDZ" = (
 /obj/decal/stalagmite{
@@ -26107,7 +25875,7 @@
 	icon_state = "valve";
 	name = "rusted valve"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEp" = (
 /obj/decal/fakeobjects/pipe{
@@ -26117,7 +25885,7 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEq" = (
 /obj/decal/fakeobjects/pipe{
@@ -26131,7 +25899,7 @@
 	icon_state = "intact_off";
 	name = "pump"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEr" = (
 /obj/item/crowbar,
@@ -26141,19 +25909,19 @@
 	icon_state = "body3";
 	name = "corpse"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEs" = (
 /obj/machinery/light/small/iomoon{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEt" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEv" = (
 /obj/decal/stalagmite{
@@ -26295,7 +26063,7 @@
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bET" = (
 /obj/decal/fakeobjects/pipe{
@@ -26308,7 +26076,7 @@
 	icon_state = "meter";
 	name = "meter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bEV" = (
 /obj/map/light/lava,
@@ -26425,7 +26193,7 @@
 /area/catacombs)
 "bFu" = (
 /obj/machinery/light/small/iomoon,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "bFv" = (
 /obj/lattice{
@@ -27507,16 +27275,16 @@
 /area/crunch)
 "bIZ" = (
 /obj/gravity_well_generator,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJa" = (
 /obj/machinery/emitter,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJb" = (
 /obj/machinery/door/unpowered/wood,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJc" = (
 /turf/unsimulated/floor/specialroom/chapel{
@@ -27587,7 +27355,7 @@
 	},
 /area/solarium)
 "bJn" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJo" = (
 /turf/unsimulated/floor/stairs{
@@ -27707,13 +27475,13 @@
 /area/crunch)
 "bJF" = (
 /obj/storage/closet/emergency,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJG" = (
 /obj/storage/crate,
 /obj/item/shipcomponent/engine/helios,
 /obj/item/clothing/under/gimmick/donk,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJH" = (
 /turf/unsimulated/floor/stairs/wide{
@@ -27814,13 +27582,13 @@
 	name = "telesci"
 	},
 /obj/decal/residual_energy,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bJZ" = (
 /obj/landmark{
 	name = "telesci"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/solarium)
 "bKa" = (
 /turf/unsimulated/floor/caution/west,
@@ -29012,7 +28780,7 @@
 	name = "Restroom"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/crew)
 "bOb" = (
 /turf/unsimulated/floor/black,
@@ -29027,7 +28795,7 @@
 	dir = 4
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/crew)
 "bOd" = (
 /obj/stool/chair/comfy{
@@ -29637,7 +29405,7 @@
 	name = "Crew Quarters"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/crew)
 "bPZ" = (
 /obj/item/caution{
@@ -29977,7 +29745,7 @@
 	req_access_txt = "5"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/lab)
 "bQX" = (
 /obj/racing_boosterstrip{
@@ -30208,7 +29976,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/mainhall)
 "bRQ" = (
 /obj/stool/chair{
@@ -30457,7 +30225,7 @@
 	req_access_txt = ""
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma)
 "bSI" = (
 /turf/unsimulated/floor/stairs,
@@ -30510,7 +30278,7 @@
 /area/crypt/sigma/mainhall)
 "bTa" = (
 /obj/grille/steel,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma)
 "bTb" = (
 /turf/unsimulated/floor/caution/corner/nw{
@@ -30578,7 +30346,7 @@
 	name = "broken airlock"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/mainhall)
 "bTm" = (
 /turf/unsimulated/floor/stairs/wide/other{
@@ -30671,7 +30439,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/biodome_elevator/upper)
 "bTx" = (
 /obj/grille/catwalk{
@@ -30679,11 +30447,11 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/biodome_elevator/upper)
 "bTy" = (
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma)
 "bTz" = (
 /turf/unsimulated/floor/caution/east,
@@ -30773,7 +30541,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/biodome_elevator/upper)
 "bTN" = (
 /obj/grille/catwalk{
@@ -30781,7 +30549,7 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/shuttle/biodome_elevator/upper)
 "bTO" = (
 /obj/decal/tile_edge/line/black{
@@ -31132,7 +30900,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/mainhall)
 "bVl" = (
 /turf/unsimulated/wall/setpieces/leadwindow/gray{
@@ -31376,7 +31144,7 @@
 	opacity = 1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/kitchen)
 "bWi" = (
 /turf/unsimulated/floor/grey,
@@ -31552,7 +31320,7 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "bWW" = (
 /obj/machinery/door/airlock/pyro/command{
@@ -31560,7 +31328,7 @@
 	req_access_txt = "19"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/rd)
 "bWX" = (
 /obj/decal/fakeobjects/pipe/heat,
@@ -31626,10 +31394,10 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 10
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "bXj" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "bXl" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -31749,7 +31517,7 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/crypt/sigma/rd)
 "bXD" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/storage)
 "bXE" = (
 /obj/racing_boosterstrip{
@@ -32671,7 +32439,7 @@
 /area/syndicate_station/battlecruiser)
 "cat" = (
 /obj/machinery/door/airlock/pyro/maintenance,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cau" = (
 /obj/iomoon_puzzle/ancient_robot_door/meat{
@@ -32865,11 +32633,11 @@
 /turf/unsimulated/floor/setpieces/gauntlet,
 /area/gauntlet/staging)
 "caX" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "caY" = (
 /obj/item/clothing/under/gimmick/donk,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "caZ" = (
 /obj/iomoon_puzzle/meat_ganglion{
@@ -32972,7 +32740,7 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cbA" = (
 /obj/decal/fakeobjects/pipe{
@@ -32982,19 +32750,19 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cbB" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cbC" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 10
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cbD" = (
 /obj/table/auto,
@@ -33043,16 +32811,16 @@
 /area/crunch)
 "cbN" = (
 /obj/storage/closet/thunderdome/green,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cbO" = (
 /obj/landmark{
 	name = "tdome1"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cbP" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cbQ" = (
 /obj/table/auto,
@@ -33061,7 +32829,7 @@
 /obj/item/stimpack,
 /obj/item/stimpack,
 /obj/item/stimpack,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cbS" = (
 /turf/unsimulated/floor/stairs/dark{
@@ -33110,20 +32878,20 @@
 /obj/item/stimpack,
 /obj/item/stimpack,
 /obj/item/stimpack,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ccb" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ccc" = (
 /obj/landmark{
 	name = "tdome2"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ccd" = (
 /obj/storage/closet/thunderdome/red,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ccf" = (
 /obj/map/light/secretblue,
@@ -33158,7 +32926,7 @@
 	icon_state = "fdoor1";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cci" = (
 /obj/decal/fakeobjects/pipe{
@@ -33168,13 +32936,13 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ccj" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 9
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cck" = (
 /obj/decal/fakeobjects/pipe{
@@ -33184,7 +32952,7 @@
 	icon_state = "intact_off";
 	name = "pump"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ccl" = (
 /obj/item/device/audio_log/meatland_grody,
@@ -33203,7 +32971,7 @@
 /area/meat_derelict/guts)
 "ccn" = (
 /obj/critter/monster_door/floor,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cco" = (
 /obj/machinery/light/worn,
@@ -33267,7 +33035,7 @@
 	name = "TEAM ROOMS";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "ccy" = (
 /obj/machinery/door/poddoor{
@@ -33275,7 +33043,7 @@
 	id = "thunderdome";
 	name = "Thunderdome"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/bball)
 "ccz" = (
 /turf/unsimulated/floor{
@@ -33310,7 +33078,7 @@
 	name = "TEAM ROOMS";
 	pixel_y = 24
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ccF" = (
 /turf/unsimulated/floor/setpieces/gauntlet{
@@ -33323,7 +33091,7 @@
 	icon_state = "fdoor0"
 	},
 /obj/machinery/door/airlock/pyro/maintenance,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ccH" = (
 /obj/decal/fakeobjects/pipe{
@@ -33332,7 +33100,7 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ccI" = (
 /obj/item/device/audio_log/meatland_02,
@@ -33408,7 +33176,7 @@
 /area/crunch)
 "ccS" = (
 /obj/adventurepuzzle/triggerable/light/gauntlet,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "ccT" = (
 /turf/unsimulated/floor{
@@ -33465,13 +33233,13 @@
 	icon_state = "meter";
 	name = "meter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cdb" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cdc" = (
 /obj/table,
@@ -33598,7 +33366,7 @@
 /area/sim/bball)
 "cdz" = (
 /obj/adventurepuzzle/triggerable/light/gauntlet,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "cdA" = (
 /obj/overlay{
@@ -33630,7 +33398,7 @@
 /area/meat_derelict/entry)
 "cdD" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cdE" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -33647,7 +33415,7 @@
 	icon_state = "fdoor1";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cdF" = (
 /turf/unsimulated/floor/setpieces/bloodfloor,
@@ -33689,7 +33457,7 @@
 /area/meat_derelict/guts)
 "cdK" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cdL" = (
 /obj/machinery/door/airlock/pyro/medical{
@@ -33709,7 +33477,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cdN" = (
 /obj/table/auto,
@@ -33717,7 +33485,7 @@
 /obj/item/gun/kinetic/flaregun,
 /obj/item/sword,
 /obj/item/sword,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cdP" = (
 /obj/item/bballbasket{
@@ -33775,7 +33543,7 @@
 /obj/item/gun/kinetic/flaregun,
 /obj/item/sword,
 /obj/item/sword,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "cdZ" = (
 /obj/landmark{
@@ -33785,7 +33553,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "cea" = (
 /obj/decal/fakeobjects{
@@ -33838,13 +33606,13 @@
 	icon_state = "vent";
 	name = "rusted vent"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cef" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 5
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ceg" = (
 /obj/decal/fakeobjects/pipe{
@@ -33857,7 +33625,7 @@
 	icon_state = "meter";
 	name = "meter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ceh" = (
 /obj/table,
@@ -33870,13 +33638,13 @@
 /turf/unsimulated/wall/auto/adventure/meat,
 /area/meat_derelict/guts)
 "cej" = (
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cek" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 5
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cel" = (
 /obj/machinery/light/worn{
@@ -33939,7 +33707,7 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome1)
 "cex" = (
 /turf/unsimulated/floor{
@@ -33984,7 +33752,7 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdome2)
 "ceI" = (
 /obj/decal/fakeobjects/firealarm_broken{
@@ -33997,7 +33765,7 @@
 /area/meat_derelict/entry)
 "ceL" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "ceM" = (
 /turf/unsimulated/floor/plating/scorched,
@@ -34215,13 +33983,13 @@
 /area/meat_derelict/entry)
 "cfA" = (
 /obj/item/reagent_containers/food/drinks/water,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfB" = (
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfC" = (
 /obj/decal/fakeobjects{
@@ -34235,7 +34003,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfD" = (
 /obj/decal/fakeobjects{
@@ -34247,7 +34015,7 @@
 	name = "strange machine"
 	},
 /obj/decal/cleanable/cobweb2,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfE" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -34266,7 +34034,7 @@
 	icon_state = "fdoor1";
 	opacity = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "cfF" = (
 /obj/meatlight,
@@ -34368,7 +34136,7 @@
 	distress = 1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfW" = (
 /obj/landmark{
@@ -34388,7 +34156,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cfZ" = (
 /obj/decal/fakeobjects{
@@ -34400,7 +34168,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cga" = (
 /turf/unsimulated/wall/auto/adventure/meat,
@@ -34472,7 +34240,7 @@
 	name = "GREEN TEAM CHUTE"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdomea{
 	name = "Thunderdome Lounge"
 	})
@@ -34503,7 +34271,7 @@
 	pixel_y = 8
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdomea{
 	name = "Thunderdome Lounge"
 	})
@@ -34519,7 +34287,7 @@
 	name = "Thunderdome Intercom"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdomea{
 	name = "Thunderdome Lounge"
 	})
@@ -34543,7 +34311,7 @@
 	name = "RED TEAM CHUTE"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/sim/tdome/tdomea{
 	name = "Thunderdome Lounge"
 	})
@@ -34678,7 +34446,7 @@
 /area/shuttle/john/owlery)
 "cgH" = (
 /obj/item/device/light/flashlight,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cgI" = (
 /obj/machinery/door_control/oneshot{
@@ -34689,7 +34457,7 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "cgJ" = (
 /obj/decal/fakeobjects{
@@ -34859,7 +34627,7 @@
 	icon_state = "offbroken";
 	name = "broken computer"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "che" = (
 /obj/overlay{
@@ -34869,7 +34637,7 @@
 	icon_state = "lavamachine_10";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "chf" = (
 /obj/overlay{
@@ -34879,7 +34647,7 @@
 	icon_state = "lavamachine_11";
 	name = "huge machine"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "chg" = (
 /obj/meatlight{
@@ -35229,7 +34997,7 @@
 /area/meat_derelict/main)
 "cif" = (
 /obj/critter/monster_door/floor,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "cig" = (
 /obj/item/gun/gibgun,
@@ -35407,7 +35175,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "ciQ" = (
 /obj/decal/nothing{
@@ -35573,23 +35341,23 @@
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjk" = (
 /obj/decal/fakeobjects/pipe,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjl" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 6
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjm" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjn" = (
 /obj/decal/fakeobjects/pipe{
@@ -35599,23 +35367,23 @@
 	icon_state = "intact_off";
 	name = "filter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjo" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 10
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjp" = (
 /obj/decal/cleanable/blood{
 	icon_state = "floor6"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjq" = (
 /obj/critter/monster_door,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjr" = (
 /obj/iomoon_puzzle/meat_ganglion{
@@ -35794,11 +35562,11 @@
 /obj/decal/fakeobjects/pipe{
 	dir = 9
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjM" = (
 /obj/item/device/audio_log/meatland_01,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjN" = (
 /obj/decal/fakeobjects/pipe{
@@ -35811,7 +35579,7 @@
 	icon_state = "meter";
 	name = "meter"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "cjO" = (
 /obj/decal/fakeobjects{
@@ -36091,7 +35859,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "ckt" = (
 /obj/machinery/door/unpowered/wood{
@@ -36637,7 +36405,7 @@
 	icon_state = "small"
 	},
 /obj/grille/steel/broken,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/soviet)
 "clZ" = (
 /turf/unsimulated/wall/auto/adventure/meat/eyes,
@@ -38582,7 +38350,7 @@
 /area/crunch/wtc)
 "csJ" = (
 /obj/decal/fakeobjects/teleport_pad,
-/turf/unsimulated/floor/damaged4,
+/turf/unsimulated/floor/plating,
 /area/crunch/wtc)
 "csK" = (
 /turf/unsimulated/floor/plating,
@@ -38616,9 +38384,6 @@
 /obj/decal/floatingtiles,
 /obj/lattice,
 /turf/unsimulated/floor/void,
-/area/crunch/wtc)
-"csR" = (
-/turf/unsimulated/floor/damaged2,
 /area/crunch/wtc)
 "csS" = (
 /obj/decal/floatingtiles{
@@ -39498,7 +39263,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "cvu" = (
 /turf/unsimulated/wall/auto/adventure/iomoon,
@@ -45651,7 +45416,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "cLg" = (
 /obj/machinery/computer/security/wooden_tv{
@@ -45889,7 +45654,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "cLQ" = (
 /obj/storage/closet/dresser/random,
@@ -52521,7 +52286,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "dav" = (
 /obj/lattice{
@@ -54501,7 +54266,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "dfM" = (
 /obj/decal/fakeobjects{
@@ -54514,7 +54279,7 @@
 	name = "power conduit"
 	},
 /obj/critter/domestic_bee/trauma,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "dfN" = (
 /obj/decal/fakeobjects{
@@ -56552,9 +56317,7 @@
 	name = "rusty blastdoor";
 	tag = "icon-bdoorbroken (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "doL" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -56661,9 +56424,7 @@
 	dir = 10;
 	tag = "icon-intact (SOUTHWEST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dpE" = (
 /obj/decal/fakeobjects{
@@ -56708,18 +56469,14 @@
 	dir = 5;
 	tag = "icon-intact (NORTHEAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dpL" = (
 /obj/decal/fakeobjects/pipe{
 	dir = 4;
 	tag = "icon-intact-f (EAST)"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dpP" = (
 /obj/lattice{
@@ -57011,9 +56768,7 @@
 /area/shuttle/merchant_shuttle/right_centcom/destiny)
 "dsA" = (
 /obj/decal/cleanable/oil/streak,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dsZ" = (
 /obj/decal/fakeobjects/firelock_broken{
@@ -57023,9 +56778,7 @@
 	name = "rusted airlock"
 	},
 /obj/chaser/hospital_trigger,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dta" = (
 /turf/unsimulated/floor/carpet{
@@ -57174,15 +56927,11 @@
 	icon_state = "conduit";
 	name = "power conduit"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dtU" = (
 /obj/decal/cleanable/blood/tracks,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dtV" = (
 /turf/unsimulated/floor/shuttle{
@@ -57212,9 +56961,7 @@
 	pixel_y = 30;
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "dtY" = (
 /turf/unsimulated/floor/shuttle{
@@ -57433,9 +57180,7 @@
 	dir = 8;
 	icon = 'icons/turf/walls_hospital.dmi'
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "duM" = (
 /obj/decal/fakeobjects{
@@ -57451,9 +57196,7 @@
 /obj/decal/cleanable/blood/tracks{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "duO" = (
 /obj/decal/fakeobjects{
@@ -57470,9 +57213,7 @@
 	dir = 6
 	},
 /obj/decal/fakeobjects/lightbulb_broken,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "duP" = (
 /obj/decal/fakeobjects{
@@ -58874,7 +58615,7 @@
 	icon = 'icons/obj/doors/door_office.dmi';
 	lock_dir = 4
 	},
-/turf/unsimulated/floor/caution,
+/turf/unsimulated/floor/darkblue,
 /area/centcom/offices/simianc)
 "dzg" = (
 /obj/cabinet/restrictedmedical,
@@ -60736,9 +60477,7 @@
 /area/centcom/lounge)
 "dGR" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lounge)
 "dGS" = (
 /obj/stool/chair/red{
@@ -61900,9 +61639,7 @@
 /area/centcom/lounge)
 "dKk" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/garden)
 "dKl" = (
 /obj/table/round/auto,
@@ -62156,9 +61893,7 @@
 /area/centcom/garden)
 "dKL" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dKM" = (
 /obj/machinery/door/unpowered/wood,
@@ -62798,9 +62533,7 @@
 	dir = 5;
 	icon_state = "lattice-dir-b"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dMD" = (
 /obj/lattice{
@@ -62809,18 +62542,14 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dME" = (
 /obj/lattice{
 	dir = 9;
 	icon_state = "lattice-dir-b"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dMF" = (
 /obj/machinery/computer3/generic/secure_data{
@@ -62981,9 +62710,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dNb" = (
 /obj/machinery/communications_dish{
@@ -63004,9 +62731,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/small/floor/harsh,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dNd" = (
 /obj/machinery/power/data_terminal,
@@ -63172,18 +62897,14 @@
 	dir = 10;
 	icon_state = "lattice-dir-b"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dNw" = (
 /obj/lattice{
 	dir = 6;
 	icon_state = "lattice-dir-b"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/lobby)
 "dNx" = (
 /obj/machinery/computer3/generic/med_data{
@@ -65132,7 +64853,7 @@
 	opacity = 1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/lab)
 "dTJ" = (
 /obj/decal/cleanable/paper,
@@ -65451,9 +65172,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "egw" = (
 /obj/tree,
@@ -66242,7 +65961,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "fqx" = (
 /obj/railing/yellow/reinforced{
@@ -66454,7 +66173,7 @@
 	icon = 'icons/obj/doors/door_office.dmi';
 	lock_dir = 8
 	},
-/turf/unsimulated/floor/caution,
+/turf/unsimulated/floor/wood/two,
 /area/centcom/offices/studenterhue)
 "fKc" = (
 /obj/indestructible/shuttle_corner{
@@ -67000,11 +66719,7 @@
 	name = "broken door";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "gyt" = (
 /obj/tree{
@@ -67220,6 +66935,10 @@
 /obj/railing/velvet,
 /turf/unsimulated/floor/marble/black,
 /area/centcom/gallery)
+"gSq" = (
+/obj/map/light/lava,
+/turf/unsimulated/floor/plating,
+/area/iomoon)
 "gTb" = (
 /obj/item/cigbutt{
 	pixel_x = 9;
@@ -67404,7 +67123,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 5
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "hgZ" = (
 /obj/grille/catwalk{
@@ -67636,7 +67355,7 @@
 /obj/machinery/light/small/iomoon{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "hyC" = (
 /obj/effects/precipitation/rain/dense/tile,
@@ -67648,7 +67367,7 @@
 /obj/machinery/door/airlock/pyro{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "hzM" = (
 /obj/tree,
@@ -67895,9 +67614,7 @@
 	name = "Compartment Access";
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "hSE" = (
 /turf/unsimulated/floor/logo_xg{
@@ -68023,7 +67740,7 @@
 /obj/rack,
 /obj/item/crowbar,
 /obj/item/weldingtool,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "ihk" = (
 /obj/table/reinforced/auto,
@@ -68500,7 +68217,7 @@
 	id = "meatstation_wrath";
 	name = "Safety Interlock"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "iMA" = (
 /obj/wingrille_spawn/auto,
@@ -68718,7 +68435,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "jaC" = (
 /obj/tree,
@@ -69239,6 +68956,9 @@
 	icon_state = "fpurple2"
 	},
 /area/centcom/lounge)
+"jUU" = (
+/turf/unsimulated/floor/plating,
+/area/centcom/outside)
 "jUW" = (
 /obj/decal/fakeobjects/firelock_broken{
 	desc = "This blast door looks rusted over.  Junk.";
@@ -69870,7 +69590,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "lcu" = (
 /obj/indestructible/shuttle_corner{
@@ -69934,7 +69654,7 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/railing/yellow/reinforced,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "lfQ" = (
 /obj/decal/cleanable/sakura,
@@ -70033,7 +69753,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "loK" = (
 /obj/effects/precipitation/rain/dense/tile,
@@ -70448,7 +70168,7 @@
 	info = "kinda smells like tacos back here.<br><br>wish i knew how to get out though.";
 	name = "Paper"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "lPG" = (
 /obj/map/light/lava,
@@ -70578,7 +70298,7 @@
 	req_access_txt = "33"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/mainhall)
 "lZf" = (
 /turf/unsimulated/floor/carpet{
@@ -70672,9 +70392,7 @@
 	icon_state = "air_gizmo";
 	name = "industrial atmospheric processor"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "miu" = (
 /mob/living/critter/crunched,
@@ -71058,9 +70776,7 @@
 	desc = "So, it was you!";
 	name = "source of all of those really atmospheric webs around"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "mJF" = (
 /turf/unsimulated/wall/auto/lead/blue,
@@ -71313,7 +71029,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "ndE" = (
 /obj/lattice{
@@ -71408,7 +71124,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "nhM" = (
 /obj/indestructible/shuttle_corner{
@@ -72468,7 +72184,7 @@
 	name = "utility sink";
 	pixel_y = 16
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "oHu" = (
 /obj/cable{
@@ -72780,7 +72496,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "pbV" = (
 /turf/unsimulated/wall/generic{
@@ -73295,11 +73011,7 @@
 	name = "airlock";
 	opacity = 1
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon)
 "pJw" = (
 /obj/machinery/shuttle/engine/heater{
@@ -73626,7 +73338,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "qcH" = (
 /obj/table/reinforced/auto,
@@ -74197,11 +73909,7 @@
 	dir = 4;
 	name = "Maintenance Hub"
 	},
-/turf/unsimulated/floor{
-	carbon_dioxide = 16;
-	name = "warm plating";
-	temperature = 313.15
-	},
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "raS" = (
 /obj/stool/chair/comfy,
@@ -74453,7 +74161,7 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "rqw" = (
 /obj/pedestal,
@@ -74734,7 +74442,7 @@
 	},
 /obj/random_item_spawner/organs/bloody/one_to_three,
 /obj/random_item_spawner/organs/bloody/one_to_three,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "rHr" = (
 /turf/unsimulated/wall/auto/lead/gray,
@@ -75010,7 +74718,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "sbi" = (
 /obj/decal/fakeobjects{
@@ -75063,9 +74771,7 @@
 	dir = 4;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "scU" = (
 /obj/admin_plaque{
@@ -75655,9 +75361,7 @@
 /area/drone/office)
 "tij" = (
 /obj/wingrille_spawn/auto,
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/centcom/offices{
 	icon_state = "blue"
 	})
@@ -75838,10 +75542,6 @@
 	dir = 8
 	},
 /area/iomoon/base)
-"two" = (
-/obj/lattice,
-/turf/space,
-/area/void_diner)
 "txc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -75919,7 +75619,7 @@
 /obj/railing/yellow/reinforced{
 	dir = 4
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "tED" = (
 /obj/stool/bee_bed,
@@ -75987,9 +75687,7 @@
 	icon_state = "air_gizmo";
 	name = "industrial atmospheric processor"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
+/turf/unsimulated/floor/plating,
 /area/hospital)
 "tKt" = (
 /turf/unsimulated/outdoors/grass,
@@ -76755,7 +76453,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "uQv" = (
 /obj/tree/sakura_tree/tree_2,
@@ -76772,7 +76470,7 @@
 	id = "ddan"
 	},
 /obj/item/shipcomponent/engine/hermes,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/office)
 "uTj" = (
 /obj/table/nanotrasen/auto,
@@ -76790,7 +76488,7 @@
 	req_access_txt = "33"
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "uVv" = (
 /turf/simulated/wall/auto/reinforced/old,
@@ -76821,7 +76519,7 @@
 	icon_state = "intact_off";
 	name = "pump"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "vab" = (
 /turf/unsimulated/floor/dream/beach{
@@ -76849,7 +76547,7 @@
 "vdq" = (
 /obj/decal/fakeobjects/firelock_broken,
 /obj/machinery/door/airlock/pyro/maintenance,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "vdu" = (
 /obj/lattice{
@@ -77276,7 +76974,7 @@
 /obj/machinery/light/small/iomoon{
 	dir = 1
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "vGO" = (
 /mob/living/critter/crunched,
@@ -77589,7 +77287,7 @@
 	layer = 1.9;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "wky" = (
 /obj/decal/fakeobjects{
@@ -78093,7 +77791,7 @@
 	opacity = 1
 	},
 /obj/decal/stripe_delivery,
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/crypt/sigma/lab)
 "wUl" = (
 /obj/decal/fakeobjects{
@@ -78112,7 +77810,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "wVp" = (
 /obj/machinery/door/unpowered/wood{
@@ -78393,7 +78091,7 @@
 /obj/machinery/conveyor/EW{
 	id = "ddan"
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/drone/office)
 "xsc" = (
 /obj/decal/tile_edge/flowers{
@@ -78644,7 +78342,7 @@
 /obj/railing/yellow/reinforced{
 	dir = 8
 	},
-/turf/unsimulated/floor,
+/turf/unsimulated/floor/plating,
 /area/iomoon/base)
 "xIj" = (
 /obj/item/currency/spacecash/tourist,
@@ -80456,7 +80154,7 @@ boW
 boW
 boW
 boW
-boW
+gSq
 boW
 boH
 aaa
@@ -87982,9 +87680,9 @@ izT
 izT
 btl
 btL
-btM
-btM
-btM
+bsn
+bsn
+bsn
 bvO
 bxq
 diC
@@ -89509,7 +89207,7 @@ sBL
 izT
 vGE
 bEo
-btM
+bsn
 izT
 bsX
 bqP
@@ -89811,7 +89509,7 @@ buK
 vdq
 jbK
 bEp
-btM
+bsn
 izT
 bsX
 bqq
@@ -90113,7 +89811,7 @@ izT
 izT
 izT
 bEp
-btM
+bsn
 izT
 bsX
 bpD
@@ -90415,7 +90113,7 @@ byO
 bDv
 izT
 bEp
-btM
+bsn
 izT
 izT
 bpD
@@ -90700,8 +90398,8 @@ bpD
 izT
 izT
 oHh
-btM
-btM
+bsn
+bsn
 izT
 izT
 mLm
@@ -90717,7 +90415,7 @@ bwv
 buK
 izT
 bEp
-btM
+bsn
 izT
 bsX
 bpD
@@ -91001,8 +90699,8 @@ bpE
 bpE
 bsY
 buq
-btM
-btM
+bsn
+bsn
 izT
 izT
 bvS
@@ -91019,7 +90717,7 @@ bCP
 lrK
 izT
 bEq
-btM
+bsn
 izT
 bCJ
 bpE
@@ -91623,9 +91321,9 @@ bCR
 bDx
 bDX
 izT
-btM
-btM
-btM
+bsn
+bsn
+bsn
 bxq
 boV
 boW
@@ -91925,8 +91623,8 @@ bCS
 bDy
 bDY
 bxq
-btM
-btM
+bsn
+bsn
 bFu
 izT
 boV
@@ -92227,9 +91925,9 @@ bCR
 bDx
 bDX
 izT
-btM
-btM
-btM
+bsn
+bsn
+bsn
 bxq
 boV
 boW
@@ -92831,7 +92529,7 @@ bCU
 bxj
 izT
 bEq
-btM
+bsn
 izT
 bFv
 bpR
@@ -93133,7 +92831,7 @@ bCV
 bDz
 izT
 bEp
-btM
+bsn
 izT
 bsX
 bpD
@@ -93435,7 +93133,7 @@ izT
 izT
 izT
 bEp
-btM
+bsn
 izT
 wXY
 bpD
@@ -93737,7 +93435,7 @@ tvS
 izT
 hyt
 bEp
-btM
+bsn
 izT
 bsX
 bpD
@@ -94039,7 +93737,7 @@ buK
 bzp
 jbK
 bEp
-btM
+bsn
 izT
 bsX
 abo
@@ -94117,7 +93815,7 @@ css
 csn
 csC
 csJ
-csR
+csK
 csZ
 bKw
 bKw
@@ -94341,7 +94039,7 @@ izT
 izT
 izT
 bEp
-btM
+bsn
 izT
 bsX
 boH
@@ -94944,8 +94642,8 @@ bCi
 bCX
 bDB
 izT
-btM
-btM
+bsn
+bsn
 izT
 izT
 boH
@@ -95247,7 +94945,7 @@ bAa
 bDC
 izT
 bEr
-btM
+bsn
 izT
 boH
 boH
@@ -95548,8 +95246,8 @@ bAa
 bCY
 bDD
 izT
-btM
-btM
+bsn
+bsn
 izT
 boH
 boH
@@ -95850,8 +95548,8 @@ bAa
 bCZ
 bDE
 izT
-btM
-btM
+bsn
+bsn
 izT
 boH
 boH
@@ -96152,8 +95850,8 @@ bAa
 bDa
 bDF
 izT
-btM
-btM
+bsn
+bsn
 izT
 boH
 boH
@@ -96454,8 +96152,8 @@ bAa
 bAa
 bDG
 izT
-btM
-btM
+bsn
+bsn
 izT
 izT
 boH
@@ -96757,7 +96455,7 @@ bDb
 bDH
 izT
 bEs
-btM
+bsn
 izT
 boH
 boH
@@ -97058,8 +96756,8 @@ bAa
 bDc
 bDI
 izT
-btM
-btM
+bsn
+bsn
 izT
 boH
 boH
@@ -97360,8 +97058,8 @@ nqU
 bAa
 bDJ
 izT
-btM
-btM
+bsn
+bsn
 izT
 boH
 boH
@@ -97958,13 +97656,13 @@ diC
 wOp
 xLa
 jbK
-btM
-btM
+bsn
+bsn
 bCj
-btM
-btM
-btM
-btM
+bsn
+bsn
+bsn
+bsn
 btq
 izT
 aaR
@@ -98259,14 +97957,14 @@ izT
 diC
 wOp
 izT
-btM
-btM
-btM
-btM
-btM
-btM
-btM
-btM
+bsn
+bsn
+bsn
+bsn
+bsn
+bsn
+bsn
+bsn
 izT
 izT
 bpD
@@ -103681,7 +103379,7 @@ boW
 boW
 bqw
 izT
-bso
+btK
 izT
 izT
 izT
@@ -103983,7 +103681,7 @@ boV
 boV
 bqw
 izT
-bsp
+bvO
 bsJ
 bta
 bts
@@ -104285,7 +103983,7 @@ boV
 boV
 bqw
 izT
-bsp
+bvO
 bsK
 bsK
 btt
@@ -104587,10 +104285,10 @@ boV
 boV
 bqw
 izT
-bsq
-bsq
-bsq
-bsq
+btq
+btq
+btq
+btq
 izT
 byg
 bpD
@@ -118388,7 +118086,7 @@ uVv
 uVv
 uVv
 uVv
-two
+glz
 uVv
 tKt
 uVv
@@ -121362,7 +121060,7 @@ adQ
 aeX
 ajm
 aoq
-awR
+afb
 awQ
 aoq
 ajm
@@ -148860,7 +148558,7 @@ dnY
 dnY
 dFN
 wLo
-aES
+jUU
 aES
 aES
 wLo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the unneeded second definition of /turf/unsimulated/floor which was setting an incorrect sprite.
Fixes plating/floor discrepancies that comes from this change on z2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Confusing bug which caused thousands of varedited floor turfs to change the icon back to floor


