### PR TITLE
Split IM_REALLY_IN_A_FUCKING_HURRY_HERE into separate defines

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,8 +30,15 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+
+//#define SKIP_FEA_SETUP // Skip setting up atmospheric system
+//#define SKIP_Z5_SETUP // Skip generation of mining level
+//#define SKIP_PLANETS_SETUP // Skip planet generation (for Artemis)
+//#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME // Skip changelogs
+//#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO // Automatically ready up and start the game ASAP. No input required.
 
 //////--- CONVENIENCE OPTIONS FOR TESTING ETC ---//
 //#define DEBUG_EVERYONE_GETS_CAPTAIN_ID // all IDs are captain rank, kept separate from below options to avoid disrupting access-related tests
@@ -175,6 +182,14 @@ o+`        `-` ``..-:yooos-..----------..`
 #define I_AM_HACKERMAN
 #define CHECK_MORE_RUNTIMES
 #define QUICK_MOB_DELETION
+#endif
+
+#ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE
+#define SKIP_FEA_SETUP 1
+#define SKIP_Z5_SETUP 1
+#define SKIP_PLANETS_SETUP 1
+#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME 1
+#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO 1
 #endif
 
 //----- Testmerge & Revision Information -----//

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -37,6 +37,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level
 //#define SKIP_PLANETS_SETUP // Skip planet generation (for Artemis)
+//#define SKIP_CAMERA_COVERAGE // Skip calculating security camera coverage
 //#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME // Skip changelogs
 //#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO // Automatically ready up and start the game ASAP. No input required.
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -186,11 +186,12 @@ o+`        `-` ``..-:yooos-..----------..`
 #endif
 
 #ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE
-#define SKIP_FEA_SETUP 1
-#define SKIP_Z5_SETUP 1
-#define SKIP_PLANETS_SETUP 1
-#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME 1
-#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO 1
+#define SKIP_FEA_SETUP
+#define SKIP_Z5_SETUP
+#define SKIP_PLANETS_SETUP
+#define SKIP_CAMERA_COVERAGE
+#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME
+#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO
 #endif
 
 //----- Testmerge & Revision Information -----//

--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -7,7 +7,7 @@
 #define ABSTRACT_VIOLATION_CRASH
 #endif
 
-#ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE
+/*#ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE
 #define SKIP_FEA_SETUP 1
 #define SKIP_Z5_SETUP 1
 #define SKIP_PLANETS_SETUP 1
@@ -19,7 +19,7 @@
 #define SKIP_FEA_SETUP 0 //Skip atmos setup
 #define SKIP_Z5_SETUP 0 //Skip z5 gen
 #define SKIP_PLANETS_SETUP 0
-#endif
+#endif*/
 
 // Server side profiler stuff for when you want to profile how laggy the game is
 // FULL_ROUND

--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -7,20 +7,6 @@
 #define ABSTRACT_VIOLATION_CRASH
 #endif
 
-/*#ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE
-#define SKIP_FEA_SETUP 1
-#define SKIP_Z5_SETUP 1
-#define SKIP_PLANETS_SETUP 1
-#define IM_TESTING_SHIT_STOP_BARFING_CHANGELOGS_AT_ME 1 //Skip changelogs
-#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO 1 //Automatically ready up and start the game ASAP. No input required.
-#endif
-
-#ifndef IM_REALLY_IN_A_FUCKING_HURRY_HERE
-#define SKIP_FEA_SETUP 0 //Skip atmos setup
-#define SKIP_Z5_SETUP 0 //Skip z5 gen
-#define SKIP_PLANETS_SETUP 0
-#endif*/
-
 // Server side profiler stuff for when you want to profile how laggy the game is
 // FULL_ROUND
 //   Start profiling immediately, save profiler data when world is rebooting (data/profile/xxxxxxxx-full.log)

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -65,7 +65,7 @@ var/global/total_gas_mixtures = 0
 /datum/controller/air_system/proc/setup(datum/controller/process/air_system/controller)
 	parent_controller = controller
 
-	#if SKIP_FEA_SETUP == 1
+	#ifdef SKIP_FEA_SETUP
 	return
 	#else
 

--- a/code/modules/camera_coverage/datum/controller/camera_coverage.dm
+++ b/code/modules/camera_coverage/datum/controller/camera_coverage.dm
@@ -9,7 +9,7 @@ var/global/datum/controller/camera_coverage/camera_coverage_controller
  * Called at world setup, creates an image on all turfs that will overlay for the AI when a turf is not visible in the camera coverage. At the end will update all camera coverage.
  */
 /datum/controller/camera_coverage/proc/setup()
-#if defined(IM_REALLY_IN_A_FUCKING_HURRY_HERE) && !defined(SPACEMAN_DMM)
+#if defined(SKIP_CAMERA_COVERAGE) && !defined(SPACEMAN_DMM)
 	return
 #endif
 #if !defined(MAP_OVERRIDE_POD_WARS) && !defined(UPSCALED_MAP) && !defined(MAP_OVERRIDE_EVENT)
@@ -84,7 +84,7 @@ var/global/datum/controller/camera_coverage/camera_coverage_controller
 	PRIVATE_PROC(TRUE)
 	// This is a list of turfs that require an update.
 	. = list()
-#if defined(IM_REALLY_IN_A_FUCKING_HURRY_HERE) && !defined(SPACEMAN_DMM)
+#if defined(SKIP_CAMERA_COVERAGE) && !defined(SPACEMAN_DMM)
 	return
 #endif
 	var/list/turf/prev_coverage = emitter.coverage ? emitter.coverage : list()

--- a/code/world/initialization/2_init.dm
+++ b/code/world/initialization/2_init.dm
@@ -129,7 +129,7 @@
 	//QM Categories by ZeWaka
 	build_qm_categories()
 
-	#if SKIP_Z5_SETUP == 0
+	#ifndef SKIP_Z5_SETUP
 	UPDATE_TITLE_STATUS("Building mining level")
 	Z_LOG_DEBUG("World/Init", "Setting up mining level...")
 	makeMiningLevel()
@@ -161,7 +161,7 @@
 	initialize_mail_system()
 	#endif
 
-	#if ENABLE_ARTEMIS && SKIP_PLANETS_SETUP == 0
+	#if ENABLE_ARTEMIS && !defined(SKIP_PLANETS_SETUP)
 	UPDATE_TITLE_STATUS("Building planet level")
 	Z_LOG_DEBUG("World/Init", "Setting up planet level...")
 	makePlanetLevel()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the ifdef for IM_REALLY_IN_A_FUCKING_HURRY_HERE into _build.dm and lets you pick individual options from it if you don't want to enable every thing it does. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It can be annoying when you're trying to test something affected by the define eg. atmos, camera coverage, but you can only choose between disabling everything or waiting a million years for Z5 to generate on your machine.