### PR TITLE
Parallax on Generated Planets

### DIFF
--- a/_std/map.dm
+++ b/_std/map.dm
@@ -24,7 +24,6 @@ var/list/default_z_level_parallax_settings = list(
 		/atom/movable/screen/parallax_layer/asteroids_far,
 		/atom/movable/screen/parallax_layer/asteroids_near,
 		),
-	"[Z_LEVEL_SECRET]" = list(),
 	)
 
 /// A list of each z-level define and it's current associated parallax layer types.

--- a/_std/map.dm
+++ b/_std/map.dm
@@ -24,6 +24,7 @@ var/list/default_z_level_parallax_settings = list(
 		/atom/movable/screen/parallax_layer/asteroids_far,
 		/atom/movable/screen/parallax_layer/asteroids_near,
 		),
+	"[Z_LEVEL_SECRET]" = list(),
 	)
 
 /// A list of each z-level define and it's current associated parallax layer types.

--- a/code/WorkInProgress/artemis/GeneratePlanets.dm
+++ b/code/WorkInProgress/artemis/GeneratePlanets.dm
@@ -273,9 +273,11 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 			/atom/movable/screen/parallax_layer/foreground/dust/sparse=list(color=color_matrix, scroll_speed=scroll_speed*1.5, scroll_angle=angle)
 		)
 
+	// Occlude overlays on edges
 	if(planet_area.area_parallax_layers)
 		for(var/turf/cordon/CT in planet_area)
-			CT.update_parallax_occlusion_overlay()
+			new/obj/foreground_parallax_occlusion(CT)
+
 
 	//Populate with Biome!
 	var/turfs = block(locate(region.bottom_left.x+1, region.bottom_left.y+1, region.bottom_left.z), locate(region.bottom_left.x+region.width-2, region.bottom_left.y+region.height-2, region.bottom_left.z) )
@@ -371,7 +373,7 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 				break
 
 			T = pick(turfs)
-			if(T.density)
+			if(!checkTurfPassable(T))
 				maxTries--
 				continue
 

--- a/code/WorkInProgress/artemis/GeneratePlanets.dm
+++ b/code/WorkInProgress/artemis/GeneratePlanets.dm
@@ -243,6 +243,40 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 	planet_area.name = name
 	region.clean_up(main_area=planet_area)
 
+	//Parallax it?
+	if(istype(generator, /datum/map_generator/snow_generator) )
+		var/angle = rand(110,250)
+		var/scroll_speed = rand(50, 100)
+		var/color_alpha = rand(30,60)/100
+		var/color_matrix = list(
+								1, 0, 0, color_alpha,
+								0, 1, 0, color_alpha,
+								0, 0, 1, color_alpha,
+								0, 0, 0, 1,
+								0, 0, 0, -1)
+		planet_area.area_parallax_layers = list(
+		/atom/movable/screen/parallax_layer/foreground/snow=list(color=color_matrix, scroll_speed=scroll_speed, scroll_angle=angle),
+		/atom/movable/screen/parallax_layer/foreground/snow/sparse=list(color=color_matrix, scroll_speed=scroll_speed+25, scroll_angle=angle),
+		)
+	else if(istype(generator, /datum/map_generator/desert_generator) )
+		var/angle = rand(110,250)
+		var/scroll_speed = rand(75, 175)
+		var/color_alpha = rand(40,80)/100
+		var/color_matrix = list(
+								1, 0, 0, color_alpha,
+								0, 1, 0, color_alpha,
+								0, 0, 1, color_alpha,
+								0, 0, 0, 1,
+								0, 0, 0, -1)
+		planet_area.area_parallax_layers = list(
+			/atom/movable/screen/parallax_layer/foreground/dust=list(color=color_matrix, scroll_speed=scroll_speed, scroll_angle=angle),
+			/atom/movable/screen/parallax_layer/foreground/dust/sparse=list(color=color_matrix, scroll_speed=scroll_speed*1.5, scroll_angle=angle)
+		)
+
+	if(planet_area.area_parallax_layers)
+		for(var/turf/cordon/CT in planet_area)
+			CT.update_parallax_occlusion_overlay()
+
 	//Populate with Biome!
 	var/turfs = block(locate(region.bottom_left.x+1, region.bottom_left.y+1, region.bottom_left.z), locate(region.bottom_left.x+region.width-2, region.bottom_left.y+region.height-2, region.bottom_left.z) )
 	generator.generate_terrain(turfs, reuse_seed=TRUE, flags=mapgen_flags)

--- a/code/WorkInProgress/artemis/GeneratePlanets.dm
+++ b/code/WorkInProgress/artemis/GeneratePlanets.dm
@@ -244,7 +244,7 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 	region.clean_up(main_area=planet_area)
 
 	//Parallax it?
-	if(istype(generator, /datum/map_generator/snow_generator) )
+	if(istype(generator, /datum/map_generator/snow_generator) && prob(15) )
 		var/angle = rand(110,250)
 		var/scroll_speed = rand(50, 100)
 		var/color_alpha = rand(30,60)/100
@@ -258,7 +258,7 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 		/atom/movable/screen/parallax_layer/foreground/snow=list(color=color_matrix, scroll_speed=scroll_speed, scroll_angle=angle),
 		/atom/movable/screen/parallax_layer/foreground/snow/sparse=list(color=color_matrix, scroll_speed=scroll_speed+25, scroll_angle=angle),
 		)
-	else if(istype(generator, /datum/map_generator/desert_generator) )
+	else if(istype(generator, /datum/map_generator/desert_generator)&& prob(15) )
 		var/angle = rand(110,250)
 		var/scroll_speed = rand(75, 175)
 		var/color_alpha = rand(40,80)/100

--- a/code/modules/events/gimmick/generate_planet.dm
+++ b/code/modules/events/gimmick/generate_planet.dm
@@ -97,7 +97,7 @@
 					break
 
 				var/turf/T = pick(turfs)
-				if(T.density)
+				if(checkTurfPassable(T))
 					maxTries--
 					continue
 

--- a/code/modules/parallax/foreground_parallax_occlusion_overlay.dm
+++ b/code/modules/parallax/foreground_parallax_occlusion_overlay.dm
@@ -3,6 +3,13 @@
 	icon_state = "overlay-0"
 	plane = PLANE_FOREGROUND_PARALLAX_OCCLUSION
 
+/obj/foreground_parallax_occlusion
+	mouse_opacity = 0
+	icon = 'icons/misc/foreground_parallax_occlusion_overlay.dmi'
+	icon_state = "overlay-255"
+	plane = PLANE_FOREGROUND_PARALLAX_OCCLUSION
+
+
 /turf/New()
 	. = ..()
 	var/area/A = get_area(src)

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -92,8 +92,13 @@ var/global/parallax_enabled = TRUE
 		else if (ispath(parallax_layer_type_or_types))
 			parallax_layer_types = list(parallax_layer_type_or_types)
 
+		if(isnull(src.z_level_parallax_layers["[z_level]"]))
+			src.z_level_parallax_layers["[z_level]"] = list()
+
 		var/list/parallax_layer_list = src.z_level_parallax_layers["[z_level]"]
 		for (var/parallax_layer_type in parallax_layer_types)
+			if(parallax_layer_types[parallax_layer_type])
+				layer_params = parallax_layer_types[parallax_layer_type]
 			var/atom/movable/screen/parallax_layer/parallax_layer = new parallax_layer_type(null, src.owner, layer_params)
 			parallax_layer_list += parallax_layer
 

--- a/code/modules/parallax/parallax_layer_parent.dm
+++ b/code/modules/parallax/parallax_layer_parent.dm
@@ -62,6 +62,8 @@
 				src.parallax_icon_state = params["parallax_icon_state"]
 			if (params["static_colour"])
 				src.static_colour = params["static_colour"]
+			if (params["color"])
+				src.color = params["color"]
 			if (params["parallax_value"])
 				src.parallax_value = params["parallax_value"]
 			if (params["scroll_speed"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds handling needed for parallax to be applied to an arbitrary zlevel.
Support for dynamically generated layers to be applied with same conditions/options
% chance for Desert and Snow to use randomized occluded foreground parallax layers similar to existing azones.

Added foreground occlusion object to allow for exclusion of turfs/regions that may not be visible to players.

https://streamable.com/cojptj


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improve immersion and dynamic experience of procedural generated content.
