### PR TITLE
Use orange mop icon overhead while mopping

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1732,6 +1732,8 @@ var/datum/action_controller/actions
 		mop = Mop
 		target = Target
 		duration = istype(target,/obj/fluid) ? 0 : 10
+		if (istype(mop, /obj/item/mop/orange))
+			icon_state = "mop_orange"
 		..()
 
 	onUpdate()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1732,8 +1732,7 @@ var/datum/action_controller/actions
 		mop = Mop
 		target = Target
 		duration = istype(target,/obj/fluid) ? 0 : 10
-		if (istype(mop, /obj/item/mop/orange))
-			icon_state = "mop_orange"
+		icon_state = mop.icon_state
 		..()
 
 	onUpdate()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using an orange mop from Janitor job rewards level 15, the mopping icon above the player's head is now orange. 
![image](https://github.com/goonstation/goonstation/assets/5091297/43ffbd45-6d14-481d-ac9e-4619088fe482)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Experienced janitors should be able to flaunt their sanitation superiority more easily. Fixes [#12927](https://github.com/goonstation/goonstation/issues/12927)
