### PR TITLE
Minimaps now track targets within other atoms such as pods

### DIFF
--- a/code/modules/minimap/minimap_marker.dm
+++ b/code/modules/minimap/minimap_marker.dm
@@ -35,27 +35,23 @@
 			src.name = name
 
 		if (target && istype(target, /atom/movable))
-			src.RegisterSignal(target, COMSIG_MOVABLE_SET_LOC, PROC_REF(handle_move))
-			src.RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
-			src.handle_move(target)
+			src.RegisterSignal(target, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(handle_move))
+			// set initial marker position
+			src.handle_move(target, null, get_turf(target))
 
 		src.can_be_deleted_by_player = can_be_deleted_by_player
 		src.list_on_ui = list_on_ui
 		src.scale_marker(marker_scale)
 
 	disposing()
-		src.UnregisterSignal(target, COMSIG_MOVABLE_SET_LOC)
-		src.UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
+		src.UnregisterSignal(target, XSIG_MOVABLE_TURF_CHANGED)
 		. = ..()
 
-	proc/handle_move(var/atom/movable/target)
-		if (!map || !target)
+	proc/handle_move(thing, turf/old_turf, turf/new_turf)
+		if (!map || !thing || !new_turf)
 			return
 
-		var/turf/T = get_turf(target)
-		if (!T)
-			return
-		map.set_marker_position(src, T.x, T.y, T.z)
+		map.set_marker_position(src, new_turf.x, new_turf.y, new_turf.z)
 
 	proc/scale_marker(var/scale)
 		var/scale_factor = (scale / src.marker_scale)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Minimaps now track targets within other atoms (e.g. pods)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* minimap does not currently handle tracking targets contained within other atoms as it operates of the targets x y coords


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Minimaps can now track targets inside of things, such as pods
```
