### PR TITLE
Fix crematorium not burning all mobs

### DIFF
--- a/code/obj/machinery/traymachines.dm
+++ b/code/obj/machinery/traymachines.dm
@@ -352,36 +352,32 @@ ABSTRACT_TYPE(/obj/machine_tray)
 	icon_state = "crema_active"
 	playsound(src.loc, 'sound/machines/crematorium.ogg', 90, 0)
 
-	for (var/M in contents)
-		if (M in non_tray_contents)
+	for (var/mob/living/L in contents)
+		if (L in non_tray_contents)
 			continue
-		if (M == my_tray)	//no cremating the tray tyvm
-			continue
-		if (isliving(M))
-			var/mob/living/L = M
-			L.changeStatus("stunned", 10 SECONDS)
+		L.changeStatus("stunned", 10 SECONDS)
 
 	sleep(1 SECOND)
 	for (var/i in 1 to 10)
 		if(isnull(src))
 			return
-		sleep(1 SECOND)
 		for (var/mob/living/L in contents)
 			if (L in non_tray_contents)
 				continue
 			L.TakeDamage("chest", 0, 30)
 			if (!isdead(L) && prob(25))
 				L.emote("scream")
+		sleep(1 SECOND)
 
 	if(isnull(src))
 		return
-	for (var/M in contents)
-		if (M in non_tray_contents)
+	for (var/I in contents)
+		if (I in non_tray_contents)
 			continue
-		if (M == my_tray)	//no cremating the tray tyvm
+		if (I == my_tray)	//no cremating the tray tyvm
 			continue
-		if (isliving(M))
-			var/mob/living/L = M
+		if (isliving(I))
+			var/mob/living/L = I
 			for (var/obj/item/W in L)
 				if (prob(10))
 					W.set_loc(L.loc)
@@ -389,10 +385,10 @@ ABSTRACT_TYPE(/obj/machine_tray)
 			logTheThing(LOG_COMBAT, user, "cremates [constructTarget(L,"combat")] in a crematorium at [log_loc(src)].")
 			L.remove()
 			ashes += 1
-		else if (!ismob(M))
+		else if (!ismob(I))
 			if (prob(max(0, 100 - (ashes * 10))))
 				ashes += 1
-		qdel(M)
+		qdel(I)
 
 	if(isnull(src))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks crematorium so we loop through all contents each time instead of just what was in the crematorium at the start. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In rare circumstances a dead ling could headspider in a working crematorium and survive.