### PR TITLE
Adjustable IV drips + Helptext

### DIFF
--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -26,6 +26,10 @@
 	var/mode = IV_DRAW
 	var/in_use = 0
 	var/slashed = 0
+	var/max_transfer_rate = 5
+	HELP_MESSAGE_OVERRIDE({"
+		Use this item in-hand with the <b>grab</b> intent to adjust the drip rate,
+		use any other intent to switch between drawing blood or injecting."})
 
 	New()
 		..()
@@ -81,9 +85,16 @@
 			src.UpdateIcon()
 
 	attack_self(mob/user as mob)
-		src.mode = !(src.mode)
-		user.show_text("You switch [src] to [src.mode ? "inject" : "draw"].")
-		src.UpdateIcon()
+		if (user.a_intent != INTENT_GRAB)
+			src.mode = !(src.mode)
+			user.show_text("You switch [src] to [src.mode ? "inject" : "draw"].")
+			src.UpdateIcon()
+		else 
+			if (src.amount_per_transfer_from_this >= src.max_transfer_rate)
+				src.amount_per_transfer_from_this = 1
+			else
+				src.amount_per_transfer_from_this++
+			user.show_text("You switch the drip rate of \the [src] to [src.amount_per_transfer_from_this].")
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
 		if (!ishuman(M))

--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -85,16 +85,16 @@
 			src.UpdateIcon()
 
 	attack_self(mob/user as mob)
-		if (user.a_intent != INTENT_GRAB)
-			src.mode = !(src.mode)
-			user.show_text("You switch [src] to [src.mode ? "inject" : "draw"].")
-			src.UpdateIcon()
-		else 
+		if (user.a_intent == INTENT_GRAB)
 			if (src.amount_per_transfer_from_this >= src.max_transfer_rate)
 				src.amount_per_transfer_from_this = 1
 			else
 				src.amount_per_transfer_from_this++
 			user.show_text("You switch the drip rate of \the [src] to [src.amount_per_transfer_from_this].")
+		else 
+			src.mode = !(src.mode)
+			user.show_text("You switch [src] to [src.mode ? "inject" : "draw"].")
+			src.UpdateIcon()
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
 		if (!ishuman(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDICAL][QOL][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
By using the grab intent on IV drips, you can now adjust the drip rate in increments of 1, from 1u/tick to 5u/tick.
This feature **requires the IV drip to be on a drip stand.** 

Also adds helptext to describe this functionality.
Grab was picked because it's a niche intent for surgery, and technically you're 'grabbing' an anchor clamp or whatever.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some players have voiced that the IV tends to overfill patients very quickly. 
This lets you fine tune drip-rates to only give a patient the medicine they need, rather than having them walk out of medbay dosed up on 100+ units of saline for a single operation.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)You can now adjust the drip rate of IV bags with the grab intent. This only works when the bag is properly hung from a stand!
```
