### PR TITLE
Make guns that fit on your back store to open inventory first

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -66,6 +66,21 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			forensic_IDs.Add(src.forensic_ID)
 		return ..()
 
+	// equip handling for weapons that fit on your back
+	try_specific_equip(mob/user)
+		. = ..()
+		if (!(src.c_flags & ONBACK))
+			return
+		if (!user.back?.storage)
+			return
+		if (!user.s_active)
+			return
+		if (user.s_active.master != user.back.storage)
+			return
+		if (user.back.storage.check_can_hold(src) == STORAGE_CAN_HOLD)
+			user.back.Attackby(src, user)
+			return TRUE
+
 /datum/gunTarget
 	var/params = null
 	var/target = null


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that if your backpack open, pressing the equip hotkey to equip weapons that fit on your back will attempt to add it to your inventory first, instead of swapping with whatever's being held on your back

Improvement over #13888


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When you press the equip hotkey it makes more sense that something's added to open inventory


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(+)Pressing the equip hotkey while holding a gun that fits on your back will now attempt to add it to your backpack first if it's open.
```
