### PR TITLE
Fix medal frames always returning standard glass sheets

### DIFF
--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -875,6 +875,7 @@
 			var/icon_glass = "rddiploma1"
 			var/icon_award = "rddiploma"
 			var/icon_empty = "frame"
+			var/glass_type = /obj/item/sheet/glass
 			icon_state = "rddiploma"
 			pixel_y = -6
 
@@ -907,7 +908,7 @@
 						src.usage_state = 1
 						src.icon_state = icon_glass
 						user.visible_message("[user] takes off the glass frame.", "You take off the glass frame.")
-						var/obj/item/sheet/glass/G = new /obj/item/sheet/glass()
+						var/obj/item/sheet/glass/G = new glass_type()
 						G.amount = 1
 						src.add_fingerprint(user)
 						user.put_in_hand_or_drop(G)
@@ -939,6 +940,7 @@
 				if (src.usage_state == 1)
 					if (istype(W, /obj/item/sheet/glass))
 						if (W.amount >= 1)
+							src.glass_type = W.type
 							playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 							user.u_equip(W)
 							qdel(W)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Internal] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a new `var/glass_type` to `/obj/decal/poster/framed_award`, and subsequently uses this to determine what kind of glass to return. It defaults to `/obj/item/sheet/glass`.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Take out glass from frame
-Put plasma glass in
-Plasma glass turns into regular glass
:o
