### PR TITLE
Don't store state on material trigger procs

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -340,8 +340,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		return
 
 /datum/materialProc/plasmastone
-	var/total_plasma = 200
-
 	execute(var/atom/location) //exp and temp both have the location as first argument so i can use this for both.
 		var/turf/T = get_turf(location)
 		if(!T || T.density || !istype(location))
@@ -349,23 +347,25 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		if(!location.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
 			location.material = location.material.getMutable()
 			return location.material.triggerTemp(location, 0)
+		var/total_plasma = location.material.getProperty("plasma_offgas")
 		if(total_plasma <= 0)
 			if(prob(2) && location)
 				location.visible_message("<span class='alert>[location] dissipates.</span>")
 				qdel(location)
 			return
 		for (var/turf/simulated/floor/target in range(1,location))
-			if(ON_COOLDOWN(target, "plasmastone_plasma_generate", 10 SECONDS)) continue
 			if(!target.gas_impermeable && target.air)
+				if(ON_COOLDOWN(target, "plasmastone_plasma_generate", 10 SECONDS)) continue
 				if(target.parent?.group_processing)
 					target.parent.suspend_group_processing()
 
 				var/datum/gas_mixture/payload = new /datum/gas_mixture
 				payload.toxins = 25 * location.material_amt
-				total_plasma -= payload.toxins / location.material_amt
+				total_plasma -= 1
 				payload.temperature = T20C
 				payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 				target.air.merge(payload)
+				location.material.setProperty("plasma_offgas", total_plasma)
 		return
 
 /datum/materialProc/plasmastone_on_hit
@@ -388,8 +388,8 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/datum/material/crystal/molitz/molitz = src.find_molitz(owner.material)
 		if (!istype(molitz))
 			CRASH("Molitz_temp material proc applied to non-molitz thing") //somehow applied to non-molitz
-
-		if(molitz.iterations <= 0) return
+		var/iterations = owner.material.getProperty("molitz_bubbles")
+		if(iterations <= 0) return
 
 		var/datum/gas_mixture/air
 		if(hasvar(owner, "air_contents"))
@@ -430,7 +430,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			playsound(owner, 'sound/effects/leakoxygen.ogg', 50, 1, 5)
 
 
-		molitz.iterations -= 1
+		molitz.setProperty("molitz_bubbles", iterations-1)
 
 
 /datum/materialProc/molitz_temp/agent_b
@@ -445,23 +445,22 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		if(!istype(owner.material, /datum/material/crystal/molitz))
 			return
 		var/datum/material/crystal/molitz/molitz = owner.material
-		if(molitz.unexploded <= 0)
-			return
+		var/iterations = molitz.getProperty("molitz_bubbles")
+		if(iterations <= 0) return
 		if(!owner.material.isMutable()) //this is a little hacky, but basically ensure it's mutable and then do the trigger
 			owner.material = owner.material.getMutable()
 			return owner.material.triggerExp(owner, sev)
 		var/turf/target = get_turf(owner)
 		if(sev > 0 && sev < 4) // Use pipebombs not canbombs!
-			if(molitz.iterations >= 1)
+			if(iterations >= 1)
 				playsound(owner, 'sound/effects/leakoxygen.ogg', 50, 1, 5)
-			if(molitz.iterations == 0)
+			if(iterations == 0)
 				playsound(owner, 'sound/effects/molitzcrumble.ogg', 50, 1, 5)
 			var/datum/gas_mixture/payload = new /datum/gas_mixture
 			payload.oxygen = 50
 			payload.temperature = T20C
 			target.assume_air(payload)
-			molitz.iterations = 2
-			molitz.unexploded = 0
+			molitz.setProperty("molitz_bubbles", iterations-2)
 
 
 /datum/materialProc/miracle_add

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -353,20 +353,23 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				location.visible_message("<span class='alert>[location] dissipates.</span>")
 				qdel(location)
 			return
+		if(ON_COOLDOWN(location, "plasmastone_plasma_generate", 5 SECONDS)) return
+		var/list/turf/simulated/floor/valid_turfs = list()
 		for (var/turf/simulated/floor/target in range(1,location))
-			if(!target.gas_impermeable && target.air)
-				if(ON_COOLDOWN(target, "plasmastone_plasma_generate", 10 SECONDS)) continue
-				if(target.parent?.group_processing)
-					target.parent.suspend_group_processing()
+			if(target.gas_cross(target) && target.air)
+				valid_turfs += target
+		if(length(valid_turfs))
+			var/turf/simulated/floor/target = pick(valid_turfs)
+			if(target.parent?.group_processing)
+				target.parent.suspend_group_processing()
 
-				var/datum/gas_mixture/payload = new /datum/gas_mixture
-				payload.toxins = 25 * location.material_amt
-				total_plasma -= 1
-				payload.temperature = T20C
-				payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
-				target.air.merge(payload)
-				location.material.setProperty("plasma_offgas", total_plasma)
-		return
+			var/datum/gas_mixture/payload = new /datum/gas_mixture
+			payload.toxins = 25 * location.material_amt
+			total_plasma -= 1
+			payload.temperature = T20C
+			payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
+			target.air.merge(payload)
+			location.material.setProperty("plasma_offgas", total_plasma)
 
 /datum/materialProc/plasmastone_on_hit
 	execute(var/atom/owner)

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -854,13 +854,12 @@ ABSTRACT_TYPE(/datum/material/crystal)
 	desc = "Molitz is a common crystalline substance."
 	color = "#FFFFFF"
 	alpha = 180
-	var/unexploded = 1
-	var/iterations = 4
 
 	New()
 		..()
 		setProperty("density", 3)
 		setProperty("hard", 4)
+		setProperty("molitz_bubbles", 4)
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/molitz_temp())
 		addTrigger(TRIGGERS_ON_EXPLOSION, new /datum/materialProc/molitz_exp())
 
@@ -926,6 +925,7 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("electrical", 5)
 		setProperty("radioactive", 2)
 		setProperty("flammable", 8)
+		setProperty("plasma_offgas", 10)
 
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/plasmastone())
 		addTrigger(TRIGGERS_ON_EXPLOSION, new /datum/materialProc/plasmastone())

--- a/code/modules/materials/Mat_Properties.dm
+++ b/code/modules/materials/Mat_Properties.dm
@@ -279,3 +279,45 @@ ABSTRACT_TYPE(/datum/material_property)
 				return "densely packed with plutonium"
 			if(8 to INFINITY)
 				return "mostly plutonium"
+
+/datum/material_property/molitz_bubbles
+	name = "Gas Pockets"
+	id = "molitz_bubbles"
+
+	min_value = 0
+	prefix_high_min = 0.1
+	prefix_low_max = 9
+	default_value = 0
+
+	getAdjective(var/datum/material/M)
+		switch(M.getProperty(id))
+			if(3 to INFINITY)
+				return "Filled with bubbles"
+			if(1 to 3)
+				return "Lots of small bubbles"
+			else
+				return "Barely any bubbles"
+
+/datum/material_property/plasma_offgas
+	name = "Active Plasma"
+	id = "plasma_offgas"
+
+	min_value = 0
+	prefix_high_min = 0.1
+	prefix_low_max = 9
+	default_value = 0
+
+	getAdjective(var/datum/material/M)
+		switch(M.getProperty(id))
+			if(0 to 1)
+				return "entirely depleted plasma"
+			if(1 to 2)
+				return "mostly depleted plasma"
+			if(2 to 4)
+				return "some active plasma"
+			if(4 to 6)
+				return "about half active plasma"
+			if(6 to 8)
+				return "lots of active plasma"
+			if(8 to INFINITY)
+				return "filled with active plasma"

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -237,23 +237,6 @@
 	default_material = "molitz"
 	crystal = 1
 
-	get_desc()
-		if(!istype(src.material, /datum/material/crystal/molitz))
-			return
-		var/datum/material/crystal/molitz/molitz = src.material
-		if(molitz.iterations == 2 && molitz.unexploded == 0)
-			. += " Fracture lines dash to the small bubbles of gas, getting close to them but not quite reaching them. You fail to spot any large bubbles of gas that havent imploded on themselves."
-		else if(molitz.iterations == 1 && molitz.unexploded == 0)
-			. += " All of the large bubbles of gas and a chunk of the small bubbles of gas are imploded, with fracture lines getting close to the small bubbles that remain."
-		else if(molitz.iterations == 0 && molitz.unexploded == 0)
-			. += " You fail to notice any non collapsed bubbles of gas in the structure."
-		else if(molitz.iterations >= 3)
-			. += " Both large and small bubbles of gas are highly prevalent throughout the crystal."
-		else if(molitz.iterations >= 1)
-			. += " Nearly all of the large bubbles of gas have collapsed, however small bubbles of gas remain embeded in the structure."
-		else if(molitz.iterations == 0)
-			. += " You fail to spot any large bubbles of gas that havent imploded on themselves, the crystal is lodged full with small bubbles of gas."
-
 /obj/item/raw_material/molitz_beta
 	name = "molitz crystal"
 	desc = "An unusual crystal of Molitz."
@@ -265,23 +248,6 @@
 	setup_material()
 		. = ..()
 		src.pressure_resistance = INFINITY //has to be after material setup. REASONS
-
-	get_desc()
-		if(!istype(src.material, /datum/material/crystal/molitz))
-			return
-		var/datum/material/crystal/molitz/molitz = src.material
-		if(molitz.iterations == 2 && molitz.unexploded == 0)
-			. += " Fracture lines dash to the small bubbles of gas, getting close to them but not quite reaching them. You fail to spot any large bubbles of gas that havent imploded on themselves."
-		else if(molitz.iterations == 1 && molitz.unexploded == 0)
-			. += " All of the large bubbles of gas and a chunk of the small bubbles of gas are imploded, with fracture lines getting close to the small bubbles that remain."
-		else if(molitz.iterations == 0 && molitz.unexploded == 0)
-			. += " You fail to notice any non collapsed bubbles of gas in the structure."
-		else if(molitz.iterations >= 3)
-			. += " Both large and small bubbles of gas are highly prevalent throughout the crystal."
-		else if(molitz.iterations >= 1)
-			. += " Nearly all of the large bubbles of gas have collapsed, however small bubbles of gas remain embeded in the structure."
-		else if(molitz.iterations == 0)
-			. += " You fail to spot any large bubbles of gas that havent imploded on themselves, the crystal is lodged full with small bubbles of gas."
 
 /obj/item/raw_material/pharosium
 	name = "pharosium ore"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves molitz and plasma state stuff to the material props instead.

Note this slightly changes the behaviour of molitz and plasmastone.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Clean. Bad practice to store it on the triggers because it violates the whole mutability thing.


```changelog
(u)Amylizzle
(+)Plasmastone now releases its plasma somewhat slower. You can see how much plasma is left using a material analyzer.
(+)You must now use the material analyzer to see how much gas is left in Molitz and Molitz Beta.
```