### PR TITLE
Adds mining projectile components, fixes #13570

### DIFF
--- a/code/datums/components/proj_mining.dm
+++ b/code/datums/components/proj_mining.dm
@@ -1,0 +1,34 @@
+/datum/component/proj_mining
+	var/power_ratio = 1
+	var/power_loss = 0
+
+TYPEINFO(/datum/component/proj_mining)
+	initialization_args = list(
+		ARG_INFO("power_ratio", DATA_INPUT_NUM, "conversion between projectile power to mining power", 1),
+		ARG_INFO("power_loss", DATA_INPUT_NUM, "power loss per asteroid tile mined", 0)
+
+	)
+/datum/component/proj_mining/Initialize(var/power_ratio, var/power_loss)
+	. = ..()
+	if (!istype(parent, /obj/projectile))
+		return COMPONENT_INCOMPATIBLE
+	if (power_ratio)
+		src.power_ratio = power_ratio
+	if (power_loss)
+		src.power_loss = power_loss
+	RegisterSignal(parent, COMSIG_OBJ_PROJ_COLLIDE, .proc/mine)
+
+/datum/component/proj_mining/proc/mine(var/obj/projectile/P, var/atom/hit)
+	if(istype(hit, /turf/simulated/wall/auto/asteroid))
+		var/turf/simulated/wall/auto/asteroid/T = hit
+		if(P.power <= 0)
+			return 0
+		T.damage_asteroid(P.power * power_ratio)
+		P.initial_power -= power_loss
+		if (!T.density)
+			return PROJ_PASSWALL
+
+/datum/component/proj_door_breach/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_OBJ_PROJ_COLLIDE)
+	. = ..()
+

--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -179,13 +179,11 @@ toxic - poisons
 		color_green = 0.4
 		color_blue = 1
 
-		on_hit(atom/hit)
-			if (istype(hit, /turf/simulated/wall/auto/asteroid))
-				var/turf/simulated/wall/auto/asteroid/T = hit
-				if (power <= 0)
-					return
-				T.damage_asteroid(0,allow_zero = 1)
+		on_launch(obj/projectile/O)
+			. = ..()
+			O.AddComponent(/datum/component/proj_mining, 0.2, 5)
 
+		on_hit(atom/hit)
 			if (istype(hit,/obj/critter)) //MBC : if there was a cleaner way to do this, I couldn't find it.
 				var/obj/critter/C = hit
 				C.health -= power * 2
@@ -478,12 +476,9 @@ toxic - poisons
 	color_green = 0.6
 	color_blue = 0
 
-	on_hit(atom/hit)
-		if (istype(hit, /turf/simulated/wall/auto/asteroid))
-			var/turf/simulated/wall/auto/asteroid/T = hit
-			if (power <= 0)
-				return
-			T.damage_asteroid(round(power / 5))
+	on_launch(obj/projectile/O)
+		. = ..()
+		O.AddComponent(/datum/component/proj_mining, 0.2, 2)
 
 /datum/projectile/laser/drill
 	name = "drill bit"
@@ -502,17 +497,11 @@ toxic - poisons
 	var/damtype = DAMAGE_STAB
 
 	var/hit_human_sound = 'sound/impact_sounds/Slimy_Splat_1.ogg'
+	on_launch(obj/projectile/O)
+		. = ..()
+		O.AddComponent(/datum/component/proj_mining, 0.15, 0)
+
 	on_hit(atom/hit)
-		//playsound(hit.loc, 'sound/machines/engine_grump1.ogg', 45, 1)
-		if (istype(hit, /turf/simulated/wall/auto/asteroid))
-			var/turf/simulated/wall/auto/asteroid/T = hit
-			if (power <= 0)
-				return
-			T.damage_asteroid(round(power / 7),1)
-			//if(prob(60)) // raised again
-			//	T.destroy_asteroid(1)
-			//else
-			//	T.weaken_asteroid()
 		if (ishuman(hit))
 			var/mob/living/carbon/human/M = hit
 			playsound(M.loc, hit_human_sound, 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [VEHICLES] [BUG] [CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a new component that allows projectiles to mine asteroid tiles, and changes the current mining weapon projectiles to use this new system. This also reopens the possibility for a projectile to mine multiple tiles, which was removed as a side effect of #13324.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #13570, cleans up mining projectiles a bit.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Plasma cutters and other mining weapons can break multiple asteroid tiles at once again.
```
