### PR TITLE
Change rank under parent to an assistant subtype

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -968,7 +968,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	low_priority_job = 1
 	cant_allocate_unwanted = 1
 	map_can_autooverride = 0
-	slot_jump = list(/obj/item/clothing/under/rank)
+	slot_jump = list(/obj/item/clothing/under/rank/assistant)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -904,7 +904,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	name = "Staff Assistant Jumpsuit"
 	item_paths = list("FAB-1")
 	item_amounts = list(4)
-	item_outputs = list(/obj/item/clothing/under/rank)
+	item_outputs = list(/obj/item/clothing/under/rank/assistant)
 	time = 5 SECONDS
 	create = 1
 	category = "Clothing"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -349,7 +349,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 						succ = 1*/
 
 
-				if (H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/rank))
+				if (H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/rank/assistant))
 					var/obj/origin = text2path("[H.w_uniform.type]/april_fools")
 					if (ispath(origin))
 						H.w_uniform.icon_state = "[H.w_uniform.icon_state]-alt"

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -254,18 +254,12 @@
 
 // RANKS
 
+ABSTRACT_TYPE(/obj/item/clothing/under/rank)
 /obj/item/clothing/under/rank
-	name = "staff assistant's jumpsuit"
-	desc = "It's a generic grey jumpsuit. That's about what assistants are worth, anyway."
-	icon = 'icons/obj/clothing/uniforms/item_js_rank.dmi'
-	wear_image_icon = 'icons/mob/clothing/jumpsuits/worn_js_rank.dmi'
-	inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js_rank.dmi'
-	icon_state = "assistant"
-	item_state = "assistant"
-
-	april_fools
-		icon_state = "assistant-alt"
-		item_state = "assistant-alt"
+    name = "rank under parent"
+    icon = 'icons/obj/clothing/uniforms/item_js_rank.dmi'
+    wear_image_icon = 'icons/mob/clothing/jumpsuits/worn_js_rank.dmi'
+    inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js_rank.dmi'
 
 // Heads
 
@@ -539,6 +533,16 @@
 
 
 // Civilian
+
+/obj/item/clothing/under/rank/assistant
+	name = "staff assistant's jumpsuit"
+	desc = "It's a generic grey jumpsuit. That's about what assistants are worth, anyway."
+	icon_state = "assistant"
+	item_state = "assistant"
+
+/obj/item/clothing/under/rank/assistant/april_fools
+	icon_state = "assistant-alt"
+	item_state = "assistant-alt"
 
 /obj/item/clothing/under/rank/hydroponics
 	name = "botanist's jumpsuit"

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -38190,7 +38190,7 @@
 /area/station/quartermaster/refinery)
 "nKo" = (
 /obj/table/auto,
-/obj/item/clothing/under/rank{
+/obj/item/clothing/under/rank/assistant{
 	pixel_x = -2;
 	pixel_y = -1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes `/obj/item/clothing/under/rank` from the staff assistant jumpsuit to an abstract parent.
Assistant jumpsuit is now `/obj/item/clothing/under/rank/assistant/...` 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parent usage for normal things is bad and its unclear what it is from the type alone.

