### PR TITLE
Adds the ability to repair damaged windows with sheets of the same material

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -464,6 +464,8 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
+		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material == src.material)
+			SETUP_GENERIC_ACTIONBAR(user, src, 1 SECOND, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
@@ -567,6 +569,12 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 			T.selftilenotify() //for fluids
 
 		return 1
+
+	proc/fix_window(var/obj/item/sheet/S)
+		health = health_max
+		UpdateIcon(src)
+		if (S)
+			S.change_stack_amount(-1)
 
 
 /datum/action/bar/icon/deconstruct_window

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -464,7 +464,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
-		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material == src.material)
+		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material.isSameMaterial(src.material))
 			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -464,12 +464,8 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
-		else if (src.health < src.health_max && isweldingtool(W))
-			var/time = 4 SECONDS
-			if (user.traitHolder.hasTrait("carpenter") || user.traitHolder.hasTrait("training_engineer"))
-				time = 2 SECONDS
-			if (W:try_weld(user, 1))
-				SETUP_GENERIC_ACTIONBAR(user, src, time, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
+		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material.isSameMaterial(src.material))
+			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
@@ -574,9 +570,12 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		return 1
 
-	proc/fix_window()
+	proc/fix_window(var/obj/item/sheet/S)
 		health = health_max
 		UpdateIcon(src)
+		if (S)
+			S.change_stack_amount(-1)
+
 
 /datum/action/bar/icon/deconstruct_window
 	duration = 5 SECONDS

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -465,7 +465,10 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
 		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material.isSameMaterial(src.material))
-			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
+			var/time = 4 SECONDS
+			if (user.traitHolder.hasTrait("carpenter") || user.traitHolder.hasTrait("training_engineer"))
+				time = 2 SECONDS
+			SETUP_GENERIC_ACTIONBAR(user, src, time, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -465,7 +465,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
 		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material == src.material)
-			SETUP_GENERIC_ACTIONBAR(user, src, 1 SECOND, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
+			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -464,8 +464,12 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		else if (iswrenchingtool(W) && src.state == 0 && !src.anchored)
 			actions.start(new /datum/action/bar/icon/deconstruct_window(src, W), user)
-		else if (src.health < src.health_max && istype(W, /obj/item/sheet) && W.material.isSameMaterial(src.material))
-			SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
+		else if (src.health < src.health_max && isweldingtool(W))
+			var/time = 4 SECONDS
+			if (user.traitHolder.hasTrait("carpenter") || user.traitHolder.hasTrait("training_engineer"))
+				time = 2 SECONDS
+			if (W:try_weld(user, 1))
+				SETUP_GENERIC_ACTIONBAR(user, src, time, /obj/window/proc/fix_window, list(W), null, null, "<span class='notice'> [user] repairs \the [src] with \the [W] </span>", null)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
@@ -570,12 +574,9 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 
 		return 1
 
-	proc/fix_window(var/obj/item/sheet/S)
+	proc/fix_window()
 		health = health_max
 		UpdateIcon(src)
-		if (S)
-			S.change_stack_amount(-1)
-
 
 /datum/action/bar/icon/deconstruct_window
 	duration = 5 SECONDS


### PR DESCRIPTION
[GAME OBJECTS] [PLAYER ACTIONS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability to repair damaged windows by clicking on them with sheets of the same material this takes 4 seconds but can be reduced to 2 if the user has carpenter or engi training


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current ways to repair a damaged window are either silicate(which ruins the color of the window) or tearing down and replacing the window(griefs the atmosphere).

Adding a non-intrusive way to repair station windows would make repairs a lot less tedious to do.


## Changelog

```changelog
(u)UnfunnyPerson
(+)Clicking a damaged window with a sheets of the same material will repair the window
```
