### PR TITLE
Add brig shower to Donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -10441,10 +10441,8 @@
 	dir = 5;
 	icon_state = "tile1"
 	},
-/obj/machinery/bot/buttbot{
-	desc = "It surprisingly has managed to keep the bathroom pretty clean...Somehow.";
-	name = "Bathroom Supervisor"
-	},
+/obj/machinery/shower,
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/security/brig/north_side)
 "dbt" = (
@@ -26698,6 +26696,10 @@
 /obj/decal/tile_edge/line/black{
 	dir = 6;
 	icon_state = "tile1"
+	},
+/obj/machinery/bot/buttbot{
+	desc = "It surprisingly has managed to keep the bathroom pretty clean...Somehow.";
+	name = "Bathroom Supervisor"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/security/brig/north_side)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Objects] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a shower and sink to the brig in Security.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Brings it in line with other brigs, and allows stinky stinky prisoners to shower.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Added a brig shower to Donut3.
```
