### PR TITLE
Give bruise packs and ointment a 2 second action bar and removes a certain dusty first aid kit from debris

### DIFF
--- a/code/obj/item/bruisepack_ointment.dm
+++ b/code/obj/item/bruisepack_ointment.dm
@@ -85,7 +85,6 @@
 			qdel(src)
 		src.inventory_counter?.update_number(src.amount)
 
-
 /obj/item/medical/bruise_pack
 	name = "bruise pack"
 	desc = "A pack designed to treat blunt-force trauma."

--- a/code/obj/item/bruisepack_ointment.dm
+++ b/code/obj/item/bruisepack_ointment.dm
@@ -67,7 +67,7 @@
 			var/self = FALSE
 			if (M != user)
 				self = TRUE
-			SETUP_GENERIC_ACTIONBAR(user, src, 3 SECONDS, /obj/item/medical/proc/do_use, list(M, user),\
+			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/item/medical/proc/do_use, list(M, user),\
 			src.icon, src.icon_state, "<span class='alert'>[user] applies [src] to [self ? "[M]" : "[himself_or_herself(M)]"].</span>", null)
 
 	proc/do_use(mob/M, mob/user)

--- a/code/obj/item/bruisepack_ointment.dm
+++ b/code/obj/item/bruisepack_ointment.dm
@@ -64,11 +64,13 @@
 				user.show_text("You can't seem to find any flesh on this patient.", "red")
 			return
 		if (user)
+			var/self = FALSE
 			if (M != user)
-				M.visible_message("<span class='alert'>[user] applies [src] to [M].</span>",)
-			else
-				M.visible_message("<span class='alert'>[M] applies [src] to [himself_or_herself(M)].</span>")
+				self = TRUE
+			SETUP_GENERIC_ACTIONBAR(user, src, 3 SECONDS, /obj/item/medical/proc/do_use, list(M, user),\
+			src.icon, src.icon_state, "<span class='alert'>[user] applies [src] to [self ? "[M]" : "[himself_or_herself(M)]"].</span>", null)
 
+	proc/do_use(mob/M, mob/user)
 		if (M != user && ishuman(M) && ishuman(user))
 			if (M.gender != user.gender)
 				M.unlock_medal("Oh, Doctor!", 1)
@@ -82,6 +84,7 @@
 		if (src.amount <= 0)
 			qdel(src)
 		src.inventory_counter?.update_number(src.amount)
+
 
 /obj/item/medical/bruise_pack
 	name = "bruise pack"

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -14871,10 +14871,6 @@
 	},
 /turf/simulated/floor/airless/plating/damaged1,
 /area/abandonedship)
-"blh" = (
-/obj/item/storage/firstaid/old,
-/turf/simulated/floor/white/grime,
-/area/derelict_ai_sat)
 "bli" = (
 /obj/table/auto,
 /obj/item/motherboard{
@@ -63745,7 +63741,7 @@ amV
 amV
 biB
 biI
-blh
+aRo
 aRo
 bmg
 aSl


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bruise packs and ointment will have a 2 second action bar when using them.

Also removes a certain dusty first aid kit from debris (Was located in the derelict ai satellite)
![image](https://github.com/goonstation/goonstation/assets/77701409/54c14016-c955-42dd-9234-1600822aadf7)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Both of these items are stupidly overpowered in terms of healing(60 brute/40 burn a second). Especially during combat encounters when most other healing items dont work. For example someone can take 3 csaber hits and heal to full health in 3 seconds.

This keeps them as a really good healing item outside of combat but makes them useless in combat.

I removed the debris kit because its laughably easy to rush and other easily rushable dusty kits got removed(recent oshan/nadir change)

## Changelog

```changelog
(u)UnfunnyPerson
(+)Bruise packs and Ointment take 2 seconds to use instead of being instant.
(+)Removed a certain dusty first aid kit from the debris field.
```
[BALANCE]