### PR TITLE
Removes the syndicate megaphone from surplus crates

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1007,7 +1007,6 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 5
 	vr_allowed = FALSE // no
 	not_in_crates = TRUE
-	can_buy = UPLINK_TRAITOR
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1006,6 +1006,8 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/megaphone/syndicate
 	cost = 5
 	vr_allowed = FALSE // no
+	not_in_crates = TRUE
+	can_buy = UPLINK_TRAITOR
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////


### PR DESCRIPTION
## About the PR 
Prevents the black market megaphone from appearing in surplus crates.


## Why's this needed? 
Joke items are blacklisted from surplus crates. Why isnt this one blacklisted?

## Changelog

```changelog
(u)UnfunnyPerson
(+)The black market megaphone can no longer be found in surplus crates.
```
[GAME OBJECTS] [REMOVAL]