### PR TITLE
Fixes improperly named mail junction on donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -21704,7 +21704,7 @@
 /area/station/medical/medbay/treatment)
 "gAp" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = "cargo"
+	mail_tag = "QM"
 	},
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15003 by changing the mail_tag on the junction to match the one on the chute

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The mail never stops
