### PR TITLE
Reword the Extended (PDA) Description for Revolutionary Flashbangs

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1299,7 +1299,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	name = "Revolutionary Flashbang"
 	item = /obj/item/chem_grenade/flashbang/revolution
 	cost = 2
-	desc = "This single-use flashbang will convert all crew within range. It doesn't matter who primes the flash - it will convert all the same."
+	desc = "This single-use flashbang will convert all crew within range, but only shatter the loyalty implants of crew who have them. It doesn't matter who primes the flash - but crew will need a few seconds after a flashbang to respond to another."
 
 /datum/syndicate_buylist/generic/head_rev/revsign
 	name = "Revolutionary Sign"


### PR DESCRIPTION
[QOL] [UI] [OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[Reword PDA Desc. of rev flashbangs](https://forum.ss13.co/showthread.php?tid=21648)
Rewords the description of Revolutionary Flashbangs in the PDA description to more accurately reflect how they work. This is intended to increase clarity for revheads on what their flashbangs do, as currently their functionality differs from how the description claims them to work.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Verbatim what I said on the forum thread:

> PDA Rev flashbang extended description could use a bit of a tweak to reflect how it actually works.
> 
> Current Description:
> This single-use flashbang will convert all crew within range. It doesn't matter who primes the flash - it will convert all the same.
> 
> My problem with this is it implies it will convert crew with loyalty no matter what - this is false, it only breaks implants, and flashbangs have a cooldown on their effect.
> 
> Proposed Description:
> This single-use flashbang will convert all crew within range, but only shatter the loyalty implants of crew who have them. It doesn't matter who primes the flash - but crew will need a few seconds after a flashbang to respond to another.
> 
> This more accurately reflects the functionality of the item - the cooldown of revving someone with two flashbangs is considerable enough that it should be said - As even waiting for the current one to detonate and priming immediately does not work
> 
> Making this post because the current description misled me about how rev flashbangs worked when I rolled revhead and looked at it, hoping for clarity. It would have been nice if I got clarification on mechanics of the item that REALLY should have been described.
