### PR TITLE
Fix the Oshan Cloner west door

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -90211,8 +90211,8 @@ jTS
 akC
 aqW
 aqW
-mnD
 cmq
+mnD
 aqW
 aqW
 auP


### PR DESCRIPTION
[Mapping] [Revert]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Looks like the west door on Oshan's cloning room got moved down a tile. Wiring's disconnected, which means the room gets no power. Locker is also blocking the door. This PR reverts this, putting the door and the wire one tile north in its previous location.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cloners need power to function. And doors not leading into lockers is nice.
