### PR TITLE
Buff the effect of EMP on borgs

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -994,9 +994,10 @@
 
 	emp_act()
 		vision.noise(60)
+		src.do_disorient(disorient = 5 SECONDS)
 		boutput(src, "<span class='alert'><B>*BZZZT*</B></span>")
 		for (var/obj/item/parts/robot_parts/RP in src.contents)
-			if (RP.ropart_take_damage(0,50) == 1) src.compborg_lose_limb(RP)
+			if (RP.ropart_take_damage(0,55) == 1) src.compborg_lose_limb(RP)
 
 	meteorhit(obj/O as obj)
 		src.visible_message("<font color=red><b>[src]</b> is struck by [O]!</font>")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -996,7 +996,7 @@
 		vision.noise(60)
 		boutput(src, "<span class='alert'><B>*BZZZT*</B></span>")
 		for (var/obj/item/parts/robot_parts/RP in src.contents)
-			if (RP.ropart_take_damage(0,10) == 1) src.compborg_lose_limb(RP)
+			if (RP.ropart_take_damage(0,50) == 1) src.compborg_lose_limb(RP)
 
 	meteorhit(obj/O as obj)
 		src.visible_message("<font color=red><b>[src]</b> is struck by [O]!</font>")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -995,7 +995,7 @@
 	emp_act()
 		vision.noise(60)
 		src.changeStatus("stunned", 5 SECONDS, optional=null)
-		src.changeStatus("module_disabled", 5 SECONDS, optional=null)
+		src.changeStatus("upgrade_disabled", 5 SECONDS, optional=null)
 		boutput(src, "<span class='alert'><B>*BZZZT*</B></span>")
 		for (var/obj/item/parts/robot_parts/RP in src.contents)
 			if (RP.ropart_take_damage(0,55) == 1) src.compborg_lose_limb(RP)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -994,7 +994,8 @@
 
 	emp_act()
 		vision.noise(60)
-		src.do_disorient(disorient = 5 SECONDS)
+		src.changeStatus("stunned", 5 SECONDS, optional=null)
+		src.changeStatus("module_disabled", 5 SECONDS, optional=null)
 		boutput(src, "<span class='alert'><B>*BZZZT*</B></span>")
 		for (var/obj/item/parts/robot_parts/RP in src.contents)
 			if (RP.ropart_take_damage(0,55) == 1) src.compborg_lose_limb(RP)

--- a/code/modules/robotics/robot/upgrade/parent.dm
+++ b/code/modules/robotics/robot/upgrade/parent.dm
@@ -24,7 +24,10 @@ ABSTRACT_TYPE(/obj/item/roboupgrade)
 /obj/item/roboupgrade/proc/upgrade_activate(mob/living/silicon/robot/user)
 	if (!user)
 		return 1
-	if (!src.activated)
+	if(user.hasStatus("module_disabled"))
+		boutput(user, "<span class='alert'>Your modules are currently disabled!</span>")
+		return 1
+	if (!src.activated && !src.active)
 		src.activated = 1
 	if (src.charges > 0)
 		src.charges--

--- a/code/modules/robotics/robot/upgrade/parent.dm
+++ b/code/modules/robotics/robot/upgrade/parent.dm
@@ -24,7 +24,7 @@ ABSTRACT_TYPE(/obj/item/roboupgrade)
 /obj/item/roboupgrade/proc/upgrade_activate(mob/living/silicon/robot/user)
 	if (!user)
 		return 1
-	if(user.hasStatus("module_disabled"))
+	if(user.hasStatus("upgrade_disabled"))
 		boutput(user, "<span class='alert'>Your modules are currently disabled!</span>")
 		return 1
 	if (!src.activated && !src.active)

--- a/code/modules/robotics/robot/upgrade/recovery.dm
+++ b/code/modules/robotics/robot/upgrade/recovery.dm
@@ -1,25 +1,25 @@
 /obj/item/roboupgrade/aware
 	name = "cyborg recovery upgrade"
-	desc = "Allows a cyborg to immediateley reboot its systems if incapacitated in any way."
+	desc = "Allows a cyborg to immediately reboot its systems if incapacitated in any way."
 	icon_state = "up-aware"
 	active = 1
 	drainrate = 3333
 
-/obj/item/roboupgrade/aware/upgrade_activate(var/mob/living/silicon/robot/user as mob)
-	if (!user)
-		return
-	boutput(user, "<b>REBOOTING...</b>")
-	user.delStatus("stunned")
-	user.delStatus("weakened")
-	user.delStatus("paralysis")
-	user.blinded = 0
-	user.take_eye_damage(-INFINITY)
-	user.take_eye_damage(-INFINITY, 1)
-	user.blinded = 0
-	user.take_ear_damage(-INFINITY)
-	user.take_ear_damage(-INFINITY, 1)
-	user.change_eye_blurry(-INFINITY)
-	user.druggy = 0
-	user.change_misstep_chance(-INFINITY)
-	user.dizziness = 0
-	boutput(user, "<b>REBOOT COMPLETE</b>")
+	upgrade_activate(var/mob/living/silicon/robot/user as mob)
+		if (..())
+			return
+		boutput(user, "<b>REBOOTING...</b>")
+		user.delStatus("stunned")
+		user.delStatus("weakened")
+		user.delStatus("paralysis")
+		user.blinded = 0
+		user.take_eye_damage(-INFINITY)
+		user.take_eye_damage(-INFINITY, 1)
+		user.blinded = 0
+		user.take_ear_damage(-INFINITY)
+		user.take_ear_damage(-INFINITY, 1)
+		user.change_eye_blurry(-INFINITY)
+		user.druggy = 0
+		user.change_misstep_chance(-INFINITY)
+		user.dizziness = 0
+		boutput(user, "<b>REBOOT COMPLETE</b>")

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2345,14 +2345,14 @@
 	getTooltip()
 		. = "The recharge upgrade has quickly charged you, this now prevents you from using another one again until it's safe for your battery to quick charge again."
 
-/datum/statusEffect/moduledisabled
-	id = "module_disabled"
-	name = "Modules disabled"
+/datum/statusEffect/upgradedisabled
+	id = "upgrade_disabled"
+	name = "Upgrades disabled"
 	icon_state = "stam-"
 	maxDuration = 5 SECONDS
 
 	getTooltip()
-		. = "Your modules are currently disabled"
+		. = "Your upgrades are currently disabled"
 	onAdd()
 		if(istype(owner, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/robot = owner

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2340,11 +2340,25 @@
 	id = "quick_charged"
 	name = "Quick charged"
 	icon_state = "stam-"
-	maxDuration = 7 MINUTES
+	maxDuration = 0 MINUTES
 
 	getTooltip()
 		. = "The recharge upgrade has quickly charged you, this now prevents you from using another one again until it's safe for your battery to quick charge again."
 
+/datum/statusEffect/moduledisabled
+	id = "module_disabled"
+	name = "Modules disabled"
+	icon_state = "stam-"
+	maxDuration = 5 SECONDS
+
+	getTooltip()
+		. = "Your modules are currently disabled"
+	onAdd()
+		if(istype(owner, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/robot = owner
+			for (var/obj/item/roboupgrade/R in robot.contents)
+				if (R.activated) R.upgrade_deactivate(robot)
+		. = ..()
 
 /datum/statusEffect/criticalcondition
 	id = "critical_condition"

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -596,7 +596,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 	name = "sturdy cyborg left arm"
 	appearanceString = "sturdy"
 	icon_state = "l_arm-sturdy"
-	max_health = 100
+	max_health = 110
 	weight = 0.2
 	kind_of_limb = (LIMB_ROBOT | LIMB_HEAVY)
 
@@ -670,7 +670,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/right)
 	name = "sturdy cyborg right arm"
 	appearanceString = "sturdy"
 	icon_state = "r_arm-sturdy"
-	max_health = 100
+	max_health = 110
 	weight = 0.2
 	kind_of_limb = (LIMB_ROBOT | LIMB_HEAVY)
 

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -823,7 +823,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/left)
 	appearanceString = "treads"
 	icon_state = "l_leg-treads"
 	handlistPart = "legL-treads" // THIS ONE gets to layer with the hands because it looks ugly if jumpsuits are over it. Will fix codewise later
-	max_health = 100
+	max_health = 115
 	powerdrain = 2.5
 	step_image_state = "tracksL"
 	movement_modifier = /datum/movement_modifier/robottread_left
@@ -858,7 +858,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 	appearanceString = "treads"
 	icon_state = "r_leg-treads"
 	handlistPart = "legR-treads"  // THIS ONE gets to layer with the hands because it looks ugly if jumpsuits are over it. Will fix codewise later
-	max_health = 100
+	max_health = 115
 	powerdrain = 2.5
 	step_image_state = "tracksR"
 	movement_modifier = /datum/movement_modifier/robottread_right

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -256,7 +256,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 
 /obj/item/parts/robot_parts/head/standard
 	name = "standard cyborg head"
-	max_health = 175
+	max_health = 150
 	attackby(obj/item/W, mob/user)
 		if (istype(W,/obj/item/sheet))
 			var/obj/item/sheet/M = W

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -256,7 +256,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 
 /obj/item/parts/robot_parts/head/standard
 	name = "standard cyborg head"
-	max_health = 150
+	max_health = 160
 	attackby(obj/item/W, mob/user)
 		if (istype(W,/obj/item/sheet))
 			var/obj/item/sheet/M = W
@@ -596,7 +596,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 	name = "sturdy cyborg left arm"
 	appearanceString = "sturdy"
 	icon_state = "l_arm-sturdy"
-	max_health = 110
+	max_health = 115
 	weight = 0.2
 	kind_of_limb = (LIMB_ROBOT | LIMB_HEAVY)
 
@@ -670,7 +670,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/right)
 	name = "sturdy cyborg right arm"
 	appearanceString = "sturdy"
 	icon_state = "r_arm-sturdy"
-	max_health = 110
+	max_health = 115
 	weight = 0.2
 	kind_of_limb = (LIMB_ROBOT | LIMB_HEAVY)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr increases the damage emp do to borgs from 10 to 55. This also makes emps stun borgs for 5 seconds. To make these thresholds work, standard heads have had their healths decreased from 175 to 160, and sturdy arms and treads have gone from 100 health to 115. 

With the current numbers, it takes 1 emp to remove all of a light borgs limbs, 2 emps to kill a light borg and remove all of a stanrdard borgs limbs, and 3 emps to kill a standard borg and strip a sturdy borg of all its limbs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, it takes 3 pulse rifles or emp grenades just to remove a light borgs limbs. This should make emp a far stronger counter to borgs.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)EMP's now stun borgs for 5 seconds, disable modules for a max of 5 seconds, and now do far more damage to borgs.
```
