### PR TITLE
Graphene reacts to completion

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2101,10 +2101,10 @@
 		name = "Graphene"
 		id = "graphene"
 		result = "graphene"
-		required_reagents = list("fuel" = 4, "iron" = 1, "silicon_dioxide" = 1)
+		required_reagents = list("fuel" = 2, "iron" = 0.5, "silicon_dioxide" = 0.5)
 		min_temperature = T0C + 150
 		result_amount = 2
-		reaction_speed = 1
+		reaction_speed = 2
 		instant = 0
 		mix_phrase = "A small particulate forms into a tiny lattice."
 		on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -3501,10 +3501,10 @@
 		name = "contaminated food E.Coli"
 		id = "contaminated food E.Coli"
 		result = "e.coli"
-		required_reagents = list("sewage" = 5, "cholesterol" = 4)
+		required_reagents = list("sewage" = 5, "cholesterol" = 1)
 		result_amount = 1
 		instant = 0 // bacteria needs some time to grow in this medium
-		reaction_speed = 0.25
+		reaction_speed = 1
 		mix_phrase = "An unbearable stench emancipates from the mixture as it slowly coagulates."
 		mix_sound = 'sound/misc/fuse.ogg'
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2103,8 +2103,8 @@
 		result = "graphene"
 		required_reagents = list("fuel" = 2, "iron" = 0.5, "silicon_dioxide" = 0.5)
 		min_temperature = T0C + 150
-		result_amount = 2
-		reaction_speed = 2
+		result_amount = 1
+		reaction_speed = 1
 		instant = 0
 		mix_phrase = "A small particulate forms into a tiny lattice."
 		on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -3501,10 +3501,10 @@
 		name = "contaminated food E.Coli"
 		id = "contaminated food E.Coli"
 		result = "e.coli"
-		required_reagents = list("sewage" = 5, "cholesterol" = 1)
+		required_reagents = list("sewage" = 5, "cholesterol" = 4)
 		result_amount = 1
 		instant = 0 // bacteria needs some time to grow in this medium
-		reaction_speed = 1
+		reaction_speed = 0.25
 		mix_phrase = "An unbearable stench emancipates from the mixture as it slowly coagulates."
 		mix_sound = 'sound/misc/fuse.ogg'
 


### PR DESCRIPTION
[chemistry][bug]
## About the PR 
This PR changes the mechanics of the recipe for graphene and one of the e.coli recipes so that they react to completion. Reaction speed in-game is unchanged.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Due to the way the code works, if the reaction_speed and the result_amount of a chemical aren't equal to one another, it can cause the ratios to react in such a way that there's some leftover chemicals. (anyone who's tried to make graphene knows the pain of that last 0.5u of SiO2...)

This fixes that the easy way by changing the recipes to fit the code's quirks.