### PR TITLE
Add wall busting shrapnel to the nuclear meltdown

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1731,3 +1731,26 @@ datum/projectile/bullet/autocannon
 	shot_sound = null
 	projectile_speed = 12
 	implanted = null
+
+/datum/projectile/bullet/wall_buster_shrapnel // for nuclear meltdowns
+	name = "shrapnel"
+	damage = 70
+	damage_type = D_PIERCING
+	armor_ignored = 0.66
+	hit_type = DAMAGE_CUT
+	window_pass = 0
+	icon = 'icons/obj/scrap.dmi'
+	icon_state = "2metal0"
+	casing = null
+	impact_image_state = "bhole-staple"
+	implanted = /obj/item/implant/projectile/shrapnel/radioactive
+
+	on_hit(atom/hit, angle, obj/projectile/O)
+		if(istype(hit,  /turf/simulated/wall))
+			//let's pretend these walls were destroyed in the explosion
+			hit.ex_act(2)
+		else if(istype(hit, /obj/window))
+			//I'm onto you with your stacks of thindows
+			for(var/obj/window/maybe_thindow in hit.loc)
+				maybe_thindow.ex_act(2)
+		. = ..()

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1746,11 +1746,11 @@ datum/projectile/bullet/autocannon
 	implanted = /obj/item/implant/projectile/shrapnel/radioactive
 
 	on_hit(atom/hit, angle, obj/projectile/O)
-		if(istype(hit,  /turf/simulated/wall))
-			//let's pretend these walls were destroyed in the explosion
-			hit.ex_act(2)
-		else if(istype(hit, /obj/window))
+		if(!ismob(hit))
 			//I'm onto you with your stacks of thindows
-			for(var/obj/window/maybe_thindow in hit.loc)
-				maybe_thindow.ex_act(2)
+			if(!isturf(hit)) //did you know that turf.loc is /area? because I didn't
+				for(var/obj/window/maybe_thindow in hit.loc)
+					maybe_thindow.ex_act(2)
+			//let's pretend these walls/objects were destroyed in the explosion
+			hit.ex_act(2)
 		. = ..()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -916,6 +916,13 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			..()
 			implant_overlay = null
 
+		radioactive
+			name = "radioactive shrapnel"
+
+			New()
+				..()
+				src.AddComponent(/datum/component/radioactive, 50, FALSE, FALSE, 0)
+
 	body_visible
 		bleed_time = 0
 		leaves_wound = FALSE

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -383,6 +383,10 @@
 		src.current_gas.temperature = src.temperature
 		var/turf/current_loc = get_turf(src)
 		current_loc.assume_air(current_gas)
+
+		for(var/i = 1 to rand(5,20))
+			shoot_projectile_XY(src, new /datum/projectile/bullet/wall_buster_shrapnel(), rand(-10,10), rand(-10,10))
+
 		explosion_new(src,current_loc,2500,1,0,360,TRUE)
 		SPAWN(15 SECONDS)
 			alarm.repeat = FALSE //haha this is horrendous, this cannot be the way to do this


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a blast of 5 to 20 radioactive shrapnel projectiles which can bust walls and piles of thindows.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The explosion of the reactor is turf safe so the fallout gas doesn't leak into space, but that also means that walls and windows aren't destroyed either so it doesn't spread. 
Now when the reactor blows, it will destroy a handful of immediately close walls and piles of thindows (which some engineers are using to deal with radiation). Additionally if a mob is hit with one of these projectiles instead, they get implanted with radioactive shrapnel, though I don't expect this to happen often since being in the room when the meltdown goes off is basically an instagib.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)The catastrophic nuclear meltdown is now slightly more catastrophic. Enjoy.
```
