### PR TITLE
Adds clothing booth support to robots and allows robots to dress themselves

### DIFF
--- a/code/datums/character_preview.dm
+++ b/code/datums/character_preview.dm
@@ -83,7 +83,7 @@
 	. = ..()
 
 /// See: [/datum/movable_preview/var/custom_setup]
-/datum/movable_preview/proc/custom_setup(client/viewer, window_id, control_id)
+/datum/movable_preview/proc/custom_setup(client/viewer, window_id, control_id, is_robot = FALSE)
 	return
 
 /**
@@ -113,6 +113,11 @@
 	real_name = "character preview"
 	unobservable = TRUE
 
+/mob/living/silicon/robot/preview
+	name = "character preview"
+	real_name = "character preview"
+	unobservable = TRUE
+
 /**
  * # Character Preview
  *
@@ -124,31 +129,50 @@
 /datum/movable_preview/character
 	custom_setup = TRUE
 
-	custom_setup(client/viewer, window_id, control_id)
-		var/mob/living/carbon/human/preview/H = new(global.get_centcom_mob_cloner_spawn_loc())
-		mobs -= H
-		src.preview_thing = H
-		qdel(H.name_tag)
-		H.name_tag = null
+	custom_setup(client/viewer, window_id, control_id, is_robot = FALSE)
+		if (!is_robot)
+			var/mob/living/carbon/human/preview/H = new(global.get_centcom_mob_cloner_spawn_loc())
+			mobs -= H
+			src.preview_thing = H
+			qdel(H.name_tag)
+			H.name_tag = null
 
-		if(isturf(H.loc))
-			put_mob_in_centcom_cloner(H)
+			if(isturf(H.loc))
+				put_mob_in_centcom_cloner(H)
+		else
+			var/mob/living/silicon/robot/preview/R = new(global.get_centcom_mob_cloner_spawn_loc())
+			mobs -= R
+			src.preview_thing = R
+			qdel(R.name_tag)
+			R.name_tag = null
+
+			if(isturf(R.loc))
+				put_mob_in_centcom_cloner(R)
 
 	/// Sets the appearance, mutant race, and facing direction of the human mob.
 	/// Assumes the `preview_thing` is a mob
-	proc/update_appearance(datum/appearanceHolder/AH, datum/mutantrace/MR = null, direction = SOUTH, name = "human")
+	proc/update_appearance(datum/appearanceHolder/AH, datum/mutantrace/MR = null, direction = SOUTH, name = "human", list/clothes = null)
 		src.flat_icon = null
-		var/mob/living/carbon/human/preview_mob = src.preview_thing
-		preview_mob.dir = direction
-		preview_mob.bioHolder.mobAppearance.CopyOther(AH)
-		preview_mob.set_mutantrace(MR)
-		preview_mob.organHolder.head.donor = preview_mob
-		preview_mob.organHolder.head.donor_appearance.CopyOther(preview_mob.bioHolder.mobAppearance)
-		preview_mob.update_colorful_parts()
-		preview_mob.set_body_icon_dirty()
-		preview_mob.set_face_icon_dirty()
-		preview_mob.real_name = "clone of " + name
-		preview_mob.name = "clone of " + name
+		var/mob/living/preview_mob = src.preview_thing
+		if(!clothes)
+			var/mob/living/carbon/human/preview_human = preview_mob
+			preview_human.dir = direction
+			preview_human.bioHolder.mobAppearance.CopyOther(AH)
+			preview_human.set_mutantrace(MR)
+			preview_human.organHolder.head.donor = preview_human
+			preview_human.organHolder.head.donor_appearance.CopyOther(preview_human.bioHolder.mobAppearance)
+			preview_human.update_colorful_parts()
+			preview_human.set_body_icon_dirty()
+			preview_human.set_face_icon_dirty()
+			preview_human.real_name = "clone of " + name
+			preview_human.name = "clone of " + name
+		else
+			var/mob/living/silicon/robot/preview_borg = preview_mob
+			preview_borg.dir = direction
+			preview_borg.clothes = clothes
+			preview_borg.real_name = "clone of " + name
+			preview_borg.name = "clone of " + name
+			preview_borg.update_appearance()
 
 	proc/get_icon()
 		if (!src.flat_icon)

--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -639,3 +639,14 @@
 			var/datum/hud/silicon/robot/H = src.hud
 			H.update_status_effects()
 		return
+
+/mob/living/silicon/robot/proc/get_slot(slot)
+	switch(slot) // Robots have no slots, so we remap them
+		if(SLOT_WEAR_MASK)
+			return src.clothes["mask"]
+		if(SLOT_HEAD)
+			return src.clothes["head"]
+		if(SLOT_WEAR_SUIT)
+			return src.clothes["suit"]
+		if(SLOT_W_UNIFORM)
+			return src.clothes["under"]

--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -640,7 +640,7 @@
 			H.update_status_effects()
 		return
 
-/mob/living/silicon/robot/proc/get_slot(slot)
+/mob/living/silicon/robot/get_slot(slot)
 	switch(slot) // Robots have no slots, so we remap them
 		if(SLOT_WEAR_MASK)
 			return src.clothes["mask"]

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -382,6 +382,9 @@
 		else if (!pixelable && W)
 			W.AfterAttack(target, src, reach, params)
 
+/mob/living/proc/get_slot(slot)
+	return
+
 /mob/living/onMouseDrag(src_object,over_object,src_location,over_location,src_control,over_control,params)
 	if (!src.restrained() && !is_incapacitated(src))
 		var/obj/item/W = src.equipped()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1904,7 +1904,7 @@
 				else
 					return 0
 
-/mob/living/carbon/human/proc/get_slot(slot)
+/mob/living/carbon/human/get_slot(slot)
 	switch(slot)
 		if (slot_back)
 			return src.back

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -641,3 +641,55 @@ var/global/list/module_editors = list()
 	var/chosen = tgui_input_list(usr, "Select a rack to link", "Law racks", racks)
 	if (chosen)
 		src.set_law_rack(racks[chosen])
+
+/mob/living/silicon/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
+	if (can_act(user) && istype(AM, /obj/item/clothing))
+		src.put_on_clothes(AM, user)
+		return
+
+	return ..()
+
+/mob/living/silicon/proc/put_on_clothes(/obj/item/clothing/cloth, atom/movable/AM as mob|obj)
+	if (!isrobot(src))
+		return
+
+	var/obj/machinery/recharge_station/station
+	var/mob/living/source
+	var/mob/living/silicon/robot/R = src
+
+	if (isliving(AM))
+		source = AM
+	else
+		station = AM
+
+	if (istype(cloth, /obj/item/clothing))
+		var/slot
+		if(istype(cloth, /obj/item/clothing/under))
+			slot = "under"
+		else if (istype(cloth, /obj/item/clothing/suit))
+			slot = "suit"
+		else if (istype(cloth, /obj/item/clothing/mask))
+			slot = "mask"
+		else if (istype(cloth, /obj/item/clothing/head))
+			slot = "head"
+
+		if(!slot)
+			return
+
+		if(station)
+			if (R.clothes[slot] != null)
+				var/obj/old = R.clothes[slot]
+				station.clothes.Add(old)
+				old.set_loc(station)
+			R.clothes[slot] = cloth
+			station.clothes.Remove(cloth)
+			cloth.set_loc(R)
+		else if(source)
+			if (R.clothes[slot] != null)
+				var/obj/old = R.clothes[slot]
+				source.put_in_hand_or_drop(old)
+			R.clothes[slot] = cloth
+			source.u_equip(cloth)
+
+	R.update_appearance()
+	. = TRUE

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -643,13 +643,31 @@ var/global/list/module_editors = list()
 		src.set_law_rack(racks[chosen])
 
 /mob/living/silicon/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
-	if (can_act(user) && istype(AM, /obj/item/clothing))
-		src.put_on_clothes(AM, user)
+	if (can_act(user))
+		var/slot
+		if(istype(AM, /obj/item/clothing/under))
+			slot = SLOT_W_UNIFORM
+		else if (istype(AM, /obj/item/clothing/suit))
+			slot = SLOT_WEAR_SUIT
+		else if (istype(AM, /obj/item/clothing/mask))
+			slot = SLOT_WEAR_MASK
+		else if (istype(AM, /obj/item/clothing/head))
+			slot = SLOT_HEAD
+
+		if(slot)
+			actions.start(new/datum/action/bar/icon/otherItem(
+				user,
+				src,
+				AM,
+				slot,
+				0,
+				0
+			), user)
 		return
 
 	return ..()
 
-/mob/living/silicon/proc/put_on_clothes(/obj/item/clothing/cloth, atom/movable/AM as mob|obj)
+/mob/living/silicon/proc/handle_clothing(var/obj/item/clothing/cloth, atom/movable/AM as mob|obj)
 	if (!isrobot(src))
 		return
 
@@ -659,7 +677,7 @@ var/global/list/module_editors = list()
 
 	if (isliving(AM))
 		source = AM
-	else
+	else if (istype(AM, /obj/machinery/recharge_station))
 		station = AM
 
 	if (istype(cloth, /obj/item/clothing))
@@ -688,8 +706,10 @@ var/global/list/module_editors = list()
 			if (R.clothes[slot] != null)
 				var/obj/old = R.clothes[slot]
 				source.put_in_hand_or_drop(old)
+			if (R != source)
+				source.u_equip(cloth)
 			R.clothes[slot] = cloth
-			source.u_equip(cloth)
+			cloth.set_loc(R)
 
 	R.update_appearance()
 	. = TRUE

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -906,7 +906,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			var/clothingRef = params["clothingRef"]
 			if(clothingRef)
 				var/obj/item/clothing/cloth = locate(clothingRef) in src.clothes
-				R.put_on_clothes(cloth, src)
+				R.handle_clothing(cloth, src)
 			. = TRUE
 		if("clothing-remove")
 			if (!isrobot(src.occupant))

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -906,40 +906,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			var/clothingRef = params["clothingRef"]
 			if(clothingRef)
 				var/obj/item/clothing/cloth = locate(clothingRef) in src.clothes
-				if (istype(cloth, /obj/item/clothing))
-					if (istype(cloth, /obj/item/clothing/under))
-						if (R.clothes["under"] != null)
-							var/obj/old = R.clothes["under"]
-							src.clothes.Add(old)
-							old.set_loc(src)
-						R.clothes["under"] = cloth
-						src.clothes.Remove(cloth)
-						cloth.set_loc(R)
-					else if (istype(cloth, /obj/item/clothing/suit))
-						if (R.clothes["suit"] != null)
-							var/obj/old = R.clothes["suit"]
-							src.clothes.Add(old)
-							old.set_loc(src)
-						R.clothes["suit"] = cloth
-						src.clothes.Remove(cloth)
-						cloth.set_loc(R)
-					else if (istype(cloth, /obj/item/clothing/mask))
-						if (R.clothes["mask"] != null)
-							var/obj/old = R.clothes["mask"]
-							src.clothes.Add(old)
-							old.set_loc(src)
-						R.clothes["mask"] = cloth
-						src.clothes.Remove(cloth)
-						cloth.set_loc(R)
-					else if (istype(cloth, /obj/item/clothing/head))
-						if (R.clothes["head"] != null)
-							var/obj/old = R.clothes["head"]
-							src.clothes.Add(old)
-							old.set_loc(src)
-						R.clothes["head"] = cloth
-						src.clothes.Remove(cloth)
-						cloth.set_loc(R)
-			R.update_appearance()
+				R.put_on_clothes(cloth, src)
 			. = TRUE
 		if("clothing-remove")
 			if (!isrobot(src.occupant))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [QoL] [Clothing]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new proc `/mob/living/silicon/proc/handle_clothing` which is used to dress up robots. It supports both the original method via recharging stations, as well as a method that's more similar to other humanoids, by simply dropping the clothing on the ground.

Robots can now dress themselves via `/datum/action/bar/icon/otherItem`, this will start a dress action that can be interrupted. This is done by dragging a clothing item onto the robot. Both the robot as well as other people can start this action.

Additionally, this PR adds support for robots to the clothing booth. This will display a generic robot that will display the clothing. If clothing items don't fit, they won't be displayed on the robot. Robots can wear heads, masks, uniforms and suits. They can still purchase other items, but they won't be able to wear them.

To facilitate silicon usage, money can now also be click and dragged onto the clothing booth to slot it in.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The idea that clothing booths can only be used by humans is probably antiquated by now, given that its display message reads "Human clothes don't fit you!". Many robots have been using regular human clothing for a while now, and usually have to ask a human to buy items from the clothing booth for them. This process is tedious and tricky, especially if you want to browse for the selection and do not have it memorized.

Additionally, it's a quality of life feature for robots to allow dressing themselves anywhere, even without a recharging station. As clothing is primarily used cosmetically, I don't see this as an issue, but just to alleviate any potential problems this requires an interruptible action that takes anywhere from 2-5 seconds depending on the item.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(*)Robots can now use the clothing booth. Turns out human clothes DO fit!
(*)Robots can now dress and be dressed by dragging a piece of clothing onto them.
```
