### PR TITLE
Adds option to edit buttons in mechcomp button panel component

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2767,26 +2767,27 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 			return 0
 
 		var/to_edit = input(user, "Choose button to edit", "Button Panel") in src.active_buttons + "*CANCEL*"
-		if(!in_interact_range(src, user) || user.stat)
+		if(!in_interact_range(src, user) || !isalive(user))
 			return 0
 		if(!to_edit || to_edit == "*CANCEL*")
 			return 0
 		var/new_label = input(user, "Button label", "Button Panel", to_edit) as text
 		var/new_signal = input(user, "Button signal", "Button Panel", src.active_buttons[to_edit]) as text
-		if(length(new_label) && length(new_signal))
-			new_label = adminscrub(new_label)
-			new_signal = adminscrub(new_signal)
+		if(!length(new_label) || !length(new_signal))
+			return 0
+		new_label = adminscrub(new_label)
+		new_signal = adminscrub(new_signal)
+		if(to_edit != new_label)
 			if(new_label in src.active_buttons)
 				boutput(user, "<span class='alert'>There's already a button with that label.")
 				return 0
 			var/button_index = src.active_buttons.Find(to_edit)
 			src.active_buttons.Insert(button_index, new_label)
-			src.active_buttons[new_label] = new_signal
 			src.active_buttons.Remove(to_edit)
-			boutput(user, "Edited button with new label: [new_label] and new value: [new_signal]")
-			tooltip_rebuild = 1
-			return 1
-		return 0
+		src.active_buttons[new_label] = new_signal
+		boutput(user, "Edited button with new label: [new_label] and new value: [new_signal]")
+		tooltip_rebuild = 1
+		return 1
 
 
 	proc/removeButton(obj/item/W as obj, mob/user as mob)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2735,6 +2735,7 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 		..()
 		active_buttons = list()
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Add Button",PROC_REF(addButton))
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Edit Button",PROC_REF(editButton))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Remove Button",PROC_REF(removeButton))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT, "Add Button", PROC_REF(signalAddButton))
 
@@ -2759,6 +2760,34 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 			tooltip_rebuild = 1
 			return 1
 		return 0
+
+	proc/editButton(obj/item/W as obj, mob/user as mob)
+		if(!length(src.active_buttons))
+			boutput(user, "<span class='alert'>[src] has no active buttons - there's nothing to edit!</span>")
+			return 0
+
+		var/to_edit = input(user, "Choose button to edit", "Button Panel") in src.active_buttons + "*CANCEL*"
+		if(!in_interact_range(src, user) || user.stat)
+			return 0
+		if(!to_edit || to_edit == "*CANCEL*")
+			return 0
+		var/new_label = input(user, "Button label", "Button Panel", to_edit) as text
+		var/new_signal = input(user, "Button signal", "Button Panel", src.active_buttons[to_edit]) as text
+		if(length(new_label) && length(new_signal))
+			new_label = adminscrub(new_label)
+			new_signal = adminscrub(new_signal)
+			if(new_label in src.active_buttons)
+				boutput(user, "<span class='alert'>There's already a button with that label.")
+				return 0
+			var/button_index = src.active_buttons.Find(to_edit)
+			src.active_buttons.Insert(button_index, new_label)
+			src.active_buttons[new_label] = new_signal
+			src.active_buttons.Remove(to_edit)
+			boutput(user, "Edited button with new label: [new_label] and new value: [new_signal]")
+			tooltip_rebuild = 1
+			return 1
+		return 0
+
 
 	proc/removeButton(obj/item/W as obj, mob/user as mob)
 		if(!length(src.active_buttons))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an option in the multitool pop-up for button panels to edit the label and/or signal of a button. The current values of the button are auto-filled in the respective text boxes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adding a button and realizing you made a typo in a really long signal and having to delete the button then make a new one then paste the corrected text back in is annoying

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Adds the option to edit a button's label and signal value on button panel components.
```
