### PR TITLE
Remove maintenance cameras for cogmap1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -9770,6 +9770,11 @@
 /area/station/crew_quarters/catering)
 "aDp" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aDq" = (
@@ -49988,6 +49993,11 @@
 	},
 /obj/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -621,11 +621,6 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/disposalpipe/segment/food{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -844,15 +839,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction)
-"ady" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/observatory)
 "adz" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'CONSTRUCTION AREA'";
@@ -1168,19 +1154,6 @@
 "aeB" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersB)
-"aeC" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
 "aeD" = (
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
@@ -2274,21 +2247,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
-"ahM" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/disposalpipe/segment/food{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "ahN" = (
@@ -3855,12 +3813,6 @@
 /area/station/maintenance/northwest)
 "amF" = (
 /obj/machinery/atmospherics/pipe/simple,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -4855,12 +4807,6 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "apH" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -4906,15 +4852,6 @@
 /area/station/maintenance/northeast)
 "apP" = (
 /obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
-"apQ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "apR" = (
@@ -7263,12 +7200,6 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "awZ" = (
@@ -7466,12 +7397,6 @@
 "axB" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/kitchen{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
@@ -9844,12 +9769,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "aDp" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -10434,12 +10353,6 @@
 	},
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/shieldgenerator/meteorshield,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aER" = (
@@ -12387,12 +12300,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aJP" = (
@@ -13656,11 +13563,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -14171,16 +14073,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"aOm" = (
-/obj/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -15349,11 +15241,6 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/item/crowbar{
 	pixel_x = 3;
 	pixel_y = 5
@@ -15462,16 +15349,6 @@
 "aRD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/detectives_office)
-"aRE" = (
-/obj/storage/closet/emergency,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aRF" = (
 /obj/stool/chair{
 	dir = 4
@@ -19297,18 +19174,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"bbC" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "bbD" = (
 /obj/item/tile/steel,
 /obj/disposalpipe/segment/mail{
@@ -19360,11 +19225,6 @@
 /obj/item/clothing/mask/gas/emergency{
 	pixel_x = -3;
 	pixel_y = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -20098,12 +19958,6 @@
 	dir = 1;
 	name = "Chapel Repressurization West"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bdF" = (
@@ -20401,12 +20255,6 @@
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -20993,11 +20841,6 @@
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/storage/crate,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/disposal)
 "bgk" = (
@@ -21005,12 +20848,6 @@
 	name = "blobstart"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bgl" = (
@@ -21297,12 +21134,6 @@
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -21668,11 +21499,6 @@
 "bie" = (
 /obj/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -23540,15 +23366,6 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/grey/side,
 /area/station/routing/engine)
-"bof" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
 "boh" = (
 /obj/machinery/mass_driver{
 	drive_range = 6;
@@ -23954,6 +23771,11 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bpu" = (
@@ -24149,11 +23971,6 @@
 "bpS" = (
 /obj/stool/chair{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -33764,12 +33581,6 @@
 /area/station/maintenance/southwest)
 "bZu" = (
 /obj/reagent_dispensers/foamtank,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bZv" = (
@@ -34233,12 +34044,6 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -36418,12 +36223,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "chv" = (
@@ -37881,12 +37680,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cly" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -41840,16 +41633,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"cwW" = (
-/obj/storage/closet/emergency,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "cwX" = (
 /obj/storage/crate,
 /obj/item/sponge{
@@ -43750,11 +43533,6 @@
 /obj/disposaloutlet,
 /obj/disposalpipe/trunk{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -47403,12 +47181,6 @@
 /area/station/maintenance/east)
 "fVJ" = (
 /obj/machinery/space_heater,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "fVT" = (
@@ -49056,12 +48828,6 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "hyz" = (
@@ -50217,12 +49983,6 @@
 "izj" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/item/cell/supercell/charged{
 	pixel_x = 2
 	},
@@ -53858,18 +53618,6 @@
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"mdx" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
 "mea" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -58934,20 +58682,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/science/lab)
-"qIl" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/morgue,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "qIu" = (
 /obj/window/reinforced{
 	dir = 8
@@ -101723,7 +101457,7 @@ aPd
 aCw
 aOC
 aRg
-aRE
+baJ
 bfn
 aVE
 aUk
@@ -105307,7 +105041,7 @@ abn
 abn
 abD
 abn
-ady
+abn
 abE
 acz
 add
@@ -106565,7 +106299,7 @@ aPj
 aPj
 aPj
 aPj
-mdx
+aPj
 bfa
 aPj
 bgP
@@ -106573,7 +106307,7 @@ bhE
 aPj
 bjK
 aIe
-bof
+aIe
 aGT
 bmA
 bnf
@@ -107759,7 +107493,7 @@ aId
 aId
 aId
 aId
-aOm
+aId
 aId
 aRo
 aSl
@@ -108332,7 +108066,7 @@ mMk
 acG
 adh
 adR
-aeC
+afi
 afi
 afi
 afi
@@ -109959,7 +109693,7 @@ aif
 cuw
 ahd
 cwo
-cwW
+ubf
 ahh
 aah
 adC
@@ -110450,7 +110184,7 @@ aeH
 afn
 agg
 agT
-ahM
+ahO
 aiG
 ajP
 ajP
@@ -118397,7 +118131,7 @@ bZz
 lGR
 cbe
 ccm
-qIl
+ceP
 ceP
 cge
 chm
@@ -121326,7 +121060,7 @@ aie
 onU
 aie
 aie
-apQ
+aie
 bLI
 arc
 arq
@@ -121964,7 +121698,7 @@ aXL
 aYM
 aSD
 baA
-bbC
+bbB
 aYQ
 bdG
 beE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes nearly all cameras from cogmap1 maintenance.

A camera in disposals was moved to reduce it's vision into disposals belt hell.

Cameras I could not decide if should be removed:
Air hookup
Router
Electrical Substation
North Solar Maintenance
Exterior cameras

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cogmap1 has a very high level of AI camera coverage with almost all of maintenance covered.
In comparison, Donut3 has almost no camera coverage of maintenance and Cogmap2 only has a few areas covered.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(*)AI camera coverage of Cogmap1 maintenance has been significantly reduced.
```
