### PR TITLE
Bugfixes to the trickster's runetrap

### DIFF
--- a/code/modules/antagonists/wraith/abilties/trickster/lay_trap.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/lay_trap.dm
@@ -12,7 +12,8 @@
 	"Illusions",
 	"EMP",
 	"Blinding",
-	"Sleepyness")
+	"Sleepyness",
+	"Slipperiness")
 
 	cast()
 		if (..())

--- a/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
+++ b/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
@@ -52,6 +52,7 @@
 		if(!armed) return
 		if(!isliving(AM)) return
 		if(istype(AM, /mob/living/critter/wraith/trickster_puppet)) return
+		if(isintangible(AM)) return
 		return TRUE
 
 
@@ -201,12 +202,11 @@
 		src.visible_message("<span class='alert>[M] steps on [src] and triggers it! You can hear a slippery sound!</span>")
 		M.remove_pulling()
 		M.changeStatus("weakened", 3 SECONDS)
-		boutput(M, "<span class='notice'>You suddenly slip!</span>")
+		boutput(M, "<span class='notice'>An ethereal force slips you!</span>")
 		playsound(M, 'sound/misc/slip.ogg', 50, 1, -3)
 		var/atom/target = get_edge_target_turf(M, M.dir)
 		M.throw_at(target, 12, 1, throw_type = THROW_SLIP)
 		playsound(src, 'sound/voice/wraith/wraithraise3.ogg', 80)
-		elecflash(src, 1, 1)
 
 /proc/checkRun(var/mob/M)	//If we are above walking speed, this triggers
 	if(!M) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an oversight that allows intangible mobs (such as the ai eye) to trigger trickster traps.
Adds an unreferenced slipperiness trap that i thought i added in https://github.com/goonstation/goonstation/pull/11195 
Turns out i never added it to the list, so i added it for real this time.

Also removes the elecflash the slipperiness trap had and instead write a specific message in the chat of the slipped person so the trap isnt immediatly obvious. Other behaviors remain unchanged.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly bugfixing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)Trickster wraith can now spawn a slippery runetrap. Intangible mobs no longer trigger the runetrap.
```
