### PR TITLE
connect donut2 brig chute properly

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -25618,12 +25618,12 @@
 /area/station/medical/staff)
 "emR" = (
 /obj/machinery/light/incandescent,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
@@ -31740,6 +31740,13 @@
 /obj/item/clothing/head/bandana/random_color,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"jcn" = (
+/obj/disposalpipe/segment/brig{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/red/side,
+/area/station/security/processing)
 "jeb" = (
 /obj/machinery/conveyor/NS{
 	id = "zetadisposals";
@@ -97807,7 +97814,7 @@ vVo
 bgP
 hVA
 tMz
-lus
+jcn
 set
 stt
 bkP


### PR DESCRIPTION
[MAPPING] [MINOR]
## About the PR
There was a break in the piping that meant that it wasn't connected properly. This connects it properly.
![68747470733a2f2f616666656374656461726330372e626c6f622e636f72652e77696e646f77732e6e65742f6d6462322f696d616765732f3235323034373438332f31363034323635383639322f6d2f6d6170735f646f6e7574322f302d646966662e706e67](https://github.com/goonstation/goonstation/assets/51260013/82d4c338-3a10-465e-bcb0-c5ac59894848)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes  #15451