### PR TITLE
Nuclear glowsticks

### DIFF
--- a/code/modules/materials/Mat_FabParts.dm
+++ b/code/modules/materials/Mat_FabParts.dm
@@ -196,6 +196,13 @@
 		if(!I.material || (I.material.getID() != "starstone")) return 0
 		return ..()
 
+/datum/matfab_part/glowstick
+	name = "Glowsticks"
+	checkMatch(var/obj/item/I)
+		if(!istype(I, /obj/item/device/light/glowstick)) return 0
+		return ..()
+
+
 //////////////////////////////////////////////BASE CLASS BELOW
 
 /// Base material fabrication part

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -23,6 +23,24 @@
 	materials = list("!any"=2)
 	result = /obj/item/reactor_component/fuel_rod
 
+/datum/matfab_recipe/makeshift_fuel_rod
+	name = "Makeshift Nuclear Fuel Rod"
+	desc = "A fuel rod for a nuclear reactor, made out of glowsticks"
+	category = "Nuclear"
+
+	New()
+		..()
+		required_parts.Add(new/datum/matfab_part/glowstick {part_name = "Glowstick"; required_amount = 1} ())
+
+	build(amount, obj/machinery/nanofab/owner)
+		for(var/i=0, i<amount, i++)
+			var/obj/item/device/light/glowstick/stick = getObjectByPartName("Glowstick")
+			var/datum/material/glowstick_mat = getMaterial("glowstick")
+			glowstick_mat = glowstick_mat.getMutable()
+			glowstick_mat.setColor(rgb(stick.col_r*255, stick.col_g*255, stick.col_b*255))
+			var/obj/item/reactor_component/fuel_rod/glowsticks/result_rod = new /obj/item/reactor_component/fuel_rod/glowsticks(glowstick_mat)
+			result_rod.set_loc(getOutputLocation(owner))
+
 /datum/matfab_recipe/simple/nuclear/control_rod
 	name = "Control Rod"
 	desc = "A control rod for a nuclear reactor"

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -50,7 +50,8 @@
 	blueprints = list(/datum/matfab_recipe/simple/nuclear/gas_channel,
 	/datum/matfab_recipe/simple/nuclear/heat_exchanger,
 	/datum/matfab_recipe/simple/nuclear/control_rod,
-	/datum/matfab_recipe/simple/nuclear/fuel_rod)
+	/datum/matfab_recipe/simple/nuclear/fuel_rod,
+	/datum/matfab_recipe/makeshift_fuel_rod)
 
 /obj/machinery/nanofab/prototype
 	name = "Nano-fabricator (Protoype)"

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -733,3 +733,13 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				attacker.visible_message("<span class='alert'>Cuts apart [owner], revealing space!</span>","<span class='alert'>You finish cutting apart [owner], revealing space.</span>","The sound of cutting cardboard stops.")
 				floor_owner.ReplaceWithSpace()
 				return
+
+/datum/materialProc/glowstick_add
+	desc = "It has a chemical glow."
+	max_generations = 1
+	var/datum/component/loctargeting/sm_light/light_c
+
+	execute(var/atom/owner)
+		var/list/color = rgb2num(owner.material.getColor())
+		light_c = owner.AddComponent(/datum/component/loctargeting/sm_light, color[1], color[2], color[3], 255 * 0.33)
+		light_c.update(1)

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1855,3 +1855,22 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		setProperty("n_radioactive", 5)
 		setProperty("radioactive", 3)
 		setProperty("electrical", 7)
+
+/// Material for bundles of glowsticks as fuel rods
+/datum/material/metal/glowstick
+	mat_id = "glowstick"
+	name = "glowsticks" //"it is made of glowsticks"
+	canMix = 0 //don't make alloys of this
+	desc = "It's just a bunch of glowsticks stuck together. How is this an ingot?"
+	color = "#00e618"
+	alpha = 200
+	quality = 60
+
+	New()
+		..()
+		setProperty("density", 3)
+		setProperty("hard", 3)
+		setProperty("radioactive", 1)
+		setProperty("electrical", 2)
+		setProperty("thermal", 3)
+		addTrigger(TRIGGERS_ON_ADD, new /datum/materialProc/glowstick_add())

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -712,6 +712,17 @@
 					src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("cerenkite")
 		..()
 
+/obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/glowstick
+	New()
+		var/datum/material/glowstick_mat = getMaterial("glowstick")
+		glowstick_mat = glowstick_mat.getMutable()
+
+		for(var/x=1 to REACTOR_GRID_WIDTH)
+			for(var/y=1 to REACTOR_GRID_HEIGHT)
+				glowstick_mat.setColor(rgb(rand(0,255), rand(0,255), rand(0,255)))
+				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod/glowsticks(glowstick_mat)
+		..()
+
 #undef REACTOR_GRID_WIDTH
 #undef REACTOR_GRID_HEIGHT
 #undef REACTOR_TOO_HOT_TEMP

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -43,9 +43,12 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	var/thermal_mass = 420*250//specific heat capacity of steel (420 J/KgK) * mass of component (Kg)
 
 
-	New(material_name="steel")
+	New(material="steel")
 		..()
-		src.setMaterial(getMaterial(material_name))
+		if(istype(material, /datum/material))
+			src.setMaterial(material)
+		else
+			src.setMaterial(getMaterial(material))
 		melt_health = _max_health
 		var/img_check = ui_image_base64_cache[src.type]
 		if (img_check)
@@ -89,9 +92,6 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 					src.cap_icon.MapColors(arglist(setcolor))
 				else
 					src.cap_icon.Blend(rgb(setcolor[1],setcolor[2],setcolor[3],setcolor[4]), ICON_MULTIPLY)
-
-
-
 
 	proc/melt()
 		if(melted)
@@ -243,6 +243,17 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	extra_info()
 		. = ..()
 		. += "Radioactivity: [max(src.material.getProperty("n_radioactive")*10,src.material.getProperty("radioactive")*10)]%"
+
+/obj/item/reactor_component/fuel_rod/glowsticks
+	name = "makeshift fuel rod"
+	desc = "A fuel rod fo- hey this is just a bundle of glowsticks!"
+	melting_point = T0C+400 //plastic glowsticks melt easy
+
+	New(material)
+		if(isnull(material))
+			.=..("glowstick") //force material
+		else
+			.=..()
 ////////////////////////////////////////////////////////////////
 //Control rod
 /obj/item/reactor_component/control_rod
@@ -479,7 +490,8 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 		15;"cardboard",\
 		15;"frozenfart",\
 		5;"negativematter",\
-		5;"plutonium"
+		5;"plutonium",\
+		100; "glowstick"
 
 /obj/item/reactor_component/fuel_rod/random_material
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds glowsticks as an alternative fuel source for the nuclear reactor. They're really bad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes there's nobody in mining.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(*)You can now make shoddy fuel rods using a glowstick in the nuclear fabricator.
```
