### PR TITLE
Adds Anti-Pod Shells to Nadir's Armory

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -51478,6 +51478,10 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/item/ammo/bullets/autocannon/seeker{
+	pixel_x = 7;
+	pixel_y = 7
+	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/ai_monitored/armory)
 "wxN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a pack of HE pod seekers to Nadir's armory


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, salvagers are incredibly difficult to deal with on Nadir. This should help deal with salvager pods.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Added HE pod-seeking shells to Nadir's armory
```
