### PR TITLE
Fix Plasmastone & Molitz not working after one use

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -449,7 +449,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			return
 		if(!owner.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
 			owner.material = owner.material.getMutable()
-			return owner.material.triggerExp(owner)
+			return owner.material.triggerExp(owner, sev)
 		var/turf/target = get_turf(owner)
 		if(sev > 0 && sev < 4) // Use pipebombs not canbombs!
 			if(molitz.iterations >= 1)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -346,6 +346,9 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/turf/T = get_turf(location)
 		if(!T || T.density || !istype(location))
 			return
+		if(!location.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
+			location.material = location.material.getMutable()
+			return location.material.triggerTemp(location, 0)
 		if(total_plasma <= 0)
 			if(prob(2) && location)
 				location.visible_message("<span class='alert>[location] dissipates.</span>")
@@ -402,6 +405,9 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		if(ON_COOLDOWN(owner, "molitz_gas_generate", 30 SECONDS)) return
 
 		//okay, now we've passed all the conditions for gas generation - do that
+		if(!owner.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
+			owner.material = owner.material.getMutable()
+			return owner.material.triggerTemp(owner, temp)
 		var/datum/gas_mixture/payload = new /datum/gas_mixture
 
 		if(agent_b && air.toxins > MINIMUM_REACT_QUANTITY)
@@ -441,6 +447,9 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/datum/material/crystal/molitz/molitz = owner.material
 		if(molitz.unexploded <= 0)
 			return
+		if(!owner.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
+			owner.material = owner.material.getMutable()
+			return owner.material.triggerExp(owner)
 		var/turf/target = get_turf(owner)
 		if(sev > 0 && sev < 4) // Use pipebombs not canbombs!
 			if(molitz.iterations >= 1)

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -199,7 +199,7 @@ ABSTRACT_TYPE(/datum/material)
 
 	///Returns a mutable version of this material. Will return a copy of this material if it is already mutable.
 	///The reason this is a separate proc and not using in getMaterial() is prevent cargo-culting accidentally reintroducing the
-	//issue this was supposed to fix. Force the coders to explicitly ask for a mutable instance, demand to know why they want it to be mutable in reviews!
+	///issue this was supposed to fix. Force the coders to explicitly ask for a mutable instance, demand to know why they want it to be mutable in reviews!
 	proc/getMutable()
 		return src.copyMaterial() //copy is mutable by default
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bit of logic to these triggers so that the parent material becomes mutable when they fire.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Plasmastone and molitz currently only trigger a couple times, because they're operating on the immutable one in the cache which is bad.