### PR TITLE
Random gang member selection at roundstart

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -5,7 +5,7 @@
 	regular = FALSE
 
 	/// Makes it so gang members are chosen randomly at roundstart instead of being recruited.
-	var/random_gangs = FALSE
+	var/random_gangs = TRUE
 
 	antag_token_support = TRUE
 	var/list/gangs = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns on the experimental toggle that makes gang member selection random and disables recruitment. Essentially this acts as if every gang leader immediately recruited random people to their gang. Gang member names and jobs will be in chat once you spawn. Gang name is shown to you when the leader chooses it, similarly the locker location is shown to you when the leader places it.

For now this PR exists just as a temporary test merge to test the waters on the idea. I don't plan on merging it unless there's positive feedback on this.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Recruitment leads to weird meta strategies of picking only the most "robust" people on classic and to awkwardness of having to justify why your character would join a gang on RP. I'd like to try out this alternative idea and see how it holds up.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)pali
(*)Experiment: Gang members are recruited randomly at roundstart instead of being recruited manually.<br>Give feedback <a href="https://forum.ss13.co/showthread.php?tid=21701">here</a>.
```
