### PR TITLE
Switch pipeshot's w_class from normal to tiny

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -752,7 +752,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_cat = AMMO_SHOTGUN_HIGH
 	delete_on_reload = TRUE
 	sound_load = 'sound/weapons/gunload_heavy.ogg'
-	w_class = W_CLASS_NORMAL
 
 /obj/item/ammo/bullets/pipeshot/plasglass // plasmaglass handmade shells
 	sname = "plasmaglass load"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pipeshot was originally implemented as normal to match pipeframes: https://github.com/goonstation/goonstation/pull/9726#discussion_r922900436. This PR switches the pipeshot's `w_class` from `normal` to `tiny`. This allows pipeshot to be stored in boxes inline with all other ammo types of it's equivalent.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This ammo is the only type that is `w_class = normal` for shotguns. This significantly limits the amount of pipeshot a player can carry, compared to other types of ammo such as slugs, AEX rounds, flare rounds and buckshot. You're likely to run out of ammo before you actually kill anything especially with the recent mobification overall, which buffs the health of most hostile mobs. For comparison, the only other `w_class = normal` ammo types are 40mm grenades and rockets. All other shotgun ammo types are `w_class = tiny`.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Blackrep
(+)Buff: Pipeshot shells are now tiny objects.
```
