### PR TITLE
Fix various Mulebot things

### DIFF
--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -226,7 +226,7 @@
 				dat += "<A href='byond://?src=\ref[src];op=stop'>Stop</A><BR>"
 				dat += "<A href='byond://?src=\ref[src];op=go'>Proceed</A><BR>"
 				dat += "<A href='byond://?src=\ref[src];op=home'>Return to Home</A><BR>"
-				dat += "<A href='byond://?src=\ref[src];op=destination'>Set Destination</A><BR>"
+				dat += "<A href='byond://?src=\ref[src];op=setdest'>Set Destination</A><BR>"
 				dat += "<A href='byond://?src=\ref[src];op=setid'>Set Bot ID</A><BR>"
 				dat += "<A href='byond://?src=\ref[src];op=sethome'>Set Home</A><BR>"
 				dat += "<A href='byond://?src=\ref[src];op=autoret'>Toggle Auto Return Home</A> ([auto_return ? "On":"Off"])<BR>"

--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -259,35 +259,28 @@
 	return_text()
 		if(..())
 			return
+		// Pre scan destinations
+		beacons = null
+		src.post_status("bot_beacon", "findbeacon", "delivery", "address_tag", "delivery")
 
 		. = list(src.return_text_header())
 		. += "<h4>M.U.L.E. bot Interlink V0.8</h4>"
-
 		if(!src.active)
 			// list of bots
 			if(!src.botlist || (src.botlist && src.botlist.len==0))
 				. += "No bots found.<BR>"
-
 			else
 				for(var/obj/machinery/bot/mulebot/B in src.botlist)
 					. += "<A href='byond://?src=\ref[src];op=control;bot=\ref[B]'>[B] at [get_area(B)]</A><BR>"
-
-
-
 			. += "<BR><A href='byond://?src=\ref[src];op=scanbots'>Scan for active bots</A><BR>"
-
 		else	// bot selected, control it
 
-
 			. += "<B>[src.active]</B><BR> Status: (<A href='byond://?src=\ref[src];op=control;bot=\ref[src.active]'><i>refresh</i></A>)<BR>"
-
 			if(!src.botstatus)
 				. += "Waiting for response...<BR>"
 			else
-
 				. += "Location: [src.botstatus["loca"] ]<BR>"
 				. += "Mode: "
-
 				switch(src.botstatus["mode"])
 					if(0)
 						. += "Ready"

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -33846,7 +33846,7 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
-	location = "Medbay"
+	location = "Hydroponics"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -39650,7 +39650,7 @@
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
-	location = "Hydroponics"
+	location = "Medbay"
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)


### PR DESCRIPTION
[MAPPING] [MINOR] [QOL]
## About the PR
- Unswaps the Donut2 Medbay and Hydroponics beacons.
- Makes the mulebot tooltip holder "set destination" use a dropdown menu like in the pda
- Makes it so that destinations are scanned automatically when you open the PDA app (you can still rescan them ofc)
- removed a load of empty lines that were there for no reason

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mulebots are somewhat neglected. What would wisemonster say? We should give them a bit more care.

## Changelog
```changelog
(u)Tyrant
(+)The mulebot's destinations are now scanned automatically when opening the menu and displayed as a list.
```