### PR TITLE
Make azure tables deconstruct into glass

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -618,6 +618,7 @@ TYPEINFO_NEW(/obj/table/nanotrasen)
 	desc = "An industrial grade table with an azure glass panel on the top. The glass looks extremely sturdy."
 	icon = 'icons/obj/furniture/table_nanotrasen.dmi'
 	parts_type = /obj/item/furniture_parts/table/nanotrasen
+	default_material = "glass"
 
 	auto
 		auto = TRUE


### PR DESCRIPTION
[TRIVIAL]
## About the PR
Makes it so that `obj/table/nanotrasen` aka azure glass tables deconstruct into glass and not steel sheets.
## Why's this needed?
fixes #12670