### PR TITLE
A couple of new unarmed combat moves

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -587,6 +587,12 @@
 	G.dispose()
 	return 1
 
+/turf/grab_smash(obj/item/grab/G, mob/user)
+	var/mob/affecting = G.affecting //the parent disposes G
+	if(..())
+		var/duration = (G.state > 0) ? 4 SECONDS : 2 SECONDS
+		affecting.do_disorient(20, disorient = duration)
+
 
 /turf/simulated/floor/grab_smash(obj/item/grab/G as obj, mob/user as mob)
 	var/mob/M = G.affecting

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -591,7 +591,7 @@
 	var/mob/affecting = G.affecting //the parent disposes G
 	if(..())
 		var/duration = (G.state > 0) ? 4 SECONDS : 2 SECONDS
-		affecting.do_disorient(40, disorient = duration)
+		affecting.do_disorient(40, disorient = duration, stack_stuns = FALSE)
 
 /obj/window/grab_smash(obj/item/grab/G, mob/user)
 	if (!ismob(G.affecting) || BOUNDS_DIST(G.affecting, src) != 0)
@@ -609,7 +609,7 @@
 		playsound(src.loc, src.hitsound , 100, 1)
 
 	var/duration = (G.state > 0) ? 4 SECONDS : 2 SECONDS
-	G.affecting.do_disorient(20, disorient = duration)
+	G.affecting.do_disorient(20, disorient = duration, stack_stuns = FALSE)
 
 	G.dispose()
 	return 1

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -591,8 +591,28 @@
 	var/mob/affecting = G.affecting //the parent disposes G
 	if(..())
 		var/duration = (G.state > 0) ? 4 SECONDS : 2 SECONDS
-		affecting.do_disorient(20, disorient = duration)
+		affecting.do_disorient(40, disorient = duration)
 
+/obj/window/grab_smash(obj/item/grab/G, mob/user)
+	if (!ismob(G.affecting) || BOUNDS_DIST(G.affecting, src) != 0)
+		return
+	G.affecting.TakeDamage("head", 5, 0)
+	src.damage_blunt(10)
+	if (QDELETED(src))
+		src.visible_message("<span class='alert'><B>[user] smashes [G.affecting]'s head straight through [src]!</B></span>")
+		logTheThing(LOG_COMBAT, user, "smashes [constructTarget(user,"combat")]'s head through [src]")
+		take_bleeding_damage(G.affecting, user, 15, DAMAGE_CUT, TRUE)
+		playsound(src.loc, 'sound/impact_sounds/Blade_Small_Bloody.ogg', 50, 1)
+	else
+		src.visible_message("<span class='alert'><B>[user] slams [G.affecting]'s head into [src]!</B></span>")
+		logTheThing(LOG_COMBAT, user, "slams [constructTarget(user,"combat")]'s head into [src]")
+		playsound(src.loc, src.hitsound , 100, 1)
+
+	var/duration = (G.state > 0) ? 4 SECONDS : 2 SECONDS
+	G.affecting.do_disorient(20, disorient = duration)
+
+	G.dispose()
+	return 1
 
 /turf/simulated/floor/grab_smash(obj/item/grab/G as obj, mob/user as mob)
 	var/mob/M = G.affecting

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -75,6 +75,16 @@
 		src.open()
 		playsound(src.loc, 'sound/impact_sounds/locker_break.ogg', 70, 1)
 
+	Crossed(atom/movable/AM)
+		. = ..()
+		if (src.open && ismob(AM) && AM.throwing)
+			var/datum/thrown_thing/thr = global.throwing_controller.throws_of_atom(AM)[1]
+			AM.throw_impact(src, thr)
+			AM.throwing = FALSE
+			AM.changeStatus("weakened", 2 SECONDS)
+			AM.set_loc(src.loc)
+			src.close()
+
 /obj/storage/closet/emergency
 	name = "emergency supplies closet"
 	desc = "It's a closet! This one can be opened AND closed. Comes prestocked with emergency equipment. <i>Hopefully</i>."

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -81,7 +81,7 @@
 			var/datum/thrown_thing/thr = global.throwing_controller.throws_of_atom(AM)[1]
 			AM.throw_impact(src, thr)
 			AM.throwing = FALSE
-			AM.changeStatus("weakened", 2 SECONDS)
+			AM.changeStatus("weakened", 1 SECOND)
 			AM.set_loc(src.loc)
 			src.close()
 

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -161,6 +161,16 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 		src.open()
 		playsound(src.loc, 'sound/impact_sounds/locker_break.ogg', 70, 1)
 
+	Crossed(atom/movable/AM) //copy pasted from closet because inheritence is a lie
+		. = ..()
+		if (src.open && ismob(AM) && AM.throwing)
+			var/datum/thrown_thing/thr = global.throwing_controller.throws_of_atom(AM)[1]
+			AM.throw_impact(src, thr)
+			AM.throwing = FALSE
+			AM.changeStatus("weakened", 2 SECONDS)
+			AM.set_loc(src.loc)
+			src.close()
+
 /obj/storage/secure/closet/personal
 	name = "personal locker"
 	desc = "The first card swiped gains control."

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -167,7 +167,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 			var/datum/thrown_thing/thr = global.throwing_controller.throws_of_atom(AM)[1]
 			AM.throw_impact(src, thr)
 			AM.throwing = FALSE
-			AM.changeStatus("weakened", 2 SECONDS)
+			AM.changeStatus("weakened", 1 SECOND)
 			AM.set_loc(src.loc)
 			src.close()
 

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -450,16 +450,6 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
-
-		else if (istype(W, /obj/item/grab))
-			var/obj/item/grab/G = W
-			if (ishuman(G.affecting) && BOUNDS_DIST(G.affecting, src) == 0)
-				src.visible_message("<span class='alert'><B>[user] slams [G.affecting]'s head into [src]!</B></span>")
-				logTheThing(LOG_COMBAT, user, "slams [constructTarget(user,"combat")]'s head into [src]")
-				playsound(src.loc, src.hitsound , 100, 1)
-				G.affecting.TakeDamage("head", 5, 0)
-				src.damage_blunt(G.affecting.throwforce)
-				qdel(W)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Throwing someone into an open locker will now interrupt the throw and shut it on the victim, stunning them for 2 seconds.
Smashing someone into a wall will deal 40 stamina damage and disorient them for 2 seconds for a passive grab or 4 seconds for an aggressive one. Smashing them into a window will do the same thing for 20 stamina damage and 15 bleeding damage if the window shatters.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More environmental effects for unarmed combat, dull the neuron activation response from vending machines and glass tables.
I always thought smashing people into walls was very underwhelming.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Throwing someone into an open locker will now shut it on them, causing a short stun.
(+)Smashing someone into a wall or window with a grab will now disorient them.
```
