### PR TITLE
Eating your favorite food as picky eater heals more hunger

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -325,6 +325,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				if (length(eater_trait.fav_foods) > 0)
 					if (!check_favorite_food(H))
 						displease_picky_eater(H)
+					else
+						H.sims?.affectMotive("Hunger", 20)
 				else
 					logTheThing(LOG_DEBUG, src, "Empty favorite foods list for [src] despite having the picky_eater trait.")
 		src.heal(consumer)

--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -253,17 +253,17 @@
 		reagents.add_reagent("love", 15)
 
 /obj/item/reagent_containers/food/snacks/burger/heartburger/synth
-	name = "heartburger"
+	name = "synthetic heartburger"
 	desc = "A hearty meal, made with Love. This one seems to contain a green synthetic heart."
 	icon_state = "synthheartburger"
 
 /obj/item/reagent_containers/food/snacks/burger/heartburger/cyber
-	name = "heartburger"
+	name = "cyber heartburger"
 	desc = "A hearty meal, made with Love. This one seems to contain a shiny cyberheart."
 	icon_state = "roboheartburger"
 
 /obj/item/reagent_containers/food/snacks/burger/heartburger/flock
-	name = "heartburger"
+	name = "flock heartburger"
 	desc = "A hearty meal, made with Love. This one seems to cotain a teal pulsing octahedron."
 	icon_state = "flockheartburger"
 
@@ -276,17 +276,17 @@
 	meal_time_flags = MEAL_TIME_FORBIDDEN_TREAT
 
 /obj/item/reagent_containers/food/snacks/burger/brainburger/synth
-	name = "brainburger"
+	name = "synthetic brainburger"
 	desc = "A strange looking burger. It looks almost sentient. It seems to contain a green synthetic brain."
 	icon_state = "synthbrainburger"
 
 /obj/item/reagent_containers/food/snacks/burger/brainburger/cyber
-	name = "brainburger"
+	name = "cyber brainburger"
 	desc = "A strange looking burger. It looks almost sentient. It seems to contain a Spontaneous Intelligence Creation Core."
 	icon_state = "robobrainburger"
 
 /obj/item/reagent_containers/food/snacks/burger/brainburger/flock
-	name = "brainburger"
+	name = "flock brainburger"
 	desc = "A strange looking burger. It looks almost sentient. It seems to contain an odd crystal."
 	icon_state = "flockbrainburger"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On RP or with sims mode enabled, picky eaters now heal a flat 20% hunger per bite when eating one of their favorite foods.

Also changes a few burger names to reflect what they actually are, as while testing this PR it asked me for a "heartburger" which turned out to be a flock heartburger specifically.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The picky eater trait currently has no upsides whatsoever. Giving a small reward to people willing to go out of their way to seek out one of this round's favorite food should increase the incentive to play along and not just drink chicken soup.
Also helps if someone rolls foods which heal an extremely low amount of hunger by giving them a flat amount of satiety per bite.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)Picky eaters will now heal substantially more hunger when eating one of their favorite foods.
```
