### PR TITLE
Moves the NT commander to crew lounge

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -21545,7 +21545,6 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/dialogueobj/ntrepresentative,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -39123,6 +39122,11 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/purple,
+/area/station/crew_quarters/quartersA)
+"jKI" = (
+/obj/dialogueobj/ntrepresentative,
+/obj/stool/chair/comfy/blue,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
 "jKL" = (
 /obj/cable{
@@ -78902,7 +78906,7 @@ rHe
 aiz
 alJ
 amD
-amD
+jKI
 aos
 apm
 aqD


### PR DESCRIPTION
[MAPPING] [BALANCE]
## About the PR
Moves the commander to the crew lounge in the northwest of oshan, so that people who aren't in command can earn NT points instead of having to break in.

## Why's this needed?
Suggested by https://forum.ss13.co/showthread.php?tid=21705
The feature is really underused due to its being in the bridge and inaccessible. People who get circuit boards can't usually do anything with them.

## Changelog
```changelog
(u)Tyrant
(*)The NT commander of Oshan has decided to go sit in the crew lounge instead.
```