### PR TITLE
Removes Oshan Pathology

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -4580,13 +4580,10 @@
 	},
 /area/station/medical/medbay/surgery/storage)
 "alB" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/stool/chair/office/purple{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor,
 /area/research_outpost/chamber)
 "alC" = (
 /obj/cable{
@@ -16134,9 +16131,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aRe" = (
-/obj/storage/closet/biohazard,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor,
+/area/research_outpost/toxins)
 "aRf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -18839,7 +18836,6 @@
 /obj/machinery/atmospherics/portables_connector{
 	name = "Mixing Port"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
@@ -19028,7 +19024,6 @@
 	dir = 4;
 	name = "Mixing Port"
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bbC" = (
@@ -19219,7 +19214,6 @@
 	dir = 1;
 	name = "Mixing Port"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "bcC" = (
@@ -19292,12 +19286,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
-"bcT" = (
-/obj/machinery/computer/pathology{
-	dir = 8
-	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
 "bcV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost/toxins)
@@ -19362,13 +19350,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
-"bdm" = (
-/obj/submachine/chef_sink/chem_sink{
-	layer = 3;
-	pixel_y = 8
-	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
 "bdq" = (
@@ -19441,15 +19422,6 @@
 	},
 /turf/space/fluid,
 /area/space)
-"bdC" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
 "bdD" = (
 /turf/simulated/floor/caution/east,
 /area/research_outpost/hangar)
@@ -19473,27 +19445,12 @@
 	dir = 6
 	},
 /area/flock_trader)
-"bdI" = (
-/obj/machinery/optable,
-/obj/machinery/drainage,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
 "bdK" = (
 /obj/item/organ/brain/flockdrone,
 /obj/table/flock/auto,
 /obj/machinery/light/flock,
 /turf/simulated/floor/shuttle/flock,
 /area/flock_trader)
-"bdO" = (
-/obj/item/device/radio/beacon,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
 "bdP" = (
 /obj/machinery/power/smes{
 	charge = 100000;
@@ -19549,24 +19506,13 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/maint)
 "bdY" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/reagent_containers/iv_drip/saline{
-	pixel_x = 6
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4
 	},
-/obj/item/handcuffs,
-/obj/item/clothing/glasses/blindfold,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = -4
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
+/obj/firedoor_spawn,
+/obj/access_spawn/tox_storage,
+/turf/simulated/floor,
+/area/research_outpost/toxins)
 "bdZ" = (
 /obj/disposalpipe/trunk/south,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -19591,16 +19537,9 @@
 /turf/simulated/floor/black,
 /area/research_outpost)
 "bed" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/kitchen/utensil/knife{
-	pixel_x = -3
-	},
-/obj/item/kitchen/utensil/fork,
-/obj/item/kitchen/utensil/spoon{
-	pixel_x = 3
-	},
-/turf/simulated/floor/engine,
-/area/research_outpost/chamber)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/research_outpost/toxins)
 "bee" = (
 /obj/reagent_dispensers/fueltank,
 /obj/machinery/light/incandescent/netural,
@@ -36100,13 +36039,12 @@
 /area/station/ai_monitored/armory)
 "bYr" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/pyro/sci_alt,
-/obj/firedoor_spawn,
-/obj/access_spawn/pathology,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/machinery/optable,
+/obj/machinery/drainage,
+/turf/simulated/floor/engine,
+/area/research_outpost/chamber)
 "bYt" = (
 /obj/table/reinforced/industrial/auto,
 /obj/item/kitchen/food_box/donut_box{
@@ -40383,9 +40321,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "cuy" = (
-/obj/machinery/synthomatic,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/table/reinforced/chemistry/auto,
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "cwj" = (
 /obj/item/storage/secure/ssafe/diner_arcade{
 	pixel_x = -30
@@ -40714,8 +40652,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "dvD" = (
 /obj/disposalpipe/trunk/mail/north,
 /obj/machinery/disposal/mail/small/autoname{
@@ -40952,9 +40890,19 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "dVf" = (
-/obj/access_spawn/pathology,
-/turf/simulated/floor,
-/area/research_outpost)
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/research_outpost/chamber)
 "dWG" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -41663,11 +41611,14 @@
 /turf/simulated/floor,
 /area/station/maintenance/northwest)
 "fTt" = (
-/obj/machinery/incubator{
-	dir = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/sci_alt,
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/area/research_outpost/chamber)
 "fTM" = (
 /obj/stool/chair{
 	dir = 1
@@ -41822,16 +41773,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "gie" = (
-/obj/machinery/autoclave,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8
 	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/research_outpost/toxins)
 "gim" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
@@ -42225,8 +42172,14 @@
 /turf/simulated/wall/auto/martian,
 /area/evilreaver/storage/tools)
 "hBQ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/research_outpost/pathology)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/research_outpost/chamber)
 "hFC" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/decal/stripe_caution,
@@ -42719,11 +42672,8 @@
 /obj/stool/chair/office/purple{
 	dir = 4
 	},
-/obj/landmark/start{
-	name = "Pathologist"
-	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "jiS" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -42846,11 +42796,6 @@
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
-"jxG" = (
-/obj/machinery/light/incandescent/netural,
-/obj/cabinet/pathology,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
 "jzB" = (
 /obj/machinery/manufacturer/science,
 /turf/simulated/floor,
@@ -42985,8 +42930,8 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "jMz" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
@@ -43101,7 +43046,7 @@
 	},
 /obj/machinery/door/airlock/pyro/sci_alt,
 /obj/firedoor_spawn,
-/obj/access_spawn/pathology,
+/obj/access_spawn/research,
 /turf/simulated/floor/green,
 /area/research_outpost/maint)
 "kjH" = (
@@ -43407,13 +43352,13 @@
 /area/station/medical/medbay/pharmacy)
 "ljO" = (
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "llR" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "lmk" = (
@@ -43473,9 +43418,9 @@
 	},
 /area/station/medical/medbay/surgery/storage)
 "luP" = (
-/obj/machinery/centrifuge,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/wingrille_spawn/auto/crystal/reinforced,
+/turf/simulated/floor/plating/random,
+/area/research_outpost/chamber)
 "lxj" = (
 /obj/table/auto,
 /obj/drink_rack/mug{
@@ -43842,11 +43787,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "mIT" = (
-/obj/stool/chair/office/purple{
-	dir = 8
-	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "mLz" = (
 /obj/table/wood/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -44033,20 +43975,11 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "ndI" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/reagent_containers/dropper/mechanical{
-	pixel_x = 9
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/item/clothing/glasses/spectro{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = -4
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost)
 "nej" = (
 /obj/machinery/light/incandescent/blueish,
 /obj/item/pen/crayon/white,
@@ -44155,10 +44088,6 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "nBR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
@@ -44447,11 +44376,9 @@
 /turf/simulated/floor,
 /area/station/security/processing)
 "oDh" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/airlock/pyro/sci_alt,
+/obj/firedoor_spawn,
+/obj/access_spawn/tox_storage,
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "oFy" = (
@@ -44667,14 +44594,22 @@
 /area/station/maintenance/northwest)
 "phi" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/item/reagent_containers/iv_drip/saline{
+	pixel_x = 6
 	},
-/obj/item/device/reagentscanner,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/engine,
+/obj/item/handcuffs,
+/obj/item/clothing/glasses/blindfold,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_y = -4
+	},
+/turf/simulated/floor,
 /area/research_outpost/chamber)
 "phM" = (
 /obj/item/reagent_containers/food/drinks/eggnog,
@@ -44826,12 +44761,12 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "pFS" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/engine,
+/area/research_outpost/chamber)
 "pGJ" = (
 /obj/item/skull,
 /obj/item/currency/spacecash/thousand,
@@ -45184,10 +45119,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
 /area/shuttle/sea_elevator_room)
-"qXh" = (
-/obj/machinery/pathogen_manipulator,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
 "qYb" = (
 /obj/indestructible/shuttle_corner{
 	dir = 10;
@@ -45236,11 +45167,10 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
 "ret" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/machinery/microscope,
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/table/reinforced/chemistry/auto,
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "rfp" = (
 /obj/indestructible/shuttle_corner{
 	dir = 5;
@@ -45837,9 +45767,22 @@
 /area/station/security/checkpoint/escape)
 "tMA" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/microscope,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/item/kitchen/utensil/knife{
+	pixel_x = -3
+	},
+/obj/item/kitchen/utensil/fork,
+/obj/item/kitchen/utensil/spoon{
+	pixel_x = 3
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "tNa" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -45867,12 +45810,6 @@
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
-"tRf" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/research_outpost/chamber)
 "tRo" = (
 /obj/decal/cleanable/dirt,
 /obj/critter/martian/soldier/dead,
@@ -46487,8 +46424,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "wgg" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -46932,8 +46869,16 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/arcade)
 "xFh" = (
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
+/obj/table/reinforced/chemistry/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/reagentscanner,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor,
+/area/research_outpost/chamber)
 "xHw" = (
 /obj/wingrille_spawn/auto/crystal/reinforced,
 /obj/cable,
@@ -46959,11 +46904,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
-"xIA" = (
-/obj/machinery/vending/pathology,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/green,
-/area/research_outpost/pathology)
 "xNc" = (
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -129100,7 +129040,7 @@ bcL
 wJK
 uah
 nSl
-dVf
+bcL
 bcL
 bcL
 bds
@@ -129398,11 +129338,11 @@ bcV
 bbh
 bbl
 bZd
-bdw
+bZd
 bbK
 oVm
 rxc
-bZd
+bdw
 bZd
 bZd
 tWw
@@ -129700,11 +129640,11 @@ bcV
 aRh
 tDZ
 bcL
-bdx
-bbM
-bbM
-bbM
 bcL
+bbM
+bbM
+bbM
+bdx
 bcL
 bcL
 bds
@@ -130000,13 +129940,13 @@ aTq
 iwt
 lou
 bZd
-tDZ
+ndI
+bcL
+bcL
+bcL
+bcL
 bcL
 bdx
-bcL
-bcL
-bcL
-bcL
 bcL
 bcL
 bds
@@ -130297,18 +130237,18 @@ aQb
 bZF
 baX
 aTq
-bbP
-bcs
+aTq
+aTq
 llR
 bcV
 afT
-bdx
+bcL
 cxH
-bdx
+bcL
 bcL
 umv
 bcL
-bcL
+bdx
 bcL
 umv
 bds
@@ -130599,9 +130539,13 @@ aRN
 baZ
 bbk
 aTq
-bbP
-bcs
+aTq
+aTq
 nBR
+bcV
+bcV
+bdY
+bcV
 bcV
 bZE
 bbo
@@ -130610,10 +130554,6 @@ lZa
 bbN
 bbN
 bZE
-hBQ
-hBQ
-hBQ
-hBQ
 bcl
 aqn
 aeB
@@ -130901,24 +130841,24 @@ aRO
 bZF
 bbq
 aTq
-gNp
-bct
+aTq
+aTq
+aTq
 oDh
-bcV
+aTq
+aTq
+aTq
+bbP
+bZE
 bdl
-alB
 beh
-bdC
+hBQ
 bZn
 bZn
-bdY
-hBQ
-aRe
-xFh
-hBQ
-hBQ
-hBQ
-hBQ
+bZE
+bZE
+bZE
+bZE
 bbg
 ksg
 jwF
@@ -131207,20 +131147,20 @@ hXO
 eqg
 bcE
 bcW
+gNp
+aTq
+aTq
+bbP
+bZE
 bcS
-bZn
 bZn
 bbE
 bZn
 bZn
-phi
-hBQ
-jxG
-xFh
-ndI
+luP
 tMA
 cuy
-hBQ
+bZE
 bdt
 bdt
 sBY
@@ -131509,19 +131449,19 @@ hXO
 eqg
 rwx
 bdf
+gNp
+aTq
+aTq
+bbP
+bZE
 sRT
-bZn
 bZn
 bbE
 bZn
 bZn
-bed
-hBQ
-xFh
-xFh
-xFh
+luP
 mIT
-xFh
+alB
 ljO
 bdt
 ggG
@@ -131811,17 +131751,17 @@ jBU
 bcw
 bcF
 bdf
-bdm
+bcs
+bcs
+aTq
+bct
+bZE
+dVf
 bZn
-bZn
-bdI
-bdO
-beh
-beh
 bYr
-wfi
-wfi
-wfi
+pFS
+beh
+fTt
 wfi
 wfi
 jMv
@@ -132113,19 +132053,19 @@ aSF
 bcV
 bcV
 bdf
+bcs
+bcs
+aTq
+bct
+bZE
 fsJ
 bZn
 bZn
 bZn
-bZn
-bZn
 azm
-hBQ
-fTt
-xFh
-xFh
-xFh
-xFh
+luP
+phi
+mIT
 duw
 bdt
 sso
@@ -132414,21 +132354,21 @@ aqn
 aqn
 aqn
 aqn
-tRf
-bcS
-bZn
-bZn
-bZn
-bZn
-bZn
-bcS
-hBQ
+bdf
+bcV
+bed
 gie
-xFh
-xFh
+bed
+bZE
+bcS
+bZn
+bZn
+bZn
+bcS
+luP
 xFh
 jiM
-xFh
+mIT
 bdt
 gcE
 eXS
@@ -132716,20 +132656,20 @@ aqn
 aqn
 aqn
 aqn
-tRf
+bdf
+bcV
+aRe
+aRe
+aRe
 bZE
-bZn
 bZn
 cKm
 asN
 bZn
 bca
-hBQ
-xIA
-pFS
 luP
-qXh
-bcT
+cuy
+cuy
 ret
 bdt
 vNP
@@ -133019,20 +132959,20 @@ aqn
 aqn
 aqn
 uEG
-bZE
+bcV
+bcV
+bcV
+bcV
 bZE
 auN
 auN
 auN
 bZE
 bZE
-hBQ
-hBQ
-hBQ
-hBQ
-hBQ
-hBQ
-hBQ
+bZE
+bZE
+bZE
+bZE
 bdt
 bdP
 bdX

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -19488,6 +19488,9 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/research_outpost/hangar)
 "bdW" = (
@@ -40649,11 +40652,10 @@
 /area/station/ranch)
 "duw" = (
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor,
-/area/research_outpost/chamber)
+/turf/simulated/floor/caution/south,
+/area/research_outpost/hangar)
 "dvD" = (
 /obj/disposalpipe/trunk/mail/north,
 /obj/machinery/disposal/mail/small/autoname{
@@ -42477,6 +42479,12 @@
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"iIe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/research_outpost/hangar)
 "iIT" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -42523,6 +42531,9 @@
 "iMs" = (
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -42927,11 +42938,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/research_outpost/chamber)
+/turf/simulated/floor/shuttlebay,
+/area/research_outpost/hangar)
 "jMz" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
@@ -44050,6 +44058,9 @@
 "nvJ" = (
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/research_outpost/hangar)
@@ -45801,6 +45812,12 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
+"tOE" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/research_outpost/hangar)
 "tPK" = (
 /obj/shrub,
 /obj/landmark/spawner/loot,
@@ -46094,6 +46111,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/janitor/office)
+"uZz" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/research_outpost/hangar)
 "vac" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -129347,11 +129370,11 @@ bZd
 bZd
 tWw
 nvJ
-aRD
-cHP
-bdU
-bdU
-bdU
+tOE
+duw
+jMv
+jMv
+uZz
 bdU
 beb
 aqn
@@ -129653,7 +129676,7 @@ aRD
 cHP
 gyC
 bdF
-bdU
+iIe
 gyC
 beb
 aqn
@@ -130257,7 +130280,7 @@ bds
 bds
 bbg
 ksg
-ksg
+jwF
 bec
 mZL
 aqn
@@ -131764,7 +131787,7 @@ beh
 fTt
 wfi
 wfi
-jMv
+wfi
 kgN
 fhb
 prZ
@@ -132066,7 +132089,7 @@ azm
 luP
 phi
 mIT
-duw
+mIT
 bdt
 sso
 prZ


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the tes chamber down a bit, and adds a toxins storage room. This makes use of the space vacated by removing pathology.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We're... not using pathology anymore.
## Changelog
```changelog
(u)Tyrant
(+)Pathology has been removed from Oshan.
```
