### PR TITLE
Fix Teleporter access on atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -5750,7 +5750,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/teleporter,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "atz" = (


### PR DESCRIPTION
[MAPPING]
## About the PR
The teleporter room on atlas mistakenly used head access spawners instead of teleporter access. Having checked all other rotation maps, this is the only map to have that error.

## Why's this needed?
Bugs bad