### PR TITLE
change oxygen grenade name to the correct colour

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -614,7 +614,7 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 	mats = list("MET-2"=2, "CON-1"=2, "molitz"=10, "char"=1 )
 
 /obj/item/old_grenade/oxygen
-	name = "red oxygen grenade"
+	name = "blue oxygen grenade"
 	desc = "It is set to detonate in 3 seconds."
 	det_time = 3 SECONDS
 	org_det_time = 3 SECONDS


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR 
changes the oxygen grenade name from red oxygen grenade to blue oxygen grenade



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
because it has been bugging me how the red oxygen grenade is actually blue


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)deathrobotpunch1
(*) the oxygen grenades name is now true to it’s appearance!
```
