### PR TITLE
Ethanol strength nerf for non-evil alcoholic drinks

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1207,7 +1207,7 @@
 		result = "ginfizz"
 		required_reagents = list("gin" = 1, "juice_lemon" = 1, "tonic" = 1)
 		result_amount = 3
-		mix_phrase = "The mixed drink starts fizzing on its own. Somehow."
+		mix_phrase = "The mixed drink starts fizzing. Somehow."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 
 	cocktail_gimlet

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1205,7 +1205,7 @@
 		name = "Gin Fizz"
 		id = "ginfizz"
 		result = "ginfizz"
-		required_reagents = list("gin" = 1, "juice_lemon" = 1, "water" = 1)
+		required_reagents = list("gin" = 1, "juice_lemon" = 1, "tonic" = 1)
 		result_amount = 3
 		mix_phrase = "The mixed drink starts fizzing on its own. Somehow."
 		mix_sound = 'sound/misc/drinkfizz.ogg'

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -136,7 +136,7 @@ datum
 			transparency = 5
 			addiction_prob = 1
 			addiction_min = 10
-			depletion_rate = 0.05 // ethanol depletes slower but is formed in smaller quantities
+			depletion_rate = 0.1 // ethanol depletes slower but is formed in smaller quantities
 			overdose = 100 // ethanol poisoning
 			thirst_value = -0.02
 			bladder_value = -0.2

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -136,7 +136,7 @@ datum
 			transparency = 5
 			addiction_prob = 1
 			addiction_min = 10
-			depletion_rate = 0.1 // ethanol depletes slower but is formed in smaller quantities
+			depletion_rate = 0.05 // ethanol depletes slower but is formed in smaller quantities
 			overdose = 100 // ethanol poisoning
 			thirst_value = -0.02
 			bladder_value = -0.2

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -206,7 +206,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				M.reagents.add_reagent("ethanol", alch_strength * mult)
+				M.reagents.add_reagent("ethanol", alch_strength * mult * depletion_rate) //Multiplying by depletion rate makes alch_strength describe ABV, with 1 being 100% ABV
 				M.reagents.remove_reagent(src, 1 * mult)
 				..()
 				return
@@ -564,7 +564,7 @@ datum
 			fluid_g = 163
 			fluid_b = 30
 			transparency = 190
-			alch_strength = 0.1 //half vodka by content, half vodka strength
+			alch_strength = 0.25 //half vodka by content, half vodka strength
 
 		fooddrink/alcoholic/cocktail_bloodymary
 			name = "Bloody Mary"
@@ -576,7 +576,7 @@ datum
 			fluid_g = 53
 			fluid_b = 0
 			transparency = 190
-			alch_strength = 0.1
+			alch_strength = 0.25
 
 		fooddrink/alcoholic/cocktail_bloodyscary
 			name = "Bloody Scary"
@@ -980,7 +980,7 @@ datum
 			fluid_r = 248
 			fluid_g = 255
 			fluid_b = 206
-			alch_strength = 0.25
+			alch_strength = 0.15
 			description = "Don't question how it's fizzing without seltzer."
 			reagent_state = LIQUID
 			taste = "fizzy"

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -209,7 +209,6 @@ datum
 				M.reagents.add_reagent("ethanol", alch_strength * mult * depletion_rate)
 				//Multiplying by depletion rate makes alch_strength describe ABV, with 1 being 100% ABV
 				//This means that drinks ~15% ABV need a higher depletion rate so that the ethanol can accumulate
-				M.reagents.remove_reagent(src, 1 * mult)
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -206,7 +206,9 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				M.reagents.add_reagent("ethanol", alch_strength * mult * depletion_rate) //Multiplying by depletion rate makes alch_strength describe ABV, with 1 being 100% ABV
+				M.reagents.add_reagent("ethanol", alch_strength * mult * depletion_rate)
+				//Multiplying by depletion rate makes alch_strength describe ABV, with 1 being 100% ABV
+				//This means that drinks ~15% ABV need a higher depletion rate so that the ethanol can accumulate
 				M.reagents.remove_reagent(src, 1 * mult)
 				..()
 				return
@@ -297,6 +299,7 @@ datum
 			fluid_g = 65
 			fluid_b = 7
 			alch_strength = 0.06
+			depletion_rate = 1
 			description = "An alcoholic beverage derived from apples."
 			taste = "fruity"
 			reagent_state = LIQUID
@@ -319,6 +322,7 @@ datum
 			fluid_g = 71
 			fluid_b = 231
 			alch_strength = 0.13
+			depletion_rate = 0.7
 			description = "An alcoholic beverage derived from grapes."
 			reagent_state = LIQUID
 			taste = "sweet"
@@ -338,6 +342,7 @@ datum
 			fluid_g = 140
 			fluid_b = 108
 			alch_strength = 0.12
+			depletion_rate = 0.7
 			description = "A fizzy alcoholic beverage derived from grapes, made in Champagne, France."
 			reagent_state = LIQUID
 			taste = "bubbly"
@@ -393,6 +398,7 @@ datum
 			fluid_g = 237
 			fluid_b = 198
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "An alcoholic beverage derived from fermented rice."
 			reagent_state = LIQUID
 			taste = "subdued"
@@ -420,6 +426,7 @@ datum
 			fluid_b = 56
 			transparency = 200
 			alch_strength = 0.1 //stronger than regular beer; fortified by the LAW
+			depletion_rate = 0.7
 			viscosity = 0.3
 
 			on_mob_life(var/mob/living/M, var/mult = 1)
@@ -600,6 +607,7 @@ datum
 			fluid_g = 74
 			fluid_b = 37
 			alch_strength = 0.15
+			depletion_rate = 0.7
 
 		fooddrink/alcoholic/caipirinha
 			name = "Pineapple Caipirinha"
@@ -611,6 +619,7 @@ datum
 			fluid_g = 236
 			fluid_b = 110
 			alch_strength = 0.1
+			depletion_rate = 0.7
 
 		fooddrink/alcoholic/piscosour
 			name = "Pisco Sour"
@@ -787,6 +796,7 @@ datum
 			fluid_g = 71
 			fluid_b = 231
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A fortified wine with botanicals for flavor."
 			reagent_state = LIQUID
 			taste = "sweet"
@@ -970,6 +980,7 @@ datum
 			fluid_g = 24
 			fluid_b = 24
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "Made to celebrate the liberation of Space Cuba in 2028."
 			reagent_state = LIQUID
 			taste = "festive"
@@ -981,6 +992,7 @@ datum
 			fluid_g = 255
 			fluid_b = 206
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "Don't question how it's fizzing."
 			reagent_state = LIQUID
 			taste = "fizzy"
@@ -1014,6 +1026,7 @@ datum
 			fluid_g = 244
 			fluid_b = 244
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "Nice drink, Dude."
 			reagent_state = LIQUID
 
@@ -1034,6 +1047,7 @@ datum
 			fluid_g = 42
 			fluid_b = 42
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "The breakfast of hung-over champions."
 			reagent_state = LIQUID
 			thirst_value = -0.5
@@ -1046,6 +1060,7 @@ datum
 			fluid_g = 206
 			fluid_b = 253
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "Well, at least it's not giving awful dating advice."
 			reagent_state = LIQUID
 			taste = "fruity"
@@ -1057,6 +1072,7 @@ datum
 			fluid_g = 121
 			fluid_b = 98
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "Fun fact: the previous name of this cocktail was deemed a war crime in 2025."
 			reagent_state = LIQUID
 			taste = "blissfully"
@@ -1069,6 +1085,7 @@ datum
 			fluid_b = 195
 			transparency = 50
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "Once made to make bitter medication taste better, now drunk for its flavor."
 			reagent_state = LIQUID
 
@@ -1080,6 +1097,7 @@ datum
 			fluid_b = 195
 			transparency = 50
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "All the bitterness of a gin and tonic, now without any other flavor but alcohol burn!"
 			reagent_state = LIQUID
 			taste = "caustic"
@@ -1127,6 +1145,7 @@ datum
 			fluid_g = 212
 			fluid_b = 212
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A gin and tonic for people who think the gin gets in the way."
 			reagent_state = LIQUID
 			taste = "medicinal"
@@ -1424,6 +1443,7 @@ datum
 			fluid_g = 255
 			fluid_b = 204
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "I don't really like being caught in the rain all that much, to be honest."
 			reagent_state = LIQUID
 			taste = "tropical"
@@ -1435,6 +1455,7 @@ datum
 			fluid_g = 184
 			fluid_b = 1
 			alch_strength = 0.05
+			depletion_rate = 1
 			description = "Not a flower, but a sweet cocktail typically served at formal functions."
 			reagent_state = LIQUID
 			taste = "like sunshine"
@@ -1446,6 +1467,7 @@ datum
 			fluid_g = 147
 			fluid_b = 41
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A strong champagne cocktail."
 			reagent_state = LIQUID
 			taste = "effervescent"
@@ -1457,6 +1479,7 @@ datum
 			fluid_g = 26
 			fluid_b = 54
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A tasty fruit wine cocktail."
 			reagent_state = LIQUID
 			taste = list("rich", "fruity")
@@ -1501,6 +1524,7 @@ datum
 			fluid_g = 176
 			fluid_b = 163
 			alch_strength = 0.14
+			depletion_rate = 0.7
 			description = "Named after an Italian artist, peach purée and white wine mixed together."
 			reagent_state = LIQUID
 			taste = "perfumed"
@@ -1512,6 +1536,7 @@ datum
 			fluid_g = 163
 			fluid_b = 195
 			alch_strength = 0.14
+			depletion_rate = 0.7
 			description = "Named after an Italian composer and like a Bellini, but with strawberry purée instead of peach."
 			reagent_state = LIQUID
 			taste = "perfumed"
@@ -1523,6 +1548,7 @@ datum
 			fluid_g = 42
 			fluid_b = 86
 			alch_strength = 0.14
+			depletion_rate = 0.7
 			description = "This tart cocktail softens gin with blackberries and lemon juice."
 			reagent_state = LIQUID
 			taste = "tart"
@@ -1534,6 +1560,7 @@ datum
 			fluid_g = 111
 			fluid_b = 111
 			alch_strength = 0.14
+			depletion_rate = 0.7
 			description = "Vodka, raspberry liqueur, and pineapple juice. Not actually French."
 			reagent_state = LIQUID
 			taste = "delicate"
@@ -1545,6 +1572,7 @@ datum
 			fluid_g = 219
 			fluid_b = 238
 			alch_strength = 0.14
+			depletion_rate = 0.7
 			description = "This unnaturally blue lemonade looks too radical not to drink."
 			reagent_state = LIQUID
 			taste = "blue"
@@ -1556,6 +1584,7 @@ datum
 			fluid_g = 211
 			fluid_b = 118
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A ginger ale and vodka concoction with a dash of lime."
 			reagent_state = LIQUID
 			taste = "astringent"
@@ -1567,6 +1596,7 @@ datum
 			fluid_g = 124
 			fluid_b = 30
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A strikingly orange drink."
 			reagent_state = LIQUID
 			taste = "like sunshine"
@@ -1579,6 +1609,7 @@ datum
 			fluid_b = 183
 			description = "A delicious summer cocktail."
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			taste = "tangy"
 
 		fooddrink/alcoholic/mintjulep
@@ -1588,6 +1619,7 @@ datum
 			fluid_g = 208
 			fluid_b = 83
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A refreshing cocktail with a minty aftertaste."
 			reagent_state = LIQUID
 			taste = "refreshing"
@@ -1711,6 +1743,7 @@ datum
 			fluid_g = 217
 			fluid_b = 255
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A visually and flavorfully pleasing cocktail."
 			reagent_state = LIQUID
 			taste = "seaworthy"
@@ -1765,6 +1798,7 @@ datum
 			fluid_g = 77
 			fluid_b = 65
 			alch_strength = 0.15
+			depletion_rate = 0.7
 			description = "A refreshing Spanish mixture of cola and wine."
 			reagent_state = LIQUID
 
@@ -1808,6 +1842,7 @@ datum
 			fluid_g = 127
 			fluid_b = 0
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A mixture of tea and rum. Huh."
 			reagent_state = LIQUID
 			taste = "smoky"
@@ -1819,6 +1854,7 @@ datum
 			fluid_g = 116
 			fluid_b = 101
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A refreshing mixed drink evocative of the seaside."
 			reagent_state = LIQUID
 			taste = "refreshing"
@@ -1863,6 +1899,7 @@ datum
 			fluid_g = 53
 			fluid_b = 8
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "¡Una cerveza preparada de perfecta para los sedientos habitantes de la estación espacial que quieren algo con un bocado!"
 			reagent_state = LIQUID
 
@@ -1873,6 +1910,7 @@ datum
 			fluid_g = 48
 			fluid_b = 22
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "Does this really count as a Martini?"
 			reagent_state = LIQUID
 			taste = list("smooth", "chocolatey")
@@ -1884,6 +1922,7 @@ datum
 			fluid_g = 215
 			fluid_b = 58
 			alch_strength = 0.1
+			depletion_rate = 0.7
 			description = "A lemonade and beer shandy."
 			reagent_state = LIQUID
 			taste = list("sweet", "sour")

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -403,7 +403,7 @@ datum
 			fluid_r = 121
 			fluid_g = 171
 			fluid_b = 121
-			alch_strength = 0.6
+			alch_strength = 1.3
 			description = "An alcoholic beverage derived from maize. Also ghosts."
 			taste = "spooky"
 			viscosity = 0.4
@@ -471,7 +471,7 @@ datum
 			fluid_g = 65
 			fluid_b = 30
 			transparency = 190
-			alch_strength = 5
+			alch_strength = 26
 			depletion_rate = 0.2
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume_passed)
@@ -493,7 +493,7 @@ datum
 			id = "bojack"
 			description = "A strong beverage. Drinking this will put hair on your chest. Maybe."
 			reagent_state = LIQUID
-			alch_strength = 5
+			alch_strength = 13
 			value = 0.25 //most of the alcohol content is handled below
 			taste = "manly"
 
@@ -588,7 +588,7 @@ datum
 			fluid_g = 53
 			fluid_b = 0
 			transparency = 200
-			alch_strength = 0.3
+			alch_strength = 2.3
 
 		fooddrink/alcoholic/snakebite
 			name = "Snakebite"
@@ -644,7 +644,7 @@ datum
 			fluid_g = 53
 			fluid_b = 0
 			transparency = 190
-			alch_strength = 1
+			alch_strength = 3
 
 		fooddrink/alcoholic/cocktail_grog
 			name = "grog"
@@ -658,7 +658,7 @@ datum
 			fluid_g = 255
 			fluid_b = 0
 			transparency = 255
-			alch_strength = 5 //1 unit grog = 100 ticks drunk
+			alch_strength = 13 //1 unit grog = 100 ticks drunk
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
@@ -889,7 +889,7 @@ datum
 			fluid_r = 255
 			fluid_g = 238
 			fluid_b = 238
-			alch_strength = 1.1
+			alch_strength = 3.5
 			transparency = 190
 			description = "Made from apples, mostly."
 			reagent_state = LIQUID
@@ -981,7 +981,7 @@ datum
 			fluid_g = 255
 			fluid_b = 206
 			alch_strength = 0.15
-			description = "Don't question how it's fizzing without seltzer."
+			description = "Don't question how it's fizzing."
 			reagent_state = LIQUID
 			taste = "fizzy"
 
@@ -1209,7 +1209,7 @@ datum
 			fluid_g = 163
 			fluid_b = 25
 			transparency = 190
-			alch_strength = 1 //its literally methanol
+			alch_strength = 2.5 //its literally methanol
 			depletion_rate = 0.4
 			thirst_value = -0.3
 
@@ -1742,7 +1742,7 @@ datum
 			fluid_r = 152
 			fluid_g = 171
 			fluid_b = 0
-			alch_strength = 0.5
+			alch_strength = 1.5
 			description = "A hellish cocktail that stinks of rotting garbage."
 			reagent_state = LIQUID
 			taste = "deathly"
@@ -1894,7 +1894,7 @@ datum
 			fluid_r = 178
 			fluid_g = 254
 			fluid_b = 15
-			alch_strength = 0.6
+			alch_strength = 1
 			description = "Contains no tea, and also no radioactive particles."
 			reagent_state = LIQUID
 			taste = "overwhelming"
@@ -4333,6 +4333,7 @@ datum
 			description = "Preferred by changelings, crew members, and the surprising overlap between them."
 			reagent_state = LIQUID
 			alch_strength = 0
+			depletion_rate = 0.1
 			fluid_r = 137
 			fluid_g = 158
 			fluid_b = 81
@@ -4343,7 +4344,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 0)
 
 				if (!M) M = holder.my_atom
-				alch_counter += rand(0,0.1) + 0.2 // RNG rolls moved to accumulation proc for consistency
+				alch_counter += rand(0,0.05) + 0.1 // RNG rolls moved to accumulation proc for consistency
 
 				..()
 


### PR DESCRIPTION
[Chemistry] [Catering] [Balance] [Bug] [QoL] [add-to-wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Alcoholic drinks have a variable called "alch_strength" that determines how much ethanol is put into the drinker's bloodstream per tick. These values are often based on real-life alcohol by volume (ABV) values: drinks like beer, wine, and bourbon have alch_strength values that closely follow conventional ABVs.

However, because alch_strength does not account for the depletion rate of the drink (often 0.4), these values do not represent ABV. Bourbon, with an ABV of 0.45, adds 0.45 units of ethanol every time 0.40 units of it decay; Hilariously, this makes it _stronger than pure ethanol,_ and easier to get into a drink too. More extreme cases of easy-to-mix drinks with high ABVs include Tequila, with an ABV of 150%, and Rum and Coke with an ABV of 175%. Rather than change the alch_strength of all 112 drinks in the game to account for this, this PR multiplies the depletion rate of the reagent to the amount of ethanol added per life tick. Reagents that rely on their alch_strength to function as poison have had their alch_strength increased to avoid nerfing them.

Gin Fizz also got its recipe changed to finally use tonic water instead of using normal water and relying on magic, and has a more realistic ABV because it was looking at me funny. Gin Fizz's description and mix phrase have had minor changes so that the drink doesn't start to bubble "on it's own," but the observer is still seemingly incredulous to the mechanics of the eponymous fizz. The spaceman fears the Gin Fizz, for he does not understand it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Low-effort mixed drinks having a higher potency than pure ethanol is unintuitive for new players and discourages people from having drinks at the bar, for fear of taking in debilitating levels of alcohol. Rough for RP, funny for classic. Imagine a world where a drinking glass with 30u of Rum and Coke and 20u of ice only gives you 17.7u of ethanol at its peak rather than putting you halfway to the 100 unit overdose threshhold. That could be _this_ world!

This change doesn't block off the "hilariously drunk" aspect from Classic, either: drinks that would be used as poisons are actually at slightly higher ABVs now than they were before the change, and there's still plenty of options for drinks at the power level they used to be (such as three mile island iced tea, Squeeze, and Boorbon). 

```changelog
(u)Mintyphresh
(*)Greatly reduced the ABV of most non-evil drinks. See minor changes for exceptions. Drink up!
(+)Necroni, Grog, Bo Jack Daniels, Squeeze, Suicider, Murdini, Moonshine, BOOrbon, Bloody Scary, and Ling Island Iced Tea have increased in strength.
```