### PR TITLE
Adds a station wide annoucement when the entire security team dies.

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -365,14 +365,14 @@ var/global/sec_wipe_alert = FALSE
 	/// Security member this implant originally belonged to
 	var/mob/living/original_owner
 
-	/// Check if anyone with a sec implant is alive, if sec is dead send the annoucement that sec has been killed
+	/// Check if anyone with a sec implant is alive and not in cryo, if sec is dead send the annoucement that sec has been killed
 	proc/send_annoucement()
 		var/sec_alive = FALSE
 		for_by_tcl(I, /obj/item/implant/health/security/anti_mindhack)
 			var/possible_implantee = I.loc
 			if (istype(possible_implantee, /mob/living))
 				var/mob/living/implantee = possible_implantee
-				if (I.functional && isalive(implantee))
+				if (I.functional && isalive(implantee) && !istype(implantee.loc, /obj/cryotron))
 					sec_alive = TRUE
 
 		if (!sec_alive && !sec_wipe_alert)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -401,7 +401,6 @@ var/global/sec_wipe_alert = FALSE
 
 	death_alert()
 		. = ..()
-		src.send_annoucement()
 		src.on_remove(src.owner)
 		qdel(src)
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -368,7 +368,7 @@ var/global/sec_wipe_alert = FALSE
 	/// Check if anyone with a sec implant is alive, if sec is dead send the annoucement that sec has been killed
 	proc/send_annoucement()
 		var/sec_alive = FALSE
-		for (var/obj/item/implant/health/security/anti_mindhack/I in by_type[/obj/item/implant/health/security/anti_mindhack])
+		for_by_tcl(I, /obj/item/implant/health/security/anti_mindhack)
 			var/possible_implantee = I.loc
 			if (istype(possible_implantee, /mob/living))
 				var/mob/living/implantee = possible_implantee
@@ -389,13 +389,18 @@ var/global/sec_wipe_alert = FALSE
 
 	implanted(mob/living/M, mob/I)
 		..()
-		if (!src.original_owner)
+		if (current_state != GAME_STATE_PLAYING) // *scream
+			src.functional = FALSE
+			return
+		if (!src.original_owner && src.functional == TRUE)
 			original_owner = M
-		else if (src.original_owner == src.loc && isalive(src.original_owner)) // allows sec to reinsert their implant
+		else if (src.original_owner == src.loc && isalive(src.original_owner)) // allows sec to reinsert their implant in case of surgery
 			src.functional = TRUE
 
 	on_remove()
 		..()
+		if (src.functional == FALSE)
+			return
 		src.functional = FALSE
 		src.send_annoucement()
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -377,7 +377,7 @@ var/global/sec_wipe_alert = FALSE
 
 		if (!sec_alive && !sec_wipe_alert)
 			sec_wipe_alert = TRUE
-			command_alert("After monitoring the vitals of [station_name]'s security team. We have discovered the entire team has been eliminated by an unknown force. It is advised that all crew members stay in pairs, obtain improvised weaponry and prepare for the worst.", "Emergency Security Update", alert_origin = "NT Security Division", sound_to_play = 'sound/misc/airraid_loop_short.ogg')
+			command_alert("After monitoring the vitals of [station_name]'s security team, We have discovered the entire team has been eliminated by an unknown force. It is advised that all crew members stay in pairs, obtain improvised weaponry and prepare for the worst.", "Emergency Security Update", alert_origin = "NT Security Division", sound_to_play = 'sound/misc/airraid_loop_short.ogg')
 
 	New()
 		..()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -377,7 +377,7 @@ var/global/sec_wipe_alert = FALSE
 
 		if (!sec_alive && !sec_wipe_alert)
 			sec_wipe_alert = TRUE
-			command_alert("After monitoring the vitals of [station_name]'s security team. We have discovered the entire team has been eliminated by an unknown force. It is adivised that all crew members stay in pairs, obtain improvised weaponry and prepare for the worst.", "Emergency Security Update", alert_origin = "NT Security Division", sound_to_play = 'sound/misc/airraid_loop_short.ogg')
+			command_alert("After monitoring the vitals of [station_name]'s security team. We have discovered the entire team has been eliminated by an unknown force. It is advised that all crew members stay in pairs, obtain improvised weaponry and prepare for the worst.", "Emergency Security Update", alert_origin = "NT Security Division", sound_to_play = 'sound/misc/airraid_loop_short.ogg')
 
 	New()
 		..()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -362,7 +362,7 @@ var/global/sec_wipe_alert = FALSE
 	impcolor = "b"
 	/// Set to FALSE on remove, this is here so that nerds cant remove the implant and put it in a random monkey to avoid triggering the alert.
 	var/functional = TRUE
-	/// Security member this implant orginally belonged to
+	/// Security member this implant originally belonged to
 	var/mob/living/original_owner
 
 	/// Check if anyone with a sec implant is alive, if sec is dead send the annoucement that sec has been killed


### PR DESCRIPTION
[BALANCE] [PLAYER ACTIONS]

## About the PR 
https://forum.ss13.co/showthread.php?tid=21581

When the entire sec team dies an annoucement is sent warning the crew to get improvised weapons and stay in pairs. 

The way this works is through the anti-mindhack implants. Each time someone dies with an anti-mindhack or gets it removed the game checks if anyone else has a functional anti-mindhack implant. If no implants are found in living/non-croyed officers the alert is sent.

Removing a implant and placing it in a random monkey to avoid the alert wont work because the implant only works if its inside its original owner.

The alert doesnt care about detectives or security assistants because detectives arent very trustworthy and sec assistants cant do much to stop antagonists.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

If a rampager kills all of sec the crew should have some amount of warning before they start murdering the crew.


## Changelog 

```changelog
(u)UnfunnyPerson
(*)When the entire security team is killed(Not including detectives and sec assistants) an annoucement is sent to the station warning the crew.
```
