### PR TITLE
Adds fallout gas to gas artifacts

### DIFF
--- a/code/obj/artifacts/artifact_machines/gas_radiator.dm
+++ b/code/obj/artifacts/artifact_machines/gas_radiator.dm
@@ -32,7 +32,8 @@
 					100;"nitrogen",
 					100;"plasma",
 					100;"carbon dioxide",
-					75;"sleeping agent")
+					75;"sleeping agent",
+					10;"fallout")
 			if("martian") // organic stuff
 				gas_type = pick(
 					200;"oxygen",
@@ -53,7 +54,8 @@
 					50;"carbon dioxide",
 					30;"farts",
 					30;"agent b",
-					30;"sleeping agent")
+					30;"sleeping agent",
+					10;"fallout")
 
 		// temperature
 		gas_temp = rand(0 KELVIN, 620 KELVIN)
@@ -113,6 +115,8 @@
 					gas.oxygen_agent_b = src.gas_amount_current
 				if("sleeping agent")
 					gas.nitrous_oxide = src.gas_amount_current
+				if("fallout")
+					gas.radgas = src.gas_amount_current
 			gas.temperature = src.gas_temp
 			if (L)
 				L.assume_air(gas)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds Fallout as a rare-ish roll to precursor and eldritch gas generator artifacts


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spicy
![Screenshot from 2023-08-08 13-46-47](https://github.com/goonstation/goonstation/assets/3855802/a395bb9f-da40-4454-8a00-f978cafc2740)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Gas generator artifacts can now emit fallout gas.
```
