### PR TITLE
Rate limit animations on singularity

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -117,7 +117,8 @@ TYPEINFO(/obj/machinery/the_singularitygen)
 	var/maxradius = INFINITY//the maximum size the singularity can grow to
 	var/restricted_z_allowed = FALSE
 	var/right_spinning //! boolean for the spaghettification animation spin direction
-
+	///Count for rate-limiting the spaghettification effect
+	var/spaget_count = 0
 
 
 #ifdef SINGULARITY_TIME
@@ -279,32 +280,35 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	if(QDELETED(A)) // Don't bump that which no longer exists
 		return
 
-	var/spaget_time = 15 SECONDS
-	var/obj/dummy/spaget_overlay = new()
-	spaget_overlay.appearance = A.appearance
-	spaget_overlay.appearance_flags = RESET_COLOR | RESET_ALPHA | PIXEL_SCALE
-	spaget_overlay.pixel_x = A.pixel_x + (A.x - src.x + 0.5)*32
-	spaget_overlay.pixel_y = A.pixel_y + (A.y - src.y + 0.5)*32
-	spaget_overlay.vis_flags = 0
-	spaget_overlay.plane = PLANE_DEFAULT
-	spaget_overlay.mouse_opacity = 0
-	spaget_overlay.transform = A.transform
-	if(prob(0.1)) // easteregg
-		spaget_overlay.icon = 'icons/obj/foodNdrink/food_meals.dmi'
-		spaget_overlay.icon_state = "spag-dish"
-		spaget_overlay.Scale(2, 2)
-	var/angle = get_angle(A, src)
-	var/matrix/flatten = matrix((A.x - src.x)*(cos(angle)), 0, -spaget_overlay.pixel_x, (A.y - src.y)*(sin(angle)), 0, -spaget_overlay.pixel_y)
-	animate(spaget_overlay, spaget_time, FALSE, QUAD_EASING, 0, alpha=0, transform=flatten)
-	var/obj/dummy/spaget_turner = new()
-	spaget_turner.vis_contents += spaget_overlay
-	spaget_turner.mouse_opacity = 0
-	spaget_turner.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM | KEEP_TOGETHER
-	animate_spin(spaget_turner, right_spinning ? "R" : "L", spaget_time / 8 + randfloat(-2, 2), looping=2, parallel=FALSE)
-	src.vis_contents += spaget_turner
-	SPAWN(spaget_time + 1 SECOND)
-		qdel(spaget_overlay)
-		qdel(spaget_turner)
+	if(src.spaget_count < 25)
+		src.spaget_count++
+		var/spaget_time = 15 SECONDS
+		var/obj/dummy/spaget_overlay = new()
+		spaget_overlay.appearance = A.appearance
+		spaget_overlay.appearance_flags = RESET_COLOR | RESET_ALPHA | PIXEL_SCALE
+		spaget_overlay.pixel_x = A.pixel_x + (A.x - src.x + 0.5)*32
+		spaget_overlay.pixel_y = A.pixel_y + (A.y - src.y + 0.5)*32
+		spaget_overlay.vis_flags = 0
+		spaget_overlay.plane = PLANE_DEFAULT
+		spaget_overlay.mouse_opacity = 0
+		spaget_overlay.transform = A.transform
+		if(prob(0.1)) // easteregg
+			spaget_overlay.icon = 'icons/obj/foodNdrink/food_meals.dmi'
+			spaget_overlay.icon_state = "spag-dish"
+			spaget_overlay.Scale(2, 2)
+		var/angle = get_angle(A, src)
+		var/matrix/flatten = matrix((A.x - src.x)*(cos(angle)), 0, -spaget_overlay.pixel_x, (A.y - src.y)*(sin(angle)), 0, -spaget_overlay.pixel_y)
+		animate(spaget_overlay, spaget_time, FALSE, QUAD_EASING, 0, alpha=0, transform=flatten)
+		var/obj/dummy/spaget_turner = new()
+		spaget_turner.vis_contents += spaget_overlay
+		spaget_turner.mouse_opacity = 0
+		spaget_turner.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM | KEEP_TOGETHER
+		animate_spin(spaget_turner, right_spinning ? "R" : "L", spaget_time / 8 + randfloat(-2, 2), looping=2, parallel=FALSE)
+		src.vis_contents += spaget_turner
+		SPAWN(spaget_time + 1 SECOND)
+			src.spaget_count--
+			qdel(spaget_overlay)
+			qdel(spaget_turner)
 
 	if (isliving(A) && !isintangible(A))//if its a mob
 		var/mob/living/L = A


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Weird issue that seems to affect a few users (including me) - large singularities cause flickering and general badness. It's a a BYOND bug, but lummox can't reproduce on his machine so there's not much to do but workaround it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14798
Fixes #14748 
Fixes #14746 