### PR TITLE
fix mAntistes appearing

### DIFF
--- a/strings/station_name.txt
+++ b/strings/station_name.txt
@@ -12,7 +12,7 @@ greek@=Alpha@,Beta@,Gamma@,Delta@,Epsilon@,Zeta@,Eta@,Theta@,Iota@,Kappa@,Lambda
 
 romanNum@=II@,III@,IV@,V@,VI@,VII@,VIII@,IX@,X@,XI@,XII@,XIII@,XIV@,XV@,XVI@,XVII@,XVIII@,XIX@,XX
 
-frontierLocations@=Typhon@,Plasma Star@,Fortitudo@,mAntistes@,Quadriga@,Fatuus@,Domus Dei@,Mundus@,Iustitia@,Iudicium@,Rota Fortuna@,Amantes@,Magus@,Regis@,Regina@,Mors@,Flaminica@,Senex@,Estella@,Shidd@,Šid@,Abzu@,Fugg@,Fugere@,Frontier@,Channel@,Buttes@,Buttes Junction
+frontierLocations@=Typhon@,Plasma Star@,Fortitudo@,Antistes@,Quadriga@,Fatuus@,Domus Dei@,Mundus@,Iustitia@,Iudicium@,Rota Fortuna@,Amantes@,Magus@,Regis@,Regina@,Mors@,Flaminica@,Senex@,Estella@,Shidd@,Šid@,Abzu@,Fugg@,Fugere@,Frontier@,Channel@,Buttes@,Buttes Junction
 
 militaryLetters@=Alpha@,Bravo@,Charlie@,Delta@,Echo@,Foxtrot@,Golf@,Hotel@,India@,Juliet@,Kilo@,Lima@,Mike@,November@,Oscar@,Papa@,Quebec@,Romeo@,Sierra@,Tango@,Uniform@,Victor@,Whiskey@,X-ray@,Yankee@,Zulu
 


### PR DESCRIPTION
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes it so that auto generated station names won't spell Antistes as mAntistes.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad