### PR TITLE
addiction message only plays when addiction reset

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -167,10 +167,11 @@ datum
 				if(INGEST)
 					var/datum/ailment_data/addiction/AD = M.addicted_to_reagent(src)
 					if (AD)
-						boutput(M, "<span class='notice'><b>You feel slightly better, but for how long?</b></span>")
 						M.make_jittery(-5)
 						AD.last_reagent_dose = world.timeofday
-						AD.stage = 1
+						if (AD.stage != 1)
+							boutput(M, "<span class='notice'><b>You feel slightly better, but for how long?</b></span>")
+							AD.stage = 1
 
 			M.material_trigger_on_chems(src, volume)
 			for(var/atom/A in M)


### PR DESCRIPTION
[MINOR] [QOL]
## About the PR
Adds an if condition, so that `/datum/ailment_data/addiction/AD.stage` only plays the "you feel better" message when the addiction stage is being changed. This means that if you're sipping coffee, the message will only appear once instead of on every sip.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Whenever you ingest an addictive food, it would say "You feel slightly better, but for how long?". Now it will only say it when your addiction level is reset to 1.
Also, fixes #15321
