### PR TITLE
adds a new riot barrier

### DIFF
--- a/code/obj/item/barrier.dm
+++ b/code/obj/item/barrier.dm
@@ -161,3 +161,34 @@ TYPEINFO(/obj/item/barrier)
 
 		src.setItemSpecial(/datum/item_special/barrier)
 		BLOCK_SETUP(BLOCK_ALL)
+
+/obj/item/riot_barrier
+	name = "riot barrier"
+	desc = "a two handed barrier designed for riot situations
+	icon = 'icons/obj/items/weapons.dmi'
+	icon_state = "barrier0"
+	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
+	item_state = "barrier0"
+	flags = FPRINT | TABLEPASS
+	c_flags = EQUIPPED_WHILE_HELD | ONBELT
+	force = 4
+	throwforce = 6
+	w_class = W_CLASS_SMALL
+	stamina_damage = 50
+	stamina_cost = 30
+	stamina_crit_chance = 0
+	hitsound = 0
+
+	var/use_two_handed = 1
+
+	setupProperties()
+		..()
+		setProperty("meleeprot_all", 12)
+		setProperty("rangedprot", 3)
+		setProperty("movespeed", 0.6)
+		setProperty("disorient_resist", 65)
+		setProperty("disorient_resist_eye", 65)
+		setProperty("disorient_resist_ear", 50)
+
+		src.setItemSpecial(/datum/item_special/barrier)
+		BLOCK_SETUP(BLOCK_ALL)


### PR DESCRIPTION
[ITEM]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this PR adds a two handed riot variant of the barrier intended to be used in riot situations, this will buff the melee and ranged protection and the downsides are that it’s two handed and it has a 0.6 slowdown debuff


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel that we need more items to defend yourself in riot situations and mimics the effects of a riot shield in game


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)deathrobotpunch
(*)Added a riot variant of the barrier that can be found in the armoury
```
