### PR TITLE
Fix bug that makes PDA UI open when you receive a message

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -886,8 +886,6 @@
 					if(length(src.hosted_files) >= 1)
 						src.CheckForPasskey(signal.data["message"], signal.data["sender"])
 
-					src.master.updateSelfDialog()
-
 				if("file_send_req")
 					if(!message_on)
 						return

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -772,14 +772,6 @@
 				newsignal.data["owner"] = src.master.owner
 				src.post_signal(newsignal)
 
-				if(!ON_COOLDOWN(src.master, "report_pda_refresh", 1 SECOND))
-					src.master.updateSelfDialog()
-				else if(!src.report_refresh_queued)
-					src.report_refresh_queued = TRUE
-					SPAWN(1 SECOND)
-						src.report_refresh_queued = FALSE
-						src.master.updateSelfDialog()
-
 			if(signal.encryption) return
 
 			if(signal.data["address_1"] && signal.data["address_1"] != src.master.net_id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes the bug that happens after you use your PDA to message another PDA (specifically clicking the reply hyperlink in chat) that makes your PDA open every time you receive a message after that point, or even randomly (its actually cause someone on station is scanning for PDAs). This is accomplished by removing two calls to the updateSelfDialog proc that don't really have a reason to be there (when you receive a message and when your PDA responds to a "scan" ping). 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This bug seems to be really old and also the bane of a lot of peoples existence including my own.
