### PR TITLE
Removes werewolf stunlock from repeatedly being dragged over aconite.

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -421,11 +421,14 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 	Crossed(atom/movable/AM as mob|obj)
 		var/mob/M = AM
 		if(iswerewolf(M))
-			M.changeStatus("weakened", 3 SECONDS)
-			M.force_laydown_standup()
-			M.TakeDamage("All", 0, 5, 0, DAMAGE_BURN)
-			M.visible_message("<span class='alert'>The [M] steps too close to [src] and falls down!</span>")
-			return
+			if(M.hasStatus("weakened"))
+				return
+			else
+				M.changeStatus("weakened", 3 SECONDS)
+				M.force_laydown_standup()
+				M.TakeDamage("All", 0, 5, 0, DAMAGE_BURN)
+				M.visible_message("<span class='alert'>The [M] steps too close to [src] and falls down!</span>")
+				return
 		..()
 	attack(mob/M, mob/user)
 		//if a wolf attacks with this, which they shouldn't be able to, they'll just drop it


### PR DESCRIPTION
[BALANCE] 
## About the PR 
Currently you can stunlock and kill a werewolf by repeatedly  dragging them over aconite.
This adds a check if werewolf is already stunned to prevent killing a werewolf using only one aconite flower (because its silly)
It also fixes aconite stacks on one tile instantly applying 30 second stun and critting the werewolf.

## Why's this needed? 
As mentioned above you can easily kill a werewolf using no weapons with 1-2 aconite flowers and just dragging them around on them. Stack of multiple aconite on one tile also does a lot of damage to the werewolf which was described as 'not fun' by a lot of players.
You probably shouldnt be able to kill a werewolf that easily and aconite seems a little too punishing.

