### PR TITLE
Severly reduces the value of trip laser beams in the singularity

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -367,6 +367,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 					src.grow()
 					sleep(0.5 SECONDS)
 			qdel(A)
+		else if (istype(A, /obj/mechbeam)) //let's not make lazy feeders with trip lasers
+			gain += 0.25
+			qdel(A)
 		else
 			var/obj/O = A
 			gain += 2


### PR DESCRIPTION
[Game-object][Balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR reduces the amount of power a trip laser beam adds to the singularity from 2 down to 0.25.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Trip lasers are a method which very low effort to feed the singularity with items, which require no player interaction once set up and no recources. Beyond that, it simply does not make sense that lasers offter that much mass to a singularity.

This changes still enables feeding of singularities with trip lasers, but makes it far less powerfull so methods which consume recources will be preferred.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)New research found that beams from trip lasers offer much less nutritional value to singularities than before.
```
