### PR TITLE
Shamblers delimb/damage when devouring a player

### DIFF
--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -31,6 +31,19 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
+		if (!ON_COOLDOWN(target, "changeling_remove_limb", 1.5 SECONDS))
+			var/list/valid_limbs = list("l_leg", "r_arm", "r_leg", "l_arm")
+			var/mob/living/carbon/human/H = target
+			H.TakeDamage("All", 15, 0, 0)
+			playsound(H, pick('sound/impact_sounds/Flesh_Tear_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Flesh_Tear_3.ogg'), 50)
+			for (var/L in valid_limbs)
+				var/possible_limb = H.limbs?[L]
+				if (possible_limb)
+					ownerMob.visible_message("<span class='combat bold'>[ownerMob] viciously tears off [H]'s [possible_limb]!</span>")
+					H.limbs.sever(L)
+					H.emote("scream", FALSE)
+					break
+
 	onStart()
 		..()
 		if(BOUNDS_DIST(owner, target) > 0 || target == null || owner == null || !devour)

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -35,12 +35,14 @@
 			var/list/valid_limbs = list("l_leg", "r_arm", "r_leg", "l_arm")
 			var/mob/living/carbon/human/H = target
 			H.TakeDamage("All", 15, 0, 0)
-			playsound(H, pick('sound/impact_sounds/Flesh_Tear_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Flesh_Tear_3.ogg'), 50)
+			take_bleeding_damage(H, null, 8, DAMAGE_STAB, TRUE)
 			for (var/L in valid_limbs)
-				var/possible_limb = H.limbs?[L]
+				var/obj/item/parts/possible_limb = H.limbs?[L]
 				if (possible_limb)
-					ownerMob.visible_message("<span class='combat bold'>[ownerMob] viciously tears off [H]'s [possible_limb]!</span>")
-					H.limbs.sever(L)
+					ownerMob.visible_message("<span class='combat bold'>[ownerMob] viciously devours [H]'s [possible_limb]!</span>")
+					possible_limb.remove(FALSE)
+					qdel(possible_limb)
+					playsound(H, 'sound/voice/burp_alien.ogg', 35)
 					H.emote("scream", FALSE)
 					break
 


### PR DESCRIPTION
[BALANCE] [PLAYER ACTIONS]

## About the PR 
Every 1.5 seconds while devouring a player, shamblers will delete 1 limb and deal 15 brute damage.


## Why's this needed? 
Its really odd someone can just walk away from a shambler 0.1 seconds before they were about to be eaten and suffer no damage. 
Shamblers also dont have much use outside of rampaging on the shuttle so this should give them more general use.


## Changelog 

```changelog
(u)UnfunnyPerson
(+)Shamblers will eat limbs while using devour.
```
