### PR TITLE
Adds a random wig crate

### DIFF
--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -58,17 +58,21 @@
 /obj/item/clothing/head/wig/spawnable/random
 
 	New()
-		var/list/possible_hairstyles = null
+		src.name = "wig"
+		var/list/possible_hairstyles
+
 		if (prob(50))
 			possible_hairstyles = filtered_concrete_typesof(/datum/customization_style, /proc/ismasc)
 		else
 			possible_hairstyles = filtered_concrete_typesof(/datum/customization_style, /proc/isfem)
-		var/datum/customization_style/hair_type = null
+
+		var/datum/customization_style/hair_type
 		var/picked_color = rgb(rand(0,255),rand(0,255),rand(0,255))
 		hair_type = pick(possible_hairstyles)
 		first_id = initial(hair_type.id)
 		first_color = picked_color
 		if (prob(33))
+			hair_type = pick(possible_hairstyles)
 			second_id = initial(hair_type.id)
 			second_color = picked_color
 		..()

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -54,6 +54,24 @@
 		hair_list[third_id] = third_color
 		src.setup_wig(hair_list)
 
+///Randomized wig for the cargo crate
+/obj/item/clothing/head/wig/spawnable/random
+
+	New()
+		var/list/possible_hairstyles = concrete_typesof(/datum/customization_style) - concrete_typesof(/datum/customization_style/biological) - concrete_typesof(/datum/customization_style/hair/gimmick)
+		var/datum/customization_style/hair_type = pick(possible_hairstyles)
+		first_id = initial(hair_type.id)
+		first_color = random_saturated_hex_color()
+		if (prob(75))
+			hair_type = pick(possible_hairstyles)
+			second_id = initial(hair_type.id)
+			second_color = random_saturated_hex_color()
+		if (prob(75))
+			hair_type = pick(possible_hairstyles)
+			third_id = initial(hair_type.id)
+			third_color = random_saturated_hex_color()
+		..()
+
 /obj/item/clothing/head/bald_cap
 	name = "bald cap"
 	desc = "You can't tell the difference, Honest!"

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -58,18 +58,19 @@
 /obj/item/clothing/head/wig/spawnable/random
 
 	New()
-		var/list/possible_hairstyles = concrete_typesof(/datum/customization_style) - concrete_typesof(/datum/customization_style/biological) - concrete_typesof(/datum/customization_style/hair/gimmick)
-		var/datum/customization_style/hair_type = pick(possible_hairstyles)
+		var/list/possible_hairstyles = null
+		if (prob(50))
+			possible_hairstyles = filtered_concrete_typesof(/datum/customization_style, /proc/ismasc)
+		else
+			possible_hairstyles = filtered_concrete_typesof(/datum/customization_style, /proc/isfem)
+		var/datum/customization_style/hair_type = null
+		var/picked_color = rgb(rand(0,255),rand(0,255),rand(0,255))
+		hair_type = pick(possible_hairstyles)
 		first_id = initial(hair_type.id)
-		first_color = random_saturated_hex_color()
-		if (prob(75))
-			hair_type = pick(possible_hairstyles)
+		first_color = picked_color
+		if (prob(33))
 			second_id = initial(hair_type.id)
-			second_color = rgb(rand(0,255),rand(0,255),rand(0,255))
-		if (prob(75))
-			hair_type = pick(possible_hairstyles)
-			third_id = initial(hair_type.id)
-			third_color = random_saturated_hex_color()
+			second_color = picked_color
 		..()
 
 /obj/item/clothing/head/bald_cap

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -65,7 +65,7 @@
 		if (prob(75))
 			hair_type = pick(possible_hairstyles)
 			second_id = initial(hair_type.id)
-			second_color = random_saturated_hex_color()
+			second_color = rgb(rand(0,255),rand(0,255),rand(0,255))
 		if (prob(75))
 			hair_type = pick(possible_hairstyles)
 			third_id = initial(hair_type.id)

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1188,7 +1188,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containername = "Haberdasher's Crate"
 
 /datum/supply_packs/random_wigs
-	name = "Wigs"
+	name = "Spare wigs crate"
 	desc = "7x assorted wigs."
 	category = "Civilian Department"
 	contains = list(/obj/item/clothing/head/wig/spawnable/random = 7)

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1187,6 +1187,15 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/packing
 	containername = "Haberdasher's Crate"
 
+/datum/supply_packs/random_wigs
+	name = "Wigs"
+	desc = "7x assorted wigs."
+	category = "Civilian Department"
+	contains = list(/obj/item/clothing/head/wig/spawnable/random = 7)
+	cost = 2000
+	containertype = /obj/storage/crate/packing
+	containername = "Wig Crate"
+
 /datum/supply_packs/headbands
 	name = "Bargain Bows and Bands Box"
 	desc = "Headbands for all occasions."


### PR DESCRIPTION
[CLOTHING] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a wig crate for 2000 credits that contains 7 randomized wigs. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More things for cargo to buy are always cool. Also allows for bald people, borgs, and mutantraces to get hair more easily.


## Changelog

```changelog
(u)UnfunnyPerson
(+)Added a randomized wig crate. Cargo can order this crate for 2000 credits.
```
