### PR TITLE
Change under parent usage to a prisoner subtype

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2916,7 +2916,7 @@
 
 	var/mob/living/carbon/human/newbody = new()
 	newbody.set_loc(reappear_turf)
-	newbody.equip_new_if_possible(/obj/item/clothing/under/misc, SLOT_W_UNIFORM)
+	newbody.equip_new_if_possible(/obj/item/clothing/under/misc/prisoner, SLOT_W_UNIFORM)
 
 	newbody.real_name = src.real_name
 

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -208,7 +208,7 @@
 	New()
 		..()
 		SPAWN(1 SECOND)
-			src.equip_new_if_possible(/obj/item/clothing/under/misc, SLOT_W_UNIFORM)
+			src.equip_new_if_possible(/obj/item/clothing/under/misc/prisoner, SLOT_W_UNIFORM)
 			src.equip_new_if_possible(/obj/item/clothing/head/beret/prisoner, SLOT_HEAD)
 			if(prob(80)) // couldnt figure out how to hide it in the debris field, so i just chucked it in a monkey
 				var/obj/item/disk/data/cartridge/ringtone_numbers/idk = new

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -623,7 +623,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			/obj/item/device/flash = 3,
 			/obj/item/clothing/head/beret/prisoner = 5,
 			/obj/item/clothing/shoes/orange = 5,
-			/obj/item/clothing/under/misc = 5,
+			/obj/item/clothing/under/misc/prisoner = 5,
 			/obj/item/clothing/shoes/swat = 2,
 			/obj/item/clothing/head/red = 4,
 			/obj/item/clothing/head/helmet/siren = 2,

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -592,12 +592,16 @@
 
 // Not jobs, but not gimmicks
 
+ABSTRACT_TYPE(/obj/item/clothing/under/misc)
 /obj/item/clothing/under/misc
-	name = "prisoner's jumpsuit"
-	desc = "Busted."
+	name = "under misc parent"
 	icon = 'icons/obj/clothing/uniforms/item_js_misc.dmi'
 	wear_image_icon = 'icons/mob/clothing/jumpsuits/worn_js_misc.dmi'
 	inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js_misc.dmi'
+
+/obj/item/clothing/under/misc/prisoner
+	name = "prisoner's jumpsuit"
+	desc = "Busted."
 	icon_state = "prisoner"
 	item_state = "prisoner"
 

--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -131,7 +131,7 @@ TYPEINFO(/obj/item/storage/wall)
 	icon_state = "miniorange"
 	pixel_y = 32
 	spawn_contents = list(/obj/item/clothing/under/color/orange = 2,
-	/obj/item/clothing/under/misc = 2,
+	/obj/item/clothing/under/misc/prisoner = 2,
 	/obj/item/clothing/shoes/orange = 3)
 
 /obj/item/storage/wall/blue

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -84,7 +84,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	icon_state = "orange"
 	icon_closed = "orange"
 	spawn_contents = list(/obj/item/clothing/under/color/orange = 4,
-	/obj/item/clothing/under/misc = 3,
+	/obj/item/clothing/under/misc/prisoner = 3,
 	/obj/item/clothing/shoes/orange = 4)
 
 /obj/storage/closet/wardrobe/yellow


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes `/obj/item/clothing/misc/under` from the prisoner jumpsuit to an abstract parent.
Prisoner jumpsuit is now `/obj/item/clothing/misc/under/prisoner` 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parent usage for normal things is bad and its unclear what it is from the type alone.

