### PR TITLE
Fix bad card icon in map editor

### DIFF
--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -355,7 +355,9 @@
 				logTheThing(LOG_COMBAT, user, "was partygibbed by [src] at [log_loc(src)].")
 				user.partygib(1)
 
-/obj/item/card_group //since "playing_card"s are singular cards, card_groups handling groups of playing_cards in the form of either a deck or hand
+ABSTRACT_TYPE(/obj/item/card_group)
+/// since "playing_card"s are singular cards, card_groups handling groups of playing_cards in the form of either a deck or hand
+/obj/item/card_group
 	name = "deck of cards"
 	icon = 'icons/obj/items/playing_card.dmi'
 	icon_state = "plain_deck_4"

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -358,6 +358,7 @@
 /obj/item/card_group //since "playing_card"s are singular cards, card_groups handling groups of playing_cards in the form of either a deck or hand
 	name = "deck of cards"
 	icon = 'icons/obj/items/playing_card.dmi'
+	icon_state = "plain_deck_4"
 	dir = NORTH
 	w_class = W_CLASS_TINY
 	burn_point = 220
@@ -832,6 +833,7 @@
 	card_style = "tarot"
 	total_cards = 78
 	card_name = "tarot"
+	icon_state = "tarot_deck_4"
 
 	New()
 		..()
@@ -900,6 +902,7 @@
 	card_style = "hanafuda"
 	total_cards = 48
 	card_name = "hanafuda"
+	icon_state = "hanafuda_deck_4"
 
 	New()
 		..()
@@ -991,6 +994,7 @@
 	card_style = "stg"
 	total_cards = 40
 	card_name = "Spacemen the Griffening"
+	icon_state = "stg_deck_4"
 
 	New()
 		..()
@@ -1003,6 +1007,7 @@
 	card_style = "clow"
 	total_cards = 52
 	card_name = "Clow"
+	icon_state = "clow_deck_4"
 
 	New()
 		..()


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR
Sets a default icon state for the playing card decks so that they don't use the "bad icon" sprite. It doesn't actually matter since the sprite is updated by `update_group_sprite()` when `New()` is called but it'll look nicer in the map editor.
Also makes the parent deck of cards abstract, just in case.

## Why's this needed?
It was annoying to see "bad icon" in the map editor instead of a deck of playing cards.