### PR TITLE
Make shuttle corners impermeable to gas

### DIFF
--- a/code/modules/transport/shuttle/shuttle_turfobjs.dm
+++ b/code/modules/transport/shuttle/shuttle_turfobjs.dm
@@ -203,6 +203,7 @@ TYPEINFO_NEW(/turf/simulated/wall/auto/shuttle)
 	icon_state = "corner"
 	density = 1
 	opacity = 0
+	gas_impermeable = TRUE
 	layer = EFFECTS_LAYER_BASE - 1
 	flags = ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 


### PR DESCRIPTION
[BUG]
## About the PR
Makes shuttle corners impermeable to gas, which in theory should work despite them being objs and not turfs.
Might cause balance issues? But personally I don't think it will.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15423 by preventing all the air from jetting out through the front edges of bombini's ship.