### PR TITLE
Fix an oversight on melted reactor components

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -702,7 +702,10 @@
 	New()
 		for(var/x=2 to REACTOR_GRID_WIDTH-1)
 			for(var/y=2 to REACTOR_GRID_HEIGHT-1)
-				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
+				if(x==4 && y==4)
+					src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
+				else
+					src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("cerenkite")
 		..()
 
 #undef REACTOR_GRID_WIDTH

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -105,7 +105,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 			parent.MarkGridForUpdate()
 			parent.UpdateIcon()
 		src.neutron_cross_section = 5.0
-		src.thermal_cross_section = 1.0
+		src.thermal_cross_section = 20.0
 		src.is_control_rod = FALSE
 
 	proc/extra_info()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Thermal cross section used to be on a scale of 0 to 1, but then I fixed the math, and now it's unbounded. I forgot to update the melting code to reflect this new scale, so instead melted components became very good insulators. This is the opposite of the intended effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Melted components should heat up the reactor/nearby components dangerously. It's a bug that they didn't.
