### PR TITLE
Changes how lastgasp works for silicons

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2506,9 +2506,6 @@
 
 	update_canmove() // this is called on Life() and also by force_laydown_standup() btw
 		..()
-		if (!src.canmove)
-			if (isalive(src))
-				src.lastgasp() // calling lastgasp() here because we just got knocked out
 		if (src.misstep_chance > 0)
 			switch(misstep_chance)
 				if(50 to INFINITY)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -962,6 +962,11 @@
 				playsound(owner, sound, 17, 1, 0.4, 1.6)
 				violent_twitch(owner)
 			. = ..(timePassed)
+		onAdd()
+			if(istype(owner, /mob/living/silicon/robot))
+				var/mob/living/silicon/robot/robot = owner
+				robot.lastgasp()
+			. = ..()
 
 	drunk
 		id = "drunk"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, whenever a silicon is alive and can't move, lastgasp is called. Meaning that when you're stunned, your text is constantly interrupted. This has been removed and replaced with silicons calling lastgasp only onAdd of cyborg_disorient.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you want meaningful conversations, you need more time to speak then .7 seconds.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Silicons now only WOOP or BZZT when first stunned. 
```
