### PR TITLE
fix amanitin not working with calomel (and other flushes)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,8 @@
 	"tgstationTestExplorer.project.DMEName": "goonstation.dme",
 	"tgstationTestExplorer.project.defines": [
 		"#define UNIT_TESTS"
+	],
+	"githubPullRequests.ignoredPullRequestBranches": [
+		"master"
 	]
 }

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -207,11 +207,13 @@ datum
 					M = holder.my_atom
 				damage_counter += rand(2, 4) * mult * min(1, volume)
 				..()
-
-			on_mob_life_complete(mob/living/M)
-				if(M)
-					M.take_toxin_damage(damage_counter)
-					logTheThing(LOG_COMBAT, M, "took [damage_counter] TOX damage from amanitin.")
+			on_remove()
+				..()
+				var/mob/living/carbon/human/H = holder.my_atom
+				if (!istype(H)) return
+				H.take_toxin_damage(damage_counter)
+				damage_counter = 0
+				logTheThing(LOG_COMBAT, H, "took [damage_counter] TOX damage from amanitin.")
 
 
 		harmful/chemilin

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -15777,9 +15777,9 @@
 /area/station/security/interrogation)
 "bic" = (
 /obj/machinery/camera{
-	c_tag = "Gas Chamber";
+	c_tag = "autotag";
 	dir = 8;
-	network = "Gas Chamber"
+	network = "autoname - SS13"
 	},
 /obj/item/device/radio/intercom/security{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes amanitin from only proccing its damage when metabolism takes it out of the person, to what its supposed to be, it leaving the system in anyway.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

currently calomel or other purgatories stop amanitin from doing any damage. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeDude
(+)Fixed amanitin not doing any damage when purged.
```
