### PR TITLE
Fixed Disposal outlets not linking on being build and some disposal chute cleanup

### DIFF
--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -1760,8 +1760,10 @@ TYPEINFO(/obj/disposaloutlet)
 	icon_state = "outlet"
 	density = 1
 	anchored = ANCHORED
+	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER
 	var/active = 0
 	var/turf/target	// this will be where the output objects are 'thrown' to.
+	var/obj/disposalpipe/trunk/trunk = null // the attached pipe trunk
 	var/range = 10
 
 	var/message = null
@@ -1771,6 +1773,7 @@ TYPEINFO(/obj/disposaloutlet)
 	var/frequency = FREQ_PDA
 	var/flusher_id = null
 	throw_speed = 1
+
 
 	ex_act(var/severity)
 		switch(severity)
@@ -1794,17 +1797,41 @@ TYPEINFO(/obj/disposaloutlet)
 	New()
 		..()
 
-		SPAWN(1 DECI SECOND)
-			target = get_ranged_target_turf(src, dir, range)
+		SPAWN(0.5 SECONDS)
+			if(src)
+				src.target = get_ranged_target_turf(src, dir, range)
+				src.trunk = locate() in src.loc
+				if(src.trunk)
+					src.trunk.linked = src	// link the pipe trunk to self
 		if(!src.net_id)
 			src.net_id = generate_net_id(src)
 		MAKE_SENDER_RADIO_PACKET_COMPONENT(null, frequency)
 
+	was_built_from_frame(mob/user, newly_built)
+		if (!newly_built)
+			src.target = get_ranged_target_turf(src, dir, range)
+			src.trunk = locate() in src.loc
+			if(src.trunk)
+				src.trunk.linked = src	// link the pipe trunk to self
+		return ..()
+
+	was_deconstructed_to_frame(mob/user)
+		if (src.trunk && src.trunk.linked == src)
+			src.trunk.linked = null
+		src.target = null
+		src.trunk = null
+
+		var/turf/target_turf = get_turf(src)
+		for (var/atom/movable/manipulated_atom in src)
+			manipulated_atom.set_loc(target_turf)
+
+		return ..()
+
 	disposing()
-		var/obj/disposalpipe/trunk/trunk = locate() in src.loc
-		if (trunk && trunk.linked == src)
-			trunk.linked = null
-		trunk = null
+		if (src.trunk && src.trunk.linked == src)
+			src.trunk.linked = null
+		src.target = null
+		src.trunk = null
 		..()
 
 	// expel the contents of the holder object, then delete it

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -42,24 +42,24 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		src.AddComponent(/datum/component/obj_projectile_damage)
 		SPAWN(0.5 SECONDS)
 			if (src)
-				trunk = locate() in src.loc
-				if(!trunk)
-					mode = DISPOSAL_CHUTE_OFF
-					flush = 0
+				src.trunk = locate() in src.loc
+				if(!src.trunk)
+					src.mode = DISPOSAL_CHUTE_OFF
+					src.flush = 0
 				else
-					trunk.linked = src	// link the pipe trunk to self
+					src.trunk.linked = src	// link the pipe trunk to self
 
 				initair()
 				update()
 
 	disposing()
-		if (trunk)
-			trunk.linked = null
+		if (src.trunk && src.trunk.linked == src)
+			src.trunk.linked = null
 		else
-			trunk = locate() in src.loc //idk maybe this can happens
-			if (trunk)
-				trunk.linked = null
-		trunk = null
+			src.trunk = locate() in src.loc //idk maybe this can happens
+			if (src.trunk && src.trunk.linked == src)
+				src.trunk.linked = null
+		src.trunk = null
 
 		if(air_contents)
 			qdel(air_contents)
@@ -67,13 +67,13 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		..()
 
 	was_deconstructed_to_frame(mob/user)
-		if (trunk)
-			trunk.linked = null
+		if (src.trunk && src.trunk.linked == src)
+			src.trunk.linked = null
 		else
-			trunk = locate() in src.loc //idk maybe this can happens
-			if (trunk)
-				trunk.linked = null
-		trunk = null
+			src.trunk = locate() in src.loc //idk maybe this can happens
+			if (src.trunk && src.trunk.linked == src)
+				src.trunk.linked = null
+		src.trunk = null
 
 		var/turf/T = get_turf(src)
 		for (var/atom in src)
@@ -81,6 +81,17 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			A.set_loc(T)
 
 		return ..()
+
+	was_built_from_frame(mob/user, newly_built)
+		if (!newly_built)
+			src.trunk = locate() in src.loc
+			if(!src.trunk)
+				src.mode = DISPOSAL_CHUTE_OFF
+				src.flush = 0
+			else
+				src.trunk.linked = src	// link the pipe trunk to self
+		return ..()
+
 
 	onDestroy()
 		if (src.powered())


### PR DESCRIPTION
[Game Objects][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR enables disposal outlets being able to link to disposal trunks on being build.

Also, this cleans up some stuff in the code around linking/delinking of disposal chutes. Especially chutes trying to delink disposal trunks if they were not linked to them (e.g. by trying to stack multiple disposals on a tile)

Also, this fixes disposal chutes not linking again after being deconstructed and then constructed again

On top of that, this now makes disposal outlets requiring tools to be deconstructed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I was unable to chuck ~~pipebombs~~ trash onto the station from a newly build ship via ~~cannons~~ disposal outlets. I was so upset that i went to make this PR. I may have forgot to report that issue...

While disposal outlets are mechscanable, the ability to construct/deconstruct them was only partially implemented. They were able to be build but essentially non-functional if dont that way. This fixes this.