### PR TITLE
Preassembled Pod Kits

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2912,6 +2912,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Component"
 
+/datum/manufacture/pod/preassembeled_parts
+	name = "Preassembeled Pod Frame Kit"
+	item_paths = list("MET-2","CON-1","CRY-1")
+	item_amounts = list(40, 20, 15)
+	item_outputs = list(/obj/item/preassembled_frame_box/pod)
+	time = 50 SECONDS
+	create = 1
+	category = "Component"
+
 ABSTRACT_TYPE(/datum/manufacture/sub)
 
 /datum/manufacture/sub/parts
@@ -2950,6 +2959,15 @@ ABSTRACT_TYPE(/datum/manufacture/sub)
 	create = 1
 	category = "Component"
 
+/datum/manufacture/sub/preassembeled_parts
+	name = "Preassembeled Minisub Frame Kit"
+	item_paths = list("MET-2","CON-1","CRY-1")
+	item_amounts = list(20, 9, 7)
+	item_outputs = list(/obj/item/preassembled_frame_box/sub)
+	time = 25 SECONDS
+	create = 1
+	category = "Component"
+
 ABSTRACT_TYPE(/datum/manufacture/putt)
 
 /datum/manufacture/putt/parts
@@ -2985,6 +3003,15 @@ ABSTRACT_TYPE(/datum/manufacture/putt)
 	item_amounts = list(5,5)
 	item_outputs = list(/obj/item/putt/control)
 	time = 5 SECONDS
+	create = 1
+	category = "Component"
+
+/datum/manufacture/putt/preassembeled_parts
+	name = "Preassembeled MiniPutt Frame Kit"
+	item_paths = list("MET-2","CON-1","CRY-1")
+	item_amounts = list(20, 9, 7)
+	item_outputs = list(/obj/item/preassembled_frame_box/putt)
+	time = 25 SECONDS
 	create = 1
 	category = "Component"
 

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2915,7 +2915,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 /datum/manufacture/pod/preassembeled_parts
 	name = "Preassembeled Pod Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")
-	item_amounts = list(40, 20, 15)
+	item_amounts = list(45, 25, 19)
 	item_outputs = list(/obj/item/preassembled_frame_box/pod)
 	time = 50 SECONDS
 	create = 1
@@ -2962,7 +2962,7 @@ ABSTRACT_TYPE(/datum/manufacture/sub)
 /datum/manufacture/sub/preassembeled_parts
 	name = "Preassembeled Minisub Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")
-	item_amounts = list(20, 9, 7)
+	item_amounts = list(23, 12, 9)
 	item_outputs = list(/obj/item/preassembled_frame_box/sub)
 	time = 25 SECONDS
 	create = 1
@@ -3009,7 +3009,7 @@ ABSTRACT_TYPE(/datum/manufacture/putt)
 /datum/manufacture/putt/preassembeled_parts
 	name = "Preassembeled MiniPutt Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")
-	item_amounts = list(20, 9, 7)
+	item_amounts = list(23, 12, 9)
 	item_outputs = list(/obj/item/preassembled_frame_box/putt)
 	time = 25 SECONDS
 	create = 1

--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -106,77 +106,98 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 /* Construction                */
 /*-----------------------------*/
 
-/obj/structure/preassembeled_vehicleframe/attackby(obj/item/W, mob/living/user)
+/obj/structure/preassembeled_vehicleframe/attackby(obj/item/I, mob/living/user)
+	var/datum/action/bar/icon/callback/action_bar
+
+	if (I)
+		action_bar = new /datum/action/bar/icon/callback(user, src, src.step_build_time, \
+			/obj/structure/preassembeled_vehicleframe/proc/step_wrench_1, \
+			list(user), I.icon, I.icon_state, null, null)
+		action_bar.maximum_range = 2
+
 	switch(src.stage)
 		if(BUILD_STEP_PLACED)
-			if (iswrenchingtool(W))
+			if (iswrenchingtool(I))
 				user.visible_message("[user] begins securing the frame...")
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_wrench_1, list(user), \
-			 		W.icon, W.icon_state, "[user] finishes wrenching the frame parts together.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_wrench_1
+				action_bar.end_message = "[user] finishes wrenching the frame parts together."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a wrench to secure the parts together.")
 
 		if(BUILD_STEP_WRENCH_1)
-			if (isweldingtool(W))
-				if(!W:try_weld(user, 1))
+			if (isweldingtool(I))
+				if(!I:try_weld(user, 1))
 					return
 				user.visible_message("[user] begins welding the joints of the frame...")
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_weld_1, list(user), \
-			 		W.icon, W.icon_state, "[user] welds the joints of the frame together.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_weld_1
+				action_bar.end_message = "[user] welds the joints of the frame together."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a welder to weld the joints together.")
 
 		if(BUILD_STEP_WELD_1)
-			if (isscrewingtool(W))
+			if (isscrewingtool(I))
 				user.visible_message("[user] begins screwing down the frame's circuit boards and it's engine...")
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_screw_1, list(user), \
-			 		W.icon, W.icon_state, "[user] finishes screwing the the frame's circuit boards and it's engine.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_screw_1
+				action_bar.end_message = "[user] finishes screwing the the frame's circuit boards and it's engine."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a screwdriver to screw the circuit boards and the engine together.")
 
 
 		if(BUILD_STEP_SCREW_1)
-			if(istype(W, /obj/item/podarmor))
-				var/obj/item/podarmor/armor = W
+			if(istype(I, /obj/item/podarmor))
+				var/obj/item/podarmor/armor = I
 				if(!armor.vehicle_types["[src.type]"])
 					boutput(user, "That type of armor is not compatible with this frame.")
 					return
-				user.visible_message("[user] begins installing the [W]...")
+				user.visible_message("[user] begins installing the [I]...")
 				playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_armor, list(user, armor), \
-			 		W.icon, W.icon_state, "[user] loosely attaches the light armor plating.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_armor
+				action_bar.proc_args = list(user, armor)
+				action_bar.end_message = "[user] loosely attaches the light armor plating."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need some pod armor to put on.")
 
 		if(BUILD_STEP_ARMOR)
-			if (iswrenchingtool(W))
+			if (iswrenchingtool(I))
 				user.visible_message("[user] begins securing the pod's thrusters and control system...")
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_wrench_2, list(user), \
-			 		W.icon, W.icon_state, "[user] secures the pod's thrusters and control system.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_wrench_2
+				action_bar.end_message = "[user] secures the pod's thrusters and control system."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a wrench to secure the pod's thrusters and control system.")
 
 		if(BUILD_STEP_WRENCH_2)
-			if (isweldingtool(W))
-				if(!W:try_weld(user, 1))
+			if (isweldingtool(I))
+				if(!I:try_weld(user, 1))
 					return
 				user.visible_message("[user] begins welding the exterior...")
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_weld_2, list(user), \
-			 		W.icon, W.icon_state, "[user] welds the seams of the outer skin to make it air-tight.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_weld_2
+				action_bar.end_message = "[user] welds the seams of the outer skin to make it air-tight."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a welder to weld the exterior.")
 
 		if(BUILD_STEP_WELD_2)
-			if (isscrewingtool(W))
+			if (isscrewingtool(I))
 				user.visible_message("[user] begins screwing the pod's maintenance panels shut...")
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				SETUP_GENERIC_ACTIONBAR(user, src, src.step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_screw_2, list(user), \
-			 		W.icon, W.icon_state, "With the cockpit and exterior indicators secured, the control system automatically starts up.", null)
+				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_screw_2
+				action_bar.end_message = "With the cockpit and exterior indicators secured, the control system automatically starts up."
+				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a screwdriver to close the maintenance panels.")
+
+/obj/structure/preassembeled_vehicleframe/attack_hand(mob/user)
+	. = ..()
+	//Let's call attackby with no item to get the step advice
+	attackby(null, user)
 
 /obj/structure/preassembeled_vehicleframe/proc/step_wrench_1(var/mob/user)
 	src.overlays += image(src.icon, "[pick("frame1", "frame2")]")
@@ -237,7 +258,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 	if (usr.stat)
 		return
 
-	boutput(usr, "Deconstructing frame...")
+	usr.visible_message("[usr] begins deconstructing the pod frame...")
 
 	var/timer = (5 * src.stage + 30) DECI SECONDS
 

--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -19,11 +19,11 @@ ABSTRACT_TYPE(/obj/item/preassembled_frame_box)
 	frame_type = /obj/structure/preassembeled_vehicleframe/puttframe
 
 /obj/item/preassembled_frame_box/sub
-	name = "Minisub Frame Kit"
+	name = "Preasembled Minisub Frame Kit"
 	frame_type = /obj/structure/preassembeled_vehicleframe/subframe
 
 /obj/item/preassembled_frame_box/pod
-	name = "Pod Frame Kit"
+	name = "Preasembled Pod Frame Kit"
 	frame_type = /obj/structure/preassembeled_vehicleframe/podframe
 
 	attack_self(mob/user as mob)

--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -1,0 +1,253 @@
+ABSTRACT_TYPE(/obj/item/preassembled_frame_box)
+/obj/item/preassembled_frame_box
+	desc = "You can hear an awful lot of junk rattling around in this box."
+	help_message = "Use the frame kit in a pod bay to begin construction, for which you'll need a wrench, a welder, a screwdriver and some pod armor from a manufacturer."
+	icon = 'icons/obj/electronics.dmi'
+	icon_state = "dbox"
+	var/frame_type
+
+	attack_self(mob/user as mob)
+		boutput(user, "<span class='notice'>You dump out the box of parts onto the floor.</span>")
+		var/obj/O = new frame_type( get_turf(user) )
+		logTheThing(LOG_STATION, user, "builds [O] in [get_area(user)] ([log_loc(user)])")
+		O.fingerprints = src.fingerprints
+		O.fingerprints_full = src.fingerprints_full
+		qdel(src)
+
+/obj/item/preassembled_frame_box/putt
+	name = "Preasembled MiniPutt Frame Kit"
+	frame_type = /obj/structure/preassembeled_vehicleframe/puttframe
+
+/obj/item/preassembled_frame_box/sub
+	name = "Minisub Frame Kit"
+	frame_type = /obj/structure/preassembeled_vehicleframe/subframe
+
+/obj/item/preassembled_frame_box/pod
+	name = "Pod Frame Kit"
+	frame_type = /obj/structure/preassembeled_vehicleframe/podframe
+
+	attack_self(mob/user as mob)
+		// lets assume everything is ok so we can stop checking at the first sign of trouble
+		var/canbuild = 1
+
+		// buffers whee
+		var/list/checkturfs = block(get_turf(user),locate(user.x+1,user.y+1,user.z))
+		var/turf/T
+		var/atom/A
+
+		// check the 2x2 square that the finished pod will occupy
+		for(T in checkturfs)
+			if (istype(T, /turf/space))
+				continue
+			if (!T.allows_vehicles || T.density)
+				canbuild = 0
+				boutput(user, "<span class='alert'>You can't build a pod here! It'd get stuck.</span>")
+				break
+			for (A in T)
+				if (A == user)
+					continue
+				if (A.density)
+					canbuild = 0
+					boutput(user, "<span class='alert'>You can't build a pod here! [A] is in the way.</span>")
+					break
+			if (!canbuild)
+				break
+
+		if (canbuild)
+			..()
+
+ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
+/obj/structure/preassembeled_vehicleframe
+	var/stage = 0
+	var/obj/item/podarmor/armor_type = null
+	var/box_type = null
+	var/vehicle_name = null
+	var/vehicle_type = null
+	anchored = ANCHORED
+	density = 1
+	help_message = "Use a wrench to secure the parts together."
+	var/step_build_time = 10 SECONDS //per each 7 steps
+
+/obj/structure/preassembeled_vehicleframe/puttframe
+	name = "Preassembeled MiniPutt Frame"
+	desc = "A MiniPutt ship under construction."
+	icon = 'icons/obj/ship.dmi'
+	icon_state = "parts"
+	box_type = /obj/item/preassembled_frame_box/putt
+	vehicle_name = "MiniPutt"
+
+/obj/structure/preassembeled_vehicleframe/subframe
+	name = "Preassembeled Minisub Frame"
+	desc = "A minisub under construction."
+	icon = 'icons/obj/machines/8dirvehicles.dmi'
+	icon_state = "parts"
+	box_type = /obj/item/preassembled_frame_box/sub
+	vehicle_name = "Minisub"
+
+/obj/structure/preassembeled_vehicleframe/podframe
+	name = "Preassembeled Pod Frame"
+	desc = "A vehicle pod under construction."
+	icon = 'icons/effects/64x64.dmi'
+	icon_state = "parts"
+	bound_width = 64
+	bound_height = 64
+	box_type = /obj/item/preassembled_frame_box/pod
+	vehicle_name = "Pod"
+
+/*-----------------------------*/
+/* Construction                */
+/*-----------------------------*/
+
+/obj/structure/preassembeled_vehicleframe/attackby(obj/item/W, mob/living/user)
+	switch(stage)
+		if(0)
+			if (iswrenchingtool(W))
+				user.visible_message("[user] begins securing the frame...")
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_wrench_1, list(user), \
+			 		W.icon, W.icon_state, "[user] finishes wrenching the frame parts together.", null)
+			else
+				boutput(user, "You need a wrench to secure the parts together.")
+
+		if(1)
+			if (isweldingtool(W))
+				if(!W:try_weld(user, 1))
+					return
+				user.visible_message("[user] begins welding the joints of the frame...")
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_weld_1, list(user), \
+			 		W.icon, W.icon_state, "[user] welds the joints of the frame together.", null)
+			else
+				boutput(user, "You need a welder to weld the joints together.")
+
+		if(2)
+			if (isscrewingtool(W))
+				user.visible_message("[user] begins screwing down the frame's circuit boards and it's engine...")
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_screw_1, list(user), \
+			 		W.icon, W.icon_state, "[user] finishes screwing the the frame's circuit boards and it's engine.", null)
+			else
+				boutput(user, "You need a screwdriver to screw the circuit boards and the engine together.")
+
+
+		if(3)
+			if(istype(W, /obj/item/podarmor))
+				var/obj/item/podarmor/armor = W
+				if(!armor.vehicle_types["[src.type]"])
+					boutput(user, "That type of armor is not compatible with this frame.")
+					return
+				user.visible_message("[user] begins installing the [W]...")
+				playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_armor, list(user, armor), \
+			 		W.icon, W.icon_state, "[user] loosely attaches the light armor plating.", null)
+			else
+				boutput(user, "You need some pod armor to put on.")
+
+		if(4)
+			if (iswrenchingtool(W))
+				user.visible_message("[user] begins securing the pod's thrusters and control system...")
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_wrench_2, list(user), \
+			 		W.icon, W.icon_state, "[user] secures the pod's thrusters and control system.", null)
+			else
+				boutput(user, "You need a wrench to secure the pod's thrusters and control system.")
+
+		if(5)
+			if (isweldingtool(W))
+				if(!W:try_weld(user, 1))
+					return
+				user.visible_message("[user] begins welding the exterior...")
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_weld_2, list(user), \
+			 		W.icon, W.icon_state, "[user] welds the seams of the outer skin to make it air-tight.", null)
+			else
+				boutput(user, "You need a welder to weld the exterior.")
+
+		if(6)
+			if (isscrewingtool(W))
+				user.visible_message("[user] begins screwing the pod's maintenance panels shut...")
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				SETUP_GENERIC_ACTIONBAR(user, src, step_build_time, /obj/structure/preassembeled_vehicleframe/proc/step_screw_2, list(user), \
+			 		W.icon, W.icon_state, "With the cockpit and exterior indicators secured, the control system automatically starts up.", null)
+			else
+				boutput(user, "You need a screwdriver to close the maintenance panels.")
+
+/obj/structure/preassembeled_vehicleframe/proc/step_wrench_1(var/mob/user)
+	src.overlays += image(src.icon, "[pick("frame1", "frame2")]")
+	stage = 1
+	help_message = "Use a welder to weld the joints together."
+
+/obj/structure/preassembeled_vehicleframe/proc/step_weld_1(var/mob/user)
+	src.overlays -= image(src.icon, "frame1")
+	src.overlays -= image(src.icon, "frame2")
+	icon_state = "frame"
+	stage = 2
+	help_message = "Use a screwdriver to screw the circuit boards and the engine together."
+
+/obj/structure/preassembeled_vehicleframe/proc/step_screw_1(var/mob/user)
+	src.overlays += image(src.icon, "wires")
+	src.overlays += image(src.icon, "circuits")
+	stage = 3
+	help_message = "Use any kind of pod armor from a manufacturer."
+
+/obj/structure/preassembeled_vehicleframe/proc/step_armor(var/mob/user, var/obj/item/podarmor/armor)
+	user.u_equip(armor)
+	qdel(armor)
+	src.overlays += image(src.icon, armor.overlay_state)
+	stage = 4
+	help_message = "Use a wrench to secure the pod's thrusters and control system."
+	armor_type = armor.type
+	src.vehicle_type = armor.vehicle_types["[src.type]"]
+	if(istype(armor, /obj/item/podarmor/armor_custom))
+		src.setMaterial(armor.material)
+
+/obj/structure/preassembeled_vehicleframe/proc/step_wrench_2(var/mob/user)
+	src.overlays += image(src.icon, "thrust")
+	src.overlays += image(src.icon, "control")
+	stage = 5
+	help_message = "Use a welder to weld the exterior."
+
+/obj/structure/preassembeled_vehicleframe/proc/step_weld_2(var/mob/user)
+	src.overlays += image(src.icon, "covers")
+	stage = 6
+	help_message = "Use a screwdriver to close the maintenance panels."
+
+/obj/structure/preassembeled_vehicleframe/proc/step_screw_2(var/mob/user)
+	var/obj/machinery/vehicle/V = new vehicle_type( src.loc )
+	if (src.armor_type == /obj/item/podarmor/armor_custom)
+		V.name = src.vehicle_name
+		V.setMaterial(src.material)
+	logTheThing(LOG_STATION, user, "finishes building a [V] in [get_area(user)] ([log_loc(user)])")
+	qdel(src)
+
+/*-----------------------------*/
+/* Deconstruction              */
+/*-----------------------------*/
+
+/obj/structure/preassembeled_vehicleframe/verb/deconstruct()
+	set src in oview(1)
+	set category = "Local"
+
+	if (usr.stat)
+		return
+
+	boutput(usr, "Deconstructing frame...")
+
+	var/timer = (5 * stage + 30) DECI SECONDS
+
+	SETUP_GENERIC_ACTIONBAR(usr, src, timer, /obj/structure/preassembeled_vehicleframe/proc/deconstruct_done, list(usr), \
+		null, null, "[usr] deconstructed the [src].", null)
+
+/obj/structure/preassembeled_vehicleframe/proc/deconstruct_done(var/mob/user)
+	var/obj/O
+	if (stage >= 4)
+		O = new src.armor_type( get_turf(src) )
+		O.fingerprints = src.fingerprints
+		O.fingerprints_full = src.fingerprints_full
+		if (istype(O,/obj/item/podarmor/armor_custom))
+			O.setMaterial(src.material)
+			src.removeMaterial()
+
+	O = new src.box_type( get_turf(src) )
+	logTheThing(LOG_STATION, usr, "deconstructs [src] in [get_area(usr)] ([log_loc(usr)])")
+	O.fingerprints = src.fingerprints
+	O.fingerprints_full = src.fingerprints_full
+	qdel(src)

--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -247,7 +247,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 			src.removeMaterial()
 
 	O = new src.box_type( get_turf(src) )
-	logTheThing(LOG_STATION, usr, "deconstructs [src] in [get_area(usr)] ([log_loc(usr)])")
+	logTheThing(LOG_STATION, user, "deconstructs [src] in [get_area(user)] ([log_loc(user)])")
 	O.fingerprints = src.fingerprints
 	O.fingerprints_full = src.fingerprints_full
 	qdel(src)

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -413,7 +413,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 		qdel(src)
 
 /obj/item/sub/frame_box
-	name = "Minisib Frame Kit"
+	name = "Minisub Frame Kit"
 	desc = "You can hear an awful lot of junk rattling around in this box."
 	icon = 'icons/obj/electronics.dmi'
 	icon_state = "dbox"
@@ -1230,7 +1230,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin1"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
 
 /obj/item/podarmor/armor_custom
 	name = "Pod Armor"
@@ -1240,7 +1243,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin1"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
 
 /obj/item/podarmor/armor_heavy
 	name = "Heavy Pod Armor"
@@ -1250,7 +1256,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin2"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nanoputt,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/heavy,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/heavy)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/heavy,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nanoputt,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/heavy,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/heavy)
 
 /obj/item/podarmor/nt_light
 	name = "Light NT Pod Armor"
@@ -1259,7 +1268,9 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	icon_state = "dbox"
 	overlay_state = "pod_skinB"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nt_light,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_light)
+		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_light,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nt_light,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_light)
 
 /obj/item/podarmor/nt_robust
 	name = "Robust NT Pod Armor"
@@ -1268,7 +1279,9 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	icon_state = "dbox"
 	overlay_state = "pod_skinBF"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nt_robust,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_robust)
+		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_robust,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/nt_robust,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/nt_robust)
 
 /obj/item/podarmor/sy_light
 	name = "Light Syndicate Pod Armor"
@@ -1277,7 +1290,9 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	icon_state = "dbox"
 	overlay_state = "pod_skinR"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/sy_light,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_light)
+		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_light,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/sy_light,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_light)
 
 /obj/item/podarmor/sy_robust
 	name = "Robust Syndicate Pod Armor"
@@ -1286,7 +1301,9 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	icon_state = "dbox"
 	overlay_state = "pod_skinRF"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/sy_robust,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_robust)
+		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_robust,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/sy_robust,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/sy_robust)
 
 
 /obj/item/podarmor/armor_black
@@ -1297,7 +1314,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin3"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/black,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/black,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/black)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/black,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/black,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/black,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/black)
 
 /obj/item/podarmor/armor_red
 	name = "Syndicate Pod Armor"
@@ -1307,7 +1327,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin2"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/syndiputt,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/syndicate,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/syndisub)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/syndisub,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/syndiputt,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/syndicate,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/syndisub)
 
 /obj/item/podarmor/armor_industrial
 	name = "Industrial Pod Armor"
@@ -1317,7 +1340,10 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	overlay_state = "skin3"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/indyputt,
 		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/industrial,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/industrial)
+		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/industrial,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/indyputt,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/industrial,
+		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/industrial)
 
 /obj/item/podarmor/armor_gold
 	name = "Gold Pod Armor"
@@ -1326,7 +1352,9 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 	icon_state = "dbox"
 	overlay_state = "skin4"
 	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/gold,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/gold)
+		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/gold,
+		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/gold,
+		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/gold)
 
 /obj/item/pod/frame_box
 	name = "Pod Frame Kit"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1451,6 +1451,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\transport\pods\locomotion.dm"
 #include "code\modules\transport\pods\MainWeapon.dm"
 #include "code\modules\transport\pods\pod_lights.dm"
+#include "code\modules\transport\pods\preassembled_frame_kit.dm"
 #include "code\modules\transport\pods\secondary_system.dm"
 #include "code\modules\transport\pods\secondary_weapon.dm"
 #include "code\modules\transport\pods\sensors.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 3 manufacturing recipes: `/datum/manufacture/pod/preassembeled_parts`, `/datum/manufacture/sub/preassembeled_parts` and `/datum/manufacture/putt/preassembeled_parts`.
This PR does not implement them in the game, for atomization's sake, this can be done in another PR for either the regular maps' Ship Component Fabricator and/or the pod wars one.
Preassembled kits result in the same ships as their current counterpart, with the difference that they have:
1. Action bars for building steps
2. "Built-in" Engine manifolds, Circuit boards, Control interfaces, metal, glass and wires.
3. Different building steps that end up in roughly the same amount a time pod used to take to build.
    - The steps are Wrench, Weld, Screw, Put armor, Wrench, Weld, Screw, each with a 10s action bar.  
    **[Recording of a pod construction](https://files.catbox.moe/7a36ut.mp4)**
5. Their cost and build times are upped the sum of the built in parts (roughly)  
    ![image](https://github.com/goonstation/goonstation/assets/6396368/8c0eaf8b-7df2-4ed9-8b0c-f2ef890330e9)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Follow up of an idea I had a year ago: https://forum.ss13.co/showthread.php?tid=17100&pid=183818#pid183818
The pod building experience isn't great. Every time I go back to building a pod for the first time in months, I tend to confuse what's a (Pod) Engine Manifold vs a MiniPutt Engine Manifold vs an actual engine. Every icon being the down arrow mechanic box doesn't help. Having to take a break from pod construction and going out to scavenge for wires or reinforced glass isn't much fun either.
With this new system, all you need is the pod kit, some armor, a wrench, a wielder and a screwdriver. To improve the pod wars experience, we could also have "Building Pods for Dummies" image guides scattered around, listing what you need and what the steps are.
Action bars and help text are nice.

[Vehicles][Rework]