### PR TITLE
Donut2 AIsat tweaks

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -18174,10 +18174,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
 "btm" = (
-/obj/cable/yellow,
 /obj/grille/steel,
-/obj/cable{
-	icon_state = "0-2"
+/obj/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
@@ -19943,7 +19942,7 @@
 	},
 /area/station/solar/aisat)
 "bBk" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -20133,45 +20132,45 @@
 	},
 /area/station/solar/aisat)
 "bCb" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/machinery/turret,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "9-10"
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCc" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCd" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-4"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "8-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-5"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCe" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -20283,30 +20282,30 @@
 	},
 /area/station/solar/aisat)
 "bCM" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCN" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCO" = (
-/obj/cable,
+/obj/cable/blue,
 /obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCQ" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -20548,16 +20547,6 @@
 /obj/landmark/spawner/artifact/one_in_ten,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"bDY" = (
-/obj/grille/steel,
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/turret_protected/AIbaseoutside)
 "bEa" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -20577,19 +20566,19 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "bEe" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bEg" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
@@ -21474,9 +21463,8 @@
 /area/station/turret_protected/AIbaseoutside)
 "bHp" = (
 /obj/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/cable,
 /turf/simulated/floor/plating/airless/shuttlebay{
 	name = "reinforced floor"
 	},
@@ -22443,7 +22431,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bQx" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command/alt,
@@ -23110,6 +23098,19 @@
 /obj/decal/cleanable/generic,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"cwC" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "cwW" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
@@ -24585,7 +24586,7 @@
 /area/station/maintenance/inner/central)
 "dAF" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-10"
 	},
 /obj/machinery/networked/radio,
@@ -24753,10 +24754,7 @@
 "dHX" = (
 /obj/grille/steel,
 /obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
@@ -25896,7 +25894,7 @@
 /area/station/science/lobby)
 "euL" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/machinery/door_control{
@@ -26082,7 +26080,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "eBm" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/AI,
@@ -26237,7 +26235,7 @@
 	chargelevel = 100000;
 	output = 10000
 	},
-/obj/cable,
+/obj/cable/blue,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "eKA" = (
@@ -26678,7 +26676,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/security,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -26874,6 +26872,12 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"ffA" = (
+/obj/cable/blue{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
 "fgb" = (
 /obj/machinery/conveyor/NW{
 	id = "cargo-art-in"
@@ -26933,7 +26937,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/power/apc/autoname_east,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/engine,
@@ -27459,7 +27463,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -27875,6 +27879,7 @@
 /area/station/crew_quarters/observatory)
 "fTT" = (
 /obj/stool/chair/office/red,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "fUe" = (
@@ -28002,6 +28007,19 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/science/lobby)
+"gbY" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "gcf" = (
 /obj/table/auto,
 /obj/item/reagent_containers/hypospray{
@@ -28023,7 +28041,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "gcq" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/camera{
@@ -28354,10 +28372,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "gqN" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-9"
 	},
 /turf/simulated/floor/black,
@@ -28858,7 +28876,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "gOr" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -28867,7 +28885,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
@@ -29025,16 +29043,16 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/cable/blue{
+	icon_state = "0-4"
 	},
-/obj/cable,
+/obj/cable/blue,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -29664,7 +29682,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "hup" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit/red,
@@ -29892,7 +29910,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "hEw" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -30377,7 +30395,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "iat" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -30501,8 +30519,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "ifA" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/cable/blue{
+	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -30513,8 +30531,8 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/blue,
+/obj/cable/blue{
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -30945,7 +30963,7 @@
 	dir = 4;
 	tag = ""
 	},
-/obj/cable,
+/obj/cable/blue,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
@@ -31057,7 +31075,7 @@
 	},
 /area/station/science/lobby)
 "iCI" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
@@ -31589,7 +31607,7 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "iWB" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent,
@@ -31687,7 +31705,7 @@
 /area/station/hydroponics/bay)
 "iZW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -32796,7 +32814,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "jPK" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -32995,7 +33013,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -33027,10 +33045,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/heads)
 "kbc" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -33726,13 +33744,13 @@
 	},
 /area/station/science/lobby)
 "kzT" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-6"
 	},
 /turf/simulated/floor/black,
@@ -34550,7 +34568,7 @@
 "ldw" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-10"
 	},
 /turf/simulated/floor/black,
@@ -35422,10 +35440,10 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "lIf" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-5"
 	},
 /turf/simulated/floor/black,
@@ -35628,10 +35646,10 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "lNU" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -36360,7 +36378,7 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/quartermaster/magnet)
 "mrr" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
@@ -37211,14 +37229,14 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/blue,
+/obj/cable/blue{
 	icon_state = "0-4"
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-8"
 	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "mXH" = (
@@ -38048,7 +38066,7 @@
 "nFv" = (
 /obj/item/device/radio/beacon,
 /obj/landmark/gps_waypoint,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
@@ -38585,7 +38603,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -38846,12 +38864,13 @@
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
 "oik" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "oio" = (
@@ -38964,7 +38983,7 @@
 /area/station/garden/owlery)
 "omo" = (
 /obj/machinery/teleport/portal_ring,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
@@ -39235,10 +39254,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "otU" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/black,
@@ -39687,6 +39706,19 @@
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"oJG" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/ai)
 "oJW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40735,7 +40767,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "pyH" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
@@ -41195,7 +41227,7 @@
 /turf/space,
 /area/space)
 "pSU" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
@@ -41243,7 +41275,7 @@
 	tag = ""
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-10"
 	},
 /obj/machinery/computer3/generic/secure_data,
@@ -41684,7 +41716,7 @@
 /area/station/medical/medbay)
 "qoa" = (
 /obj/machinery/teleport/portal_generator,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-4"
 	},
 /obj/machinery/light/incandescent,
@@ -41700,8 +41732,8 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/blue,
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -42419,10 +42451,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "qLS" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-10"
 	},
 /turf/simulated/floor/black,
@@ -43749,7 +43781,7 @@
 /obj/machinery/computer/teleporter{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine,
@@ -44101,7 +44133,7 @@
 "rZI" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/mapping_helper/firedoor_spawn,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/engineering_power,
@@ -44290,7 +44322,7 @@
 	tag = ""
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-6"
 	},
 /obj/machinery/computer/announcement{
@@ -45005,14 +45037,14 @@
 /turf/simulated/floor/caution/west,
 /area/listeningpost)
 "sDe" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/machinery/turret,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-6"
 	},
 /obj/decal/stripe_delivery,
@@ -47092,10 +47124,10 @@
 	},
 /area/station/quartermaster/office)
 "ugu" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -47241,7 +47273,7 @@
 /turf/simulated/floor,
 /area/station/engine/inner)
 "ult" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/circuit/red,
@@ -47537,7 +47569,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "uxt" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
@@ -48036,6 +48068,12 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
+"uUx" = (
+/obj/cable/blue{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
 "uUD" = (
 /obj/machinery/light/small/sticky/frostedred,
 /obj/storage/closet/fire,
@@ -48363,7 +48401,7 @@
 "vjd" = (
 /obj/machinery/computer/robotics,
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-6"
 	},
 /turf/simulated/floor/black,
@@ -49770,7 +49808,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "wlI" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command/alt,
@@ -50061,7 +50099,7 @@
 	},
 /area/station/quartermaster/magnet)
 "wwb" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -50374,7 +50412,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -50442,7 +50480,7 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "wRk" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "6-10"
 	},
 /turf/simulated/floor/black,
@@ -51136,13 +51174,13 @@
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "xse" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
@@ -51204,10 +51242,10 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-8"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -51513,7 +51551,7 @@
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
 "xEZ" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -51955,7 +51993,7 @@
 /area/station/crew_quarters/bar)
 "xWR" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "0-6"
 	},
 /obj/machinery/computer/bank_data,
@@ -51975,8 +52013,8 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/blue,
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -52009,13 +52047,13 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "yaN" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "2-4"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "5-9"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "9-10"
 	},
 /turf/simulated/floor/black,
@@ -52071,13 +52109,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "ydk" = (
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-4"
 	},
-/obj/cable{
+/obj/cable/blue{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
@@ -121712,7 +121750,7 @@ bvy
 bvy
 bvy
 bvy
-eNY
+gbY
 bvy
 bvy
 bvy
@@ -125023,7 +125061,7 @@ bzE
 sqP
 btm
 hEw
-qwl
+cwC
 cjG
 siY
 bFg
@@ -125648,7 +125686,7 @@ sNX
 bGF
 ecY
 xtu
-iat
+ffA
 iyz
 mjM
 nEX
@@ -125949,7 +125987,7 @@ sNX
 bFg
 bGF
 aMS
-xEZ
+uUx
 nEX
 fTT
 mjM
@@ -128356,7 +128394,7 @@ bvy
 bvy
 bvy
 bvy
-eNY
+oJG
 bvy
 bvy
 bvy
@@ -128960,7 +128998,7 @@ btl
 btl
 btl
 btl
-bDY
+dHX
 btl
 btl
 btl

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -27879,7 +27879,6 @@
 /area/station/crew_quarters/observatory)
 "fTT" = (
 /obj/stool/chair/office/red,
-/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "fUe" = (


### PR DESCRIPTION
[MAPPING]
## About the PR
- adds a secoff spawn point in the little checkpoint in the ai satellite. For fun. (they're able to use the teleporter to get back)
- Changes the interior ai satellite power grid to blue cabling to distinguish it from the out solar connections (red and yellow). The blue network is controlled by the SMES.

## Why's this needed?
Sec spawn? It's funny. And there's actually equipment there that they can use to suit up with first anyway.
Blue cables? It visually distinguishes the inner and outer grids. And looks nice.