### PR TITLE
Let's Silicons Use the Supply Request Console

### DIFF
--- a/code/obj/machinery/computer/QM_order.dm
+++ b/code/obj/machinery/computer/QM_order.dm
@@ -23,10 +23,6 @@
 	icon = 'icons/obj/computerpanel.dmi'
 	icon_state = "qmreq1"
 
-/obj/machinery/computer/ordercomp/attack_ai(var/mob/user as mob)
-	boutput(user, "<span class='alert'>AI Interfacing with this computer has been disabled.</span>")
-	return
-
 /obj/machinery/computer/ordercomp/attack_hand(var/mob/user)
 	if(..())
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [SILICONS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the access restriction on AIs/Cyborgs with the supply request consoles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not really much point in having it if they can just barge in and use the qm console anyways, plus it's helpful for rp.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Silicons can now use the supply request consoles
```
