### PR TITLE
Fixes trickster puppet name

### DIFF
--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -639,6 +639,7 @@
 	var/copied_desc = null
 	var/copied_name = null
 	var/copied_real_name = null
+	var/copied_pronouns = null
 	var/traps_laid = 0
 
 	New(var/mob/M)

--- a/code/modules/antagonists/wraith/abilties/haunt.dm
+++ b/code/modules/antagonists/wraith/abilties/haunt.dm
@@ -31,11 +31,11 @@
 			if ((istype(W, /mob/living/intangible/wraith/wraith_trickster)))	//Trickster can appear as a human, living or dead.
 				var/mob/living/intangible/wraith/wraith_trickster/T = holder.owner
 				if (T.copied_appearance != null)
-					var/mob/living/critter/wraith/trickster_puppet/puppet = new /mob/living/critter/wraith/trickster_puppet(get_turf(T), T)
+					var/mob/living/critter/wraith/trickster_puppet/puppet = new /mob/living/critter/wraith/trickster_puppet(get_turf(T), T, T.copied_name, T.copied_real_name)
+					puppet.name_tag.set_info_tag(T.copied_pronouns)
+					puppet.name_tag.set_name(puppet.name, strip_parentheses=TRUE)
 					T.mind.transfer_to(puppet)
 					puppet.appearance = T.copied_appearance
-					puppet.name = T.copied_name
-					puppet.real_name = T.copied_real_name
 					puppet.desc = T.copied_desc
 					puppet.traps_laid = T.traps_laid
 					puppet.playsound_local(puppet.loc, 'sound/voice/wraith/wraithhaunt.ogg', 40, 0)

--- a/code/modules/antagonists/wraith/abilties/trickster/choose_haunt_appearance.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/choose_haunt_appearance.dm
@@ -18,12 +18,14 @@
 				W.copied_desc = H.get_desc()
 				W.copied_name = H.name
 				W.copied_real_name = H.real_name
+				W.copied_pronouns = he_or_she(H)
 				return 0
 			else if (W.copied_appearance != null)
 				W.copied_appearance = null
 				W.copied_desc = null
 				W.copied_name = null
 				W.copied_real_name = null
+				W.copied_pronouns = null
 				boutput(holder.owner, "We discard our disguise.")
 			else
 				boutput(holder.owner, "We cannot copy this appearance.")

--- a/code/modules/antagonists/wraith/critters/trickster_puppet.dm
+++ b/code/modules/antagonists/wraith/critters/trickster_puppet.dm
@@ -21,12 +21,14 @@
 
 	faction = FACTION_WRAITH
 
-	New(var/turf/T, var/mob/living/intangible/wraith/wraith_trickster/M = null)
+	New(var/turf/T, var/mob/living/intangible/wraith/wraith_trickster/M = null, var/new_name = "Trickster puppet", var/new_real_name = "Trickster puppet")
 		..(T)
 		if(M != null)
 			src.master = M
 
 		last_life_update = TIME
+		src.name = new_name
+		src.real_name = new_real_name
 
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION_WEAK, src)
 		AH = src.add_ability_holder(/datum/abilityHolder/wraith)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes trickster puppet nametags so that they copy the crewmate's name and pronouns when the nametag is shown on holding examine.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A trickster wraith manifesting as a trickster puppet (the shell that appears like a crewmember) doesn't use the proper nametag. Anyone holding examine (default: ALT) can see the puppet come up as "Trickster puppet" with the "It" pronouns. This completely defeats the purpose of the ability, which is supposed to be a sneaky way to pass among crewmembers.