### PR TITLE
Mentormouse ability incapacitation fix

### DIFF
--- a/code/datums/abilities/critter.dm
+++ b/code/datums/abilities/critter.dm
@@ -4,7 +4,8 @@
 			return
 		if (!owner.holder)
 			return
-		if (!isturf(usr.loc))
+		var/datum/targetable/critter/ability = owner
+		if (!isturf(usr.loc) && ability.needs_turf)
 			return
 		..()
 
@@ -28,6 +29,7 @@
 	disabled = 0
 	var/toggled = 0
 	var/is_on = 0   // used if a toggle ability
+	var/needs_turf = TRUE	//set to false if it can be cast while not on a turf. E.g. inside a locker
 	preferred_holder_type = /datum/abilityHolder/critter
 
 	New()

--- a/code/datums/abilities/critter.dm
+++ b/code/datums/abilities/critter.dm
@@ -29,7 +29,7 @@
 	disabled = 0
 	var/toggled = 0
 	var/is_on = 0   // used if a toggle ability
-	var/needs_turf = TRUE	//set to false if it can be cast while not on a turf. E.g. inside a locker
+	var/needs_turf = TRUE	//! set to false if it can be cast while not on a turf. E.g. inside a locker
 	preferred_holder_type = /datum/abilityHolder/critter
 
 	New()

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3904,7 +3904,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	desc = "Leave your body and return to ghost form"
 	icon_state = "mentordisappear"
 	needs_turf = FALSE //always castable
-	var/disappearance_time = 0.5 SECONDS
+	var/const/disappearance_time = 0.5 SECONDS
 
 	cast(mob/target)
 

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3903,7 +3903,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	name = "Vanish"
 	desc = "Leave your body and return to ghost form"
 	icon_state = "mentordisappear"
-
+	needs_turf = FALSE //always castable
+	var/disappearance_time = 0.5 SECONDS
 
 	cast(mob/target)
 
@@ -3913,21 +3914,29 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		logTheThing(LOG_ADMIN, src, "turned from a mentor mouse to a ghost") // I can remove this but it seems like a good thing to have
 		M.visible_message("<span class='alert'><B>[M] does a funny little jiggle with their body and then vanishes into thin air!</B></span>") // MY ASCENSION BEGINS
 		animate_bouncy(src)
-		SPAWN(0.5 SECONDS)
+		animate(M, alpha=0, time=disappearance_time)
+		SPAWN(disappearance_time)
 			M.ghostize()
 			qdel(M)
+
+	incapacitationCheck()
+		return FALSE
 
 /datum/targetable/critter/mentortoggle
 	name = "Toggle Pick Up Requests"
 	desc = "Enable or disable player pick up requests."
 	icon_state = "mentordisappear"
 	icon_state = "mentortoggle"
+	needs_turf = FALSE //always castable
 
 	cast(mob/target)
 		var/mob/living/critter/small_animal/mouse/weak/mentor/M = holder.owner
 		M.allow_pickup_requests = !M.allow_pickup_requests
 		boutput(M, "<span class='notice'>You have toggled pick up requests [M.allow_pickup_requests ? "on" : "off"]</span>")
 		logTheThing(LOG_ADMIN, src, "Toggled mentor mouse pick up requests [M.allow_pickup_requests ? "on" : "off"]")
+
+	incapacitationCheck()
+		return FALSE
 
 /mob/living/critter/small_animal/mouse/weak/mentor/admin
 	name = "admin mouse"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mentormouse abilities can now be cast while stunned, and while inside a container or not on a turf.

Also minorly changes mentormouse disappear ability so that the mouse visually disappears during it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As funny as it is that you can kidnap a mentormouse in a pet carrier, not being able to escape is a problem. Also being able to stunlock a mentormouse and preventing it from disappearing without a suicide should probably be fixed too.