### PR TITLE
Add lanyards to tourist (also adds blob and cow mutantrace)

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1323,6 +1323,8 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		M.equip_if_possible(L, M.slot_wear_id, FALSE)
 		M.spawnId(src)
 		var/obj/item/card/id = locate() in M
+		if (!id)
+			return
 		L.storage.add_contents(id, M, FALSE)
 
 /datum/job/special/space_cowboy
@@ -2855,6 +2857,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		M.equip_if_possible(L, M.slot_wear_id, FALSE)
 		M.spawnId(src)
 		var/obj/item/card/id = locate() in M
+		if (!id)
+			return
 		L.storage.add_contents(id, M, FALSE)
 
 /datum/job/daily/saturday

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1316,10 +1316,14 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		..()
 		if (!M)
 			return
-		if(prob(25))
-			var/morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian)
+		if(prob(33))
+			var/morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian,/datum/mutantrace/blob,/datum/mutantrace/cow)
 			M.set_mutantrace(morph)
-
+		var/obj/item/clothing/lanyard/L = new /obj/item/clothing/lanyard(M.loc)
+		M.equip_if_possible(L, M.slot_wear_id, FALSE)
+		M.spawnId(src)
+		var/obj/item/card/id = locate() in M
+		L.storage.add_contents(id, M, FALSE)
 
 /datum/job/special/space_cowboy
 	name = "Space Cowboy"
@@ -2845,8 +2849,13 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 		if(prob(33))
-			var/morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian)
+			var/morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian,/datum/mutantrace/blob,/datum/mutantrace/cow)
 			M.set_mutantrace(morph)
+		var/obj/item/clothing/lanyard/L = new /obj/item/clothing/lanyard(M.loc)
+		M.equip_if_possible(L, M.slot_wear_id, FALSE)
+		M.spawnId(src)
+		var/obj/item/card/id = locate() in M
+		L.storage.add_contents(id, M, FALSE)
 
 /datum/job/daily/saturday
 	name = "Musician"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [Respawning]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes all tourists start with a lanyard in their ID slot, which contains their ID.

It also adds `/datum/mutantrace/blob` and `/datum/mutantrace/cow` to its possible mutant races, putting it in line with the Ambassador job.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lanyards are cool, tourists seem like the perfect job for it because they don't start with a PDA.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Tourists now spawn with a lanyard containing their ID.
```
