### PR TITLE
makes the new lab table subtypes auto-connect

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -766,15 +766,13 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	auto
 		auto = 1
 
-/obj/table/reinforced/chemistry/beakers //starts with 7 :B:eakers inside it, wow!!
+/obj/table/reinforced/chemistry/auto/beakers //starts with 7 :B:eakers inside it, wow!!
 	name = "beaker storage"
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/reagent_containers/glass/beaker = 7)
 
-/obj/table/reinforced/chemistry/basicsup
+/obj/table/reinforced/chemistry/auto/basicsup
 	name = "basic supply lab counter"
 	desc = "Everything an aspiring chemist needs to start making chemicals!"
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/paper/book/from_file/pharmacopia,
 				/obj/item/storage/box/beakerbox = 2,
 				/obj/item/reagent_containers/glass/beaker/large = 2,
@@ -783,10 +781,9 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/reagent_containers/dropper/mechanical = 2,
 				/obj/item/reagent_containers/dropper = 2)
 
-/obj/table/reinforced/chemistry/auxsup
+/obj/table/reinforced/chemistry/auto/auxsup
 	name = "auxiliary supply lab counter"
 	desc = "Extra supplies for the discerning chemist."
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/storage/box/beakerbox,
 				/obj/item/storage/box/patchbox,
 				/obj/item/storage/box/syringes,
@@ -796,10 +793,9 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/reagent_containers/dropper/mechanical)
 
 
-/obj/table/reinforced/chemistry/clericalsup
+/obj/table/reinforced/chemistry/auto/clericalsup
 	name = "clerical supply lab counter"
 	desc = "It's only science if you write it down! Or blow yourself up."
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/paper_bin = 2,
 				/obj/item/hand_labeler,
 				/obj/item/clipboard = 2,
@@ -809,17 +805,15 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/audio_tape = 2)
 
 
-/obj/table/reinforced/chemistry/firstaid
+/obj/table/reinforced/chemistry/auto/firstaid
 	name = "toxin care lab counter"
 	desc = "These drawers have been labeled EMERGENCY TOXIN CARE, which means they're probably already close to empty."
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/storage/firstaid/toxin,
 				/obj/item/reagent_containers/emergency_injector/calomel)
 
-/obj/table/reinforced/chemistry/chemstorage
+/obj/table/reinforced/chemistry/auto/chemstorage
 	name = "chemical storage lab counter"
 	desc = "A set of basic precursor chemicals to expedite order fulfillment, increase efficiency, and synergize your workflow. Whatever the fuck that means."
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/reagent_containers/glass/bottle/oil,
 				/obj/item/reagent_containers/glass/bottle/phenol,
 				/obj/item/reagent_containers/glass/bottle/acid,
@@ -827,10 +821,9 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/reagent_containers/glass/bottle/diethylamine,
 				/obj/item/reagent_containers/glass/bottle/ammonia)
 
-/obj/table/reinforced/chemistry/drugs
+/obj/table/reinforced/chemistry/auto/drugs
 	name = "seedy-looking lab counter"
 	desc = ""
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/plant/herb/cannabis/spawnable = 2,
 				/obj/item/device/light/zippo,
 				/obj/item/reagent_containers/syringe/krokodil,
@@ -843,10 +836,9 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 		else
 			. = "<br>A stash of drugs, and maybe the only positive contribution the RD ever made to the station. Too bad they cheaped out on the selection."
 
-/obj/table/reinforced/chemistry/allinone
+/obj/table/reinforced/chemistry/auto/allinone
 	name = "jam-packed lab counter"
 	desc = "The drawers on these barely close, and rattle loudly when moved. Guess they tried to put too much crap in it."
-	has_drawer = TRUE
 	drawer_contents = list(/obj/item/paper/book/from_file/pharmacopia,
 				/obj/item/storage/box/beakerbox = 2,
 				/obj/item/storage/box/syringes,

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4791,7 +4791,7 @@
 	light_type = /obj/item/light/tube/light_purpleish;
 	pixel_y = 21
 	},
-/obj/table/reinforced/chemistry/chemstorage,
+/obj/table/reinforced/chemistry/auto/chemstorage,
 /obj/item/paper/labdrawertips,
 /turf/simulated/floor/purplewhite{
 	dir = 9
@@ -9000,7 +9000,7 @@
 	pixel_y = 14
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/table/reinforced/chemistry/allinone,
+/obj/table/reinforced/chemistry/auto/allinone,
 /turf/simulated/floor/purplewhite{
 	dir = 5
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14140,7 +14140,7 @@
 /area/station/crew_quarters/fitness)
 "bks" = (
 /obj/machinery/phone,
-/obj/table/reinforced/chemistry/basicsup,
+/obj/table/reinforced/chemistry/auto/basicsup,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bkt" = (
@@ -14345,14 +14345,14 @@
 	name = "mail chute-'Chemistry'"
 	},
 /obj/machinery/chem_heater/chemistry,
-/obj/table/reinforced/chemistry/clericalsup,
+/obj/table/reinforced/chemistry/auto/clericalsup,
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
 /area/station/science/chemistry)
 "blD" = (
 /obj/item/paper/labdrawertips,
-/obj/table/reinforced/chemistry/auxsup,
+/obj/table/reinforced/chemistry/auto/auxsup,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "blE" = (
@@ -14553,7 +14553,7 @@
 /area/station/science/chemistry)
 "bmQ" = (
 /obj/machinery/glass_recycler,
-/obj/table/reinforced/chemistry/firstaid,
+/obj/table/reinforced/chemistry/auto/firstaid,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bmR" = (
@@ -15028,7 +15028,7 @@
 	},
 /area/station/hallway/primary/east)
 "bpj" = (
-/obj/table/reinforced/chemistry/drugs,
+/obj/table/reinforced/chemistry/auto/drugs,
 /turf/simulated/floor/purpleblack{
 	dir = 10
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -54614,7 +54614,7 @@
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
 	},
-/obj/table/reinforced/chemistry/clericalsup,
+/obj/table/reinforced/chemistry/auto/clericalsup,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cMo" = (
@@ -55134,7 +55134,7 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/phone,
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/table/reinforced/chemistry/firstaid,
+/obj/table/reinforced/chemistry/auto/firstaid,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cNH" = (
@@ -55683,14 +55683,14 @@
 /area/station/science/chemistry)
 "cOZ" = (
 /obj/machinery/light,
-/obj/table/reinforced/chemistry/basicsup,
+/obj/table/reinforced/chemistry/auto/basicsup,
 /obj/item/paper/book/from_file/pharmacopia{
 	pixel_y = 6
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cPa" = (
-/obj/table/reinforced/chemistry/auxsup,
+/obj/table/reinforced/chemistry/auto/auxsup,
 /obj/item/paper/labdrawertips,
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
@@ -58093,21 +58093,21 @@
 	name = "Mounted Igniter";
 	pixel_x = -24
 	},
-/obj/table/reinforced/chemistry/drugs,
+/obj/table/reinforced/chemistry/auto/drugs,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
 /area/station/science/chemistry)
 "cVc" = (
 /obj/machinery/light/lamp/black,
-/obj/table/reinforced/chemistry/basicsup,
+/obj/table/reinforced/chemistry/auto/basicsup,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
 /area/station/science/chemistry)
 "cVd" = (
 /obj/item/clothing/mask/gas,
-/obj/table/reinforced/chemistry/auxsup,
+/obj/table/reinforced/chemistry/auto/auxsup,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -64352,7 +64352,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/table/reinforced/chemistry/beakers,
+/obj/table/reinforced/chemistry/auto/beakers,
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
@@ -65983,7 +65983,7 @@
 	pixel_x = 1;
 	pixel_y = -25
 	},
-/obj/table/reinforced/chemistry/beakers,
+/obj/table/reinforced/chemistry/auto/beakers,
 /obj/machinery/glass_recycler,
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -8157,7 +8157,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ays" = (
-/obj/table/reinforced/chemistry/drugs,
+/obj/table/reinforced/chemistry/auto/drugs,
 /obj/item/toy/plush/small/bunny/mask{
 	name = "chemical safety bun";
 	pixel_x = 5;
@@ -10678,7 +10678,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aFQ" = (
-/obj/table/reinforced/chemistry/clericalsup,
+/obj/table/reinforced/chemistry/auto/clericalsup,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aFR" = (
@@ -11308,7 +11308,7 @@
 /turf/simulated/floor/bluegreen,
 /area/station/medical/medbay/treatment1)
 "aHA" = (
-/obj/table/reinforced/chemistry/auxsup,
+/obj/table/reinforced/chemistry/auto/auxsup,
 /obj/item/paper/book/from_file/pharmacopia{
 	pixel_y = 5
 	},
@@ -11443,7 +11443,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHV" = (
-/obj/table/reinforced/chemistry/basicsup,
+/obj/table/reinforced/chemistry/auto/basicsup,
 /obj/item/paper/labdrawertips,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
@@ -38592,7 +38592,7 @@
 /turf/simulated/floor/grass,
 /area/space)
 "gsh" = (
-/obj/table/reinforced/chemistry/firstaid,
+/obj/table/reinforced/chemistry/auto/firstaid,
 /obj/machinery/light/incandescent/cool,
 /obj/disposalpipe/segment/mail{
 	dir = 4


### PR DESCRIPTION
[Mapping] [Chemistry] [Bug] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR repaths the tables added in #14808 to be subtypes of the "auto" table, which allows their textures to connect. Maps that have already been merged to include these were also changed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Connected textures look way better and provide more counter space.