### PR TITLE
Pull borg pronouns from preferences when latejoining and being constructed

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -248,6 +248,7 @@
 			update_bodypart() //TODO probably remove this later. keeping in for safety
 			if(!isnull(src.client))
 				src.bioHolder.mobAppearance.pronouns = src.client.preferences.AH.pronouns
+				src.update_name_tag()
 			if (src.syndicate)
 				src.show_antag_popup("syndieborg")
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -246,6 +246,8 @@
 					B.set_loc(H)
 					H.brain = B
 			update_bodypart() //TODO probably remove this later. keeping in for safety
+			if(!isnull(src.client))
+				src.bioHolder.mobAppearance.pronouns = src.client.preferences.AH.pronouns
 			if (src.syndicate)
 				src.show_antag_popup("syndieborg")
 

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -209,8 +209,8 @@ mob/new_player
 							logTheThing(LOG_STATION, src, "[key_name(S)] late-joins as an emagged cyborg.")
 							S.mind?.add_antagonist(ROLE_EMAGGED_ROBOT, respect_mutual_exclusives = FALSE, source = ANTAGONIST_SOURCE_LATE_JOIN)
 						SPAWN(1 DECI SECOND)
-							S.choose_name()
 							S.bioHolder?.mobAppearance?.pronouns = S.client.preferences.AH.pronouns
+							S.choose_name()
 							qdel(src)
 					else
 						close_spawn_windows()

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -210,6 +210,7 @@ mob/new_player
 							S.mind?.add_antagonist(ROLE_EMAGGED_ROBOT, respect_mutual_exclusives = FALSE, source = ANTAGONIST_SOURCE_LATE_JOIN)
 						SPAWN(1 DECI SECOND)
 							S.choose_name()
+							S.bioHolder?.mobAppearance?.pronouns = S.client.preferences.AH.pronouns
 							qdel(src)
 					else
 						close_spawn_windows()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Copies a client's pronoun preference in character setup to 1. SICC cyborgs they're latejoining into, and 2. A freshly built cyborg their brain is inside on activation

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cyborgs only got pronouns if they were one of the roundstart ones, this makes the behavior consistent in (I believe) all the ways someone can become a cyborg
