### PR TITLE
Update constructName to handle /datum/mind

### DIFF
--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -104,6 +104,7 @@
 		var/list/dat = ..()
 		if (length(dat))
 			dat.Insert(2,"They collected [src.salvager_points] points worth of material.")
+			logTheThing(LOG_DIARY, src.owner, "collected [src.salvager_points || 0] points worth of material.")
 		return dat
 
 /datum/job/special/salvager

--- a/code/procs/logging.dm
+++ b/code/procs/logging.dm
@@ -240,7 +240,6 @@ var/global/logLength = 0
 			return(constructName(mindRef.current, type))
 		else
 			name = "[mindRef.displayed_key] (character destroyed)"
-			mindRef
 			if (mindRef.key)
 				key = mindRef.key
 			if (mindRef.ckey)

--- a/code/procs/logging.dm
+++ b/code/procs/logging.dm
@@ -234,6 +234,17 @@ var/global/logLength = 0
 		nice_rack += "(UID: [rack_ref.unique_id]) at "
 		nice_rack += log_loc(rack_ref)
 		return nice_rack.Join()
+	else if(istype(ref,/datum/mind))
+		var/datum/mind/mindRef = ref
+		if(mindRef.current && ismob(mindRef.current))
+			return(constructName(mindRef.current, type))
+		else
+			name = "[mindRef.displayed_key] (character destroyed)"
+			mindRef
+			if (mindRef.key)
+				key = mindRef.key
+			if (mindRef.ckey)
+				ckey = mindRef.ckey
 	else
 		return ref
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows `constructName` to handle cases where a mob is present.
Allows `constructName` to handle cases where it isn't.
Allows `constructName` to give meaningful data to logs where used.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves logged data to properly parse out `/datum/mind` to something useful.  Current objectives simply list `/datum/mind`
