### PR TITLE
Tries out doubling the speed of Atmospheric machines and pipe_networks.

### DIFF
--- a/code/datums/controllers/process/machines.dm
+++ b/code/datums/controllers/process/machines.dm
@@ -30,7 +30,7 @@
 	doWork()
 		var/c = 0
 
-		if (ticker % 8 == 0)
+		if (ticker % 4 == 0)
 			src.atmos_machines = by_cat[TR_CAT_ATMOS_MACHINES]
 			for (var/obj/machinery/machine as anything in atmos_machines)
 				if( !machine || machine.z == 4 && !Z4_ACTIVE || istype(machine.loc, /obj/item/electronics/frame) ) continue
@@ -45,7 +45,7 @@
 
 				if (!(c++ % 100))
 					scheck()
-		if (ticker % 8 == 1)
+		if (ticker % 4 == 1)
 			src.pipe_networks = global.pipe_networks
 			for(var/X in src.pipe_networks)
 				if(!X) continue


### PR DESCRIPTION
[ATMOSPHERICS][EXPERIMENTAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tests out doubling processing speeds for atmos machines and pipe_networks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I guess because it would be nice not to wait a century for a room to fill from a vent?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(*)The rate at which pipe_networks and atmospheric machines do stuff has been doubled. Experience things such as vents, injectors, pumps, and probably more are no longer painfully slow. Also observe as nothing is done to preserve balance.
```
