### PR TITLE
Adds bottles of white wine and other juices to the bartender vendor

### DIFF
--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -399,6 +399,23 @@
 	amount_per_transfer_from_this = 5
 	initial_reagents = "formaldehyde"
 
+/* ========================================================= */
+/* -------------------- Bartender Juice -------------------- */
+/* ========================================================= */
+/obj/item/reagent_containers/glass/bottle/juice
+	name = "juice bottle"
+	desc = "A small bottle for juice. There's a warning sticker about preservatives that's completely covering the label."
+	bottle_style = "2"
+	initial_volume = 35
+	amount_per_transfer_from_this = 5
+	initial_reagents = null
+	New()
+		src.initial_reagents = list(pick("juice_apple", "juice_blackberry", "juice_blueberry", "juice_blueraspberry", "capsaicin", "juice_grapefruit", "juice_peach", "juice_strawberry") = 30)
+		if (prob(50))
+			src.initial_reagents["formaldehyde"] = 5
+		else
+			src.initial_reagents["water"] = 5
+		..()
 /* ============================================== */
 /* -------------------- Misc -------------------- */
 /* ============================================== */

--- a/code/modules/food_and_drink/alcohol.dm
+++ b/code/modules/food_and_drink/alcohol.dm
@@ -55,6 +55,11 @@
 	initial_volume = 100
 	initial_reagents = list("wine"=60)
 
+/obj/item/reagent_containers/food/drinks/bottle/wine/white
+	name = "white wine"
+	desc = "Wine made from those nasty green grapes."
+	initial_reagents = list("white_wine"=60)
+
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine
 	name = "fortified wine"
 	desc = "Some sort of bottom-shelf booze. Wasn't this brand banned awhile ago?"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2723,12 +2723,15 @@ TYPEINFO(/obj/machinery/vending/monkey)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/cocktail_doodads, 4)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/straws, 2)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/fruit_wedges, 1)
+		product_list += new/datum/data/vending_product(/obj/item/storage/box/juice, 2)
 		product_list += new/datum/data/vending_product(/obj/item/shaker/salt, 1)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/cocktailshaker, 1)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/hobo_wine, 2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff, 1, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/bottle/wine/white, 4, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/abg, 2, cost=PAY_TRADESMAN, hidden=1)
+
 
 TYPEINFO(/obj/machinery/vending/chem)
 	mats = null

--- a/code/obj/item/storage/food.dm
+++ b/code/obj/item/storage/food.dm
@@ -90,6 +90,12 @@
 	/obj/item/reagent_containers/food/snacks/plant/lime,\
 	/obj/item/kitchen/utensil/knife)
 
+/obj/item/storage/box/juice
+	name = "juice box"
+	icon_state = "beer"
+	desc = "A box of assorted juices for more niche cocktails."
+	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/juice = 7)
+
 /obj/item/storage/box/ic_cones
 	name = "ice cream cone box"
 	icon_state = "ic_cones"


### PR DESCRIPTION
[QoL] [Catering]
## About the PR
This PR adds bottles of white wine to the hidden section of the bartender vendor, as well as 2 boxes with a random assortment of fruit juices (apple, blackberry, blue raspberry, raspberry, capsaicin, grapefruit, peach, and strawberry juice) to the normal selection.

## Why's this needed?
Currently these juices are only available through botany, and only service between 1-3 possible mixes. This change allows a bartender to mix these drinks regardless of whether botany is around. It's hard to justify asking botany for 7 trays (3 of them mutations) for drink ingredients that might not even be needed, so this change allows bartenders to have a little more freedom in the drinks they offer. Notably, however, the selection of juices available is entirely random. It's not guaranteed that any juice will be there, and it might not be in the quantity wanted (each of the 7 bottles in a box has 30u of juice), so botany may still be required.

## Changelog
```changelog
(u)Mintyphresh
(+)Boxes of juices are now available in the bartending vendor. Order a Prairie Fire today! :)
```
