### PR TITLE
Deprecates /datum/admins/proc/evilize()

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2420,31 +2420,49 @@ var/global/noir = 0
 								tgui_alert(usr,"The game hasn't started yet!")
 								return
 
-							var/which_traitor = input("What kind of traitor?","Everyone's a Traitor") as null|anything in list(ROLE_TRAITOR,ROLE_WIZARD,ROLE_CHANGELING,ROLE_WEREWOLF,ROLE_VAMPIRE,ROLE_ARCFIEND,ROLE_HUNTER,ROLE_WRESTLER,ROLE_GRINCH,ROLE_OMNITRAITOR)
-							if(!which_traitor)
+							var/list/antag_options = list()
+							var/list/eligible_antagonist_types = concrete_typesof(/datum/antagonist) - (concrete_typesof(/datum/antagonist/subordinate) + concrete_typesof(/datum/antagonist/generic))
+							for (var/V as anything in eligible_antagonist_types)
+								var/datum/antagonist/A = V
+								antag_options[initial(A.display_name)] = initial(A.id)
+
+							var/selected_keyvalue = tgui_input_list(usr, "Choose an antagonist role to assign to everyone.", "Everyone's a Traitor", antag_options)
+							if (!selected_keyvalue)
 								return
-							var/hardmode = null
-							if (which_traitor == ROLE_TRAITOR)
-								if (tgui_alert(usr,"Hard Mode?","Everyone's a Traitor",list("Yes", "No")) == "Yes")
-									hardmode = "hardmode"
-							var/custom_objective = input("What should the objective be?","Everyone's a Traitor") as null|text
+
+							var/antagonist_role_id = antag_options[selected_keyvalue]
+
+							var/equip_traitor = TRUE
+							if (antagonist_role_id == ROLE_TRAITOR)
+								if (tgui_alert(usr, "Hard Mode?", "Everyone's a Traitor", list("Yes", "No")) == "Yes")
+									equip_traitor = FALSE
+
+							var/custom_objective = tgui_input_text(usr, "What should the objective be?", "Everyone's a Traitor")
 							if (!custom_objective)
 								return
-							var/escape_objective = input("Which escaping objective?") as null|anything in typesof(/datum/objective/escape/) + "None"
+							var/escape_objective = tgui_input_list(usr, "Which escaping objective?", "Everyone's a Traitor", typesof(/datum/objective/escape/) + "None")
 							if (!escape_objective)
 								return
 
 							if (escape_objective == "None")
 								escape_objective = null
 
-							for(var/mob/living/carbon/human/H in mobs)
-								if(isdead(H) || !(H.client)) continue
-								if(checktraitor(H)) continue
-								evilize(H, which_traitor, hardmode, custom_objective, escape_objective)
+							for (var/mob/living/carbon/human/H in mobs)
+								if (isdead(H) || !H.mind || !H.client)
+									continue
 
-							message_admins("<span class='internal'>[key_name(usr)] made everyone a[hardmode ? " hard-mode" : ""] [which_traitor]. Objective is [custom_objective]</span>")
-							logTheThing(LOG_ADMIN, usr, "made everyone a[hardmode ? " hard-mode" : ""] [which_traitor]. Objective is [custom_objective]")
-							logTheThing(LOG_DIARY, usr, "made everyone a[hardmode ? " hard-mode" : ""] [which_traitor]. Objective is [custom_objective]", "admin")
+								H.mind.add_antagonist(antagonist_role_id, do_equip = equip_traitor, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN, respect_mutual_exclusives = FALSE)
+								var/datum/antagonist/antagonist_role = H.mind.get_antagonist(antagonist_role_id)
+								if (istext(custom_objective))
+									new /datum/objective(custom_objective, antagonist_role.owner, antagonist_role)
+								if (ispath(escape_objective))
+									new escape_objective(null, antagonist_role.owner, antagonist_role)
+								antagonist_role.announce_objectives()
+
+							message_admins("<span class='internal'>[key_name(usr)] made everyone a[equip_traitor ? "" : " hard-mode"] [antagonist_role_id]. Objective is [custom_objective]</span>")
+							logTheThing(LOG_ADMIN, usr, "made everyone a[equip_traitor ? "" : " hard-mode"] [antagonist_role_id]. Objective is [custom_objective]")
+							logTheThing(LOG_DIARY, usr, "made everyone a[equip_traitor ? "" : " hard-mode"] [antagonist_role_id]. Objective is [custom_objective]", "admin")
+
 						else
 							tgui_alert(usr,"You're not of a high enough rank to do this")
 					if("flicklights")
@@ -4106,168 +4124,6 @@ var/global/noir = 0
 		return 1
 
 	return 0
-
-/datum/admins/proc/evilize(mob/M as mob, var/traitor_type, var/special = null, var/mass_traitor_obj = null, var/mass_traitor_esc = null, do_objectives = TRUE)
-	if (!M || !traitor_type)
-		boutput(usr, "<span class='alert'>No mob or traitor type specified.</span>")
-		return
-	if (!src.level >= LEVEL_SA)
-		boutput(usr, "<span class='alert'>You need to be a Secondary Administrator or above to use this command.</span>")
-		return
-	if(isdead(M) || isobserver(M))
-		boutput(usr, "<span class='alert'>You cannot make someone who is dead an antagonist.</span>")
-		return
-	if (istype(M,/mob/new_player/))
-		boutput(usr, "<span class='alert'>You cannot make someone who has not entered the game an antagonist.</span>")
-		return
-	if (!M.client)
-		boutput(usr, "<span class='alert'>You cannot make someone who is logged out an antagonist.</span>")
-		return
-	if(checktraitor(M))
-		boutput(usr, "<span class='alert'>That person is already an antagonist.</span>")
-		return
-	if(!(ticker?.mode && istype(ticker.mode, /datum/game_mode/gang)) && traitor_type == ROLE_GANG_LEADER)
-		boutput(usr, "<span class='alert'>Gang Leaders are currently restricted to gang mode only.</span>")
-		return
-
-	traitor_type = lowertext(traitor_type)
-	special = lowertext(special)
-
-	if (do_objectives)
-		if(mass_traitor_obj)
-			new /datum/objective(mass_traitor_obj, M.mind)
-
-			if(mass_traitor_esc)
-				new mass_traitor_esc(null, M.mind)
-		else
-			var/list/eligible_objectives = list()
-			if (ishuman(M) || ismobcritter(M))
-				eligible_objectives = typesof(/datum/objective/regular/) + typesof(/datum/objective/escape/)
-			else if (issilicon(M))
-				eligible_objectives = list(/datum/objective/regular,/datum/objective/regular/assassinate,
-				/datum/objective/regular/force_evac_time,/datum/objective/regular/gimmick,/datum/objective/escape,/datum/objective/escape/hijack,
-				/datum/objective/escape/survive,/datum/objective/escape/kamikaze)
-				/*if (isrobot(M))
-					eligible_objectives += /datum/objective/regular/borgdeath*/
-				traitor_type = ROLE_TRAITOR
-			switch(traitor_type)
-				if (ROLE_CHANGELING)
-					eligible_objectives += /datum/objective/specialist/absorb
-				if (ROLE_WEREWOLF)
-					eligible_objectives += /datum/objective/specialist/werewolf/feed
-				if (ROLE_VAMPIRE)
-					eligible_objectives += /datum/objective/specialist/drinkblood
-				if (ROLE_HUNTER)
-					eligible_objectives += /datum/objective/specialist/hunter/trophy
-				if (ROLE_GRINCH)
-					eligible_objectives += /datum/objective/specialist/ruin_xmas
-				if (ROLE_GANG_LEADER)
-					eligible_objectives += /datum/objective/specialist/gang
-			var/done = 0
-			var/select_objective = null
-			var/custom_text = "Go hog wild!"
-			while (done != 1)
-				select_objective = input(usr, "Add a new objective. Hit cancel when finished adding.", "Traitor Objectives") as null|anything in eligible_objectives
-				if (!select_objective)
-					done = 1
-					break
-				if (select_objective == /datum/objective/regular)
-					custom_text = input(usr,"Enter custom objective text.","Traitor Objectives","Go hog wild!") as null|text
-					if (custom_text)
-						new select_objective(custom_text, M.mind)
-					else
-						boutput(usr, "<span class='alert'>No text was entered. Objective not given.</span>")
-				else
-					new select_objective(null, M.mind)
-
-			if (M.mind.objectives.len < 1)
-				boutput(usr, "<span class='alert'>Not enough objectives specified.</span>")
-				return
-
-	if (isAI(M))
-		var/mob/living/silicon/ai/A = M
-		A.syndicate = 1
-		A.syndicate_possible = 1
-		A.make_syndicate("admin")
-	else if (isrobot(M))
-		var/mob/living/silicon/robot/R = M
-		if (R.dependent)
-			boutput(usr, "<span class='alert'>You can't evilize AI-controlled shells.</span>")
-			return
-		R.syndicate = 1
-		R.syndicate_possible = 1
-		R.make_syndicate("admin")
-	else if (ishuman(M) || ismobcritter(M))
-		switch(traitor_type)
-			if(ROLE_TRAITOR)
-				M.show_text("<h2><font color=red><B>You have defected and become a traitor!</B></font></h2>", "red")
-				if(special != "hardmode")
-					M.mind.special_role = ROLE_TRAITOR
-					M.verbs += /client/proc/gearspawn_traitor
-					M.show_antag_popup("traitorradio")
-				else
-					M.mind.special_role = ROLE_HARDMODE_TRAITOR
-					M.show_antag_popup("traitorhard")
-			if(ROLE_CHANGELING)
-				M.show_text("<h2><font color=red><B>You have mutated into a changeling!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_CHANGELING, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_WIZARD)
-				M.show_text("<h2><font color=red><B>You have been seduced by magic and become a wizard!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_WIZARD, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_VAMPIRE)
-				M.show_text("<h2><font color=red><B>You have joined the ranks of the undead and are now a vampire!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_VAMPIRE, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_HUNTER)
-				M.show_text("<h2><font color=red><B>You have become a hunter!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_HUNTER, do_equip = FALSE, do_relocate = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_WRESTLER)
-				M.show_text("<h2><font color=red><B>You feel an urgent need to wrestle!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_WRESTLER, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_WEREWOLF)
-				M.show_text("<h2><font color=red><B>You have become a werewolf!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_WEREWOLF, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_GRINCH)
-				M.show_text("<h2><font color=red><B>You have become a grinch!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_GRINCH, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_FLOOR_GOBLIN)
-				M.show_text("<h2><font color=red><B>You have become a floor goblin!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_FLOOR_GOBLIN, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_ARCFIEND)
-				M.show_text("<h2><font color=red><B>You feel starved for power!</B></font></h2>", "red")
-				M.mind.add_antagonist(ROLE_ARCFIEND, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_GANG_LEADER)
-				M.mind.add_antagonist(ROLE_GANG_LEADER, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_OMNITRAITOR)
-				M.mind.add_antagonist(ROLE_OMNITRAITOR, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_SPY_THIEF)
-				if (M.stat || !isliving(M) || isintangible(M) || !ishuman(M) || !M.mind)
-					return
-				M.show_text("<h1><font color=red><B>You have defected to become a Spy Thief!</B></font></h1>", "red")
-				M.mind.add_antagonist(ROLE_SPY_THIEF, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_NUKEOP)
-				M.show_text("<h1><font color=red><B>You have been chosen as a Nuclear Operative! And you have accepted! Because you would be silly not to!</B></font></h1>", "red")
-				M.mind.add_antagonist(ROLE_NUKEOP, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
-			if(ROLE_NUKEOP_COMMANDER)
-				M.show_text("<h1><font color=red><B>You have been chosen as a Nuclear Operative Commander! And you have accepted! Because you would be silly not to!</B></font></h1>", "red")
-				M.mind.add_antagonist(ROLE_NUKEOP_COMMANDER, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN)
-
-	else
-		M.show_text("<h2><font color=red><B>You have become evil and are now an antagonist!</B></font></h2>", "red")
-
-	if (!(M.mind in ticker.mode.Agimmicks))
-		ticker.mode.Agimmicks += M.mind
-
-	var/obj_count = 1
-	for(var/datum/objective/OBJ in M.mind.objectives)
-		boutput(M, "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]")
-		obj_count++
-
-	//to stop spamming during traitor all secret
-	if(!mass_traitor_obj)
-		logTheThing(LOG_ADMIN, usr, "made [constructTarget(M,"admin")] a[special ? " [special]" : ""] [traitor_type].")
-		logTheThing(LOG_DIARY, usr, "made [constructTarget(M,"diary")] a[special ? " [special]" : ""] [traitor_type].", "admin")
-		message_admins("<span class='internal'>[key_name(usr)] has made [key_name(M)] a[special ? " [special]" : ""] [traitor_type].</span>")
-	return
 
 /proc/get_matches_string(var/text, var/list/possibles)
 	var/list/matches = new()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2426,7 +2426,7 @@ var/global/noir = 0
 								var/datum/antagonist/A = V
 								antag_options[initial(A.display_name)] = initial(A.id)
 
-							var/selected_keyvalue = tgui_input_list(usr, "Choose an antagonist role to assign to everyone.", "Everyone's a Traitor", antag_options)
+							var/selected_keyvalue = tgui_input_list(usr, "Choose an antagonist role to assign to everyone.", "Make Everyone An Antagonist", antag_options)
 							if (!selected_keyvalue)
 								return
 
@@ -2434,13 +2434,13 @@ var/global/noir = 0
 
 							var/equip_traitor = TRUE
 							if (antagonist_role_id == ROLE_TRAITOR)
-								if (tgui_alert(usr, "Hard Mode?", "Everyone's a Traitor", list("Yes", "No")) == "Yes")
+								if (tgui_alert(usr, "Hard Mode?", "Make Everyone An Antagonist", list("Yes", "No")) == "Yes")
 									equip_traitor = FALSE
 
-							var/custom_objective = tgui_input_text(usr, "What should the objective be?", "Everyone's a Traitor")
+							var/custom_objective = tgui_input_text(usr, "What should their objective be?", "Make Everyone An Antagonist")
 							if (!custom_objective)
 								return
-							var/escape_objective = tgui_input_list(usr, "Which escaping objective?", "Everyone's a Traitor", typesof(/datum/objective/escape/) + "None")
+							var/escape_objective = tgui_input_list(usr, "What should their escape objective be?", "Make Everyone An Antagonist", typesof(/datum/objective/escape/) + "None")
 							if (!escape_objective)
 								return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2448,7 +2448,7 @@ var/global/noir = 0
 								escape_objective = null
 
 							for (var/mob/living/carbon/human/H in mobs)
-								if (isdead(H) || !H.mind || !H.client)
+								if (isdead(H) || !H.mind || !H.key)
 									continue
 
 								H.mind.add_antagonist(antagonist_role_id, do_equip = equip_traitor, do_objectives = FALSE, source = ANTAGONIST_SOURCE_ADMIN, respect_mutual_exclusives = FALSE)

--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -27,9 +27,7 @@
 
 	proc/makeAntag(mob/M as mob)
 		M.show_text("<h2><font color=red><B>You have defected and become a traitor!</B></font></h2>", "red")
-		M.mind.special_role = ROLE_TRAITOR
-		M.verbs += /client/proc/gearspawn_traitor
-		M.show_antag_popup("traitorradio")
+		M.mind.add_antagonist(ROLE_TRAITOR)
 
 /obj/traitorifier/wizard
 	name = "Eldritch Altar"

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -1,30 +1,3 @@
-/client/proc/gearspawn_traitor()
-	set category = "Commands"
-	set name = "Call Syndicate"
-	set desc="Teleports useful items to your location."
-
-	if (usr.stat || !isliving(usr) || isintangible(usr))
-		usr.show_text("You can't use this command right now.", "red")
-		return
-
-	var/uplink_path = get_uplink_type(usr, /obj/item/uplink/syndicate)
-	var/obj/item/uplink/syndicate/U = new uplink_path(usr.loc)
-	if (!usr.put_in_hand(U))
-		U.set_loc(get_turf(usr))
-		usr.show_text("<h3>Uplink spawned. You can find it on the floor at your current location.</h3>", "blue")
-	else
-		usr.show_text("<h3>Uplink spawned. You can find it in your active hand.</h3>", "blue")
-
-	if (usr.mind && istype(usr.mind))
-		U.lock_code_autogenerate = 1
-		U.setup(usr.mind)
-		usr.show_text("<h3>The password to your uplink is '[U.lock_code]'.</h3>", "blue")
-		usr.mind.store_memory("<B>Uplink password:</B> [U.lock_code].")
-
-	usr.verbs -= /client/proc/gearspawn_traitor
-
-	return
-
 /proc/alive_player_count()
 	. = 0
 	for(var/client/C)


### PR DESCRIPTION
[Internal] [Code Quality]


## About The PR:
Deprecates `/datum/admins/proc/evilize()` and `/client/proc/gearspawn_traitor()`.
Additionally renovates the "Make everyone an antagonist" admin command.



## Why Is This needed?
Removal of remnants from the old antagonist system that has been superceded by antagonist datums.