### PR TITLE
Gives the HoP command teleporter access

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -207,7 +207,7 @@
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo, access_supply_console,
 						access_research, access_hydro, access_ranch, access_mail, access_ai_upload, access_pathology, access_researchfoyer,
-						access_telesci)
+						access_telesci, access_teleporter)
 		if("Head of Security")
 #ifdef RP_MODE
 			var/list/hos_access = get_all_accesses()


### PR DESCRIPTION
[BUG]
## About the PR
Gives the HoP command teleporter access. Since they're part of the command structure.

## Why's this needed?
Seems like an oversight. Fixes #15165
If this isn't a bug, then, well, better close the issue as intended.

## Changelog
```changelog
(u)Tyrant
(+)The HoP now has access to the command teleporter by default.
```
