### PR TITLE
Printing press cleanup refactor thing

### DIFF
--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -19,31 +19,52 @@
 	var/is_running = FALSE
 	/// FALSE by default, set to TRUE when ink colors upgrade is installed
 	var/colors_upgrade = FALSE
-	var/books_upgrade = 0 //0 by default, set to 1 when custom book covers upgrade is installed
-	var/forbidden_upgrade = 0 //0 by default, set to 1 when forbidden covers/symbols/styles upgrade is installed
-	var/ink_level = 100 //decrements by 2 for each book printed, can be refilled (expensively)
+	/// FALSE by default, set to TRUE when custom book covers upgrade is installed
+	var/books_upgrade = FALSE
+	/// FALSE by default, set to TRUE when forbidden covers/symbols/styles upgrade is installed
+	var/forbidden_upgrade = FALSE
+	/// decrements by 2 for each book printed, can be refilled (expensively)
+	var/ink_level = 100
+	/// the default modes, can be expanded to have "Ink Colors" and "Custom Cover"
 	var/list/press_modes = list("Choose cover", "Set book info", "Set book contents",\
-	"Amount to make", "Print books", "View Information") //default, can be expanded to have "Ink Colors" and "Custom Cover"
+	"Amount to make", "Print books", "View Information")
 
-	var/book_amount = 0 //how many books to make?
-	var/book_cover = "" //what cover design to use?
-	var/book_info = "" //what text will the made books have?
-	var/book_info_raw = "" // raw version of the text, for editing.
-	var/book_name = "" //whats the made books name?
-	var/const/info_len_lim = 64 //64 character titles/author names max
-	var/book_author = "" //who made the book?
-	var/ink_color = "#000000" //what color is the text written in?
+	/// how many books to make?
+	var/book_amount = 0
+	/// what cover design to use?
+	var/book_cover = ""
+	/// what text will the made books have?
+	var/book_info = ""
+	/// raw version of the text, for editing.
+	var/book_info_raw = ""
+	/// whats the made book's name?
+	var/book_name = ""
+	/// 64 character titles/author names max
+	var/const/info_len_lim = 64
+	/// who made the book?
+	var/book_author = ""
+	/// what color is the text written in?
+	var/ink_color = "#000000"
+	/// list of covers to choose from
 	var/list/cover_designs = list("Grey", "Dull red", "Red", "Blue", "Green", "Yellow", "Dummies", "Robuddy", "Skull", "Latch", "Bee",\
-	"Albert", "Surgery", "Law", "Nuke", "Rat", "Pharma", "Bar") //list of covers to choose from
-	var/list/non_writing_icons = list("bible") //just the bible for now. !!!add covers to this list if their icon file isnt icons/obj/writing.dmi!!!
+	"Albert", "Surgery", "Law", "Nuke", "Rat", "Pharma", "Bar")
+	/// just the bible for now. add covers to this list if their icon file isnt icons/obj/writing.dmi
+	var/list/non_writing_icons = list("bible")
 
-	var/cover_color = "#FFFFFF" //white by default, what colour will our book be?
-	var/cover_symbol = "" //what symbol is on our front cover?
-	var/symbol_color = "#FFFFFF" //white by default, if our symbol is colourable, what colour is it?
-	var/cover_flair = "" //whats the "flair" thing on the book?
-	var/flair_color = "#FFFFFF" //white by default, whats the color of the flair (if its colorable)?
-	var/symbol_colorable = 0 //this is a bugfix for non-colourable symbols being coloured
-	var/flair_colorable = 0 //this is a bugfix for non-colourable flairs being coloured
+	/// white by default, what colour will our book be?
+	var/cover_color = "#FFFFFF"
+	/// what symbol is on our front cover?
+	var/cover_symbol = ""
+	/// white by default, if our symbol is colourable, what colour is it?
+	var/symbol_color = "#FFFFFF"
+	/// whats the "flair" thing on the book?
+	var/cover_flair = ""
+	/// white by default, whats the color of the flair (if its colorable)?
+	var/flair_color = "#FFFFFF"
+	/// this is a bugfix for non-colourable symbols being coloured
+	var/symbol_colorable = FALSE
+	/// this is a bugfix for non-colourable flairs being coloured
+	var/flair_colorable = FALSE
 
 	var/list/standard_symbols = list("None", "Bee", "Blood", "Eye", "No", "Clown", "Wizhat", "CoolS", "Brimstone", "Duck", "Planet+Moon", "Sol",\
 	"Candle", "Shelterbee")//symbols that cant be colored
@@ -199,14 +220,14 @@
 					if (books_upgrade)
 						src.visible_message("\The [src] already has that upgrade installed.")
 						return
-					books_upgrade = 1
+					books_upgrade = TRUE
 					press_modes += "Customise cover"
 					src.visible_message("\The [src] accepts the upgrade.")
 				if ("press_forbidden")
 					if (forbidden_upgrade)
 						src.visible_message("\The [src] already has that upgrade installed.")
 						return
-					forbidden_upgrade = 1
+					forbidden_upgrade = TRUE
 					standard_symbols += list("Anarchy", "Syndie")
 					colorable_symbols += list("FixMe")
 					standard_flairs += list("Fire")
@@ -384,7 +405,7 @@
 							var/symbol_sel = input("What would you like the symbol to be?", "Cover Control") as null|anything in standard_symbols
 							if (symbol_sel)
 								cover_symbol = lowertext(symbol_sel)
-								symbol_colorable = 0
+								symbol_colorable = FALSE
 							else
 								cover_symbol = "none"
 
@@ -395,7 +416,7 @@
 								var/color_sel = input("What color would you like the symbol to be?", "Cover Control") as color
 								if (color_sel)
 									symbol_color = color_sel
-									symbol_colorable = 1
+									symbol_colorable = TRUE
 							else
 								cover_symbol = "none"
 
@@ -403,7 +424,7 @@
 							var/symbol_sel = input("What would you like the symbol to be?", "Cover Control") as null|anything in alchemical_symbols
 							if (symbol_sel)
 								cover_symbol = lowertext(symbol_sel)
-								symbol_colorable = 0
+								symbol_colorable = FALSE
 							else
 								cover_symbol = "none"
 
@@ -414,7 +435,7 @@
 								var/color_sel = input("What color would you like the symbol to be?", "Cover Control") as color
 								if (color_sel)
 									symbol_color = color_sel
-									symbol_colorable = 1
+									symbol_colorable = TRUE
 							else
 								cover_symbol = "none"
 
@@ -424,7 +445,7 @@
 						var/flair_sel = input("What would you like the flair to be?", "Cover Control") as null|anything in standard_flairs
 						if (flair_sel)
 							cover_flair = lowertext(flair_sel)
-							flair_colorable = 0
+							flair_colorable = FALSE
 						else
 							cover_flair = "none"
 
@@ -435,7 +456,7 @@
 							var/color_sel = input("What color would you like the flair to be?", "Cover Control") as color
 							if (color_sel)
 								flair_color = color_sel
-								flair_colorable = 1
+								flair_colorable = TRUE
 						else
 							cover_flair = "none"
 

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -66,17 +66,22 @@
 	/// this is a bugfix for non-colourable flairs being coloured
 	var/flair_colorable = FALSE
 
+	/// symbols that can't be coloured
 	var/list/standard_symbols = list("None", "Bee", "Blood", "Eye", "No", "Clown", "Wizhat", "CoolS", "Brimstone", "Duck", "Planet+Moon", "Sol",\
-	"Candle", "Shelterbee")//symbols that cant be colored
+	"Candle", "Shelterbee")
+	/// list of symbols that can be coloured
 	var/list/colorable_symbols = list("None", "Skull", "Drop", "Shortcross", "Smile", "One", "FadeCircle", "Square", "NT", "Ghost", "Bone",\
-	"Heart", "Pentagram", "Key", "Lock") //list of symbols that can be coloured
+	"Heart", "Pentagram", "Key", "Lock")
+	/// alchemical symbols (because theres a lot of them)
 	var/list/alchemical_symbols = list("None", "Mercury", "Salt", "Sulfur", "Urine", "Water", "Fire", "Air", "Earth", "Calcination", "Congelation",\
 	"Fixation", "Dissolution", "Digestion", "Distillation", "Sublimation", "Seperation", "Ceration", "Fermentation", "Multiplication",\
-	"Projection") //alchemical symbols (because theres a lot of them)
+	"Projection")
 	var/list/alphanumeric_symbols = list("None", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S",\
 	"T", "U", "V", "W", "X", "Y", "Z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-	var/list/standard_flairs = list("None", "Gold", "Latch", "Dirty", "Scratch", "Torn") //flairs that cant be coloured
-	var/list/colorable_flairs = list("None", "Corners", "Bookmark", "RightCover", "SpineCover") //flairs that can be coloured
+	/// flairs that can't be coloured
+	var/list/standard_flairs = list("None", "Gold", "Latch", "Dirty", "Scratch", "Torn")
+	/// flairs that can be coloured
+	var/list/colorable_flairs = list("None", "Corners", "Bookmark", "RightCover", "SpineCover")
 
 ////////////////////
 //Appearance stuff//

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -483,87 +483,60 @@
 //Book making stuff//
 /////////////////////
 
-	proc/make_books() //alright so this makes our books
-		is_running = TRUE
-		var/books_to_make = book_amount
-		while (books_to_make)
+/obj/machinery/printing_press/proc/make_books() //alright so this makes our books
+	is_running = TRUE
+	var/books_to_make = book_amount
+	while (books_to_make)
 
-			if (paper_amt < 2 || ink_level < 2) // can we keep doin printing?
-				if (paper_amt < 2) // If we don't have enough paper to print...
-					src.visible_message("\The [src] runs out of paper and stops printing.")
-				if (ink_level < 2) // ...or enough ink
-					src.visible_message("\The [src] runs out of ink and stops printing.")
+		if (paper_amt < 2 || ink_level < 2) // can we keep doin printing?
+			if (paper_amt < 2) // If we don't have enough paper to print...
+				src.visible_message("\The [src] runs out of paper and stops printing.")
+			if (ink_level < 2) // ...or enough ink
+				src.visible_message("\The [src] runs out of ink and stops printing.")
 
-				is_running = FALSE
-				UpdateIcon()
-				break
-
-			playsound(src.loc, 'sound/machines/printer_press.ogg', 50, 1)
+			is_running = FALSE
 			UpdateIcon()
+			break
 
-			var/obj/item/paper/book/custom/B = new
+		playsound(src.loc, 'sound/machines/printer_press.ogg', 50, 1)
+		UpdateIcon()
 
-			if (book_name)
-				B.name = src.book_name
-			else
-				B.name = "unnamed book"
+		var/obj/item/paper/book/custom/B = new
 
-			B.desc = "A book printed by a machine! The future is now! (if you live in the 15th century)"
-			if (book_author)
-				B.desc += " It says it was written by [src.book_author]."
-			else
-				B.desc += " It says it was written by... anonymous."
+		if (book_name)
+			B.name = src.book_name
+		else
+			B.name = "unnamed book"
 
-			if (src.book_cover)
-				if (src.book_cover == "custom")
-					B.custom_cover = 1
-					B.cover_color = src.cover_color
-					B.cover_symbol = src.cover_symbol
-					B.symbol_color = src.symbol_color
-					B.cover_flair = src.cover_flair
-					B.flair_color = src.cover_flair
-					B.symbol_colorable = src.symbol_colorable
-					B.flair_colorable = src.flair_colorable
-				B.info = src.book_info
-				B.ink_color = src.ink_color
-				B.book_cover = src.book_cover
-				B.build_custom_book()
-				B.layer = src.layer + 0.1
-			TRANSFER_OR_DROP(src, B)
-/*					if (cover_color) //should always be yes
-						var/image/I = SafeGetOverlayImage("cover", B.icon, "base-colorable")
-						I.color = cover_color
-						B.UpdateOverlays(I, "cover")
-					if (cover_symbol)
-						var/image/I = SafeGetOverlayImage("symbol", B.icon, "symbol-[cover_symbol]")
-						if (symbol_colorable)
-							I.color = symbol_color
-						B.UpdateOverlays(I, "symbol")
-					if (cover_flair)
-						var/image/I = SafeGetOverlayImage("flair", B.icon, "flair-[cover_flair]")
-						if (flair_colorable)
-							I.color = flair_color
-						B.UpdateOverlays(I, "flair")
-				else
-					if (book_cover in non_writing_icons) //for our non-writing.dmi icons
-						switch (book_cover)
-							if ("bible")
-								B.icon = 'icons/obj/items/storage.dmi'
-								B.icon_state = book_cover
-					else
-						B.icon_state = book_cover
-			else
-				B.icon_state = "book0"
-			if (book_info)
-				B.info = "<span style=\"color:[src.ink_color]\">[src.book_info]</span>"*/
+		B.desc = "A book printed by a machine! The future is now! (if you live in the 15th century)"
+		if (book_author)
+			B.desc += " It says it was written by [src.book_author]."
+		else
+			B.desc += " It says it was written by... anonymous."
 
-			books_to_make--
-			ink_level -= 2
-			paper_amt -= 2
+		if (src.book_cover)
+			if (src.book_cover == "custom")
+				B.custom_cover = 1
+				B.cover_color = src.cover_color
+				B.cover_symbol = src.cover_symbol
+				B.symbol_color = src.symbol_color
+				B.cover_flair = src.cover_flair
+				B.flair_color = src.cover_flair
+				B.symbol_colorable = src.symbol_colorable
+				B.flair_colorable = src.flair_colorable
+			B.info = src.book_info
+			B.ink_color = src.ink_color
+			B.book_cover = src.book_cover
+			B.build_custom_book()
+			B.layer = src.layer + 0.1
+		TRANSFER_OR_DROP(src, B)
+		books_to_make--
+		ink_level -= 2
+		paper_amt -= 2
 
-		is_running = FALSE
-		UpdateIcon() //just in case?
-		src.visible_message("\The [src] finishes printing and shuts down.")
+	is_running = FALSE
+	UpdateIcon() //just in case?
+	src.visible_message("\The [src] finishes printing and shuts down.")
 
 /obj/item/press_upgrade //parent just to i dont have to set name and icon a bunch i am PEAK lazy
 	name = "printing press upgrade module"

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -1,4 +1,5 @@
-/obj/machinery/printing_press //this makes books
+/// makes books and pamphlets.
+/obj/machinery/printing_press
 	name = "\improper Academy automated printing press"
 	desc = "This is an Aurora Lithographics 'Academy' model automated printing press, used to reproduce books and pamphlets. This doesn't still use stone plates, does it?"
 	icon = 'icons/obj/large/64x32.dmi'
@@ -10,10 +11,14 @@
 	var/const/paper_max = 70
 	var/const/ink_max = 500
 
-	var/paper_amt = 0 //empty by default, 0 to 70
-	var/was_paper = 0 //workaround for now, need to update icon if paper_amt is 0 to clear overlay
-	var/is_running = 0 //1 if its working, 0 when idle/depowered
-	var/colors_upgrade = 0 //0 by default, set to 1 when ink colors upgrade is installed
+	/// empty by default, 0 to 70
+	var/paper_amt = 0
+	/// workaround for now, need to update icon if paper_amt is 0 to clear overlay
+	var/was_paper = 0
+	/// TRUE if its working, FALSE when idle/depowered
+	var/is_running = FALSE
+	/// FALSE by default, set to TRUE when ink colors upgrade is installed
+	var/colors_upgrade = FALSE
 	var/books_upgrade = 0 //0 by default, set to 1 when custom book covers upgrade is installed
 	var/forbidden_upgrade = 0 //0 by default, set to 1 when forbidden covers/symbols/styles upgrade is installed
 	var/ink_level = 100 //decrements by 2 for each book printed, can be refilled (expensively)
@@ -187,7 +192,7 @@
 					if (colors_upgrade)
 						src.visible_message("\The [src] already has that upgrade installed.")
 						return
-					colors_upgrade = 1
+					colors_upgrade = TRUE
 					press_modes += "Ink color"
 					src.visible_message("\The [src] accepts the upgrade.")
 				if ("press_books")
@@ -453,7 +458,7 @@
 /////////////////////
 
 	proc/make_books() //alright so this makes our books
-		is_running = 1
+		is_running = TRUE
 		var/books_to_make = book_amount
 		while (books_to_make)
 
@@ -463,7 +468,7 @@
 				if (ink_level < 2) // ...or enough ink
 					src.visible_message("\The [src] runs out of ink and stops printing.")
 
-				is_running = 0
+				is_running = FALSE
 				UpdateIcon()
 				break
 
@@ -530,7 +535,7 @@
 			ink_level -= 2
 			paper_amt -= 2
 
-		is_running = 0
+		is_running = FALSE
 		UpdateIcon() //just in case?
 		src.visible_message("\The [src] finishes printing and shuts down.")
 


### PR DESCRIPTION
## About the PR
I was gonna mess with the printing press but noticed most of it was untouched since the 2020 epoch. Lots of it was missing doc comments, `TRUE FALSE` defines, and etc. So i cleaned that up a little. Also, did a bit of absolute pathing for some of the longer procs, for reducing the amount of indents reasons.

## Why's this needed?
Clean code is good.