### PR TITLE
Increases light borg head hp to 60

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -371,7 +371,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 	desc = "A cyborg head with little reinforcement, to be built in times of scarce resources."
 	appearanceString = "light"
 	icon_state = "head-light"
-	max_health = 50
+	max_health = 60
 	robot_movement_modifier = /datum/movement_modifier/robot_part/head
 	kind_of_limb = (LIMB_ROBOT | LIMB_LIGHT)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Light borg head health has been upped from 50 to 60.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I thought I made it to where a light borg needs two emps to have its head gone in #14889, but I did not, now they can last.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)light borg heads now have 60 hp, meaning they can now actually take two emp shots
```
