### PR TITLE
Mass driver updates for correct distance

### DIFF
--- a/code/modules/unit_tests/_map_correctness.dm
+++ b/code/modules/unit_tests/_map_correctness.dm
@@ -181,7 +181,7 @@ proc/check_mass_drivers()
 			var/turf/new_end = end
 			while(TRUE)
 				new_end = get_step(new_end, M.dir)
-				if(!istype(new_end, /turf/space) || (new_end.x == 1 || new_end.x == world.maxx || new_end.y == 1 || new_end.y == world.maxy) )
+				if(!istype(new_end, /turf/space) || istype(new_end, /turf/space/fluid/warp_z5) || (new_end.x == 1 || new_end.x == world.maxx || new_end.y == 1 || new_end.y == world.maxy) )
 					distance = GET_DIST(M, new_end)
 					break
 

--- a/code/modules/unit_tests/_map_correctness.dm
+++ b/code/modules/unit_tests/_map_correctness.dm
@@ -174,6 +174,8 @@ proc/check_mass_drivers()
 
 			if(!istype(end, /turf/space))
 				continue
+			else if(istype(end, /turf/space/fluid/warp_z5))
+				continue
 			else if((end.x == 1 || end.x == world.maxx || end.y == 1 || end.y == world.maxy))
 				continue
 

--- a/code/modules/unit_tests/_map_correctness.dm
+++ b/code/modules/unit_tests/_map_correctness.dm
@@ -177,7 +177,6 @@ proc/check_mass_drivers()
 			else if((end.x == 1 || end.x == world.maxx || end.y == 1 || end.y == world.maxy))
 				continue
 
-			var/turfs = block(end, get_edge_target_turf(end, M.dir))
 			var/distance = 0
 			var/turf/new_end = end
 			while(TRUE)
@@ -185,7 +184,6 @@ proc/check_mass_drivers()
 				if(!istype(new_end, /turf/space) || (new_end.x == 1 || new_end.x == world.maxx || new_end.y == 1 || new_end.y == world.maxy) )
 					distance = GET_DIST(M, new_end)
 					break
-
 
 			log_lines += "([M.x], [M.y]) only reaches [end] ([end.x],[end.y]) consider range of [distance] to reach [new_end] ([new_end?.x],[new_end?.y]) "
 	if(length(log_lines))

--- a/code/modules/unit_tests/_map_correctness.dm
+++ b/code/modules/unit_tests/_map_correctness.dm
@@ -19,6 +19,7 @@ proc/check_map_correctness()
 	check_xmas_tree()
 	#endif
 	check_turf_underlays()
+	check_mass_drivers()
 
 proc/check_missing_navbeacons()
 	var/list/all_beacons = list()
@@ -164,6 +165,31 @@ proc/check_duplicate_area_names()
 			log_msg += "The following areas have duplicate name \"[dupe || "***EMPTY STRING***"]\": [english_list(names[dupe])]\n"
 
 		CRASH(log_msg)
+
+proc/check_mass_drivers()
+	var/list/log_lines = list()
+	for(var/obj/machinery/mass_driver/M as anything in machine_registry[MACHINES_MASSDRIVERS])
+		if(M.z == Z_LEVEL_STATION)
+			var/atom/end = get_ranged_target_turf(M, M.dir, M.drive_range)
+
+			if(!istype(end, /turf/space))
+				continue
+			else if((end.x == 1 || end.x == world.maxx || end.y == 1 || end.y == world.maxy))
+				continue
+
+			var/turfs = block(end, get_edge_target_turf(end, M.dir))
+			var/distance = 0
+			var/turf/new_end = end
+			while(TRUE)
+				new_end = get_step(new_end, M.dir)
+				if(!istype(new_end, /turf/space) || (new_end.x == 1 || new_end.x == world.maxx || new_end.y == 1 || new_end.y == world.maxy) )
+					distance = GET_DIST(M, new_end)
+					break
+
+
+			log_lines += "([M.x], [M.y]) only reaches [end] ([end.x],[end.y]) consider range of [distance] to reach [new_end] ([new_end?.x],[new_end?.y]) "
+	if(length(log_lines))
+		CRASH("Insufficient Mass Driver Range:\n" + jointext(log_lines, "\n"))
 
 proc/check_missing_material()
 	var/list/missing = list()

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2195,7 +2195,7 @@
 "ahb" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 100;
+	drive_range = 105;
 	id = "chapelgun"
 	},
 /turf/simulated/floor/plating,
@@ -2203,7 +2203,7 @@
 "ahc" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 100;
+	drive_range = 104;
 	id = "chapelgun"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -3674,8 +3674,8 @@
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon6,
 /obj/item/device/radio/intercom/AI{
-	dir = 8;
-	broadcasting = 0
+	broadcasting = 0;
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -10020,7 +10020,7 @@
 "aFU" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 105;
 	id = "trash"
 	},
 /turf/simulated/floor/plating,
@@ -10028,7 +10028,7 @@
 "aFV" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 104;
 	id = "trash"
 	},
 /obj/machinery/door/poddoor/pyro{

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -6953,7 +6953,7 @@
 "aBH" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 139;
 	id = "disposals_vent"
 	},
 /turf/simulated/floor/caution/northsouth{
@@ -15867,7 +15867,7 @@
 /obj/machinery/mass_driver{
 	desc = "A device that launches objects, like ANCIENT BOMBS, for example, on it at great velocity when activated.";
 	dir = 4;
-	drive_range = 100;
+	drive_range = 135;
 	id = "artlabgun"
 	},
 /turf/simulated/floor/engine/caution/northsouth,
@@ -18482,6 +18482,7 @@
 "bMa" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 50;
 	id = "drone_launcher"
 	},
 /turf/simulated/floor/plating/random,
@@ -18489,6 +18490,7 @@
 "bMb" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 50;
 	id = "drone_launcher"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -20092,8 +20094,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
@@ -21169,8 +21171,8 @@
 /area/station/medical/medbay)
 "dXf" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Robotics Lab";
-	dir = 4
+	dir = 4;
+	name = "Robotics Lab"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/robotics,
@@ -21523,8 +21525,8 @@
 "ejL" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 1;
-	autoclose = 0
+	autoclose = 0;
+	dir = 1
 	},
 /obj/item/paper_bin{
 	pixel_x = 6;
@@ -27671,6 +27673,16 @@
 /obj/machinery/cashreg,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
+"jsd" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 138;
+	id = "disposals_vent"
+	},
+/turf/simulated/floor/caution/northsouth{
+	dir = 1
+	},
+/area/station/maintenance/disposal)
 "jsG" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -31295,8 +31307,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -34926,12 +34938,12 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/blast/single{
+	dir = 6;
 	doordir = "noblasts";
 	icon_state = "bdoornoblasts1";
 	id = "mining2qm_sec_door";
 	layer = 4;
-	name = "QM Security Door";
-	dir = 6
+	name = "QM Security Door"
 	},
 /turf/simulated/floor/caution/misc{
 	dir = 4
@@ -37949,8 +37961,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple{
-	level = 2;
-	dir = 6
+	dir = 6;
+	level = 2
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -45636,8 +45648,8 @@
 "yis" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 1;
-	autoclose = 0
+	autoclose = 0;
+	dir = 1
 	},
 /obj/item/clipboard{
 	pixel_x = -7
@@ -87229,7 +87241,7 @@ aaa
 sqY
 plf
 avz
-aBH
+jsd
 aSm
 asm
 aES

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -76,7 +76,7 @@
 "aat" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 23;
+	drive_range = 71;
 	id = "north_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -119,7 +119,7 @@
 "aaD" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 25;
+	drive_range = 69;
 	id = "north_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -182,7 +182,7 @@
 /area/space)
 "aaO" = (
 /obj/machinery/mass_driver{
-	drive_range = 25;
+	drive_range = 67;
 	id = "north_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -3199,7 +3199,7 @@
 "all" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 23;
+	drive_range = 14;
 	id = "cateringdock_out"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -3470,7 +3470,7 @@
 "amo" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 23;
+	drive_range = 15;
 	id = "cateringdock_out"
 	},
 /turf/simulated/floor/plating,
@@ -11770,7 +11770,7 @@
 "aJZ" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 100;
+	drive_range = 104;
 	id = "chapelgun"
 	},
 /turf/simulated/floor/plating,
@@ -11778,7 +11778,7 @@
 "aKa" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 100;
+	drive_range = 103;
 	id = "chapelgun"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -21288,7 +21288,7 @@
 "bkl" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 25;
+	drive_range = 68;
 	id = "north_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -22290,7 +22290,7 @@
 "bnA" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 23;
+	drive_range = 27;
 	id = "outer_in"
 	},
 /turf/simulated/floor/plating/airless,
@@ -22891,7 +22891,7 @@
 /area/station/ai_monitored/storage/eva)
 "bpk" = (
 /obj/machinery/mass_driver{
-	drive_range = 100;
+	drive_range = 70;
 	id = "south_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -24933,6 +24933,7 @@
 "byi" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 58;
 	id = "drone_launcher"
 	},
 /turf/simulated/floor/plating/random,
@@ -24940,6 +24941,7 @@
 "byj" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 57;
 	id = "drone_launcher"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -33181,7 +33183,7 @@
 "cbD" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 5;
+	drive_range = 41;
 	id = "magnet"
 	},
 /turf/simulated/floor/plating/airless,
@@ -40569,6 +40571,7 @@
 "cyI" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 17;
 	id = "chemdock_in"
 	},
 /turf/simulated/floor/plating/airless,
@@ -40580,7 +40583,7 @@
 "cyV" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 50;
+	drive_range = 33;
 	id = "south_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -40588,7 +40591,7 @@
 "cyW" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 25;
+	drive_range = 218;
 	id = "south_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -40596,7 +40599,7 @@
 "cyX" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 25;
+	drive_range = 108;
 	id = "south_ext"
 	},
 /turf/simulated/floor/plating/airless,
@@ -42907,6 +42910,14 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
+"dCU" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 28;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "dDl" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -44220,6 +44231,14 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"eGu" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 40;
+	id = "magnet"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "eGB" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -44657,6 +44676,14 @@
 /obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
+"eWX" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 68;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "eXq" = (
 /obj/machinery/vehicle/pod_smooth/light,
 /obj/machinery/light{
@@ -46596,6 +46623,14 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/eva)
+"gGO" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 29;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "gIi" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Test Chamber Access";
@@ -47372,6 +47407,14 @@
 /obj/landmark/pest,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
+"hwF" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 28;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "hwO" = (
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side{
@@ -50385,6 +50428,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"kkz" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 107;
+	id = "south_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "kms" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/eastright{
@@ -50523,6 +50574,13 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/staff)
+"krk" = (
+/obj/machinery/mass_driver{
+	drive_range = 68;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "krl" = (
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -52187,6 +52245,14 @@
 	id = "qmin"
 	},
 /turf/space,
+/area/space)
+"mhv" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 32;
+	id = "south_ext"
+	},
+/turf/simulated/floor/plating/airless,
 /area/space)
 "mhN" = (
 /obj/machinery/conveyor/WE{
@@ -54442,6 +54508,14 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
+"ofF" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 29;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "ogb" = (
 /obj/machinery/door/window/northleft{
 	req_access_txt = null
@@ -54608,6 +54682,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/engine)
+"ola" = (
+/obj/machinery/mass_driver{
+	drive_range = 71;
+	id = "south_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "olI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55918,6 +55999,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"pzJ" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 219;
+	id = "south_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "pzO" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -62251,6 +62340,14 @@
 	dir = 10
 	},
 /area/mining/magnet)
+"vdw" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 28;
+	id = "outer_in"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "vdx" = (
 /obj/landmark/start/latejoin,
 /obj/stool/chair/comfy/shuttle,
@@ -62570,6 +62667,14 @@
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
+"vre" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 67;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "vrm" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -63743,6 +63848,14 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/science/teleporter)
+"wuJ" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 16;
+	id = "chemdock_in"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "wuM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -64956,6 +65069,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"xBi" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 72;
+	id = "north_ext"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "xBy" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -99370,7 +99491,7 @@ adC
 adC
 adC
 adC
-cyI
+wuJ
 cyI
 ojv
 aax
@@ -99978,7 +100099,7 @@ adC
 adC
 xaG
 aay
-cyX
+kkz
 aah
 adC
 adC
@@ -100129,7 +100250,7 @@ adC
 aag
 aaq
 aay
-aaD
+eWX
 aaG
 adC
 adC
@@ -120965,7 +121086,7 @@ adC
 adC
 adC
 aag
-aat
+xBi
 aax
 hPO
 aaG
@@ -122779,7 +122900,7 @@ adC
 aag
 xaG
 aax
-aaD
+gGO
 aaG
 adC
 adC
@@ -123081,7 +123202,7 @@ adC
 aag
 xaG
 aay
-aaD
+hwF
 aaG
 adC
 adC
@@ -131535,7 +131656,7 @@ adC
 adC
 adC
 aag
-aat
+dCU
 aay
 hPO
 aaG
@@ -131610,7 +131731,7 @@ adC
 aag
 hPO
 aax
-bnA
+vdw
 aaG
 adC
 adC
@@ -131837,7 +131958,7 @@ adC
 adC
 adC
 aag
-aat
+ofF
 aax
 hPO
 aap
@@ -131988,7 +132109,7 @@ aar
 aar
 aaw
 aap
-cyW
+pzJ
 aax
 aap
 aaG
@@ -132143,7 +132264,7 @@ aau
 aax
 avp
 aaA
-aaO
+krk
 aaO
 adC
 adC
@@ -132216,7 +132337,7 @@ hPO
 fxp
 bnB
 aaA
-bpk
+ola
 bpk
 adC
 adC
@@ -132813,7 +132934,7 @@ aah
 adC
 adC
 adC
-bkl
+vre
 bkl
 blw
 bmh
@@ -132859,7 +132980,7 @@ adC
 adC
 adC
 adC
-cbD
+eGu
 cbD
 blw
 bAK
@@ -132893,7 +133014,7 @@ adC
 adC
 aag
 aap
-cyV
+mhv
 cyV
 blw
 fxp

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -81,7 +81,7 @@
 "aau" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 70;
+	drive_range = 39;
 	id = "chapel_relayE";
 	name = "cargo driver"
 	},
@@ -140,7 +140,7 @@
 "aaO" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 70;
+	drive_range = 65;
 	id = "chapel_relayW";
 	name = "cargo driver"
 	},
@@ -173,7 +173,7 @@
 "aaU" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 30;
+	drive_range = 38;
 	id = null;
 	name = "cargo driver"
 	},
@@ -223,7 +223,7 @@
 /area/station/turret_protected/ai)
 "abc" = (
 /obj/machinery/mass_driver{
-	drive_range = 5;
+	drive_range = 25;
 	id = "arrivals_in";
 	name = "cargo driver"
 	},
@@ -1773,7 +1773,7 @@
 "afJ" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 4;
+	drive_range = 14;
 	id = "catering_out";
 	name = "cargo driver"
 	},
@@ -2038,6 +2038,7 @@
 "agu" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 262;
 	id = "drone_launcher"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -2050,6 +2051,7 @@
 "agv" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 262;
 	id = "drone_launcher"
 	},
 /turf/simulated/floor/plating/random,
@@ -2100,7 +2102,7 @@
 "agI" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 4;
+	drive_range = 15;
 	id = "catering_out";
 	name = "cargo driver"
 	},
@@ -2249,7 +2251,7 @@
 "ahn" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 3;
+	drive_range = 20;
 	id = "chapel_out";
 	name = "cargo driver"
 	},
@@ -3330,7 +3332,7 @@
 "aky" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 3;
+	drive_range = 20;
 	id = "chapel_out";
 	name = "cargo driver"
 	},
@@ -5913,7 +5915,7 @@
 "arK" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 2;
+	drive_range = 25;
 	id = "arrivals_out";
 	name = "cargo driver"
 	},
@@ -6370,7 +6372,7 @@
 "asZ" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 2;
+	drive_range = 26;
 	id = "arrivals_out";
 	name = "cargo driver"
 	},
@@ -21255,7 +21257,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun1"
 	},
 /turf/simulated/floor/shuttlebay{
@@ -21265,7 +21267,7 @@
 "bhm" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun1"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -21372,7 +21374,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun2"
 	},
 /turf/simulated/floor/shuttlebay{
@@ -21389,7 +21391,7 @@
 "bhz" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun2"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -22167,7 +22169,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 5;
+	drive_range = 7;
 	id = "owlery_in";
 	name = "cargo driver"
 	},
@@ -22463,7 +22465,7 @@
 "bkO" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun1"
 	},
 /obj/machinery/activation_button/driver_button{
@@ -22478,7 +22480,7 @@
 "bkP" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun1"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -22766,7 +22768,7 @@
 "blJ" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 5;
+	drive_range = 8;
 	id = "owlery_in";
 	name = "cargo driver"
 	},
@@ -23460,7 +23462,7 @@
 "bnN" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun2"
 	},
 /obj/machinery/activation_button/driver_button{
@@ -23475,7 +23477,7 @@
 "bnO" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 20;
+	drive_range = 87;
 	id = "evagun2"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -25885,7 +25887,7 @@
 "buc" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 5;
+	drive_range = 4;
 	id = "security_in";
 	name = "cargo driver"
 	},
@@ -37609,7 +37611,7 @@
 "bVA" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 5;
+	drive_range = 6;
 	id = "engine_in";
 	name = "cargo driver"
 	},
@@ -37629,7 +37631,7 @@
 "bVB" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 5;
+	drive_range = 7;
 	id = "engine_in";
 	name = "cargo driver"
 	},
@@ -46561,7 +46563,7 @@
 "cvn" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 15;
+	drive_range = 9;
 	id = "disposals_up";
 	name = "cargo driver"
 	},
@@ -47250,7 +47252,7 @@
 "cwX" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 15;
+	drive_range = 10;
 	id = "disposals_up";
 	name = "cargo driver"
 	},
@@ -56309,7 +56311,7 @@
 /area/station/hangar/escape)
 "cVZ" = (
 /obj/machinery/mass_driver{
-	drive_range = 5;
+	drive_range = 13;
 	id = "escape_out";
 	name = "cargo driver"
 	},
@@ -56849,7 +56851,7 @@
 /area/station/hangar/escape)
 "cXn" = (
 /obj/machinery/mass_driver{
-	drive_range = 5;
+	drive_range = 13;
 	id = "escape_out";
 	name = "cargo driver"
 	},
@@ -57338,7 +57340,7 @@
 /area/station/mining/magnet)
 "cYC" = (
 /obj/machinery/mass_driver{
-	drive_range = 5;
+	drive_range = 8;
 	id = "cargo_out";
 	name = "cargo driver"
 	},
@@ -58477,7 +58479,7 @@
 	})
 "dbi" = (
 /obj/machinery/mass_driver{
-	drive_range = 5;
+	drive_range = 7;
 	id = "cargo_out";
 	name = "cargo driver"
 	},
@@ -59837,7 +59839,7 @@
 /area/station/hangar/science)
 "dfy" = (
 /obj/machinery/mass_driver{
-	drive_range = 3;
+	drive_range = 4;
 	id = "medsci_out";
 	name = "cargo driver"
 	},
@@ -60214,7 +60216,7 @@
 "dgJ" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 5;
+	drive_range = 8;
 	id = "cargo_in";
 	name = "cargo driver"
 	},
@@ -60298,7 +60300,7 @@
 "dgX" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 5;
+	drive_range = 13;
 	id = "escape_in";
 	name = "cargo driver"
 	},
@@ -60352,7 +60354,7 @@
 "dhf" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 37;
+	drive_range = 41;
 	id = "cargo_relayE";
 	name = "cargo driver"
 	},
@@ -60361,7 +60363,7 @@
 "dhg" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 27;
+	drive_range = 40;
 	id = "cargo_relayE";
 	name = "cargo driver"
 	},
@@ -60491,7 +60493,7 @@
 "dhC" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 27;
+	drive_range = 40;
 	id = "escape_relay";
 	name = "cargo driver"
 	},
@@ -65930,6 +65932,15 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"ioV" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 39;
+	id = null;
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "ipl" = (
 /obj/machinery/conveyor/EW{
 	name = "cargo belt - west";
@@ -67576,6 +67587,7 @@
 /area/station/crew_quarters/locker)
 "kwQ" = (
 /obj/machinery/mass_driver{
+	drive_range = 34;
 	id = "to_outpost";
 	name = "cargo driver"
 	},
@@ -69636,6 +69648,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
+"nwM" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 7;
+	id = "cargo_in";
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "nwQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -70004,6 +70025,15 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
+"ogh" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 12;
+	id = "escape_in";
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "ogF" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -70647,6 +70677,7 @@
 /area/station/hangar/arrivals)
 "prn" = (
 /obj/machinery/mass_driver{
+	drive_range = 33;
 	name = "cargo driver"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -71171,6 +71202,15 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"qkW" = (
+/obj/machinery/mass_driver{
+	dir = 8;
+	drive_range = 41;
+	id = "escape_relay";
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "qkZ" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -74519,6 +74559,14 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"vfT" = (
+/obj/machinery/mass_driver{
+	drive_range = 26;
+	id = "arrivals_in";
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "vht" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light/emergency/exitsign,
@@ -74607,6 +74655,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/arrivals)
+"vqu" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 38;
+	id = "chapel_relayE";
+	name = "cargo driver"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "vrU" = (
 /obj/table/wood/auto,
 /obj/item/plantanalyzer,
@@ -125784,7 +125841,7 @@ aaa
 aaa
 aaa
 aaa
-dgJ
+nwM
 dgJ
 vzP
 dhd
@@ -127148,7 +127205,7 @@ aaa
 aaa
 aaa
 aam
-aau
+vqu
 aaE
 rZr
 aal
@@ -138928,7 +138985,7 @@ aaa
 aam
 kTY
 pVn
-aaU
+ioV
 aan
 aaS
 aah
@@ -139681,7 +139738,7 @@ aaS
 aan
 kTY
 eNc
-dhC
+qkW
 aaI
 aaa
 aaa
@@ -139835,7 +139892,7 @@ aal
 kiN
 kiN
 rSM
-abc
+vfT
 abc
 aaa
 aaa
@@ -139979,7 +140036,7 @@ aaa
 aaa
 aaa
 aaa
-dgX
+ogh
 dgX
 iae
 eNc

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -735,6 +735,7 @@
 "acp" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 135;
 	id = "outpostla2"
 	},
 /turf/simulated/floor/engine/vacuum{
@@ -756,7 +757,7 @@
 /area/space)
 "acw" = (
 /obj/machinery/mass_driver{
-	dir = 2;
+	drive_range = 43;
 	id = "outpostla3"
 	},
 /turf/simulated/floor/engine/vacuum{
@@ -5374,6 +5375,7 @@
 "awc" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 70;
 	id = "drone_launcher"
 	},
 /turf/simulated/floor/plating/random,
@@ -5381,6 +5383,7 @@
 "awd" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 70;
 	id = "drone_launcher"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -7089,6 +7092,7 @@
 "aCe" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 26;
 	id = "outpost_mail_in"
 	},
 /turf/simulated/floor/engine/vacuum{
@@ -7801,6 +7805,7 @@
 "aEt" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 82;
 	id = "outpost_mail_out"
 	},
 /turf/simulated/floor/engine/vacuum{
@@ -26818,6 +26823,7 @@
 "fed" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 10;
 	id = "outpostla"
 	},
 /turf/simulated/floor/plating,
@@ -43546,6 +43552,7 @@
 "rEV" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 9;
 	id = "outpostla"
 	},
 /obj/machinery/door/poddoor/pyro{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -22239,7 +22239,7 @@
 "gKv" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 62;
+	drive_range = 64;
 	id = "QM_Sell"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -46021,7 +46021,7 @@
 "ocs" = (
 /obj/machinery/mass_driver{
 	dir = 4;
-	drive_range = 62;
+	drive_range = 63;
 	id = "QM_Sell"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -48509,7 +48509,7 @@
 /obj/plasticflaps,
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 75;
+	drive_range = 83;
 	id = "crusher2"
 	},
 /turf/simulated/floor/plating/jen,
@@ -56909,6 +56909,7 @@
 "rqm" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 66;
 	id = "drone_launcher"
 	},
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -57915,6 +57916,7 @@
 "rGY" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 66;
 	id = "drone_launcher"
 	},
 /turf/simulated/floor/plating/random,
@@ -64202,7 +64204,7 @@
 "tHi" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 75;
+	drive_range = 82;
 	id = "crusher2"
 	},
 /obj/machinery/door/poddoor/pyro{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8344,7 +8344,7 @@
 "aDk" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 50;
+	drive_range = 114;
 	id = "trashgun"
 	},
 /obj/machinery/door/poddoor/pyro{
@@ -8535,7 +8535,7 @@
 "aDN" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	drive_range = 50;
+	drive_range = 115;
 	id = "trashgun"
 	},
 /turf/simulated/floor/black/grime,
@@ -24834,6 +24834,7 @@
 "bPt" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 17;
 	id = "kd_scinorth"
 	},
 /turf/simulated/floor/airless/plating,
@@ -29482,6 +29483,7 @@
 "chU" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 18;
 	id = "sw_router_north"
 	},
 /turf/simulated/floor/airless/plating,
@@ -35963,6 +35965,14 @@
 	dir = 9
 	},
 /area/station/engine/monitoring)
+"eYN" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 16;
+	id = "kd_scinorth"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/southwest)
 "eZq" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
@@ -36043,6 +36053,7 @@
 "fcO" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 10;
 	id = "kondaru_qmfetch"
 	},
 /obj/decal/stripe_delivery,
@@ -59268,6 +59279,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"xIu" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 17;
+	id = "sw_router_north"
+	},
+/turf/simulated/floor/airless/plating,
+/area/space)
 "xII" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -90220,7 +90239,7 @@ aaa
 rUW
 jdn
 jjy
-bPt
+eYN
 bPt
 vRn
 bTI
@@ -90848,7 +90867,7 @@ aaa
 aaa
 aaa
 aaa
-chU
+xIu
 chU
 cij
 ciq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -751,6 +751,7 @@
 "acw" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 32;
 	id = "nw_router_east"
 	},
 /turf/simulated/floor/airless/plating,
@@ -1159,6 +1160,7 @@
 	})
 "adB" = (
 /obj/machinery/mass_driver{
+	drive_range = 64;
 	id = "nw_router_south"
 	},
 /turf/simulated/floor/airless/plating,
@@ -17780,6 +17782,7 @@
 "boM" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 65;
 	id = "kd_mednorth"
 	},
 /turf/simulated/floor/airless/plating,
@@ -19435,6 +19438,7 @@
 /area/station/hangar/engine)
 "bwq" = (
 /obj/machinery/mass_driver{
+	drive_range = 16;
 	id = "kd_medsouth"
 	},
 /turf/simulated/floor/airless/plating,
@@ -26472,6 +26476,7 @@
 /area/station/crew_quarters/catering)
 "bVV" = (
 /obj/machinery/mass_driver{
+	drive_range = 19;
 	id = "kd_scisouth"
 	},
 /turf/simulated/floor/airless/plating,
@@ -29500,6 +29505,7 @@
 "cic" = (
 /obj/machinery/mass_driver{
 	dir = 1;
+	drive_range = 9;
 	id = "kd_qmnorth"
 	},
 /turf/simulated/floor/airless/plating,
@@ -29529,6 +29535,7 @@
 "cik" = (
 /obj/machinery/mass_driver{
 	dir = 8;
+	drive_range = 59;
 	id = "kd_qmwest"
 	},
 /turf/simulated/floor/airless/plating,
@@ -29578,6 +29585,7 @@
 "cix" = (
 /obj/machinery/mass_driver{
 	dir = 4;
+	drive_range = 60;
 	id = "sw_router_east"
 	},
 /turf/simulated/floor/airless/plating,
@@ -39818,6 +39826,14 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
+"iiz" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 59;
+	id = "sw_router_east"
+	},
+/turf/simulated/floor/airless/plating,
+/area/space)
 "iiL" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/machinery/power/apc/autoname_east,
@@ -42232,6 +42248,14 @@
 	dir = 1
 	},
 /area/station/crew_quarters/ce)
+"jXY" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	drive_range = 64;
+	id = "kd_mednorth"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/west)
 "jYd" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1;
@@ -43102,6 +43126,13 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/caution/north,
 /area/station/engine/gas)
+"kNb" = (
+/obj/machinery/mass_driver{
+	drive_range = 17;
+	id = "kd_medsouth"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/west)
 "kNj" = (
 /obj/storage/secure/closet/personal,
 /obj/cable{
@@ -53326,6 +53357,13 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
+"taF" = (
+/obj/machinery/mass_driver{
+	drive_range = 20;
+	id = "kd_scisouth"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/maintenance/southwest)
 "taS" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/escape,
@@ -55452,6 +55490,15 @@
 "uIC" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"uJv" = (
+/obj/machinery/mass_driver{
+	drive_range = 65;
+	id = "nw_router_south"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/routing/eva{
+	name = "Router Cabinet"
+	})
 "uKA" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -56142,6 +56189,16 @@
 	},
 /turf/space,
 /area/space)
+"vlq" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 31;
+	id = "nw_router_east"
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/routing/eva{
+	name = "Router Cabinet"
+	})
 "vlr" = (
 /obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /obj/machinery/light,
@@ -90443,7 +90500,7 @@ aaa
 aaa
 aaa
 acb
-boM
+jXY
 boM
 bsB
 uPl
@@ -90470,7 +90527,7 @@ bTC
 qMf
 bTE
 bUK
-bVV
+taF
 bVV
 afw
 aaa
@@ -90681,7 +90738,7 @@ ach
 acv
 acN
 adg
-adB
+uJv
 adB
 aaa
 uGT
@@ -90751,7 +90808,7 @@ aMt
 buc
 xJs
 ucj
-bwq
+kNb
 bwq
 aaa
 aaa
@@ -91282,7 +91339,7 @@ aaa
 aaa
 aaa
 ach
-acw
+vlq
 acO
 aaa
 amc
@@ -91399,7 +91456,7 @@ aaa
 aci
 aaa
 aci
-cix
+iiz
 cpy
 aaa
 aaa

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -26292,7 +26292,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 50;
+	drive_range = 65;
 	id = "trashgun"
 	},
 /turf/space/fluid/acid/clear,
@@ -28067,8 +28067,8 @@
 	pixel_y = 13
 	},
 /obj/item/device/nanoloom{
-	pixel_y = 1;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 1
 	},
 /obj/item/nanoloom_cartridge{
 	pixel_x = -7;
@@ -31713,12 +31713,12 @@
 "nAt" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/food_box/sugar_box{
-	pixel_y = 16;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 16
 	},
 /obj/item/reagent_containers/food/drinks/creamer{
-	pixel_y = 5;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
@@ -45936,8 +45936,8 @@
 	pixel_y = 7
 	},
 /obj/item/kitchen/food_box/sugar_box{
-	pixel_y = 12;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 12
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -46684,8 +46684,8 @@
 "ujg" = (
 /obj/table/reinforced/auto,
 /obj/item/crowbar{
-	pixel_y = 5;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /obj/item/device/multitool{
 	pixel_x = -17;
@@ -50313,9 +50313,9 @@
 /obj/item/storage/wall{
 	icon_state = "miniorange";
 	name = "Donk-Closet";
+	pixel_x = -4;
 	pixel_y = 32;
-	spawn_contents = list(/obj/item/storage/box/donkpocket_kit);
-	pixel_x = -4
+	spawn_contents = list(/obj/item/storage/box/donkpocket_kit)
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -50893,12 +50893,12 @@
 "wgR" = (
 /obj/table/reinforced/auto,
 /obj/item/device/gps{
-	pixel_y = 4;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /obj/item/device/gps{
-	pixel_y = 4;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 5

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -41691,7 +41691,7 @@
 /obj/mapping_helper/access/research,
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 101;
+	drive_range = 102;
 	id = "research"
 	},
 /turf/simulated/floor/plating/random,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9623,11 +9623,11 @@
 /obj/window_blinds/cog2/middle,
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "test_chamber";
 	name = "Test Chamber Blast Door";
-	opacity = 0;
-	dir = 4
+	opacity = 0
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
@@ -38696,8 +38696,8 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/security/alt{
-	req_access_txt = "1";
-	name = "Detective's Office"
+	name = "Detective's Office";
+	req_access_txt = "1"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/forensics,
@@ -41691,7 +41691,7 @@
 /obj/mapping_helper/access/research,
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 100;
+	drive_range = 101;
 	id = "research"
 	},
 /turf/simulated/floor/plating/random,
@@ -44175,11 +44175,11 @@
 /obj/window_blinds/cog2/right,
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "test_chamber";
 	name = "Test Chamber Blast Door";
-	opacity = 0;
-	dir = 4
+	opacity = 0
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
@@ -44327,8 +44327,8 @@
 /area/station/medical/robotics)
 "tcD" = (
 /obj/machinery/door/airlock/pyro/security/alt{
-	req_access_txt = "1";
-	name = "Detective's Office"
+	name = "Detective's Office";
+	req_access_txt = "1"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/forensics,
@@ -44360,9 +44360,9 @@
 	icon_state = "2-8"
 	},
 /obj/item/reagent_containers/food/snacks/popcorn{
+	bites_left = 100;
 	desc = "Those chickens are up to something...";
-	name = "suspicious popcorn";
-	bites_left = 100
+	name = "suspicious popcorn"
 	},
 /obj/landmark/start/job/detective,
 /turf/simulated/floor/carpet/grime,
@@ -44885,11 +44885,11 @@
 /obj/window_blinds/cog2/left,
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "test_chamber";
 	name = "Test Chamber Blast Door";
-	opacity = 0;
-	dir = 4
+	opacity = 0
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
@@ -46590,8 +46590,8 @@
 	dir = 9;
 	name = "autoname - SS13";
 	pixel_x = 10;
-	tag = "";
-	pixel_y = -17
+	pixel_y = -17;
+	tag = ""
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -41691,7 +41691,7 @@
 /obj/mapping_helper/access/research,
 /obj/machinery/mass_driver{
 	dir = 1;
-	drive_range = 102;
+	drive_range = 100;
 	id = "research"
 	},
 /turf/simulated/floor/plating/random,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates mass drivers "power/distance" to get to the next section or edge of the map.  This will resolve issues with broken mass driver paths when Terrainify or intermediate space tiles are replaced.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tired of manually checking that Terrainify works.

Resolves: https://discord.com/channels/182249960895545344/469379618168897538/967847716707266570




