### PR TITLE
Fix initialisation stage of map helpers

### DIFF
--- a/code/obj/mapping/_helper_parent.dm
+++ b/code/obj/mapping/_helper_parent.dm
@@ -15,7 +15,7 @@ ABSTRACT_TYPE(/obj/mapping_helper)
 
 	New()
 		..()
-		if (current_state > GAME_STATE_WORLD_INIT)
+		if (current_state >= GAME_STATE_WORLD_INIT)
 			SPAWN(5 DECI SECONDS)
 				src.initialize()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes > to >=

Fixes #14814

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
windows were spawning after init and causing depressurisation.

