### PR TITLE
Add access spawner and firelock to Donut2 CE office

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -37484,7 +37484,7 @@
 	pixel_y = 6
 	},
 /obj/displaycase{
-	displayed = new /obj/item/captaingun()
+	displayed = new/obj/item/captaingun()
 	},
 /obj/blind_switch/area/west{
 	pixel_y = -6
@@ -38022,6 +38022,8 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/mapping_helper/access/engineering_chief,
+/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/ce)
 "nEX" = (


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR
The CE's office door on donut2 had no firelock, and more importantly, no access spawner. Anyone could walk in. This is bad.
Anyway so i've plonked those in.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15309
## Changelog
```changelog
(u)Tyrant
(+)The CE's office on Donut 2 is no longer open to the public.
```