### PR TITLE
directional fire alarm presets

### DIFF
--- a/code/obj/machinery/firealarm.dm
+++ b/code/obj/machinery/firealarm.dm
@@ -256,7 +256,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/firealarm, proc/alarm, proc/reset)
 	dir = NORTH
 	pixel_y = -22
 
-
 /obj/machinery/firealarm/east
 	dir = WEST
 	pixel_x = 24

--- a/code/obj/machinery/firealarm.dm
+++ b/code/obj/machinery/firealarm.dm
@@ -247,3 +247,20 @@ ADMIN_INTERACT_PROCS(/obj/machinery/firealarm, proc/alarm, proc/reset)
 		reply.data["type"] = "Fire"
 		SPAWN(0.5 SECONDS)
 			SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, reply)
+
+// these seem kind of inverted but it's because an eastward alarm hangs on a west wall and etc
+/obj/machinery/firealarm/north
+	pixel_y = 30
+
+/obj/machinery/firealarm/south
+	dir = SOUTH
+	pixel_y = -22
+
+
+/obj/machinery/firealarm/east
+	dir = WEST
+	pixel_x = 24
+
+/obj/machinery/firealarm/west
+	dir = EAST
+	pixel_x = -24

--- a/code/obj/machinery/firealarm.dm
+++ b/code/obj/machinery/firealarm.dm
@@ -253,7 +253,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/firealarm, proc/alarm, proc/reset)
 	pixel_y = 30
 
 /obj/machinery/firealarm/south
-	dir = SOUTH
+	dir = NORTH
 	pixel_y = -22
 
 

--- a/code/obj/machinery/firealarm.dm
+++ b/code/obj/machinery/firealarm.dm
@@ -248,7 +248,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/firealarm, proc/alarm, proc/reset)
 		SPAWN(0.5 SECONDS)
 			SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, reply)
 
-// these seem kind of inverted but it's because an eastward alarm hangs on a west wall and etc
+// these seem kind of inverted but it's because an alarm on a wall to the north faces south and etc
 /obj/machinery/firealarm/north
 	pixel_y = 30
 


### PR DESCRIPTION
[MAPPING] [QOL] [INTERNAL]
## About the PR
Adds some fire alarm presets with built in pixel offsets, for ease of mapping. This now matches similar convention with light switches and blind switches and APC units. Doesn't affect existing fire alarms.

## Why's this needed?
Makes mapping easier and offsets more consistent for future mapping if needed. Mapping QoL is good.