### PR TITLE
fix chairs becoming steelgrey when unfolded

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -553,6 +553,7 @@ TYPEINFO(/obj/stool/wooden)
 	scoot_sounds = list( 'sound/misc/chair/normal/scoot1.ogg', 'sound/misc/chair/normal/scoot2.ogg', 'sound/misc/chair/normal/scoot3.ogg', 'sound/misc/chair/normal/scoot4.ogg', 'sound/misc/chair/normal/scoot5.ogg' )
 	parts_type = null
 	material_amt = 0.1
+	mat_appearances_to_ignore = "steel"
 
 	moveable
 		anchored = UNANCHORED
@@ -935,8 +936,7 @@ TYPEINFO(/obj/item/chair/folded)
 	else
 		C = new/obj/stool/chair(user.loc)
 	if (src.material)
-		if (!isSameMaterial(src.material, C.material))
-			C.setMaterial(src.material)
+		C.setMaterial(src.material)
 	if (src.c_color)
 		C.icon_state = src.c_color
 	C.set_dir(user.dir)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -935,7 +935,8 @@ TYPEINFO(/obj/item/chair/folded)
 	else
 		C = new/obj/stool/chair(user.loc)
 	if (src.material)
-		C.setMaterial(src.material)
+		if (!isSameMaterial(src.material, C.material))
+			C.setMaterial(src.material)
 	if (src.c_color)
 		C.icon_state = src.c_color
 	C.set_dir(user.dir)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -534,6 +534,8 @@ TYPEINFO(/obj/stool/wooden)
 /* ================================================ */
 /* -------------------- Chairs -------------------- */
 /* ================================================ */
+TYPEINFO(/obj/stool/chair)
+	mat_appearances_to_ignore = list("steel")
 
 /obj/stool/chair
 	name = "chair"
@@ -553,7 +555,6 @@ TYPEINFO(/obj/stool/wooden)
 	scoot_sounds = list( 'sound/misc/chair/normal/scoot1.ogg', 'sound/misc/chair/normal/scoot2.ogg', 'sound/misc/chair/normal/scoot3.ogg', 'sound/misc/chair/normal/scoot4.ogg', 'sound/misc/chair/normal/scoot5.ogg' )
 	parts_type = null
 	material_amt = 0.1
-	mat_appearances_to_ignore = "steel"
 
 	moveable
 		anchored = UNANCHORED


### PR DESCRIPTION
[MINOR]
## About the PR
When a chair is unfolded, it checks whether it has a material, and if it does, it sets that material to the unfolded version. Sadly, this means that unfolding a steel chair always makes it darker, as it becomes a steel steel chair. If that makes sense.

This PR makes it so that if chairs are the same as the default materials, the material is not manually set. Testing seems to indicate that this has worked.

## Why's this needed?
Fixes  #14941