### PR TITLE
Reduce melt time of 3D printed bottle to 1 decisecond

### DIFF
--- a/code/datums/components/biodegradable.dm
+++ b/code/datums/components/biodegradable.dm
@@ -11,4 +11,4 @@ TYPEINFO(/datum/component/biodegradable)
 /datum/component/biodegradable/proc/biodegrade(source)
 	var/obj/O = parent
 	if(O.reagents?.total_volume <= 0)
-		O.setStatus("acid", 1 SECOND, list("do_color" = FALSE, "message" = " biodegrades instantly.[prob(95) ? "": " DO NOT QUESTION THIS."]"))
+		O.setStatus("acid", 1 DECI SECOND, list("do_color" = FALSE, "message" = " biodegrades instantly.[prob(95) ? "": " DO NOT QUESTION THIS."]"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the time between a 3D printed bottle running out of reagents and being deleted from 1 second to 1 decisecond, making it effectively instant.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's possible and apparently common for people to accidentally fill the bottle after emptying it while rapidly clicking and then having those reagents be deleted along with the bottle, which sucks.