### PR TITLE
Re magic the sandals in wizard den

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -391,12 +391,9 @@ TYPEINFO(/obj/item/clothing/shoes/moon)
 	desc = "They magically stop you from slipping on magical hazards. It's not the mesh on the underside that does that. It's MAGIC. Read a fucking book."
 	c_flags = NOSLIP
 	magical = 1
-	laces = LACES_NONE
-	step_sound = "step_flipflop"
-	step_priority = STEP_PRIORITY_LOW
 	duration_remove = 10 SECONDS
 
-	/// Subtype that wizards spawn with, and is in their vendor. Cows can wear them, unlike regular sandals (might also be useful in the future)
+/// Subtype that wizards spawn with, and is in their vendor. Cows can wear them, unlike regular sandals (might also be useful in the future)
 /obj/item/clothing/shoes/sandal/magic/wizard
 	compatible_species = list("human", "cow")
 

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -1904,10 +1904,10 @@
 /area/space)
 "fz" = (
 /obj/table/wood/auto,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal/magic/wizard,
+/obj/item/clothing/shoes/sandal/magic/wizard,
+/obj/item/clothing/shoes/sandal/magic/wizard,
+/obj/item/clothing/shoes/sandal/magic/wizard,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor5"
 	},

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -48682,16 +48682,16 @@
 /area/wizard_station)
 "djZ" = (
 /obj/rack,
-/obj/item/clothing/shoes/sandal{
+/obj/item/clothing/shoes/sandal/magic/wizard{
 	pixel_y = -5
 	},
-/obj/item/clothing/shoes/sandal{
+/obj/item/clothing/shoes/sandal/magic/wizard{
 	pixel_y = -2
 	},
-/obj/item/clothing/shoes/sandal{
+/obj/item/clothing/shoes/sandal/magic/wizard{
 	pixel_y = 1
 	},
-/obj/item/clothing/shoes/sandal{
+/obj/item/clothing/shoes/sandal/magic/wizard{
 	pixel_y = 4
 	},
 /obj/item/device/light/magic_lantern{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the sandals on the rack in wizard den not being the magic version.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accidental change from reducing magic sandals


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheffie
(+)Wizard den sandals are magic again.
```
