### PR TITLE
Make the Dispensary interlink accept patch boxes from chemmaster

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3319,6 +3319,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/jobclothing)
 		/obj/item/reagent_containers/ampoule,
 		/obj/item/chem_pill_bottle,
 		/obj/item/storage/box/patchbox,
+		/obj/item/item_box/medical_patches,
 	)
 
 	New()


### PR DESCRIPTION
[Bug][Game-Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Enables the dispensary interlink to accept boxes of patches that can be made with the chemmaster

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You were forced before to put in any single patch by hand which... became tiring and bad for my hand.

This fixes #14909 