### PR TITLE
Fixes #14866 - Outermost Movable Components Now Track Changes In Area

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -81,6 +81,8 @@
 
 	/// when the outermost movable in the .loc chain changes (thing, old_outermost_movable, new_outermost_movable)
 	#define XSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
+	/// When the outermost movable in the .loc chain moves to a new area. (thing, old_area, new_area)
+	#define XSIG_MOVABLE_AREA_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_area_changed")
 	/// When the outermost movable in the .loc chain moves to a new turf. (thing, old_turf, new_turf)
 	#define XSIG_MOVABLE_TURF_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_turf_changed")
 	/// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)

--- a/code/area.dm
+++ b/code/area.dm
@@ -200,8 +200,6 @@ TYPEINFO(/area)
 				if (sound_loop)
 					M.client.playAmbience(src, AMBIENCE_LOOPING, sound_loop_vol)
 
-				M.client.parallax_controller?.update_area_parallax_layers(src, lastarea)
-
 				if (!played_fx_1 && prob(AMBIENCE_ENTER_PROB))
 					src.pickAmbience()
 					M.client.playAmbience(src, AMBIENCE_FX_1, 18)

--- a/code/mob/dead/target_observer.dm
+++ b/code/mob/dead/target_observer.dm
@@ -77,9 +77,7 @@
 		if(src.target == target)
 			return //No sense in doing all this if we're not changing targets
 
-		var/area/old_area
 		if(src.target)
-			old_area = get_area(src.target)
 			var/mob/living/M = src.target
 			src.target = null
 			M.removeOverlaysClient(src.client)
@@ -94,7 +92,6 @@
 		//Let's have a proc so as to make it easier to reassign an observer.
 		src.target = target
 		src.set_loc(target)
-		src.client?.parallax_controller?.update_area_parallax_layers(get_area(src.target), old_area)
 		if(src.ghost?.auto_tgui_open)
 			RegisterSignal(target, COMSIG_TGUI_WINDOW_OPEN, PROC_REF(open_tgui_if_interactive))
 		set_eye(target)

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -79,7 +79,7 @@ var/global/parallax_enabled = TRUE
 		src.add_parallax_layer(A.area_parallax_layers, z_level = A.z)
 
 	/// Updates the parallax layers displayed to a client by an area.
-	proc/update_area_parallax_layers(area/new_area, area/old_area)
+	proc/update_area_parallax_layers(area/old_area, area/new_area)
 		if (old_area && new_area && (old_area.area_parallax_layers ~= new_area.area_parallax_layers))
 			return
 
@@ -168,6 +168,7 @@ var/global/parallax_enabled = TRUE
 /mob/proc/register_parallax_signals()
 	if (src.client?.parallax_controller)
 		RegisterSignal(src, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(update_parallax))
+		RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(update_area_parallax))
 		RegisterSignal(src, XSIG_MOVABLE_Z_CHANGED, PROC_REF(update_parallax_z))
 		RegisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED, PROC_REF(update_outermost_movable))
 
@@ -178,6 +179,7 @@ var/global/parallax_enabled = TRUE
 /mob/proc/unregister_parallax_signals()
 	if (src.GetComponent(/datum/component/complexsignal/outermost_movable))
 		UnregisterSignal(src, XSIG_MOVABLE_TURF_CHANGED)
+		UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
 		UnregisterSignal(src, XSIG_MOVABLE_Z_CHANGED)
 		UnregisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED)
 
@@ -186,6 +188,9 @@ var/global/parallax_enabled = TRUE
 
 /mob/proc/update_parallax_z()
 	src.client?.parallax_controller?.update_parallax_z()
+
+/mob/proc/update_area_parallax(datum/component/component, area/old_area, area/new_area)
+	src.client?.parallax_controller?.update_area_parallax_layers(old_area, new_area)
 
 /mob/proc/update_outermost_movable(datum/component/component, atom/movable/old_outermost, atom/movable/new_outermost)
 	src.client?.parallax_controller?.outermost_movable = new_outermost


### PR DESCRIPTION
[UI] [Internal] [Bug]


## About The PR:
Fixes #14866 and fixes #15030 by permitting `/datum/component/complexsignal/outermost_movable` to track changes in area. Also slightly restructures it to be more performant.
In the current implementation, the component checks changes in area for every call of `on_turf_change`; profiling shows that is minimally expensive (~5µs). I have opted for this implementation over using signals in conjunction with the `Entered()` proc on `/area`, as testing has revealed `Entered()` to be overtly unreliable with nested contents, even when using a component designed to mitigate this.