### PR TITLE
Prevent div by zero on reactor gas processing

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -338,7 +338,7 @@
 				CRASH("TEMP WENT NEGATIVE")
 
 			. = src.current_gas
-		if(inGas)
+		if(inGas && (THERMAL_ENERGY(inGas) > 0))
 			src.current_gas = inGas.remove((src.reactor_vessel_gas_volume*MIXTURE_PRESSURE(inGas))/(R_IDEAL_GAS_EQUATION*inGas.temperature))
 			if(src.current_gas && TOTAL_MOLES(src.current_gas) < 1)
 				if(istype(., /datum/gas_mixture))

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -395,7 +395,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 					T.assume_air(air_contents)
 			else
 				. = src.air_contents
-		if(inGas)
+		if(inGas && (THERMAL_ENERGY(inGas) > 0))
 			src.air_contents = inGas.remove((src.gas_volume*MIXTURE_PRESSURE(inGas))/(R_IDEAL_GAS_EQUATION*inGas.temperature))
 			src.air_contents?.volume = gas_volume
 			if(src.air_contents && TOTAL_MOLES(src.air_contents) < 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I just make the assumption that gas packets with 0 thermal energy are errors and discard them. I have no idea why they were there, nor what process creates them, but this at least will prevent associated runtimes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Couple runtimes on a round recently from div by zero with gas packets with 0 temperature.
