### PR TITLE
Adds the hitman jacket to the clothing booth and makes it no longer a labcoat subtype

### DIFF
--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -107,7 +107,7 @@
 			abilityHolder.updateButtons()
 
 			src.equip_new_if_possible(/obj/item/clothing/under/misc/lawyer/red/demonic, src.slot_w_uniform)
-			src.equip_new_if_possible(/obj/item/clothing/suit/labcoat/hitman/satansuit, slot_wear_suit)
+			src.equip_new_if_possible(/obj/item/clothing/suit/hitman/satansuit, slot_wear_suit)
 			src.equip_new_if_possible(/obj/item/clothing/shoes/red, slot_shoes)
 			src.equip_new_if_possible(/obj/item/storage/backpack, slot_back)
 			src.equip_new_if_possible(/obj/item/clothing/gloves/ring/wizard/teleport, slot_gloves) //Yes I could make a special satan teleport power, or I can give him a ring. Fuck it right?

--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -626,6 +626,10 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/outerwear)
 	name = "Baseball Jacket"
 	path = /obj/item/clothing/suit/jacketsjacket
 
+/datum/clothingbooth_item/outerwear/hitman
+	name = "Black Jacket"
+	path = /obj/item/clothing/suit/hitman
+
 /datum/clothingbooth_item/outerwear/tuxedojacket
 	name = "Tuxedo Jacket"
 	path = /obj/item/clothing/suit/tuxedo_jacket

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1811,17 +1811,22 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 		..()
 		setProperty("coldprot", 5)
 
-/obj/item/clothing/suit/labcoat/hitman
-    name = "black jacket"
-    desc = "A stylish black suitjacket."
-    icon_state = "hitmanc"
-    item_state = "hitmanc"
-    coat_style = "hitmanc"
+/obj/item/clothing/suit/hitman
+	name = "black jacket"
+	desc = "A stylish black suitjacket."
+	icon_state = "hitmanc_o"
+	item_state = "hitmanc"
+	coat_style = "hitmanc"
 
-/obj/item/clothing/suit/labcoat/hitman/satansuit
+	New()
+		..()
+		src.AddComponent(/datum/component/toggle_coat, coat_style = "[src.coat_style]", buttoned = FALSE)
+
+/obj/item/clothing/suit/hitman/satansuit
 	icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
-	icon_state = "inspectorc"
+	icon_state = "inspectorc_o"
 	item_state = "inspectorc"
+	coat_style = "inspectorc"
 
 /obj/item/clothing/suit/witchfinder
 	name = "witchfinder general's coat"

--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -264,7 +264,7 @@ TYPEINFO(/obj/item/storage/wall)
 	spawn_contents = list(/obj/item/clothing/under/gimmick/utena = 1,
 	/obj/item/clothing/suit/hoodie = 1,
 	/obj/item/clothing/suit/wintercoat = 1,
-	/obj/item/clothing/suit/labcoat/hitman = 1,
+	/obj/item/clothing/suit/hitman = 1,
 	/obj/item/clothing/suit/johnny_coat = 1,
 	/obj/item/clothing/under/gimmick/chaps= 1,
 	/obj/item/clothing/under/gimmick/shirtnjeans = 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing] [balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the "hitman" jacket to the clothing booth and changes it from a subtype of labcoat for balance reasons. This should allow players to properly make suits without being too fancy.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We have a LOT of shirts with ties and stuff but not many coats, even less of our coats are short coats! It feels like a missed opportunity.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DimWhat
(+)Added a simple black jacket to the clothing booth.
```
