### PR TITLE
Makes space GPS be able to fit into mechcomp cabinets

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -19,7 +19,7 @@
 	name="Generic MechComp Housing"
 	desc="You should not bee seeing this! Call 1-800-CODER or just crusher it"
 	icon='icons/misc/mechanicsExpansion.dmi'
-	can_hold=list(/obj/item/mechanics)
+	can_hold=list(/obj/item/mechanics, /obj/item/device/gps)
 	var/list/users = list() // le chumps who have opened the housing
 	deconstruct_flags = DECON_NONE //nope, so much nope.
 	slots=1

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/item/device/gps)
 	g_amt = 100
 	var/frequency = FREQ_GPS
 	var/net_id
+	var/wrenched_in = FALSE //! is this wrenched in a cabinet frame?
 
 	proc/get_z_info(var/turf/T)
 		. =  "Landmark: Unknown"
@@ -138,6 +139,28 @@ TYPEINFO(/obj/item/device/gps)
 
 		user.Browse(HTML.Join(), "window=gps_[src];title=GPS;size=400x540;override_setting=1")
 		onclose(user, "gps")
+
+	attack_hand(mob/user)
+		if(src.wrenched_in) return
+		..()
+
+	attackby(obj/item/used_tool, mob/user)
+		if(iswrenchingtool(used_tool))
+			if(src.wrenched_in)
+				boutput(user, "You detach the [src] from the housing.")
+				logTheThing(LOG_STATION, user, "detaches a <b>[src]</b> from the housing at [log_loc(src)].")
+				src.wrenched_in = FALSE
+				src.anchored = UNANCHORED
+				return
+
+			else
+				if(istype(src.stored?.linked_item,/obj/item/storage/mechanics))
+					boutput(user, "You attach the [src] to the housing.")
+					logTheThing(LOG_STATION, user, "attaches a <b>[src]</b> to the housing  at [log_loc(src)].")
+					src.wrenched_in = TRUE
+					src.anchored = ANCHORED
+					return
+		..()
 
 	attack_ai(mob/user)
 		. = ..()


### PR DESCRIPTION
[FEATURE][OBJECTS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Enables the space GPS to be able to be wrenched into the mechcomp cabinets (device frame/MechComp Cabinet).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With the movement components, people are enabled to make little bots that can move arround and do some mischief. What is currently missing is a convenient way to make them navigate themselves. While a space GPS can be attached to a frame via space glue, this is very temporary and can be easily destroyed by just removing the glued in component from the frame This makes a reliable, less sabotage-able way to make component bots able to navigate from A to B.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Enables the space GPS to be able to be wrenched into the device frame and mechcomp cabinet.
```
