### PR TITLE
Large storage adjustments

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -490,7 +490,8 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 				/obj/item/raw_material = "materials",
 				/obj/item/material_piece = "processed materials",
 				/obj/item/paper = "paper",
-				/obj/item/tile = "floor tiles")
+				/obj/item/tile = "floor tiles",
+				/obj/item/fish = "fish")
 			for(var/drag_type in draggable_types)
 				if(!istype(O, drag_type))
 					continue
@@ -501,6 +502,8 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 				var/staystill = user.loc
 				for (var/obj/thing in view(1,user))
 					if(!istype(thing, drag_type))
+						continue
+					if (thing.anchored)
 						continue
 					if (thing in user)
 						continue


### PR DESCRIPTION
[objects][bug][feature]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so anchored items cannot be tried to be stuffed in lockers/crates. Also, it enables fish to be stuffed into the same storage items

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Normally, there are no anchored items among the corresponding item parents that can be stuffed. Recent testmerged PR's showed that can happen. This fixes #14755 

Also, fish are created in large quantitites by fishers and wholetuna plants. This makes it easier for chefs/botanist/fisherman to handle the tide of fish that washes onto their departments shore.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Fish can now be quickly stuffed into crates/lockers
```
