### PR TITLE
Reagent Amount poured into trays fix

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -701,7 +701,8 @@ TYPEINFO(/obj/machinery/plantpot)
 				boutput(user, "<span class='alert'>There is nothing in [W] to pour!</span>")
 				return
 			else
-				user.visible_message("<span class='notice'>[user] pours [W:amount_per_transfer_from_this] units of [W]'s contents into [src].</span>")
+				//corrects the amount of reagents shown to have been used when pouring into a tray
+                user.visible_message("<span class='notice'>[user] pours [min(W:amount_per_transfer_from_this,W.reagents.total_volume)] units of [W]'s contents into [src].</span>")
 				playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
 				W.reagents.trans_to(src, W:amount_per_transfer_from_this)
 				if(!(user in src.contributors))

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -702,9 +702,9 @@ TYPEINFO(/obj/machinery/plantpot)
 				return
 			else
 				//corrects the amount of reagents shown to have been used when pouring into a tray
-				user.visible_message("<span class='notice'>[user] pours [min(W:amount_per_transfer_from_this,W.reagents.total_volume)] units of [W]'s contents into [src].</span>")
+				var/trans = W.reagents.trans_to(src, W:amount_per_transfer_from_this)
+				user.visible_message("<span class='notice'>[user] pours [trans] units of [W]'s contents into [src].</span>")
 				playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
-				W.reagents.trans_to(src, W:amount_per_transfer_from_this)
 				if(!(user in src.contributors))
 					src.contributors += user
 				if(!W.reagents.total_volume) boutput(user, "<span class='alert'><b>[W] is now empty.</b></span>")

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -702,7 +702,7 @@ TYPEINFO(/obj/machinery/plantpot)
 				return
 			else
 				//corrects the amount of reagents shown to have been used when pouring into a tray
-                user.visible_message("<span class='notice'>[user] pours [min(W:amount_per_transfer_from_this,W.reagents.total_volume)] units of [W]'s contents into [src].</span>")
+				user.visible_message("<span class='notice'>[user] pours [min(W:amount_per_transfer_from_this,W.reagents.total_volume)] units of [W]'s contents into [src].</span>")
 				playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
 				W.reagents.trans_to(src, W:amount_per_transfer_from_this)
 				if(!(user in src.contributors))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Hydroponics] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes issue https://github.com/goonstation/goonstation/issues/14804
Adds correct amount poured from watering cans(and other containers) when used on hydroponic trays


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The game currently shows the amount per transfer which is the maximum instead of what the reagents are actually transfering.
This would improve the correctness of ingame feedback your given. When interacting with hydroponics