### PR TITLE
Nadir roundstart borgs 2 -> 4

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5104,6 +5104,7 @@
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/landmark/start/job/cyborg,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "coD" = (
@@ -11894,6 +11895,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/landmark/start/job/cyborg,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "fuo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds 2 new landmarks for borgs to spawn roundstart, increasing the total roundstart amount to 4. locations seen below

![Screenshot (196)](https://github.com/goonstation/goonstation/assets/73998720/ef2a7184-8ad7-465a-9fd3-0333a858fb4a)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

2 roundstart borgs is a weirdly small amount, and kubius gave the go ahead to up it to 4. spawn locations were also suggested by him. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)adds 2 more roundstart borg spawns to nadir
```
