### PR TITLE
Standardise Rancher Closets on all rotation maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9853,15 +9853,7 @@
 /obj/machinery/light{
 	layer = 3
 	},
-/obj/storage/closet{
-	name = "rancher's supply closet"
-	},
-/obj/item/device/camera_viewer/ranch,
-/obj/item/paper/ranch_guide,
-/obj/item/storage/box/clothing/rancher,
-/obj/item/fishing_rod,
-/obj/item/chicken_carrier,
-/obj/item/clothing/mask/chicken,
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "aFv" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5077,6 +5077,7 @@
 	layer = 4;
 	pixel_x = 24
 	},
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "auH" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6216,17 +6216,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "avy" = (
-/obj/storage/closet{
-	name = "rancher supply closet"
-	},
-/obj/item/paper/ranch_guide,
-/obj/item/fishing_rod/basic,
-/obj/item/chicken_carrier,
-/obj/item/device/camera_viewer/ranch,
-/obj/item/storage/box/syringes,
-/obj/item/satchel/hydro,
-/obj/item/clothing/mask/chicken,
-/obj/item/storage/box/clothing/rancher,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -6238,6 +6227,7 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -29937,7 +29937,7 @@
 /area/station/routing/depot)
 "bBb" = (
 /obj/disposalpipe/switch_junction/left/north{
-	mail_tag = list("brig","customs  checkpoint","bridge","security");
+	mail_tag = list("brig","customs checkpoint","bridge","security");
 	name = "mail junction (command sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -30795,7 +30795,7 @@
 /area/station/routing/depot)
 "bCY" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("chapel","chapel  checkpoint","crewA","arrivals  checkpoint");
+	mail_tag = list("chapel","chapel checkpoint","crewA","arrivals checkpoint");
 	name = "mail junction (arrivals sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -33406,7 +33406,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical  booth");
+	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical booth");
 	name = "mail junction (catering sector)"
 	},
 /turf/simulated/floor/grime,
@@ -35249,7 +35249,7 @@
 /area/station/routing/depot)
 "bMl" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("engineering","podbay","podbay  checkpoint");
+	mail_tag = list("engineering","podbay","podbay checkpoint");
 	name = "mail junction (engineering sector)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -36008,7 +36008,7 @@
 /area/station/routing/depot)
 "bNQ" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("medbay  lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
+	mail_tag = list("medbay lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
 	name = "mail junction (medsci sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -36672,7 +36672,7 @@
 /area/station/routing/depot)
 "bPu" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("janitor","escape  checkpoint","mining","escape  hallway","mechanics","cargo  checkpoint","QM","refinery");
+	mail_tag = list("janitor","escape checkpoint","mining","escape hallway","mechanics","cargo checkpoint","QM","refinery");
 	name = "mail junction (escape and cargo sectors)"
 	},
 /turf/simulated/wall/auto/supernorn,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -29937,7 +29937,7 @@
 /area/station/routing/depot)
 "bBb" = (
 /obj/disposalpipe/switch_junction/left/north{
-	mail_tag = list("brig","customs checkpoint","bridge","security");
+	mail_tag = list("brig","customs  checkpoint","bridge","security");
 	name = "mail junction (command sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -30795,7 +30795,7 @@
 /area/station/routing/depot)
 "bCY" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("chapel","chapel checkpoint","crewA","arrivals checkpoint");
+	mail_tag = list("chapel","chapel  checkpoint","crewA","arrivals  checkpoint");
 	name = "mail junction (arrivals sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -33406,7 +33406,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical booth");
+	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical  booth");
 	name = "mail junction (catering sector)"
 	},
 /turf/simulated/floor/grime,
@@ -35249,7 +35249,7 @@
 /area/station/routing/depot)
 "bMl" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("engineering","podbay","podbay checkpoint");
+	mail_tag = list("engineering","podbay","podbay  checkpoint");
 	name = "mail junction (engineering sector)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -36008,7 +36008,7 @@
 /area/station/routing/depot)
 "bNQ" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("medbay lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
+	mail_tag = list("medbay  lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
 	name = "mail junction (medsci sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -36672,7 +36672,7 @@
 /area/station/routing/depot)
 "bPu" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("janitor","escape checkpoint","mining","escape hallway","mechanics","cargo checkpoint","QM","refinery");
+	mail_tag = list("janitor","escape  checkpoint","mining","escape  hallway","mechanics","cargo  checkpoint","QM","refinery");
 	name = "mail junction (escape and cargo sectors)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -74375,17 +74375,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/garden)
 "tat" = (
-/obj/storage/closet{
-	name = "rancher's supply closet"
-	},
-/obj/item/paper/ranch_guide,
-/obj/item/storage/box/clothing/rancher,
-/obj/item/fishing_rod,
-/obj/item/chicken_carrier,
-/obj/item/device/camera_viewer/ranch{
-	pixel_y = 5
-	},
-/obj/item/clothing/mask/chicken,
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "tck" = (
@@ -75851,6 +75841,10 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"wmd" = (
+/obj/storage/secure/closet/civilian/ranch,
+/turf/space,
+/area/space)
 "wmO" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -104146,7 +104140,7 @@ aQx
 ilw
 pJZ
 aXD
-aaa
+wmd
 aaa
 aaa
 aaa

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -48233,21 +48233,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
 "veb" = (
-/obj/storage/closet{
-	name = "rancher supply closet"
-	},
-/obj/item/paper/ranch_guide,
-/obj/item/fishing_rod/basic,
-/obj/item/chicken_carrier,
-/obj/item/device/camera_viewer/ranch,
-/obj/item/storage/box/syringes,
-/obj/item/satchel/hydro,
-/obj/item/clothing/mask/chicken,
-/obj/item/storage/box/clothing/rancher,
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 9
-	},
-/obj/item/sponge,
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/green/side{
 	dir = 6
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -21085,27 +21085,17 @@
 	},
 /area/station/crew_quarters/bar)
 "gqO" = (
-/obj/storage/closet{
-	name = "rancher supply closet"
-	},
-/obj/item/paper/ranch_guide,
-/obj/item/fishing_rod/basic,
-/obj/item/chicken_carrier,
 /obj/machinery/light_switch/east{
 	dir = 4;
 	pixel_x = -28;
 	pixel_y = -4
 	},
-/obj/item/device/camera_viewer/ranch,
-/obj/item/storage/box/syringes,
-/obj/item/satchel/hydro,
-/obj/item/clothing/mask/chicken,
-/obj/item/storage/box/clothing/rancher,
 /obj/blind_switch/east{
 	dir = 4;
 	pixel_x = -28;
 	pixel_y = 4
 	},
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "gqX" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -775,7 +775,7 @@
 /area/station/hangar/main)
 "acA" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -15896,7 +15896,7 @@
 /area/station/security/checkpoint/podbay)
 "bhP" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/cable{
@@ -27275,7 +27275,7 @@
 /area/station/crew_quarters/market)
 "bZR" = (
 /obj/machinery/computer/barcode/qm{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM");
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -34751,7 +34751,7 @@
 /area/station/maintenance/inner/sw)
 "ecb" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
@@ -34811,22 +34811,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
 "eew" = (
-/obj/storage/closet{
-	name = "rancher supply closet"
-	},
-/obj/item/paper/ranch_guide,
-/obj/item/fishing_rod/basic,
-/obj/item/chicken_carrier,
-/obj/item/device/camera_viewer/ranch,
-/obj/item/storage/box/syringes,
-/obj/item/satchel/hydro,
-/obj/item/clothing/mask/chicken,
-/obj/item/storage/box/clothing/rancher,
 /obj/decal/tile_edge/line/black{
 	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "eeR" = (
@@ -37690,7 +37680,7 @@
 /area/station/medical/medbay)
 "gow" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
 	dir = 8
 	},
 /obj/cable{
@@ -44279,7 +44269,7 @@
 /area/station/crew_quarters/cafeteria)
 "lBy" = (
 /obj/machinery/computer/barcode/qm{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -47017,7 +47007,7 @@
 /area/station/security/main)
 "nTf" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/cable{
@@ -52378,7 +52368,7 @@
 /area/station/crew_quarters/courtroom)
 "sqi" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
@@ -53552,7 +53542,7 @@
 /area/station/security/interrogation)
 "thB" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
 	},
 /obj/cable{
 	icon_state = "0-2"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -775,7 +775,7 @@
 /area/station/hangar/main)
 "acA" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -15896,7 +15896,7 @@
 /area/station/security/checkpoint/podbay)
 "bhP" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/cable{
@@ -27275,7 +27275,7 @@
 /area/station/crew_quarters/market)
 "bZR" = (
 /obj/machinery/computer/barcode/qm{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM");
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -34751,7 +34751,7 @@
 /area/station/maintenance/inner/sw)
 "ecb" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
@@ -37680,7 +37680,7 @@
 /area/station/medical/medbay)
 "gow" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 8
 	},
 /obj/cable{
@@ -44269,7 +44269,7 @@
 /area/station/crew_quarters/cafeteria)
 "lBy" = (
 /obj/machinery/computer/barcode/qm{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -47007,7 +47007,7 @@
 /area/station/security/main)
 "nTf" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Ejection","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/cable{
@@ -52368,7 +52368,7 @@
 /area/station/crew_quarters/courtroom)
 "sqi" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod  Bay","Research","Security","QM");
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Pod Bay","Research","Security","QM");
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
@@ -53542,7 +53542,7 @@
 /area/station/security/interrogation)
 "thB" = (
 /obj/machinery/computer/barcode{
-	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod  Bay","Security","QM")
+	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
 	},
 /obj/cable{
 	icon_state = "0-2"

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -24129,8 +24129,7 @@
 /turf/simulated/floor/blueblack,
 /area/station/medical/staff)
 "ksL" = (
-/obj/table/reinforced/auto,
-/obj/item/instrument/fiddle,
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ksM" = (
@@ -24457,6 +24456,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/item/instrument/fiddle,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "kyo" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13425,6 +13425,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/grasstodirt{
 	icon_state = "dirt";
 	name = "not grass"
@@ -34588,13 +34589,6 @@
 	dir = 10
 	},
 /area/station/crew_quarters/bar)
-"cgx" = (
-/obj/railing/orange/reinforced,
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt,
-/area/station/ranch)
 "cgy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35356,6 +35350,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
 "cjz" = (
+/mob/living/critter/small_animal/ranch_base/sheep/white/dolly/ai_controlled,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -35384,9 +35379,6 @@
 "cjG" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/machinery/plantpot,
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/grasstodirt{
 	icon_state = "dirt";
 	name = "not grass"
@@ -45735,7 +45727,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "vRM" = (
-/mob/living/critter/small_animal/ranch_base/sheep/white/dolly/ai_controlled,
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/grasstodirt{
 	icon_state = "dirt";
 	name = "not grass"
@@ -83904,7 +83899,7 @@ chc
 cgn
 wji
 vRM
-cgx
+ciN
 cjx
 ciB
 ciC


### PR DESCRIPTION
[MAPPING]
## About the PR
The rancher closet was made pretty much randomly. It was a renamed closet with the stuff placed on top of it. Not every map even had it. But now, the secure rancher locker has been merged as of #14850, so now we can add em to maps.

Every map with a rancher closet has had theirs replaced with the secure one. Maps without rancher closets have had them added.

## Why's this needed?
fixes #14320 and fixes #14578

## Changelog
```changelog
(u)Tyrant
(+)Rancher closets have been standardised across all maps, and added to Nadir and Clarion accordingly
```