### PR TITLE
Oshan Lab Drawer Conversion

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -8157,7 +8157,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ays" = (
-/obj/table/reinforced/chemistry/auto,
+/obj/table/reinforced/chemistry/drugs,
 /obj/item/toy/plush/small/bunny/mask{
 	name = "chemical safety bun";
 	pixel_x = 5;
@@ -8556,7 +8556,6 @@
 /area/station/hallway/primary/north)
 "azw" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/paper/book/from_file/pharmacopia,
 /obj/machinery/phone{
 	pixel_y = 6
 	},
@@ -10679,9 +10678,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aFQ" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/patchbox,
-/obj/item/storage/box/syringes,
+/obj/table/reinforced/chemistry/clericalsup,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aFR" = (
@@ -10859,9 +10856,6 @@
 /area/research_outpost/toxins)
 "aGt" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/hand_labeler,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aGu" = (
@@ -11314,11 +11308,10 @@
 /turf/simulated/floor/bluegreen,
 /area/station/medical/medbay/treatment1)
 "aHA" = (
-/obj/item/device/reagentscanner,
-/obj/item/device/reagentscanner,
-/obj/table/reinforced/chemistry/auto,
-/obj/item/clothing/glasses/spectro,
-/obj/item/clothing/glasses/spectro,
+/obj/table/reinforced/chemistry/auxsup,
+/obj/item/paper/book/from_file/pharmacopia{
+	pixel_y = 5
+	},
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHC" = (
@@ -11450,11 +11443,8 @@
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHV" = (
-/obj/item/storage/box/beakerbox,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/table/reinforced/chemistry/auto,
+/obj/table/reinforced/chemistry/basicsup,
+/obj/item/paper/labdrawertips,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHW" = (
@@ -38602,9 +38592,7 @@
 /turf/simulated/floor/grass,
 /area/space)
 "gsh" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/table/reinforced/chemistry/firstaid,
 /obj/machinery/light/incandescent/cool,
 /obj/disposalpipe/segment/mail{
 	dir = 4


### PR DESCRIPTION
[Chemistry] [Mapping] [Science] [QoL]
## About the PR
This PR replaces the empty drawers in Oshan's chemlab with filled versions that now contain its chemistry equipment, using the counters added in #14808. Most handheld equipment lying on the counter has been removed, and a note detailing how to open drawers has been left in their stead.

## Why's this needed?
(Copied from #14808)
These components are part of a larger goal to eliminate lab counter clutter in chemlabs while simultaneously standardizing the equipment that a player could expect to find in a typical chemlab. Switching to this method will provide a more consistent chemlab experience between maps; it also means that if these loadouts need to be changed in the future, they can be changed within their subtypes rather than having to change each map individually.
