### PR TITLE
Fixes Space Heaters Occasionally Not Heating Their Surroundings

### DIFF
--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -241,7 +241,7 @@ TYPEINFO(/obj/machinery/space_heater)
 
 						//boutput(world, "now at [removed.temperature]")
 
-					env.merge(removed)
+					L.assume_air(removed)
 					UpdateIcon()
 					//boutput(world, "turf now at [env.temperature]")
 


### PR DESCRIPTION
[Atmospherics] [Bug]



## Why Is This Needed?
Replaces a `/datum/gas_mixture/proc/merge()` call with a `/turf/proc/assume_air()` call within space heaters' process loop. Calling `/datum/gas_mixture/proc/merge()` resulted in space heaters being incapable of heating their surroundings if single turf processing had not been enabled by an external source.