### PR TITLE
Fix lamp manufacturer using ammo when it shouldn't

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -790,14 +790,15 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 			boutput(user, "This fitting isn't user-serviceable.")
 			return
 
+		var/lamp_cost = null
 		if (!inserted_lamp) //Taking charge/sheets
 			if (!M.check_ammo(user, M.cost_empty))
 				return
-			M.take_ammo(user, M.cost_empty)
+			lamp_cost = M.cost_empty
 		else
 			if (!M.check_ammo(user, M.cost_broken))
 				return
-			M.take_ammo(user, M.cost_broken)
+			lamp_cost = M.cost_broken
 		var/obj/item/light/L = null
 
 		if (fitting == "tube")
@@ -813,6 +814,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 		insert(user, L)
 		if (!isghostdrone(user)) // Same as ghostdrone RCDs, no sparks
 			elecflash(user)
+		M.take_ammo(user, lamp_cost)
 		return
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #14861 by saving the calculated cost for the operation and taking it at the end once all other logic branches have been passed instead of doing it early (before the identical bulb check)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixy
