### PR TITLE
add mister to Atlas and the afterlife bar garden

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -5875,6 +5875,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/hydro_mister,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "atM" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -74601,6 +74601,14 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/sim/gunsim/lobby)
+"uEQ" = (
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1";
+	tag = "icon-line1"
+	},
+/obj/machinery/hydro_mister,
+/turf/unsimulated/floor/grass/random,
+/area/afterlife/heaven/hydroponics)
 "uFv" = (
 /obj/machinery/light{
 	dir = 8;
@@ -133612,7 +133620,7 @@ bQI
 bQI
 bQI
 bko
-bUo
+uEQ
 lmT
 bLw
 bVD


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR simply adds mister machines to hydroponics in atlas and the afterlife bar garden.
atlas:
![image](https://github.com/goonstation/goonstation/assets/58966116/4800f7c4-6c68-477c-a3dc-c4df06cc98d5)
afterlife bar:
![image](https://github.com/goonstation/goonstation/assets/58966116/b5ab7474-67bf-4d0f-9f9b-081c7cc99f5e)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Every other map currently in rotation has one by default, why shouldn't these ones have it as well


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)soapcyst
(+)Added misters to atlas and afterlife bar
```
