### PR TITLE
Adds pre-filled chemlab counter subtypes

### DIFF
--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -1141,3 +1141,15 @@ Only trained personnel should operate station systems. Follow all procedures car
 	Flake out this time and you will regret it. <br>
 	You know where to find us larry, bring the money, 100,000 credits.
 	"}
+
+/obj/item/paper/labdrawertips
+	name = "stern lab safety warning"
+	icon_state = "paper"
+	info ={"
+	I've had it with you nincompoops taking shortcuts. For the last
+	time, <b> when you open the drawers under the lab counter,
+	USE AN EMPTY HAND!</b> There's no excuse for you to be
+	melting holes in the floor because you tried to grab a
+	handle with the same hand that holds your beloved
+	napalm-phlogiston-thermite """hell mix."""
+	"}

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -789,12 +789,10 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	drawer_contents = list(/obj/item/storage/box/beakerbox,
 				/obj/item/storage/box/patchbox,
 				/obj/item/storage/box/syringes,
-				/obj/item/reagent_containers/food/drinks/fueltank,
 				/obj/item/reagent_containers/glass/beaker/large,
 				/obj/item/clothing/glasses/spectro = 2,
 				/obj/item/device/reagentscanner = 2,
-				/obj/item/reagent_containers/dropper/mechanical,
-				/obj/item/reagent_containers/iv_drip = 2)
+				/obj/item/reagent_containers/dropper/mechanica)
 
 
 /obj/table/reinforced/chemistry/clericalsup

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -774,8 +774,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	name = "basic supply lab counter"
 	desc = "Everything an aspiring chemist needs to start making chemicals!"
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/paper/book/from_file/pharmacopia,
+	drawer_contents = list(/obj/item/paper/book/from_file/pharmacopia,
 				/obj/item/storage/box/beakerbox = 2,
 				/obj/item/reagent_containers/glass/beaker/large = 2,
 				/obj/item/clothing/glasses/spectro,
@@ -787,8 +786,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	name = "auxiliary supply lab counter"
 	desc = "Extra supplies for the discerning chemist."
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/storage/box/beakerbox,
+	drawer_contents = list(/obj/item/storage/box/beakerbox,
 				/obj/item/storage/box/patchbox,
 				/obj/item/storage/box/syringes,
 				/obj/item/reagent_containers/food/drinks/fueltank,
@@ -803,9 +801,8 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	name = "clerical supply lab counter"
 	desc = "It's only science if you write it down! Or blow yourself up."
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/paper_bin = 2,
-				/obj/item/hand_labeler
+	drawer_contents = list(/obj/item/paper_bin = 2,
+				/obj/item/hand_labeler,
 				/obj/item/clipboard = 2,
 				/obj/item/pen,
 				/obj/item/stamp,
@@ -815,18 +812,16 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 
 /obj/table/reinforced/chemistry/firstaid
 	name = "toxin care lab counter"
-	desc = "These drawers have been labeled "EMERGENCY TOXIN CARE," which means they're probably already close to empty."
+	desc = "These drawers have been labeled EMERGENCY TOXIN CARE, which means they're probably already close to empty."
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/storage/firstaid/toxin,
+	drawer_contents = list(/obj/item/storage/firstaid/toxin,
 				/obj/item/reagent_containers/emergency_injector/calomel)
 
 /obj/table/reinforced/chemistry/chemstorage
 	name = "chemical storage lab counter"
 	desc = "A set of basic precursor chemicals to expedite order fulfillment, increase efficiency, and synergize your workflow. Whatever the fuck that means."
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/reagent_containers/glass/bottle/oil,
+	drawer_contents = list(/obj/item/reagent_containers/glass/bottle/oil,
 				/obj/item/reagent_containers/glass/bottle/phenol,
 				/obj/item/reagent_containers/glass/bottle/acid,
 				/obj/item/reagent_containers/glass/bottle/acetone,
@@ -837,8 +832,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	name = "seedy-looking lab counter"
 	desc = ""
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/plant/herb/cannabis/spawnable = 2,
+	drawer_contents = list(/obj/item/plant/herb/cannabis/spawnable = 2,
 				/obj/item/device/light/zippo,
 				/obj/item/reagent_containers/syringe/krokodil,
 				/obj/item/reagent_containers/syringe/morphine,
@@ -846,16 +840,15 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 
 	get_desc(var/dist, var/mob/user)
 		if (user.mind?.assigned_role == "Research Director")
-			. = "A stash of drugs provided in an attempt to placate your underlings. Stocking this drawer was your greatest mistake."
+			. = "<br>A stash of drugs provided in an attempt to placate your underlings. Stocking this drawer was your greatest mistake."
 		else
-			. = "A stash of drugs. This might just be the RD's only positive contribution to the station. Too bad they cheaped out on the selection."
+			. = "<br>A stash of drugs. This might just be the only positive contribution the RD ever made to the station. Too bad they cheaped out on the selection."
 
 /obj/table/reinforced/chemistry/allinone
 	name = "jam-packed lab counter"
 	desc = "The drawers on these barely close, and rattle loudly when moved. Guess they tried to put too much crap in it."
 	has_drawer = TRUE
-	drawer_contents =
-		list(	/obj/item/paper/book/from_file/pharmacopia,
+	drawer_contents = list(/obj/item/paper/book/from_file/pharmacopia,
 				/obj/item/storage/box/beakerbox = 2,
 				/obj/item/storage/box/syringes,
 				/obj/item/paper_bin,

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -770,6 +770,103 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	has_drawer = TRUE
 	drawer_contents = list(/obj/item/reagent_containers/glass/beaker = 7)
 
+/obj/table/reinforced/chemistry/basicsup
+	name = "basic supply lab counter"
+	desc = "Everything an aspiring chemist needs to start making chemicals!"
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/paper/book/from_file/pharmacopia,
+				/obj/item/storage/box/beakerbox = 2,
+				/obj/item/reagent_containers/glass/beaker/large = 2,
+				/obj/item/clothing/glasses/spectro,
+				/obj/item/device/reagentscanner = 2,
+				/obj/item/reagent_containers/dropper/mechanical = 2,
+				/obj/item/reagent_containers/dropper = 2)
+
+/obj/table/reinforced/chemistry/auxsup
+	name = "auxiliary supply lab counter"
+	desc = "Extra supplies for the discerning chemist."
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/storage/box/beakerbox,
+				/obj/item/storage/box/patchbox,
+				/obj/item/storage/box/syringes,
+				/obj/item/reagent_containers/food/drinks/fueltank,
+				/obj/item/reagent_containers/glass/beaker/large,
+				/obj/item/clothing/glasses/spectro = 2,
+				/obj/item/device/reagentscanner = 2,
+				/obj/item/reagent_containers/dropper/mechanical,
+				/obj/item/reagent_containers/iv_drip = 2)
+
+
+/obj/table/reinforced/chemistry/clericalsup
+	name = "clerical supply lab counter"
+	desc = "It's only science if you write it down! Or blow yourself up."
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/paper_bin = 2,
+				/obj/item/hand_labeler
+				/obj/item/clipboard = 2,
+				/obj/item/pen,
+				/obj/item/stamp,
+				/obj/item/device/audio_log,
+				/obj/item/audio_tape = 2)
+
+
+/obj/table/reinforced/chemistry/firstaid
+	name = "toxin care lab counter"
+	desc = "These drawers have been labeled "EMERGENCY TOXIN CARE," which means they're probably already close to empty."
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/storage/firstaid/toxin,
+				/obj/item/reagent_containers/emergency_injector/calomel)
+
+/obj/table/reinforced/chemistry/chemstorage
+	name = "chemical storage lab counter"
+	desc = "A set of basic precursor chemicals to expedite order fulfillment, increase efficiency, and synergize your workflow. Whatever the fuck that means."
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/reagent_containers/glass/bottle/oil,
+				/obj/item/reagent_containers/glass/bottle/phenol,
+				/obj/item/reagent_containers/glass/bottle/acid,
+				/obj/item/reagent_containers/glass/bottle/acetone,
+				/obj/item/reagent_containers/glass/bottle/diethylamine,
+				/obj/item/reagent_containers/glass/bottle/ammonia)
+
+/obj/table/reinforced/chemistry/drugs
+	name = "seedy-looking lab counter"
+	desc = ""
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/plant/herb/cannabis/spawnable = 2,
+				/obj/item/device/light/zippo,
+				/obj/item/reagent_containers/syringe/krokodil,
+				/obj/item/reagent_containers/syringe/morphine,
+				/obj/item/storage/pill_bottle/cyberpunk)
+
+	get_desc(var/dist, var/mob/user)
+		if (user.mind?.assigned_role == "Research Director")
+			. = "A stash of drugs provided in an attempt to placate your underlings. Stocking this drawer was your greatest mistake."
+		else
+			. = "A stash of drugs. This might just be the RD's only positive contribution to the station. Too bad they cheaped out on the selection."
+
+/obj/table/reinforced/chemistry/allinone
+	name = "jam-packed lab counter"
+	desc = "The drawers on these barely close, and rattle loudly when moved. Guess they tried to put too much crap in it."
+	has_drawer = TRUE
+	drawer_contents =
+		list(	/obj/item/paper/book/from_file/pharmacopia,
+				/obj/item/storage/box/beakerbox = 2,
+				/obj/item/storage/box/syringes,
+				/obj/item/paper_bin,
+				/obj/item/hand_labeler,
+				/obj/item/reagent_containers/dropper/mechanical,
+				/obj/item/reagent_containers/dropper,
+				/obj/item/storage/firstaid/toxin,
+				/obj/item/clothing/glasses/spectro,
+				/obj/item/device/reagentscanner)
+
+
 TYPEINFO(/obj/table/reinforced/industrial)
 TYPEINFO_NEW(/obj/table/reinforced/industrial)
 	. = ..()

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -842,7 +842,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 		if (user.mind?.assigned_role == "Research Director")
 			. = "<br>A stash of drugs provided in an attempt to placate your underlings. Stocking this drawer was your greatest mistake."
 		else
-			. = "<br>A stash of drugs. This might just be the only positive contribution the RD ever made to the station. Too bad they cheaped out on the selection."
+			. = "<br>A stash of drugs, and maybe the only positive contribution the RD ever made to the station. Too bad they cheaped out on the selection."
 
 /obj/table/reinforced/chemistry/allinone
 	name = "jam-packed lab counter"

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -792,7 +792,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/reagent_containers/glass/beaker/large,
 				/obj/item/clothing/glasses/spectro = 2,
 				/obj/item/device/reagentscanner = 2,
-				/obj/item/reagent_containers/dropper/mechanica)
+				/obj/item/reagent_containers/dropper/mechanical)
 
 
 /obj/table/reinforced/chemistry/clericalsup


### PR DESCRIPTION
[Chemistry] [Mapping] [Science] [QoL]

## About the PR 

This PR is a set of subtypes for the chemlab counters that come filled with useful chemlab equipment. There's 7 new labcounter subtypes in this PR:

**Basic Supply**
_Everything an aspiring chemist needs to start making chemicals!_
Pharmacopia
Beaker Box x2
Large Beaker x2
Spectroscopic Goggles
Reagent Scanner
Mechanical Dropper
Dropper x2

**Auxiliary Supply**
_Extra supplies for the discerning chemist._
Beaker Box
Patch Box
Syringe Box
400u Anti-Static Fuel Tank
Large Beaker
Spectroscopic Goggles x2
Reagent Scanner x2
Mechanical Dropper
Dropper x2

**Clerical Supply**
_It's only science if you write it down! Or blow yourself up._
Paper Bin x2
Hand Labeler
Pen
Stamp
Audio Log
Audio Tape x2

**Toxin Care**
_These drawers have been labeled EMERGENCY TOXIN CARE, which means they're probably already close to empty._
Toxin First Aid Kit
Calomel Autoinjector

**Chemical Storage** (Intended to replace the locker in Atlas)
_A set of basic precursor chemicals to expedite order fulfillment, increase efficiency, and synergize your workflow. Whatever the fuck that means._
50u Phenol bottle
50u Sulfuric Acid bottle
50u Acetone bottle
50u Oil bottle
50u Diethylamine bottle
50u Ammonia bottle

**Seedy-Looking**
_A stash of drugs provided by the RD in an attempt to placate their underlings._ 
Cannabis Leaf x2
Zippo Lighter
Syringe (Krokodil)
Syringe (Morphine)
Pill Bottle (???)

**Jam-Packed** (Intended for use in Atlas)
_The drawers on these barely close, and rattle loudly when moved. Guess they tried to put too much crap in it._
Beaker Box x2
Syringe Box
Paper Bin
Hand Labeler
Mechanical Dropper
Dropper
Toxin First Aid Kit
Spectroscopic Goggles
Reagent Scanner

In addition, there's also a Paper subtype added that tells unfamiliar players how to access these troves of equipment:
**Stern Lab Safety Warning**

_I've had it with you nincompoops taking shortcuts. For the last
	time, **when you open the drawers under the lab counter,
	USE AN EMPTY HAND!** There's no excuse for you to be
	melting holes in the floor because you tried to grab a
	handle with the same hand that holds your beloved
	napalm-phlogiston-thermite """hell mix."""_

## Why's this needed? 
These components are part of a larger goal to eliminate lab counter clutter in chemlabs while simultaneously standardizing the equipment that a player could expect to find in a typical chemlab. Switching to this method will provide a more consistent chemlab experience between maps; it also means that if these loadouts need to be changed in the future, they can be changed within their subtypes rather than having to change each map individually.
