### PR TITLE
Small wraith fixes

### DIFF
--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -54,6 +54,8 @@
 	var/weak_tk = FALSE
 	///can the wraith hear ghosts? Toggleable with an ability
 	var/hearghosts = TRUE
+	/// what is our minion summoning marker, if we have any?
+	var/obj/spookMarker/spawn_marker = null
 
 	var/datum/movement_controller/movement_controller
 

--- a/code/modules/antagonists/wraith/abilties/harbinger/create_summon_portal.dm
+++ b/code/modules/antagonists/wraith/abilties/harbinger/create_summon_portal.dm
@@ -20,27 +20,31 @@
 
 	cast()
 		if (..())
-			return 1
+			return TRUE
 
 		var/turf/T = get_turf(holder.owner)
 		if (isturf(T) && istype(T,/turf/simulated/floor))
+			for (var/obj/O in T)
+				if (O.density)
+					boutput(holder.owner, "<span class='notice'>There is something in the way!</span>")
+					return TRUE
 			if(istype(holder.owner, /mob/living/intangible/wraith))
 				var/mob/living/intangible/wraith/W = holder.owner
 				if (!W.density)
 					boutput(holder.owner, "Your connection to the physical plane is too weak. You must be manifested to do this.")
-					return 1
+					return TRUE
 				if (W.linked_portal)
 					if (alert(holder.owner, "You already have a portal. Do you want to destroy the old one?", "Confirmation", "Yes", "No") == "Yes")
 						W.linked_portal.deleteLinkedCritters()
 						qdel(W.linked_portal)
 						W.linked_portal = null
 					else
-						return 1
+						return TRUE
 				var/mob_choice = null
 				if (length(src.mob_types) > 1)
 					mob_choice = tgui_input_list(holder.owner, "What should the portal spawn?", "Target Mob Type", mob_types)
 				if (mob_choice == null)
-					return 1
+					return TRUE
 				switch(mob_choice)
 					if("Crunched")
 						mob_choice = /mob/living/critter/crunched
@@ -75,7 +79,7 @@
 				V.alpha = 0
 				animate(V, alpha=255, time = 1 SECONDS)
 				W.linked_portal = V
-				return 0
+				return FALSE
 		else
 			boutput(holder.owner, "We cannot open a portal here")
-			return 1
+			return TRUE

--- a/code/modules/antagonists/wraith/abilties/harbinger/summon.dm
+++ b/code/modules/antagonists/wraith/abilties/harbinger/summon.dm
@@ -32,6 +32,7 @@
 			return
 
 		var/obj/spookMarker/marker = new /obj/spookMarker(T)
+		W.spawn_marker = marker
 		var/list/text_messages = list()
 		text_messages.Add("Would you like to respawn as a harbinger's summon? Your name will be added to the list of eligible candidates.")
 		text_messages.Add("You are eligible to be respawned as a harbinger's summon. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
@@ -62,3 +63,4 @@
 			message_admins("[lucky_dude.key] respawned as a harbinger summon for [src.holder.owner].")
 			usr.playsound_local(usr.loc, 'sound/voice/wraith/ghostrespawn.ogg', 50, 0)
 		qdel(marker)
+		W.spawn_marker = null

--- a/code/modules/antagonists/wraith/abilties/plaguebringer/curses.dm
+++ b/code/modules/antagonists/wraith/abilties/plaguebringer/curses.dm
@@ -188,6 +188,9 @@ ABSTRACT_TYPE(/datum/targetable/wraithAbility/curse)
 		if (ishuman(target))
 			var/mob/living/carbon/human/H = target
 			var/mob/living/intangible/wraith/W = holder.owner
+			if(H?.bioHolder.HasEffect("death_curse"))
+				boutput(holder.owner, "That curse is already applied to this being...")
+				return TRUE
 			if (H?.bioHolder.HasEffect("rot_curse") && H?.bioHolder.HasEffect("weak_curse") && H?.bioHolder.HasEffect("blind_curse") && H?.bioHolder.HasEffect("blood_curse"))
 				W.playsound_local(W.loc, 'sound/voice/wraith/wraithhaunt.ogg', 40, 0)
 				H.bioHolder.AddEffect("death_curse")

--- a/code/modules/antagonists/wraith/abilties/plaguebringer/make_plague_rat.dm
+++ b/code/modules/antagonists/wraith/abilties/plaguebringer/make_plague_rat.dm
@@ -43,12 +43,13 @@
 			boutput(holder.owner, "<span class='alert'>This [station_or_ship()] is already a rat den, you cannot summon another rat!</span>")
 			return TRUE
 
-	proc/make_plague_rat(var/mob/W, var/turf/T, var/tries = 0)
-		if (!istype(W, /mob/living/intangible/wraith/wraith_decay))
+	proc/make_plague_rat(var/mob/living/intangible/wraith/W, var/turf/T, var/tries = 0)
+		if (!istype(W))
 			boutput(W, "something went terribly wrong, call 1-800-CODER")
 			return
 
 		var/obj/spookMarker/marker = new /obj/spookMarker(T)
+		W.spawn_marker = marker
 		var/list/text_messages = list()
 		text_messages.Add("Would you like to respawn as a plague rat? Your name will be added to the list of eligible candidates.")
 		text_messages.Add("You are eligible to be respawned as a plague rat. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
@@ -79,3 +80,4 @@
 			message_admins("[lucky_dude.key] respawned as a plague rat for [src.holder.owner].")
 			usr.playsound_local(usr.loc, 'sound/voice/wraith/ghostrespawn.ogg', 50, 0)
 		qdel(marker)
+		W.spawn_marker = null

--- a/code/modules/antagonists/wraith/abilties/trickster/make_poltergeist.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/make_poltergeist.dm
@@ -35,6 +35,7 @@
 			return
 
 		var/obj/spookMarker/marker = new /obj/spookMarker(T)
+		W.spawn_marker = marker
 		var/list/text_messages = list()
 		text_messages.Add("Would you like to respawn as a poltergeist? Your name will be added to the list of eligible candidates.")
 		text_messages.Add("You are eligible to be respawned as a poltergeist. You have [src.ghost_confirmation_delay / 10] seconds to respond to the offer.")
@@ -63,5 +64,5 @@
 			message_admins("[lucky_dude.key] respawned as a poltergeist for [src.holder.owner].")
 			usr.playsound_local(usr.loc, 'sound/voice/wraith/ghostrespawn.ogg', 50, 0)
 			var/mob/living/intangible/wraith/poltergeist/P = lucky_dude.current
-			P.set_loc(T)
 			P.marker = marker
+		W.spawn_marker = null

--- a/code/modules/antagonists/wraith/harbinger_summon.dm
+++ b/code/modules/antagonists/wraith/harbinger_summon.dm
@@ -5,7 +5,14 @@
 
 	give_equipment()
 		var/mob/current_mob = src.owner.current
-		var/mob/living/critter/wraith/nascent/summon_mob = new/mob/living/critter/wraith/nascent(get_turf(src.master.current), src.master.current)
+		var/mob/living/critter/wraith/nascent/summon_mob = null
+		//Find our spookmarker and spawn the mob on it
+		var/mob/living/intangible/wraith/W = src.master.current
+		if (W.spawn_marker)
+			summon_mob = new/mob/living/critter/wraith/nascent(get_turf(W.spawn_marker), src.master.current)
+		//We couldnt find a spookmarker somehow, spawn on the wraith instead
+		else
+			summon_mob = new/mob/living/critter/wraith/nascent(get_turf(src.master.current), src.master.current)
 		src.owner.transfer_to(summon_mob)
 		qdel(current_mob)
 

--- a/code/modules/antagonists/wraith/plague_rat.dm
+++ b/code/modules/antagonists/wraith/plague_rat.dm
@@ -5,7 +5,14 @@
 
 	give_equipment()
 		var/mob/current_mob = src.owner.current
-		var/mob/living/critter/wraith/plaguerat/young/plague_rat_mob = new/mob/living/critter/wraith/plaguerat/young(get_turf(src.master.current), src.master.current)
+		var/mob/living/critter/wraith/plaguerat/young/plague_rat_mob = null
+		//Find our spookmarker and spawn the mob on it
+		var/mob/living/intangible/wraith/W = src.master.current
+		if (W.spawn_marker)
+			plague_rat_mob = new/mob/living/critter/wraith/plaguerat/young/(get_turf(W.spawn_marker), src.master.current)
+		//We couldnt find a spookmarker somehow, spawn on the wraith instead
+		else
+			plague_rat_mob = new/mob/living/critter/wraith/plaguerat/young/(get_turf(src.master.current), src.master.current)
 		src.owner.transfer_to(plague_rat_mob)
 		qdel(current_mob)
 

--- a/code/modules/antagonists/wraith/poltergeist.dm
+++ b/code/modules/antagonists/wraith/poltergeist.dm
@@ -5,7 +5,14 @@
 
 	give_equipment()
 		var/mob/current_mob = src.owner.current
-		var/mob/living/intangible/wraith/poltergeist/poltergeist_mob = new/mob/living/intangible/wraith/poltergeist(get_turf(src.master.current), src.master.current)
+		var/mob/living/intangible/wraith/poltergeist/poltergeist_mob = null
+		//Find our spookmarker and spawn the mob on it
+		var/mob/living/intangible/wraith/W = src.master.current
+		if (W.spawn_marker)
+			poltergeist_mob = new/mob/living/intangible/wraith/poltergeist(get_turf(W.spawn_marker), src.master.current)
+		//We couldnt find a spookmarker somehow, spawn on the wraith instead
+		else
+			poltergeist_mob = new/mob/living/intangible/wraith/poltergeist(get_turf(src.master.current), src.master.current)
 		src.owner.transfer_to(poltergeist_mob)
 		qdel(current_mob)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes harbinger and plaguebringer's summons spawning on the wraith instead of on the marker which is spawned when the ability is used.
Fixes harbinger spawning portals inside dense objects (looking at you, nuclear reactor).
Fixes plaguebringer being able to use curse of death on someone who already had been affected by it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad.

Fixes #14460