### PR TITLE
This is a nuclear reactor. It is radiating blindingly with a worrying blue light.

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -708,7 +708,7 @@
 	New()
 		for(var/x=2 to REACTOR_GRID_WIDTH-1)
 			for(var/y=2 to REACTOR_GRID_HEIGHT-1)
-				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("cerenkite")
+				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
 		..()
 
 #undef REACTOR_GRID_WIDTH

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -354,7 +354,14 @@
 		if(rads <= 0)
 			return
 
-		src.AddComponent(/datum/component/radioactive, min(rads*3, 100), TRUE, FALSE, 5)
+		var/datum/component/radioactive/rads_comp = src.GetComponent(/datum/component/radioactive)
+		if(!rads_comp)
+			src.AddComponent(/datum/component/radioactive, min((rads*2 > 100) ? rads*2/4 : rads*2, 100), TRUE, (rads*2 > 100), 5)
+		else
+			rads_comp.radStrength = min((rads*2 > 100) ? rads*2/4 : rads*2, 100)
+			rads_comp.neutron = (rads*2 > 100)
+			rads_comp.do_filters()
+
 		rads -= 5
 
 		if(rads <= 0)
@@ -701,7 +708,7 @@
 	New()
 		for(var/x=2 to REACTOR_GRID_WIDTH-1)
 			for(var/y=2 to REACTOR_GRID_HEIGHT-1)
-				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
+				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("cerenkite")
 		..()
 
 #undef REACTOR_GRID_WIDTH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the range of radiation the reactor can be at for the radioactivity component, and makes it more responsive to changes.
At above 50 rads, the reactor goes to neutron radiation. Neutron rads are 4x stronger than normal rads, so the strength is divided by 4 to keep it consistent. 
Also it increases the dose from the reactor when you're stood next to it by 33% because it made it go blue at 50 rads which matches the danger area on the dial.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It indicates high radiation levels visually without needing the UI open.

