### PR TITLE
Tweak AI shell naming behavior slightly

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -71,6 +71,7 @@
 	var/alohamaton_skin = 0 // for the bank purchase
 	var/metalman_skin = 0	//mbc : i'm getting tired of copypasting this, i promise to fix this somehow next time i add a cyborg skin ok
 	var/glitchy_speak = 0
+	var/chosename = 0
 
 	sound_fart = 'sound/voice/farts/poo2_robot.ogg'
 	var/sound_automaton_scratch = 'sound/misc/automaton_scratch.ogg'
@@ -803,9 +804,10 @@
 				break
 
 		if (src.shell && src.mainframe)
+			if (!src.chosename)
+				src.real_name = "SHELL/[src.mainframe]"
+				src.UpdateName()
 			src.bioHolder.mobAppearance.pronouns = src.client.preferences.AH.pronouns
-			src.real_name = "SHELL/[src.mainframe]"
-			src.UpdateName()
 			src.update_name_tag()
 
 		update_clothing()
@@ -814,7 +816,7 @@
 
 	Logout()
 		..()
-		if (src.shell)
+		if (src.shell && !src.chosename)
 			src.real_name = "AI Cyborg Shell [copytext("\ref[src]", 6, 11)]"
 			src.name = src.real_name
 			src.update_name_tag()

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -619,6 +619,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			if(newname && newname != R.name)
 				phrase_log.log_phrase("name-cyborg", newname, no_duplicates=TRUE)
 			logTheThing(LOG_STATION, user, "uses a docking station to rename [constructTarget(R,"combat")] to [newname].")
+			R.chosename = 1
 			R.real_name = "[newname]"
 			R.UpdateName()
 			if (R.internal_pda)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Basically, adds the variable "chosename" to determine if an AI has changed the name of a shell within a charging dock, and uses said variable to keep that name consistent when deploying and undeploying. Also HUGE thanks to callow for helping me figure out how to code this

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allows for easier organization of AI shells. Trying to figure out whether shell 89796 or shell 12415 is the one you want to deploy to is kind of annoying, be it because of specific modules in one vs the other, or in a case where 2 or more AIs exist and they want to keep track of which shell is theirs.

![Screenshot (263)](https://github.com/goonstation/goonstation/assets/73998720/b3913e10-99cd-435d-b15f-81facb4337b3)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)AIs can now name their shells to better keep track of them.
```
