### PR TITLE
Fix disposal chutes on ocean maps not emptying their air after flush

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -442,7 +442,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		if (!isnull(src.destination_tag))
 			H.mail_tag = src.destination_tag
 
-		air_contents.zero()
+		ZERO_GASES(src.air_contents)
 
 		sleep(1 SECOND)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS] [ATMOSPHERICS] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15445 and fixes #13093, calling .zero() on gas_mixture on an ocean map empties it then fills it up with some other gases, presumably because it's used by "outer space" turfs, so make it call ZERO_GASES() instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugg