### PR TITLE
Makes airbridge pressurization uniform across all tiles

### DIFF
--- a/code/obj/airbridge.dm
+++ b/code/obj/airbridge.dm
@@ -82,15 +82,9 @@ ADMIN_INTERACT_PROCS(/obj/airbridge_controller, proc/toggle_bridge, proc/pressur
 			for(var/turf/simulated/T in maintaining_turfs)
 				if(!T.air && T.density)
 					continue
-				ZERO_GASES(T.air)
-#ifdef ATMOS_ARCHIVING
-				ZERO_ARCHIVED_GASES(T.air)
-				T.air.ARCHIVED(temperature) = null
-#endif
-				T.air.oxygen = MOLES_O2STANDARD
-				T.air.nitrogen = MOLES_N2STANDARD
-				T.air.fuel_burnt = 0
-				T.air.temperature = T20C
+				if(T.parent?.group_processing)
+					T.parent.suspend_group_processing()
+				T.stabilize()
 				LAGCHECK(LAG_LOW)
 
 			working = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [ATMOSPHERICS] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #11224 by making all airbridge tiles suspend group processing before pressurization.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Airbridge pressurization is currently really finnicky and I often find the pressurize button doesn't actually work (and I confirmed this with the atmos overlay), it also causes some smaller airbridges like the one in Kondaru's engineering to start the round with no air. This change fixes that and makes airbridges consistently pressurize when you tell them to.