### PR TITLE
Makes new option when entering the industrial cryogenic unit: "Observe".

### DIFF
--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -177,11 +177,30 @@
 
 	proc/enter_prompt(var/mob/living/user as mob)
 		if (mob_can_enter_storage(user)) // check before the prompt for dead/incapped/restrained/etc users
-			if (tgui_alert(user, "Would you like to enter cryogenic storage? You will be unable to leave it again until 5 minutes have passed.", "Confirmation", list("Yes", "No")) == "Yes")
-				if (tgui_alert(user, "Are you absolutely sure you want to enter cryogenic storage?", "Confirmation", list("Yes", "No")) == "Yes")
-					if (mob_can_enter_storage(user)) // check again in case they left the prompt up and moved away/died/whatever
-						add_person_to_storage(user)
-					return 1
+			var/what_does_the_player_want = tgui_alert(user, "Would you like to enter cryogenic storage? You will be unable to leave it again until 5 minutes have passed. You can also \"Observe\", where you free up your role slot in the round and become an observer.", "Confirmation", list("Yes", "No", "Observe"))
+			switch (what_does_the_player_want)
+				if ("Yes")
+					if (tgui_alert(user, "Are you absolutely sure you want to enter cryogenic storage?", "Confirmation", list("Yes", "No")) == "Yes")
+						if (mob_can_enter_storage(user)) // check again in case they left the prompt up and moved away/died/whatever
+							add_person_to_storage(user)
+							user.show_text("<b style=\"font-size: 200%\">Remember, if you want to abandon the round and free up space for someone else, simply use the \"ghost\" command in the Commands tab. (top-right corner)</b>", "blue")
+						return 1
+
+				if ("Observe")
+					var/confirmation_message = "Are you absolutely sure you want to abandon the round? "
+#ifdef RP_MODE
+					confirmation_message += "You can respawn back to the round later."
+#else
+					confirmation_message += "You will be an observer until the next round."
+#endif
+					if (tgui_alert(user, confirmation_message, "Confirmation", list("Yes", "No")) == "Yes")
+						if (mob_can_enter_storage(user))
+							add_person_to_storage(user)
+							respawn_controller.subscribeNewRespawnee(user.ckey)
+							user.mind?.get_player()?.dnr = TRUE
+							user.remove()
+							return 1
+
 		return 0
 
 	proc/mob_can_enter_storage(var/mob/living/L as mob, var/mob/user as mob)

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -199,7 +199,7 @@
 							respawn_controller.subscribeNewRespawnee(user.ckey)
 							user.mind?.get_player()?.dnr = TRUE
 							user.ghostize()
-                            qdel(user)
+							qdel(user)
 							return 1
 
 		return 0

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -183,7 +183,7 @@
 					if (tgui_alert(user, "Are you absolutely sure you want to enter cryogenic storage?", "Confirmation", list("Yes", "No")) == "Yes")
 						if (mob_can_enter_storage(user)) // check again in case they left the prompt up and moved away/died/whatever
 							add_person_to_storage(user)
-							user.show_text("<b style=\"font-size: 200%\">Remember, if you want to abandon the round and free up space for someone else, simply use the \"ghost\" command in the Commands tab. (top-right corner)</b>", "blue")
+							user.show_text("<b style=\"font-size: 200%\">Remember, if you want to abandon the round to observe and free up space for someone else, simply use the \"ghost\" command in the Commands tab. (top-right corner)</b>", "blue")
 						return 1
 
 				if ("Observe")

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -198,7 +198,8 @@
 							add_person_to_storage(user)
 							respawn_controller.subscribeNewRespawnee(user.ckey)
 							user.mind?.get_player()?.dnr = TRUE
-							user.remove()
+							user.ghostize()
+       qdel(user)
 							return 1
 
 		return 0

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -199,7 +199,7 @@
 							respawn_controller.subscribeNewRespawnee(user.ckey)
 							user.mind?.get_player()?.dnr = TRUE
 							user.ghostize()
-       qdel(user)
+                            qdel(user)
 							return 1
 
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title pretty much says it all. Also adds a message if you enter the cryotron (yes, that's it's in-code name), mentioning how you can ghostize yourself and free up a role slot.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Not many players know that you can free up a slot by entering the cryotron, and those who do only discover it when someone mentions it in the Discord server. And since that's a very useful utility, specially on the high-pop servers, it's weird how that functionality is not mentioned in-game at all. This PR aims to fix this problem.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->