### PR TITLE
Fix Doubled Turfs in out of rotation map files

### DIFF
--- a/maps/unused/chiron.dmm
+++ b/maps/unused/chiron.dmm
@@ -99,7 +99,6 @@
 	icon_state = "catwalk";
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross";
@@ -136,7 +135,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/engine/vesselpower)
 "aan" = (
@@ -179,7 +177,6 @@
 	icon_state = "0-4";
 	pixel_y = 0
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -195,7 +192,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -370,7 +366,6 @@
 	icon_state = "0-4";
 	pixel_y = 0
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -493,7 +488,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/engine/vesselpower)
 "aaX" = (
@@ -510,7 +504,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -1176,7 +1169,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -1208,7 +1200,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1255,7 +1246,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1311,7 +1301,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross";
@@ -1331,7 +1320,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -1345,7 +1333,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/east)
 "act" = (
@@ -1708,7 +1695,7 @@
 "adc" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -1847,7 +1834,7 @@
 "ado" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 2;
-
+	
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 5
@@ -1979,7 +1966,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -2014,7 +2000,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -2175,7 +2160,6 @@
 	icon_state = "camera";
 	name = "autoname - SS13"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -2314,7 +2298,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -2450,7 +2433,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -2714,7 +2696,6 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -3525,7 +3506,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "agp" = (
@@ -3907,7 +3887,6 @@
 	},
 /area/shuttle/research/outpost)
 "agW" = (
-/turf/space,
 /turf/simulated/shuttle/wall/cockpit{
 	dir = 8;
 	icon_state = "shuttlecock"
@@ -4009,7 +3988,6 @@
 	},
 /area/station/medical/cdc)
 "ahf" = (
-/turf/simulated/floor/shuttle,
 /turf/simulated/shuttle/wall/cockpit/window{
 	name = "window"
 	},
@@ -11018,7 +10996,7 @@
 	pixel_x = 6
 	},
 /obj/item/device/radio/intercom/catering{
-
+	
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -15770,7 +15748,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -16002,7 +15979,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -16023,7 +15999,6 @@
 	icon_state = "camera";
 	name = "autoname - SS13"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -16450,7 +16425,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -18205,7 +18179,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -18239,7 +18212,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -18421,7 +18393,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -19486,7 +19457,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -19500,7 +19470,6 @@
 	icon_state = "catwalk_cross";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -19730,7 +19699,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -19790,7 +19758,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -19805,7 +19772,6 @@
 	d1 = 4;
 	d2 = 8
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -19821,7 +19787,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -19837,7 +19802,6 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -19856,7 +19820,6 @@
 	icon_state = "bulb1";
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -19921,7 +19884,6 @@
 	d1 = 4;
 	d2 = 8
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -20049,7 +20011,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -20724,7 +20685,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "aPR" = (
@@ -21286,7 +21246,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "aQT" = (
@@ -21555,7 +21514,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -22529,7 +22487,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -24256,7 +24213,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -24554,7 +24510,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -24576,7 +24531,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -25240,7 +25194,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -25268,7 +25221,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -25837,7 +25789,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -26000,7 +25951,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -31853,7 +31803,7 @@
 "bly" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-
+	
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -31861,7 +31811,7 @@
 /obj/stool/bench/yellow/auto,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-
+	
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/exit)
@@ -31869,7 +31819,7 @@
 /obj/stool/bench/yellow/auto,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-
+	
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -31883,7 +31833,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-
+	
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -31893,7 +31843,7 @@
 "blE" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 9;
-
+	
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -31999,7 +31949,7 @@
 /area/station/hallway/secondary/exit)
 "blR" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/table/auto,
 /obj/item/decoration/ashtray,
@@ -32541,13 +32491,6 @@
 	icon_state = "ast1"
 	},
 /area/space)
-"bnn" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 1;
-	icon_state = "ast1"
-	},
-/area/space)
 "bno" = (
 /obj/cable{
 	icon_state = "1-2";
@@ -32752,13 +32695,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/listeningpost)
-"bnM" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 5;
-	icon_state = "ast1"
-	},
-/area/space)
 "bnN" = (
 /obj/cable{
 	icon_state = "0-4";
@@ -33574,7 +33510,7 @@
 "bpK" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4;
-
+	
 	},
 /turf/simulated/wall/auto/gannets,
 /area/station/hallway/secondary/exit)
@@ -114159,7 +114095,7 @@ aaa
 bnj
 bnj
 bnj
-bnn
+bnm
 bnp
 bns
 bny
@@ -114763,7 +114699,7 @@ aaa
 bnj
 bnj
 bnj
-bnn
+bnm
 bnp
 bnu
 bnA
@@ -116882,7 +116818,7 @@ aaa
 aao
 aaa
 aaa
-bnM
+bnq
 aap
 aap
 aap

--- a/maps/unused/concept_fixed.dmm
+++ b/maps/unused/concept_fixed.dmm
@@ -2304,7 +2304,7 @@
 "aeF" = (
 /obj/rack,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -2652,7 +2652,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -3513,7 +3513,7 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/janitor/office)
@@ -3557,7 +3557,7 @@
 /area/station/maintenance/northeast)
 "agU" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -4183,7 +4183,7 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/grime,
 /area/station/janitor/office)
@@ -5890,7 +5890,7 @@
 /area/station/quartermaster/storage)
 "alp" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -8631,7 +8631,7 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -9879,10 +9879,6 @@
 "ats" = (
 /turf/simulated/floor/airless/plating/scorched,
 /area/station/engine/proto_gangway)
-"att" = (
-/turf/simulated/floor/airless/plating/scorched,
-/turf/simulated/floor/airless/plating/damaged2,
-/area/station/engine/proto_gangway)
 "atu" = (
 /obj/cable{
 	icon_state = "1-2";
@@ -10212,10 +10208,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
-"auh" = (
-/turf/simulated/floor/airless/plating/damaged1,
-/turf/simulated/floor/airless/plating/damaged2,
-/area/station/engine/proto_gangway)
 "aui" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -10787,7 +10779,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -11750,7 +11742,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "axg" = (
-/turf/simulated/floor/plating/airless,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/station/engine/proto)
 "axh" = (
@@ -12721,7 +12712,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "azm" = (
-/turf/simulated/floor/airless/plating/damaged3,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/station/engine/proto_gangway)
 "azn" = (
@@ -12996,10 +12986,6 @@
 /obj/window/reinforced,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"azL" = (
-/turf/simulated/floor/airless/plating/scorched,
-/turf/simulated/floor/airless/plating/damaged2,
-/area/station/engine/proto)
 "azM" = (
 /obj/cable{
 	icon_state = "0-2";
@@ -13502,10 +13488,6 @@
 	},
 /turf/simulated/floor/blackwhite/side,
 /area/station/medical/research)
-"aAP" = (
-/turf/simulated/floor/airless/plating/damaged1,
-/turf/simulated/floor/airless/plating/damaged2,
-/area/station/engine/proto)
 "aAQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -20743,7 +20725,7 @@
 /obj/poolwater,
 /mob/living/critter/small_animal/walrus{
 	name = "Willy the Space Walrus";
-
+	
 	},
 /turf/simulated/floor{
 	icon = 'icons/turf/floors.dmi';
@@ -22046,7 +22028,6 @@
 	icon_state = "solarpanel";
 	name = "solar paneling"
 	},
-/turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "aPZ" = (
 /turf/simulated/wall,
@@ -22633,7 +22614,6 @@
 "aRb" = (
 /obj/cable,
 /obj/item/cable_coil/cut,
-/turf/simulated/floor/plating/airless,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "aRc" = (
@@ -22927,7 +22907,6 @@
 /area/space)
 "aRH" = (
 /obj/item/cable_coil/cut,
-/turf/space,
 /turf/simulated/floor/plating/damaged2,
 /area/space)
 "aRI" = (
@@ -35229,7 +35208,6 @@
 /obj/item/device/radio{
 	pixel_y = 15
 	},
-/turf/simulated/floor/plating/damaged3,
 /turf/simulated/floor/plating/damaged2,
 /area/station/chapel/sanctuary)
 "bok" = (
@@ -35381,7 +35359,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/simulated/floor/airless/plating/scorched,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/station/engine/proto_gangway)
 "box" = (
@@ -35426,7 +35403,6 @@
 	d1 = 4;
 	d2 = 8
 	},
-/turf/simulated/floor/plating/airless,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/station/engine/proto)
 "boD" = (
@@ -35882,7 +35858,6 @@
 /turf/simulated/floor/caution/east,
 /area/space)
 "bpr" = (
-/turf/simulated/floor,
 /turf/simulated/floor/plating/damaged2,
 /area/space)
 "bps" = (
@@ -36739,10 +36714,6 @@
 	d2 = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
-"caB" = (
-/turf/space,
-/turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "caF" = (
 /obj/item/raw_material/shard/glass{
@@ -47136,7 +47107,7 @@ aww
 aww
 aww
 axg
-azL
+axg
 ayA
 aww
 cqb
@@ -47363,7 +47334,7 @@ axd
 axI
 ayw
 axJ
-azL
+axg
 axJ
 aww
 aww
@@ -47818,8 +47789,8 @@ axK
 boC
 axg
 axK
-azL
-aAP
+axg
+axg
 axI
 aww
 cqb
@@ -48271,7 +48242,7 @@ axg
 axe
 axK
 axe
-aAP
+axg
 axI
 axI
 axI
@@ -48943,9 +48914,9 @@ cqb
 asN
 ats
 ats
-auh
-auh
-auh
+azm
+azm
+azm
 avq
 avq
 ats
@@ -49168,9 +49139,9 @@ cqb
 cqb
 cqb
 asN
-att
-auh
-auh
+azm
+azm
+azm
 asN
 avq
 ats
@@ -79279,7 +79250,7 @@ cqb
 cqb
 cqb
 bZO
-caB
+aqp
 bZO
 cae
 aqo

--- a/maps/unused/density.dmm
+++ b/maps/unused/density.dmm
@@ -5871,7 +5871,7 @@
 "mx" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo{
 	dir = 4;
-
+	
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -6549,22 +6549,6 @@
 /obj/item/sheet/steel/fullstack,
 /turf/simulated/floor/red,
 /area/station/storage/warehouse)
-"nW" = (
-/obj/grille/catwalk,
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/mining/magnet)
 "nX" = (
 /obj/item/rcd_ammo/big,
 /turf/simulated/floor/red,
@@ -6785,11 +6769,7 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
-	intact = 0
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	
 	},
 /area/mining/magnet)
 "ou" = (
@@ -6824,10 +6804,6 @@
 	dir = 6;
 	layer = 2
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6;
-	layer = 2
-	},
 /area/mining/magnet)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -6838,19 +6814,12 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/obj/machinery/magnet_chassis{
-	bound_width = 64;
-	dir = 1;
-	icon_state = "chassis";
-	pixel_x = 16
-	},
 /obj/machinery/mining_magnet{
 	bound_width = 64;
 	dir = 1;
 	icon_state = "magnet";
 	pixel_x = 16
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -6864,7 +6833,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -6880,7 +6848,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -6899,7 +6866,6 @@
 	dir = 4;
 	icon_state = "mmagnet"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -51923,7 +51889,7 @@ fp
 fp
 fp
 fp
-nW
+fp
 ou
 en
 ad

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -7,7 +7,6 @@
 /turf/space,
 /area/space)
 "ac" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "ad" = (
@@ -47,10 +46,9 @@
 	},
 /area/space)
 "aj" = (
-/turf/simulated/floor/airless,
 /turf/simulated/shuttle/wall{
-	dir = 6;
-	icon_state = "wall3"
+	dir = 4;
+	icon_state = "diagonalWall3"
 	},
 /area/space)
 "ak" = (
@@ -181,9 +179,8 @@
 /turf/simulated/floor/airless/damaged4,
 /area/space)
 "az" = (
-/turf/simulated/floor/airless,
 /turf/simulated/shuttle/wall{
-	dir = 6;
+	dir = 1;
 	icon_state = "diagonalWall3"
 	},
 /area/space)
@@ -322,7 +319,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
 	})
@@ -374,7 +373,9 @@
 	d2 = 4;
 	icon_state = "4-9"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
 	})
@@ -432,7 +433,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
 	})
@@ -519,7 +522,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
 	})
@@ -627,9 +632,6 @@
 /obj/item/raw_material/shard/glass,
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg2"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
 	},
 /area/research_outpost/indigo_rye)
 "by" = (
@@ -778,7 +780,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -1496,7 +1497,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -1886,7 +1886,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -1994,7 +1993,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -2303,7 +2301,6 @@
 /area/station/science/tenebrae)
 "ff" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
@@ -2680,7 +2677,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -2815,7 +2811,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -2946,7 +2941,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "gw" = (
@@ -3005,7 +2999,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
 	})
@@ -3042,7 +3038,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
 	})
@@ -3059,7 +3057,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
 	})
@@ -3079,7 +3079,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
 	})
@@ -3493,7 +3495,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
 	})
@@ -3510,7 +3514,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
 	})
@@ -3530,7 +3536,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
 	})
@@ -3639,11 +3647,7 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "ic" = (
 /obj/machinery/light{
@@ -3687,7 +3691,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "ii" = (
@@ -4292,7 +4295,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -4516,7 +4518,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -4574,7 +4575,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -4667,7 +4667,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -4917,7 +4916,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5350,7 +5348,6 @@
 /obj/warp_beacon/mining{
 	name = "Maru beacon"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5377,7 +5374,6 @@
 /area/station/security/detectives_office)
 "lF" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
@@ -5524,8 +5520,8 @@
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIbaseoutside{
-	name = "Hammer Defense Zone"
+/area/station/security/hos{
+	name = "Hammer Command"
 	})
 "lY" = (
 /obj/machinery/light{
@@ -5549,7 +5545,6 @@
 	name = "Magnet Area Boundary"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "ma" = (
@@ -5796,7 +5791,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -6551,7 +6545,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -6862,7 +6855,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -6912,7 +6904,6 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
@@ -7186,7 +7177,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
 	})
@@ -7706,7 +7699,6 @@
 	id = "maru";
 	name = "Maru solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -7721,9 +7713,6 @@
 "qu" = (
 /turf/simulated/floor/airless/plating{
 	icon_state = "platingdmg2"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
 	},
 /area/research_outpost/indigo_rye)
 "qv" = (
@@ -7795,7 +7784,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
 	})
@@ -7830,7 +7821,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
 	})
@@ -7850,7 +7843,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
 	})
@@ -7898,7 +7893,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
 	})
@@ -8137,7 +8134,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
 	})
@@ -8154,7 +8153,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
 	})
@@ -8174,7 +8175,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
 	})
@@ -8507,10 +8510,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/small_backup2{
 	name = "Maru Solar Array"
@@ -8732,7 +8733,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -8822,7 +8822,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -9424,7 +9423,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -9594,7 +9592,6 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
@@ -9636,7 +9633,6 @@
 	id = "ham";
 	name = "Hammer solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -9746,10 +9742,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/turret_protected/AIbaseoutside{
 	name = "Hammer Defense Zone"
@@ -10240,7 +10234,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -10681,7 +10674,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -11252,7 +11244,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -11519,7 +11510,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -12101,7 +12091,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -12181,7 +12170,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -12413,7 +12401,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
 	})
@@ -12609,7 +12599,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -12716,7 +12705,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
 	})
@@ -12747,7 +12738,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -12764,7 +12757,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -12782,7 +12777,9 @@
 	},
 /obj/cable,
 /obj/disposalpipe/segment/transport,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -12803,7 +12800,9 @@
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/transport,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -13271,7 +13270,6 @@
 /area/station/turret_protected/ai)
 "Bh" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
@@ -13483,7 +13481,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/east{
 	name = "Demeter Solar Array"
 	})
@@ -13500,7 +13500,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/east{
 	name = "Demeter Solar Array"
 	})
@@ -13722,7 +13724,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -13817,7 +13818,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -13881,7 +13881,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -13958,7 +13957,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -14670,7 +14668,6 @@
 	})
 "DX" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
@@ -14870,7 +14867,6 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
@@ -15288,7 +15284,6 @@
 	id = "asc";
 	name = "Asclepius solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -15362,10 +15357,8 @@
 	d2 = 4;
 	icon_state = "8-10"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/north{
 	name = "Asclepius Solar Array"
@@ -15825,7 +15818,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -16029,7 +16021,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -16046,7 +16040,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -16073,7 +16069,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -16085,7 +16083,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -16269,7 +16266,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -16739,7 +16738,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/east{
 	name = "Demeter Solar Array"
 	})
@@ -16760,7 +16761,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/east{
 	name = "Demeter Solar Array"
 	})
@@ -16997,7 +17000,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -17070,7 +17072,6 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
@@ -18651,7 +18652,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -18834,7 +18837,6 @@
 	id = "dio";
 	name = "Dionysus solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -19092,10 +19094,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/south{
 	name = "Dionysus Solar Array"
@@ -19693,7 +19693,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -19709,7 +19708,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -19903,7 +19901,6 @@
 	d2 = 8;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -19995,7 +19992,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -20016,7 +20012,6 @@
 	d2 = 8;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -20041,7 +20036,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -20095,7 +20089,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -20111,7 +20104,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -20165,7 +20157,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west{
 	name = "Meridian Solar Array"
@@ -20765,7 +20756,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -20806,7 +20796,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -20827,7 +20816,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -20882,7 +20870,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -20910,7 +20897,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -20936,7 +20922,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/east{
 	name = "Demeter Solar Array"
@@ -20949,7 +20934,6 @@
 	},
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/transport,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west{
 	name = "Meridian Solar Array"
@@ -20992,7 +20976,6 @@
 	id = "meri";
 	name = "Meridian solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -21018,10 +21001,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
@@ -21043,7 +21024,6 @@
 /obj/cable{
 	icon_state = "1-10"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21088,7 +21068,6 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/transport,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -21110,7 +21089,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21143,7 +21121,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -21163,7 +21140,6 @@
 	d2 = 8;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21276,7 +21252,6 @@
 	id = "deme";
 	name = "Demeter solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -21302,10 +21277,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/east{
 	name = "Demeter Solar Array"
@@ -21323,7 +21296,6 @@
 	dir = 5
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21363,7 +21335,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -21388,7 +21359,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -21540,7 +21510,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21556,7 +21525,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -21585,7 +21553,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21610,7 +21577,6 @@
 /area/station/crew_quarters/tenebrae)
 "QD" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
@@ -21622,7 +21588,6 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
@@ -21639,7 +21604,6 @@
 	id = "tene";
 	name = "Tenebrae solar tracker"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -21665,10 +21629,8 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/small_backup3{
 	name = "Tenebrae Solar Array"
@@ -21686,7 +21648,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -21702,7 +21663,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -21721,7 +21681,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -22759,7 +22718,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -23131,8 +23092,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
@@ -23284,7 +23244,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/west{
 	name = "Meridian Solar Array"
 	})
@@ -23788,7 +23750,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})
@@ -24538,7 +24502,9 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/station/solar/small_backup1{
 	name = "Erebus Solar Array"
 	})

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -129,7 +129,6 @@
 	d2 = 4;
 	icon_state = "4-6"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -144,7 +143,6 @@
 	d2 = 4;
 	icon_state = "2-9"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -166,7 +164,6 @@
 	d2 = 4;
 	icon_state = "4-10"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -188,7 +185,6 @@
 	d2 = 4;
 	icon_state = "5-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -205,7 +201,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -223,7 +218,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -241,7 +235,6 @@
 /turf/space,
 /area/space)
 "aaA" = (
-/turf/space,
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -315,7 +308,6 @@
 /turf/simulated/wall/auto/asteroid/lighted,
 /area/station/solar/east)
 "aaP" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -472,7 +464,6 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/wreckage)
 "abn" = (
 /obj/decal/cleanable/dirt,
@@ -902,7 +893,6 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/wreckage)
 "acj" = (
 /obj/machinery/shuttle/engine/heater{
@@ -947,7 +937,6 @@
 	d2 = 4;
 	icon_state = "2-9"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -964,7 +953,6 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/wreckage)
 "acs" = (
 /obj/table/wood/auto,
@@ -1131,7 +1119,7 @@
 	},
 /obj/machinery/vending/alcohol{
 	name = "??? hEaghra's Vaguely-Irish-Swill-Dispenser";
-	slogan_list = list("Please drink responsibly.","No Refunds.","Please enjoy your stay at the Kuiper Inn!","No admittance under the age of 13.")
+	slogan_list = list("Please  drink  responsibly.","No  Refunds.","Please  enjoy  your  stay  at  the  Kuiper  Inn!","No  admittance  under  the  age  of  13.")
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/lounge)
@@ -1215,7 +1203,6 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/wreckage)
 "acU" = (
 /obj/stool/chair/comfy/shuttle/red{
@@ -1231,9 +1218,6 @@
 "acV" = (
 /turf/simulated/shuttle/wall{
 	dir = 9
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
 	},
 /area/station/security/checkpoint/podbay{
 	name = "NanoTrasen Labor Camp Shuttle"
@@ -1333,7 +1317,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -1359,7 +1342,6 @@
 /area/space)
 "adk" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "adl" = (
@@ -1514,7 +1496,6 @@
 /turf/space,
 /area/space)
 "adF" = (
-/turf/space,
 /turf/simulated/shuttle/wall/cockpit{
 	dir = 4
 	},
@@ -1908,7 +1889,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -1927,7 +1907,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -1942,7 +1921,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -2131,7 +2109,6 @@
 	},
 /area/space)
 "afi" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -2717,10 +2694,9 @@
 	})
 "agT" = (
 /turf/simulated/shuttle/wall{
-	dir = 6;
-	icon_state = "wall3"
+	dir = 5;
+	icon_state = "diagonalWall3"
 	},
-/turf/simulated/floor/plating,
 /area/station/science/spectral)
 "agU" = (
 /obj/cable{
@@ -2733,10 +2709,8 @@
 /area/station/science/spectral)
 "agW" = (
 /turf/simulated/shuttle/wall{
-	dir = 10;
 	icon_state = "diagonalWall3"
 	},
-/turf/simulated/floor/plating,
 /area/station/science/spectral)
 "agX" = (
 /obj/cable{
@@ -3761,7 +3735,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -4010,7 +3983,6 @@
 /turf/simulated/wall/auto/reinforced/gannets,
 /area/station/science/construction)
 "ala" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "alb" = (
@@ -4328,7 +4300,6 @@
 	dir = 8;
 	icon_state = "diagonalWall3"
 	},
-/turf/simulated/floor/plating,
 /area/station/science/spectral)
 "alR" = (
 /turf/simulated/shuttle/wall{
@@ -4469,7 +4440,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -4695,7 +4665,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -4800,7 +4769,6 @@
 	d2 = 4;
 	icon_state = "8-9"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5032,7 +5000,6 @@
 	icon_state = "0-2"
 	},
 /obj/item/raw_material/scrap_metal,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -5110,7 +5077,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5136,7 +5102,6 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5146,7 +5111,6 @@
 	dir = 4
 	},
 /obj/item/material_piece/slag,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5188,7 +5152,6 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5267,7 +5230,6 @@
 	icon_state = "0-8"
 	},
 /obj/item/rods,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5284,7 +5246,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -5296,7 +5257,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "apg" = (
@@ -5344,7 +5304,6 @@
 	d2 = 4;
 	icon_state = "1-6"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "apn" = (
@@ -5370,7 +5329,6 @@
 	d2 = 4;
 	icon_state = "1-5"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "apt" = (
@@ -5601,7 +5559,6 @@
 	d2 = 4;
 	icon_state = "5-6"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "apX" = (
@@ -5810,7 +5767,6 @@
 /area/station/science/restroom)
 "aqt" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "aqu" = (
@@ -5830,7 +5786,6 @@
 	icon_state = "2-9"
 	},
 /obj/item/scrap,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "aqy" = (
@@ -6177,7 +6132,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -6248,7 +6202,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -6262,7 +6215,6 @@
 	d2 = 4;
 	icon_state = "6-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -6272,7 +6224,6 @@
 	icon_state = "1-4"
 	},
 /obj/grille/steel,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -6294,7 +6245,6 @@
 	icon_state = "0-8"
 	},
 /obj/grille/steel,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -6303,7 +6253,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -6319,7 +6268,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -6333,7 +6281,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "arJ" = (
@@ -6429,7 +6376,6 @@
 	},
 /area/station/hangar/arrivals)
 "arV" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "arW" = (
@@ -8475,7 +8421,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/transport,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -9893,7 +9838,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -9969,7 +9913,6 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/disposalpipe/segment/transport,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -10351,7 +10294,6 @@
 /obj/grille/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -10677,7 +10619,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -11622,7 +11563,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -11813,7 +11753,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -12171,7 +12110,6 @@
 "aId" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/junction,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "aIe" = (
@@ -12663,7 +12601,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "aJz" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -13219,7 +13156,6 @@
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aKO" = (
 /obj/disposalpipe/junction/right/north,
@@ -13893,7 +13829,6 @@
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aMx" = (
 /obj/cable{
@@ -14136,7 +14071,6 @@
 /turf/simulated/floor/sand,
 /area/station/hallway/primary/central)
 "aNk" = (
-/turf/space,
 /turf/simulated/shuttle/wall/cockpit{
 	icon_state = "shuttlecock_busted"
 	},
@@ -14307,7 +14241,6 @@
 /turf/space,
 /area/space)
 "aNK" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/hallway/secondary/exit)
 "aNL" = (
@@ -19271,7 +19204,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -21990,7 +21922,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -22413,7 +22344,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -23853,7 +23783,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "blk" = (
@@ -24189,7 +24118,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bmc" = (
@@ -25252,7 +25180,6 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/machinery/r_door_control/podbay/qm/new_walls/west,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -28842,7 +28769,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -29922,7 +29848,6 @@
 	dir = 8;
 	icon_state = "wall3_trans"
 	},
-/turf/space,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bCA" = (
@@ -30011,7 +29936,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -33027,7 +32951,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -33922,7 +33845,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
@@ -34575,7 +34497,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -35254,7 +35175,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bRm" = (
@@ -40331,7 +40251,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "cdX" = (
@@ -40693,7 +40612,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mineral,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -40758,7 +40676,6 @@
 	icon_state = "catwalk_cross"
 	},
 /obj/disposalpipe/segment,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -42100,7 +42017,6 @@
 	dir = 6
 	},
 /obj/disposalpipe/segment/bent/east,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -42111,9 +42027,6 @@
 /obj/item/device/radio,
 /turf/simulated/shuttle/wall/escape{
 	dir = 10
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
 	},
 /area/station/hallway/secondary/exit)
 "ciz" = (
@@ -42151,7 +42064,6 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42252,7 +42164,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42339,7 +42250,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42655,10 +42565,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/station/solar/small_backup2)
 "cjP" = (
@@ -42671,7 +42579,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42695,7 +42602,6 @@
 	d2 = 4;
 	icon_state = "6-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42721,7 +42627,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -42798,16 +42703,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/east)
-"ckd" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/shuttle/wall/escape{
-	dir = 9
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/station/hallway/secondary/exit)
 "cke" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -43003,7 +42898,6 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/bent/east,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -43766,7 +43660,6 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/bent/west,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -43777,7 +43670,6 @@
 	dir = 6
 	},
 /obj/disposalpipe/segment,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -43808,7 +43700,6 @@
 	operating = 1
 	},
 /obj/map/light/dimreddish,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -43823,7 +43714,6 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -43833,7 +43723,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "cmW" = (
@@ -43902,7 +43791,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -43926,7 +43814,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -44060,7 +43947,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44148,7 +44034,6 @@
 	d2 = 4;
 	icon_state = "5-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44162,7 +44047,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44200,7 +44084,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44221,7 +44104,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44242,7 +44124,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -44263,7 +44144,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -44285,7 +44165,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -44303,7 +44182,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44315,7 +44193,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "cnU" = (
@@ -44331,7 +44208,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -44350,7 +44226,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -44401,9 +44276,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg2"
-	},
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "coe" = (
@@ -44411,19 +44283,14 @@
 /obj/machinery/bot/guardbot/bad{
 	on = 0
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg2"
-	},
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "cof" = (
 /obj/item/raw_material/scrap_metal,
 /turf/simulated/floor/airless/plating/damaged2,
-/turf/simulated/floor/airless/plating,
 /area/space)
 "cog" = (
 /obj/decal/cleanable/molten_item,
-/turf/space,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "coh" = (
@@ -44435,10 +44302,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/listeningpost/solars)
 "coi" = (
@@ -44685,7 +44550,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -44699,10 +44563,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/small_backup4,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
+	dir = 4
 	},
 /area/listeningpost/solars)
 "coI" = (
@@ -44718,7 +44580,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -45249,7 +45110,6 @@
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/outer/se)
 "cqA" = (
 /obj/machinery/manufacturer/general,
@@ -45533,7 +45393,6 @@
 /turf/space,
 /area/ghostdrone_factory)
 "crZ" = (
-/turf/space,
 /turf/simulated/shuttle/wall/cockpit{
 	dir = 1;
 	icon_state = "shuttlecock_mining"
@@ -47195,7 +47054,6 @@
 /turf/simulated/floor/airless/plating/damaged1,
 /area/space)
 "cwR" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
@@ -47246,7 +47104,6 @@
 	dir = 10;
 	icon_state = "diagonalWall3"
 	},
-/turf/simulated/floor/airless,
 /area/space)
 "cxc" = (
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -47267,7 +47124,6 @@
 	},
 /area/listeningpost/power)
 "cxf" = (
-/turf/space,
 /turf/simulated/shuttle/wall/cockpit{
 	dir = 8;
 	icon_state = "shuttlecock_mining"
@@ -47495,7 +47351,6 @@
 /turf/simulated/floor/airless/plating/damaged1,
 /area/space)
 "cxH" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -47548,7 +47403,6 @@
 	dir = 8;
 	icon_state = "diagonalWall3"
 	},
-/turf/simulated/floor/airless,
 /area/space)
 "cxN" = (
 /obj/decal/fakeobjects{
@@ -47683,7 +47537,6 @@
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/listeningpost/power)
 "cyl" = (
-/turf/space,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "cym" = (
@@ -47883,14 +47736,18 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/listeningpost/solars)
 "cyK" = (
 /obj/lattice{
 	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
 /area/listeningpost/solars)
 "cyL" = (
 /turf/space,
@@ -49988,9 +49845,6 @@
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
-	},
 /area/station/security/checkpoint/podbay{
 	name = "NanoTrasen Labor Camp Shuttle"
 	})
@@ -50001,7 +49855,6 @@
 	},
 /obj/map/light/dimreddish,
 /obj/disposalpipe/segment/ejection,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -50297,7 +50150,6 @@
 	dir = 1;
 	icon_state = "wall3_trans"
 	},
-/turf/simulated/floor/plating,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "dxN" = (
@@ -51964,7 +51816,6 @@
 	dir = 10;
 	icon_state = "wall3_trans"
 	},
-/turf/simulated/floor/plating,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "gdq" = (
@@ -52635,7 +52486,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -53398,7 +53248,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -53452,7 +53301,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -53626,7 +53474,6 @@
 "iQB" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/bent/south,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "iQE" = (
@@ -54423,7 +54270,6 @@
 "kim" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "kjn" = (
@@ -54855,7 +54701,6 @@
 	},
 /obj/machinery/crusher,
 /obj/map/light/dimreddish,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -55709,7 +55554,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -56196,7 +56040,6 @@
 	dir = 9;
 	icon_state = "wall3_trans"
 	},
-/turf/space,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ncb" = (
@@ -57620,7 +57463,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "pqC" = (
@@ -57886,9 +57728,6 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4;
 	icon_state = "wall_trans"
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
@@ -58348,7 +58187,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -58557,7 +58395,6 @@
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -58577,7 +58414,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -58988,7 +58824,6 @@
 	},
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
-/turf/unsimulated/grasstodirt,
 /area/station/ranch)
 "rBo" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -59414,7 +59249,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -60038,7 +59872,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mineral,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "tiZ" = (
@@ -60478,9 +60311,6 @@
 	anchored = 1
 	},
 /turf/simulated/floor/grasstodirt{
-	dir = 1
-	},
-/turf/unsimulated/grasstodirt{
 	dir = 1
 	},
 /area/station/ranch)
@@ -76248,7 +76078,7 @@ cwy
 cwS
 cxl
 cxG
-aaP
+aaa
 aaa
 aaa
 aaa
@@ -109071,7 +108901,7 @@ ciu
 aLL
 aLL
 aSh
-ckd
+aNy
 aKJ
 aaa
 aaa

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -3011,9 +3011,9 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "akE" = (
-/turf/simulated/shuttle/wall{
+/obj/indestructible/shuttle_corner{
 	dir = 8;
-	icon_state = "diagonalWall3"
+	icon_state = "wall3_trans"
 	},
 /turf/space/fluid/manta,
 /area/listeningpost/syndicateassaultvessel)
@@ -3022,9 +3022,9 @@
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
 "akG" = (
-/turf/simulated/shuttle/wall{
-	dir = 6;
-	icon_state = "diagonalWall3"
+/obj/indestructible/shuttle_corner{
+	dir = 1;
+	icon_state = "wall3_trans"
 	},
 /turf/space/fluid/manta,
 /area/listeningpost/syndicateassaultvessel)
@@ -3454,9 +3454,9 @@
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "alP" = (
-/turf/simulated/shuttle/wall{
+/obj/indestructible/shuttle_corner{
 	dir = 8;
-	icon_state = "diagonalWall3"
+	icon_state = "wall3_trans"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -3472,9 +3472,9 @@
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "alR" = (
-/turf/simulated/shuttle/wall{
-	dir = 6;
-	icon_state = "diagonalWall3"
+/obj/indestructible/shuttle_corner{
+	dir = 1;
+	icon_state = "wall3_trans"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
@@ -3488,9 +3488,8 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alU" = (
-/turf/simulated/shuttle/wall{
-	dir = 10;
-	icon_state = "diagonalWall3"
+/obj/indestructible/shuttle_corner{
+	icon_state = "wall3_trans"
 	},
 /turf/space/fluid/manta,
 /area/listeningpost/syndicateassaultvessel)
@@ -3660,9 +3659,9 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "amq" = (
-/turf/simulated/shuttle/wall{
-	dir = 6;
-	icon_state = "wall3"
+/obj/indestructible/shuttle_corner{
+	dir = 4;
+	icon_state = "wall3_trans"
 	},
 /turf/space/fluid/manta,
 /area/listeningpost/syndicateassaultvessel)
@@ -33598,6 +33597,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
+"dxS" = (
+/obj/indestructible/shuttle_corner{
+	dir = 9;
+	icon_state = "wall3_trans"
+	},
+/turf/space/fluid/manta,
+/area/listeningpost/syndicateassaultvessel)
 "dyv" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -39825,6 +39831,13 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"rUa" = (
+/obj/indestructible/shuttle_corner{
+	dir = 10;
+	icon_state = "wall3_trans"
+	},
+/turf/space/fluid/manta,
+/area/listeningpost/syndicateassaultvessel)
 "rVY" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -84590,7 +84603,7 @@ aaa
 aaa
 aaa
 aaa
-akE
+dxS
 akH
 akV
 akV
@@ -87610,7 +87623,7 @@ aaa
 aaa
 aaa
 aaa
-akG
+rUa
 akH
 akV
 akV

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -2841,7 +2841,6 @@
 	name = "Engineering Announcement Computer";
 	req_access_txt = "19"
 	},
-/turf/space,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/engine/engineering/ce)
 "amX" = (
@@ -9687,10 +9686,6 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
-"aQe" = (
-/turf/space,
-/turf/space,
-/area/space)
 "aQf" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
@@ -15286,7 +15281,6 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "blv" = (
-/turf/space,
 /turf/simulated/wall/auto/asteroid{
 	dir = 9
 	},
@@ -15315,12 +15309,6 @@
 	dir = 9
 	},
 /area/station/hallway/primary/central)
-"blB" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 8
-	},
-/area/space)
 "blC" = (
 /turf/simulated/wall/auto/asteroid{
 	dir = 6
@@ -15336,18 +15324,6 @@
 	icon_state = "wall3"
 	},
 /area/listeningpost)
-"blI" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 4
-	},
-/area/space)
-"blK" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 5
-	},
-/area/space)
 "blL" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -15383,18 +15359,6 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
-"blR" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 1
-	},
-/area/space)
-"blS" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 10
-	},
-/area/space)
 "blT" = (
 /obj/storage/closet/syndicate/personal,
 /obj/decal/stripe_caution,
@@ -15653,16 +15617,6 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost)
-"bmL" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 6
-	},
-/area/space)
-"bmM" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid,
-/area/space)
 "bmN" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -43571,7 +43525,7 @@ aaa
 aaa
 aaa
 aaa
-blB
+bln
 bkZ
 aaa
 aaa
@@ -43874,9 +43828,9 @@ aaa
 aaa
 bkU
 bla
-blS
+bkZ
 bln
-blS
+bkZ
 aaa
 aaa
 aaa
@@ -44176,9 +44130,9 @@ aaa
 baI
 blv
 blC
-blK
+bkX
 bla
-blS
+bkZ
 bkZ
 aaa
 aaa
@@ -44479,7 +44433,7 @@ blm
 abm
 abm
 abm
-blK
+bkX
 bla
 bkZ
 bkZ
@@ -44781,7 +44735,7 @@ aaB
 abm
 abm
 abm
-blR
+bkU
 bla
 bla
 bkZ
@@ -45385,7 +45339,7 @@ aaB
 abm
 abm
 abm
-blS
+bkZ
 blH
 bmi
 bmp
@@ -45682,7 +45636,7 @@ aaa
 bkU
 bla
 bla
-blS
+bkZ
 bln
 blw
 hmW
@@ -46283,7 +46237,7 @@ aaa
 acT
 acT
 acT
-blR
+bkU
 bla
 blc
 blg
@@ -46887,7 +46841,7 @@ aaa
 acT
 acT
 acT
-blR
+bkU
 bla
 blc
 bli
@@ -47206,8 +47160,8 @@ blE
 blH
 blH
 blH
-blS
-blS
+bkZ
+bkZ
 aaa
 aaa
 aaa
@@ -47509,7 +47463,7 @@ bmA
 bmH
 blH
 bla
-bmM
+bla
 aaa
 aaa
 aaa
@@ -47811,7 +47765,7 @@ bmB
 bmI
 blH
 bla
-bmM
+bla
 aaa
 aaa
 aaa
@@ -48113,7 +48067,7 @@ bmC
 bmJ
 blH
 bla
-bmM
+bla
 aaa
 aaa
 aaa
@@ -48415,7 +48369,7 @@ ugq
 blH
 blH
 bla
-bmM
+bla
 blb
 aaa
 aaa
@@ -48716,8 +48670,8 @@ bmD
 bmD
 bmD
 blH
-bmL
-bmL
+blC
+blC
 aaa
 aaa
 aaa
@@ -48894,21 +48848,21 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49005,8 +48959,8 @@ aaa
 aaa
 blb
 aaa
-blK
-blK
+bkX
+bkX
 bla
 bla
 bla
@@ -49018,7 +48972,7 @@ bmD
 bmG
 bmK
 blH
-bmL
+blC
 aaa
 aaa
 aaa
@@ -49196,7 +49150,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -49210,7 +49163,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -49308,13 +49260,15 @@ aaa
 aaa
 aaa
 aaa
-blK
-blI
-blI
-blI
-blI
-blI
-blK
+aaa
+aaa
+bkX
+ble
+ble
+ble
+ble
+ble
+bkX
 blH
 bmE
 bmD
@@ -49498,7 +49452,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -49512,7 +49465,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49616,7 +49570,7 @@ aaa
 aaa
 bla
 bla
-blK
+bkX
 blH
 blH
 blH
@@ -49800,7 +49754,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -49814,7 +49767,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50102,7 +50056,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -50116,7 +50069,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50404,7 +50358,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -50418,7 +50371,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50706,7 +50660,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -50720,7 +50673,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51008,7 +50962,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -51022,7 +50975,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51310,7 +51264,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -51324,7 +51277,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51612,7 +51566,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -51626,7 +51579,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51914,7 +51868,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -51928,7 +51881,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -52216,7 +52170,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -52230,7 +52183,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -52518,7 +52472,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -52532,7 +52485,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -52820,7 +52774,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -52834,7 +52787,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -53122,21 +53076,21 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -53430,10 +53384,10 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -53732,10 +53686,10 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -54029,15 +53983,15 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -54331,15 +54285,15 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57049,18 +57003,18 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57351,18 +57305,18 @@ aaa
 aaa
 aaa
 aaa
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
-aQe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57664,7 +57618,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -57966,7 +57920,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -58268,7 +58222,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -58570,7 +58524,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -58872,7 +58826,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -59174,7 +59128,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -63023,11 +62977,11 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64615,7 +64569,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -64913,7 +64867,7 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
 aaa
 aaa
 aaa
@@ -65796,7 +65750,6 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
@@ -65824,7 +65777,8 @@ aaa
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66043,11 +65997,11 @@ aaa
 aaa
 aaa
 aaa
-aQe
 aaa
 aaa
 aaa
-aQe
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/maps/unused/oldmap.dmm
+++ b/maps/unused/oldmap.dmm
@@ -3,7 +3,6 @@
 /turf/space,
 /area/space)
 "ab" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	tag = "icon-diagonalWall (WEST)";
 	icon_state = "diagonalWall";
@@ -14,7 +13,6 @@
 /turf/simulated/shuttle/wall,
 /area/shuttle/arrival/station)
 "ad" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	tag = "icon-diagonalWall (NORTH)";
 	icon_state = "diagonalWall";
@@ -1548,7 +1546,7 @@
 "dI" = (
 /obj/table,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/bridge)
@@ -3559,7 +3557,7 @@
 /area/crew_quarters/courtroom)
 "is" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/crew_quarters/courtroom)
@@ -3747,7 +3745,7 @@
 /obj/table,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/white,
 /area/medical/medbay)
@@ -5578,7 +5576,7 @@
 "nl" = (
 /obj/secure_closet/personal,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/crew_quarters/quarters)
@@ -6514,7 +6512,7 @@
 /obj/item/cleaner,
 /obj/item/cleaner,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/janitor)
@@ -6638,7 +6636,7 @@
 	network = "SS13"
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/security/main)
@@ -6757,7 +6755,7 @@
 /area/hallway/secondary/exit)
 "qb" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/exit)
@@ -6939,7 +6937,7 @@
 "qF" = (
 /obj/closet/wardrobe/pink,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/crew_quarters/quarters)
@@ -6985,7 +6983,7 @@
 /area/atmos)
 "qO" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/machinery/computer/general_air_control{
 	frequency = 1441;
@@ -7964,7 +7962,6 @@
 /turf/simulated/floor,
 /area/atmos)
 "tf" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "diagonalWall3"
@@ -7976,7 +7973,6 @@
 	},
 /area/syndicate_station)
 "th" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 1;
 	icon_state = "diagonalWall3"
@@ -7996,7 +7992,7 @@
 	c_tag = "Bar"
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/crew_quarters/bar)
@@ -8045,7 +8041,7 @@
 /area/crew_quarters/cafeteria)
 "tr" = (
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/white,
 /area/crew_quarters/cafeteria)
@@ -8548,7 +8544,6 @@
 	initialize_directions = 6;
 	layer = 3
 	},
-/turf/space,
 /turf/simulated/shuttle/wall{
 	icon_state = "diagonalWall3"
 	},
@@ -8595,7 +8590,6 @@
 	},
 /area/syndicate_station)
 "uI" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"
@@ -9110,7 +9104,6 @@
 /area/syndicate_station)
 "wd" = (
 /obj/machinery/atmospherics/pipe/simple,
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 1;
 	icon_state = "diagonalWall3"
@@ -9129,11 +9122,6 @@
 /obj/grille/steel,
 /obj/item/tank/oxygen,
 /turf/simulated/floor/plating/airless,
-/area/maintenance/maintcentral)
-"wh" = (
-/obj/grille/steel,
-/turf/simulated/floor/plating/airless,
-/turf/simulated/floor/plating/damaged2,
 /area/maintenance/maintcentral)
 "wi" = (
 /obj/table{
@@ -9725,7 +9713,6 @@
 /turf/space,
 /area/space)
 "xj" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	icon_state = "diagonalWall3"
 	},
@@ -9749,7 +9736,6 @@
 	icon_state = "intact-f";
 	layer = 3
 	},
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "diagonalWall3"
@@ -9782,7 +9768,6 @@
 	},
 /area/wizard_station)
 "xq" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 1;
 	icon_state = "diagonalWall3"
@@ -9848,7 +9833,6 @@
 	},
 /area/wizard_station)
 "xy" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "diagonalWall3"
@@ -10037,7 +10021,6 @@
 	},
 /area/wizard_station)
 "xR" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	icon_state = "diagonalWall3"
 	},
@@ -10049,7 +10032,6 @@
 	},
 /area/wizard_station)
 "xT" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"
@@ -10085,7 +10067,6 @@
 	},
 /area/wizard_station)
 "xX" = (
-/turf/space,
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"
@@ -10098,7 +10079,6 @@
 	initialize_directions = 5;
 	layer = 3
 	},
-/turf/space,
 /turf/simulated/shuttle/wall{
 	icon_state = "diagonalWall3"
 	},
@@ -11862,7 +11842,7 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/black,
 /area/turret_protected/aisat_interior)
@@ -15511,10 +15491,6 @@
 /obj/closet/emcloset,
 /turf/simulated/floor,
 /area/zeta)
-"JJ" = (
-/turf/simulated/floor,
-/area/russian/radiation,
-/area/zeta)
 "JK" = (
 /turf/simulated/wall,
 /area/artifact)
@@ -17432,36 +17408,6 @@
 "Nl" = (
 /turf/space,
 /area/fuck/main)
-"Nm" = (
-/turf/space/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "nw1"
-	},
-/area/fuck/main)
-"Nn" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "north1"
-	},
-/area/fuck/main)
-"No" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ne1"
-	},
-/area/fuck/main)
-"Np" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "nw1"
-	},
-/area/fuck/main)
-"Nq" = (
-/turf/space/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "north1"
-	},
-/area/fuck/main)
 "Nr" = (
 /turf/simulated/wall/auto/asteroid{
 	icon_state = "north1"
@@ -17472,12 +17418,6 @@
 	icon_state = "on1"
 	},
 /area/space)
-"Nt" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "inw1"
-	},
-/area/fuck/main)
 "Nu" = (
 /obj/landmark/mining{
 	icon_state = "mining2";
@@ -17488,18 +17428,6 @@
 /area/fuck/main)
 "Nv" = (
 /turf/simulated/wall/auto/asteroid,
-/area/fuck/main)
-"Nw" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "east1"
-	},
-/area/fuck/main)
-"Nx" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ine1"
-	},
 /area/fuck/main)
 "Ny" = (
 /turf/simulated/wall/auto/asteroid{
@@ -17820,12 +17748,6 @@
 	icon_state = "sw1"
 	},
 /area/fuck/main)
-"Oq" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "isw1"
-	},
-/area/fuck/main)
 "Or" = (
 /obj/landmark/mining{
 	icon_state = "mining3";
@@ -18032,24 +17954,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"OO" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "west1"
-	},
-/area/fuck/main)
-"OP" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "north1"
-	},
-/area/fuck/main)
-"OQ" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ne1"
-	},
-/area/fuck/main)
 "OR" = (
 /obj/lattice,
 /turf/simulated/floor/plating/airless/asteroid,
@@ -18135,12 +18039,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"Pb" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "se1"
-	},
-/area/fuck/main)
 "Pc" = (
 /obj/cable{
 	icon_state = "0-4";
@@ -18396,12 +18294,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
-"Pz" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "sw1"
-	},
-/area/fuck/main)
 "PA" = (
 /obj/grille/steel,
 /obj/window/reinforced,
@@ -18465,12 +18357,6 @@
 /obj/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
-"PI" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "east1"
-	},
-/area/fuck/main)
 "PJ" = (
 /obj/crate{
 	desc = "Storage for space GPSes.";
@@ -18647,12 +18533,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"Qe" = (
-/turf/space/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "west1"
-	},
-/area/fuck/main)
 "Qf" = (
 /obj/grille/steel,
 /obj/window/reinforced,
@@ -18755,18 +18635,6 @@
 /obj/secure_closet/engineering_mining,
 /turf/simulated/floor,
 /area/engine/miningoutpost)
-"Qq" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ise1"
-	},
-/area/fuck/main)
-"Qr" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "se1"
-	},
-/area/fuck/main)
 "Qs" = (
 /obj/landmark/mining{
 	icon_state = "mining2";
@@ -18897,12 +18765,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"QI" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ise1"
-	},
-/area/fuck/main)
 "QJ" = (
 /obj/decal/fakeobjects/shuttlethruster{
 	dir = 4
@@ -18926,12 +18788,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
-"QN" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "south1"
-	},
-/area/fuck/main)
 "QO" = (
 /obj/table{
 	icon_state = "tabledir";
@@ -18951,12 +18807,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
-"QR" = (
-/turf/space/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ise1"
-	},
-/area/fuck/main)
 "QS" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall_space"
@@ -18975,12 +18825,6 @@
 "QV" = (
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
-"QW" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ine1"
-	},
-/area/fuck/main)
 "QX" = (
 /obj/landmark/mining{
 	icon_state = "mining2";
@@ -19051,12 +18895,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"Rf" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "oe1"
-	},
-/area/fuck/main)
 "Rg" = (
 /obj/landmark/mining{
 	icon_state = "mining3";
@@ -19065,12 +18903,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"Rh" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "nw1"
-	},
-/area/fuck/main)
 "Ri" = (
 /obj/landmark/mining{
 	name = "CoVe2";
@@ -19083,18 +18915,6 @@
 	},
 /turf/simulated/wall/auto/asteroid,
 /area/space)
-"Rj" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "ne1"
-	},
-/area/fuck/main)
-"Rk" = (
-/turf/simulated/floor/plating/airless,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "inw1"
-	},
-/area/fuck/main)
 "Rl" = (
 /obj/landmark/mining{
 	icon_state = "mining3";
@@ -19150,12 +18970,6 @@
 /obj/rack,
 /obj/item/disk/data/floppy/read_only/communications,
 /turf/simulated/floor/plating,
-/area/fuck/main)
-"Rs" = (
-/turf/space/asteroid,
-/turf/simulated/wall/auto/asteroid{
-	icon_state = "east1"
-	},
 /area/fuck/main)
 "Rt" = (
 /obj/landmark/mining{
@@ -20830,7 +20644,7 @@
 /obj/stool/bed,
 /obj/landmark/start/job/captain,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
@@ -30416,7 +30230,7 @@ qR
 qR
 uS
 pn
-wh
+qw
 pn
 aa
 aa
@@ -93060,7 +92874,7 @@ GI
 EM
 Jj
 Jy
-JJ
+EM
 Fo
 aa
 aa
@@ -120786,9 +120600,9 @@ aa
 aa
 aa
 aa
-Np
-OO
-Pz
+NB
+Og
+Op
 aa
 aa
 aa
@@ -120937,15 +120751,15 @@ aa
 aa
 aa
 aa
-Np
-Nt
+NB
+NN
 Nu
-Oq
-OO
-OO
-Qe
-OO
-Pz
+Om
+Og
+Og
+Og
+Og
+Op
 aa
 aa
 aa
@@ -121086,10 +120900,10 @@ aa
 aa
 aa
 aa
-Np
-OO
-OO
-Nt
+NB
+Og
+Og
+NN
 Nv
 Nu
 Nu
@@ -121097,20 +120911,20 @@ Nu
 Nv
 Nv
 Nv
-Oq
-OO
-Qe
-OO
-Pz
+Om
+Og
+Og
+Og
+Op
 aa
 aa
 aa
 aa
-Np
-OO
-OO
-OO
-Pz
+NB
+Og
+Og
+Og
+Op
 eH
 aa
 cL
@@ -121237,8 +121051,8 @@ Om
 Op
 aa
 aa
-Np
-Nt
+NB
+NN
 Nv
 NO
 Nv
@@ -121253,12 +121067,12 @@ Nv
 Nv
 Nv
 Nv
-Oq
-OO
-OO
-OO
-OO
-Nt
+Om
+Og
+Og
+Og
+Og
+NN
 Nv
 Nv
 Nv
@@ -121387,8 +121201,8 @@ Nv
 NW
 Nv
 Ol
-Np
-Nt
+NB
+NN
 Nv
 Nv
 Nv
@@ -121538,8 +121352,8 @@ Nv
 NW
 NW
 Nv
-Oq
-Nt
+Om
+NN
 Nv
 Nv
 Nv
@@ -121836,7 +121650,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -121988,7 +121802,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 NO
 Nv
@@ -122140,7 +121954,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -122174,7 +121988,7 @@ NP
 Nv
 Nv
 Nv
-Qq
+Ok
 NS
 NS
 Oo
@@ -122292,7 +122106,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -122306,17 +122120,17 @@ Nv
 Nv
 Nv
 Nv
-Pb
+Oo
 Ou
-OQ
-PI
-PI
-PI
-PI
-PI
-PI
-QI
-Pb
+NC
+NS
+NS
+NS
+NS
+NS
+NS
+Ok
+Oo
 Ou
 Nv
 NP
@@ -122326,7 +122140,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 aa
 aa
@@ -122444,7 +122258,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -122470,7 +122284,7 @@ Qu
 QJ
 QJ
 QS
-QW
+NY
 Nv
 Nv
 Nv
@@ -122478,7 +122292,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 aa
 aa
@@ -122596,7 +122410,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -122630,7 +122444,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 aa
 aa
@@ -122747,8 +122561,8 @@ aa
 aa
 aa
 aa
-Np
-Nt
+NB
+NN
 Nv
 Nv
 Nv
@@ -122782,7 +122596,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 aa
 aa
@@ -122899,7 +122713,7 @@ aa
 aa
 aa
 aa
-Nt
+NN
 Nv
 Nv
 Nv
@@ -122934,7 +122748,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 NB
 Op
@@ -123050,7 +122864,7 @@ aa
 aa
 aa
 aa
-Nm
+NB
 Nu
 Nv
 Nv
@@ -123063,7 +122877,7 @@ Nv
 Nv
 Nv
 Ou
-OP
+Nr
 Nv
 Nv
 Ou
@@ -123086,7 +122900,7 @@ Nv
 Nv
 Nv
 Nv
-Oq
+Om
 Og
 NO
 Om
@@ -123202,7 +123016,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nu
 Nu
 Nv
@@ -123215,8 +123029,8 @@ Nv
 Nv
 Nv
 Ou
-OQ
-Pb
+NC
+Oo
 Ou
 OR
 Ow
@@ -123354,7 +123168,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -123506,8 +123320,8 @@ aa
 aa
 aa
 aa
-No
-Nw
+NC
+NS
 Nv
 Nv
 NP
@@ -123659,7 +123473,7 @@ aa
 aa
 aa
 aa
-Np
+NB
 Nv
 Nv
 Nv
@@ -123810,8 +123624,8 @@ aa
 aa
 aa
 aa
-Np
-Nt
+NB
+NN
 Nv
 Nv
 Nv
@@ -123962,7 +123776,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -123993,9 +123807,9 @@ Pt
 PR
 Rb
 OR
-Rf
+Os
 Ow
-Rj
+NC
 Nv
 NQ
 NQ
@@ -124114,7 +123928,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -124266,8 +124080,8 @@ aa
 aa
 aa
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -124298,8 +124112,8 @@ PR
 Rb
 OR
 Ow
-Rh
-Rk
+NB
+NN
 Nv
 Nv
 Nv
@@ -124419,7 +124233,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -124570,8 +124384,8 @@ aa
 aa
 aa
 aa
-Np
-Nt
+NB
+NN
 Nv
 Nv
 Nv
@@ -124722,7 +124536,7 @@ aa
 aa
 aa
 aa
-Nq
+Nr
 Nv
 Nv
 Nv
@@ -124874,7 +124688,7 @@ aa
 aa
 aa
 aa
-Nn
+Nr
 Nv
 Nv
 Nv
@@ -125068,7 +124882,7 @@ Nv
 Nv
 Nv
 Nv
-Qq
+Ok
 NY
 NQ
 Ok
@@ -125219,8 +125033,8 @@ NP
 Nv
 Nv
 Nv
-Qq
-Qr
+Ok
+Oo
 NC
 NS
 Oo
@@ -125370,8 +125184,8 @@ Nv
 Nv
 Nv
 Nv
-Qq
-Qr
+Ok
+Oo
 aa
 aa
 aa
@@ -125482,8 +125296,8 @@ aa
 aa
 aa
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -125521,8 +125335,8 @@ Nv
 Nv
 Nv
 Nv
-Qq
-Qr
+Ok
+Oo
 aa
 aa
 aa
@@ -125635,8 +125449,8 @@ aa
 aa
 aa
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -125667,13 +125481,13 @@ Nv
 Nv
 Nv
 NO
-Qq
-Nw
-Nw
-Rs
-Nw
-Nw
-Qr
+Ok
+NS
+NS
+NS
+NS
+NS
+Oo
 aa
 aa
 aa
@@ -126252,9 +126066,9 @@ NJ
 Nv
 Or
 NP
-Nt
-Nw
-Nx
+NN
+NS
+NY
 Nv
 Nv
 Nv
@@ -126406,8 +126220,8 @@ Nv
 NP
 Ol
 aa
-No
-Nx
+NC
+NY
 Nv
 Nu
 Nv
@@ -126423,7 +126237,7 @@ Nv
 Nv
 Nv
 Nv
-Qq
+Ok
 NS
 NS
 Oo
@@ -126559,7 +126373,7 @@ NP
 Om
 Op
 aa
-Nn
+Nr
 Nv
 Nu
 Nv
@@ -126575,7 +126389,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 Nk
 aa
 aa
@@ -126711,7 +126525,7 @@ NP
 NP
 Ol
 aa
-Nn
+Nr
 Nv
 Nu
 Nu
@@ -126726,8 +126540,8 @@ Nv
 Nv
 Nv
 Nv
-Qq
-Qr
+Ok
+Oo
 aa
 aa
 aa
@@ -126863,8 +126677,8 @@ Nv
 Or
 Ol
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -126876,9 +126690,9 @@ Nv
 Nv
 Nv
 Nv
-QR
-Nw
-Qr
+Ok
+NS
+Oo
 aa
 aa
 aa
@@ -127016,8 +126830,8 @@ NP
 Ol
 aa
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -127027,8 +126841,8 @@ Ou
 Nv
 Nv
 Nv
-Qq
-Qr
+Ok
+Oo
 aa
 aa
 aa
@@ -127169,8 +126983,8 @@ Ol
 aa
 aa
 aa
-No
-Nx
+NC
+NY
 Nv
 Nv
 Nv
@@ -127179,7 +126993,7 @@ Nv
 Nv
 Nv
 Nv
-QN
+Ol
 aa
 aa
 Nk
@@ -127322,16 +127136,16 @@ aa
 aa
 aa
 aa
-No
-Nw
-Nw
-Nx
+NC
+NS
+NS
+NY
 Nv
 Nv
-Qq
-Nw
-Qq
-Qr
+Ok
+NS
+Ok
+Oo
 aa
 aa
 aa
@@ -127477,10 +127291,10 @@ aa
 Nk
 aa
 aa
-No
-Nw
-Nw
-Qr
+NC
+NS
+NS
+Oo
 Nk
 aa
 aa

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -85760,7 +85760,7 @@
 "vJl" = (
 /obj/machinery/manufacturer/general/grody{
 	free_resource_amt = 2;
-
+	
 	},
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -781,7 +781,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -805,7 +804,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -820,7 +818,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -842,7 +839,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross";
@@ -862,7 +858,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -1033,7 +1028,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/east)
 "acm" = (
@@ -1153,7 +1147,6 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1168,7 +1161,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1181,7 +1173,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1199,7 +1190,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1217,7 +1207,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1237,7 +1226,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_south,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -1256,7 +1244,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -1393,7 +1380,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/east)
 "acX" = (
@@ -1545,7 +1531,6 @@
 	dir = 2
 	},
 /obj/machinery/power/tracker/east,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -1566,7 +1551,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -2279,7 +2263,6 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/turf/simulated/floor/grime,
 /turf/simulated/floor/plating/damaged2,
 /area/station/hallway/secondary/construction)
 "aeP" = (
@@ -2289,7 +2272,6 @@
 	name = "ratty blue couch"
 	},
 /obj/landmark/start/job/assistant,
-/turf/simulated/floor/grime,
 /turf/simulated/floor/plating/damaged2,
 /area/station/hallway/secondary/construction)
 "aeQ" = (
@@ -2304,7 +2286,6 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -2314,7 +2295,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -2330,7 +2310,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -2982,7 +2961,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -3131,7 +3109,6 @@
 /area/mining/magnet)
 "agA" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/maintenance/solar/east)
 "agB" = (
@@ -3145,7 +3122,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -3529,7 +3505,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -3543,7 +3518,6 @@
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
-/turf/simulated/floor/plating,
 /turf/simulated/floor/plating/damaged2,
 /area/station/hallway/secondary/construction)
 "ahg" = (
@@ -3607,7 +3581,6 @@
 /obj/item/device/infra,
 /obj/item/device/infra,
 /obj/item/clothing/head/helmet/hardhat,
-/turf/simulated/floor/plating,
 /turf/simulated/floor/plating/damaged2,
 /area/station/hallway/secondary/construction)
 "ahr" = (
@@ -3622,7 +3595,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "aht" = (
@@ -4076,7 +4048,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -4147,7 +4118,6 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -4158,7 +4128,6 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -4263,7 +4232,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "aiY" = (
@@ -4586,7 +4554,6 @@
 /area/space)
 "ajD" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "ajE" = (
@@ -4965,7 +4932,6 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -4984,7 +4950,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -5066,7 +5031,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -5086,7 +5050,6 @@
 "akN" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/horizontal,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "akO" = (
@@ -5573,7 +5536,6 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "alS" = (
@@ -5782,7 +5744,6 @@
 	name = "Magnet Area Boundary"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
 "amm" = (
@@ -5947,7 +5908,6 @@
 "amF" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "amG" = (
@@ -5958,7 +5918,6 @@
 "amH" = (
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "amI" = (
@@ -6270,7 +6229,6 @@
 	},
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "anv" = (
@@ -6282,7 +6240,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -6297,7 +6254,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -6313,7 +6269,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -6329,7 +6284,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -6832,7 +6786,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -6844,7 +6797,6 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -7407,7 +7359,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -7598,7 +7549,6 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -7816,7 +7766,6 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/mining/staff_room)
 "aqW" = (
@@ -7848,7 +7797,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -7925,7 +7873,6 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -8076,7 +8023,6 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -8363,7 +8309,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -9878,16 +9823,6 @@
 /obj/item/reagent_containers/food/snacks/plant/orange,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
-"avP" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
-	},
-/area/station/mining/refinery)
 "avQ" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/cogmap)
@@ -9955,7 +9890,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -9995,7 +9929,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross";
@@ -10046,7 +9979,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "awi" = (
@@ -10088,7 +10020,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "awo" = (
@@ -10143,7 +10074,6 @@
 	dir = 2
 	},
 /obj/machinery/power/tracker/alt,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -10658,7 +10588,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -11417,7 +11346,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -11758,7 +11686,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -12654,7 +12581,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "aCc" = (
@@ -13150,7 +13076,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -13594,7 +13519,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -13611,7 +13535,6 @@
 	icon_state = "catwalk";
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -15412,7 +15335,6 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -16166,7 +16088,6 @@
 /area/station/hangar/catering)
 "aJR" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "aJS" = (
@@ -17164,7 +17085,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -18694,7 +18614,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -19135,7 +19054,6 @@
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross";
@@ -20186,7 +20104,6 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -20353,7 +20270,6 @@
 /area/station/hallway/primary/east)
 "aTE" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/maintenance/disposal)
 "aTF" = (
@@ -20896,7 +20812,6 @@
 	d1 = 4;
 	d2 = 8
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -21380,7 +21295,6 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/maintenance/disposal)
 "aVT" = (
@@ -21774,7 +21688,6 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -22804,7 +22717,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -23264,7 +23176,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -23296,7 +23207,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/maintenance/disposal)
 "aZY" = (
@@ -23973,7 +23883,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/maintenance/east)
 "bby" = (
@@ -26157,7 +26066,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "bgc" = (
@@ -27361,7 +27269,6 @@
 	d1 = 2;
 	d2 = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "biO" = (
@@ -28105,7 +28012,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -28982,7 +28888,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -29438,7 +29343,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -29873,7 +29777,6 @@
 	icon_state = "catwalk";
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -32296,7 +32199,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "btN" = (
@@ -37431,7 +37333,6 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/hallway/secondary/construction2)
 "bGc" = (
@@ -37532,7 +37433,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/hallway/secondary/construction2)
 "bGr" = (
@@ -37836,7 +37736,6 @@
 	dir = 2
 	},
 /obj/machinery/power/tracker/north,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -38063,7 +37962,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -38382,7 +38280,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -38395,7 +38292,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/hallway/secondary/construction2)
 "bIu" = (
@@ -38413,7 +38309,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "bIv" = (
@@ -38434,7 +38329,6 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -39338,7 +39232,6 @@
 	icon_state = "bedsheet-black"
 	},
 /turf/simulated/floor/plating/damaged3,
-/turf/simulated/floor/plating/damaged2,
 /area/station/hallway/secondary/construction2)
 "bKu" = (
 /obj/machinery/atmospherics/pipe/simple,
@@ -39724,7 +39617,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bLk" = (
@@ -40159,7 +40051,6 @@
 /area/station/science/storage)
 "bLV" = (
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/hallway/secondary/construction2)
 "bLW" = (
@@ -40353,7 +40244,6 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -40414,7 +40304,6 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -40429,7 +40318,6 @@
 	d1 = 4;
 	d2 = 8
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -40646,7 +40534,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bMS" = (
@@ -40844,7 +40731,6 @@
 	icon_state = "1-4"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10;
 	layer = 2
@@ -47501,7 +47387,6 @@
 	d2 = 8
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	layer = 2
@@ -48017,7 +47902,6 @@
 	d2 = 2
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "ccP" = (
@@ -48399,7 +48283,6 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross";
@@ -48423,7 +48306,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -48438,7 +48320,6 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -48462,7 +48343,6 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -48482,7 +48362,6 @@
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
@@ -48494,7 +48373,6 @@
 	icon_state = "2-4"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
@@ -48505,7 +48383,6 @@
 	icon_state = "1-8"
 	},
 /obj/grille/catwalk,
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6;
 	layer = 2
@@ -48521,7 +48398,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -48534,7 +48410,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -48553,7 +48428,6 @@
 	d1 = 1;
 	d2 = 2
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
@@ -48572,7 +48446,6 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -48594,7 +48467,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	intact = 0
@@ -111504,7 +111376,7 @@ aqw
 aeb
 arp
 afg
-avP
+akR
 asx
 afh
 atk
@@ -111806,7 +111678,7 @@ ajP
 aeb
 arq
 afg
-avP
+akR
 asy
 asO
 atl
@@ -112108,7 +111980,7 @@ aqx
 aeb
 arr
 afg
-avP
+akR
 asy
 asP
 atm
@@ -112410,7 +112282,7 @@ afg
 afg
 afg
 afg
-avP
+akR
 asy
 afh
 atn
@@ -112712,7 +112584,7 @@ afg
 afg
 afg
 afg
-avP
+akR
 asy
 afh
 ato
@@ -113014,7 +112886,7 @@ afg
 afg
 afg
 afg
-avP
+akR
 asy
 asQ
 atn

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -2186,7 +2186,6 @@
 /turf/simulated/floor/plating,
 /area/listeningpost)
 "afT" = (
-/turf/space,
 /turf/simulated/wall/auto/asteroid{
 	dir = 9
 	},
@@ -9093,7 +9092,7 @@
 "aCS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
-
+	
 	},
 /obj/machinery/light{
 	dir = 4
@@ -9611,7 +9610,7 @@
 "aEP" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
-
+	
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -23598,12 +23597,6 @@
 	dir = 4
 	},
 /area/listeningpost)
-"bvQ" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 1
-	},
-/area/space)
 "bvR" = (
 /turf/simulated/wall/auto/asteroid{
 	dir = 5
@@ -24224,12 +24217,6 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost)
-"bxm" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 5
-	},
-/area/space)
 "bxn" = (
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -24512,18 +24499,6 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/storage)
-"bxZ" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 8
-	},
-/area/space)
-"byf" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 4
-	},
-/area/space)
 "byg" = (
 /obj/grille/steel,
 /obj/window/reinforced/north,
@@ -24668,10 +24643,6 @@
 	dir = 4
 	},
 /area/station/science/lobby)
-"byO" = (
-/turf/space,
-/turf/space,
-/area/space)
 "byP" = (
 /obj/cable{
 	d1 = 4;
@@ -24997,22 +24968,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"bAr" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 10
-	},
-/area/space)
-"bAs" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid{
-	dir = 6
-	},
-/area/space)
-"bAt" = (
-/turf/space,
-/turf/simulated/wall/auto/asteroid,
-/area/space)
 "bAu" = (
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
@@ -39438,7 +39393,7 @@ aaa
 aaa
 aaa
 aaa
-bxZ
+afI
 bwd
 aaa
 aaa
@@ -39741,9 +39696,9 @@ aaa
 aaa
 bvM
 btR
-bAr
+bwd
 afI
-bAr
+bwd
 aaa
 aaa
 aaa
@@ -40043,9 +39998,9 @@ aaa
 afy
 afT
 afZ
-bxm
+bvR
 btR
-bAr
+bwd
 bwd
 aaa
 aaa
@@ -40346,7 +40301,7 @@ afH
 afU
 afU
 afU
-bxm
+bvR
 btR
 bwd
 bwd
@@ -40648,7 +40603,7 @@ aab
 afU
 afU
 afU
-bvQ
+bvM
 btR
 btR
 bwd
@@ -41252,7 +41207,7 @@ aab
 afU
 afU
 agj
-bAr
+bwd
 afz
 agE
 bvw
@@ -41549,7 +41504,7 @@ aaa
 bvM
 btR
 btR
-bAr
+bwd
 afI
 afV
 age
@@ -42150,7 +42105,7 @@ aaa
 afr
 afr
 afr
-bvQ
+bvM
 btR
 afz
 afB
@@ -42754,7 +42709,7 @@ aaa
 afr
 afr
 afr
-bvQ
+bvM
 btR
 afz
 afD
@@ -43073,8 +43028,8 @@ agf
 afz
 afz
 afz
-bAr
-bAr
+bwd
+bwd
 aaa
 aaa
 aaa
@@ -43376,7 +43331,7 @@ bwN
 bxg
 afz
 btR
-bAt
+btR
 aaa
 aaa
 aaa
@@ -43678,7 +43633,7 @@ bwO
 bxh
 afz
 btR
-bAt
+btR
 aaa
 aaa
 aaa
@@ -43980,7 +43935,7 @@ bwT
 bxi
 afz
 btR
-bAt
+btR
 aaa
 aaa
 aaa
@@ -44282,7 +44237,7 @@ bxe
 afz
 afz
 btR
-bAt
+btR
 aaz
 aaa
 aaa
@@ -44583,8 +44538,8 @@ bwQ
 bwQ
 bwQ
 afz
-bAs
-bAs
+afZ
+afZ
 aaa
 aaa
 aaa
@@ -44872,8 +44827,8 @@ aaa
 aaa
 aaz
 aaa
-bxm
-bxm
+bvR
+bvR
 btR
 btR
 btR
@@ -44885,7 +44840,7 @@ bwR
 bxf
 bxj
 afz
-bAs
+afZ
 aaa
 aaa
 aaa
@@ -45175,13 +45130,13 @@ aaa
 aaa
 aaa
 aaa
-bxm
-byf
-byf
-byf
-byf
-byf
-bxm
+bvR
+bwC
+bwC
+bwC
+bwC
+bwC
+bvR
 afz
 bwS
 bwQ
@@ -45483,7 +45438,7 @@ aaa
 aaa
 btR
 btR
-bxm
+bvR
 afz
 afz
 afz
@@ -85037,12 +84992,12 @@ aaa
 aaa
 aaa
 aaa
-byO
 aaa
 aaa
 aaa
 aaa
-byO
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85336,7 +85291,7 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
 aaa
 aaa
 aaa
@@ -86242,7 +86197,7 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
 aaa
 aaa
 aaa
@@ -86547,12 +86502,12 @@ aaa
 aaa
 aaa
 aaa
-byO
 aaa
 aaa
 aaa
 aaa
-byO
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96629,7 +96584,7 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
 aaa
 aaa
 aaa
@@ -97237,7 +97192,7 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
 aaa
 aaa
 aaa
@@ -97536,8 +97491,6 @@ aaa
 aaa
 aaa
 aaa
-byO
-byO
 aaa
 aaa
 aaa
@@ -97547,7 +97500,9 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99070,7 +99025,7 @@ aaa
 aaa
 aaa
 aaa
-byO
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes every map key with multiple turfs in the unused maps.

Atomised from #14686

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Turfs are meant to be alone :(. Update paths keeps screaming.
