### PR TITLE
Add AI Intercom [144.7] Access in AI Shells

### DIFF
--- a/_std/defines/radio.dm
+++ b/_std/defines/radio.dm
@@ -22,6 +22,7 @@
 #define RADIOCL_RESEARCH "rresearch"
 #define RADIOCL_CIVILIAN "rcivilian"
 #define RADIOCL_SYNDICATE "rsyndicate"
+#define RADIOCL_INTERCOM_AI "rintercomai"
 #define RADIOCL_OTHER "rother"
 
 // Frequency defines for headsets & intercoms (Convair880).

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -383,6 +383,7 @@ h1.alert, h2.alert {color: #000000;}
 .rresearch {color: #461B7E;}
 .rcivilian {color: #A10082;}
 .rsyndicate {color: #962121;}
+.rintercomai {color: #39397d}
 .rother {color: #800080;}
 
 .connectionClosed, .fatalError {background: red; color: white; padding: 5px;}
@@ -548,6 +549,7 @@ body.theme-dark .rmedical {color: #00bbff;}
 body.theme-dark .rresearch {color: #bf83e2;}
 body.theme-dark .rcivilian {color: #ce45b2;}
 body.theme-dark .rsyndicate {color: #cf5757;}
+body.theme-dark .rintercomai {color: #7F7FE2}
 body.theme-dark .rother {color: #E896E5;}
 
 body.theme-dark .help {

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -89,6 +89,7 @@
 		"r" = R_FREQ_RESEARCH,
 		"m" = R_FREQ_MEDICAL,
 		"c" = R_FREQ_CIVILIAN,
+		"a" = R_FREQ_INTERCOM_AI,
 		)
 	secure_classes = list(
 		"h" = RADIOCL_COMMAND,
@@ -97,6 +98,7 @@
 		"r" = RADIOCL_RESEARCH,
 		"m" = RADIOCL_MEDICAL,
 		"c" = RADIOCL_CIVILIAN,
+		"a" = RADIOCL_INTERCOM_AI,
 		)
 	icon_override = "ai"
 	icon_tooltip = "Artificial Intelligence"


### PR DESCRIPTION
Add AI Intercom [144.7] Access in AI Shells
	modified:   browserassets/css/browserOutput.css
	modified:   code/obj/item/device/radios/headsets.dm

[A-Silicons] [C-QoL] [size/XS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds access to the 144.7 frequency for the AI headset item, which is equipped to eyebots and borg shells controlled by the AI. It also adds a radio color for light mode that improves readability!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The AI intercom was made expressly to communicate with the AI, but if they're in the shell there's no way for the AI to know activity's happening in that channel. This fixes that by giving the AI constant access to the channel both in and out of the shell.
