### PR TITLE
engivac spelling error fix

### DIFF
--- a/code/obj/item/tool/engivac.dm
+++ b/code/obj/item/tool/engivac.dm
@@ -9,7 +9,7 @@
 #define ENGIVAC_MISC_ITEM_LIMIT 2 //How much non-listed crap a toolbox can have before the engivac rejects it.
 
 obj/item/engivac
-	name = "engineering materiel vacuum"
+	name = "engineering material vacuum"
 	desc = "A tool that sucks up debris and building materials into an inserted toolbox. It is also capable of automatically laying floor tiles on plating."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "engivac"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixed the material vacuum name that used to be materiel



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
spelling error bad



