### PR TITLE
Reworks Interdictor Mob Protection

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -585,7 +585,6 @@
 					tmob_effect.deactivate(10)
 					tmob_effect.update_charge(-1)
 					//spatial interdictor: mitigate biomagnetic discharges
-					//consumes 100 units of charge (50,000 joules) to interdict a repulsion, permitting safe discharge of the fields
 					if (tmob.hasStatus("spatial_protection"))
 						src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")
 						var/atom/source = get_turf(tmob)
@@ -631,7 +630,6 @@
 					tmob_effect.deactivate(10)
 					tmob_effect.update_charge(-tmob_effect.charge)
 					//spatial interdictor: mitigate biomagnetic discharges
-					//consumes 150 units of charge (75,000 joules) to interdict an attraction, permitting safe discharge of the fields
 
 					if (tmob.hasStatus("spatial_protection"))
 						src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -633,12 +633,11 @@
 					//spatial interdictor: mitigate biomagnetic discharges
 					//consumes 150 units of charge (75,000 joules) to interdict an attraction, permitting safe discharge of the fields
 
-					for_by_tcl(IX, /obj/machinery/interdictor)
-						if (IX.expend_interdict(150,src))
-							src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")
-							var/atom/source = get_turf(tmob)
-							playsound(source, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
-							return
+					if (tmob.hasStatus("spatial_protection"))
+						src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")
+						var/atom/source = get_turf(tmob)
+						playsound(source, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
+						return
 					// opposite attracts - fling everything nearby at these dumbasses
 					src.now_pushing = 1
 					tmob.now_pushing = 1

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -586,12 +586,11 @@
 					tmob_effect.update_charge(-1)
 					//spatial interdictor: mitigate biomagnetic discharges
 					//consumes 100 units of charge (50,000 joules) to interdict a repulsion, permitting safe discharge of the fields
-					for_by_tcl(IX, /obj/machinery/interdictor)
-						if (IX.expend_interdict(100,src))
-							src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")
-							var/atom/source = get_turf(tmob)
-							playsound(source, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
-							return
+					if (tmob.hasStatus("spatial_protection"))
+						src.visible_message("<span class='alert'><B>[src]</B> and <B>[tmob]</B>'s magnetic fields briefly flare, then fade.</span>")
+						var/atom/source = get_turf(tmob)
+						playsound(source, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
+						return
 					// like repels - bump them away from each other
 					src.now_pushing = 0
 					var/atom/source = get_turf(tmob)

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -277,7 +277,7 @@
 			//Interdictor's protections for mobs
 			if (isliving(src) && !isintangible(src))
 				for_by_tcl(IX, /obj/machinery/interdictor)
-					var/area/A = src.loc.loc
+					var/area/area = get_area(src)
 					if (IX.expend_interdict(6,src,TRUE)) //This protects mobs from radstorms/wormholes/magnetic biofields
 						src.changeStatus("spatial_protection", 3 SECONDS)
 					if ((src.loc && isarea(A)) && A.irradiated)

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -277,8 +277,11 @@
 			//Interdictor's protections for mobs
 			if (isliving(src) && !isintangible(src))
 				for_by_tcl(IX, /obj/machinery/interdictor)
+					var/area/A = src.loc.loc
 					if (IX.expend_interdict(6,src,TRUE)) //This protects mobs from radstorms/wormholes/magnetic biofields
 						src.changeStatus("spatial_protection", 3 SECONDS)
+					if ((src.loc && isarea(A)) && A.irradiated)
+						IX.resisted = TRUE
 					if (!iscarbon(src)) //Prevents non-carbons from getting the Zephyr stam boost, but still protects other mobs
 						break
 					if (IX.expend_interdict(4,src,TRUE,ITDR_ZEPHYR)) // Zephyr-class interdictor: carbon mobs in range gain a buff to stamina recovery, which can accumulate to linger briefly

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -280,7 +280,7 @@
 					var/area/area = get_area(src)
 					if (IX.expend_interdict(6,src,TRUE)) //This protects mobs from radstorms/wormholes/magnetic biofields
 						src.changeStatus("spatial_protection", 3 SECONDS)
-					if ((src.loc && isarea(A)) && A.irradiated)
+					if (istype(area) && area.irradiated)
 						IX.resisted = TRUE
 					if (!iscarbon(src)) //Prevents non-carbons from getting the Zephyr stam boost, but still protects other mobs
 						break

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -274,10 +274,14 @@
 					animate(src, transform = matrix(), time = 1)
 				last_no_gravity = src.no_gravity
 
-			// Zephyr-class interdictor: carbon mobs in range gain a buff to stamina recovery, which can accumulate to linger briefly
-			if (iscarbon(src))
+			//Interdictor's protections for mobs
+			if (isliving(src) && !isintangible(src))
 				for_by_tcl(IX, /obj/machinery/interdictor)
-					if (IX.expend_interdict(4,src,TRUE,ITDR_ZEPHYR))
+					if (IX.expend_interdict(6,src,TRUE)) //This protects mobs from radstorms/wormholes/magnetic biofields
+						src.changeStatus("spatial_protection", 3 SECONDS)
+					if (!iscarbon(src)) //Prevents non-carbons from getting the Zephyr stam boost, but still protects other mobs
+						break
+					if (IX.expend_interdict(4,src,TRUE,ITDR_ZEPHYR)) // Zephyr-class interdictor: carbon mobs in range gain a buff to stamina recovery, which can accumulate to linger briefly
 						src.changeStatus("zephyr_field", 3 SECONDS * life_mult)
 						break
 

--- a/code/mob/living/life/disability.dm
+++ b/code/mob/living/life/disability.dm
@@ -37,7 +37,7 @@
 			if (A.irradiated)
 				//spatial interdictor: mitigate effect of radiation
 				//power expenditure is managed centrally by the interdictor
-				if (owner.!hasStatus("spatial_protection"))
+				if (!owner.hasStatus("spatial_protection"))
 					owner.take_radiation_dose((rand() * 0.3 SIEVERTS * A.irradiated * mult))
 
 		if (owner.bioHolder && ishuman(owner))

--- a/code/mob/living/life/disability.dm
+++ b/code/mob/living/life/disability.dm
@@ -37,9 +37,7 @@
 			if (A.irradiated)
 				//spatial interdictor: mitigate effect of radiation
 				//power expenditure is managed centrally by the interdictor
-				if (owner.hasStatus("spatial_protection"))
-					return
-				else
+				if (owner.!hasStatus("spatial_protection"))
 					owner.take_radiation_dose((rand() * 0.3 SIEVERTS * A.irradiated * mult))
 
 		if (owner.bioHolder && ishuman(owner))

--- a/code/mob/living/life/disability.dm
+++ b/code/mob/living/life/disability.dm
@@ -37,12 +37,9 @@
 			if (A.irradiated)
 				//spatial interdictor: mitigate effect of radiation
 				//power expenditure is managed centrally by the interdictor
-				var/interdictor_influence = 0
-				for_by_tcl(IX, /obj/machinery/interdictor)
-					if (IX.radstorm_interdict(owner))
-						interdictor_influence = 1
-						break
-				if(!interdictor_influence)
+				if (owner.hasStatus("spatial_protection"))
+					return
+				else
 					owner.take_radiation_dose((rand() * 0.3 SIEVERTS * A.irradiated * mult))
 
 		if (owner.bioHolder && ishuman(owner))

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2411,3 +2411,4 @@
 	desc = "You are being protected from wormholes, radiation storms, and polar biofields."
 	icon_state = "blocking" //This gives the general idea that they are being protected, but could use a better icon
 	maxDuration = 3 SECONDS
+	effect_quality = STATUS_QUALITY_POSITIVE

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2412,3 +2412,11 @@
 	icon_state = "blocking" //This gives the general idea that they are being protected, but could use a better icon
 	maxDuration = 3 SECONDS
 	effect_quality = STATUS_QUALITY_POSITIVE
+
+	onAdd(optional=null)
+		owner.add_filter("protection", 1, outline_filter(color="#e6ec21"))
+		..()
+
+	onRemove()
+		owner.remove_filter("protection")
+		..()

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2410,7 +2410,7 @@
 	name = "Spatial Protection"
 	desc = "You are being protected from wormholes, radiation storms, and polar biofields."
 	icon_state = "blocking" //This gives the general idea that they are being protected, but could use a better icon
-	maxDuration = 3 SECONDS
+	maxDuration = 4 SECONDS
 	effect_quality = STATUS_QUALITY_POSITIVE
 
 	onAdd(optional=null)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2408,7 +2408,7 @@
 /datum/statusEffect/interdictor //Status effect for letting people know they are protected from some spatial anomalies
 	id = "spatial_protection"
 	name = "Spatial Protection"
-	desc = "You are being protected from wormholes, radiation storms, and polar biofields."
+	desc = "You are being protected from wormholes, radiation storms, and magnetic biofields."
 	icon_state = "blocking" //This gives the general idea that they are being protected, but could use a better icon
 	maxDuration = 4 SECONDS
 	effect_quality = STATUS_QUALITY_POSITIVE

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2404,3 +2404,10 @@
 	name = "De-revving"
 	desc = "An implant is attempting to convert you from the revolution! Remove the implant!"
 	icon_state = "mindhack"
+
+/datum/statusEffect/interdictor //Status effect for letting people know they are protected from some spatial anomalies
+	id = "spatial_protection"
+	name = "Spatial Protection"
+	desc = "You are being protected from wormholes, radiation storms, and polar biofields."
+	icon_state = "blocking" //This gives the general idea that they are being protected, but could use a better icon
+	maxDuration = 3 SECONDS

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -8,6 +8,7 @@
 	icon_state = "interdictor"
 	power_usage = 1250 //drawn while interdiction field is active; charging is a separate usage value that can be concurrent
 	density = 1
+	var/resisted = FALSE //Changes if someone is being protected from a radstorm
 	anchored = UNANCHORED
 	req_access = list(access_engineering)
 
@@ -296,6 +297,10 @@
 	if(doupdateicon)
 		src.UpdateIcon()
 
+	if (src.resisted)
+		radstorm_interdict(src)
+		src.resisted = FALSE
+
 
 
 /**
@@ -332,7 +337,9 @@
 
 ///Specialized radiation storm interdiction proc that allows multiple protections under a single unified cost per process.
 /obj/machinery/interdictor/proc/radstorm_interdict(var/target = null)
-	var/use_cost = 400 //how much it costs per machine tick to interdict radstorms, regardless of number of mobs protected
+	var/use_cost = 350 //how much it costs per machine tick to interdict radstorms, regardless of number of mobs protected
+	if (!src.resisted) //Don't spend power if no one is around to protect
+		return
 	if (status & BROKEN || !src.canInterdict)
 		return 0
 	if (!target || !IN_RANGE(src,target,src.interdict_range))

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -268,6 +268,9 @@
 		message_admins("Interdictor at ([log_loc(src)]) is missing a power cell. This is not supposed to happen, yell at kubius")
 		return
 	if(anchored)
+		if (src.resisted)
+			radstorm_interdict(src)
+			src.resisted = FALSE
 		if(intcap.charge < intcap.maxcharge && powered())
 			var/amount_to_add = min(round(intcap.maxcharge - intcap.charge, 10), src.chargerate)
 			if(amount_to_add)

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -300,10 +300,6 @@
 	if(doupdateicon)
 		src.UpdateIcon()
 
-	if (src.resisted)
-		radstorm_interdict(src)
-		src.resisted = FALSE
-
 
 
 /**
@@ -339,13 +335,11 @@
 		return 1
 
 ///Specialized radiation storm interdiction proc that allows multiple protections under a single unified cost per process.
-/obj/machinery/interdictor/proc/radstorm_interdict(var/target = null)
+/obj/machinery/interdictor/proc/radstorm_interdict()
 	var/use_cost = 350 //how much it costs per machine tick to interdict radstorms, regardless of number of mobs protected
 	if (!src.resisted) //Don't spend power if no one is around to protect
 		return
 	if (status & BROKEN || !src.canInterdict)
-		return 0
-	if (!target || !IN_RANGE(src,target,src.interdict_range))
 		return 0
 	if (!intcap)
 		src.stop_interdicting()

--- a/code/obj/portal.dm
+++ b/code/obj/portal.dm
@@ -92,14 +92,12 @@
 
 	Bumped(mob/M as mob|obj)
 		//spatial interdictor: when something would enter a wormhole, it doesn't
-		//consumes 200 units of charge (100,000 joules) per wormhole interdicted
-		for_by_tcl(IX, /obj/machinery/interdictor)
-			if (IX.expend_interdict(200,src))
-				icon = 'icons/effects/effects.dmi'
-				icon_state = "sparks_attack"
-				playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
-				density = 0
-				return
+		if (M.hasStatus("spatial_protection"))
+			icon = 'icons/effects/effects.dmi'
+			icon_state = "sparks_attack"
+			playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
+			density = 0
+			return
 		..()
 
 /obj/portal/afterlife


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [STATUS EFFECTS] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr refactors the interdictor's mob protection effects for wormholes/radstorms/magnetic biofields to a status effect. This also makes it so the interdictor's power drain will be affected by the amount of players in it's AoE, and not be drained whenever someone within the AoE negates a portal/magnetic biofield.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, not many people know what interdictors do, and not many people realize that being within an interdictor during a radstorm protects you. This pr aims to make it so that people are more aware that the interdictor protects them from wormholes/radstorms/magnetic biofields, and make it so that the amount of people protected will influence power drain to a degree.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(*)Interdictors will now drain 6u of power per player in their influence
(*)Removed power drain on interdictors from negating worm holes and magnetic biofields
(+)Changed the interdictor protection to be tied to a status effect
(+)Added a particle effect for the interdictor status effect
```
