### PR TITLE
Add grenade storage capability to several Nuke Ops armor suits

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1255,7 +1255,7 @@
 		assault
 			New()
 				..()
-				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/flashbang, /obj/item/chem_grenede/stinger), slots = 6, opens_if_worn = TRUE)
+				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/flashbang, /obj/item/old_grenade/stinger), slots = 6, opens_if_worn = TRUE)
 
 		medic
 			name = "specialist operative medic uniform"
@@ -1292,7 +1292,7 @@
 			New()
 				..()
 				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/napalm, /obj/item/chem_grenade/incendiary,
-					/obj/item/chem_greande/very_incendiary, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
+					/obj/item/chem_grenade/very_incendiary, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
 
 			setupProperties()
 				..()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1169,10 +1169,15 @@
 	contraband = 3
 	team_num = TEAM_SYNDICATE
 	item_function_flags = IMMUNE_TO_ACID
+	/// if it has storage for holding grenades and similar
+	var/receives_storage = FALSE // /obj/item/clothing/suit/space/industrial/syndicate/specialist has similar storage addition
 
 	New()
 		..()
 		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+
+		if (src.receives_storage)
+			src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade, /obj/item/old_grenade, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
 
 	setupProperties()
 		..()
@@ -1216,9 +1221,7 @@
 				src.dropped(user)
 				qdel(src)
 		#else
-		New()
-			..()
-			src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade, /obj/item/old_grenade, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
+		src.receives_storage = TRUE
 		#endif
 
 		setupProperties()
@@ -1257,9 +1260,7 @@
 			setProperty("radprot", 50)
 
 		assault
-			New()
-				..()
-				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/flashbang, /obj/item/old_grenade/stinger), slots = 6, opens_if_worn = TRUE)
+			receives_storage = TRUE
 
 		medic
 			name = "specialist operative medic uniform"
@@ -1293,10 +1294,7 @@
 
 			protective_temperature = 100000
 
-			New()
-				..()
-				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/napalm, /obj/item/chem_grenade/incendiary,
-					/obj/item/chem_grenade/very_incendiary, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
+			receives_storage = TRUE
 
 			setupProperties()
 				..()
@@ -1316,9 +1314,7 @@
 			icon_state = "syndie_specialist-sniper"
 			item_state = "syndie_specialist-sniper"
 
-			New()
-				..()
-				src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/smoke), slots = 6, opens_if_worn = TRUE)
+			receives_storage = TRUE
 
 			setupProperties()
 				..()
@@ -1326,10 +1322,7 @@
 
 		grenadier
 			name = "specialist operative bombsuit"
-
-			New()
-				..()
-				src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/stinger), slots = 6, opens_if_worn = TRUE)
+			receives_storage = TRUE
 
 			setupProperties()
 				..()
@@ -1567,7 +1560,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
 
 		New()
 			..()
-			src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/high_explosive), slots = 6, opens_if_worn = TRUE)
+			src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade, /obj/item/old_grenade, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
 
 TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	mats = list("MET-3"=20, "uqil"=10, "CON-2" = 10, "POW-2" = 10)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1216,6 +1216,8 @@
 				src.dropped(user)
 				qdel(src)
 		#else
+		New()
+			..()
 			src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade, /obj/item/old_grenade, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
 		#endif
 

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1252,6 +1252,11 @@
 			setProperty("rangedprot", 1.5)
 			setProperty("radprot", 50)
 
+		assault
+			New()
+				..()
+				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/flashbang, /obj/item/chem_grenede/stinger), slots = 6, opens_if_worn = TRUE)
+
 		medic
 			name = "specialist operative medic uniform"
 			desc = "A syndicate issue combat dress system, pressurized for space travel."
@@ -1284,6 +1289,11 @@
 
 			protective_temperature = 100000
 
+			New()
+				..()
+				src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade/napalm, /obj/item/chem_grenade/incendiary,
+					/obj/item/chem_greande/very_incendiary, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
+
 			setupProperties()
 				..()
 				setProperty("heatprot", 100)
@@ -1301,12 +1311,21 @@
 			name = "specialist operative marksman's suit"
 			icon_state = "syndie_specialist-sniper"
 			item_state = "syndie_specialist-sniper"
+
+			New()
+				..()
+				src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/smoke), slots = 6, opens_if_worn = TRUE)
+
 			setupProperties()
 				..()
 				setProperty("radprot", 50)
 
 		grenadier
 			name = "specialist operative bombsuit"
+
+			New()
+				..()
+				src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/stinger), slots = 6, opens_if_worn = TRUE)
 
 			setupProperties()
 				..()
@@ -1541,6 +1560,10 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
 		desc = "A syndicate issue heavy combat dress system, pressurized for space travel and reinforced for greater protection in firefights."
 		icon_state = "syndie_specialist-heavy"
 		item_state = "syndie_specialist-heavy"
+
+		New()
+			..()
+			src.create_storage(/datum/storage, can_hold = list(/obj/item/old_grenade/high_explosive), slots = 6, opens_if_worn = TRUE)
 
 TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	mats = list("MET-3"=20, "uqil"=10, "CON-2" = 10, "POW-2" = 10)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1221,7 +1221,9 @@
 				src.dropped(user)
 				qdel(src)
 		#else
-		src.receives_storage = TRUE
+		New()
+			src.receives_storage = TRUE
+			..()
 		#endif
 
 		setupProperties()
@@ -1293,7 +1295,6 @@
 			item_state = "syndie_specialist-firebrand"
 
 			protective_temperature = 100000
-
 			receives_storage = TRUE
 
 			setupProperties()
@@ -1313,7 +1314,6 @@
 			name = "specialist operative marksman's suit"
 			icon_state = "syndie_specialist-sniper"
 			item_state = "syndie_specialist-sniper"
-
 			receives_storage = TRUE
 
 			setupProperties()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1215,6 +1215,8 @@
 				user.u_equip(src)
 				src.dropped(user)
 				qdel(src)
+		#else
+			src.create_storage(/datum/storage, can_hold = list(/obj/item/chem_grenade, /obj/item/old_grenade, /obj/item/firebot_deployer), slots = 6, opens_if_worn = TRUE)
 		#endif
 
 		setupProperties()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -512,7 +512,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/storage/pouch/assault_rifle/mixed,
 		/obj/item/storage/grenade_pouch/mixed_standard,
 		/obj/item/breaching_charge = 2,
-		/obj/item/clothing/suit/space/syndicate/specialist,
+		/obj/item/clothing/suit/space/syndicate/specialist/assault,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist)
 
 	agent // not avaliable for purchase


### PR DESCRIPTION
[GAME MODES][FEATURE][QoL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a grenade storage to the nuke ops armor suits for classes that come with a grenade pouch. Specifically, Assault, Heavy, Firebrand, Marksman, and Grenadier. Commander's coat gets one too. The storage can also hold firebot deployers.

Maybe replacing with ammo storage instead, or allowing ammo and grenades would be better? Wanted to propose an idea at least

At best, this just frees up one slot in your inventory that would otherwise be used for holding the grenade pouch, so I don't think it should negatively impact balance too much?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some of the nuke ops classes are in an awkward position where they get two pouches, one for ammo and one for grenades, but have one pocket reserved for oxygen. You just have to hold the other pouch in your hand and take out items with your free hand to use it.

One way to make it more QoL would be to add storage to the armor suit. Thought it might be a fun change to add to the tactical/specialist/operative vibe of nuke ops. Not sure if good or bad change.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Nuke Ops classes Assault, Heavy, Firebrand, Marksman, and Grenadier, now have storage on their armor suit, as well as for the Commander's coat, that can hold the grenades that their grenade pouches come with.
```
