### PR TITLE
prevents runtime on mobs without hands attacking

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1366,9 +1366,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 			if (src.critter_ability_attack(target))
 				src.ai_attack_count = 0 //ability used successfully, reset the count
 				return
-		//default to a basic attack
+		//Check if we can range attack, if not default to a basic attack
 		var/datum/handHolder/hand = src.get_active_hand()
-		if (hand.can_range_attack)
+		if (hand && hand.can_range_attack)
 			if (src.critter_range_attack(target))
 				src.ai_attack_count += 1
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks if we have hand when attacking so theres no null hand errors

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bad bug I made

