### PR TITLE
Fixes helmets that hide hair fucking up hair layering after unequip

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1703,8 +1703,8 @@
 		src.update_clothing()
 	else if (W == src.head)
 		W.unequipped(src)
-		src.update_hair_layer()
 		src.head = null
+		src.update_hair_layer()
 		src.update_clothing()
 	else if (W == src.ears)
 		W.unequipped(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CLOTHING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a bug wherein equipping headgear that hid your hair (like a biohood) would screw up the layering on your sprite and make your hair appear underneath your backpack. update_hair_layer() checks src.head for a helmet to determine layering but on unequip src.head was nulled after the call to it instead of before.

Proper hair layering:
![image](https://github.com/goonstation/goonstation/assets/75404941/739cf5de-0a32-40e1-9a71-1a33d1de5185)

Bugged hair layering after equipping and removing bio hood:
![image](https://github.com/goonstation/goonstation/assets/75404941/3988c6bb-b316-4643-a98e-4a75cb9d94a6)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Looks dumb and is wrong
