### PR TITLE
Fixes latejoin AI core spawning when it shouldn't

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -273,8 +273,8 @@ var/global/current_state = GAME_STATE_INVALID
 			break
 #endif
 
-	for(var/turf/T in job_start_locations["AI"])
-		if(isnull(locate(/mob/living/silicon/ai) in T))
+	if(!countJob("AI")) // There is no roundstart AI, spawn in a Latejoin AI on the spawn landmark.
+		for(var/turf/T in job_start_locations["AI"])
 			new /mob/living/silicon/ai/latejoin(T)
 	if(!processScheduler.isRunning)
 		processScheduler.start()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
### Summary 
if the AI uses the spacebux items "missile arrival" or "space diner patron", it will no longer spawn in a latejoin AI in the core

### Technical
Previously, this code checked if there's an AI core at the AI spawn landmark to see if it should spawn in the Latejoin AI. However if the player who rolled AI used an alternative method of arrival (Space Diner Patron, Missile Arrival), it would incorrectly assume there was no AI at roundstart because the AI wasn't on the landmark (since it would be in space or in the diner), and would wrongfully spawn a latejoin core despite the existance of an AI.
This fixes that: now it checks for the presence of an AI via countJob, and if there is an AI at all (even if it arrives via missile or the space diner) then the core will be completely empty. (I asked if spawning the cardboard box instead of a latejoin core in that case would be OK, and Pali said no)

### Shortcomings
This isn't robust enough to handle all cases of multiple AI job slots at roundstart: if there is atleast one AI at all, no latejoin cores will be created.
This also isn't robust enough to handle all cases of multiple AI spawn landmarks: if there are no AIs, there is a latejoin core created on every landmark regardless of the maximum amount of AIs allowed.
However, i'm pretty sure we don't do any of either on any maps in rotation, so it should be fine

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15472