### PR TITLE
Remove two tables on Atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -69708,7 +69708,7 @@ sck
 afA
 agT
 ahF
-aiF
+aeX
 ajF
 akv
 akt
@@ -70009,8 +70009,8 @@ lgg
 aeX
 afB
 aSs
-agT
-agT
+aiF
+aeX
 ajF
 akw
 amd


### PR DESCRIPTION
[MAPPING] [QOL]
## About the PR
Removes two tables in Atlas's Kitchen back room thing in order to introduce a shorter path for the chef and bartender to get to the east of the room. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The chef on atlas has to go on a trek around a 3x2 table in order to get to the vendor. Terrible. Cal wouldn't stop whinging about it. Hi cal.
## Changelog
```changelog
(u)Tyrant
(+)Atlas's catering rooms should be a little easier to get around.
```