### PR TITLE
Adds the Rancher's closet

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -454,6 +454,9 @@ TRAYS
 		allowed_food = /obj/item/reagent_containers/food/snacks/ingredient/egg
 		contained_food_name = "egg"
 
+		rancher
+			count = 4
+
 	lollipop
 		name = "lollipop bowl"
 		desc = "A little bowl of lollipops, totally healthy in every way! They're medicinal, after all!"

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -834,6 +834,20 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/paper/book/from_file/hydroponicsguide,
 	/obj/item/device/appraisal)
 
+/obj/storage/secure/closet/civilian/ranch
+	name = "\improper Rancher supplies locker"
+	req_access = list(access_hydro)
+	spawn_contents = list(/obj/item/paper/ranch_guide,\
+	/obj/item/fishing_rod/basic,\
+	/obj/item/storage/box/clothing/rancher,\
+	/obj/item/device/camera_viewer/ranch,\
+	/obj/item/clothing/mask/chicken,\
+	/obj/item/chicken_carrier,\
+	/obj/item/storage/box/syringes,\
+	/obj/item/satchel/hydro,\
+	/obj/item/reagent_containers/glass/wateringcan,\
+	/obj/item/sponge)
+
 /obj/storage/secure/closet/civilian/kitchen
 	name = "\improper Catering supplies locker"
 	req_access = list(access_kitchen)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -836,7 +836,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 
 /obj/storage/secure/closet/civilian/ranch
 	name = "\improper Rancher supplies locker"
-	req_access = list(access_hydro)
+	req_access = list(access_ranch)
 	spawn_contents = list(/obj/item/paper/ranch_guide,\
 	/obj/item/fishing_rod/basic,\
 	/obj/item/storage/box/clothing/rancher,\

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -846,7 +846,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/storage/box/syringes,\
 	/obj/item/satchel/hydro,\
 	/obj/item/reagent_containers/glass/wateringcan,\
-	/obj/item/sponge)
+	/obj/item/sponge,\
+	/obj/item/kitchen/food_box/egg_box/rancher)
 
 /obj/storage/secure/closet/civilian/kitchen
 	name = "\improper Catering supplies locker"


### PR DESCRIPTION
[MAPPING] [QOL]
## About the PR
Ranching closets were manually applied across maps by var editing a closet and giving them items. This makes a secure locker variant with all the necessary items already included.
This PR DOES NOT add them to maps. That is being atomised out for merge conflict reasons.
## Why's this needed?
More convenient for mappers, and makes things more consistent across multiple maps. For instance, clarion and atlas lack a ranching locker altogether. And the contents, while the core ones stay the same, vary across maps (e.g. some maps lack syringe boxes and produce bags, while donut2 has a watering can and sponge in addition, etc.)
Once this is merged I'll start swapping them out on various maps.