### PR TITLE
Makes a SICC core if no AI joins at roundstart

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -275,7 +275,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 	for(var/turf/T in job_start_locations["AI"])
 		if(isnull(locate(/mob/living/silicon/ai) in T))
-			new /obj/item/clothing/suit/cardboard_box/ai(T)
+			new /mob/living/silicon/ai/latejoin(T)
 	if(!processScheduler.isRunning)
 		processScheduler.start()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces that horrible, mocking cardboard box that spawns in the core if there's no AI at roundstart with a empty latejoin AI core.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because I think it's silly to completely remove AIs from the round if one doesn't roundstart and the MDir doesn't feel like giving out their manudrive.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Paaiii
(+)Replaces that cardboard box that spawns in the AI core if there's no AI with an empty SICC AI core.
```
