### PR TITLE
adds a spawnable light borg and screenhead borg

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3225,6 +3225,20 @@
 			src.shell = 1
 			..(loc, frame, starter, syndie, frame_emagged)
 
+/mob/living/silicon/robot/spawnable/light
+    New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
+        if (!src.part_chest)
+            src.part_chest = new/obj/item/parts/robot_parts/chest/light(src)
+            src.part_chest.wires = 1
+            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+            src.cell = src.part_chest.cell
+        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/light(src)
+        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/light(src)
+        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/light(src)
+        if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/light(src)
+        if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/light(src)
+        ..(loc, frame, starter, syndie, frame_emagged)
+
 /mob/living/silicon/robot/spawnable/standard
 	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
 		if (!src.part_chest)
@@ -3303,6 +3317,20 @@
 		New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 1, var/syndie = 0, var/frame_emagged = 0)
 			src.shell = 1
 			..(loc, frame, starter, syndie, frame_emagged)
+
+/mob/living/silicon/robot/spawnable/screenhead
+    New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
+        if (!src.part_chest)
+            src.part_chest = new/obj/item/parts/robot_parts/chest/standard(src)
+            src.part_chest.wires = 1
+            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+            src.cell = src.part_chest.cell
+        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/screen(src)
+        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/standard(src)
+        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/standard(src)
+        if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/treads(src)
+        if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/treads(src)
+        ..(loc, frame, starter, syndie, frame_emagged)
 
 /mob/living/silicon/robot/uber
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3226,18 +3226,18 @@
 			..(loc, frame, starter, syndie, frame_emagged)
 
 /mob/living/silicon/robot/spawnable/light
-    New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
-        if (!src.part_chest)
-            src.part_chest = new/obj/item/parts/robot_parts/chest/light(src)
-            src.part_chest.wires = 1
-            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
-            src.cell = src.part_chest.cell
-        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/light(src)
-        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/light(src)
-        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/light(src)
-        if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/light(src)
-        if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/light(src)
-        ..(loc, frame, starter, syndie, frame_emagged)
+	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
+		if (!src.part_chest)
+		src.part_chest = new/obj/item/parts/robot_parts/chest/light(src)
+		src.part_chest.wires = 1
+		src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+		src.cell = src.part_chest.cell
+		if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/light(src)
+		if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/light(src)
+		if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/light(src)
+		if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/light(src)
+		if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/light(src)
+		..(loc, frame, starter, syndie, frame_emagged)
 
 /mob/living/silicon/robot/spawnable/standard
 	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
@@ -3319,18 +3319,18 @@
 			..(loc, frame, starter, syndie, frame_emagged)
 
 /mob/living/silicon/robot/spawnable/screenhead
-    New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
-        if (!src.part_chest)
-            src.part_chest = new/obj/item/parts/robot_parts/chest/standard(src)
-            src.part_chest.wires = 1
-            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
-            src.cell = src.part_chest.cell
-        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/screen(src)
-        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/standard(src)
-        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/standard(src)
-        if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/treads(src)
-        if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/treads(src)
-        ..(loc, frame, starter, syndie, frame_emagged)
+	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
+		if (!src.part_chest)
+		src.part_chest = new/obj/item/parts/robot_parts/chest/standard(src)
+		src.part_chest.wires = 1
+		src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+		src.cell = src.part_chest.cell
+		if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/screen(src)
+		if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/standard(src)
+		if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/standard(src)
+		if (!src.part_leg_l) src.part_leg_l = new/obj/item/parts/robot_parts/leg/left/treads(src)
+		if (!src.part_leg_r) src.part_leg_r = new/obj/item/parts/robot_parts/leg/right/treads(src)
+		..(loc, frame, starter, syndie, frame_emagged)
 
 /mob/living/silicon/robot/uber
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3228,10 +3228,10 @@
 /mob/living/silicon/robot/spawnable/light
 	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
 	        if (!src.part_chest)
-	            src.part_chest = new/obj/item/parts/robot_parts/chest/light(src)
-	            src.part_chest.wires = 1
-	            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
-	            src.cell = src.part_chest.cell
+	        	src.part_chest = new/obj/item/parts/robot_parts/chest/light(src)
+	        	src.part_chest.wires = 1
+	        	src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+	        	src.cell = src.part_chest.cell
 	        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/light(src)
 	        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/light(src)
 	        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/light(src)
@@ -3321,10 +3321,10 @@
 /mob/living/silicon/robot/spawnable/screenhead
 	New(loc, var/obj/item/parts/robot_parts/robot_frame/frame = null, var/starter = 0, var/syndie = 0, var/frame_emagged = 0)
 	        if (!src.part_chest)
-	            src.part_chest = new/obj/item/parts/robot_parts/chest/standard(src)
-	            src.part_chest.wires = 1
-	            src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
-	            src.cell = src.part_chest.cell
+	        	src.part_chest = new/obj/item/parts/robot_parts/chest/standard(src)
+	        	src.part_chest.wires = 1
+	        	src.part_chest.cell = new/obj/item/cell/cerenkite/charged(src.part_chest)
+	        	src.cell = src.part_chest.cell
 	        if (!src.part_head) src.part_head = new/obj/item/parts/robot_parts/head/screen(src)
 	        if (!src.part_arm_l) src.part_arm_l = new/obj/item/parts/robot_parts/arm/left/standard(src)
 	        if (!src.part_arm_r) src.part_arm_r = new/obj/item/parts/robot_parts/arm/right/standard(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds a spawnable borg subtype with full light parts, and another with a screenhead, treads, and standard chest/arms

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

requested by angel. no longer do you have to build an entire light borg or screenhead borg just to debug
