### PR TITLE
Adds spacecillin cure to food poisoning description

### DIFF
--- a/code/modules/medical/diseases/food_poisoning.dm
+++ b/code/modules/medical/diseases/food_poisoning.dm
@@ -2,7 +2,7 @@
 	name = "Food Poisoning"
 	max_stages = 3
 	spread = "Non-Contagious"
-	cure = "Sleep"
+	cure = "Sleep, Spaceacillin"
 	associated_reagent = "salmonella"
 	reagentcure = list("spaceacillin")
 	affected_species = list("Human")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [MEDICAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds spacecillin to the list of cures on the medical scanner for food poisoning.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Considering it is a cure, might as well let people know through the scanner.


