### PR TITLE
adds a kitchen dispenser to cogmap1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5642,13 +5642,11 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "aso" = (
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
+/obj/machinery/chem_dispenser/chef,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "xtra_bigstripe-edge2";
+	dir = 1
 	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "asp" = (
@@ -56331,6 +56329,20 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
+"okH" = (
+/obj/storage/cart/hotdog{
+	req_access_txt = "28"
+	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "okK" = (
 /obj/disposalpipe/switch_junction{
 	dir = 1;
@@ -119507,7 +119519,7 @@ aie
 amj
 qVo
 aox
-apJ
+okH
 aqW
 asu
 qDG


### PR DESCRIPTION
[MAPPING] [CATERING]
## About the PR
Moves the hotdog cart to the back rooms of the kitchen, and puts a kitchen dispenser in its place. Carts can be moved around so anyone terribly upset by the cart moving can just move it back into the kitchen I guess. Also put a hazard stripe on the floor around the dispenser because it looked odd by itself.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cog1 didn't have one before. How were chefs meant to decorate cakes?
## Changelog
```changelog
(u)Tyrant
(*)Added a kitchen dispenser to cogmap1. It's in the spot where hot dog carts used to be.
(+)The hotdog cart in cogmap1 has been moved to the back rooms.
```