### PR TITLE
Reorganizes Glass Recyclers' Inventories

### DIFF
--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -50,7 +50,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 	icon_state = "synthesizer"
 	anchored = ANCHORED
 	density = 0
-	var/glass_amt = 4
+	var/glass_amt = 0
 	var/list/product_list = list()
 	flags = NOSPLASH | FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL
@@ -238,6 +238,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 		product_list += new /datum/glass_product("shot", /obj/item/reagent_containers/food/drinks/drinkingglass/shot, 1)
 		product_list += new /datum/glass_product("drinkbottle", /obj/item/reagent_containers/food/drinks/bottle/soda, 2)
 		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)
+		product_list += new /datum/glass_product("bowl", /obj/item/reagent_containers/food/drinks/bowl, 1) // for making "spicy dip"
 
 /obj/machinery/glass_recycler/bar //the bar should not have to scroll through all this chemmy crap to get to the glasses and pitchers they use
 	name = "chemistry glass recycler"

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -241,7 +241,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 		product_list += new /datum/glass_product("bowl", /obj/item/reagent_containers/food/drinks/bowl, 1) // for making "spicy dip"
 
 /obj/machinery/glass_recycler/bar //the bar should not have to scroll through all this chemmy crap to get to the glasses and pitchers they use
-	name = "chemistry glass recycler"
+	name = "kitchen glass recycler"
 
 	get_products()
 		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -50,7 +50,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 	icon_state = "synthesizer"
 	anchored = ANCHORED
 	density = 0
-	var/glass_amt = 0
+	var/glass_amt = 4
 	var/list/product_list = list()
 	flags = NOSPLASH | FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL
@@ -235,5 +235,33 @@ TYPEINFO(/obj/machinery/glass_recycler)
 		product_list += new /datum/glass_product("bottle", /obj/item/reagent_containers/glass/bottle, 1)
 		product_list += new /datum/glass_product("vial", /obj/item/reagent_containers/glass/vial, 1)
 		product_list += new /datum/glass_product("flask", /obj/item/reagent_containers/glass/flask, 1)
+		product_list += new /datum/glass_product("shot", /obj/item/reagent_containers/food/drinks/drinkingglass/shot, 1)
+		product_list += new /datum/glass_product("drinkbottle", /obj/item/reagent_containers/food/drinks/bottle/soda, 2)
+		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)
 
+/obj/machinery/glass_recycler/bar //the bar should not have to scroll through all this chemmy crap to get to the glasses and pitchers they use
+	name = "chemistry glass recycler"
+
+	get_products()
+		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)
+		product_list += new /datum/glass_product("drinking", /obj/item/reagent_containers/food/drinks/drinkingglass, 1)
+		product_list += new /datum/glass_product("mug", /obj/item/reagent_containers/food/drinks/mug/random_color, 1)
+		product_list += new /datum/glass_product("oldf", /obj/item/reagent_containers/food/drinks/drinkingglass/oldf, 1)
+		product_list += new /datum/glass_product("shot", /obj/item/reagent_containers/food/drinks/drinkingglass/shot, 1)
+		product_list += new /datum/glass_product("wine", /obj/item/reagent_containers/food/drinks/drinkingglass/wine, 1)
+		product_list += new /datum/glass_product("cocktail", /obj/item/reagent_containers/food/drinks/drinkingglass/cocktail, 1)
+		product_list += new /datum/glass_product("flute", /obj/item/reagent_containers/food/drinks/drinkingglass/flute, 1)
+		product_list += new /datum/glass_product("drinkbottle", /obj/item/reagent_containers/food/drinks/bottle/soda, 2)
+		product_list += new /datum/glass_product("longbottle", /obj/item/reagent_containers/food/drinks/bottle/empty/long, 2)
+		product_list += new /datum/glass_product("tallbottle", /obj/item/reagent_containers/food/drinks/bottle/empty/tall, 2)
+		product_list += new /datum/glass_product("rectangularbottle", /obj/item/reagent_containers/food/drinks/bottle/empty/rectangular, 2)
+		product_list += new /datum/glass_product("squarebottle", /obj/item/reagent_containers/food/drinks/bottle/empty/square, 2)
+		product_list += new /datum/glass_product("masculinebottle", /obj/item/reagent_containers/food/drinks/bottle/empty/masculine, 2)
+		product_list += new /datum/glass_product("round", /obj/item/reagent_containers/food/drinks/drinkingglass/round, 2)
+		product_list += new /datum/glass_product("plate", /obj/item/plate, PLATE_COST)
+		product_list += new /datum/glass_product("bowl", /obj/item/reagent_containers/food/drinks/bowl, 1)
+		product_list += new /datum/glass_product("beaker", /obj/item/reagent_containers/glass/beaker, 1)
+		product_list += new /datum/glass_product("largebeaker", /obj/item/reagent_containers/glass/beaker/large, 2)
+		product_list += new /datum/glass_product("bottle", /obj/item/reagent_containers/glass/bottle, 1)
+		product_list += new /datum/glass_product("vial", /obj/item/reagent_containers/glass/vial, 1)
 #undef PLATE_COST

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2910,7 +2910,7 @@
 /area/station/hallway/secondary/exit)
 "ajs" = (
 /obj/table/wood/round/auto,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/bar,
 /obj/item/clothing/glasses/spectro{
 	pixel_y = 11
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7888,7 +7888,7 @@
 "aEC" = (
 /obj/table/reinforced/bar/auto,
 /obj/random_item_spawner/tableware,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/bar,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "aED" = (
@@ -14552,7 +14552,7 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bmQ" = (
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/chemistry,
 /obj/table/reinforced/chemistry/auto/firstaid,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6878,10 +6878,7 @@
 /area/station/crew_quarters/fitness)
 "axq" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/glass_recycler{
-	density = 1;
-	pixel_y = 2
-	},
+/obj/machinery/glass_recycler/bar,
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 5
 	},
@@ -38937,7 +38934,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/chemistry,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/firealarm{
 	pixel_y = 24

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -8089,10 +8089,7 @@
 /area/station/crew_quarters/bar)
 "aws" = (
 /obj/table/auto,
-/obj/machinery/glass_recycler{
-	density = 1;
-	pixel_y = 6
-	},
+/obj/machinery/glass_recycler/bar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "awt" = (
@@ -56236,7 +56233,7 @@
 /area/station/science/chemistry)
 "cQv" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -980,7 +980,7 @@
 	pixel_y = 10
 	},
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -28388,10 +28388,7 @@
 /area/station/science/lobby)
 "gnP" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/glass_recycler{
-	density = 1;
-	pixel_y = 2
-	},
+/obj/machinery/glass_recycler/bar,
 /obj/item/storage/box/glassbox{
 	pixel_x = -2;
 	pixel_y = 11

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6668,7 +6668,7 @@
 /area/station/medical/cdc)
 "bSq" = (
 /obj/table/wood/auto,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/bar,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bSQ" = (
@@ -65933,7 +65933,7 @@
 	pixel_y = -25
 	},
 /obj/table/reinforced/chemistry/auto/drugs,
-/obj/machinery/glass_recycler,
+/obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
 "ukM" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -16624,10 +16624,7 @@
 	pixel_x = -10
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
+/obj/machinery/glass_recycler/bar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "bkI" = (
@@ -21723,10 +21720,7 @@
 /area/station/science/lobby)
 "bFe" = (
 /obj/table/reinforced/chemistry/auto/basicsup,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
+/obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purpleblack/corner{
 	dir = 8
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1388,10 +1388,7 @@
 /area/station/hallway/primary/northeast)
 "aES" = (
 /obj/table/reinforced/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
+/obj/machinery/glass_recycler/bar,
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/access/bar,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -21579,10 +21576,7 @@
 /area/station/hallway/primary/northwest)
 "jpE" = (
 /obj/table/reinforced/chemistry/auto/auxsup,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
+/obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "jpG" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -10874,9 +10874,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aHy" = (
-/obj/machinery/glass_recycler{
-	name = "Glassware Recycler"
-	},
+/obj/machinery/glass_recycler/chemistry,
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
@@ -18917,9 +18915,7 @@
 /area/station/maintenance/northwest)
 "bmw" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/glass_recycler{
-	name = "Glassware Recycler"
-	},
+/obj/machinery/glass_recycler/bar,
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet/blue/fancy/narrow/sw,
 /area/station/crew_quarters/bar)
@@ -38020,6 +38016,10 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
+"hGx" = (
+/obj/machinery/glass_recycler/chemistry,
+/turf/space/fluid,
+/area/space)
 "hGJ" = (
 /obj/indestructible/shuttle_corner{
 	dir = 5;
@@ -48877,7 +48877,7 @@ aqn
 aqn
 aqn
 aqn
-aqn
+hGx
 aqn
 aTs
 aqn


### PR DESCRIPTION
[chemistry] [catering] [game objects] [qol] 
## About the PR
This PR changes the order of glass fabs in the bar. Check this out:
![image](https://github.com/goonstation/goonstation/assets/120209597/fba49911-eb7c-4ed8-8d60-4f9ea2e68cf6)![image](https://github.com/goonstation/goonstation/assets/120209597/4581fcb7-3fab-4814-ab23-6616c245b2e6)

It also reorders and changes what's available in the chemlab's glass fab. Take a look at this.
![image](https://github.com/goonstation/goonstation/assets/120209597/537342b5-6ef9-48e1-b590-ce75122434a2)
(Post-screenshot, I also added a bowl for making spicy dip)

It also adds these new fabricators to every map in rotation.

## Why's this needed? 
Bartending is hard. Having to scroll through beakers and plates to get to the bottle/glass types you want is a pain. I know I'll be happy to find the drinking glasses and pitchers at the top there. 

Chemistry changes are not so that I can nerf Chemistry-- I want to make it easier. Big part of my design philosophy is removing meaningless choice to simplify gameplay. Why does a chemlab need plates? Fancy cups? 5 different types of 100-unit drinking bottles? The usefulness for chemistry is limited. Players unfamiliar with the bar would be confused, and it obfuscates some useful stuff too, like the 120u-capacity pitcher, or the shot glass with a triple-sized sip. I'd argue that having things like the shot glass and the bowl in a purpose-made chemistry list emphasizes the idea that NT provides these drinking implements in a chemlab on purpose-- because they know someone's gonna drink the deadly poisons made here.