### PR TITLE
Readds the wannabe pirate costume to the clothing booth

### DIFF
--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1131,6 +1131,10 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/costume)
 	slot = SLOT_WEAR_SUIT
 	cost = PAY_TRADESMAN/2
 
+	/datum/clothingbooth_item/costume/guybrush
+	name = "Wannabe Pirate Costume"
+	path = /obj/item/clothing/under/gimmick/guybrush
+
 //Western
 
 ABSTRACT_TYPE(/datum/clothingbooth_item/western)

--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1128,12 +1128,12 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/costume)
 	/datum/clothingbooth_item/costume/guybrush
 	name = "Wannabe Pirate Costume"
 	path = /obj/item/clothing/under/gimmick/guybrush
+
 /datum/clothingbooth_item/costume/dinosuar
 	name = "Dinosaur Pajamas"
 	path = /obj/item/clothing/suit/gimmick/dinosaur
 	slot = SLOT_WEAR_SUIT
 	cost = PAY_TRADESMAN/2
-
 
 //Western
 

--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1125,7 +1125,7 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/costume)
 	slot = SLOT_HEAD
 	cost = PAY_TRADESMAN/2
 
-	/datum/clothingbooth_item/costume/guybrush
+/datum/clothingbooth_item/costume/guybrush
 	name = "Wannabe Pirate Costume"
 	path = /obj/item/clothing/under/gimmick/guybrush
 

--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1125,15 +1125,15 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/costume)
 	slot = SLOT_HEAD
 	cost = PAY_TRADESMAN/2
 
+	/datum/clothingbooth_item/costume/guybrush
+	name = "Wannabe Pirate Costume"
+	path = /obj/item/clothing/under/gimmick/guybrush
 /datum/clothingbooth_item/costume/dinosuar
 	name = "Dinosaur Pajamas"
 	path = /obj/item/clothing/suit/gimmick/dinosaur
 	slot = SLOT_WEAR_SUIT
 	cost = PAY_TRADESMAN/2
 
-	/datum/clothingbooth_item/costume/guybrush
-	name = "Wannabe Pirate Costume"
-	path = /obj/item/clothing/under/gimmick/guybrush
 
 //Western
 


### PR DESCRIPTION
[Game Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Readds the wannabe pirate costume to the clothing booth, which was (in my opinion) wrongly removed from the clothing booth for being bloat last year.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The only way of obtaining it now is from the novelty clothing crate from cargo, which costs 7500 credits, and defeats the 
 purpose of the clothing booth (providing a reliable and Relatively cheap way of obtaining clothing).
Also it makes sense for there to be a pirate outfit for the two pirate hats that're already in the costumes section