### PR TITLE
Fix picky eaters not being picky at all

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -323,17 +323,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			if (H.traitHolder.hasTrait("picky_eater"))
 				var/datum/trait/picky_eater/eater_trait = H.traitHolder.getTrait("picky_eater")
 				if (length(eater_trait.fav_foods) > 0)
-					if (check_favorite_food(H))
-						src.heal(H)
-					else
+					if (!check_favorite_food(H))
 						displease_picky_eater(H)
 				else
 					logTheThing(LOG_DEBUG, src, "Empty favorite foods list for [src] despite having the picky_eater trait.")
-					src.heal(H)
-			else
-				src.heal(H)
-		else
-			src.heal(consumer)
+		src.heal(consumer)
 		playsound(consumer.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 		on_bite(consumer, feeder, ethereal_eater)
 		if (src.festivity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes picky eaters on RP being able to eat anything if their hunger is ABOVE 30% as opposed to below.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not only did i briefly cause world hunger before flappybat fixed it, i also coded it backwards. Sometimes i astound myself.