### PR TITLE
Fixes antag critter spiders losing their maintenance access upon evolving

### DIFF
--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -132,11 +132,17 @@
 	proc/grow_up()
 		if (!src.babyspider || !ispath(src.adultpath))
 			return 0
+		var/has_implant = FALSE
+		//antag critter spiders have a maintenance implant. Transfer it when they grow up
+		for (var/obj/item/implant/access/infinite/assistant/I in src.contents)
+			has_implant = TRUE
 		src.unequip_all()
 		src.visible_message("<span class='alert'><b>[src] grows up!</b></span>",\
 		"<span class='notice'><b>You grow up!</b></span>")
 		SPAWN(0)
-			src.make_critter(src.adultpath)
+			var/mob/new_mob = src.make_critter(src.adultpath)
+			if (has_implant)
+				new /obj/item/implant/access/infinite/assistant(new_mob)
 
 	valid_target(mob/living/C)
 		if (C.bioHolder.HasEffect("husk")) return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
What it says in the title.
#15225 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spiders should live in maintenance, and gaining bigger bulk should not be a penalty.