### PR TITLE
Salvager use secure frequency

### DIFF
--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -30,14 +30,16 @@
 			H.equip_if_possible(headset, H.slot_ears)
 		else
 			headset.protected_radio = TRUE
-		headset.frequency = src.pick_radio_freq()
-		H.mind.store_memory("<b>Salvager Radio frequency:</b> [headset.frequency]")
+
+		//headset.frequency = src.pick_radio_freq()
+		//H.mind.store_memory("<b>Salvager Radio frequency:</b> [headset.frequency]")
+
 		// Allow for Salvagers to have a secure channel
-		//headset.secure_frequencies = list("z" = R_FREQ_SYNDICATE)
-		//headset.secure_classes = list(RADIOCL_OTHER)
-		//headset.secure_colors = list("#a18146")
-		//headset.set_secure_frequency("z", src.pick_radio_freq())
-		//headset.desc += " The headset is covered in scratch marks and the screws look nearly stripped."
+		headset.secure_frequencies = list("z" = src.pick_radio_freq())
+		headset.secure_classes = list(RADIOCL_OTHER)
+		headset.secure_colors = list("#a18146")
+		headset.set_secure_frequency("z", src.pick_radio_freq())
+		headset.desc += " The headset is covered in scratch marks and the screws look nearly stripped."
 
 		H.equip_if_possible(new /obj/item/clothing/under/color/grey(H), H.slot_w_uniform)
 		H.equip_if_possible(new /obj/item/storage/backpack/salvager(H), H.slot_back)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the randomized channel to a secure channel.  This will provide a color distinction as well as a quick access to that channel.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Time to try out a requested feature.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Azrun
(+)Salvagers investigate securing their comm channels...
```
