### PR TITLE
Hacked sec techs contain 2-4 donuts.

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1437,6 +1437,7 @@ TYPEINFO(/obj/machinery/vending/medical)
 #endif
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/donut, rand(2, 4), hidden=1) // emergency snack
 
 /obj/machinery/vending/security_ammo //shitsec time yes
 	name = "AmmoTech"


### PR DESCRIPTION
[GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 2-4 donuts to hacked security vendors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its a funny joke for security vendors to contain donuts.

## Changelog 

```changelog
(u)UnfunnyPerson
(+)Hacked SecTechs will contain 2-4 donuts.
```
