### PR TITLE
Fixes #15102 - Makes the stun cane craftable again

### DIFF
--- a/_std/defines/materials.dm
+++ b/_std/defines/materials.dm
@@ -44,7 +44,8 @@ var/global/list/material_category_names = list(
 	"REF-1" = "Reflective Material",
 	"ORG|RUB" = "Organic or Rubber Material",
 	"RUB" = "Rubber Material",
-	"WOOD" = "Wood"
+	"WOOD" = "Wood",
+	"GEM-1" = "Any Gemstone"
 )
 
 #define TRIGGERS_ON_BULLET "triggersOnBullet"

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -348,7 +348,7 @@ TYPEINFO(/obj/item/baton/beepsky)
 	cell_type = /obj/item/ammo/power_cell
 
 TYPEINFO(/obj/item/baton/cane)
-	mats = list("MET-3"=10, "CON-2"=10, "gem"=1, "gold"=1)
+	mats = list("MET-3"=10, "CON-2"=10, "GEM-1"=10, "gold"=1)
 
 /obj/item/baton/cane
 	name = "stun cane"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1675,6 +1675,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 								return TRUE
 				if ("FAB")
 					return mat.getMaterialFlags() & (MATERIAL_CLOTH | MATERIAL_RUBBER | MATERIAL_ORGANIC)
+				if ("GEM")
+					return istype(mat, /datum/material/crystal/gemstone)
 		else if (pattern == mat.getID()) // specific material id
 			return TRUE
 		return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stun canes had a bad material and so were uncraftable. Now "GEM-1" is a valid material pattern indicating any gemstone. Maybe other numbers could be used for higher rarities, whatever.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15102


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Stun cane manufacturing blueprint works now.
```
