### PR TITLE
Make click dragging an item onto a stored HUD equip it

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -78,9 +78,9 @@
 		if (master && (!master.click_check || (usr in master.mobs)))
 			master.MouseDrop(src, over_object, src_location, over_location, over_control, params)
 
-	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
+	MouseDrop_T(atom/movable/O as obj, mob/user as mob, src_location, over_location, over_control, src_control, params)
 		if (master && (!master.click_check || (user in master.mobs)))
-			master.MouseDrop_T(src, O, user)
+			master.MouseDrop_T(src, O, user, params)
 
 	disposing()
 		src.master = null
@@ -240,7 +240,7 @@
 	proc/MouseEntered(id,location, control, params)
 	proc/MouseExited(id)
 	proc/MouseDrop(var/atom/movable/screen/hud/H, atom/over_object, src_location, over_location, over_control, params)
-	proc/MouseDrop_T(var/atom/movable/screen/hud/H, atom/movable/O as obj, mob/user as mob)
+	proc/MouseDrop_T(var/atom/movable/screen/hud/H, atom/movable/O as obj, mob/user as mob, params)
 
 /*
 	dynamic hud stuff

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -31,61 +31,16 @@
 	relay_click(id, mob/user, params)
 		switch (id)
 			if ("boxes")
-				if (params && islist(src.obj_locs))
-					var/list/prams = params
-					if (!islist(prams))
-						prams = params2list(prams)
-					if (islist(prams))
-						var/clicked_loc = prams["screen-loc"] // should be in the format 1:16,1:16 (tile x : pixel offset x, tile y : pixel offset y)
-						//DEBUG_MESSAGE(clicked_loc)
-						//var/regex/loc_regex = regex("(\\d*):\[^,]*,(\\d*):\[^\n]*")
-						//clicked_loc = loc_regex.Replace(clicked_loc, "$1,$2")
-						//DEBUG_MESSAGE(clicked_loc)
-
-						//MBC : I DONT KNOW REGEX BUT THE ABOVE IS NOT WORKING LETS DO THIS INSTEAD
-
-
-						var/firstcolon = findtext(clicked_loc,":")
-						var/comma = findtext(clicked_loc,",")
-						var/secondcolon = findtext(clicked_loc,":",comma)
-						if (firstcolon == secondcolon)
-							if (firstcolon > comma)
-								firstcolon = 0
-							else
-								secondcolon = 0
-
-						var/x = copytext(clicked_loc,1,firstcolon ? firstcolon : comma)
-						var/px = firstcolon ? copytext(clicked_loc,firstcolon+1,comma) : 0
-						var/y = copytext(clicked_loc,comma+1,secondcolon ? secondcolon : 0)
-						var/py = secondcolon ? copytext(clicked_loc,secondcolon+1) : 0
-
-						if (user.client && user.client.byond_version == 512 && user.client.byond_build == 1469) //sWAP EM BECAUSE OF BAD BYOND BUG
-							var/temp = y
-							y = px
-							px = temp
-
-						//ddumb hack for offset storage
-						var/turfd = (isturf(master.linked_item.loc) && !istype(master.linked_item, /obj/item/bible))
-
-						var/pixel_y_adjust = 0
-						if (user && user.client && user.client.tg_layout && !turfd)
-							pixel_y_adjust = 1
-
-						if (pixel_y_adjust && text2num(py) > 16)
-							y = text2num(y) + 1
-							py = text2num(py) - 16
-						//end dumb hack
-
-						clicked_loc = "[x],[y]"
-
-
-						var/obj/item/I = src.obj_locs[clicked_loc]
-						if (I)
-							//DEBUG_MESSAGE("clicking [I] with params [list2params(params)]")
-							user.click(I, params)
-						else if (user.equipped())
-							//DEBUG_MESSAGE("clicking [src.master.linked_item] with [user.equipped()] with params [list2params(params)]")
-							user.click(src.master.linked_item, params)
+				var/clicked_loc = src.get_clicked_position(user, params)
+				if (!clicked_loc)
+					return
+				var/obj/item/I = src.obj_locs[clicked_loc]
+				if (I)
+					//DEBUG_MESSAGE("clicking [I] with params [list2params(params)]")
+					user.click(I, params)
+				else if (user.equipped())
+					//DEBUG_MESSAGE("clicking [src.master.linked_item] with [user.equipped()] with params [list2params(params)]")
+					user.click(src.master.linked_item, params)
 
 			if ("close")
 				user.detach_hud(src)
@@ -104,6 +59,70 @@
 	MouseExited(var/atom/movable/screen/hud/H)
 		if (!H) return
 		sel.screen_loc = null
+
+	MouseDrop_T(atom/movable/screen/hud/H, atom/movable/O, mob/user, params)
+		if (!(user in src.mobs))
+			return
+		if (!(O in src.master.get_contents()))
+			return
+		var/clicked_position = src.get_clicked_position(user, params)
+		if (!clicked_position)
+			return
+		if (src.obj_locs[clicked_position] == O)
+			user.click(O, params2list(params))
+
+	proc/get_clicked_position(mob/user, list/params)
+		if (!params)
+			return
+		if (!islist(src.obj_locs))
+			return
+
+		var/list/prams = params
+		if (!islist(prams))
+			prams = params2list(prams)
+		if (!islist(prams))
+			return
+
+		var/clicked_loc = prams["screen-loc"] // should be in the format 1:16,1:16 (tile x : pixel offset x, tile y : pixel offset y)
+		//DEBUG_MESSAGE(clicked_loc)
+		//var/regex/loc_regex = regex("(\\d*):\[^,]*,(\\d*):\[^\n]*")
+		//clicked_loc = loc_regex.Replace(clicked_loc, "$1,$2")
+		//DEBUG_MESSAGE(clicked_loc)
+
+		//MBC : I DONT KNOW REGEX BUT THE ABOVE IS NOT WORKING LETS DO THIS INSTEAD
+
+		var/firstcolon = findtext(clicked_loc,":")
+		var/comma = findtext(clicked_loc,",")
+		var/secondcolon = findtext(clicked_loc,":",comma)
+		if (firstcolon == secondcolon)
+			if (firstcolon > comma)
+				firstcolon = 0
+			else
+				secondcolon = 0
+
+		var/x = copytext(clicked_loc,1,firstcolon ? firstcolon : comma)
+		var/px = firstcolon ? copytext(clicked_loc,firstcolon+1,comma) : 0
+		var/y = copytext(clicked_loc,comma+1,secondcolon ? secondcolon : 0)
+		var/py = secondcolon ? copytext(clicked_loc,secondcolon+1) : 0
+
+		if (user.client && user.client.byond_version == 512 && user.client.byond_build == 1469) //sWAP EM BECAUSE OF BAD BYOND BUG
+			var/temp = y
+			y = px
+			px = temp
+
+		//ddumb hack for offset storage
+		var/turfd = (isturf(master.linked_item.loc) && !istype(master.linked_item, /obj/item/bible))
+
+		var/pixel_y_adjust = 0
+		if (user && user.client && user.client.tg_layout && !turfd)
+			pixel_y_adjust = 1
+
+		if (pixel_y_adjust && text2num(py) > 16)
+			y = text2num(y) + 1
+			py = text2num(py) - 16
+		//end dumb hack
+
+		return "[x],[y]"
 
 //idk if i can even use the params of mousedrop for this
 /*

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -71,6 +71,7 @@
 		if (src.obj_locs[clicked_position] == O)
 			user.click(O, params2list(params))
 
+	/// returns position of the hud clicked
 	proc/get_clicked_position(mob/user, list/params)
 		if (!params)
 			return


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that click dragging an item stored in a storage HUD onto the HUD location where it's stored will equip it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When you are trying really fast to equip an item, it's common that instead of just clicking the item, you will click the item, hold left mouse button, and release when it's on the HUD where it's stored which won't equip it, making you think you never clicked it or some bug happened. This makes it so that doing so will actually equip it instead of doing nothing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(+)Improved item equip consistency when equipping an item from your inventory with fast mouse flicks.
```
