### PR TITLE
Latejoining Stowaways, Pilots, and Heavy Sleepers no longer get announced

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -206,8 +206,8 @@
 	proc/announce_arrival(var/mob/living/person)
 		if (!src.announces_arrivals)
 			return 1
-		if ((person.traitHolder.hasTrait("stowaway")) || (person.traitHolder.hasTrait("sleepy")))
-			return 1 //people who have been on the ship the whole time won't be announced
+		if ((person.traitHolder.hasTrait("stowaway")) || (person.traitHolder.hasTrait("pilot")) || (person.traitHolder.hasTrait("sleepy")))
+			return 1 //people who have been on the ship the whole time, or who aren't on the ship, won't be announced
 		if (!src.announcement_radio)
 			src.announcement_radio = new(src)
 

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -206,6 +206,8 @@
 	proc/announce_arrival(var/mob/living/person)
 		if (!src.announces_arrivals)
 			return 1
+		if ((person.traitHolder.hasTrait("stowaway")) || (person.traitHolder.hasTrait("sleepy")))
+			return 1 //people who have been on the ship the whole time won't be announced
 		if (!src.announcement_radio)
 			src.announcement_radio = new(src)
 


### PR DESCRIPTION
## About the PR 
Makes the announcement computer not announce characters who have ostensibly been on the station for the whole shift, or who aren't on the station.

## Why's this needed? 
Doesn't make sense for the announcement computer to be all-knowing about stowaways & pilots, and heavy sleepers have been on station all shift. Makes things like undercover secasses possible for non-roundstart players.

```changelog
(u)Mintyphresh
(+)Latejoining players with the Stowaway, Pilot, or Heavy Sleeper trait will no longer be announced.
```
