### PR TITLE
twirl knife to flick off the blood

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -50,6 +50,8 @@
 	#define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
 	/// get radioactivity level of atom (0 if signal not registered - ie, has no radioactive component) (return_val as a list)
 	#define COMSIG_ATOM_RADIOACTIVITY "atom_get_radioactivity"
+	/// when this atom has clean_forensic called, send this signal.
+	#define COMSIG_ATOM_CLEANED "atom_cleaned"
 
 // ---- minimap ----
 
@@ -151,6 +153,8 @@
 	#define COMSIG_ITEM_PROCESS "itm_process"
 	/// After attacking any atom (not just mob) with this item (item, atom/target, mob/user, reach, params)
 	#define COMSIG_ITEM_AFTERATTACK "itm_afterattack"
+	/// When the item in hand is twirl emoted and spun in hand. (user, item)
+	#define COMSIG_ITEM_TWIRLED "itm_twirled"
 
 	// ---- bomb assembly signals ----
 

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -41,7 +41,7 @@ TYPEINFO(/datum/component/bloodflick)
 		make_cleanable(/obj/decal/cleanable/blood, get_turf(src.parent))
 		playsound(src.weapon.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 40, 1)
 		SPAWN(1 DECI SECOND) // so that the twirl emote message appears first (in theory)
-			boutput("Blood splatters onto the floor!") // i will be accepting suggestions on this line btw, reviewers
+			boutput("<span class='notice'>Blood splatters onto the floor!</span>") 
 
 /// applies wet blood to the knife and starts the blood drying countdown
 /datum/component/bloodflick/proc/wetten()

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -2,22 +2,20 @@ TYPEINFO(/datum/component/bloodflick)
 	initialization_args = list()
 
 /datum/component/bloodflick
+	/// typecasted thing that we're flicking blood off.
+	var/obj/item/blade
 
 /datum/component/bloodflick/Initialize()
-	. = ..()
-	if (!isitem(src.parent))
+	if (isitem(src.parent))
+		src.blade = src.parent
+	else
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, COMSIG_ATOM_HITBY_PROJ, PROC_REF(handle_impact))
-	RegisterSignal(parent, COMSIG_UPDATE_ICON, PROC_REF(redraw_impacts)) // just in case
-
-/datum/component/bloodflick/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ATOM_HITBY_PROJ)
-	. = ..()
+	..()
 
 /datum/component/bloodflick/proc/flick()
 	var/isbloody = FALSE
-	if (src.blood_DNA)
+	if (src.blade.blood_DNA)
 		isbloody = TRUE
 		make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
-		src.clean_forensic()
+		src.blade.clean_forensic()
 	return isbloody

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -57,6 +57,10 @@ TYPEINFO(/datum/component/bloodflick)
 			return
 		// it could get cleaned while it's drying
 		if (!dummy.blood_DNA)
+			src.hasdry = FALSE
+			src.haswet = FALSE
+			src.iswet = 0
+			// just in case
 			return
 		// if the parent is wet, dry it
 		if (src.haswet)

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -18,7 +18,7 @@ TYPEINFO(/datum/component/bloodflick)
 	if (!isitem(src.parent))
 		return COMPONENT_INCOMPATIBLE
 	src.weapon = src.parent
-	RegisterSignal(parent, COMSIG_ITEM_TWIRLED, PROC_REF(flick))
+	RegisterSignal(parent, COMSIG_ITEM_TWIRLED, PROC_REF(flickblood))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_POST, PROC_REF(wetten))
 	RegisterSignal(parent, COMSIG_ATOM_CLEANED, PROC_REF(clean))
 	..()
@@ -29,7 +29,7 @@ TYPEINFO(/datum/component/bloodflick)
 	UnregisterSignal(parent, COMSIG_ATOM_CLEANED)
 	..()
 
-/datum/component/bloodflick/proc/flick()
+/datum/component/bloodflick/proc/flickblood()
 	if (!src.weapon.blood_DNA)
 		return
 	// if all the blood is wet, flicking it off cleans it.

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -1,0 +1,23 @@
+TYPEINFO(/datum/component/bloodflick)
+	initialization_args = list()
+
+/datum/component/bloodflick
+
+/datum/component/bloodflick/Initialize()
+	. = ..()
+	if (!isitem(src.parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ATOM_HITBY_PROJ, PROC_REF(handle_impact))
+	RegisterSignal(parent, COMSIG_UPDATE_ICON, PROC_REF(redraw_impacts)) // just in case
+
+/datum/component/bloodflick/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ATOM_HITBY_PROJ)
+	. = ..()
+
+/datum/component/bloodflick/proc/flick()
+	var/isbloody = FALSE
+	if (src.blood_DNA)
+		isbloody = TRUE
+		make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
+		src.clean_forensic()
+	return isbloody

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -11,11 +11,13 @@ TYPEINFO(/datum/component/bloodflick)
 	var/iswet = 0
 	/// how long the blood takes to dry.
 	var/drytime = 30 SECONDS
+	/// typecasted parent
+	var/obj/item/weapon
 
 /datum/component/bloodflick/Initialize()
 	if (!isitem(src.parent))
 		return COMPONENT_INCOMPATIBLE
-	var/obj/item/blade = src.parent
+	src.weapon = src.parent
 	RegisterSignal(parent, COMSIG_ITEM_TWIRLED, PROC_REF(flick))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_POST, PROC_REF(wetten))
 	RegisterSignal(parent, COMSIG_ATOM_CLEANED, PROC_REF(clean))
@@ -28,24 +30,23 @@ TYPEINFO(/datum/component/bloodflick)
 	..()
 
 /datum/component/bloodflick/proc/flick()
-	var/obj/item/blade = src.parent
-	if (!blade.blood_DNA)
+	if (!src.weapon.blood_DNA)
 		return
 	// if all the blood is wet, flicking it off cleans it.
 	if (!src.hasdry)
-		blade.clean_forensic()
+		src.weapon.clean_forensic()
 	// if there's wet blood on it, flick it off
 	if (src.haswet)
 		src.haswet = FALSE
 		make_cleanable(/obj/decal/cleanable/blood, get_turf(src.parent))
-		playsound(blade.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 40, 1)
+		playsound(src.weapon.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 40, 1)
 		SPAWN(1 DECI SECOND) // so that the twirl emote message appears first (in theory)
 			boutput("Blood splatters onto the floor!") // i will be accepting suggestions on this line btw, reviewers
 
 /// applies wet blood to the knife and starts the blood drying countdown
 /datum/component/bloodflick/proc/wetten()
 	var/obj/item/dummy = src.parent
-	if (!dummy.blood_DNA) // not all attacks leave blood on the blade
+	if (!dummy.blood_DNA) // not all attacks leave blood on the parent
 		return
 	if (!src.haswet)
 		src.haswet = TRUE
@@ -57,10 +58,11 @@ TYPEINFO(/datum/component/bloodflick)
 		// it could get cleaned while it's drying
 		if (!dummy.blood_DNA)
 			return
-		// if the blade is wet, dry it
+		// if the parent is wet, dry it
 		if (src.haswet)
 			src.hasdry = TRUE
 			src.iswet -= 1
+		// if there's no more lingering sets of wet blood waiting to dry, dry the parent
 		if (!src.iswet)
 			src.haswet = FALSE
 

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -1,21 +1,63 @@
 TYPEINFO(/datum/component/bloodflick)
 	initialization_args = list()
 
+/// a component that makes items flick blood off them and onto the ground when twirled.
 /datum/component/bloodflick
-	/// typecasted thing that we're flicking blood off.
-	var/obj/item/blade
+	/// is the blood on the blade dried? if so, can't be cleaned by flicking.
+	var/hasdry = FALSE
+	/// Can blood be flicked off?
+	var/haswet = FALSE
+	/// a counter thingy. when it's at zero, the blade should get dry. when it's above that, stay wet.
+	var/iswet = 0
+	/// how long the blood takes to dry. once it's dry, you can't blood flick to clean it.
+	var/drytime = 30 SECONDS
 
 /datum/component/bloodflick/Initialize()
-	if (isitem(src.parent))
-		src.blade = src.parent
-	else
+	if (!isitem(src.parent))
 		return COMPONENT_INCOMPATIBLE
+	var/obj/item/blade = src.parent
+	RegisterSignal(parent, COMSIG_ITEM_TWIRLED, PROC_REF(flick))
+	RegisterSignal(parent, COMSIG_ITEM_ATTACK_POST, PROC_REF(wetten))
+	RegisterSignal(parent, COMSIG_ATOM_CLEANED, PROC_REF(clean))
+	..()
+
+/datum/component/bloodflick/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ITEM_TWIRLED)
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_POST)
+	UnregisterSignal(parent, COMSIG_ATOM_CLEANED)
 	..()
 
 /datum/component/bloodflick/proc/flick()
-	var/isbloody = FALSE
-	if (src.blade.blood_DNA)
-		isbloody = TRUE
-		make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
-		src.blade.clean_forensic()
-	return isbloody
+	var/obj/item/blade = src.parent
+	if (!blade.blood_DNA)
+		return
+	// if all the blood is wet, flicking it off cleans it.
+	if (!src.hasdry)
+		blade.clean_forensic()
+	// if there's wet blood on it, flick it off
+	if (src.haswet)
+		src.haswet = FALSE
+		make_cleanable(/obj/decal/cleanable/blood, get_turf(src.parent))
+		playsound(blade.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 40, 1)
+		SPAWN(1 DECI SECOND) // so that the twirl message appears first. Also i just guessed the time.
+			boutput("Blood splatters onto the floor!") // i will be accepting suggestions on this line btw, reviewers
+
+/// applies blood to the knife and starts the blood drying countdown
+/datum/component/bloodflick/proc/wetten()
+	var/obj/item/dummy = src.parent
+	if (!dummy.blood_DNA) // not all attacks leave blood on the blade
+		return
+	if (!src.haswet)
+		src.haswet = TRUE
+		src.iswet += 1
+	SPAWN(drytime)
+		if (src.haswet)
+			src.hasdry = TRUE
+			src.iswet -= 1
+		if (!src.iswet)
+			src.haswet = FALSE
+
+/// resets the variables
+/datum/component/bloodflick/proc/clean()
+	src.hasdry = FALSE
+	src.haswet = FALSE

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -3,13 +3,13 @@ TYPEINFO(/datum/component/bloodflick)
 
 /// a component that makes items flick blood off them and onto the ground when twirled.
 /datum/component/bloodflick
-	/// is the blood on the blade dried? if so, can't be cleaned by flicking.
+	/// is the blood on the parent dried? if so, can't be cleaned by flicking.
 	var/hasdry = FALSE
 	/// Can blood be flicked off?
 	var/haswet = FALSE
-	/// a counter thingy. when it's at zero, the blade should get dry. when it's above that, stay wet.
+	/// a counter. represents how many sets of wet blood are on the parent
 	var/iswet = 0
-	/// how long the blood takes to dry. once it's dry, you can't blood flick to clean it.
+	/// how long the blood takes to dry.
 	var/drytime = 30 SECONDS
 
 /datum/component/bloodflick/Initialize()
@@ -39,10 +39,10 @@ TYPEINFO(/datum/component/bloodflick)
 		src.haswet = FALSE
 		make_cleanable(/obj/decal/cleanable/blood, get_turf(src.parent))
 		playsound(blade.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 40, 1)
-		SPAWN(1 DECI SECOND) // so that the twirl message appears first. Also i just guessed the time.
+		SPAWN(1 DECI SECOND) // so that the twirl emote message appears first (in theory)
 			boutput("Blood splatters onto the floor!") // i will be accepting suggestions on this line btw, reviewers
 
-/// applies blood to the knife and starts the blood drying countdown
+/// applies wet blood to the knife and starts the blood drying countdown
 /datum/component/bloodflick/proc/wetten()
 	var/obj/item/dummy = src.parent
 	if (!dummy.blood_DNA) // not all attacks leave blood on the blade
@@ -51,6 +51,13 @@ TYPEINFO(/datum/component/bloodflick)
 		src.haswet = TRUE
 		src.iswet += 1
 	SPAWN(drytime)
+		// in case
+		if (!src)
+			return
+		// it could get cleaned while it's drying
+		if (!dummy.blood_DNA)
+			return
+		// if the blade is wet, dry it
 		if (src.haswet)
 			src.hasdry = TRUE
 			src.iswet -= 1
@@ -61,3 +68,4 @@ TYPEINFO(/datum/component/bloodflick)
 /datum/component/bloodflick/proc/clean()
 	src.hasdry = FALSE
 	src.haswet = FALSE
+	src.iswet = 0

--- a/code/datums/components/bloodflick.dm
+++ b/code/datums/components/bloodflick.dm
@@ -52,9 +52,6 @@ TYPEINFO(/datum/component/bloodflick)
 		src.haswet = TRUE
 		src.iswet += 1
 	SPAWN(drytime)
-		// in case
-		if (!src)
-			return
 		// it could get cleaned while it's drying
 		if (!dummy.blood_DNA)
 			src.hasdry = FALSE

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -662,10 +662,10 @@
 							var/isbloody = FALSE
 							if (istype(thing, /obj/item/kitchen/utensil/knife))
 								var/obj/item/kitchen/utensil/knife/kKnife = thing
-								var/isbloody = kKnife.bloodflick()
+								isbloody = kKnife.bloodflick()
 							else if (istype(thing, /obj/item/knife/butcher))
 								var/obj/item/knife/butcher/bKnife = thing
-								var/isbloody = bKnife.bloodflick()
+								isbloody = bKnife.bloodflick()
 							message = thing.on_spin_emote(src, isbloody)
 							maptext_out = "<I>twirls [thing]</I>"
 							animate_spin(thing, prob(50) ? "L" : "R", 1, 0)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -659,7 +659,14 @@
 							else if (src.r_hand)
 								thing = src.r_hand
 						if (thing)
-							message = thing.on_spin_emote(src)
+							var/isbloody = FALSE
+							if (istype(thing, /obj/item/kitchen/utensil/knife))
+								var/obj/item/kitchen/utensil/knife/kKnife = thing
+								var/isbloody = kKnife.bloodflick()
+							else if (istype(thing, /obj/item/knife/butcher))
+								var/obj/item/knife/butcher/bKnife = thing
+								var/isbloody = bKnife.bloodflick()
+							message = thing.on_spin_emote(src, isbloody)
 							maptext_out = "<I>twirls [thing]</I>"
 							animate_spin(thing, prob(50) ? "L" : "R", 1, 0)
 						else

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -659,10 +659,8 @@
 							else if (src.r_hand)
 								thing = src.r_hand
 						if (thing)
-							var/isbloody = FALSE
-							if (thing.GetComponent(/datum/component/bloodflick))
-								thing.flick()
-							message = thing.on_spin_emote(src, isbloody)
+							SEND_SIGNAL(thing, COMSIG_ITEM_TWIRLED, src, thing)
+							message = thing.on_spin_emote(src)
 							maptext_out = "<I>twirls [thing]</I>"
 							animate_spin(thing, prob(50) ? "L" : "R", 1, 0)
 						else

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -660,12 +660,8 @@
 								thing = src.r_hand
 						if (thing)
 							var/isbloody = FALSE
-							if (istype(thing, /obj/item/kitchen/utensil/knife))
-								var/obj/item/kitchen/utensil/knife/kKnife = thing
-								isbloody = kKnife.bloodflick()
-							else if (istype(thing, /obj/item/knife/butcher))
-								var/obj/item/knife/butcher/bKnife = thing
-								isbloody = bKnife.bloodflick()
+							if (thing.GetComponent(/datum/component/bloodflick))
+								thing.flick()
 							message = thing.on_spin_emote(src, isbloody)
 							maptext_out = "<I>twirls [thing]</I>"
 							animate_spin(thing, prob(50) ? "L" : "R", 1, 0)

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -254,6 +254,7 @@
 			L.forensics_blood_color = null
 			L.tracked_blood = null
 			L.set_clothing_icon_dirty()
+	SEND_SIGNAL(src, COMSIG_ATOM_CLEANED)
 
 /atom/movable/proc/track_blood()
 	return

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1533,7 +1533,7 @@ ABSTRACT_TYPE(/obj/item)
 
 	..()
 
-/obj/item/proc/on_spin_emote(var/mob/living/carbon/human/user as mob, var/cleanit = FALSE)
+/obj/item/proc/on_spin_emote(var/mob/living/carbon/human/user as mob)
 	if(src in user.juggling)
 		return ""
 	if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5))
@@ -1542,7 +1542,7 @@ ABSTRACT_TYPE(/obj/item)
 		src.set_loc(user.loc)
 		JOB_XP(user, "Clown", 1)
 	else
-		. = "<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand.[cleanit ? " Some blood splatters onto the ground." : ""]"
+		. = "<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand."
 
 
 //This proc handles any manipulation that happens due to plantstats

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1533,7 +1533,7 @@ ABSTRACT_TYPE(/obj/item)
 
 	..()
 
-/obj/item/proc/on_spin_emote(var/mob/living/carbon/human/user as mob)
+/obj/item/proc/on_spin_emote(var/mob/living/carbon/human/user as mob, var/cleanit = FALSE)
 	if(src in user.juggling)
 		return ""
 	if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5))
@@ -1542,7 +1542,7 @@ ABSTRACT_TYPE(/obj/item)
 		src.set_loc(user.loc)
 		JOB_XP(user, "Clown", 1)
 	else
-		. = "<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand."
+		. = "<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand.[cleanit ? " Some blood splatters onto the ground." : ""]"
 
 
 //This proc handles any manipulation that happens due to plantstats

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -191,9 +191,8 @@ TRAYS
 		var/isbloody = FALSE
 		if (src.blood_DNA)
 			isbloody = TRUE
-			src.loc.add_blood
-			make_cleanable(/obj/decal/cleanable/blood,splat)
-			src.clean_forensic
+			make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
+			src.clean_forensic()
 		return isbloody
 
 

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -187,6 +187,16 @@ TRAYS
 		user.TakeDamage("head", 150, 0)
 		return 1
 
+	proc/bloodflick()
+		var/isbloody = FALSE
+		if (src.blood_DNA)
+			isbloody = TRUE
+			src.loc.add_blood
+			make_cleanable(/obj/decal/cleanable/blood,splat)
+			src.clean_forensic
+		return isbloody
+
+
 /obj/item/kitchen/utensil/spoon/plastic
 	name = "plastic spoon"
 	icon_state = "spoon_plastic"

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -168,6 +168,7 @@ TRAYS
 
 	New()
 		..()
+		src.AddComponent(/datum/component/bloodflick)
 		src.setItemSpecial(/datum/item_special/double)
 
 	attack(mob/living/carbon/M, mob/living/carbon/user)
@@ -186,15 +187,6 @@ TRAYS
 		blood_slash(user, 25)
 		user.TakeDamage("head", 150, 0)
 		return 1
-
-	proc/bloodflick()
-		var/isbloody = FALSE
-		if (src.blood_DNA)
-			isbloody = TRUE
-			make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
-			src.clean_forensic()
-		return isbloody
-
 
 /obj/item/kitchen/utensil/spoon/plastic
 	name = "plastic spoon"

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -856,9 +856,8 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	var/isbloody = FALSE
 	if (src.blood_DNA)
 		isbloody = TRUE
-		src.loc.add_blood
-		make_cleanable(/obj/decal/cleanable/blood,splat)
-		src.clean_forensic
+		make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
+		src.clean_forensic()
 	return isbloody
 
 /////////////////////////////////////////////////// Hunter Spear ////////////////////////////////////////////

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1712,6 +1712,7 @@ obj/item/whetstone
 	New()
 		..()
 		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+		src.AddComponent(/datum/component/bloodflick)
 		src.setItemSpecial(/datum/item_special/swipe)
 		src.update_special_color()
 		AddComponent(/datum/component/itemblock/saberblock, null, PROC_REF(get_reflect_color))

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -852,6 +852,15 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	user.TakeDamage("head", 150, 0)
 	return 1
 
+/obj/item/knife/butcher/proc/bloodflick()
+	var/isbloody = FALSE
+	if (src.blood_DNA)
+		isbloody = TRUE
+		src.loc.add_blood
+		make_cleanable(/obj/decal/cleanable/blood,splat)
+		src.clean_forensic
+	return isbloody
+
 /////////////////////////////////////////////////// Hunter Spear ////////////////////////////////////////////
 
 /obj/item/knife/butcher/hunterspear

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -796,6 +796,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 
 /obj/item/knife/butcher/New()
 	..()
+	src.AddComponent(/datum/component/bloodflick)
 	BLOCK_SETUP(BLOCK_KNIFE)
 
 /obj/item/knife/butcher/throw_impact(atom/A, datum/thrown_thing/thr)
@@ -851,14 +852,6 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	blood_slash(user, 25)
 	user.TakeDamage("head", 150, 0)
 	return 1
-
-/obj/item/knife/butcher/proc/bloodflick()
-	var/isbloody = FALSE
-	if (src.blood_DNA)
-		isbloody = TRUE
-		make_cleanable(/obj/decal/cleanable/blood, get_turf(src))
-		src.clean_forensic()
-	return isbloody
 
 /////////////////////////////////////////////////// Hunter Spear ////////////////////////////////////////////
 
@@ -1129,6 +1122,10 @@ TYPEINFO(/obj/item/bat)
 	var/midair_fruit_slice = FALSE //! if this is TRUE, blocking with this weapon can slice thrown food items midair
 	var/midair_fruit_slice_stamina_cost = 7 //! The amount of stamina it costs to slice food midair
 	custom_suicide = 1
+
+/obj/item/swords/New()
+	src.AddComponent(/datum/component/bloodflick)
+	..()
 
 /obj/item/swords/proc/handle_parry(mob/target, mob/user)
 	if (target != user && ishuman(target))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -190,6 +190,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\baseball_bat_reflect.dm"
 #include "code\datums\components\battleroyale_death.dm"
 #include "code\datums\components\biodegradable.dm"
+#include "code\datums\components\bloodflick.dm"
 #include "code\datums\components\buildableturf.dm"
 #include "code\datums\components\bullet_holes.dm"
 #include "code\datums\components\cell_holder.dm"


### PR DESCRIPTION
[FEATURE]
## About the PR
Adds the ability to flick blood off knives and onto the floor. Performed by using the twirl emote. Forensic traces still remain though.

Currently added to kitchen knives, all swords, and syndicate butcher knives.

## Why's this needed?
It's a fun little thing that could be used in rp for extra drama. For classic, you can think of it as wiping it off on a shirt.

## Changelog
```changelog
(u)Tyrant
(+)Twirling a bloody knife will flick the blood off and onto the floor. Doesn't work if the blood is dried.
```