### PR TITLE
Clarion Lab Drawer Conversion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14139,8 +14139,8 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bks" = (
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/phone,
+/obj/table/reinforced/chemistry/basicsup,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bkt" = (
@@ -14337,7 +14337,6 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/disposal/mail/small{
 	dir = 4;
 	mail_tag = "chemistry";
@@ -14346,19 +14345,14 @@
 	name = "mail chute-'Chemistry'"
 	},
 /obj/machinery/chem_heater/chemistry,
+/obj/table/reinforced/chemistry/clericalsup,
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
 /area/station/science/chemistry)
 "blD" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/device/reagentscanner,
-/obj/item/device/reagentscanner,
-/obj/item/clothing/glasses/spectro,
-/obj/item/clothing/glasses/spectro,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper/mechanical,
+/obj/item/paper/labdrawertips,
+/obj/table/reinforced/chemistry/auxsup,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "blE" = (
@@ -14558,12 +14552,8 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bmQ" = (
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
+/obj/table/reinforced/chemistry/firstaid,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bmR" = (
@@ -15038,20 +15028,13 @@
 	},
 /area/station/hallway/primary/east)
 "bpj" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/patchbox,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/dropper/mechanical,
+/obj/table/reinforced/chemistry/drugs,
 /turf/simulated/floor/purpleblack{
 	dir = 10
 	},
 /area/station/science/chemistry)
 "bpk" = (
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/beakerbox,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "bpl" = (


### PR DESCRIPTION
[Chemistry] [Mapping] [Science] [QoL]
## About the PR
This PR replaces the empty drawers in Clarion's chemlab with filled versions that now contain its chemistry equipment, using the counters added in #14808. Most handheld equipment lying on the counter has been removed, and a note detailing how to open drawers has been left in their stead.

## Why's this needed?
(Copied from #14808)
These components are part of a larger goal to eliminate lab counter clutter in chemlabs while simultaneously standardizing the equipment that a player could expect to find in a typical chemlab. Switching to this method will provide a more consistent chemlab experience between maps; it also means that if these loadouts need to be changed in the future, they can be changed within their subtypes rather than having to change each map individually.

Clarion's chemlab is another cramped one, and being able to easily use counter space will make it just a tad more bearable.