### PR TITLE
Adds electric guitar and tambourine to ghost bar

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -47737,6 +47737,7 @@
 "ddw" = (
 /obj/table/wood/round/auto,
 /obj/item/storage/box/nerd_kit,
+/obj/item/instrument/tambourine,
 /turf/unsimulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
@@ -58745,10 +58746,18 @@
 /area/cavetiny)
 "dSO" = (
 /obj/table/wood/round/auto,
+/obj/map/light/white,
+/obj/item/cigpacket/cigarillo{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /obj/item/decoration/ashtray{
 	icon_state = "ashtray4"
 	},
-/obj/map/light/white,
+/obj/item/cigpacket/cigarillo{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/unsimulated/floor/wood/two,
 /area/afterlife/bar)
 "dSP" = (
@@ -58793,20 +58802,14 @@
 /area/afterlife/bar)
 "dSV" = (
 /obj/table/wood/round/auto,
-/obj/item/decoration/ashtray,
 /obj/map/light/white,
+/obj/item/instrument/electricguitar{
+	pixel_y = 3
+	},
 /turf/unsimulated/floor/wood/two,
 /area/afterlife/bar)
 "dSW" = (
 /obj/table/wood/round/auto,
-/obj/item/cigpacket/cigarillo{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/cigpacket/cigarillo{
-	pixel_x = 4;
-	pixel_y = 1
-	},
 /obj/map/light/white,
 /turf/unsimulated/floor/wood/two,
 /area/afterlife/bar)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Very minor PR following the merging of the electric guitar.
This adds my electric guitar (and a tambourine) to the ghost bar, also moved the cigarettes to the table with the chessboard seeing as the guitar is a 64x32 sprite

What it looks like ingame:
<img width="389" alt="barimage" src="https://github.com/goonstation/goonstation/assets/112985775/7954ebb7-bd2b-4679-b021-1013a24c0d21">


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives more stuff to do in the ghost bar, and allows for an expanded range of music you can make in the bar
