### PR TITLE
add neutral map to pod wars NSV Reliant

### DIFF
--- a/code/datums/gamemodes/pod_wars.dm
+++ b/code/datums/gamemodes/pod_wars.dm
@@ -1,5 +1,6 @@
 #define TEAM_NANOTRASEN 1
 #define TEAM_SYNDICATE 2
+#define TEAM_NEUTRAL 3
 
 #define FORTUNA "FORTUNA"
 #define RELIANT "RELIANT"

--- a/code/modules/minimap/minimap_object.dm
+++ b/code/modules/minimap/minimap_object.dm
@@ -171,6 +171,17 @@
 			STOP_TRACKING
 			. = ..()
 
+	both_teams
+		map_type = MAP_POD_WARS_NANOTRASEN | MAP_POD_WARS_SYNDICATE
+
+		New()
+			. = ..()
+			START_TRACKING
+
+		disposing()
+			STOP_TRACKING
+			. = ..()
+
 /obj/minimap_controller
 	name = "Map Controller"
 	layer = TURF_LAYER
@@ -429,8 +440,18 @@ ABSTRACT_TYPE(/obj/machinery/computer/pod_wars_minimap_controller)
 					src.minimap_controller = new(minimap)
 					src.minimap_ui = new(src, "synd_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "syndicate")
 
+			if (TEAM_NEUTRAL)
+				for_by_tcl(map, /obj/minimap/map_computer/pod_wars/both_teams)
+					minimap = map
+
+				if (minimap)
+					src.minimap_controller = new(minimap)
+					src.minimap_ui = new(src, "neutral_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "retro-dark")
 	nanotrasen
 		team_num = TEAM_NANOTRASEN
 
 	syndicate
 		team_num = TEAM_SYNDICATE
+
+	neutral
+		team_num = TEAM_NEUTRAL

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -211,9 +211,7 @@
 "aX" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "aY" = (
 /obj/stool/chair{
@@ -366,9 +364,14 @@
 	},
 /area/pod_wars/spacejunk/miningoutpost)
 "bE" = (
-/obj/storage/crate,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/black,
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/communications_dish,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
 /area/pod_wars/spacejunk/reliant)
 "bF" = (
 /turf/simulated/floor/black,
@@ -378,9 +381,7 @@
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "bH" = (
 /obj/machinery/light/incandescent/netural,
@@ -543,9 +544,7 @@
 "cp" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/access/heads,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "cq" = (
 /obj/grille/catwalk{
@@ -596,9 +595,7 @@
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/spraybottle/cleaner/tsunami,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "cx" = (
 /obj/machinery/optable,
@@ -655,9 +652,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "cJ" = (
 /obj/cable{
@@ -706,9 +701,7 @@
 	dir = 8
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "cU" = (
 /obj/cable{
@@ -798,9 +791,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "do" = (
 /obj/cable{
@@ -859,9 +850,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "dD" = (
 /obj/machinery/neosmelter,
@@ -1048,9 +1037,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/machinery/recharger,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "eq" = (
 /obj/table/auto,
@@ -1082,9 +1069,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "ev" = (
 /obj/disposalpipe/segment,
@@ -1268,9 +1253,7 @@
 /turf/simulated/floor/airless/plating,
 /area/space)
 "eR" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "eS" = (
 /obj/cable{
@@ -1341,9 +1324,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "fe" = (
 /obj/mapping_helper/wingrille_spawn/auto,
@@ -1359,8 +1340,8 @@
 "fj" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
-	pixel_x = -10;
-	nostick = 1
+	nostick = 1;
+	pixel_x = -10
 	},
 /turf/unsimulated/floor/blue/side{
 	dir = 9
@@ -1373,9 +1354,7 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "fn" = (
 /obj/table/auto,
@@ -1393,9 +1372,7 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "fo" = (
 /obj/cable{
@@ -1578,9 +1555,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "fV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -1652,17 +1627,13 @@
 "gg" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "gh" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "gi" = (
 /obj/lattice,
@@ -1715,9 +1686,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "gw" = (
 /obj/storage/secure/closet/fridge,
@@ -1842,9 +1811,7 @@
 /obj/mopbucket,
 /obj/machinery/light/incandescent/netural,
 /obj/item/reagent_containers/glass/bucket,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "gU" = (
 /turf/simulated/floor/blue/side{
@@ -1909,10 +1876,25 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
+"hg" = (
+/obj/storage/closet,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/spraybottle/cleaner,
+/obj/item/spraybottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "hh" = (
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4;
@@ -2123,15 +2105,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "hR" = (
 /obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/bridge)
 "hS" = (
 /obj/machinery/light/incandescent{
@@ -2219,9 +2197,7 @@
 "ij" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/bar)
 "ik" = (
 /obj/disposalpipe/segment{
@@ -2269,9 +2245,7 @@
 "ir" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "is" = (
 /turf/simulated/floor,
@@ -2292,9 +2266,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "ix" = (
 /obj/machinery/power/apc/autoname_north,
@@ -2322,6 +2294,10 @@
 /obj/item/organ/eye,
 /turf/simulated/wall/auto/asteroid/pod_wars,
 /area/pod_wars/asteroid/minor/nospawn)
+"iC" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/reliant)
 "iD" = (
 /obj/stool/chair/office/red{
 	dir = 1
@@ -2339,16 +2315,12 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "iI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "iK" = (
 /turf/simulated/floor/green/side{
@@ -2362,6 +2334,9 @@
 /obj/machinery/light/incandescent/netural,
 /obj/storage/crate,
 /obj/random_item_spawner/med_kit/maybe_few,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "iN" = (
@@ -2371,8 +2346,13 @@
 	},
 /area/pod_wars/spacejunk/fstation)
 "iP" = (
-/obj/shrub/captainshrub,
-/turf/simulated/floor/black,
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/space,
 /area/pod_wars/spacejunk/reliant)
 "iR" = (
 /obj/cable{
@@ -2446,9 +2426,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "jq" = (
 /turf/unsimulated/floor/blue/side{
@@ -2604,9 +2582,7 @@
 "jT" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "jU" = (
 /obj/machinery/r_door_control/podbay/t1d2/new_walls/west,
@@ -2623,9 +2599,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "jY" = (
 /obj/machinery/vehicle/pod_wars_dingy/nanotrasen/mining{
@@ -2644,9 +2618,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "kb" = (
 /obj/rack,
@@ -2694,6 +2666,12 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/pod_wars/spacejunk/fstation/computercore)
+"kk" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "kl" = (
 /obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
@@ -2715,6 +2693,13 @@
 	dir = 6
 	},
 /area/pod_wars/team1/mining)
+"kq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/reliant)
 "kr" = (
 /obj/storage/crate,
 /obj/random_item_spawner/tools/maybe_few,
@@ -2826,9 +2811,7 @@
 /area/pod_wars/spacejunk/fstation)
 "kM" = (
 /obj/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "kN" = (
 /obj/machinery/light/incandescent/netural,
@@ -2866,10 +2849,14 @@
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
 "kV" = (
-/obj/control_point_computer{
-	dir = 4;
-	name = "Reliant Control Console"
+/obj/item/device/radio/intercom{
+	desc = "A powerful radio transmitter. Enable the microphone to begin broadcasting your radio show.";
+	device_color = "#E52780";
+	icon = 'icons/obj/radiostation.dmi';
+	icon_state = "mixtable-1";
+	name = "broadcast radio"
 	},
+/obj/table/wood/auto,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "kW" = (
@@ -2877,9 +2864,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "kX" = (
 /obj/submachine/chem_extractor{
@@ -2890,9 +2875,7 @@
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "kZ" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "la" = (
 /obj/machinery/nanofab/refining,
@@ -2969,9 +2952,7 @@
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "ln" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "lo" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -3004,8 +2985,11 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
 "ly" = (
-/obj/submachine/tape_deck,
-/obj/machinery/light/incandescent/netural,
+/obj/submachine/mixing_desk,
+/obj/table/wood/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "lA" = (
@@ -3076,8 +3060,8 @@
 	},
 /area/pod_wars/team1/bridge)
 "lM" = (
-/obj/rack,
-/obj/random_item_spawner/hat/one,
+/obj/submachine/record_player,
+/obj/table/wood/auto,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "lN" = (
@@ -3210,6 +3194,15 @@
 "mp" = (
 /turf/simulated/floor/circuit/off,
 /area/pod_wars/spacejunk/memorial_stats)
+"mq" = (
+/obj/submachine/chef_sink{
+	density = 0;
+	dir = 8;
+	name = "utility sink";
+	pixel_y = 3
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "ms" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
@@ -3300,9 +3293,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "mF" = (
 /obj/machinery/light/incandescent/netural,
@@ -3333,16 +3324,12 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "mO" = (
 /obj/machinery/light/incandescent/netural,
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "mP" = (
 /obj/machinery/power/tracker/diner,
@@ -3389,9 +3376,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "mW" = (
 /obj/storage/crate,
@@ -3633,9 +3618,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "nR" = (
 /obj/storage/crate,
@@ -3671,9 +3654,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "nY" = (
 /obj/cable{
@@ -3728,7 +3709,8 @@
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/fstation)
 "og" = (
-/obj/table/reinforced/auto,
+/obj/submachine/tape_deck,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "oi" = (
@@ -3768,9 +3750,7 @@
 "or" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "os" = (
 /obj/indestructible/shuttle_corner{
@@ -3792,9 +3772,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "oy" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -3920,9 +3898,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/heads,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/bridge)
 "oU" = (
 /obj/potted_plant/potted_plant5,
@@ -4036,7 +4012,9 @@
 	},
 /area/pod_wars/spacejunk/restaurant/solars)
 "po" = (
-/obj/table/reinforced/auto,
+/obj/stool/chair/office/red{
+	dir = 1
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -4063,9 +4041,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "pv" = (
 /turf/unsimulated/floor/blue/side{
@@ -4074,9 +4050,7 @@
 /area/pod_wars/team1/bridge)
 "px" = (
 /obj/machinery/drainage,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "pz" = (
 /turf/unsimulated/floor/yellow/corner{
@@ -4160,13 +4134,7 @@
 	},
 /area/pod_wars/spacejunk/nancy/landingpad)
 "pI" = (
-/obj/machinery/computer/power_monitor/console_upper{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
+/obj/mic_stand,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "pL" = (
@@ -4277,9 +4245,7 @@
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/spraybottle/cleaner/tsunami,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "pZ" = (
 /obj/cable{
@@ -4382,9 +4348,7 @@
 "qs" = (
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /obj/mapping_helper/access/heads,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "qt" = (
 /obj/cable{
@@ -4429,9 +4393,7 @@
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "qD" = (
 /obj/storage/closet,
@@ -4448,9 +4410,7 @@
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/spraybottle/cleaner/tsunami,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/spacejunk/uvb67/crew)
 "qE" = (
 /obj/grille/catwalk{
@@ -4509,15 +4469,9 @@
 /turf/simulated/wall/auto/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_14)
 "qK" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "It seems to be locked";
-	dir = 4;
-	icon = 'icons/obj/computerpanel.dmi';
-	icon_state = "engine1";
-	name = "Engineering Console"
-	},
+/obj/table/wood/auto,
+/obj/machinery/light/incandescent/netural,
+/obj/item/storage/box/record/radio/host,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "qM" = (
@@ -4635,8 +4589,24 @@
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/starboardhall)
 "rl" = (
-/obj/submachine/record_player,
-/obj/table/wood/auto,
+/obj/storage/crate/bin,
+/obj/item/radio_tape/advertisement/grones{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio_tape/audio_book/heisenbee,
+/obj/item/radio_tape/advertisement/danitos_burritos{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/radio_tape/advertisement/quik_noodles{
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/item/radio_tape/advertisement/captain_psa{
+	pixel_x = -8;
+	pixel_y = 6
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "rm" = (
@@ -4654,9 +4624,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "rp" = (
 /obj/stool/chair/comfy/blue,
@@ -4678,9 +4646,7 @@
 /turf/space,
 /area/pod_wars/spacejunk/dorgun)
 "rt" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/power)
 "rw" = (
 /obj/machinery/vending/medical_public,
@@ -4754,9 +4720,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "rN" = (
 /obj/table/auto,
@@ -4833,9 +4797,7 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/corner/extra_big,
 /obj/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "se" = (
 /obj/cable{
@@ -4882,9 +4844,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "sp" = (
 /obj/decal/fakeobjects{
@@ -5036,9 +4996,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "sW" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t2condoor_horizontal,
@@ -5074,9 +5032,8 @@
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "td" = (
-/obj/stool/chair/comfy/shuttle/pilot{
-	dir = 8
-	},
+/obj/table/wood/auto,
+/obj/item/storage/box/record/radio/host,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "te" = (
@@ -5084,6 +5041,13 @@
 	dir = 4
 	},
 /area/pod_wars/team2/bridge)
+"tf" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/pod_wars_minimap_controller/neutral,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "th" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -5246,9 +5210,7 @@
 	dir = 8;
 	pixel_x = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "tR" = (
 /obj/cable{
@@ -5288,12 +5250,7 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "tY" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/glass/command{
-	req_access = null
-	},
+/obj/stool/chair/comfy/yellow,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "ua" = (
@@ -5483,9 +5440,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "uB" = (
 /obj/cable{
@@ -5599,9 +5554,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "va" = (
 /obj/cable{
@@ -5760,8 +5713,8 @@
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/fstation)
 "vD" = (
-/obj/table/wood/auto,
-/obj/item/storage/box/record/radio/host,
+/obj/stool/chair/comfy/yellow,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "vE" = (
@@ -5794,9 +5747,7 @@
 	icon_state = "hazard_delivery"
 	},
 /obj/machinery/manufacturer/mining/pod_wars/nanotrasen,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "vJ" = (
 /obj/grille/catwalk{
@@ -5827,6 +5778,11 @@
 	dir = 1
 	},
 /area/pod_wars/team2/central_hallway)
+"vM" = (
+/obj/storage/crate,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "vN" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -5943,9 +5899,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/bridge)
 "wi" = (
 /obj/machinery/light/incandescent/netural,
@@ -5958,12 +5912,8 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/bar)
 "wk" = (
-/obj/stool/chair/comfy/shuttle/pilot{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/table/reinforced/auto,
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "wl" = (
@@ -5994,7 +5944,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/drainage,
+/obj/machinery/door/airlock/pyro/glass/command{
+	req_access = null
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "wp" = (
@@ -6070,9 +6022,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "wG" = (
 /obj/grille/catwalk{
@@ -6125,16 +6075,12 @@
 /obj/forcefield/energyshield/perma{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "wP" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/corner/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "wQ" = (
 /obj/machinery/portable_reclaimer,
@@ -6154,9 +6100,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "wU" = (
 /obj/machinery/light/incandescent/netural,
@@ -6177,9 +6121,12 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "wZ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "xa" = (
@@ -6354,10 +6301,9 @@
 	},
 /area/pod_wars/spacejunk/fstation/mess)
 "xz" = (
-/obj/submachine/mixing_desk,
-/obj/table/wood/auto,
+/obj/machinery/light/incandescent/netural,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -6404,9 +6350,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "xG" = (
 /obj/machinery/power/terminal,
@@ -6531,9 +6475,7 @@
 /obj/item/device/gps{
 	pixel_x = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "yj" = (
 /obj/decal/tile_edge{
@@ -6557,9 +6499,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/medbay)
 "yn" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "yo" = (
 /obj/stool/chair/couch{
@@ -6691,15 +6631,26 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "yP" = (
-/obj/stool/chair/comfy/shuttle/red{
-	dir = 8
+/obj/minimap/map_computer/pod_wars/both_teams{
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"yQ" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/warp_beacon/pod_wars{
+	control_point = "RELIANT";
+	name = "NSV Reliant"
+	},
+/obj/cable,
+/turf/space,
 /area/pod_wars/spacejunk/reliant)
 "yR" = (
 /obj/cable{
@@ -6836,9 +6787,7 @@
 	dir = 8;
 	pixel_x = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/bar)
 "zu" = (
 /obj/machinery/conveyor/NS{
@@ -6854,18 +6803,14 @@
 "zw" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/power)
 "zx" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "zz" = (
 /obj/machinery/light/incandescent/netural,
@@ -7018,9 +6963,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "Ag" = (
 /obj/cable{
@@ -7045,9 +6988,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Ao" = (
 /obj/lattice{
@@ -7266,15 +7207,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/porthall)
 "Bg" = (
 /obj/machinery/light/small/floor/netural,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "Bh" = (
 /obj/machinery/r_door_control/podbay/t1d4/new_walls/east,
@@ -7340,20 +7277,10 @@
 	},
 /area/pod_wars/spacejunk/miningoutpost)
 "Bq" = (
-/obj/storage/closet,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/spraybottle/cleaner,
-/obj/item/spraybottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/obj/item/spraybottle/cleaner/tsunami,
+/obj/stool/chair/comfy/yellow{
+	dir = 1
+	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Br" = (
@@ -7421,11 +7348,10 @@
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "BG" = (
-/obj/stool/chair/office/red{
-	dir = 1
-	},
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/junk/one_or_zero,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -7470,16 +7396,14 @@
 	dir = 1
 	},
 /obj/reagent_dispensers/fueltank,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "BO" = (
 /obj/landmark/start/latejoin,
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
-	pixel_x = 10;
-	nostick = 1
+	nostick = 1;
+	pixel_x = 10
 	},
 /turf/unsimulated/floor/blue/side{
 	dir = 5
@@ -7720,9 +7644,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "CT" = (
 /obj/machinery/vending/snack,
@@ -7785,9 +7707,7 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "Dh" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
@@ -7799,9 +7719,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Dj" = (
 /obj/machinery/r_door_control/podbay/t2d1/new_walls/west,
@@ -7876,9 +7794,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "DD" = (
 /turf/simulated/floor/circuit/off,
@@ -7996,9 +7912,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/syndie_shuttle,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/power)
 "DZ" = (
 /obj/table/auto,
@@ -8042,8 +7956,8 @@
 /area/pod_wars/team1/starboardhall)
 "Eg" = (
 /obj/indestructible/shuttle_corner{
-	icon_state = "wall_trans";
-	dir = 1
+	dir = 1;
+	icon_state = "wall_trans"
 	},
 /turf/space,
 /area/pod_wars/spacejunk/brightwell)
@@ -8069,9 +7983,7 @@
 /obj/item/device/gps{
 	pixel_x = -4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Ej" = (
 /obj/machinery/chem_dispenser/alcohol,
@@ -8081,9 +7993,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "El" = (
 /obj/grille/catwalk{
@@ -8201,11 +8111,6 @@
 "EL" = (
 /turf/space,
 /area/pod_wars/asteroid/major/maj_14)
-"EN" = (
-/obj/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
 "EO" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -8222,7 +8127,6 @@
 /area/space)
 "EQ" = (
 /obj/machinery/r_door_control/podbay/t2d4/new_walls/north{
-	pixel_w = 0;
 	pixel_x = 10
 	},
 /obj/machinery/r_door_control/podbay/t2d3/new_walls/north{
@@ -8372,9 +8276,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Fr" = (
 /obj/cable{
@@ -8466,13 +8368,14 @@
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
 "FL" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/computer/power_monitor/console_upper{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/space,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "FM" = (
 /obj/machinery/light/incandescent/netural,
@@ -8510,9 +8413,7 @@
 	icon_state = "hazard_delivery"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "FV" = (
 /turf/unsimulated/floor/yellow/side{
@@ -8541,9 +8442,7 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/syndie_shuttle,
 /obj/forcefield/energyshield/perma,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "Gb" = (
 /obj/grille/catwalk{
@@ -8801,9 +8700,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "Hi" = (
 /obj/grille/catwalk{
@@ -9028,9 +8925,7 @@
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "HT" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/bridge)
 "HU" = (
 /obj/stool/bar,
@@ -9255,9 +9150,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "IT" = (
 /obj/stool/chair/comfy/blue{
@@ -9271,9 +9164,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "IV" = (
 /obj/machinery/disposal/small/east,
@@ -9471,14 +9362,13 @@
 	},
 /area/pod_wars/spacejunk/fstation/power)
 "JF" = (
-/obj/lattice{
-	icon_state = "lattice-dir-b"
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
 	},
-/obj/machinery/communications_dish,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/space,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "JG" = (
 /obj/machinery/door/airlock/pyro/alt,
@@ -9599,10 +9489,14 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
+"Kb" = (
+/obj/stool/chair/comfy/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Kd" = (
 /obj/machinery/light/incandescent/netural,
 /obj/disposalpipe/segment{
@@ -9617,16 +9511,13 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/bridge)
 "Ki" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir-b"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/warp_beacon/pod_wars{
-	control_point = "RELIANT";
-	name = "NSV Reliant"
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/cable,
-/turf/space,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Kk" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
@@ -9727,11 +9618,10 @@
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "KD" = (
-/obj/submachine/chef_sink{
-	density = 0;
-	dir = 8;
-	name = "utility sink";
-	pixel_y = 3
+/obj/machinery/computer/announcement/console_lower{
+	dir = 4;
+	name = "NSV Reliant Announcement Computer";
+	req_access = null
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -9855,9 +9745,7 @@
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Ld" = (
 /obj/cable{
@@ -9896,8 +9784,8 @@
 /area/pod_wars/team2/bar)
 "Ll" = (
 /obj/indestructible/shuttle_corner{
-	icon_state = "wall_trans";
-	dir = 8
+	dir = 8;
+	icon_state = "wall_trans"
 	},
 /turf/space,
 /area/pod_wars/spacejunk/brightwell)
@@ -9990,9 +9878,7 @@
 /area/pod_wars/spacejunk/dorgun)
 "LK" = (
 /obj/landmark/start/job/podwars/syndie,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "LL" = (
 /obj/machinery/power/smes/magical,
@@ -10175,9 +10061,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "MA" = (
 /obj/cable{
@@ -10191,9 +10075,7 @@
 /area/pod_wars/team1/mining)
 "MB" = (
 /obj/machinery/drainage,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/bar)
 "MD" = (
 /turf/simulated/wall/auto/reinforced,
@@ -10220,16 +10102,8 @@
 	},
 /area/pod_wars/spacejunk/snackstand)
 "MK" = (
-/obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/item/kitchen/food_box/lollipop,
-/obj/cable{
-	icon_state = "1-2"
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -10299,9 +10173,7 @@
 	},
 /area/pod_wars/spacejunk/fstation)
 "MW" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "MX" = (
 /obj/stool/chair{
@@ -10312,9 +10184,7 @@
 /area/pod_wars/spacejunk/fstation/observatory)
 "Na" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Nd" = (
 /obj/stool/bench/red,
@@ -10422,9 +10292,7 @@
 "NF" = (
 /obj/landmark/start/job/podwars/NT,
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "NG" = (
 /obj/machinery/deep_fryer,
@@ -10613,9 +10481,14 @@
 /turf/simulated/floor/blueblack,
 /area/pod_wars/spacejunk/memorial_stats)
 "On" = (
-/obj/table/wood/auto,
-/obj/machinery/light/incandescent/netural,
-/obj/item/storage/box/record/radio/host,
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/shrub/dead{
+	pixel_y = 12
+	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Oo" = (
@@ -10661,9 +10534,7 @@
 /obj/item/device/gps{
 	pixel_x = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Ou" = (
 /obj/machinery/computer/solar_control/west{
@@ -10690,18 +10561,14 @@
 /obj/table/auto,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "Oz" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack,
 /obj/item/sheet/steel/fullstack,
 /obj/item/storage/box/cablesbox,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "OB" = (
 /turf/unsimulated/floor/red/side{
@@ -10749,9 +10616,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "OP" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -10905,6 +10770,11 @@
 "Pz" = (
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"PA" = (
+/obj/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "PB" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -10939,9 +10809,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "PF" = (
 /obj/lattice,
@@ -10975,9 +10843,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/heads,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "PJ" = (
 /obj/machinery/light/incandescent/netural,
@@ -11025,9 +10891,7 @@
 /area/pod_wars/team1/mining)
 "PR" = (
 /obj/landmark/start/job/podwars/NT,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/mining)
 "PS" = (
 /obj/item_dispenser/barricade,
@@ -11167,24 +11031,7 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "Qu" = (
-/obj/storage/crate/bin,
-/obj/item/radio_tape/advertisement/grones{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio_tape/audio_book/heisenbee,
-/obj/item/radio_tape/advertisement/danitos_burritos{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/radio_tape/advertisement/quik_noodles{
-	pixel_x = 2;
-	pixel_y = -6
-	},
-/obj/item/radio_tape/advertisement/captain_psa{
-	pixel_x = -8;
-	pixel_y = 6
-	},
+/obj/table/reinforced/auto,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Qv" = (
@@ -11264,14 +11111,10 @@
 /turf/unsimulated/floor/red/side,
 /area/pod_wars/team2/central_hallway)
 "QM" = (
-/obj/item/device/radio/intercom{
-	desc = "A powerful radio transmitter. Enable the microphone to begin broadcasting your radio show.";
-	device_color = "#E52780";
-	icon = 'icons/obj/radiostation.dmi';
-	icon_state = "mixtable-1";
-	name = "broadcast radio"
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/table/wood/auto,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "QO" = (
@@ -11297,7 +11140,9 @@
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "QU" = (
-/obj/mic_stand,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "QV" = (
@@ -11318,9 +11163,7 @@
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "QZ" = (
 /obj/stool/bench/green,
@@ -11338,10 +11181,15 @@
 	},
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/manufacturing)
+"Rd" = (
+/obj/rack,
+/obj/random_item_spawner/hat/one,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Re" = (
 /obj/indestructible/shuttle_corner{
-	icon_state = "wall_trans";
-	dir = 5
+	dir = 5;
+	icon_state = "wall_trans"
 	},
 /turf/space,
 /area/pod_wars/spacejunk/brightwell)
@@ -11445,6 +11293,10 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/reliant)
+"RB" = (
+/obj/shrub/captainshrub,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "RC" = (
 /obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/wood/seven,
@@ -11466,9 +11318,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "RK" = (
 /obj/machinery/manufacturer/medical/pod_wars,
@@ -11548,11 +11398,17 @@
 /obj/machinery/chem_dispenser/medical,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
+"Sa" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Sb" = (
-/obj/machinery/computer/announcement/console_lower{
+/obj/control_point_computer{
 	dir = 4;
-	name = "NSV Reliant Announcement Computer";
-	req_access = null
+	name = "Reliant Control Console"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -11560,9 +11416,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "Sf" = (
 /obj/machinery/vending/coffee,
@@ -11580,9 +11434,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "Sk" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Sl" = (
 /obj/storage/closet,
@@ -11627,9 +11479,7 @@
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/storage/box/cablesbox,
 /obj/machinery/recharger,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "Sq" = (
 /obj/cable{
@@ -11719,9 +11569,7 @@
 /obj/machinery/light/incandescent/netural,
 /obj/mopbucket,
 /obj/item/reagent_containers/glass/bucket/red,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/bar)
 "SI" = (
 /obj/storage/crate,
@@ -11748,9 +11596,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "SP" = (
 /obj/machinery/vending/cola/blue,
@@ -11846,9 +11692,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/sheet/steel/fullstack,
 /obj/item/storage/box/cablesbox,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/powergen)
 "Tb" = (
 /obj/cable{
@@ -11923,9 +11767,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Tt" = (
 /obj/submachine/foodprocessor,
@@ -11954,11 +11796,16 @@
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
 "Tz" = (
+/obj/table/reinforced/auto,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
+	},
+/obj/item/kitchen/food_box/lollipop,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -11981,9 +11828,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "TF" = (
 /obj/machinery/recharger/wall{
@@ -12190,14 +12035,10 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Ux" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "Uy" = (
 /obj/lattice{
@@ -12280,9 +12121,7 @@
 /area/pod_wars/spacejunk/uvb67/central)
 "UO" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/manufacturing)
 "UP" = (
 /obj/cable{
@@ -12369,9 +12208,7 @@
 "Vf" = (
 /obj/machinery/light/incandescent/netural,
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "Vg" = (
 /obj/lattice,
@@ -12422,9 +12259,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Vs" = (
 /obj/machinery/light/incandescent/netural,
@@ -12492,9 +12327,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "VE" = (
 /obj/machinery/chem_dispenser/medical,
@@ -12771,8 +12604,8 @@
 "WH" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
-	pixel_x = 10;
-	nostick = 1
+	nostick = 1;
+	pixel_x = 10
 	},
 /turf/unsimulated/floor/blue/side{
 	dir = 5
@@ -12806,9 +12639,7 @@
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/storage/box/cablesbox,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/storage)
 "WP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12883,14 +12714,11 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/observatory)
 "Xf" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "It seems to be locked";
-	dir = 4;
-	icon = 'icons/obj/computerpanel.dmi';
-	icon_state = "securitycomputer2";
-	name = "Weapons Console"
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -12935,14 +12763,15 @@
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
 "Xs" = (
-/obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "It seems to be locked";
+	dir = 4;
+	icon = 'icons/obj/computerpanel.dmi';
+	icon_state = "engine1";
+	name = "Engineering Console"
 	},
-/obj/shrub/dead{
-	pixel_y = 12
-	},
-/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Xt" = (
@@ -13028,9 +12857,7 @@
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/spraybottle/cleaner/tsunami,
 /obj/item/spraybottle/cleaner/tsunami,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/bar)
 "XG" = (
 /turf/simulated/floor/airless/plating,
@@ -13318,9 +13145,7 @@
 /obj/item/device/gps{
 	pixel_x = -4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "YH" = (
 /obj/grille/catwalk{
@@ -13370,9 +13195,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "YP" = (
 /turf/simulated/floor/blueblack{
@@ -13389,9 +13212,7 @@
 	dir = 5
 	},
 /obj/table/wood/round/champagne,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "YT" = (
 /obj/deployable_turret/pod_wars/sy/activated/west,
@@ -13399,9 +13220,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "YU" = (
 /obj/machinery/light/incandescent/netural,
@@ -13458,9 +13277,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/hangar)
 "Zg" = (
 /turf/simulated/floor/red/side,
@@ -13484,9 +13301,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/central_hallway)
 "Zl" = (
 /obj/table/reinforced/bar/auto,
@@ -13496,9 +13311,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "Zn" = (
 /obj/machinery/door/airlock/pyro/glass/med,
@@ -13564,9 +13377,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team2/mining)
 "ZD" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -13597,9 +13408,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/pod_wars/team1/hangar)
 "ZL" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -13657,11 +13466,14 @@
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation/crewquarters)
 "ZW" = (
-/obj/stool/chair/comfy/shuttle/red{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "It seems to be locked";
+	dir = 4;
+	icon = 'icons/obj/computerpanel.dmi';
+	icon_state = "securitycomputer2";
+	name = "Weapons Console"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -124860,14 +124672,14 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+vR
+Tr
+Tr
+Tr
+Tr
+Tr
+Tr
+pg
 JW
 JW
 JW
@@ -125361,16 +125173,16 @@ JW
 JW
 JW
 JW
+vR
+Va
 JW
 JW
 JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
+Jn
+pg
 JW
 JW
 JW
@@ -125863,6 +125675,7 @@ JW
 JW
 JW
 JW
+ge
 JW
 JW
 JW
@@ -125871,8 +125684,7 @@ JW
 JW
 JW
 JW
-JW
-JW
+ge
 JW
 JW
 JW
@@ -126365,16 +126177,16 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+fV
 JW
 JW
 JW
@@ -126865,20 +126677,20 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+fV
+fV
+VQ
+FL
+KD
+bC
+Sb
+Xs
+ZW
+VQ
+fV
+fV
+fV
 JW
 JW
 JW
@@ -127364,26 +127176,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+fV
+fV
+fV
+rl
+GI
+bC
+JF
+MK
+bC
+bC
+MK
+MK
+bC
+GI
+RB
+fV
+fV
+fV
+fV
 JW
 JW
 JW
@@ -127866,26 +127678,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-vR
-Tr
-Tr
-Tr
-Tr
-Tr
-Tr
-pg
-JW
-JW
-JW
-JW
-JW
-JW
+iC
+kV
+og
+pI
+bC
+GI
+bC
+FB
+bC
+bC
+bC
+bC
+bC
+bC
+GI
+bC
+ls
+vM
+Rd
+iC
 JW
 JW
 JW
@@ -128363,36 +128175,36 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-vR
-Va
-JW
-JW
-JW
-JW
-JW
-JW
-Jn
-pg
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+bE
+iP
+iP
+iP
+iP
+kq
+ly
+po
+pL
+pL
+wo
+pL
+Ki
+On
+QM
+Tz
+On
+pL
+pL
+wo
+pL
+pL
+pL
+Sa
+kq
+iP
+iP
+iP
+iP
+yQ
 JW
 JW
 JW
@@ -128870,26 +128682,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-ge
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-ge
-JW
-JW
-JW
-JW
-JW
+iC
+lM
+bC
+bC
+bC
+GI
+bC
+bC
+Qu
+QU
+Xf
+Qu
+bC
+bC
+GI
+bC
+bC
+PA
+mq
+iC
 JW
 JW
 JW
@@ -129372,26 +129184,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
 fV
-GI
-GI
-GI
-GI
-GI
-GI
-GI
-GI
 fV
-JW
-JW
-JW
-JW
-JW
+fV
+qK
+td
+GI
+bC
+bC
+wk
+bC
+FB
+wk
+bC
+bC
+GI
+hg
+kk
+fV
+fV
+fV
 JW
 JW
 JW
@@ -129876,22 +129688,22 @@ JW
 JW
 JW
 JW
-JW
 fV
 fV
 fV
-VQ
-pI
-Sb
-bC
-kV
-qK
-Xf
-VQ
+GI
+oY
+pL
+pL
+pL
+Yw
+pL
+pL
+QI
+GI
 fV
 fV
 fV
-JW
 JW
 JW
 JW
@@ -130376,26 +130188,26 @@ JW
 JW
 JW
 JW
+JW
+JW
+JW
+JW
 fV
-fV
-fV
-fV
-Qu
-GI
+VQ
+FB
 bC
-ZW
+bC
+bC
+bC
+bC
 yP
-bC
-bC
-yP
-yP
-bC
-GI
-iP
+FB
+VQ
 fV
-fV
-fV
-fV
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -130878,26 +130690,26 @@ JW
 JW
 JW
 JW
-GI
-QM
-ly
-QU
-bC
-GI
-bC
-FB
-bC
+JW
+JW
+JW
+JW
+fV
+tY
+BG
 bC
 bC
 bC
 bC
 bC
-GI
 bC
-ls
-bE
-lM
-GI
+BG
+Kb
+fV
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -131375,36 +131187,36 @@ JW
 JW
 JW
 JW
-JF
-FL
-FL
-FL
-FL
-rD
-xz
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+fV
+tY
 BG
-pL
-pL
-tY
-pL
-Tz
-Xs
-po
-MK
-Xs
-pL
-pL
-tY
-pL
-pL
-pL
-wo
-rD
-FL
-FL
-FL
-FL
-Ki
+bC
+bC
+bC
+bC
+bC
+bC
+tf
+Kb
+fV
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -131882,26 +131694,26 @@ JW
 JW
 JW
 JW
-GI
-rl
+JW
+JW
+JW
+JW
+fV
+vD
+BG
 bC
 bC
 bC
-GI
 bC
 bC
-og
-td
-wk
-og
 bC
-bC
-GI
-bC
-bC
-EN
-KD
-GI
+FB
+Bq
+fV
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -132384,26 +132196,26 @@ JW
 JW
 JW
 JW
+JW
+JW
+JW
+JW
 fV
-fV
-fV
-On
-vD
-GI
+tY
+BG
 bC
 bC
-og
-bC
-FB
-og
 bC
 bC
-GI
-Bq
-wZ
+bC
+bC
+BG
+Kb
 fV
-fV
-fV
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -132888,22 +132700,22 @@ JW
 JW
 JW
 JW
+JW
+JW
 fV
-fV
-fV
-GI
+bC
+FB
+bC
+bC
 bC
 bC
 bC
 bC
 FB
 bC
-bC
-bC
-GI
 fV
-fV
-fV
+JW
+JW
 JW
 JW
 JW
@@ -133395,13 +133207,13 @@ JW
 fV
 fV
 iM
-bC
-bC
-bC
-FB
-bC
-bC
-VQ
+pL
+pL
+pL
+wZ
+pL
+pL
+xz
 fV
 fV
 JW
@@ -136403,7 +136215,7 @@ JW
 JW
 Qv
 Gv
-GI
+iC
 bC
 VQ
 GI
@@ -136416,7 +136228,7 @@ pL
 rD
 pL
 ND
-rD
+kq
 wU
 Qv
 JW
@@ -139415,8 +139227,8 @@ JW
 JW
 JW
 fV
-GI
-GI
+iC
+iC
 fV
 Dt
 iS
@@ -139427,8 +139239,8 @@ bC
 bC
 yk
 fV
-GI
-GI
+iC
+iC
 fV
 JW
 JW
@@ -139915,10 +139727,10 @@ JW
 JW
 JW
 fV
-GI
+iC
 fV
 fY
-GI
+iC
 bC
 bC
 bC
@@ -139929,10 +139741,10 @@ bC
 bC
 bC
 bC
-GI
+iC
 hK
 fV
-GI
+iC
 fV
 JW
 JW
@@ -140922,7 +140734,7 @@ fV
 bC
 bC
 bC
-GI
+iC
 FB
 dk
 ii
@@ -140933,7 +140745,7 @@ kr
 rW
 zR
 FB
-GI
+iC
 bC
 bC
 bC
@@ -141424,18 +141236,18 @@ fV
 Is
 iW
 Ed
-GI
+iC
 FB
 fV
-GI
-GI
-GI
-GI
-GI
-GI
+iC
+iC
+iC
+iC
+iC
+iC
 fV
 FB
-GI
+iC
 pb
 pb
 pb
@@ -141923,9 +141735,9 @@ JW
 JW
 fV
 fV
-GI
-GI
-GI
+iC
+iC
+iC
 fV
 LL
 fV
@@ -141938,9 +141750,9 @@ hL
 fV
 LL
 fV
-GI
-GI
-GI
+iC
+iC
+iC
 fV
 fV
 JW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Expands the Reliant to add a neutral map that shows the locations of both teams' pilots
* Upgrades the outer windows on the reliant to be reinforced

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Makes the objective more valuable to hold
* Easier to locate fights

```changelog
(u)Sovexe
(*)The Pod Wars NSV Reliant now has a neutral map that shows the position of pilots on both teams.
```
