### PR TITLE
adds bacon grease & lard that can be ignited/eaten

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -598,6 +598,37 @@
 				boutput(M, "<span class='notice'>A faint cheesy smell drifts through the air...</span>")
 			return
 
+
+	baconGrease
+		name = "Bacon Grease"
+		id = "lbacongrease"
+		result = "lbacongrease"
+		required_reagents = list("cbacongrease" = 1)
+		min_temperature = T0C + 35
+		result_amount = 1
+		mix_phrase = "The mass melts into a yellow oil."
+		on_reaction(var/datum/reagents/holder)
+			var/location = get_turf(holder.my_atom)
+			for(var/mob/M in all_viewers(8, location))
+				boutput(M, "<span class='notice'>A fainy bacony smell fills the room...</span>")
+			return
+
+
+
+	baconLard
+		name = "Bacon Lard"
+		id = "cbacongrease"
+		result = "cbacongrease"
+		required_reagents = list("lbacongrease" = 1)
+		max_temperature = T0C + 10
+		min_temperature = T0C + 1
+		result_amount = 1
+		mix_phrase = "The solution condenses into a marbly white solid."
+		on_reaction(var/datum/reagents/holder)
+			var/location = get_turf(holder.my_atom)
+			for(var/mob/M in all_viewers(8, location))
+				boutput(M, "<span class='notice'>A fainy bacony smell fills the room...</span>")
+			return
 	cheese2
 		name = "Cheese"
 		id = "cheese2"

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -151,7 +151,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/ingredient)
 	name = "bacon"
 	desc = "A strip of salty cured pork. Many disgusting nerds have a bizarre fascination with this meat, going so far as to construct tiny houses out of it."
 	icon_state = "bacon"
-	initial_reagents = list("porktonium"=10)
+	initial_reagents = list("porktonium"=10, "lbacongrease" = 10)
+
+
+
 	blood = 0
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Catering]
[Chemistry]
[game objects]
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds two chems, bacon grease and bacon lard. bacon grease and lard both metabolize as cholesterol, but the lard metabolizes into more cholesterol than the grease. You get bacon grease by putting bacon in a reagent extractor, and you get lard by cooling down the lard. The bacon grease can be ignited at 200C, being a little less powerful than welding fuel.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think people should be able to drink bacon grease in space station 13, and I think that the clown should be able to fill balloons with boiling bacon grease that lights things on fire.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Klushy225
(+)Added bacon lard and bacon grease found in bacon. Can be ignited
```
