### PR TITLE
fixes #14613, updates a cameras tag to no longer be "gas chamber"

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -15777,9 +15777,9 @@
 /area/station/security/interrogation)
 "bic" = (
 /obj/machinery/camera{
-	c_tag = "Gas Chamber";
+	c_tag = "autotag";
 	dir = 8;
-	network = "Gas Chamber"
+	network = "autoname - SS13"
 	},
 /obj/item/device/radio/intercom/security{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes #14613, it just updates a cameras data

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

same reason the gas chamber was removed.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

