### PR TITLE
Atlas Chem Drawer Conversion

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4785,13 +4785,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/combustion_chamber)
 "aqh" = (
-/obj/storage/secure/closet/research/chemical,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	light_type = /obj/item/light/tube/light_purpleish;
 	pixel_y = 21
 	},
+/obj/table/reinforced/chemistry/chemstorage,
+/obj/item/paper/labdrawertips,
 /turf/simulated/floor/purplewhite{
 	dir = 9
 	},
@@ -8992,18 +8993,14 @@
 	},
 /area/station/science/chemistry)
 "aDg" = (
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/device/reagentscanner,
-/obj/item/reagent_containers/dropper,
-/obj/item/clothing/glasses/spectro,
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler/chemistry{
 	pixel_y = 14
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/table/reinforced/chemistry/allinone,
 /turf/simulated/floor/purplewhite{
 	dir = 5
 	},
@@ -10517,15 +10514,6 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "aHt" = (
-/obj/storage/crate{
-	desc = "null";
-	name = "Chemistry Supplies Crate"
-	},
-/obj/item/reagent_containers/dropper/mechanical,
-/obj/item/storage/box/patchbox,
-/obj/item/paper/book/from_file/pharmacopia,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakerbox,
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /turf/simulated/floor/purplewhite{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [Chemistry] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR replaces the chemical storage locker in Atlas with a filled chemlab counter containing the same contents, as well as putting equipment previously on the counter and in a crate outside chemistry into the chemlab counter that the glass recycler rests on top of.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
(Copied from #14808)
These components are part of a larger goal to eliminate lab counter clutter in chemlabs while simultaneously standardizing the equipment that a player could expect to find in a typical chemlab. Switching to this method will provide a more consistent chemlab experience between maps; it also means that if these loadouts need to be changed in the future, they can be changed within their subtypes rather than having to change each map individually.

Additionally, while Atlas specifically may not have that much counter clutter, the addition of the extra table more than doubles usable counter space and edges the lab into being just a little more bearable to dual-chemist.
