### PR TITLE
fix lollipops always being white

### DIFF
--- a/code/modules/food_and_drink/candy.dm
+++ b/code/modules/food_and_drink/candy.dm
@@ -297,7 +297,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/jellybean)
 	icon = 'icons/obj/foodNdrink/food_candy.dmi'
 	icon_state = "lpop-0"
 	sugar_content = 5
-	var/icon_random = FALSE // does it just choose from the existing random colors?
+	var/icon_random = FALSE //! does it just choose from the existing random colors?
 	var/image/image_candy
 	heal_amt = 1
 	bites_left = 5

--- a/code/modules/food_and_drink/candy.dm
+++ b/code/modules/food_and_drink/candy.dm
@@ -297,41 +297,41 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/jellybean)
 	icon = 'icons/obj/foodNdrink/food_candy.dmi'
 	icon_state = "lpop-0"
 	sugar_content = 5
-	var/icon_random = 0 // does it just choose from the existing random colors?
+	var/icon_random = FALSE // does it just choose from the existing random colors?
 	var/image/image_candy
 	heal_amt = 1
 	bites_left = 5
 	real_name = "lollipop"
 
-	New()
-		..()
-		if (src.icon_random)
-			src.icon_state = "lpop-[rand(1,6)]"
-		else
-			SPAWN(0)
-				src.UpdateIcon()
+/obj/item/reagent_containers/food/snacks/candy/lollipop/New()
+	..()
+	if (src.icon_random)
+		src.icon_state = "lpop-[rand(1,6)]"
+	else
+		SPAWN(0)
+			src.UpdateIcon()
 
-	update_icon()
-		if (src.icon_random)
-			return
-		if (src.reagents)
-			ENSURE_IMAGE(src.image_candy, src.icon, "lpop-w")
-			var/datum/color/average = reagents.get_average_color()
-			src.image_candy.color = average.to_rgba()
-			src.UpdateOverlays(src.image_candy, "candy")
+/obj/item/reagent_containers/food/snacks/candy/lollipop/update_icon()
+	if (src.icon_random)
+		return
+	if (src.reagents)
+		ENSURE_IMAGE(src.image_candy, src.icon, "lpop-w")
+		src.reagents.remove_reagent("sugar", 5) // sugar will always override sadly. So we ignore it.
+		var/datum/color/average = src.reagents.get_average_color()
+		src.image_candy.color = average.to_rgba()
+		src.UpdateOverlays(src.image_candy, "candy")
+		src.reagents.add_reagent("sugar", 5) // then we put the sugar back in.
 
 /obj/item/reagent_containers/food/snacks/candy/lollipop/random_medical
-	icon_state = "lpop-"
+	icon_random = TRUE
 	var/list/flavors = list("omnizine", "saline", "salicylic_acid", "epinephrine", "mannitol", "synaptizine", "anti_rad", "oculine", "salbutamol", "charcoal")
 
-	New()
-		..()
-		SPAWN(0)
-			if (src.icon_state == "lpop-")
-				src.icon_state = "lpop-[rand(1,6)]"
-			if (islist(src.flavors) && length(src.flavors))
-				for (var/i=5, i>0, i--)
-					src.reagents.add_reagent(pick(src.flavors), 1)
+/obj/item/reagent_containers/food/snacks/candy/lollipop/random_medical/New()
+	..()
+	SPAWN(0)
+		if (islist(src.flavors) && length(src.flavors))
+			for (var/i=5, i>0, i--)
+				src.reagents.add_reagent(pick(src.flavors), 1)
 
 /obj/item/reagent_containers/food/snacks/candy/sugar_cube
 	name = "sugar cube"


### PR DESCRIPTION
[MINOR]
## About the PR
Because the main reagent in lollipops is sugar (5u), it would always override the colour of the actual sweet (which is supposed to be randomly assigned, or based on the main reagent). This PR fixes that.
## Why's this needed?
They're supposed to be colourful damn it.
## Changelog
```changelog
(u)Tyrant
(+)Lollipops have colours once again.
```