### PR TITLE
Makes light space and mars helmets no longer hide your face.

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -293,6 +293,7 @@
 		name = "engineering light space helmet"
 		desc = "A lightweight engineering space helmet. It's lacking any major padding or reinforcement."
 		icon_state = "spacelight-e"
+		see_face = 1
 
 /obj/item/clothing/head/helmet/space/syndicate
 	name = "red space helmet"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -293,7 +293,7 @@
 		name = "engineering light space helmet"
 		desc = "A lightweight engineering space helmet. It's lacking any major padding or reinforcement."
 		icon_state = "spacelight-e"
-		see_face = 1
+		see_face = TRUE
 
 /obj/item/clothing/head/helmet/space/syndicate
 	name = "red space helmet"

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -298,7 +298,7 @@
 	icon_state = "mars"
 	item_state = "mars"
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH
-	see_face = 1
+	see_face = TRUE
 
 
 /obj/critter/marsrobot

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -298,7 +298,7 @@
 	icon_state = "mars"
 	item_state = "mars"
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH
-	see_face = 0
+	see_face = 1
 
 
 /obj/critter/marsrobot


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing] [balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the PR title says they no longer disguise a player when being worn. This is a very small debuff to these clothing items that should make players seek additional gear to properly disguise.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The helmets are visually not opaque. You can quite easily see somebody's face through it.
![image](https://github.com/goonstation/goonstation/assets/40079883/ecb3a7f0-0efd-4243-b4e5-3699723df642)

```changelog
(u)DimWhat
(+)Light space suit helmets and martian helmets no longer hide your face.
```