### PR TITLE
Adds help messages to several traitor items

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -862,6 +862,10 @@ proc/Create_Tommyname()
 	// Are we ready to do something mean here?
 	var/wire_readied = 0
 
+	HELP_MESSAGE_OVERRIDE({"Use the garrot wire in hand to hold it with two hands, then place yourself behind your target.
+							Click them with the wire to attempt to grab them.
+							While a target is being strangled, use the wire in hand to inflict more damage and bleed in addition to the suffocation."})
+
 	New()
 		..()
 		BLOCK_SETUP(BLOCK_ROPE)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -838,7 +838,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Extra Large Shot Glasses"
 	item = /obj/item/storage/box/glassbox/syndie
 	cost = 2
-	desc = "A box of shot glasses that hold WAAAY more that normal. Cheat at drinking games!"
+	desc = "A box of shot glasses that hold WAAAY more that normal. Cheat at drinking games! Those glasses also splash all the liquid inside them to whatever they hit when thrown!"
 	job = list("Bartender")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -30,7 +30,10 @@
 	var/detonating = 0
 	///damage when loaded into a 40mm convesion chamber
 	var/launcher_damage = 25
-
+	HELP_MESSAGE_OVERRIDE({"Hit the grenade casing with a fuse to begin.
+							Hit the grenade casing with a small beaker to load it inside, up to two.
+							Hit a loaded grenade casing with a <b>screwdriver</b> to finish it. Use it in hand to begin the countdown.
+							Hit a finished grenade with an igniter assembly to add it to the grenade casing."})
 
 	New()
 		..()

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -338,6 +338,12 @@ TYPEINFO(/obj/item/card/emag)
 	input = jointext(namecheck, " ")
 	return input
 
+/obj/item/card/id/syndicate/get_help_message(dist, mob/user)
+	if (src.name == "agent card") //It's probably unmodified, should be fine to show the help message
+		return {"Use the card in hand to set it's name, appearance, job title and pronouns. Use another ID on the agent card to add the access of the ID to the agent card."}
+	else
+		return null
+
 /obj/item/card/id/syndicate/commander
 	name = "commander card"
 	access = list(access_maint_tunnels, access_syndicate_shuttle, access_syndicate_commander)

--- a/code/obj/item/cloning_modules.dm
+++ b/code/obj/item/cloning_modules.dm
@@ -33,7 +33,7 @@ Modules to do things with cloning modules
 	icon_state = "mindhack"
 	name = "Mindhack cloning module"
 	desc = "A powerful device that remaps people's brains when they get cloned to make them completely loyal to the owner of this module"
-
+	HELP_MESSAGE_OVERRIDE({"Click on a cloning pod while holding the Mindhack Cloning Module to install it. Anyone cloned while the module is on it will be loyal to the person who installed it. Use a <b>screwdriver</b> on the cloning pod to remove it."})
 
 /obj/item/storage/box/mindhack_module_kit
 	name = "Mindhack module kit"

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1682,6 +1682,10 @@
 	icon_state = "remote"
 	item_state = "electronic"
 	w_class = W_CLASS_SMALL
+	HELP_MESSAGE_OVERRIDE({"Use the remote in hand to change the appearance of all chameleon clothing.
+							Right click on a piece of chameleon clothing and use <b>"Change appearance"</b> to change the appearance of that specific piece.
+							Use a piece of clothing on the corresponding chameleon clothing piece to add that appearance to the list of possible appearances.
+							Use the remote in hand and select the <b>"New Outfit Set"</b> option to create a new set of clothing."})
 
 	var/obj/item/storage/backpack/chameleon/connected_backpack = null
 	var/obj/item/clothing/under/chameleon/connected_jumpsuit = null

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -495,6 +495,15 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	custom_suicide = TRUE
 	suicide_in_hand = FALSE
 
+	get_help_message(dist, mob/user)
+		var/keybind = "Default: CTRL + Z"
+		var/datum/keymap/current_keymap = user.client.keymap
+		for (var/key in current_keymap.keys)
+			if (current_keymap.keys[key] == "snap")
+				keybind = current_keymap.unparse_keybind(key)
+				break
+		return {"While wearing the gloves, use the <b>*snap</b> ([keybind]) emote to deploy/retract the blades."}
+
 	suicide(mob/living/carbon/human/user)
 		if (!istype(user) || !src.user_can_suicide(user) || user.gloves != src)
 			return FALSE
@@ -581,6 +590,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	can_be_charged = 1 // Quite pointless, but could be useful as a last resort away from powered wires? Hell, it's a traitor item and can get the buff (Convair880).
 	max_uses = 10
 	flags = HAS_EQUIP_CLICK
+	HELP_MESSAGE_OVERRIDE({"While standing on a powered wire, click on a tile far away while on <span class='disarm'>disarm</span> intent to non-lethally stun, or on <span class='harm'>harm</span> item to shoot out dangerous lightning. The lightning's power is directly linked to the power in the wire."})
 
 	var/spam_flag = 0
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -270,6 +270,7 @@ TYPEINFO(/obj/item/voice_changer)
 	desc = "This voice-modulation device will dynamically disguise your voice to that of whoever is listed on your identification card, via incredibly complex algorithms. Discretely fits inside most masks, and can be removed with wirecutters."
 	icon_state = "voicechanger"
 	is_syndicate = 1
+	HELP_MESSAGE_OVERRIDE({"Use the voice changer on a face-concealing mask to fit it inside. You will speak as and appear in chat as the name of your worn ID, or as "unknown" if you aren't wearing your ID. Use wirecutters on the mask to remove the voice changer."})
 
 TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	mats = 12	// 2x voice changer cost. It's complicated ok
@@ -391,6 +392,8 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	color_b = 1
 	w_class = W_CLASS_SMALL
 	var/mob/living/carbon/human/victim
+	HELP_MESSAGE_OVERRIDE({"Wearing this mask as a clown traitor will allow it to be used as a gasmask.\n
+							You can force the mask directly onto someone's face by aiming at the head while they are lying down and click on them with the mask on any intent other than <span class='help'>help</span>."})
 
 	equipped(var/mob/user, var/slot)
 		. = ..()

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -83,6 +83,7 @@ TYPEINFO(/obj/item/device/chameleon)
 	var/obj/dummy/chameleon/cham = null //No sense creating / destroying this
 	var/active = 0
 	tooltip_flags = REBUILD_DIST
+	HELP_MESSAGE_OVERRIDE({"Use the chameleon projector on any object to copy it's appearance. Use it in hand to appear as that object indefinitely. The disguise will be removed if you interact with anything else or are hit."})
 
 	is_syndicate = 1
 
@@ -200,6 +201,12 @@ TYPEINFO(/obj/item/device/chameleon)
 	icon_state = "cham_bomb"
 	burn_possible = 0
 	var/strength = 12
+
+	get_help_message(dist, mob/user)
+		if (src.name == "chameleon bomb") // We havent been disguised yet, so we can show help messages
+			return "Hit the bomb on any object to disguise it as that object. Use the bomb in hand to arm/disarm it. The bomb will explode when anyone tries to pick up the armed bomb."
+		else
+			return null
 
 	dropped()
 		return

--- a/code/obj/item/device/chemicompiler.dm
+++ b/code/obj/item/device/chemicompiler.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "chemicompiler"
 	var/datum/chemicompiler_executor/executor
+	HELP_MESSAGE_OVERRIDE({"Chemicompiler information can be found on the wiki "} + EXTERNAL_LINK("https://wiki.ss13.co/ChemiCompiler", "here") + ".")
 
 	New()
 		..()

--- a/code/obj/item/device/cloak_gen.dm
+++ b/code/obj/item/device/cloak_gen.dm
@@ -19,6 +19,7 @@ TYPEINFO(/obj/item/cloak_gen)
 	var/list/fields = new/list()
 	is_syndicate = TRUE
 	contraband = 2
+	HELP_MESSAGE_OVERRIDE({"Place the cloaking field generator on the floor, then use the associated remote to turn it on or off. While on, the cloaking field generator is immovable."})
 
 	New()
 		..()
@@ -128,6 +129,9 @@ TYPEINFO(/obj/item/cloak_gen)
 	var/obj/item/cloak_gen/my_gen = null
 	var/anti_spam = 0 // Creating and deleting overlays en masse can cause noticeable lag (Convair880).
 	contraband = 2
+	HELP_MESSAGE_OVERRIDE({"Use the remote in hand to turn the generator on or off.
+							Right click the remote to access a list of parameters that will affect the generator.
+							Hit the remote on a generator to link it to that generator."})
 
 	attack_self(mob/user)
 		. = ..()

--- a/code/obj/item/device/fingerprinter.dm
+++ b/code/obj/item/device/fingerprinter.dm
@@ -13,6 +13,9 @@
 	/// List of prints currently scanned into the device. Each print maps to the name of the owner.
 	var/list/current_prints
 	var/mode = FINGERPRINT_READ
+	HELP_MESSAGE_OVERRIDE({"Toggle modes by using the fingerprinter in hand.
+							While on <b>"Read"</b> mode, use the tool on someone or something that has prints on it to add all the prints to the tool's print database.
+							While on <b>"Plant"</b> mode, use the tool on anything to add any prints from the database on it."})
 
 	New()
 		. = ..()

--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/item/lightbreaker)
 	stamina_crit_chance = 15
 	var/ammo = 4
 	var/ammo_max = 4
+	HELP_MESSAGE_OVERRIDE({"Use the lightbreaker in hand to shatter most windows and lights around you, and deafen/stagger people around you without ear protection. To recharge the lightbreaker, hit it with a <b>screwdriver</b>."})
 
 	examine()
 		. = ..()

--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -374,6 +374,9 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 		name = "\improper Detomatix cartridge"
 		desc = "Designed with the latest advancements in blast processing."
 		icon_state = "cart-deto"
+		HELP_MESSAGE_OVERRIDE({"Put the cartridge into a pda, then from the main menu navigate to <b>"File Browser"</b>
+								Use the <b>"MISSILE"</b> app to scan for pda targets, then hit the <b>"DETONATE"</b> button to blow up the target PDA.
+								Use the <b>"SELF-DESTRUCT"</b> program to almost instantaneously explode your own PDA."})
 
 		New()
 			..()

--- a/code/obj/item/device/powersink.dm
+++ b/code/obj/item/device/powersink.dm
@@ -25,6 +25,7 @@ TYPEINFO(/obj/item/device/powersink)
 	var/mode = POWERSINK_OFF		// 0 = off, 1=clamped (off), 2=operating
 	is_syndicate = 1
 	rand_pos = 0
+	HELP_MESSAGE_OVERRIDE({"To turn the powersink on/off, use a <b>screwdriver</b> on it while it is on exposed wiring."})
 
 	var/obj/cable/attached		// the attached cable
 	var/datum/light/light

--- a/code/obj/item/device/powersink.dm
+++ b/code/obj/item/device/powersink.dm
@@ -25,7 +25,7 @@ TYPEINFO(/obj/item/device/powersink)
 	var/mode = POWERSINK_OFF		// 0 = off, 1=clamped (off), 2=operating
 	is_syndicate = 1
 	rand_pos = 0
-	HELP_MESSAGE_OVERRIDE({"To turn the powersink on/off, use a <b>screwdriver</b> on it while it is on exposed wiring."})
+	HELP_MESSAGE_OVERRIDE({"To anchor the powersink, use a <b>screwdriver</b> on it while it is on exposed wiring. To turn the powersink on/off click it with an empty hand."})
 
 	var/obj/cable/attached		// the attached cable
 	var/datum/light/light

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -632,6 +632,7 @@ TYPEINFO(/obj/item/gun/energy/teleport)
 	var/obj/machinery/computer/teleporter/our_teleporter = null // For checks before firing (Convair880).
 	uses_charge_overlay = TRUE
 	charge_icon_state = "teleport"
+	HELP_MESSAGE_OVERRIDE({"Use the teleport gun in hand to set it's destination. Destination list is pulled from all the currently activated teleporters."})
 
 	New()
 		set_current_projectile(new /datum/projectile/tele_bolt)
@@ -1168,6 +1169,12 @@ TYPEINFO(/obj/item/gun/energy/pickpocket)
 	custom_cell_max_capacity = 100
 	var/obj/item/heldItem = null
 	tooltip_flags = REBUILD_DIST
+	HELP_MESSAGE_OVERRIDE({"Use the pickpocket gun in hand to alternate between three fire modes : <b>Steal</b>, <b>Plant</b> and <b>Harass</b>.\n
+							To remove an item from the pickpocket gun, hold the gun in one hand, then use your other hand on it.\n
+							To place an item into the pickpocket gun, hold the gun in one hand, then hit it with an item in your other hand.\n
+							While on <b>Steal</b>, the gun will attempt to steal the item of the target who's body part you are aiming at.\n
+							While on <b>Plant</b>, the gun will attempt to place an item on the target on the body part you are aiming at.\n
+							While on <b>Harass</b>, the gun will perform a debilitating effect on the target depending on the body part you are aiming at."})
 
 	New()
 		set_current_projectile(new/datum/projectile/pickpocket/steal)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1201,7 +1201,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 //0.41
 /obj/item/gun/kinetic/derringer
 	name = "derringer"
-	desc = "A small and easy-to-hide gun that comes with 2 shots. (Can be hidden in worn clothes and retrieved by using the wink emote)"
+	desc = "A small and easy-to-hide gun that comes with 2 shots."
 	icon_state = "derringer"
 	force = MELEE_DMG_PISTOL
 	ammo_cats = list(AMMO_PISTOL_41)
@@ -1210,6 +1210,15 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	muzzle_flash = null
 	default_magazine = /obj/item/ammo/bullets/derringer
 	fire_animation = TRUE
+
+	get_help_message(dist, mob/user)
+		var/keybind = "Default CTRL + W"
+		var/datum/keymap/current_keymap = user.client.keymap
+		for (var/key in current_keymap.keys)
+			if (current_keymap.keys[key] == "wink")
+				keybind = current_keymap.unparse_keybind(key)
+				break
+		return "Hit the gun on a piece of clothing to hide it inside. Retrieve it by using the <b>*wink</b> ([keybind]) emote."
 
 	afterattack(obj/O as obj, mob/user as mob)
 		if (O.loc == user && O != src && istype(O, /obj/item/clothing))

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1640,6 +1640,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	name = "microbomb implanter"
 	icon_state = "implanter1-g"
 	sneaky = TRUE
+	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, an explosion relative to the amount of microbombs in them will occur. Suiciding will cause no explosion."})
 
 	New()
 		var/obj/item/implant/revenge/microbomb/newbomb = new/obj/item/implant/revenge/microbomb( src )
@@ -1651,6 +1652,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	name = "flyzapper implanter"
 	icon_state = "implanter1-g"
 	sneaky = TRUE
+	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, a ball of lightning relative to the amount of flyzapper implants in them will occur. Suiciding will cause no lightning."})
 
 	New()
 		src.imp = new /obj/item/implant/revenge/zappy(src)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -59,6 +59,7 @@ TYPEINFO(/obj/item/sword)
 	var/off_w_class = W_CLASS_SMALL
 	var/datum/component/loctargeting/simple_light/light_c
 	var/do_stun = 0
+	HELP_MESSAGE_OVERRIDE({"Use the saber in hand to turn it on/off. <span class='grab'>Block</span> with the activated saber in hand to deflect most bullets shot at you back to the sender."})
 
 	stunner
 		do_stun = 1
@@ -573,6 +574,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 /obj/item/dagger/syndicate
 	name = "syndicate dagger"
 	desc = "An ornamental dagger for syndicate higher-ups. It sounds fancy, but it's basically the munitions company equivalent of those glass cubes with the company logo frosted on."
+	HELP_MESSAGE_OVERRIDE({"Throw the dagger at someone to instantly incapacitate them for a short while."})
 
 /obj/item/dagger/syndicate/specialist //Infiltrator class knife
 	name = "syndicate fighting utility knife"
@@ -790,6 +792,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	hit_type = DAMAGE_STAB
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
 	var/makemeat = 1
+	HELP_MESSAGE_OVERRIDE({"Throw the knife at someone for a guaranteed short stun. Use the knife on a dead body to instantly turn it into meat."})
 
 /obj/item/knife/butcher/New()
 	..()
@@ -1227,6 +1230,8 @@ TYPEINFO(/obj/item/swords/katana)
 	contraband = 7 //Fun fact: sheathing your katana makes you 100% less likely to be tazed by beepsky, probably
 	hitsound = 'sound/impact_sounds/katana_slash.ogg'
 	midair_fruit_slice = TRUE
+	HELP_MESSAGE_OVERRIDE({"Hit someone while aiming at a specific limb to immediatly slice off the targeted limb. If both arms and legs are sliced off, you can decapitate your target by aiming for the head.\n
+							While on any intent other than <span class='help'>help</span>, click a tile away from you to quickly dash forward to it's location, slicing those in the way."})
 
 
 	// pickup_sfx = 'sound/items/blade_pull.ogg'

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -986,6 +986,7 @@ TYPEINFO(/obj/item/storage/belt/wrestling)
 	is_syndicate = 1
 	item_function_flags = IMMUNE_TO_ACID
 	var/fake = 0		//So the moves are all fake.
+	HELP_MESSAGE_OVERRIDE({"In addition to granting the wearer wrestler abilities, it also gives them the wrestler passives detailed "} + EXTERNAL_LINK("https://wiki.ss13.co/Wrestler#Passives", "here") + ".")
 
 	equipped(var/mob/user)
 		..()

--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -204,6 +204,17 @@
 			return 1 //welding, has fuel
 		return 0 //not welding
 
+	get_help_message(dist, mob/user)
+		if (istype(src, /obj/item/tool/omnitool/syndicate))
+			var/keybind = "Default: CTRL + X"
+			var/datum/keymap/current_keymap = user.client.keymap
+			for (var/key in current_keymap.keys)
+				if (current_keymap.keys[key] == "flex")
+					keybind = current_keymap.unparse_keybind(key)
+					break
+			return "Hit the omnitool on a piece of clothing to hide it. Retrieve the tool by using the <b>*flex</b> ([keybind]) emote."
+		else
+			return null
 
 
 /obj/item/tool/omnitool/syndicate

--- a/code/obj/machinery/portapuke.dm
+++ b/code/obj/machinery/portapuke.dm
@@ -11,6 +11,7 @@
 	var/current_bucket
 	var/n_occupants = 0
 	var/max_occupants = INFINITY
+	HELP_MESSAGE_OVERRIDE({"Click on someone on <span class='grab'>grab</span> intent, then click on the Port-A-Puke with the grab to place them inside. They will come out automatically once they reach deep critical status or die."})
 
 
 	New()

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -31,6 +31,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	contraband = 2
 	overlays = null
 	armed = FALSE
+	HELP_MESSAGE_OVERRIDE({"Use the sawfly in hand or use the remote to deploy it. Use the remote or click on the sawfly on <span class='help'>help</span> or <span class='grab'>grab</span> intent to deactivate it."})
 
 	//used in dictating behavior when deployed from grenade
 	var/mob/living/critter/robotic/sawfly/heldfly = null

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -102,6 +102,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	icon = 'icons/obj/items/device.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/omnitool.dmi'
 	icon_state = "sawflycontr"
+	HELP_MESSAGE_OVERRIDE({"Use the remote in hand to activate/deactivate any sawflies within a 5 tile radius."})
 
 	attack_self(mob/user as mob)
 		for (var/mob/living/critter/robotic/sawfly/S in range(get_turf(src), 5)) // folds active sawflies

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -977,6 +977,10 @@ TYPEINFO(/obj/vehicle/clowncar)
 	soundproofing = 5
 	var/second_icon = "clowncar2" //animated jiggling for the clowncar
 	var/peel_count = 5
+	HELP_MESSAGE_OVERRIDE({"While wearing two or more pieces of clown attire, <b>click drag</b> yourself to the car while next to it to enter it.
+							Driving into someone stuns them. If someone is lying down, <b>click drag</b> them to the car to force them inside.
+							Driving into a wall will force all the occupants out and stun the driver.
+							Click on the car while inside to get out. Click on the car while outside to free all the occupants."})
 
 /obj/vehicle/clowncar/do_special_on_relay(mob/user as mob, dir)
 	for (var/mob/living/L in src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds help messages to most complex traitor items which aren't meant to be stealthy.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ease of use is important, and a newer player can't just ask a coworker on how to use a traitor tool for fear of ratting themselves out. Having help messages on most complex traitor items should provide immediate feedback on how to get basic use out of them.

This pr doesn't add help messages to most items which require to be stealthy (i.e. cyborg convertion station, slip and sign, etc...) since one could examine it from afar to identify it as a traitor tool. It also doesn't add it to most very simple items like guns or items which already explain how to use them in the description.

```changelog
(u)Bartimeus973
(+)A lot of traitor items now have explanations on how to use them. Double examine or right click -> Help on them to read it.
```
