### PR TITLE
Allows werewolves to click themselves or other werewolves at no risk of injury

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1419,7 +1419,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	/// Has a chance to snap at mobs that try to pet them.
 	/// We don't really have a 'bite' proc and the damage/bleed procs are all kinds of fucked up so I'm just reusing the arms
 	proc/snap_at_maybe(mob/source, mob/target)
-		if (prob(SNAP_PROB) && target.a_intent == INTENT_HELP)
+		if (prob(SNAP_PROB) && target.a_intent == INTENT_HELP && !iswerewolf(target))
 			playsound(src.mob, 'sound/voice/animal/werewolf_attack1.ogg', 60, TRUE)
 			src.mob.visible_message("<span class='alert'>[src.mob] snaps at [target]!</span>", "<span class='alert'>You snap at [target]!</span>")
 			src.mob.set_a_intent(INTENT_HARM)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Werewolves can now click themselves or another werewolf on help intent without a chance to be bitten and maimed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows a werewolf to click on another werewolf to help them up when they are stunned or staunch their wounds.
Allows a werewolf to click themselves without getting confused and biting off their own hand when they need to do something (stop bleeding, remove embedded darts, buckle themselves...).
