### PR TITLE
Cog2 Lab Drawer Conversion

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -54611,10 +54611,10 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cMn" = (
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
 	},
+/obj/table/reinforced/chemistry/clericalsup,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cMo" = (
@@ -55132,9 +55132,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/phone,
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/table/reinforced/chemistry/firstaid,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cNH" = (
@@ -55147,7 +55147,6 @@
 /obj/submachine/chem_extractor{
 	dir = 8
 	},
-/obj/item/device/reagentscanner,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "cNJ" = (
@@ -55683,19 +55682,16 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cOZ" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakerbox{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light,
+/obj/table/reinforced/chemistry/basicsup,
+/obj/item/paper/book/from_file/pharmacopia{
+	pixel_y = 6
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cPa" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/item/storage/firstaid/toxin,
+/obj/table/reinforced/chemistry/auxsup,
+/obj/item/paper/labdrawertips,
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
 	},
@@ -56981,8 +56977,6 @@
 	pixel_y = -1
 	},
 /obj/table/reinforced/chemistry/auto,
-/obj/item/device/reagentscanner,
-/obj/item/clothing/glasses/spectro,
 /turf/simulated/floor/purplewhite{
 	dir = 10
 	},
@@ -56997,18 +56991,12 @@
 /area/station/science/chemistry)
 "cSl" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/device/reagentscanner,
-/obj/item/clothing/glasses/spectro,
 /turf/simulated/floor/purplewhite{
 	dir = 6
 	},
 /area/station/science/chemistry)
 "cSm" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/paper/book/from_file/pharmacopia,
-/obj/item/reagent_containers/emergency_injector/calomel,
-/obj/item/reagent_containers/emergency_injector/calomel,
-/obj/item/reagent_containers/dropper/mechanical,
 /obj/machinery/door_control{
 	id = "chemistry";
 	name = "Privacy Shutters";
@@ -58105,24 +58093,21 @@
 	name = "Mounted Igniter";
 	pixel_x = -24
 	},
-/obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/beakerbox{
-	pixel_y = 4
-	},
+/obj/table/reinforced/chemistry/drugs,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
 /area/station/science/chemistry)
 "cVc" = (
-/obj/table/reinforced/chemistry/auto,
 /obj/machinery/light/lamp/black,
+/obj/table/reinforced/chemistry/basicsup,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
 /area/station/science/chemistry)
 "cVd" = (
-/obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/mask/gas,
+/obj/table/reinforced/chemistry/auxsup,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},


### PR DESCRIPTION
[Chemistry] [Mapping] [Science] [QoL]
## About the PR
This PR replaces the empty drawers in Cog2's chemlab with filled versions that now contain its chemistry equipment, using the counters added in #14808. Most handheld equipment lying on the counter has been removed, and a note detailing how to open drawers has been left in their stead.

## Why's this needed?
(Copied from #14808)
These components are part of a larger goal to eliminate lab counter clutter in chemlabs while simultaneously standardizing the equipment that a player could expect to find in a typical chemlab. Switching to this method will provide a more consistent chemlab experience between maps; it also means that if these loadouts need to be changed in the future, they can be changed within their subtypes rather than having to change each map individually.