### PR TITLE
Moves Clarion Chemistry Request Console in QM so it no longer blocks a mulebot beacon 

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -19869,10 +19869,6 @@
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon/mule/QM1_north/east,
 /obj/decal/stripe_caution,
-/obj/machinery/computer/chem_requester/science{
-	area_name = "Quartermaster's office";
-	dir = 4
-	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "buN" = (
@@ -29773,7 +29769,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/table/reinforced/auto,
+/obj/machinery/computer/chem_requester/science{
+	area_name = "Quartermaster's office"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "hZS" = (
@@ -39623,7 +39621,7 @@
 	},
 /area/station/science/lobby)
 "rhb" = (
-/obj/decal/stripe_caution,
+/obj/decal/stripe_delivery,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "rig" = (
@@ -40721,9 +40719,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/computer/barcode/qm/no_belthell{
-	dir = 4
-	},
+/obj/machinery/computer/barcode/qm/no_belthell,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "sky" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the Chemistry Request Console in Clarion QM to no longer be on top of a Mulebot beacon.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously, the console was sitting directly on top of a mulebot beacon. This caused the Mulebot that spawns at the start of the round to be incapable of navigating to its own home beacon. As a Mulebot enjoyer, I cannot allow this to stand.
