### PR TITLE
No dumping reagents in sink from closed containers

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -55,7 +55,7 @@ TYPEINFO(/obj/submachine/chef_sink)
 				var/obj/item/reagent_containers/mender/automender = W
 				if(automender.borg)
 					return
-			if (W.reagents)
+			if (W.reagents && W.is_open_container())
 				W.reagents.clear_reagents()		// avoid null error
 
 	MouseDrop_T(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an open container check to the chef_sink when cleaning items to avoid dumping reagents from food etc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You could wash all the reagents out of a MONSTER burger and other food items.