### PR TITLE
Nadir "Eclipse" Fixbatch

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -45322,9 +45322,11 @@
 /area/space)
 "tDY" = (
 /obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_y = 17
+	},
 /obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 3;
-	pixel_y = 6
+	pixel_x = 4
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby{
@@ -54119,9 +54121,6 @@
 	})
 "xII" = (
 /obj/table/reinforced/auto,
-/obj/item/kitchen/food_box/donut_box{
-	pixel_y = -4
-	},
 /obj/machinery/light_switch/east,
 /obj/item/reagent_containers/food/drinks/mug{
 	pixel_x = 5;

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2229,8 +2229,14 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "bbq" = (
-/obj/disposalpipe/trunk/west,
-/obj/machinery/disposal,
+/obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/sugar_box{
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -5579,17 +5585,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
-"czO" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/nw{
-	name = "Northwest Breach Hull"
-	})
 "cAx" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -6939,6 +6934,20 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"dhd" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space/fluid/acid/clear,
+/area/space)
 "dhp" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -6983,18 +6992,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/elect)
-"dif" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/sw{
-	name = "Southwest Breach Hull"
-	})
 "dis" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7612,6 +7609,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
+"dxn" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "dxw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7854,22 +7861,6 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/cloner)
-"dBW" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "dCr" = (
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
@@ -8314,17 +8305,6 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
-"dKj" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/sw{
-	name = "Southwest Breach Hull"
-	})
 "dKp" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9691,6 +9671,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk/east,
 /turf/simulated/floor/greenblack,
 /area/station/hydroponics/bay)
 "etW" = (
@@ -9984,10 +9966,6 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
-"ezU" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "eAk" = (
 /obj/reagent_dispensers/still,
 /turf/simulated/floor/grime,
@@ -10896,18 +10874,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
-"eTi" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/nw{
-	name = "Northwest Breach Hull"
-	})
 "eTt" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11930,6 +11896,15 @@
 	dir = 6
 	},
 /area/station/hallway/secondary/exit)
+"ftF" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "ftP" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15175,6 +15150,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"gJq" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "gJU" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,
@@ -17793,6 +17778,16 @@
 	dir = 8
 	},
 /area/station/medical/medbay/treatment)
+"hIJ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "hIM" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -18051,17 +18046,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
-"hPc" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/ne{
-	name = "Northeast Breach Hull"
-	})
 "hPg" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/circuit/white,
@@ -18627,7 +18611,7 @@
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/southeast)
 "hZY" = (
-/obj/submachine/seed_vendor,
+/obj/machinery/vending/hydroponics,
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -20669,6 +20653,16 @@
 	dir = 4
 	},
 /area/station/crew_quarters/cafeteria)
+"iUo" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "iUu" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/item/clothing/suit/cardboard_box,
@@ -22584,17 +22578,6 @@
 	},
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"jKY" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/black,
-/area/station/maintenance/outer/ne{
-	name = "Northeast Breach Hull"
-	})
 "jLv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24226,6 +24209,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/greenblack/corner{
 	dir = 4
 	},
@@ -24298,18 +24282,17 @@
 /area/station/crew_quarters/baroffice)
 "ksw" = (
 /obj/table/reinforced/auto,
-/obj/item/nanoloom_cartridge{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/device/radio/headset/medical{
-	pixel_x = 8;
-	pixel_y = 3
-	},
 /obj/drink_rack/mug{
 	pixel_y = 32
 	},
-/obj/item/kitchen/food_box/sugar_box,
+/obj/item/kitchen/food_box/sugar_box{
+	pixel_x = -11;
+	pixel_y = 11
+	},
+/obj/item/device/radio/headset/medical{
+	pixel_x = 9;
+	pixel_y = 3
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
 "ksL" = (
@@ -27245,6 +27228,19 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"lEf" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space/fluid/acid/clear,
+/area/space)
 "lEn" = (
 /turf/simulated/floor/black,
 /area/station/science/lobby{
@@ -27552,10 +27548,12 @@
 /area/station/security/brig)
 "lIR" = (
 /obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/item/device/nanoloom{
 	pixel_x = -13;
 	pixel_y = 18
+	},
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -28120,11 +28118,15 @@
 	},
 /obj/table/reinforced/auto,
 /obj/item/robodefibrillator{
-	pixel_y = -1
+	pixel_y = 13
 	},
 /obj/item/device/nanoloom{
-	pixel_x = -12;
-	pixel_y = 9
+	pixel_y = 1;
+	pixel_x = 4
+	},
+/obj/item/nanoloom_cartridge{
+	pixel_x = -7;
+	pixel_y = -3
 	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
@@ -30149,12 +30151,6 @@
 /obj/cable{
 	icon_state = "5-8"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
@@ -31813,10 +31809,12 @@
 "nAt" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/food_box/sugar_box{
-	pixel_y = 16
+	pixel_y = 16;
+	pixel_x = -1
 	},
-/obj/machinery/computer/security/wooden_tv/small{
-	pixel_y = 8
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_y = 5;
+	pixel_x = 7
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -32610,6 +32608,16 @@
 	},
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
+"nRm" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/space/fluid/acid,
+/area/space)
 "nRn" = (
 /obj/stool/chair{
 	dir = 8
@@ -33365,10 +33373,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/pool)
-"omx" = (
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "omG" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2,
@@ -33766,18 +33770,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/solitary)
-"ovR" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "ovW" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/regular,
@@ -35459,17 +35451,6 @@
 /obj/decal/tile_edge/floorguide/security,
 /turf/simulated/floor/redblack/corner,
 /area/station/hallway/primary/southwest)
-"phU" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "phV" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -35984,12 +35965,6 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
@@ -36457,6 +36432,20 @@
 	dir = 4
 	},
 /area/station/quartermaster/refinery)
+"pFh" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/space/fluid/acid/clear,
+/area/space)
 "pFt" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -37948,6 +37937,19 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"qqC" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space/fluid/acid/clear,
+/area/space)
 "qqP" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -43173,18 +43175,6 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
-"sKM" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/sw{
-	name = "Southwest Breach Hull"
-	})
 "sKR" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -44265,7 +44255,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "tgS" = (
@@ -45941,18 +45931,16 @@
 	name = "wooden table"
 	},
 /obj/item/reagent_containers/food/drinks/creamer{
-	pixel_x = -13;
+	pixel_x = -15;
 	pixel_y = 14
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/round{
-	initial_reagents = "sugar";
-	name = "sugar bowl";
-	pixel_x = 2;
-	pixel_y = 8
-	},
 /obj/item/reagent_containers/food/drinks/creamer{
-	pixel_x = -13;
+	pixel_x = -15;
 	pixel_y = 7
+	},
+/obj/item/kitchen/food_box/sugar_box{
+	pixel_y = 12;
+	pixel_x = 1
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -48213,18 +48201,6 @@
 /area/station/maintenance/outer/ne{
 	name = "Northeast Breach Hull"
 	})
-"uUk" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/ne{
-	name = "Northeast Breach Hull"
-	})
 "uUP" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50011,12 +49987,6 @@
 	dir = 10;
 	icon_state = "lattice-dir-b"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/space/fluid/acid/clear,
 /area/space)
 "vNp" = (
@@ -50273,7 +50243,15 @@
 	icon_state = "miniorange";
 	name = "Donk-Closet";
 	pixel_y = 32;
-	spawn_contents = list(/obj/item/storage/box/donkpocket_kit)
+	spawn_contents = list(/obj/item/storage/box/donkpocket_kit);
+	pixel_x = -4
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -51897,14 +51875,11 @@
 	name = "Arrival Shuttle Hallway"
 	})
 "wIo" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
 /obj/machinery/vending/jobclothing/engineering,
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = 23
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
 	},
@@ -53062,10 +53037,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/coffeemaker/engineering,
-/obj/item/reagent_containers/food/drinks/creamer{
-	pixel_x = -5;
-	pixel_y = -6
-	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -54457,7 +54428,6 @@
 /turf/simulated/floor/caution/west,
 /area/pasiphae/hangar)
 "xQe" = (
-/obj/table/reinforced/auto,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -54469,13 +54439,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/item/kitchen/food_box/sugar_box{
-	pixel_y = 16
-	},
-/obj/item/reagent_containers/food/drinks/creamer{
-	pixel_x = -8;
-	pixel_y = 5
-	},
+/obj/submachine/seed_vendor,
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -54970,10 +54934,6 @@
 	dir = 8
 	},
 /area/station/engine/storage)
-"ycf" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
 "ycg" = (
 /obj/grille/catwalk,
 /obj/decal/cleanable/leaves{
@@ -84196,7 +84156,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+dxn
 bzS
 bzS
 bzS
@@ -84254,7 +84214,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+gJq
 bzS
 bzS
 bzS
@@ -84493,16 +84453,16 @@ bzS
 xQv
 wmj
 xQv
-inI
 xQv
 xQv
 inI
 xQv
 xQv
-inI
 xQv
 xQv
+xQv
 inI
+xQv
 xQv
 xQv
 xQv
@@ -84552,16 +84512,16 @@ jjE
 jjE
 jjE
 jjE
-kSY
-jjE
 jjE
 kSY
 jjE
 jjE
+jjE
+jjE
+jjE
 kSY
 jjE
 jjE
-kSY
 jjE
 kpm
 jjE
@@ -84786,7 +84746,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+gJq
 bzS
 bzS
 bzS
@@ -84798,13 +84758,13 @@ sja
 bRa
 fEU
 bRa
-eTi
+bRa
 bRa
 rbg
 bRa
 bRa
 bRa
-eTi
+bRa
 fEU
 qKW
 jRw
@@ -84855,13 +84815,13 @@ iIk
 fbn
 wuT
 uqC
-dif
+uqC
 uqC
 uqC
 aUV
 uqC
 uqC
-dif
+uqC
 wuT
 uqC
 poa
@@ -84872,7 +84832,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+dxn
 bzS
 bzS
 bzS
@@ -86303,7 +86263,7 @@ cPu
 xQv
 bRa
 bRa
-czO
+bRa
 anu
 anu
 xcu
@@ -86677,7 +86637,7 @@ vaV
 vaV
 vaV
 tZe
-dif
+uqC
 uqC
 uqC
 jjE
@@ -87204,8 +87164,8 @@ bzS
 bzS
 bzS
 hnw
-rJg
 inI
+bRa
 fEU
 bRa
 bRa
@@ -87285,8 +87245,8 @@ wZQ
 uqC
 uqC
 wuT
+uqC
 kSY
-rJg
 hnw
 bzS
 bzS
@@ -87507,7 +87467,7 @@ bzS
 bzS
 lAH
 xQv
-xQv
+bRa
 bRa
 bRa
 anu
@@ -87587,7 +87547,7 @@ mKo
 fOA
 uqC
 uqC
-jjE
+uqC
 jjE
 vnv
 bzS
@@ -87807,7 +87767,7 @@ bzS
 bzS
 bzS
 bzS
-lAH
+lEf
 xQv
 bRa
 bRa
@@ -87891,7 +87851,7 @@ uqC
 uqC
 uqC
 jjE
-vnv
+dhd
 bzS
 bzS
 bzS
@@ -88112,7 +88072,7 @@ bzS
 xQv
 xQv
 bRa
-czO
+bRa
 anu
 anu
 tmJ
@@ -88191,7 +88151,7 @@ mKo
 mKo
 mKo
 uqC
-dKj
+uqC
 jjE
 jjE
 bzS
@@ -88410,7 +88370,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 xOU
 bRa
@@ -88496,7 +88456,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -88713,7 +88673,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 qmk
@@ -88797,7 +88757,7 @@ poP
 mKo
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -89013,7 +88973,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -89101,7 +89061,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -89616,7 +89576,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 fEU
 bRa
@@ -89706,7 +89666,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -89919,7 +89879,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 qmk
@@ -90007,7 +89967,7 @@ mKo
 uqC
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -90219,7 +90179,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -90311,7 +90271,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -90524,7 +90484,7 @@ bzS
 xQv
 xQv
 bRa
-czO
+bRa
 qmk
 qmk
 pTa
@@ -90822,7 +90782,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 xOU
 bRa
@@ -90916,7 +90876,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -91125,7 +91085,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 qmk
@@ -91215,9 +91175,9 @@ rRY
 lPo
 jjE
 jjE
-sKM
 uqC
-jjE
+uqC
+uqC
 jjE
 jjE
 jjE
@@ -91425,7 +91385,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -92028,7 +91988,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 fEU
 bRa
@@ -92331,7 +92291,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 xYW
@@ -92631,7 +92591,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -92936,7 +92896,7 @@ bzS
 xQv
 xQv
 bRa
-czO
+bRa
 xYW
 xYW
 pkz
@@ -93031,7 +92991,7 @@ aWO
 wGw
 wGw
 uqC
-dKj
+uqC
 jjE
 jjE
 bSI
@@ -93234,7 +93194,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 xOU
 bRa
@@ -93336,7 +93296,7 @@ uqC
 uqC
 wuT
 kSY
-rJg
+kSY
 bzS
 bzS
 bzS
@@ -93537,7 +93497,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 qfE
@@ -93637,7 +93597,7 @@ ebB
 ebB
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -93837,7 +93797,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -93941,7 +93901,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -94184,8 +94144,8 @@ ajV
 ajV
 rxO
 ajV
-ezU
-ycf
+ajV
+ajV
 tgQ
 igl
 igl
@@ -94440,7 +94400,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 fEU
 bRa
@@ -94486,7 +94446,7 @@ cZD
 cZD
 ckn
 mwv
-omx
+ajV
 ajV
 ajV
 ajV
@@ -94546,7 +94506,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -94743,7 +94703,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 qfE
@@ -94847,7 +94807,7 @@ ebB
 gow
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -95043,7 +95003,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -95151,7 +95111,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -95348,7 +95308,7 @@ bzS
 xQv
 xQv
 bRa
-czO
+bRa
 jhj
 qfE
 vOi
@@ -95451,7 +95411,7 @@ vHX
 gow
 gow
 uqC
-dKj
+uqC
 jjE
 jjE
 bzS
@@ -95646,7 +95606,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 xOU
 bRa
@@ -95756,7 +95716,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -95949,7 +95909,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 jhj
@@ -96057,7 +96017,7 @@ gow
 gow
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -96249,7 +96209,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bRa
@@ -96361,7 +96321,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -96852,7 +96812,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 fEU
 bRa
@@ -96966,7 +96926,7 @@ uqC
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -97155,7 +97115,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 bRa
 jhj
@@ -97267,7 +97227,7 @@ gow
 gow
 uqC
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -97455,7 +97415,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 bAt
@@ -97571,7 +97531,7 @@ tZe
 uqC
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -97871,7 +97831,7 @@ gow
 gow
 uqC
 uqC
-dKj
+uqC
 jjE
 jjE
 bzS
@@ -98058,7 +98018,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+inI
 inI
 xOU
 bRa
@@ -98176,7 +98136,7 @@ nGV
 uqC
 wuT
 kSY
-bzS
+kSY
 bzS
 bzS
 bzS
@@ -98361,7 +98321,7 @@ bzS
 bzS
 bzS
 xQv
-xQv
+bRa
 bRa
 eIk
 bRa
@@ -98477,7 +98437,7 @@ abz
 uqC
 nKf
 uqC
-jjE
+uqC
 jjE
 bzS
 bzS
@@ -98661,7 +98621,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+aWz
 xQv
 bRa
 dsa
@@ -98781,7 +98741,7 @@ uqC
 nPT
 uqC
 jjE
-bzS
+fWG
 bzS
 bzS
 bzS
@@ -103493,7 +103453,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 sJU
@@ -103613,7 +103573,7 @@ neB
 nna
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -103797,7 +103757,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 mZy
 ylR
 uNU
@@ -103913,7 +103873,7 @@ abz
 neB
 nPr
 vTb
-dAB
+neB
 dAB
 bzS
 bzS
@@ -104098,7 +104058,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 wGt
 who
@@ -104216,7 +104176,7 @@ nIj
 cSH
 bWz
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -104515,7 +104475,7 @@ nve
 eRD
 nGd
 neB
-phU
+neB
 dAB
 dAB
 bzS
@@ -104703,7 +104663,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 wUo
@@ -104819,7 +104779,7 @@ nGi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -105007,7 +104967,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 lRC
@@ -105119,7 +105079,7 @@ eRD
 eRD
 nGm
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -105308,7 +105268,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 aGv
 uNU
@@ -105422,7 +105382,7 @@ nCM
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -105913,7 +105873,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -106025,7 +105985,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -106217,7 +106177,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 lRC
@@ -106325,7 +106285,7 @@ eRD
 eRD
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -106518,7 +106478,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 nhc
 uNU
@@ -106628,7 +106588,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -106824,7 +106784,7 @@ bzS
 rne
 rne
 uNU
-hPc
+uNU
 lRC
 lRC
 lja
@@ -106927,7 +106887,7 @@ bFf
 eRD
 eRD
 neB
-phU
+neB
 dAB
 dAB
 bzS
@@ -107123,7 +107083,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -107231,7 +107191,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -107427,7 +107387,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 lRC
@@ -107531,7 +107491,7 @@ eRD
 eRD
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -107728,7 +107688,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 aGv
 uNU
@@ -107834,7 +107794,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -108333,7 +108293,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -108437,7 +108397,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -108637,7 +108597,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 tVq
@@ -108737,7 +108697,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -108938,7 +108898,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 nhc
 uNU
@@ -109040,7 +109000,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -109244,7 +109204,7 @@ bzS
 rne
 rne
 uNU
-hPc
+uNU
 mIG
 mIG
 sEL
@@ -109339,7 +109299,7 @@ uWj
 kRh
 kRh
 neB
-phU
+neB
 dAB
 dAB
 bzS
@@ -109543,7 +109503,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -109643,7 +109603,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -109847,7 +109807,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 mIG
@@ -109943,7 +109903,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -110148,7 +110108,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 aGv
 uNU
@@ -110246,7 +110206,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -110753,7 +110713,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -110849,7 +110809,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -111057,7 +111017,7 @@ bzS
 bzS
 bzS
 rne
-rne
+uNU
 uNU
 uNU
 mIG
@@ -111149,7 +111109,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -111358,11 +111318,11 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nHe
 nHe
 nhc
 uNU
-uUk
+uNU
 uNU
 pnp
 fqi
@@ -111452,7 +111412,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -111751,7 +111711,7 @@ kCh
 kRh
 kRh
 neB
-phU
+neB
 dAB
 dAB
 bzS
@@ -111963,7 +111923,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+ftF
 rne
 uNU
 uNU
@@ -112055,7 +112015,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -112355,7 +112315,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -112658,7 +112618,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -113176,7 +113136,7 @@ hwg
 eng
 eng
 nHe
-jKY
+fPT
 xcJ
 lrf
 vzN
@@ -113261,7 +113221,7 @@ lCi
 neB
 neB
 dAB
-bzS
+hIJ
 bzS
 bzS
 bzS
@@ -113561,7 +113521,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 bzS
 bzS
@@ -113864,7 +113824,7 @@ neB
 neB
 hOA
 rEP
-bzS
+rEP
 bzS
 bzS
 bzS
@@ -114163,7 +114123,7 @@ sju
 kRh
 kRh
 neB
-phU
+neB
 dAB
 dAB
 bzS
@@ -114383,7 +114343,7 @@ bzS
 bzS
 bzS
 rJg
-lAH
+qqC
 rne
 uNU
 uNU
@@ -114467,7 +114427,7 @@ lCi
 neB
 neB
 dAB
-vnv
+pFh
 bzS
 bzS
 bzS
@@ -114687,9 +114647,9 @@ bzS
 bzS
 lAH
 rne
-rne
 uNU
-hPc
+uNU
+uNU
 pYH
 pYH
 aiC
@@ -114767,7 +114727,7 @@ kRh
 kRh
 neB
 neB
-dAB
+neB
 dAB
 vnv
 bzS
@@ -114988,9 +114948,9 @@ bzS
 bzS
 bzS
 hnw
-rJg
 mDA
 nhc
+uNU
 uNU
 uNU
 pYH
@@ -115069,8 +115029,8 @@ lka
 neB
 neB
 hOA
+neB
 rEP
-rJg
 hnw
 bzS
 bzS
@@ -115669,7 +115629,7 @@ pfe
 mTx
 gYB
 kRh
-dBW
+lCi
 neB
 neB
 dAB
@@ -115899,7 +115859,7 @@ bmX
 rne
 uNU
 uNU
-hPc
+uNU
 tVq
 tVq
 tVq
@@ -117402,7 +117362,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nRm
 bzS
 bzS
 bzS
@@ -117414,13 +117374,13 @@ cXH
 uNU
 aGv
 uNU
-uUk
+uNU
 uNU
 pnp
 uNU
 uNU
 uNU
-uUk
+uNU
 aGv
 peU
 lmE
@@ -117470,13 +117430,13 @@ uMD
 oAQ
 azi
 hOA
-ovR
+neB
 neB
 neB
 neB
 bAB
 neB
-ovR
+neB
 neB
 hOA
 neB
@@ -117488,7 +117448,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+iUo
 bzS
 bzS
 bzS
@@ -117713,16 +117673,16 @@ bzS
 rne
 iIv
 rne
-nHe
 rne
 rne
 nHe
 rne
 rne
-nHe
 rne
 rne
+rne
 nHe
+rne
 rne
 rne
 rne
@@ -117772,16 +117732,16 @@ dAB
 dAB
 dAB
 dAB
-rEP
-dAB
 dAB
 rEP
 dAB
 dAB
+dAB
+dAB
+dAB
 rEP
 dAB
 dAB
-rEP
 dAB
 pds
 dAB
@@ -118020,7 +117980,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+iUo
 bzS
 bzS
 bzS
@@ -118078,7 +118038,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+nRm
 bzS
 bzS
 bzS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

It's called Eclipse because now only the outer edges are visible!

- **Major**: Rearranged the breach hull to point its cameras outwards. The majority of the breach hull interior is now obscured to cameras, but outer camera coverage is still contiguous to allow for consistent detection of any breaches (the nominal reason for having cameras there at all), with the hull geometry adjusted slightly to permit this. It's crime time.
- Adjusted Hydroponics' eastern partition to better use space after the fishing equipment addition. A GardenGear is now present (bringing the overall department complement back up to 2) and the cream and sugar table is now a part of the main coffee table.
- Other coffee equipment has been adjusted to fit better into its surroundings after the sugar cube box addition. Two material changes are Engineering's recharger moving onto a wall, and the Bridge's sugar bowl being replaced with sugar cubes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves Nadir's crime-friendliness and overall quality of life.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Nadir's breach hull has gone dark, and its second GardenGear is back.
```
