### PR TITLE
Improves iomoon lava tile and fire gib

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1849,7 +1849,7 @@
 
 
 /mob/proc/firegib(var/drop_equipment = TRUE)
-	if (isobserver(src) || isintangible(src))
+	if (isobserver(src))
 		return
 #ifdef DATALOGGER
 	game_stats.Increment("violence")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1848,16 +1848,16 @@
 	qdel(src)
 
 
-/mob/proc/firegib(var/drop_clothes = TRUE)
-	if (isobserver(src)) return
+/mob/proc/firegib(var/drop_equipment = TRUE)
+	if (isobserver(src) || isintangible(src))
+		return
 #ifdef DATALOGGER
 	game_stats.Increment("violence")
 #endif
 	logTheThing(LOG_COMBAT, src, "is fire-gibbed at [log_loc(src)].")
 	src.death(TRUE)
 	var/atom/movable/overlay/gibs/animation = null
-	src.transforming = 1
-	src.canmove = 0
+	src.transforming = TRUE
 	src.icon = null
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_INVISIBILITY, "transform", INVIS_ALWAYS)
 
@@ -1865,23 +1865,23 @@
 		animation = new(src.loc)
 		animation.master = src
 		flick("firegibbed", animation)
-		if (drop_clothes)
+		if (drop_equipment)
 			for (var/obj/item/W in src)
 				if (istype(W, /obj/item/clothing))
 					var/obj/item/clothing/C = W
-					C.stains += "singed"
-					C.UpdateName()
+					C.add_stain("singed")
 			unequip_all()
 
-	if ((src.mind || src.client) && !istype(src, /mob/living/carbon/human/npc))
-		var/mob/dead/observer/newmob = ghostize()
-		newmob.corpse = null
-
-	if (!iscarbon(src))
-		robogibs(src.loc)
+	if (drop_equipment)
+		if (isrobot(src) || isrobocritter(src))
+			robogibs(src.loc)
+		else
+			gibs(src.loc)
 
 	if (animation)
 		animation.delaydispose()
+
+	src.ghostize()
 	qdel(src)
 
 /mob/proc/partygib(give_medal)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1925,31 +1925,28 @@ proc/countJob(rank)
 
 	return 1
 
-/proc/check_target_immunity(var/atom/target, var/ignore_everything_but_nodamage = 0, var/atom/source = 0)
-	var/is_immune = 0
+/proc/check_target_immunity(var/atom/target, var/ignore_everything_but_nodamage = FALSE, var/atom/source = 0)
+	var/is_immune = FALSE
 
-	var/area/a = get_area( target )
-	if( a?.sanctuary )
-		return 1
+	var/area/a = get_area(target)
+	if(a?.sanctuary)
+		return TRUE
 
 	if (isliving(target))
 		var/mob/living/L = target
 
 		if (!isdead(L))
-			if (ignore_everything_but_nodamage == 1)
+			if (ignore_everything_but_nodamage)
 				if (L.nodamage)
-					is_immune = 1
+					is_immune = TRUE
 			else
 				if (L.nodamage || L.spellshield)
-					is_immune = 1
+					is_immune = TRUE
 
 		if (source && istype(source,/obj/projectile) && ishuman(target))
 			var/mob/living/carbon/human/H = target
 			if(H.stance == "dodge") //matrix dodge flip
-				is_immune = 1
-
-	//if (is_immune == 1)
-	//	DEBUG_MESSAGE("[L] is immune to damage, aborting.")
+				is_immune = TRUE
 
 	return is_immune
 

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -432,6 +432,9 @@ SYNDICATE DRONE FACTORY AREAS
 			src.visible_message("<span class='alert'><B>[O]</B> falls into the [src] and melts away!</span>")
 			qdel(O)
 
+/turf/unsimulated/floor/lava/nofly
+	no_fly_zone = TRUE
+
 /obj/decal/lightshaft
 	name = "light"
 	desc = "There's light coming through a hole in the ceiling."

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -377,6 +377,7 @@ SYNDICATE DRONE FACTORY AREAS
 	pathable = FALSE
 	can_replace_with_stuff = TRUE
 	var/deadly = TRUE
+	var/no_fly_zone = FALSE
 
 	Entered(atom/movable/O, atom/old_loc)
 		..()
@@ -389,7 +390,7 @@ SYNDICATE DRONE FACTORY AREAS
 			if (isintangible(O))
 				return
 
-			if (HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING))
+			if (HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING) && !src.no_fly_zone)
 				if (isliving(O))
 					var/mob/living/M = O
 					M.setStatusMin("burning", 5 SECONDS)

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -374,24 +374,32 @@ SYNDICATE DRONE FACTORY AREAS
 	name = "Lava"
 	desc = "The floor is lava. Oh no."
 	icon_state = "lava"
-	var/deadly = 1
-	fullbright = 0
-	pathable = 0
-	can_replace_with_stuff = 1
+	pathable = FALSE
+	can_replace_with_stuff = TRUE
+	var/deadly = TRUE
 
 	Entered(atom/movable/O, atom/old_loc)
 		..()
-		if(src.deadly && !(isnull(old_loc) || O.anchored == 2))
-			if (istype(O, /obj/critter) && O:flying)
-				return
+		if(src.deadly && !(O.anchored == ANCHORED_ALWAYS))
+			return_if_overlay_or_effect(O)
 
-			if (istype(O, /obj/projectile))
+			if (check_target_immunity(O, TRUE))
 				return
 
 			if (isintangible(O))
 				return
 
-			return_if_overlay_or_effect(O)
+			if (HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING))
+				if (isliving(O))
+					var/mob/living/M = O
+					M.setStatusMin("burning", 5 SECONDS)
+				return
+
+			if (istype(O, /obj/critter) && O:flying)
+				return
+
+			if (istype(O, /obj/projectile))
+				return
 
 			if (O.throwing && !isliving(O))
 				SPAWN(0.8 SECONDS)
@@ -400,7 +408,6 @@ SYNDICATE DRONE FACTORY AREAS
 				return
 
 			melt_away(O)
-
 
 	proc/melt_away(atom/movable/O)
 		#ifdef CHECK_MORE_RUNTIMES
@@ -412,17 +419,15 @@ SYNDICATE DRONE FACTORY AREAS
 				var/mob/living/M = O
 				var/mob/living/carbon/human/H = M
 				if (istype(H))
-					H.unkillable = 0
-				if(!M.stat) M.emote("scream")
+					H.unkillable = FALSE
+				if(!M.stat)
+					M.emote("scream")
 				src.visible_message("<span class='alert'><B>[M]</B> falls into the [src] and melts away!</span>")
 				logTheThing(LOG_COMBAT, M, "was firegibbed by [src] ([src.type]) at [log_loc(M)].")
-				M.firegib() // thanks ISN!
+				M.firegib(drop_equipment = FALSE) // thanks ISN!
 		else
 			src.visible_message("<span class='alert'><B>[O]</B> falls into the [src] and melts away!</span>")
 			qdel(O)
-
-	ex_act(severity)
-		return
 
 /obj/decal/lightshaft
 	name = "light"

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -380,7 +380,7 @@ SYNDICATE DRONE FACTORY AREAS
 
 	Entered(atom/movable/O, atom/old_loc)
 		..()
-		if(src.deadly && !(O.anchored == ANCHORED_ALWAYS))
+		if(src.deadly && !(isnull(old_loc) || O.anchored == ANCHORED_ALWAYS))
 			return_if_overlay_or_effect(O)
 
 			if (check_target_immunity(O, TRUE))
@@ -395,8 +395,10 @@ SYNDICATE DRONE FACTORY AREAS
 					M.setStatusMin("burning", 5 SECONDS)
 				return
 
-			if (istype(O, /obj/critter) && O:flying)
-				return
+			if (istype(O, /obj/critter))
+				var/obj/critter/C = O
+				if (C.flying)
+					return
 
 			if (istype(O, /obj/projectile))
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes changes to /turf/unsimulated/floor/lava.
Getting melted doesn't drop equipment (causing runtimes).
Having godmode stops you from getting killed.
Having the floating atom prop stops the melting. If living sets on fire instead. acts the same as before if `no_fly_zone` is TRUE.
Casts object critter so we don't need O:isflying.

Makes changes to proc/fire_gib()
Changes strange carbon check to a robot check for robot gibs.
Removes old `can_move` var that doesn't work anymore.
Just calls ghostize instead of messing around with observer mobs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes are bad. `no_damage` should be no damage. Cuts out redundant code. Fixes up some boolean defines. Only robots should gib into robot parts.


