### PR TITLE
Removes the ability to emag cyberogans with damage

### DIFF
--- a/code/datums/controllers/process/world.dm
+++ b/code/datums/controllers/process/world.dm
@@ -12,8 +12,6 @@
 
 		last_object = "setup_radiocodes"
 		setup_radiocodes()
-		last_object = "setup_organ_thresholds"
-		setup_organ_thresholds()
 
 		last_object = "emergency_shuttle"
 		emergency_shuttle = new /datum/shuttle_controller/emergency_shuttle()

--- a/code/datums/controllers/process/world.dm
+++ b/code/datums/controllers/process/world.dm
@@ -68,9 +68,3 @@
 	tempword = pick(codewords)
 	netpass_syndicate = "[rand(111,999)]DET[tempword]=[rand(1111,9999)]"
 	codewords -= tempword
-
-/proc/setup_organ_thresholds()
-	for(var/organ in cyberorgan_brute_threshold)
-		var/amt = rand(10, 60)
-		cyberorgan_brute_threshold[organ] = amt + rand(-5, 5)
-		cyberorgan_burn_threshold[organ] = 70 - amt + rand(-5, 5)

--- a/code/global.dm
+++ b/code/global.dm
@@ -330,10 +330,6 @@ var/global
 	netpass_cargo = null
 	netpass_syndicate = null //Detomatix
 
-	//
-	//cyberorgan damage thresholds for emagging without emag
-	list/cyberorgan_brute_threshold = list("heart" = 0, "cyber_lung_L" = 0, "cyber_lung_R" = 0, "cyber_kidney" = 0, "liver" = 0, "stomach" = 0, "intestines" = 0, "spleen" = 0, "pancreas" = 0, "appendix" = 0)
-	list/cyberorgan_burn_threshold = list("heart" = 0, "cyber_lung_L" = 0, "cyber_lung_R" = 0, "cyber_kidney" = 0, "liver" = 0, "stomach" = 0, "intestines" = 0, "spleen" = 0, "pancreas" = 0, "appendix" = 0)
 
 	/// Loooooooooogs
 	list/logs = list(

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -314,9 +314,6 @@
 		src.burn_dam += burn
 		src.tox_dam += tox
 
-		if(src.robotic && (src.organ_name in cyberorgan_brute_threshold) && abs(src.brute_dam - cyberorgan_brute_threshold[src.organ_name]) <= 2 && abs(src.burn_dam - cyberorgan_burn_threshold[src.organ_name]) <= 5)
-			src.emag_act(null)
-
 		//I don't think this is used at all, but I'm afraid to get rid of it - Kyle
 		if (ishuman(donor))
 			var/mob/living/carbon/human/H = donor


### PR DESCRIPTION
[CONTROVERSIAL] [REMOVAL] [BALANCE] [INPUT WANTED] [MEDICAL]

## About the PR 
Removes the ability to emag cyberorgans by damaging them.

## Why's this needed? 

Emaged cyberorgans are extremely powerful for the required effort put into obtaining them. 15 minutes of work can get you power near the level of stimulants.
There arent many counters to a nerd running around with full emaged cyberorgans either. The only option is to grab pulse rifles from the armory.
Its fine for traitors to have this level of power but non-antag crew should have to use alternative strategies. 

## Changelog

```changelog
(u)UnfunnyPerson
(+)Cyberogans can no longer be emaged through damage.
```
