### PR TITLE
Fix null loc on soulguard respawn

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -814,7 +814,7 @@
 		if(src.spell_soulguard == SOULGUARD_RING)	//istype(src.gloves, /obj/item/clothing/gloves/ring/wizard/teleport)
 			reappear_turf = get_turf(src)
 		else
-			reappear_turf = pick(job_start_locations["wizard"])
+			reappear_turf = pick_landmark(LANDMARK_WIZARD)
 
 	////////////////Set up the new body./////////////////
 

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -378,11 +378,11 @@
 						else
 							M3.set_loc(ASLoc)
 					if (2)
-						if (!job_start_locations["wizard"])
+						if (!landmarks[LANDMARK_WIZARD])
 							boutput(M3, "<B><span class='alert'>A starting location for you could not be found, please report this bug!</span></B>")
 							M3.set_loc(ASLoc)
 						else
-							M3.set_loc(pick(job_start_locations["wizard"]))
+							M3.set_loc(pick_landmark(LANDMARK_WIZARD))
 					if (3)
 						M3.set_loc(ASLoc)
 			//nah

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -81,7 +81,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 	// Respawn player.
 	var/mob/L
 	var/ASLoc = pick_landmark(LANDMARK_LATEJOIN)
-	var/WSLoc = job_start_locations["wizard"] ? pick(job_start_locations["wizard"]) : null
+	var/WSLoc = pick_landmark(LANDMARK_WIZARD)
 
 	if (!ASLoc)
 		message_admins("Couldn't set up [which_one == 0 ? "Santa Claus" : "Krampus"] respawn (no late-join landmark found).")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes the landmark its sending wizards to

fixes #14962

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
no null space wizards please

