### PR TITLE
All gloves now leave partial prints + partial prints changes

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1273,7 +1273,7 @@
 	var/sprite_hand = 'icons/mob/inhand/hand_feethand.dmi'
 	var/print_type = "black leather fibers"
 	var/hide_prints = TRUE
-	var/print_difficulty = 0
+	var/print_difficulty = 60
 
 	insulated
 		desc = "Tough rubber work gloves styled in a high-visibility yellow color. They are electrically insulated, and provide full protection against most shocks."

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1187,7 +1187,6 @@
 	var/current_choice = new/datum/chameleon_gloves_pattern
 	material_prints = "black leather fibers"
 	hide_prints = TRUE
-	scramble_prints = FALSE
 
 	New()
 		..()
@@ -1261,6 +1260,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.material_prints = T.print_type
+			src.print_scramble_difficulty = T.print_difficulty
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_gloves_pattern
@@ -1273,7 +1273,7 @@
 	var/sprite_hand = 'icons/mob/inhand/hand_feethand.dmi'
 	var/print_type = "black leather fibers"
 	var/hide_prints = TRUE
-	var/scramble_prints = FALSE
+	var/print_difficulty = 0
 
 	insulated
 		desc = "Tough rubber work gloves styled in a high-visibility yellow color. They are electrically insulated, and provide full protection against most shocks."
@@ -1282,22 +1282,24 @@
 		item_state = "ygloves"
 		print_type = "insulative fibers"
 		hide_prints = TRUE
-		scramble_prints = FALSE
+		print_difficulty = 90
 
 	fingerless
 		desc = "These gloves lack fingers. Good for a space biker look, but not so good for concealing your fingerprints."
 		name = "fingerless gloves"
 		icon_state = "fgloves"
 		item_state = "finger-"
+		print_type = "black leather fibers"
 		hide_prints = FALSE
-		scramble_prints = FALSE
+		print_difficulty = 0
 
 	latex
 		name = "latex gloves"
 		icon_state = "latex"
 		item_state = "lgloves"
+		print_type = "latex fibers"
 		desc = "Thin, disposal medical gloves used to help prevent the spread of germs."
-		scramble_prints = TRUE
+		print_difficulty = 60
 
 	boxing
 		name = "boxing gloves"
@@ -1306,7 +1308,7 @@
 		item_state = "bogloves"
 		print_type = "red leather fibers"
 		hide_prints = TRUE
-		scramble_prints = FALSE
+		print_difficulty = 60
 
 	long
 		desc = "These long gloves protect your sleeves and skin from whatever dirty job you may be doing."
@@ -1315,7 +1317,7 @@
 		item_state = "long_gloves"
 		print_type = "synthetic silicone rubber fibers"
 		hide_prints = TRUE
-		scramble_prints = FALSE
+		print_difficulty = 90
 
 	gauntlets
 		name = "concussion gauntlets"
@@ -1324,7 +1326,7 @@
 		item_state = "bgloves"
 		print_type = "industrial-grade mineral fibers"
 		hide_prints = TRUE
-		scramble_prints = FALSE
+		print_difficulty = 90
 
 /obj/item/storage/belt/chameleon
 	name = "utility belt"

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -218,6 +218,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	icon_state = "black"
 	item_state = "r_hands"
 	material_prints = "circuit shards"
+	print_scramble_difficulty = 40
 	setupProperties()
 		..()
 		setProperty("conductivity", 1)
@@ -446,6 +447,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	cant_self_remove = 1
 	cant_other_remove = 1
 	material_prints = "greasy polymer fibers"
+	print_scramble_difficulty = 40
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -20,7 +20,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	var/activeweapon = 0 // Used for gloves that can be toggled to turn into a weapon (example, bladed gloves)
 
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
-	var/scramble_prints = 0
+	var/print_scramble_difficulty = 0 // How hard do we scramble prints? 0 for no scramble, 100 for illegible prints
 	var/material_prints = null
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
@@ -151,20 +151,28 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 
 		else
 
-			if (src.scramble_prints)
-				data += corruptText(prints, 20)
-
-			else // Seems a bit redundant to return both (Convair880).
-
-				if (src.material_prints)
-					data += src.material_prints
-				else
-					data += "unknown fiber material"
+			data += corruptPrints(prints, src.print_scramble_difficulty)
+			if (src.material_prints)
+				data += " ([src.material_prints])"
+			else
+				data += " unknown fiber material"
 
 		if (get_glove_ID)
 			data += " (Glove ID: [src.glove_ID])" // Space is required for formatting (Convair880).
 
 		return data
+
+	//Mostly copied from corrupt text except we write those characters in red and we use less eye searing characters
+	proc/corruptPrints(var/t, var/p)
+		if(!t)
+			return ""
+		var/tmp = ""
+		for(var/i = 1, i <= length(t), i++)
+			if(prob(p))
+				tmp += "<span class='alert'>[pick("{", "|", "}", "~", "€", "ƒ", "†", "‡", "‰", "¡", "¢", "£", "¤", "¥", "¦", "§", "«", "¬", "°", "±", "²", "³", "¶", "¿", "ø", "ÿ", "þ")]</span>"
+			else
+				tmp += copytext(t, i, i+1)
+		return tmp
 
 	proc/special_attack(var/mob/target, var/mob/living/user)
 		boutput(user, "Your gloves do nothing special")
@@ -207,6 +215,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	item_state = "long_gloves"
 	protective_temperature = 550
 	material_prints = "synthetic silicone rubber fibers"
+	print_scramble_difficulty = 85
 	setupProperties()
 		..()
 		setProperty("conductivity", 0.6)
@@ -231,6 +240,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	item_state = "bgloves"
 	protective_temperature = 1500
 	material_prints = "black leather fibers"
+	print_scramble_difficulty = 60
 
 	setupProperties()
 		..()
@@ -242,6 +252,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		cant_self_remove = 1
 		cant_other_remove = 1
 		material_prints = "black insulative fibers"
+		print_scramble_difficulty = 85
 
 		setupProperties()
 			..()
@@ -272,7 +283,8 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	item_state = "lgloves"
 	desc = "Thin, disposable medical gloves used to help prevent the spread of germs."
 	protective_temperature = 310
-	scramble_prints = 1
+	material_prints = "latex fibers"
+	print_scramble_difficulty = 40
 	setupProperties()
 		..()
 		setProperty("conductivity", 0.7)
@@ -298,7 +310,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "latex"
 	item_state = "lgloves"
 	desc = "Custom made gloves."
-	scramble_prints = 1
+	print_scramble_difficulty = 40
 
 	insulating
 		onMaterialChanged()
@@ -350,6 +362,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	item_state = "swat_syndie"
 	protective_temperature = 1100
 	material_prints = "high-quality synthetic fibers"
+	print_scramble_difficulty = 95
 
 	New()
 		..()
@@ -386,6 +399,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "stun"
 	item_state = "stun"
 	material_prints = "insulative fibers, electrically charged"
+	print_scramble_difficulty = 85
 	stunready = 1
 	can_be_charged = 1
 	uses = 10
@@ -404,6 +418,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "yellow"
 	item_state = "ygloves"
 	material_prints = "insulative fibers"
+	print_scramble_difficulty = 85
 	can_be_charged = 1
 	max_uses = 4
 
@@ -433,6 +448,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "boxinggloves"
 	item_state = "bogloves"
 	material_prints = "red leather fibers"
+	print_scramble_difficulty = 40
 	crit_override = 1
 	bonus_crit_chance = 0
 	stamina_dmg_mult = 0.35
@@ -488,6 +504,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "transparent"
 	item_state = "transparent"
 	material_prints = "transparent high-quality synthetic fibers"
+	print_scramble_difficulty = 95
 	var/deployed = FALSE
 
 	nodescripition = TRUE
@@ -578,6 +595,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "yellow"
 	item_state = "ygloves"
 	material_prints = "insulative fibers and nanomachines"
+	print_scramble_difficulty = 95
 	can_be_charged = 1 // Quite pointless, but could be useful as a last resort away from powered wires? Hell, it's a traitor item and can get the buff (Convair880).
 	max_uses = 10
 	flags = HAS_EQUIP_CLICK
@@ -817,6 +835,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "princess"
 	item_state = "princess"
 	material_prints = "silk fibres and glitter"
+	print_scramble_difficulty = 40
 
 	setupProperties()
 		..()

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -38,6 +38,7 @@
 	icon_state = "kote"
 	item_state = "kote"
 	material_prints = "navy blue, synthetic leather fibers"
+	print_scramble_difficulty = 40
 	crit_override = 1
 	bonus_crit_chance = 0
 	stamina_dmg_mult = 0.35

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1654,6 +1654,7 @@ obj/item/clothing/gloves/concussive
 	icon_state = "cgaunts"
 	item_state = "bgloves"
 	material_prints = "industrial-grade mineral fibers"
+	print_scramble_difficulty = 70
 	var/obj/item/mining_tool/tool = null
 
 	setupProperties()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All gloves now leave partial prints, however the readability of the prints will greatly vary depending on the gloves.

When a glove leaves a muddled print, the "fake" characters are now highlighted in red for readability.

Gloves now always leave a material on prints, so for example even latex gloves now leave "latex fibers".

Gloves which were already easily readable (latex for example) now have a 40% chance (was 20%) to replace a character in a fingerprint string to a random corrupted character.
Example of new latex prints: 

![latexprints](https://github.com/goonstation/goonstation/assets/36884328/fe862c5c-9874-4f06-9c07-b007050b784d)

Gloves which were unreadable now leave partial prints which may be up to 85% scrambled.
Example of new insulative glove prints with 85% chance for each character to be muddled:

![insulprints](https://github.com/goonstation/goonstation/assets/36884328/55e37fa2-da62-404d-bc72-8f989e91a910)

Syndicate gloves like swat gloves, bladed gloves or power-gloves have a 95% scramble chance.
Example of bladed gloves prints: 

![bladedprints](https://github.com/goonstation/goonstation/assets/36884328/92f095ae-481a-4b99-8733-ac8459470680)

Chameleon clothing gloves have higher than normal scrambling chance compared to their regular counterpart.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Forensics is a bit weak, especially on classic. It is absolutely trivial to pick up some insuls or black gloves, do crime, then swap gloves and throw the old pair in the grinder, leaving forensic gathering with very little purpose. By leaving behind heavily obfuscated prints it is now possible if enough traces are found to make up a whole print and get an investigation going.

In order to not be a straight nerf, "weaker" gloves like latex are now a bit more scrambled by default so that some research work might be required.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(*)All gloves now leave partial prints. Some gloves (like insulated gloves) have harder to read prints!
```
