### PR TITLE
Reworks Devera Hygiene Protection Into A Status Effect

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -258,9 +258,8 @@
 					protection--
 					return 0
 				// Devera-class interdictor: prevent passive hygiene decrease within the field
-				for_by_tcl(IX, /obj/machinery/interdictor)
-					if (IX.expend_interdict(1,src,TRUE,ITDR_DEVERA))
-						return 0
+				if (holder.owner.hasStatus("devera_field"))
+					return 0
 				return 1
 
 		onIncrease()

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -284,6 +284,9 @@
 						IX.resisted = TRUE
 					if (!iscarbon(src)) //Prevents non-carbons from getting the Zephyr stam boost, but still protects other mobs
 						break
+					if (IX.expend_interdict(1,src,TRUE,ITDR_DEVERA)) // Devera-class interdictor: prevents hygiene loss for mobs in range, which can accumulate to linger briefly
+						src.changeStatus("devera_field", 3 SECONDS * life_mult)
+						break
 					if (IX.expend_interdict(4,src,TRUE,ITDR_ZEPHYR)) // Zephyr-class interdictor: carbon mobs in range gain a buff to stamina recovery, which can accumulate to linger briefly
 						src.changeStatus("zephyr_field", 3 SECONDS * life_mult)
 						break

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2440,3 +2440,11 @@
 	onRemove()
 		owner.remove_filter("protection")
 		..()
+
+/datum/statusEffect/devera //Status effect for the devera hygiene protection
+	id = "devera_field"
+	name = "Devera Field"
+	desc = "You are being protected from grime gathering on you."
+	icon_state = "fragrant"
+	maxDuration = 4 SECONDS
+	effect_quality = STATUS_QUALITY_POSITIVE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATUS EFFECTS] [GAME OBJECTS] [REWORK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks Devera's hygiene protection into a status effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it more clear what it does, and why someone's hygiene suddenly isn't going down.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wisemonster
(+)Devera's hygiene protection has been changed into a status effect.
```
