### PR TITLE
Fix broken D.O.C sprite

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -11350,7 +11350,8 @@
 	icon_state = "medibot0";
 	name = "D.O.C.";
 	productset = 4;
-	trader_area = "/area/abandonedmedicalship/robot_trader"
+	trader_area = "/area/abandonedmedicalship/robot_trader";
+	icon = 'icons/misc/evilreaverstation.dmi'
 	},
 /obj/map/light/white,
 /turf/simulated/floor/white/grime,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS] [SPRITES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15260 by varediting the icon file to the correct one, it was changed by #15188 because every other robot trader NPC uses the PR-1 sprite except D.O.C. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Debated making an actual subtype of /obj/npc/trader/robot but it seems like all the other ones just do it by var-editing so I can go either way