### PR TITLE
Minor item additions to Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -20960,6 +20960,7 @@
 "jcG" = (
 /obj/storage/closet/office,
 /obj/item/camera,
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/grey/side{
 	dir = 9
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -29545,6 +29545,7 @@
 /obj/table/wood/round/auto,
 /obj/item/clothing/suit/cultist/nerd,
 /obj/item/clothing/mask/skull,
+/obj/item/clothing/head/apprentice,
 /turf/simulated/floor/carpet/red/fancy/innercorner/west,
 /area/station/crew_quarters/arcade/dungeon)
 "mDc" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[MAPPING] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds two items to Nadir, an artistic toolbox in crew quarters, and the apprentice's cap in the nerd dungeon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I saw a few people complaining about there not being an artistic toolbox on Nadir and I don't see any harm in adding one. The apprentice's cap is a spy thief objective so its absence could sort of be a bug if you squint but also it's another silly hat to wear so why not.