### PR TITLE
Give Head Revolutionary headsets a syndicate channel

### DIFF
--- a/code/modules/antagonists/revolutionary/head_revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/head_revolutionary.dm
@@ -4,6 +4,10 @@
 	antagonist_icon = "rev_head"
 
 	var/static/list/datum/mind/heads_of_staff
+	/// headrev headset
+	var/obj/item/device/radio/headset/headset = null
+	/// frequency used for headrev headset communication channel
+	var/static/headset_frequency = null
 
 	New()
 		if (!src.heads_of_staff)
@@ -12,6 +16,8 @@
 			for(var/mob/living/carbon/human/player in mobs)
 				if(player.mind?.is_head_of_staff())
 					src.heads_of_staff += player.mind
+		if (!src.headset_frequency)
+			src.headset_frequency = rand(1360, 1420)
 
 		. = ..()
 
@@ -92,6 +98,12 @@
 			boutput(H, "The Syndicate have provided you with a standalone head revolutionary uplink [loc_string]. Simply dial the frequency <b>\"[uplink.lock_code]\"</b> to unlock its hidden features.")
 			logTheThing(LOG_DEBUG, H, "Head revolutionary standalone uplink created: [uplink_source.name]. Location given: [loc_string]. Frequency: [uplink.lock_code]")
 			src.owner.store_memory("<b>Uplink frequency:</b> [uplink.lock_code].")
+
+		src.headset = H.ears
+		src.headset?.install_radio_upgrade(new /obj/item/device/radio_upgrade/revolution(null, src.headset_frequency))
+
+	remove_equipment()
+		src.headset?.remove_radio_upgrade()
 
 	add_to_image_groups()
 		. = ..()

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -644,3 +644,15 @@ TYPEINFO(/obj/item/device/radio_upgrade)
 
 			src.secure_frequencies = list("z" = frequency)
 			src.secure_classes = list("z" = RADIOCL_SYNDICATE)
+	revolution
+		name = "private radio channel upgrade"
+		desc = "A device capable of communicating over a private secure radio channel. Can be installed in a radio headset."
+		secure_frequencies = null
+		secure_classes = null
+
+		New(turf/newLoc, freq)
+			..()
+			if (!freq)
+				return
+			src.secure_frequencies = list("z" = freq)
+			src.secure_classes = list("z" = RADIOCL_SYNDICATE)


### PR DESCRIPTION
[GAME OBJECTS][GAME MODES][FEATURE][BALANCE][QoL][EXPERIMENTAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR gives head rev headsets a wiretap radio upgrade that lets themselves communicate with each other.

This can alternatively be used by the crew to listen in on what's going on once a headrev is killed, which may be bad, would need more feedback on that part. Maybe just destroying the wiretap when they die?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps for better planning with each other and coordination, rather than each head rev doing their own thing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Head Rev radio headsets now start with a private comms channel for communication with each other.
```
