### PR TITLE
Merges the two dispensers in the bar into one

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -436,13 +436,13 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 
 	dispense_sound = 'sound/misc/pourdrink2.ogg'
 
-//Combines alcohol and soda dispenser, plus mint, chocolate, and normal/strawb milk. Wow!
+//Combines alcohol and soda dispenser
 /obj/machinery/chem_dispenser/alcohol/bar
 	name = "bar dispenser"
 	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Contents pending approval for human consumption. User assumes all risks.</br>"
-	dispensable_reagents = list("beer", "bitters", "bourbon", "champagne", "juice_cherry", "chocolate", "cider", \
+	dispensable_reagents = list("beer", "bitters", "bourbon", "champagne", "juice_cherry", "cider", \
 								"coconut_milk", "cola", "juice_cran", "gin", "ginger_ale", "grenadine", "juice_lemon", \
-								"juice_lime", "milk", "mint", "juice_orange", "juice_pineapple",  "rum", "strawberry_milk", "sugar", \
+								"juice_lime", "juice_orange", "juice_pineapple",  "rum", "sugar", \
 								"tea", "tequila", "juice_tomato", "tonic", "vanilla", "vermouth", "vodka", "water", "wine")
 
 // Dispenses any drink you want. Designed for the afterlife bar

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -436,13 +436,13 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 
 	dispense_sound = 'sound/misc/pourdrink2.ogg'
 
-//Combines alcohol and soda dispenser, plus mint, chocolate, and choc/strawb milk. Wow!
+//Combines alcohol and soda dispenser, plus mint, chocolate, and normal/strawb milk. Wow!
 /obj/machinery/chem_dispenser/alcohol/bar
 	name = "bar dispenser"
-	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Contents artificially produced using industrial ethanol. Not recommended for human consumption.</br> Hey, this one's got soda too!"
-	dispensable_reagents = list("beer", "bitters", "bourbon", "champagne", "juice_cherry", "chocolate", "chocolate_milk", \
-								"cider", "coconut_milk", "cola", "juice_cran", "gin", "ginger_ale", "grenadine", "juice_lemon", \
-								"juice_lime", "mint", "juice_orange", "juice_pineapple",  "rum", "strawberry_milk", "sugar", \
+	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Contents pending approval for human consumption. User assumes all risks.</br>"
+	dispensable_reagents = list("beer", "bitters", "bourbon", "champagne", "juice_cherry", "chocolate", "cider", \
+								"coconut_milk", "cola", "juice_cran", "gin", "ginger_ale", "grenadine", "juice_lemon", \
+								"juice_lime", "milk", "mint", "juice_orange", "juice_pineapple",  "rum", "strawberry_milk", "sugar", \
 								"tea", "tequila", "juice_tomato", "tonic", "vanilla", "vermouth", "vodka", "water", "wine")
 
 // Dispenses any drink you want. Designed for the afterlife bar

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -436,6 +436,14 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 
 	dispense_sound = 'sound/misc/pourdrink2.ogg'
 
+//Combines alcohol and soda dispenser, plus mint, chocolate, and choc/strawb milk. Wow!
+/obj/machinery/chem_dispenser/alcohol/bar
+	name = "bar dispenser"
+	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Contents artificially produced using industrial ethanol. Not recommended for human consumption.</br> Hey, this one's got soda too!"
+	dispensable_reagents = list("beer", "bitters", "bourbon", "champagne", "juice_cherry", "chocolate", "chocolate_milk", \
+								"cider", "coconut_milk", "cola", "juice_cran", "gin", "ginger_ale", "grenadine", "juice_lemon", \
+								"juice_lime", "mint", "juice_orange", "juice_pineapple",  "rum", "strawberry_milk", "sugar", \
+								"tea", "tequila", "juice_tomato", "tonic", "vanilla", "vermouth", "vodka", "water", "wine")
 
 // Dispenses any drink you want. Designed for the afterlife bar
 /obj/machinery/chem_dispenser/alcohol/ultra
@@ -451,13 +459,6 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 							"mimosa","french75","sangria","tomcollins","peachschnapps","moscowmule","tequila","tequilasunrise",\
 							"paloma","mintjulep","mojito","cremedementhe","grasshopper","freeze","curacao","bluelagoon",\
 							"bluehawaiian","negroni","necroni") // ow my hands
-	icon_state = "alc_dispenser"
-	icon_base = "alc_dispenser"
-	glass_path = /obj/item/reagent_containers/food/drinks
-	glass_name = "bottle"
-	dispenser_name = "Alcohol"
-
-	dispense_sound = 'sound/misc/pourdrink2.ogg'
 
 /obj/machinery/chem_dispenser/alcohol/hydro
 	name = "ULTRA DISPENSER"


### PR DESCRIPTION
[QoL] [Catering] [Game Objects] 
## About the PR
This PR adds a new type of dispenser, the bar dispenser, that can dispense all of the reagents that the alcohol and soda dispensers can, plus chocolate, mint, strawberry milk, and chocolate milk.

![image](https://github.com/goonstation/goonstation/assets/120209597/b2f0efc2-6df2-41a7-9842-0378202469b8)

Note that the chem dispenser in Chemistry has 30 reagents. This dispenser has 31. I'm really not sure why they were separate in the first place.

This PR also cleans up a little of the code for all of the subtypes of /obj/machinery/chem_dispenser/alcohol/, since there were some repeated lines of code that didn't need to be there.

This PR does not add the dispenser to the maps in rotation.

## Why's this needed?
Like the chemlab, the bar would benefit appreciably from having a little big more counter space. And since the two separate ones have the same sprites, it's impossible to tell which is which without an alt-click, which is quite irksome. 
