### PR TITLE
ABCU marker rectangle select, overwrite notice prompts, better usability

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -365,6 +365,12 @@
 			//rebuild powernets etc.
 */
 
+#define SELECT_SKIP 0
+#define SELECT_FIRST_CORNER 1
+#define DESELECT_FIRST_CORNER 2
+#define SELECT_SECOND_CORNER 3
+#define DESELECT_SECOND_CORNER 4
+
 /obj/item/blueprint_marker
 	name = "Blueprint Marker"
 	desc = "A tool used to map rooms for the creation of blueprints."
@@ -377,7 +383,6 @@
 	w_class = W_CLASS_SMALL
 
 	var/prints_left = 5
-	var/maxSize = 20
 
 	var/mob/using = null
 	var/selecting = 0
@@ -451,6 +456,8 @@
 		var/maxx = 0
 		var/maxy = 0
 
+		var/maxSize = 20
+
 		var/permitted = 0
 		for(var/p in permittedTileTypes)
 			var/type = text2path(p)
@@ -483,18 +490,18 @@
 			return
 
 		switch (selecting)
-			if (0)
+			if (SELECT_SKIP)
 
-			if (1,2) // set to 1 or 2 by use-in-hand option list
+			if (SELECT_FIRST_CORNER, DESELECT_FIRST_CORNER) // set to 1 or 2 by use-in-hand option list
 				qdel(corner1img)
 				selectcorner1 = target
-				selecting += 2 // if 3 then select, if 4 then deselect
+				selecting += 2 // if 3 then select second corner, if 4 then deselect second corner
 				corner1img = image('icons/misc/old_or_unused.dmi', selectcorner1, "marker", layer = HUD_LAYER)
 				user << corner1img
 				playsound(src.loc, 'sound/machines/tone_beep.ogg', 15)
 				return
 
-			if (3,4)
+			if (SELECT_SECOND_CORNER, DESELECT_SECOND_CORNER)
 				var/diffx = abs(target.x - selectcorner1.x)
 				var/diffy = abs(target.y - selectcorner1.y)
 				if(diffx >= maxSize || diffy >= maxSize)
@@ -525,7 +532,7 @@
 							break
 					if(!perm) continue
 
-					if (selecting == 3)
+					if (selecting == SELECT_SECOND_CORNER)
 						if (!roomList.Find(t))
 							roomList.Add(t)
 							roomList[t] = image('icons/misc/old_or_unused.dmi', t, "tiletag", layer = HUD_LAYER)
@@ -535,13 +542,13 @@
 						roomList.Remove(t)
 
 
-				selecting = 0
+				selecting = SELECT_SKIP
 				qdel(corner1img)
 				playsound(src.loc, 'sound/machines/tone_beep.ogg', 15)
 				updateOverlays()
 				return
 
-			else selecting = 0
+			else selecting = SELECT_SKIP
 
 		if(roomList.Find(target))
 			if (using?.client)
@@ -721,9 +728,10 @@
 			return
 
 		if (selecting)
-			selecting = 0
+			selecting = SELECT_SKIP
 			qdel(corner1img)
 			boutput(user, "<span class='notice'>Cancelled rectangle select.</span>")
+			playsound(src.loc, 'sound/machines/button.ogg', 25)
 			return
 
 		var/list/options = list("Select Rectangle", "Deselect Rectangle", "Reset", "Set Blueprint Name", "Print Saved Blueprint",
@@ -732,10 +740,10 @@
 
 		switch(input)
 			if("Select Rectangle")
-				selecting = 1
+				selecting = SELECT_FIRST_CORNER
 
 			if("Deselect Rectangle")
-				selecting = 2
+				selecting = DESELECT_FIRST_CORNER
 
 			if("Reset")
 				boutput(user, "<span class='notice'>Resetting ...</span>")
@@ -798,3 +806,9 @@
 		using = user
 		updateOverlays()
 		return
+
+#undef SELECT_SKIP
+#undef SELECT_FIRST_CORNER
+#undef DESELECT_FIRST_CORNER
+#undef SELECT_SECOND_CORNER
+#undef DESELECT_SECOND_CORNER

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -724,11 +724,9 @@
 		switch(input)
 			if("Select Rectangle")
 				selecting = 1
-				//boutput(user, "<span class='notice'>Target 2 corners to select tiles in a filled rectangle shape.</span>")
 
 			if("Deselect Rectangle")
 				selecting = 2
-				//boutput(user, "<span class='notice'>Mark 2 corners to deselect many tiles in a filled rectangle shape.</span>")
 
 			if("Reset")
 				boutput(user, "<span class='notice'>Resetting ...</span>")

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -436,8 +436,8 @@
 
 	var/static/savefile/save = new/savefile("data/blueprints.dat")
 
-	afterattack(atom/target as mob|obj|turf, mob/user as mob)
-		if(GET_DIST(src,target) > 2) return
+	pixelaction(atom/target as mob|obj|turf, params, mob/user as mob)
+	//	if(GET_DIST(src,target) > 2) return
 
 		if(!isturf(target)) target = get_turf(target)
 
@@ -483,10 +483,12 @@
 			if (using?.client)
 				using.client.images -= roomList[target]
 			roomList.Remove(target)
+			playsound(src.loc, 'sound/machines/button.ogg', 25, 0.1)
 		else
 			roomList.Add(target)
 			roomList[target] = image('icons/misc/old_or_unused.dmi',target,"tiletag", layer = HUD_LAYER)
 			updateOverlays()
+			playsound(src.loc, 'sound/machines/tone_beep.ogg', 15, 0.1)
 
 		return
 

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -761,7 +761,7 @@
 
 			if("Information")
 				var/message = "<span class='notice'>This tool is used for making, saving and loading room blueprints on the server.</span><br>"
-				message += "<span class='notice'>Blueprints persist between rounds, but are limited to a size of 20 tiles on each axis, making 20x20 the largest blueprint.</span><br><br>"
+				message += "<span class='notice'>Saved blueprints persist between rounds, but are limited to a size of 20 tiles on each axis, making 20x20 the largest blueprint.</span><br><br>"
 				message += "<span class='notice'>(De)Select Rectangle: Mass-selects or deselects tiles in a filled rectangle shape, defined by 2 corners.</span><br>"
 				message += "<span class='notice'>Reset: Resets the tools and clears all marked areas.</span><br>"
 				message += "<span class='notice'>Set Blueprint Name: Sets the active blueprint that print/save/delete functions will access.</span><br>"

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -511,10 +511,19 @@
 				var/ix
 				for (ix=0, ix < (diffx + 1) * (diffy + 1), ix++) // add 1 to diffs or a whole row/column of tiles are left out by math
 					var/turf/t = locate(currx, curry, selectedz)
+
 					currx++
 					if (currx > endx)
 						currx = startx
 						curry++
+
+					var/perm = 0
+					for(var/p in permittedTileTypes)
+						var/ttype = text2path(p)
+						if(istype(t, ttype))
+							perm = 1
+							break
+					if(!perm) continue
 
 					if (selecting == 3)
 						if (!roomList.Find(t))

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -436,9 +436,7 @@
 
 	var/static/savefile/save = new/savefile("data/blueprints.dat")
 
-	pixelaction(atom/target as mob|obj|turf, params, mob/user as mob)
-	//	if(GET_DIST(src,target) > 2) return
-
+	pixelaction(atom/target, params, mob/user)
 		if(!isturf(target)) target = get_turf(target)
 
 		var/maxSize = 20

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -760,13 +760,14 @@
 				return
 
 			if("Information")
-				var/message = "<span class='notice'>Blueprint Marker Tool Usage Information:</span><br><br>"
+				var/message = "<span class='notice'>This tool is used for making, saving and loading room blueprints on the server.</span><br>"
+				message += "<span class='notice'>Blueprints persist between rounds, but are limited to a size of 20 tiles on each axis, making 20x20 the largest blueprint.</span><br><br>"
 				message += "<span class='notice'>(De)Select Rectangle: Mass-selects or deselects tiles in a filled rectangle shape, defined by 2 corners.</span><br>"
 				message += "<span class='notice'>Reset: Resets the tools and clears all marked areas.</span><br>"
 				message += "<span class='notice'>Set Blueprint Name: Sets the active blueprint that print/save/delete functions will access.</span><br>"
 				message += "<span class='notice'>Print Saved Blueprint: Prints the active blueprint for usage in the ABCU builder device.</span><br>"
 				message += "<span class='notice'>Save Blueprint: Saves a blueprint of the marked area to the server. Most structures will be saved, but it can not save all types of objects.</span><br>"
-				message += "<span class='notice'>Your saved blueprints carry over to future rounds, and are accessed solely by its Blueprint Name, so note it down.</span><br>"
+				message += "<span class='notice'>Your saved blueprints are accessed solely by its Blueprint Name, so note it down.</span><br>"
 				message += "<span class='notice'>Delete Blueprint: Permanently deletes the active blueprint from the server.</span><br>"
 				boutput(user, message)
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
ABCU marker becomes a lot friendlier to use. Rectangle select for less clicks. Audio feedback added to some actions.
Range limit increased to 10 tiles, and cooldown removed (via changing to pixelaction).
Help/info messages were rewritten to be more clear about the ABCU system as a whole.
User now gets confirmation prompts when overwriting or deleting a saved blueprint.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The marker tool is way less tedious to use now.

**Video clip of rectangle select :)**
https://github.com/goonstation/goonstation/assets/40084056/cb787093-861e-4ec6-ab72-6eb0644b2c41


![dreamseeker_pZgM63KfM6](https://github.com/goonstation/goonstation/assets/40084056/bcfb2f5b-c379-4b6e-82c9-e284e53e142b)
![dreamseeker_Cg1NGjQwcH](https://github.com/goonstation/goonstation/assets/40084056/38ff55db-d4d4-41d0-9723-1796501f2473)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(+)ABCU marker can now rectangle select, and has longer range.
```