### PR TITLE
unduplicate Materials crate declaration

### DIFF
--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -254,10 +254,6 @@
 				new /obj/item/pen/crayon/rainbow(src)
 			return 1
 
-/obj/storage/crate/materials
-	name = "building materials crate"
-	spawn_contents = list(/obj/item/sheet/steel/fullstack,
-	/obj/item/sheet/glass/fullstack)
 /obj/storage/crate/radio
 	name = "radio headsets crate"
 	spawn_contents = list(


### PR DESCRIPTION
[INTERNAL] [CODE-QUALITY]
## About the PR
The "building materials crate", `/obj/storage/crate/materials` was declared twice, once in line 206, and again at line 257.
## Why's this needed?
Why would it need to be declared twice? they're exactly identical too.
And this has been here since the initial commit too.