### PR TITLE
Make photos respect pronouns

### DIFF
--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -387,18 +387,17 @@ TYPEINFO(/obj/item/camera_film/large)
 				if (iscarbon(M))
 					var/mob/living/carbon/temp = M
 					if (temp.l_hand || temp.r_hand)
-						var/they_are = M.gender == "male" ? "He's" : M.gender == "female" ? "She's" : "They're" // I wanna just use he_or_she() but it wouldn't really work
 						if (temp.l_hand)
-							holding = "[they_are] holding \a [temp.l_hand]"
+							holding = "[hes_or_shes(M)] holding \a [temp.l_hand]"
 						if (temp.r_hand)
 							if (holding)
 								holding += " and \a [temp.r_hand]."
 							else
-								holding = "[they_are] holding \a [temp.r_hand]."
+								holding = "[hes_or_shes(M)] holding \a [temp.r_hand]."
 						else if (holding)
 							holding += "."
 
-				var/they_look = M.gender == "male" ? "he looks" : M.gender == "female" ? "she looks" : "they look"
+				var/they_look = "[he_or_she(M)] look[M.get_pronouns().pluralize ? null : "s"]"
 				var/health_info = M.health < 75 ? " - [they_look][M.health < 25 ? " really" : null] hurt" : null
 				if (powerflash && M == target && !M.eyes_protected_from_light())
 					if (!health_info)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15387 by updating camera code to use the pronoun procs in determining what to add to the photo's examine text.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

We love pronouns