### PR TITLE
Fix alt hover showing wrong pronouns

### DIFF
--- a/code/modules/interface/name_tag.dm
+++ b/code/modules/interface/name_tag.dm
@@ -59,7 +59,7 @@
 
 	proc/set_info_tag(new_info)
 		if(new_info != src.cur_info_tag)
-			src.ex_hover_image.set_info_tag(cur_name, cur_info_tag)
+			src.ex_hover_image.set_info_tag(cur_name, new_info)
 			src.cur_info_tag = new_info
 
 	proc/show_images(client/client, ex, ex_hover)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[UI] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes what seems to be a mistake in name_tag update logic that results in the pronouns on your alt-hover "lagging" one update behind the ones in your examine text. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
