### PR TITLE
Redo and improve Mushroom toxins

### DIFF
--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -3003,6 +3003,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"ans" = (
+/turf/simulated/floor,
+/area/station/science/lab)
 "anv" = (
 /obj/machinery/power/smes{
 	chargelevel = 5000;
@@ -5103,10 +5106,13 @@
 	},
 /area/mining/magnet)
 "awa" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/space)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 6
+	},
+/area/station/science/lab)
 "awc" = (
 /obj/window/reinforced{
 	dir = 4;
@@ -15003,10 +15009,6 @@
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
-"bjy" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "bjF" = (
 /obj/item/extinguisher,
 /obj/machinery/light{
@@ -17708,11 +17710,30 @@
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
+"bzd" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/purple/side,
+/area/station/science/lab)
 "bzn" = (
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/security/main)
+"bAt" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
+/area/station/science/lab)
 "bAw" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -18007,6 +18028,10 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
+"bNY" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/plating,
+/area/space)
 "bOi" = (
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -18716,13 +18741,6 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
-"cBk" = (
-/obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	pixel_x = -2
-	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "cBV" = (
 /obj/machinery/optable,
 /obj/iv_stand,
@@ -18976,12 +18994,30 @@
 	dir = 9
 	},
 /area/station/turret_protected/AIbaseoutside)
+"cQU" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "cSf" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
 /area/station/security/main)
+"cTe" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "cTu" = (
 /obj/machinery/chem_master,
 /obj/machinery/camera{
@@ -19129,6 +19165,23 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"dgz" = (
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest"
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/obj/table/reinforced/industrial/auto{
+	icon_state = "12"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "dgP" = (
 /obj/cable{
 	icon_state = "1-5"
@@ -19273,17 +19326,6 @@
 /obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
-"dsB" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "dte" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -19352,6 +19394,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"duE" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "dvi" = (
 /obj/lattice,
 /obj/machinery/atmospherics/binary/valve{
@@ -19444,6 +19493,16 @@
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"dDP" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "dDW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19682,6 +19741,12 @@
 "dVu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/space)
+"dVG" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "dWD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20585,6 +20650,10 @@
 	dir = 1
 	},
 /area/station/turret_protected/AIbaseoutside)
+"eXq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/station/science/storage)
 "eXt" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -20711,6 +20780,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"fgg" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/space,
+/area/station/science/storage)
 "fgx" = (
 /obj/machinery/light/emergency{
 	dir = 8
@@ -21387,15 +21463,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"fWk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "fWB" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/white,
@@ -21586,12 +21653,6 @@
 	icon_state = "carpet2"
 	},
 /area/station/crew_quarters/bar)
-"gjj" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/turf/simulated/floor/blue,
-/area/station/science/lab)
 "gjn" = (
 /obj/stool/bar,
 /turf/simulated/floor{
@@ -21631,6 +21692,15 @@
 	},
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
+"gkS" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "glx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -21951,13 +22021,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
-"gDB" = (
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "gDK" = (
 /obj/cable,
 /obj/cable{
@@ -21971,13 +22034,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics/bay)
-"gEC" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/space,
-/area/station/science/storage)
 "gFI" = (
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -22392,10 +22448,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"hhJ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/plating,
-/area/space)
 "hhS" = (
 /obj/table/reinforced/chemistry/auto{
 	desc = "A black countertop table for storing kitchen-y objects.";
@@ -22427,10 +22479,6 @@
 	icon_state = "9"
 	},
 /area/station/turret_protected/AIsat)
-"hlr" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/space,
-/area/station/science/storage)
 "hmQ" = (
 /obj/machinery/light,
 /obj/decal/stripe_delivery,
@@ -22600,18 +22648,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"huI" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/landmark/start/job/scientist,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "huW" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -23382,6 +23418,14 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"ins" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "inH" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Freezer"
@@ -23972,14 +24016,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
-"iWC" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "iWI" = (
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor,
@@ -24017,10 +24053,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"iXL" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "iYw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -24065,6 +24097,15 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
+"jaD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "jcJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -24721,6 +24762,14 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/turret_protected/AIsat)
+"jPz" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "jPD" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -25445,14 +25494,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"kGR" = (
-/obj/machinery/camera,
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
 "kHG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25546,16 +25587,6 @@
 	dir = 0
 	},
 /area/station/hallway/primary/south)
-"kNl" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "kND" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/cable,
@@ -25888,6 +25919,10 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
+"llB" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "lnp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -25942,13 +25977,8 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "loK" = (
-/obj/machinery/door/poddoor/pyro{
-	dir = 4;
-	id = "exhaustvent1";
-	name = "Exhaust Vent"
-	},
-/obj/grille/steel,
-/turf/simulated/floor/engine/vacuum,
+/obj/decal/poster/wallsign/fire,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "loL" = (
 /obj/window/reinforced/west,
@@ -26399,19 +26429,23 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "lPp" = (
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest"
+/obj/item/device/transfer_valve{
+	pixel_y = -1
 	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
+/obj/item/device/transfer_valve{
+	pixel_y = 7
+	},
+/obj/item/device/transfer_valve{
 	pixel_y = 5
 	},
-/obj/machinery/light,
+/obj/item/device/transfer_valve{
+	pixel_y = 3
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 1
+	},
 /obj/table/reinforced/industrial/auto{
-	icon_state = "12"
+	icon_state = "8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -26548,27 +26582,6 @@
 /obj/item/screwdriver,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"lWU" = (
-/obj/item/device/transfer_valve{
-	pixel_y = -1
-	},
-/obj/item/device/transfer_valve{
-	pixel_y = 7
-	},
-/obj/item/device/transfer_valve{
-	pixel_y = 5
-	},
-/obj/item/device/transfer_valve{
-	pixel_y = 3
-	},
-/obj/item/device/transfer_valve{
-	pixel_y = 1
-	},
-/obj/table/reinforced/industrial/auto{
-	icon_state = "8"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "lXM" = (
 /obj/table/wood/auto,
 /obj/item/cargotele,
@@ -26731,6 +26744,12 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor,
 /area/station/engine/singcore)
+"miJ" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/station/science/storage)
 "mjn" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -27148,13 +27167,6 @@
 "mKo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
-"mKu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "mKz" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -27593,12 +27605,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"nnl" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/blue,
-/area/station/science/lab)
 "nnq" = (
 /obj/grille/steel,
 /obj/cable{
@@ -27644,11 +27650,8 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"noR" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
+"noS" = (
+/obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor,
 /area/station/science/lab)
 "npM" = (
@@ -27692,15 +27695,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"nsm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "nsx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28273,10 +28267,6 @@
 /obj/storage/crate,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
-"nWQ" = (
-/obj/decal/poster/wallsign/biohazard,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
 "nWY" = (
 /obj/machinery/door/airlock/pyro,
 /obj/mapping_helper/firedoor_spawn,
@@ -28663,8 +28653,12 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "orS" = (
-/turf/simulated/floor,
-/area/station/science/lab)
+/obj/machinery/light/small{
+	tag = "icon-bulb1 (WEST)";
+	pixel_x = -2
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "otc" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -28672,9 +28666,13 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/engine/engineering/private)
 "otd" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
-/area/station/science/lab)
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "ouC" = (
 /obj/machinery/light,
 /obj/cable{
@@ -28960,12 +28958,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
-"oJw" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple/side,
-/area/station/science/lab)
 "oJz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29342,12 +29334,11 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "pbt" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/purple/side{
-	dir = 6
-	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "pcb" = (
 /turf/simulated/floor/specialroom/cafeteria,
@@ -29994,10 +29985,9 @@
 	},
 /area/station/crew_quarters/hor)
 "pJC" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/purple/corner,
+/area/station/science/lab)
 "pKG" = (
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -30816,6 +30806,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
+"qDR" = (
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "exhaustvent1";
+	name = "Exhaust Vent"
+	},
+/obj/grille/steel,
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "qDW" = (
 /obj/lattice{
 	dir = 4;
@@ -30825,14 +30824,6 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/space)
-"qEc" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 1
-	},
-/turf/simulated/floor/purple/side{
-	dir = 6
-	},
-/area/station/science/lab)
 "qEy" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -31282,6 +31273,14 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
+"qXg" = (
+/obj/machinery/camera,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "qXx" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -31370,6 +31369,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"rdv" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science/lab)
 "rdF" = (
 /obj/machinery/turret{
 	dir = 10
@@ -31519,12 +31524,6 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/garden/owlery)
-"rjY" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/turf/space,
-/area/station/science/storage)
 "rkX" = (
 /obj/machinery/light{
 	dir = 1;
@@ -31614,15 +31613,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
-"rnb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/research,
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/purple,
-/area/station/science/lab)
 "rno" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -31677,8 +31667,11 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering/private)
 "rpK" = (
-/turf/simulated/floor/purple/corner{
+/obj/machinery/atmospherics/binary/valve{
 	dir = 1
+	},
+/turf/simulated/floor/purple/side{
+	dir = 6
 	},
 /area/station/science/lab)
 "rqo" = (
@@ -31741,6 +31734,14 @@
 	dir = 4
 	},
 /area/station/science/lab)
+"rtq" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "rtO" = (
 /obj/decal/tile_edge/line/white{
 	dir = 1;
@@ -32345,6 +32346,12 @@
 	icon_state = "4"
 	},
 /turf/simulated/floor/black,
+/area/station/science/lab)
+"rUu" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/blue,
 /area/station/science/lab)
 "rUI" = (
 /turf/simulated/floor/grey/side,
@@ -33297,14 +33304,6 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
-"sWC" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "sWI" = (
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -33349,6 +33348,15 @@
 /area/station/science/lobby)
 "sXL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"sYu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "sYO" = (
 /obj/machinery/light{
@@ -33785,6 +33793,13 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
+"tpv" = (
+/obj/machinery/disposal/small,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science/lab)
 "tqb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33899,15 +33914,6 @@
 	icon_state = "airbridge"
 	},
 /area/station/turret_protected/AIsat)
-"tui" = (
-/obj/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
-	},
-/obj/machinery/meter,
-/turf/simulated/floor,
-/area/station/science/lab)
 "tuz" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -33939,14 +33945,6 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"tvz" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "tvJ" = (
 /obj/machinery/vending/paint/broken,
 /turf/simulated/floor/plating,
@@ -33959,9 +33957,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/lobby)
-"tvZ" = (
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "twy" = (
 /obj/table/auto,
 /obj/item/clothing/head/plunger,
@@ -34472,6 +34467,10 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/arcade)
+"tZs" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "tZV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -34554,7 +34553,9 @@
 	},
 /area/station/crew_quarters/pool)
 "ufh" = (
-/turf/space,
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating,
 /area/station/science/storage)
 "ufJ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -35315,12 +35316,6 @@
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/baroffice)
-"uTB" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "uTY" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -35516,14 +35511,17 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
-"viS" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
+"vhn" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
 	},
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
+/turf/simulated/floor/blue,
+/area/station/science/lab)
+"viS" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/space)
 "viT" = (
 /obj/lattice,
 /obj/item/clothing/head/snake,
@@ -36352,8 +36350,13 @@
 	},
 /area/station/science/lab)
 "vZs" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/purple/corner,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/research,
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/purple,
 /area/station/science/lab)
 "vZI" = (
 /obj/machinery/atmospherics/pipe/simple/junction,
@@ -36550,15 +36553,6 @@
 	allows_vehicles = 0
 	},
 /area/station/turret_protected/AIsat)
-"wnB" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/blue,
-/area/station/science/lab)
 "wnC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37133,11 +37127,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
 "wSO" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "wTb" = (
 /obj/machinery/door/window/westleft{
@@ -37366,12 +37356,6 @@
 "xgD" = (
 /turf/simulated/floor,
 /area/station/security/brig)
-"xgR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "xhh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -37640,13 +37624,6 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/teleporter)
-"xvL" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
 "xvS" = (
 /obj/stool/chair{
 	dir = 8;
@@ -38021,16 +37998,19 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/engine/engineering/private)
 "xQl" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/station/science/lab)
+"xRi" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/purple/side,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "xRw" = (
 /obj/disposalpipe/segment/produce,
@@ -38353,12 +38333,27 @@
 	dir = 9
 	},
 /area/station/turret_protected/AIsat)
+"ykW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/start/job/scientist,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "yla" = (
 /obj/stool/bar,
 /turf/simulated/floor{
 	icon_state = "carpetSE"
 	},
 /area/station/crew_quarters/cafeteria)
+"ylb" = (
+/turf/space,
+/area/station/science/storage)
 
 (1,1,1) = {"
 aaa
@@ -94713,7 +94708,7 @@ png
 pAm
 vVy
 uSS
-kGR
+qXg
 aaa
 aaa
 aaa
@@ -96219,7 +96214,7 @@ xMz
 tlX
 vQM
 xZf
-pJC
+ufh
 nJo
 idm
 iwQ
@@ -96517,14 +96512,14 @@ qLi
 nsj
 sXL
 wKz
-orS
-orS
-otd
+ans
+ans
+noS
 vlK
-xvL
+cQU
 vZI
-gEC
-rjY
+fgg
+miJ
 aaa
 aaa
 aaa
@@ -96819,15 +96814,15 @@ qLi
 uXc
 sXL
 wMi
-noR
-orS
-vZs
-qEc
-viS
+bAt
+ans
+pJC
+rpK
+otd
 vZI
-hlr
+eXq
 gZs
-ufh
+ylb
 aaa
 aaa
 aaa
@@ -97117,14 +97112,14 @@ pTp
 qNU
 rFx
 sXL
-nWQ
+loK
 rsQ
 sXL
 wMY
-uTB
-orS
-wSO
-rpK
+dVG
+ans
+tpv
+sXL
 tWD
 tWD
 tWD
@@ -97423,16 +97418,16 @@ tPG
 vdE
 vXY
 wOC
-tui
-wPs
 xQl
+wPs
+bzd
 sXL
-sWC
+rtq
 gmw
-iXL
+llB
 oLS
-iWC
-awa
+ins
+viS
 iIU
 aaa
 aaa
@@ -97723,18 +97718,18 @@ rLT
 sXL
 tSB
 vhm
-nsm
-fWk
+sYu
+jaD
 qET
 qET
-oJw
-rnb
+rdv
+vZs
 gfm
 tKf
 tKf
 wIK
 qwY
-hhJ
+bNY
 iIU
 aaa
 aaa
@@ -98024,19 +98019,19 @@ qPH
 rOY
 sXL
 tSY
-dsB
+cTe
 vZd
-huI
-tvz
-tvz
-pbt
+ykW
+jPz
+jPz
+awa
 sXL
 sXL
 tKf
 tKf
 oLS
 qwY
-hhJ
+bNY
 iIU
 aaa
 aaa
@@ -98325,17 +98320,17 @@ pTU
 qQh
 rXg
 sXL
-nnl
-tvZ
+rUu
+wSO
 yag
-mKu
-nnl
-tvZ
+pbt
+rUu
+wSO
 yag
 rUe
 sXL
 fsy
-cBk
+orS
 tWD
 tWD
 iIU
@@ -98627,14 +98622,14 @@ pUe
 qQj
 rXC
 sXL
-wnB
-tvZ
+gkS
+wSO
 cQt
-xgR
-gjj
-tvZ
+xRi
+vhn
+wSO
 cQt
-lPp
+dgz
 sXL
 tKf
 tKf
@@ -98930,13 +98925,13 @@ nJD
 ivd
 sXL
 gDt
-tvZ
+wSO
 fpL
 lQg
 ydz
-tvZ
+wSO
 rQF
-lWU
+lPp
 sXL
 yfD
 tKf
@@ -99848,7 +99843,7 @@ mEy
 tKf
 tZV
 jyy
-bjy
+tZs
 tNP
 aaa
 aaa
@@ -100147,9 +100142,9 @@ qAm
 rEd
 jyy
 pPR
-kNl
+dDP
 tSE
-gDB
+duE
 iIU
 aaa
 aaa
@@ -100445,7 +100440,7 @@ gIj
 sXL
 ttD
 ttD
-loK
+qDR
 sXL
 tWD
 tWD

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -24829,13 +24829,6 @@
 	dir = 5
 	},
 /area/station/turret_protected/AIsat)
-"jXb" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
 "jXg" = (
 /obj/machinery/mass_driver{
 	desc = "A device that launches objects, like ANCIENT SIRENS, for example, on it at great velocity when activated.";
@@ -28832,6 +28825,10 @@
 "oDO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
+"oEd" = (
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor,
+/area/station/science/lab)
 "oEf" = (
 /obj/rack,
 /obj/item/tank/jetpack,
@@ -30401,6 +30398,11 @@
 /obj/landmark/start/job/bartender,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/baroffice)
+"qiu" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "qiW" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -31694,9 +31696,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/tox,
-/turf/simulated/floor/white/side{
-	dir = 4
-	},
+/turf/simulated/floor/purple,
 /area/station/science/lab)
 "rtO" = (
 /obj/decal/tile_edge/line/white{
@@ -34288,12 +34288,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
-"tPB" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "tPG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -35488,13 +35482,14 @@
 	},
 /area/station/security/detectives_office)
 "vhm" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "BOTTOM"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "viS" = (
 /obj/machinery/disposal/small,
@@ -35575,10 +35570,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/science/lab)
-"voL" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor,
 /area/station/science/lab)
 "voN" = (
 /obj/machinery/light{
@@ -36345,10 +36336,11 @@
 	},
 /area/station/science/lab)
 "vZs" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "vZI" = (
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
@@ -38008,6 +38000,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
+"xNW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "xOk" = (
 /obj/machinery/light{
 	dir = 4;
@@ -96522,7 +96523,7 @@ sXL
 wKz
 vSI
 mmv
-voL
+oEd
 vlK
 azy
 vZI
@@ -98038,7 +98039,7 @@ tWD
 tKf
 tKf
 oLS
-vZs
+qiu
 qwY
 tWD
 aaa
@@ -98933,11 +98934,11 @@ nJD
 ivd
 sXL
 gDt
-vhm
+xNW
 fpL
 lQg
 ydz
-tPB
+vZs
 rQF
 tlU
 tWD
@@ -99537,11 +99538,11 @@ aaa
 aDR
 sXL
 ptB
-jXb
+vhm
 voT
 sXL
 ptB
-jXb
+vhm
 wTX
 tWD
 qQV

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -24829,6 +24829,13 @@
 	dir = 5
 	},
 /area/station/turret_protected/AIsat)
+"jXb" = (
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "jXg" = (
 /obj/machinery/mass_driver{
 	desc = "A device that launches objects, like ANCIENT SIRENS, for example, on it at great velocity when activated.";
@@ -27891,12 +27898,6 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
-"nDF" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "nDW" = (
 /obj/disposalpipe/segment,
 /obj/mapping_helper/firedoor_spawn,
@@ -32285,11 +32286,6 @@
 	},
 /area/station/turret_protected/AIsat)
 "rUe" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
 /obj/item/device/prox_sensor{
 	pixel_x = -7;
 	pixel_y = 6
@@ -32846,11 +32842,6 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/space,
 /area/station/engine/proto)
-"sCq" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "sCJ" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/access/maint,
@@ -34297,6 +34288,12 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
+"tPB" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "tPG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -35257,15 +35254,6 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
-"uQG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "uRe" = (
 /obj/cable{
 	icon_state = "6-9"
@@ -35500,11 +35488,13 @@
 	},
 /area/station/security/detectives_office)
 "vhm" = (
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine/vacuum,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "viS" = (
 /obj/machinery/disposal/small,
@@ -35585,6 +35575,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
+/area/station/science/lab)
+"voL" = (
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor,
 /area/station/science/lab)
 "voN" = (
 /obj/machinery/light{
@@ -36351,9 +36345,10 @@
 	},
 /area/station/science/lab)
 "vZs" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor,
-/area/station/science/lab)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "vZI" = (
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
@@ -37026,13 +37021,9 @@
 	},
 /area/station/bridge)
 "wMi" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	frequency = 1445;
-	name = "Station Intercom (Medical)"
-	},
 /obj/machinery/dispenser,
 /obj/machinery/light/small/floor,
+/obj/item/device/radio/intercom/science,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -38235,7 +38226,7 @@
 	id = "Chamber Inlet 2"
 	},
 /obj/machinery/door_control{
-	id = "exhaustvent";
+	id = "exhaustvent1";
 	name = "Mixing Room Vent Control";
 	pixel_x = 24;
 	pixel_y = -9
@@ -96531,7 +96522,7 @@ sXL
 wKz
 vSI
 mmv
-vZs
+voL
 vlK
 azy
 vZI
@@ -98047,7 +98038,7 @@ tWD
 tKf
 tKf
 oLS
-sCq
+vZs
 qwY
 tWD
 aaa
@@ -98942,11 +98933,11 @@ nJD
 ivd
 sXL
 gDt
-uQG
+vhm
 fpL
 lQg
 ydz
-nDF
+tPB
 rQF
 tlU
 tWD
@@ -99546,11 +99537,11 @@ aaa
 aDR
 sXL
 ptB
-vhm
+jXb
 voT
 sXL
 ptB
-vhm
+jXb
 wTX
 tWD
 qQV

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -18757,10 +18757,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
-"cCM" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor,
-/area/station/science/lab)
 "cCX" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -19568,6 +19564,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"dKh" = (
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor,
+/area/station/science/lab)
 "dKD" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
@@ -36942,7 +36942,7 @@
 /area/station/engine/engineering/ce)
 "wIK" = (
 /obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/research,
+/obj/mapping_helper/access/tox_storage,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "wJa" = (
@@ -96508,7 +96508,7 @@ sXL
 wKz
 vSI
 mmv
-cCM
+dKh
 vlK
 azy
 vZI

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -19564,10 +19564,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"dKh" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor,
-/area/station/science/lab)
 "dKD" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
@@ -20920,6 +20916,9 @@
 	pixel_x = 24;
 	pixel_y = -8
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "fqs" = (
@@ -21223,7 +21222,8 @@
 /area/station/medical/medbay/lobby)
 "fHj" = (
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "2-4";
+	pixel_y = 0
 	},
 /obj/disposalpipe/junction/right/south,
 /turf/simulated/floor/white,
@@ -26383,7 +26383,11 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -26411,10 +26415,11 @@
 	dir = 8
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light/small/floor,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "lQv" = (
@@ -27591,6 +27596,9 @@
 	icon_state = "pdoor0";
 	density = 0
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "noz" = (
@@ -27883,6 +27891,12 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
+"nDF" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "nDW" = (
 /obj/disposalpipe/segment,
 /obj/mapping_helper/firedoor_spawn,
@@ -28604,9 +28618,6 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "orS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -31615,7 +31626,7 @@
 /area/station/engine/engineering/private)
 "rpK" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/turf/simulated/floor/purple/side{
+/turf/simulated/floor/blue/side{
 	dir = 6
 	},
 /area/station/science/lab)
@@ -32835,6 +32846,11 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/space,
 /area/station/engine/proto)
+"sCq" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "sCJ" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/access/maint,
@@ -35241,6 +35257,15 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
+"uQG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "uRe" = (
 /obj/cable{
 	icon_state = "6-9"
@@ -35434,7 +35459,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -35475,16 +35500,11 @@
 	},
 /area/station/security/detectives_office)
 "vhm" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "viS" = (
 /obj/machinery/disposal/small,
@@ -35560,6 +35580,9 @@
 	icon_state = "pdoor0";
 	opacity = 0;
 	density = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
@@ -36285,10 +36308,11 @@
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc/autoname_west,
 /obj/machinery/atmospherics/portables_connector,
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/cable,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -36319,17 +36343,15 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
 /area/station/science/lab)
 "vZs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor,
 /area/station/science/lab)
 "vZI" = (
@@ -36366,9 +36388,6 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "waM" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/landmark/start/job/scientist,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -36569,10 +36588,11 @@
 /area/station/turret_protected/AIbaseoutside)
 "woX" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4";
+	pixel_y = 0
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -37139,7 +37159,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
 	},
-/turf/simulated/floor/purple/corner,
+/turf/simulated/floor/blue/corner,
 /area/station/science/lab)
 "wTb" = (
 /obj/machinery/door/window/westleft{
@@ -38219,6 +38239,9 @@
 	name = "Mixing Room Vent Control";
 	pixel_x = 24;
 	pixel_y = -9
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -96508,7 +96531,7 @@ sXL
 wKz
 vSI
 mmv
-dKh
+vZs
 vlK
 azy
 vZI
@@ -97711,9 +97734,9 @@ qOu
 rLT
 sXL
 tSB
-vhm
+vSI
 woX
-vZs
+qET
 qET
 qET
 kQP
@@ -98024,7 +98047,7 @@ tWD
 tKf
 tKf
 oLS
-qwY
+sCq
 qwY
 tWD
 aaa
@@ -98315,7 +98338,7 @@ qQh
 rXg
 sXL
 iwQ
-nIQ
+mTM
 yag
 orS
 iwQ
@@ -98617,9 +98640,9 @@ qQj
 rXC
 sXL
 ufh
-nIQ
-lsB
 mTM
+lsB
+nIQ
 cQt
 nIQ
 lsB
@@ -98919,11 +98942,11 @@ nJD
 ivd
 sXL
 gDt
-nIQ
+uQG
 fpL
 lQg
 ydz
-nIQ
+nDF
 rQF
 tlU
 tWD
@@ -99523,11 +99546,11 @@ aaa
 aDR
 sXL
 ptB
-tWn
+vhm
 voT
 sXL
 ptB
-tWn
+vhm
 wTX
 tWD
 qQV

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -18757,6 +18757,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
+"cCM" = (
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor,
+/area/station/science/lab)
 "cCX" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -28617,10 +28621,10 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/research,
 /obj/machinery/door/airlock/pyro/maintenance,
+/obj/mapping_helper/access/tox_storage,
 /turf/simulated/floor/purple,
-/area/station/science/lab)
+/area/station/science/storage)
 "ouC" = (
 /obj/machinery/light,
 /obj/cable{
@@ -31610,9 +31614,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering/private)
 "rpK" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
@@ -31672,7 +31674,6 @@
 	dir = 8;
 	name = "Mixing Room"
 	},
-/obj/mapping_helper/access/research,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -31680,6 +31681,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/tox,
 /turf/simulated/floor/white/side{
 	dir = 4
 	},
@@ -31950,7 +31952,7 @@
 	level = 2
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
+/area/station/science/storage)
 "rFj" = (
 /obj/machinery/light{
 	dir = 4
@@ -34445,7 +34447,7 @@
 	dir = 5
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
+/area/station/science/storage)
 "uad" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -37134,7 +37136,9 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
 "wSO" = (
-/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1
+	},
 /turf/simulated/floor/purple/corner,
 /area/station/science/lab)
 "wTb" = (
@@ -37978,6 +37982,9 @@
 	},
 /obj/table/reinforced/industrial/auto{
 	icon_state = "3"
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_y = 16
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -96500,8 +96507,8 @@ nsj
 sXL
 wKz
 vSI
-vSI
 mmv
+cCM
 vlK
 azy
 vZI
@@ -96802,7 +96809,7 @@ uXc
 sXL
 wMi
 rrI
-vSI
+mmv
 wSO
 rpK
 oDu
@@ -97106,8 +97113,8 @@ wMY
 urt
 vSI
 viS
-sXL
-sXL
+tWD
+tWD
 tWD
 tWD
 tWD
@@ -97408,7 +97415,7 @@ wOC
 xQl
 wPs
 awa
-sXL
+tWD
 loK
 gmw
 mdV
@@ -98012,8 +98019,8 @@ waM
 tHJ
 tHJ
 poL
-sXL
-sXL
+tWD
+tWD
 tKf
 tKf
 oLS
@@ -98315,7 +98322,7 @@ iwQ
 nIQ
 yag
 rUe
-sXL
+tWD
 fsy
 bTF
 tWD
@@ -98617,7 +98624,7 @@ cQt
 nIQ
 lsB
 cDw
-sXL
+tWD
 tKf
 tKf
 mkq
@@ -98919,7 +98926,7 @@ ydz
 nIQ
 rQF
 tlU
-sXL
+tWD
 yfD
 tKf
 qKe
@@ -99220,8 +99227,8 @@ sXL
 yfg
 noy
 yfg
-sXL
-sXL
+tWD
+tWD
 tKf
 tKf
 nKE
@@ -99522,7 +99529,7 @@ sXL
 ptB
 tWn
 wTX
-sXL
+tWD
 qQV
 gmN
 tKf
@@ -100428,8 +100435,8 @@ sXL
 pbt
 pbt
 ttD
-sXL
-sXL
+tWD
+tWD
 tWD
 tWD
 tWD

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -3003,9 +3003,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
-"ans" = (
-/turf/simulated/floor,
-/area/station/science/lab)
 "anv" = (
 /obj/machinery/power/smes{
 	chargelevel = 5000;
@@ -5106,12 +5103,16 @@
 	},
 /area/mining/magnet)
 "awa" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
-/turf/simulated/floor/purple/side{
-	dir = 6
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/light,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/purple/side,
 /area/station/science/lab)
 "awc" = (
 /obj/window/reinforced{
@@ -5928,6 +5929,13 @@
 	dir = 4
 	},
 /area/station/mining/magnet)
+"azy" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/lab)
 "azB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17710,30 +17718,11 @@
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/greenwhite,
 /area/station/medical/research)
-"bzd" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/purple/side,
-/area/station/science/lab)
 "bzn" = (
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/security/main)
-"bAt" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor,
-/area/station/science/lab)
 "bAw" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -18028,10 +18017,6 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
-"bNY" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/plating,
-/area/space)
 "bOi" = (
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -18098,6 +18083,13 @@
 	dir = 9
 	},
 /area/station/turret_protected/AIsat)
+"bSV" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "bSX" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
@@ -18120,6 +18112,13 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
+"bTF" = (
+/obj/machinery/light/small{
+	tag = "icon-bulb1 (WEST)";
+	pixel_x = -2
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "bTJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -18776,6 +18775,23 @@
 	dir = 8
 	},
 /area/station/turret_protected/AIbaseoutside)
+"cDw" = (
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest"
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/obj/table/reinforced/industrial/auto{
+	icon_state = "12"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "cDB" = (
 /obj/disposalpipe/segment/produce{
 	dir = 8;
@@ -18983,7 +18999,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/science/lab)
 "cQN" = (
 /obj/grille/catwalk,
@@ -18994,30 +19010,12 @@
 	dir = 9
 	},
 /area/station/turret_protected/AIbaseoutside)
-"cQU" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
 "cSf" = (
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
 /area/station/security/main)
-"cTe" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "cTu" = (
 /obj/machinery/chem_master,
 /obj/machinery/camera{
@@ -19165,23 +19163,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
-"dgz" = (
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest"
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/machinery/light,
-/obj/table/reinforced/industrial/auto{
-	icon_state = "12"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "dgP" = (
 /obj/cable{
 	icon_state = "1-5"
@@ -19394,13 +19375,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"duE" = (
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "dvi" = (
 /obj/lattice,
 /obj/machinery/atmospherics/binary/valve{
@@ -19493,16 +19467,6 @@
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"dDP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "dDW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19741,12 +19705,6 @@
 "dVu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/space)
-"dVG" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "dWD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20141,6 +20099,13 @@
 "eqv" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"erm" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/space,
+/area/space)
 "esX" = (
 /obj/critter/parrot/random,
 /obj/cable{
@@ -20228,6 +20193,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto_gangway)
+"eDW" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space)
 "eDZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -20301,6 +20272,11 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
+"eHm" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "eIn" = (
 /obj/cable{
 	icon_state = "2-10"
@@ -20650,10 +20626,6 @@
 	dir = 1
 	},
 /area/station/turret_protected/AIbaseoutside)
-"eXq" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/space,
-/area/station/science/storage)
 "eXt" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -20780,13 +20752,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"fgg" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/space,
-/area/station/science/storage)
 "fgx" = (
 /obj/machinery/light/emergency{
 	dir = 8
@@ -21692,15 +21657,6 @@
 	},
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
-"gkS" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/blue,
-/area/station/science/lab)
 "glx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -22287,11 +22243,9 @@
 	},
 /area/station/ranch)
 "gZs" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
-/area/station/science/storage)
+/area/space)
 "gZS" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/secure_data,
@@ -22744,6 +22698,11 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"hBH" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating,
+/area/station/science/lab)
 "hBX" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/cable{
@@ -23171,7 +23130,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/science/storage)
+/area/space)
 "idz" = (
 /obj/rack,
 /obj/item/camera,
@@ -23418,14 +23377,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"ins" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "inH" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Freezer"
@@ -23619,11 +23570,11 @@
 	},
 /area/station/bridge)
 "iwQ" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/space,
-/area/station/science/storage)
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "iyq" = (
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -24097,15 +24048,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
-"jaD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "jcJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -24762,14 +24704,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/turret_protected/AIsat)
-"jPz" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "jPD" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -25629,6 +25563,12 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
+"kQP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science/lab)
 "kRa" = (
 /obj/shrub{
 	dir = 1;
@@ -25919,10 +25859,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"llB" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "lnp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -25977,9 +25913,13 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "loK" = (
-/obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "loL" = (
 /obj/window/reinforced/west,
 /turf/simulated/floor/bluewhite{
@@ -26039,6 +25979,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"lsB" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/science/lab)
 "lsW" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
@@ -26429,25 +26375,15 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "lPp" = (
-/obj/item/device/transfer_valve{
-	pixel_y = -1
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/obj/item/device/transfer_valve{
-	pixel_y = 7
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/item/device/transfer_valve{
-	pixel_y = 5
+/turf/simulated/floor/purple/side{
+	dir = 4
 	},
-/obj/item/device/transfer_valve{
-	pixel_y = 3
-	},
-/obj/item/device/transfer_valve{
-	pixel_y = 1
-	},
-/obj/table/reinforced/industrial/auto{
-	icon_state = "8"
-	},
-/turf/simulated/floor/black,
 /area/station/science/lab)
 "lPK" = (
 /obj/mapping_helper/firedoor_spawn,
@@ -26656,6 +26592,10 @@
 	dir = 8
 	},
 /area/station/engine/engineering/breakroom)
+"mdV" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "mdW" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -26744,12 +26684,6 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor,
 /area/station/engine/singcore)
-"miJ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/turf/space,
-/area/station/science/storage)
 "mjn" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -26807,6 +26741,10 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
+"mmv" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/station/science/lab)
 "mmX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27304,6 +27242,12 @@
 "mTm" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
+"mTM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "mUu" = (
 /obj/table/auto,
 /obj/item/storage/box/stma_kit,
@@ -27499,6 +27443,10 @@
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
+"ngj" = (
+/obj/decal/poster/wallsign/fire,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "nha" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/window/southleft,
@@ -27650,10 +27598,6 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"noS" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor,
-/area/station/science/lab)
 "npM" = (
 /mob/living/critter/small_animal/walrus,
 /turf/simulated/floor/pool/no_animate,
@@ -27984,6 +27928,9 @@
 	},
 /turf/simulated/floor/caution/west,
 /area/station/science/artifact)
+"nIQ" = (
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "nIV" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/electrobox,
@@ -27995,7 +27942,7 @@
 "nJo" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/space,
-/area/station/science/storage)
+/area/space)
 "nJv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
@@ -28653,12 +28600,12 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "orS" = (
-/obj/machinery/light/small{
-	tag = "icon-bulb1 (WEST)";
-	pixel_x = -2
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "otc" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -28666,13 +28613,14 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/engine/engineering/private)
 "otd" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/research,
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/purple,
+/area/station/science/lab)
 "ouC" = (
 /obj/machinery/light,
 /obj/cable{
@@ -28857,6 +28805,14 @@
 /obj/lattice,
 /turf/space,
 /area/station/com_dish/comdish)
+"oDu" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/lab)
 "oDO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -29334,11 +29290,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "pbt" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "exhaustvent1";
+	name = "Exhaust Vent"
 	},
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/black,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "pcb" = (
 /turf/simulated/floor/specialroom/cafeteria,
@@ -29594,6 +29552,14 @@
 	dir = 1
 	},
 /area/station/engine/elect)
+"poL" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 6
+	},
+/area/station/science/lab)
 "ppa" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 4;
@@ -29985,9 +29951,9 @@
 	},
 /area/station/crew_quarters/hor)
 "pJC" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/purple/corner,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/storage)
 "pKG" = (
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -30806,15 +30772,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"qDR" = (
-/obj/machinery/door/poddoor/pyro{
-	dir = 4;
-	id = "exhaustvent1";
-	name = "Exhaust Vent"
-	},
-/obj/grille/steel,
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
 "qDW" = (
 /obj/lattice{
 	dir = 4;
@@ -31273,14 +31230,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
-"qXg" = (
-/obj/machinery/camera,
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
 "qXx" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -31369,12 +31318,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"rdv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple/side,
-/area/station/science/lab)
 "rdF" = (
 /obj/machinery/turret{
 	dir = 10
@@ -31688,6 +31631,13 @@
 /obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"rrI" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
+/area/station/science/lab)
 "rrV" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -31734,14 +31684,6 @@
 	dir = 4
 	},
 /area/station/science/lab)
-"rtq" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "rtO" = (
 /obj/decal/tile_edge/line/white{
 	dir = 1;
@@ -31797,6 +31739,14 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"rvD" = (
+/obj/machinery/camera,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "rvI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -32346,12 +32296,6 @@
 	icon_state = "4"
 	},
 /turf/simulated/floor/black,
-/area/station/science/lab)
-"rUu" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/blue,
 /area/station/science/lab)
 "rUI" = (
 /turf/simulated/floor/grey/side,
@@ -33349,15 +33293,6 @@
 "sXL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
-"sYu" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/science/lab)
 "sYO" = (
 /obj/machinery/light{
 	dir = 8
@@ -33657,6 +33592,27 @@
 	name = "sand"
 	},
 /area/station/crew_quarters/pool)
+"tlU" = (
+/obj/item/device/transfer_valve{
+	pixel_y = -1
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 7
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 5
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 3
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 1
+	},
+/obj/table/reinforced/industrial/auto{
+	icon_state = "8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "tlX" = (
 /obj/machinery/camera{
 	c_tag = "Research Sector Mixing Room";
@@ -33793,13 +33749,6 @@
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
-"tpv" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side,
-/area/station/science/lab)
 "tqb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33851,12 +33800,12 @@
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
 "ttD" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "exhaustvent1";
 	name = "Exhaust Vent"
 	},
+/obj/grille/steel,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "ttL" = (
@@ -34114,6 +34063,14 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"tHJ" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "tIy" = (
 /obj/decal/boxingrope,
 /turf/simulated/floor/specialroom/gym,
@@ -34224,6 +34181,16 @@
 "tLi" = (
 /turf/simulated/floor/white,
 /area/station/turret_protected/AIsat)
+"tLA" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "tLE" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 9;
@@ -34467,10 +34434,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/arcade)
-"tZs" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "tZV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -34553,10 +34516,14 @@
 	},
 /area/station/crew_quarters/pool)
 "ufh" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating,
-/area/station/science/storage)
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "ufJ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -34826,6 +34793,12 @@
 	dir = 8
 	},
 /area/station/crew_quarters/captain)
+"urt" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "urS" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -35511,17 +35484,13 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
-"vhn" = (
-/obj/machinery/atmospherics/binary/valve{
+"viS" = (
+/obj/machinery/disposal/small,
+/obj/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/blue,
+/turf/simulated/floor/purple/side,
 /area/station/science/lab)
-"viS" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/space)
 "viT" = (
 /obj/lattice,
 /obj/item/clothing/head/snake,
@@ -36259,6 +36228,9 @@
 /mob/living/carbon/human/npc/monkey/mr_rathen,
 /turf/simulated/floor/orangeblack/side,
 /area/station/engine/singcore)
+"vSI" = (
+/turf/simulated/floor,
+/area/station/science/lab)
 "vUU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36353,15 +36325,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/research,
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/purple,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "vZI" = (
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
-/area/station/science/storage)
+/area/space)
 "vZV" = (
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -36391,6 +36363,18 @@
 /obj/item/dice,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
+"waM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/start/job/scientist,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "waT" = (
 /obj/machinery/door/window/brigdoor/solitary2/westright,
 /obj/mapping_helper/access/brig,
@@ -36535,6 +36519,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"wmk" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/space)
 "wmz" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/green/side{
@@ -36575,6 +36565,15 @@
 	},
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
+"woX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "wpi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37108,6 +37107,14 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
+"wRn" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "wRD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37127,7 +37134,8 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
 "wSO" = (
-/turf/simulated/floor/black,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/purple/corner,
 /area/station/science/lab)
 "wTb" = (
 /obj/machinery/door/window/westleft{
@@ -38006,12 +38014,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/station/science/lab)
-"xRi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "xRw" = (
 /obj/disposalpipe/segment/produce,
 /turf/simulated/wall/auto/supernorn,
@@ -38333,27 +38335,12 @@
 	dir = 9
 	},
 /area/station/turret_protected/AIsat)
-"ykW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/landmark/start/job/scientist,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lab)
 "yla" = (
 /obj/stool/bar,
 /turf/simulated/floor{
 	icon_state = "carpetSE"
 	},
 /area/station/crew_quarters/cafeteria)
-"ylb" = (
-/turf/space,
-/area/station/science/storage)
 
 (1,1,1) = {"
 aaa
@@ -94708,7 +94695,7 @@ png
 pAm
 vVy
 uSS
-qXg
+rvD
 aaa
 aaa
 aaa
@@ -96214,10 +96201,10 @@ xMz
 tlX
 vQM
 xZf
-ufh
+hBH
 nJo
 idm
-iwQ
+iNv
 aLg
 aaa
 aaa
@@ -96512,14 +96499,14 @@ qLi
 nsj
 sXL
 wKz
-ans
-ans
-noS
+vSI
+vSI
+mmv
 vlK
-cQU
+azy
 vZI
-fgg
-miJ
+erm
+wmk
 aaa
 aaa
 aaa
@@ -96814,15 +96801,15 @@ qLi
 uXc
 sXL
 wMi
-bAt
-ans
-pJC
+rrI
+vSI
+wSO
 rpK
-otd
+oDu
 vZI
-eXq
 gZs
-ylb
+eDW
+aaa
 aaa
 aaa
 aaa
@@ -97112,21 +97099,21 @@ pTp
 qNU
 rFx
 sXL
-loK
+ngj
 rsQ
 sXL
 wMY
-dVG
-ans
-tpv
+urt
+vSI
+viS
+sXL
 sXL
 tWD
 tWD
 tWD
 tWD
 tWD
-iIU
-iIU
+tWD
 aaa
 aaa
 aaa
@@ -97420,15 +97407,15 @@ vXY
 wOC
 xQl
 wPs
-bzd
+awa
 sXL
-rtq
+loK
 gmw
-llB
+mdV
 oLS
-ins
-viS
-iIU
+wRn
+eHm
+tWD
 aaa
 aaa
 aaa
@@ -97718,19 +97705,19 @@ rLT
 sXL
 tSB
 vhm
-sYu
-jaD
-qET
-qET
-rdv
+woX
 vZs
+qET
+qET
+kQP
+otd
 gfm
 tKf
 tKf
 wIK
 qwY
-bNY
-iIU
+qwY
+tWD
 aaa
 aaa
 aaa
@@ -98019,20 +98006,20 @@ qPH
 rOY
 sXL
 tSY
-cTe
+lPp
 vZd
-ykW
-jPz
-jPz
-awa
+waM
+tHJ
+tHJ
+poL
 sXL
 sXL
 tKf
 tKf
 oLS
 qwY
-bNY
-iIU
+qwY
+tWD
 aaa
 aaa
 aaa
@@ -98320,21 +98307,21 @@ pTU
 qQh
 rXg
 sXL
-rUu
-wSO
+iwQ
+nIQ
 yag
-pbt
-rUu
-wSO
+orS
+iwQ
+nIQ
 yag
 rUe
 sXL
 fsy
-orS
+bTF
 tWD
 tWD
-iIU
-iIU
+tWD
+tWD
 aaa
 aaa
 aaa
@@ -98622,20 +98609,20 @@ pUe
 qQj
 rXC
 sXL
-gkS
-wSO
+ufh
+nIQ
+lsB
+mTM
 cQt
-xRi
-vhn
-wSO
-cQt
-dgz
+nIQ
+lsB
+cDw
 sXL
 tKf
 tKf
 mkq
 mkq
-iIU
+tWD
 aaa
 aaa
 aaa
@@ -98925,19 +98912,19 @@ nJD
 ivd
 sXL
 gDt
-wSO
+nIQ
 fpL
 lQg
 ydz
-wSO
+nIQ
 rQF
-lPp
+tlU
 sXL
 yfD
 tKf
 qKe
 qKe
-iIU
+tWD
 aaa
 aaa
 aaa
@@ -99239,7 +99226,7 @@ tKf
 tKf
 nKE
 nKE
-iIU
+tWD
 aaa
 aaa
 aaa
@@ -99541,7 +99528,7 @@ gmN
 tKf
 inK
 inK
-iIU
+tWD
 giH
 aaa
 aaa
@@ -99843,7 +99830,7 @@ mEy
 tKf
 tZV
 jyy
-tZs
+pJC
 tNP
 aaa
 aaa
@@ -100142,10 +100129,10 @@ qAm
 rEd
 jyy
 pPR
-dDP
+tLA
 tSE
-duE
-iIU
+bSV
+tWD
 aaa
 aaa
 aaa
@@ -100438,16 +100425,16 @@ gIj
 gIj
 gIj
 sXL
+pbt
+pbt
 ttD
-ttD
-qDR
+sXL
 sXL
 tWD
 tWD
 tWD
 tWD
 tWD
-iIU
 aaa
 aaa
 aaa

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -5103,9 +5103,10 @@
 	},
 /area/mining/magnet)
 "awa" = (
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/science/storage)
+/area/space)
 "awc" = (
 /obj/window/reinforced{
 	dir = 4;
@@ -15002,6 +15003,10 @@
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
+"bjy" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "bjF" = (
 /obj/item/extinguisher,
 /obj/machinery/light{
@@ -18711,6 +18716,13 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
+"cBk" = (
+/obj/machinery/light/small{
+	tag = "icon-bulb1 (WEST)";
+	pixel_x = -2
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "cBV" = (
 /obj/machinery/optable,
 /obj/iv_stand,
@@ -18953,7 +18965,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor/red,
 /area/station/science/lab)
 "cQN" = (
 /obj/grille/catwalk,
@@ -19261,6 +19273,17 @@
 /obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
+"dsB" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "dte" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -20832,13 +20855,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "fpL" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/machinery/door_control{
-	id = "mixingwaste";
-	name = "Waste Vent Control";
-	pixel_x = 24
+	id = "heatshield2";
+	name = "Heat Shield Control";
+	pixel_x = 24;
+	pixel_y = 8
 	},
-/turf/simulated/floor/purplewhite,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber Outlet 1";
+	on = 1;
+	tag = "";
+	target_pressure = 1000
+	},
+/obj/machinery/activation_button/ignition_switch{
+	id = "chamberone";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "fqs" = (
 /obj/storage/crate/rcd/CE,
@@ -20893,9 +20930,6 @@
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Research Sector Storage"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -21353,6 +21387,15 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
+"fWk" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "fWB" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/white,
@@ -21459,7 +21502,7 @@
 /area/station/turret_protected/AIsat)
 "gfm" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -21543,6 +21586,12 @@
 	icon_state = "carpet2"
 	},
 /area/station/crew_quarters/bar)
+"gjj" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "gjn" = (
 /obj/stool/bar,
 /turf/simulated/floor{
@@ -21631,8 +21680,8 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "gmN" = (
-/obj/machinery/atmospherics/pipe/simple{
-	level = 2
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -21880,17 +21929,35 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen/freezer)
 "gDt" = (
-/obj/table/auto,
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1229;
+	icon_state = "intact_on";
+	on = 1;
+	tag = "";
+	target_pressure = 1000;
+	id = "Chamber Inlet 1"
+	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
+/obj/machinery/door_control{
+	id = "exhaustvent2";
+	name = "Waste Vent Control";
+	pixel_x = 24;
+	pixel_y = -9
 	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
+"gDB" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "gDK" = (
 /obj/cable,
 /obj/cable{
@@ -21904,6 +21971,13 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics/bay)
+"gEC" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/space,
+/area/station/science/storage)
 "gFI" = (
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -21947,9 +22021,10 @@
 "gIj" = (
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
-	id = "mixingwaste";
-	name = "Waste Vent"
+	id = "exhaustvent2";
+	name = "Exhaust Vent"
 	},
+/obj/grille/steel,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "gIn" = (
@@ -22156,8 +22231,10 @@
 	},
 /area/station/ranch)
 "gZs" = (
-/obj/mapping_helper/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
 /area/station/science/storage)
 "gZS" = (
 /obj/machinery/power/data_terminal,
@@ -22263,18 +22340,6 @@
 	dir = 6
 	},
 /area/station/medical/medbay)
-"hfN" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	frequency = 1229;
-	icon_state = "intact_on";
-	id = "Chamber Outlet";
-	on = 1;
-	tag = "";
-	target_pressure = 1000
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
 "hgl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22324,14 +22389,13 @@
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
 "hhu" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8;
-	name = "Toxins Airlock"
-	},
-/obj/mapping_helper/access/research,
-/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"hhJ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/floor/plating,
+/area/space)
 "hhS" = (
 /obj/table/reinforced/chemistry/auto{
 	desc = "A black countertop table for storing kitchen-y objects.";
@@ -22363,6 +22427,10 @@
 	icon_state = "9"
 	},
 /area/station/turret_protected/AIsat)
+"hlr" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/station/science/storage)
 "hmQ" = (
 /obj/machinery/light,
 /obj/decal/stripe_delivery,
@@ -22532,6 +22600,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"huI" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/landmark/start/job/scientist,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "huW" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -22774,18 +22854,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
-"hOp" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	level = 2
-	},
-/obj/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "hOw" = (
 /obj/lattice,
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -23058,9 +23126,16 @@
 	},
 /area/station/crew_quarters/courtroom)
 "idm" = (
-/obj/machinery/atmospherics/binary/valve,
-/turf/simulated/floor/purple,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 1
+	},
+/obj/item/instrument/bikehorn/airhorn{
+	name = "strange air horn";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "idz" = (
 /obj/rack,
 /obj/item/camera,
@@ -23320,7 +23395,7 @@
 	},
 /area/station/crew_quarters/kitchen/freezer)
 "inK" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "inM" = (
@@ -23500,11 +23575,11 @@
 	},
 /area/station/bridge)
 "iwQ" = (
-/obj/machinery/atmospherics/pipe/simple{
-	level = 2
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
+/turf/space,
+/area/station/science/storage)
 "iyq" = (
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
@@ -23621,12 +23696,12 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "iIu" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4;
-	layer = 3;
-	level = 2
+/obj/machinery/door/poddoor/pyro{
+	name = "Mixing Vent";
+	id = "mixvent"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/grille/steel,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "iIy" = (
 /obj/cable{
@@ -23897,6 +23972,14 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"iWC" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "iWI" = (
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor,
@@ -23934,6 +24017,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
+"iXL" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "iYw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -24363,12 +24450,11 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "jyy" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1
 	},
-/turf/simulated/floor/purple,
-/area/station/science/lab)
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "jzK" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -24801,15 +24887,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
-"jYh" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9;
-	layer = 3;
-	level = 2;
-	tag = "icon-intact (NORTHWEST)"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
 "jYp" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -25368,6 +25445,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
+"kGR" = (
+/obj/machinery/camera,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "kHG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25461,6 +25546,16 @@
 	dir = 0
 	},
 /area/station/hallway/primary/south)
+"kNl" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "kND" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/cable,
@@ -25648,11 +25743,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"lbj" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
 "lcf" = (
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro{
@@ -25852,12 +25942,14 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "loK" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "exhaustvent1";
+	name = "Exhaust Vent"
 	},
-/obj/mapping_helper/access/research,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
+/obj/grille/steel,
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "loL" = (
 /obj/window/reinforced/west,
 /turf/simulated/floor/bluewhite{
@@ -26307,8 +26399,21 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "lPp" = (
-/obj/landmark/start/job/scientist,
-/turf/simulated/floor/purple,
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest"
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/obj/table/reinforced/industrial/auto{
+	icon_state = "12"
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "lPK" = (
 /obj/mapping_helper/firedoor_spawn,
@@ -26321,11 +26426,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "lQg" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 1;
-	tag = "icon-intact (NORTH)"
+/obj/machinery/door_control{
+	id = "mixvent";
+	name = "Mixing Room Vent Control";
+	pixel_x = 24;
+	pixel_y = 0
 	},
-/turf/simulated/floor/purple,
+/obj/machinery/computer/atmosphere/pumpcontrol{
+	frequency = 1229;
+	dir = 8
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "lQv" = (
 /obj/item/extinguisher,
@@ -26432,6 +26548,27 @@
 /obj/item/screwdriver,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"lWU" = (
+/obj/item/device/transfer_valve{
+	pixel_y = -1
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 7
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 5
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 3
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 1
+	},
+/obj/table/reinforced/industrial/auto{
+	icon_state = "8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "lXM" = (
 /obj/table/wood/auto,
 /obj/item/cargotele,
@@ -26916,11 +27053,11 @@
 	},
 /area/station/hallway/primary/south)
 "mEy" = (
-/obj/machinery/atmospherics/pipe/simple{
-	level = 2
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
 	},
-/turf/simulated/floor/purple,
-/area/station/science/lab)
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "mFj" = (
 /obj/table/wood/auto,
 /obj/item/hand_labeler,
@@ -27011,6 +27148,13 @@
 "mKo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
+"mKu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "mKz" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -27449,6 +27593,12 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/emergency)
+"nnl" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "nnq" = (
 /obj/grille/steel,
 /obj/cable{
@@ -27474,15 +27624,16 @@
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
 "noy" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8;
-	name = "Toxins Airlock"
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "heatshield";
+	name = "Heat Shielding";
+	opacity = 0;
+	icon_state = "pdoor0";
+	density = 0
 	},
-/obj/mapping_helper/access/research,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/blackwhite/side{
-	dir = 8
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "noz" = (
 /obj/disposalpipe/segment/mail{
@@ -27493,6 +27644,13 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"noR" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
+/area/station/science/lab)
 "npM" = (
 /mob/living/critter/small_animal/walrus,
 /turf/simulated/floor/pool/no_animate,
@@ -27534,6 +27692,15 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"nsm" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "nsx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27832,10 +27999,9 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "nJo" = (
-/turf/simulated/floor/purplewhite{
-	dir = 4
-	},
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/space,
+/area/station/science/storage)
 "nJv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
@@ -27851,8 +28017,7 @@
 	},
 /area/station/hydroponics/bay)
 "nKE" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "nKN" = (
@@ -28108,6 +28273,10 @@
 /obj/storage/crate,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
+"nWQ" = (
+/obj/decal/poster/wallsign/biohazard,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "nWY" = (
 /obj/machinery/door/airlock/pyro,
 /obj/mapping_helper/firedoor_spawn,
@@ -28494,13 +28663,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "orS" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor,
 /area/station/science/lab)
 "otc" = (
 /obj/cable{
@@ -28509,11 +28672,9 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/engine/engineering/private)
 "otd" = (
-/obj/item/instrument/bikehorn/airhorn{
-	name = "strange air horn"
-	},
-/turf/simulated/floor/airless/plating/damaged3,
-/area/space)
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/station/science/lab)
 "ouC" = (
 /obj/machinery/light,
 /obj/cable{
@@ -28799,6 +28960,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
+"oJw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purple/side,
+/area/station/science/lab)
 "oJz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28882,10 +29049,8 @@
 	},
 /area/station/hydroponics/bay)
 "oLS" = (
-/obj/machinery/atmospherics/pipe/simple{
-	level = 2
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/mapping_helper/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/science/storage)
 "oMr" = (
 /turf/simulated/floor/bluewhite{
@@ -29177,14 +29342,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters)
 "pbt" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/research,
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/white,
-/area/station/science/storage)
+/turf/simulated/floor/purple/side{
+	dir = 6
+	},
+/area/station/science/lab)
 "pcb" = (
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -29830,14 +29994,10 @@
 	},
 /area/station/crew_quarters/hor)
 "pJC" = (
-/obj/machinery/door/poddoor/pyro{
-	dir = 8;
-	id = "mixvent";
-	layer = 8;
-	name = "Mixing Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "pKG" = (
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -29935,7 +30095,10 @@
 	},
 /area/station/turret_protected/AIbaseoutside)
 "pPR" = (
-/obj/reagent_dispensers/foamtank,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "pQE" = (
@@ -30298,10 +30461,12 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "qjy" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/station/science/storage)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "qjR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30580,15 +30745,10 @@
 	},
 /area/station/science/lobby)
 "qAm" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2;
-	tag = "icon-manifold (WEST)"
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "qAA" = (
 /obj/cable,
@@ -30665,6 +30825,14 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/space)
+"qEc" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1
+	},
+/turf/simulated/floor/purple/side{
+	dir = 6
+	},
+/area/station/science/lab)
 "qEy" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -30675,11 +30843,10 @@
 	},
 /area/station/turret_protected/AIsat)
 "qET" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor,
 /area/station/science/lab)
 "qEU" = (
 /obj/table/reinforced,
@@ -30935,10 +31102,11 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "qQV" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 21
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "qQW" = (
@@ -31351,6 +31519,12 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/garden/owlery)
+"rjY" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/station/science/storage)
 "rkX" = (
 /obj/machinery/light{
 	dir = 1;
@@ -31440,6 +31614,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
+"rnb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/research,
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/purple,
+/area/station/science/lab)
 "rno" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -31494,9 +31677,8 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering/private)
 "rpK" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/purplewhite{
-	dir = 5
+/turf/simulated/floor/purple/corner{
+	dir = 1
 	},
 /area/station/science/lab)
 "rqo" = (
@@ -31812,13 +31994,12 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "rEd" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "rFj" = (
 /obj/machinery/light{
 	dir = 4
@@ -32043,15 +32224,27 @@
 	},
 /area/station/bridge)
 "rQF" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/activation_button/ignition_switch{
-	id = "mixingroom";
+	id = "chambertwo";
 	pixel_x = 24;
 	pixel_y = -8
 	},
-/turf/simulated/floor/purple,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber Outlet 2";
+	on = 1;
+	tag = "";
+	target_pressure = 1000
+	},
+/obj/machinery/door_control{
+	id = "heatshield";
+	name = "Heat Shield Control";
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "rRh" = (
 /obj/machinery/camera{
@@ -32133,12 +32326,25 @@
 	layer = 3.5;
 	pixel_y = -24
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/item/device/prox_sensor{
+	pixel_x = -7;
+	pixel_y = 6
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/purple,
+/obj/item/device/prox_sensor{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/device/prox_sensor{
+	pixel_y = 6
+	},
+/obj/item/device/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/table/reinforced/industrial/auto{
+	icon_state = "4"
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "rUI" = (
 /turf/simulated/floor/grey/side,
@@ -33091,6 +33297,14 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
+"sWC" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "sWI" = (
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -33440,29 +33654,20 @@
 	c_tag = "Research Sector Mixing Room";
 	dir = 4
 	},
-/obj/table/auto,
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
+/obj/item/assembly/time_ignite,
+/obj/item/assembly/time_ignite{
+	pixel_y = 5;
+	pixel_x = -3
 	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
+/obj/item/assembly/time_ignite{
+	pixel_x = 3;
+	pixel_y = 2
 	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
+/obj/table/reinforced/industrial/auto{
+	icon_state = "3"
 	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/turf/simulated/floor/purple/side{
+	dir = 8
 	},
 /area/station/science/lab)
 "tmj" = (
@@ -33631,9 +33836,13 @@
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
 "ttD" = (
-/turf/simulated/floor/purplewhite{
-	dir = 5
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "exhaustvent1";
+	name = "Exhaust Vent"
 	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "ttL" = (
 /obj/cable{
@@ -33690,6 +33899,15 @@
 	icon_state = "airbridge"
 	},
 /area/station/turret_protected/AIsat)
+"tui" = (
+/obj/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/station/science/lab)
 "tuz" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -33721,6 +33939,14 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"tvz" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lab)
 "tvJ" = (
 /obj/machinery/vending/paint/broken,
 /turf/simulated/floor/plating,
@@ -33733,6 +33959,9 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/lobby)
+"tvZ" = (
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "twy" = (
 /obj/table/auto,
 /obj/item/clothing/head/plunger,
@@ -34075,12 +34304,11 @@
 /turf/simulated/floor/circuit/white,
 /area/station/turret_protected/AIsat)
 "tNP" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	tag = "icon-intact (WEST)"
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 1
 	},
-/turf/simulated/floor/purple,
-/area/station/science/lab)
+/turf/simulated/floor/plating,
+/area/space)
 "tPk" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -34090,16 +34318,13 @@
 	},
 /area/station/bridge)
 "tPG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/purplewhite{
+/obj/storage/closet/biohazard,
+/turf/simulated/floor/purple/side{
 	dir = 9
 	},
 /area/station/science/lab)
@@ -34129,58 +34354,38 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "tSB" = (
-/obj/machinery/computer/atmosphere/pumpcontrol{
-	frequency = 1229
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/purplewhite{
+/obj/storage/closet/biohazard,
+/turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/lab)
 "tSE" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/area/station/science/lab)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "tSY" = (
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/area/station/science/lab)
-"tTC" = (
-/obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
 	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
-"tTL" = (
-/obj/table/auto,
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/turf/simulated/floor/purple/side{
+	dir = 5
 	},
 /area/station/science/lab)
 "tVg" = (
@@ -34268,12 +34473,16 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/arcade)
 "tZV" = (
-/obj/machinery/light/small,
-/obj/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "tZW" = (
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "uad" = (
 /obj/machinery/recharge_station,
@@ -34345,14 +34554,8 @@
 	},
 /area/station/crew_quarters/pool)
 "ufh" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 5
-	},
-/area/station/science/lab)
+/turf/space,
+/area/station/science/storage)
 "ufJ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -35112,6 +35315,12 @@
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/baroffice)
+"uTB" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "uTY" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -35250,15 +35459,15 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "vdE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 8
 	},
 /area/station/science/lab)
 "vfi" = (
@@ -35297,35 +35506,24 @@
 /area/station/security/detectives_office)
 "vhm" = (
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
-"vio" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
-	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "viS" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "viT" = (
 /obj/lattice,
 /obj/item/clothing/head/snake,
@@ -35345,9 +35543,10 @@
 	},
 /area/station/turret_protected/AIsat)
 "vlK" = (
-/turf/simulated/floor/purplewhite{
+/obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
+/turf/simulated/floor/purple/side,
 /area/station/science/lab)
 "vml" = (
 /obj/mapping_helper/firedoor_spawn,
@@ -35370,14 +35569,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
-"vmn" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 6
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
 "vmu" = (
 /obj/disposalpipe/block_sensing_outlet{
 	dir = 8
@@ -35392,11 +35583,15 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "vor" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "heatshield2";
+	name = "Heat Shielding";
+	icon_state = "pdoor0";
+	opacity = 0;
+	density = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "voN" = (
@@ -35422,6 +35617,11 @@
 	internal_pressure_bound = 4000;
 	pressure_checks = 2;
 	pump_direction = 0
+	},
+/obj/machinery/sparker{
+	id = "chamberone";
+	name = "Mounted Igniter";
+	pixel_x = -24
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -35950,16 +36150,58 @@
 /turf/simulated/floor/bluewhite,
 /area/station/hallway/primary/south)
 "vQM" = (
-/obj/table/auto,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/machinery/light{
-	dir = 8
+/obj/item/device/timer{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/turf/simulated/floor/purplewhite{
+/obj/item/device/timer{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/device/timer{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/device/timer{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/device/timer{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/device/timer{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/device/igniter{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/device/igniter{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/device/igniter{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/device/igniter{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/device/igniter{
+	pixel_y = -3;
+	pixel_x = 1
+	},
+/obj/item/device/igniter{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/table/reinforced/industrial/auto{
+	icon_state = "1"
+	},
+/turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -36068,13 +36310,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "vXY" = (
+/obj/disposalpipe/segment,
+/obj/machinery/power/apc/autoname_west,
+/obj/machinery/atmospherics/portables_connector,
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment,
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/purplewhite{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/purple/side{
+	dir = 8
 	},
 /area/station/science/lab)
 "vYd" = (
@@ -36088,16 +36332,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"vYk" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/purplewhite,
-/area/station/science/lab)
 "vYz" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -36110,18 +36344,21 @@
 /area/station/crew_quarters/kitchen)
 "vZd" = (
 /obj/item/cigbutt,
-/turf/simulated/floor/purplewhite{
-	dir = 10
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
 	},
 /area/station/science/lab)
 "vZs" = (
-/turf/simulated/floor/purplewhite,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/purple/corner,
 /area/station/science/lab)
 "vZI" = (
-/turf/simulated/floor/purplewhite{
-	dir = 10
-	},
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/simple/junction,
+/turf/space,
+/area/station/science/storage)
 "vZV" = (
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -36313,6 +36550,15 @@
 	allows_vehicles = 0
 	},
 /area/station/turret_protected/AIsat)
+"wnB" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "wnC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36700,16 +36946,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "wIK" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1449;
-	id = "tox_airlock_pump"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/mapping_helper/access/research,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "wJa" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/green/side{
@@ -36717,15 +36957,21 @@
 	},
 /area/station/crew_quarters/heads)
 "wJc" = (
-/obj/table/auto,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/turf/simulated/floor/purplewhite{
+/obj/item/extinguisher{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/gas,
+/obj/table/reinforced/industrial/auto{
+	icon_state = "2"
+	},
+/turf/simulated/floor/purple/side{
 	dir = 9
 	},
 /area/station/science/lab)
@@ -36748,8 +36994,9 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/purple/side{
+	dir = 1
 	},
 /area/station/science/lab)
 "wKX" = (
@@ -36770,8 +37017,9 @@
 	name = "Station Intercom (Medical)"
 	},
 /obj/machinery/dispenser,
-/turf/simulated/floor/purplewhite{
-	dir = 5
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/purple/side{
+	dir = 1
 	},
 /area/station/science/lab)
 "wMj" = (
@@ -36801,8 +37049,8 @@
 /area/station/turret_protected/AIsat)
 "wMY" = (
 /obj/machinery/vending/standard,
-/turf/simulated/floor/purplewhite{
-	dir = 9
+/turf/simulated/floor/purple/side{
+	dir = 1
 	},
 /area/station/science/lab)
 "wNO" = (
@@ -36841,8 +37089,9 @@
 /area/station/engine/elect)
 "wOC" = (
 /obj/disposalpipe/segment,
-/turf/simulated/floor/purplewhite{
-	dir = 5
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor/purple/corner{
+	dir = 1
 	},
 /area/station/science/lab)
 "wOE" = (
@@ -36852,11 +37101,9 @@
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/hor)
 "wPs" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/purple,
+/obj/disposalpipe/segment,
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor,
 /area/station/science/lab)
 "wRm" = (
 /obj/stool/chair/office/purple{
@@ -36886,7 +37133,11 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/engineering/private)
 "wSO" = (
-/turf/simulated/floor/purple,
+/obj/machinery/disposal/small,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side,
 /area/station/science/lab)
 "wTb" = (
 /obj/machinery/door/window/westleft{
@@ -36913,7 +37164,7 @@
 	pump_direction = 0
 	},
 /obj/machinery/sparker{
-	id = "mixingroom";
+	id = "chambertwo";
 	name = "Mounted Igniter";
 	pixel_x = -24
 	},
@@ -37115,6 +37366,12 @@
 "xgD" = (
 /turf/simulated/floor,
 /area/station/security/brig)
+"xgR" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "xhh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -37383,6 +37640,13 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/teleporter)
+"xvL" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating,
+/area/station/science/storage)
 "xvS" = (
 /obj/stool/chair{
 	dir = 8;
@@ -37720,24 +37984,17 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "xMz" = (
-/obj/table/auto,
-/obj/item/device/prox_sensor{
-	pixel_x = -7;
-	pixel_y = 6
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/obj/item/device/prox_sensor{
-	pixel_x = -7;
-	pixel_y = 6
+/obj/item/wrench{
+	pixel_y = 4
 	},
-/obj/item/device/prox_sensor{
-	pixel_x = -7;
-	pixel_y = 6
+/obj/table/reinforced/industrial/auto{
+	icon_state = "3"
 	},
-/obj/item/device/prox_sensor{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/turf/simulated/floor/purplewhite{
+/turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -37757,18 +38014,23 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "xPj" = (
-/turf/simulated/floor/purplewhite{
-	dir = 8
-	},
-/area/station/science/lab)
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "xPJ" = (
 /turf/simulated/floor/carpet/blue,
 /area/station/engine/engineering/private)
 "xQl" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/purple/side,
 /area/station/science/lab)
 "xRw" = (
 /obj/disposalpipe/segment/produce,
@@ -37890,23 +38152,24 @@
 	},
 /area/station/engine/gas)
 "xZf" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/weldingtool,
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
 	},
-/obj/item/extinguisher,
-/obj/item/screwdriver{
-	pixel_y = 20
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10;
+	pixel_y = 0
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor/purple/side{
+	dir = 10
+	},
 /area/station/science/lab)
 "yag" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor/red,
 /area/station/science/lab)
 "yam" = (
 /turf/simulated/floor/carpet/green/fancy/innercorner/sw,
@@ -37932,18 +38195,11 @@
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
 "ydb" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 0;
-	icon_state = "in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	pressure_checks = 2;
-	pump_direction = 0
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "ydc" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
@@ -37956,20 +38212,26 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "ydz" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/obj/machinery/door_control{
-	id = "mixvent";
-	name = "Mixing Room Vent Control";
-	pixel_x = 24;
-	pixel_y = 10
-	},
 /obj/machinery/camera{
 	c_tag = "Artifact Laboratory";
 	dir = 8
 	},
-/turf/simulated/floor/purple,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1229;
+	icon_state = "intact_on";
+	on = 1;
+	tag = "";
+	target_pressure = 1000;
+	id = "Chamber Inlet 2"
+	},
+/obj/machinery/door_control{
+	id = "exhaustvent";
+	name = "Mixing Room Vent Control";
+	pixel_x = 24;
+	pixel_y = -9
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ydQ" = (
 /obj/machinery/power/apc/autoname_west,
@@ -37986,13 +38248,8 @@
 /turf/unsimulated/floor/plating,
 /area/station/ranch)
 "yfg" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	frequency = 1229;
-	icon_state = "intact_on";
-	on = 1;
-	tag = "";
-	target_pressure = 1000
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
@@ -38003,22 +38260,16 @@
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/turret_protected/AIsat)
 "yfD" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4;
-	tag = "icon-intact (EAST)"
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
+"ygs" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
-"ygs" = (
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	name = "VACUUM AREA"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4;
-	tag = "icon-intact (EAST)"
-	},
-/turf/simulated/wall/auto/supernorn,
 /area/station/science/lab)
 "ygF" = (
 /obj/table/reinforced/bar/auto,
@@ -93858,7 +94109,7 @@ gkG
 gkG
 vcW
 uSS
-aaB
+giH
 aaa
 aaa
 aaa
@@ -94160,7 +94411,7 @@ aHc
 wCY
 oYN
 uSS
-aaB
+anA
 aaa
 aaa
 aaa
@@ -94462,7 +94713,7 @@ png
 pAm
 vVy
 uSS
-kpG
+kGR
 aaa
 aaa
 aaa
@@ -94764,7 +95015,7 @@ aHd
 reQ
 rlH
 uSS
-aaB
+anA
 aaa
 aaa
 aaa
@@ -95066,7 +95317,7 @@ aHe
 fCi
 gdB
 uSS
-aaa
+anA
 aaa
 aaa
 aaa
@@ -95368,8 +95619,8 @@ emd
 iat
 xMQ
 uSS
-aaB
-aaB
+anA
+aaa
 aaa
 aaa
 aaa
@@ -95670,8 +95921,8 @@ uSS
 uSS
 uSS
 uSS
-otd
-aaB
+anA
+aaa
 aaa
 aaa
 aaa
@@ -95968,12 +96219,12 @@ xMz
 tlX
 vQM
 xZf
-sXL
-tWD
-tWD
-tWD
-tWD
-aaB
+pJC
+nJo
+idm
+iwQ
+aLg
+aaa
 aaa
 aaa
 aaa
@@ -96266,16 +96517,16 @@ qLi
 nsj
 sXL
 wKz
-xPj
+orS
+orS
+otd
 vlK
-xPj
-vlK
-sXL
-qjy
-rEd
-qwY
-tWD
-aaB
+xvL
+vZI
+gEC
+rjY
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96568,15 +96819,15 @@ qLi
 uXc
 sXL
 wMi
-nJo
-ttD
-nJo
-rpK
-sXL
-qwY
-tKf
-qwY
-tWD
+noR
+orS
+vZs
+qEc
+viS
+vZI
+hlr
+gZs
+ufh
 aaa
 aaa
 aaa
@@ -96866,21 +97117,21 @@ pTp
 qNU
 rFx
 sXL
-sXL
+nWQ
 rsQ
 sXL
 wMY
-xPj
-vlK
-xPj
-tSE
-sXL
-tKf
-tKf
-awa
+uTB
+orS
+wSO
+rpK
 tWD
-aaa
-aaa
+tWD
+tWD
+tWD
+tWD
+iIU
+iIU
 aaa
 aaa
 aaa
@@ -97172,17 +97423,17 @@ tPG
 vdE
 vXY
 wOC
+tui
+wPs
 xQl
-wOC
-xQl
-ufh
 sXL
-loK
-gZs
-tWD
-tWD
-arz
-aaa
+sWC
+gmw
+iXL
+oLS
+iWC
+awa
+iIU
 aaa
 aaa
 aaa
@@ -97472,19 +97723,19 @@ rLT
 sXL
 tSB
 vhm
-vYk
-wPs
+nsm
+fWk
 qET
-qAm
 qET
-orS
-pbt
+oJw
+rnb
 gfm
-lbj
-tWD
-aaa
-aaa
-aaa
+tKf
+tKf
+wIK
+qwY
+hhJ
+iIU
 aaa
 aaa
 aaa
@@ -97773,20 +98024,20 @@ qPH
 rOY
 sXL
 tSY
-vio
+dsB
 vZd
-lPp
-wSO
-jyy
-idm
-mEy
-iwQ
-gmN
-hOp
+huI
+tvz
+tvz
+pbt
+sXL
+sXL
+tKf
+tKf
 oLS
-ydb
-aaa
-aaa
+qwY
+hhJ
+iIU
 aaa
 aaa
 aaa
@@ -98074,21 +98325,21 @@ pTU
 qQh
 rXg
 sXL
-tTC
-viS
-vZs
-wSO
+nnl
+tvZ
 yag
-tNP
-wSO
+mKu
+nnl
+tvZ
+yag
 rUe
 sXL
 fsy
-tZV
+cBk
 tWD
-aaB
-aaa
-aaa
+tWD
+iIU
+iIU
 aaa
 aaa
 aaa
@@ -98376,20 +98627,20 @@ pUe
 qQj
 rXC
 sXL
-tTL
-vlK
-vZI
-wSO
+wnB
+tvZ
 cQt
-wSO
-yag
+xgR
+gjj
+tvZ
 cQt
+lPp
 sXL
 tKf
-pPR
-tWD
-aaB
-aaB
+tKf
+mkq
+mkq
+iIU
 aaa
 aaa
 aaa
@@ -98679,19 +98930,19 @@ nJD
 ivd
 sXL
 gDt
-vmn
+tvZ
 fpL
 lQg
 ydz
-wSO
+tvZ
 rQF
-iIu
+lWU
 sXL
+yfD
 tKf
-tKf
-tWD
-tWD
-aaB
+qKe
+qKe
+iIU
 aaa
 aaa
 aaa
@@ -98976,24 +99227,24 @@ jXg
 ivd
 aaa
 aaa
-aaa
-aaa
-aaa
+aDR
+bcc
+aaB
 sXL
-sXL
+yfg
 vor
-sXL
+yfg
 sXL
 yfg
 noy
-hfN
-iIu
-qKe
+yfg
+sXL
+sXL
 tKf
-gmw
-mkq
-tWD
-aaB
+tKf
+nKE
+nKE
+iIU
 aaa
 aaa
 aaa
@@ -99280,23 +99531,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aDR
 sXL
+ptB
 tWn
 voT
-tWn
 sXL
-yfD
+ptB
 tWn
-wIK
-jYh
+wTX
+sXL
 qQV
-awa
-gmw
-nKE
-tWD
-aaa
-aaa
+gmN
+tKf
+inK
+inK
+iIU
+giH
 aaa
 aaa
 aaa
@@ -99584,21 +99835,21 @@ aaa
 aaa
 aaa
 sXL
-tZW
-gIj
-tZW
-tZW
+tWn
+tWn
+tWn
+iIu
 ygs
 hhu
-ygs
+qAm
 tZW
-inK
-inK
-inK
-mkq
-tWD
-aaa
-aaa
+xPj
+mEy
+tKf
+tZV
+jyy
+bjy
+tNP
 aaa
 aaa
 aaa
@@ -99885,21 +100136,21 @@ aaa
 aaa
 aaa
 aaa
-aaB
-aaa
-aaB
-aaB
-tZW
-ptB
+sXL
 tWn
-wTX
-tZW
-tWD
-tWD
-tWD
-tWD
-tWD
-aaa
+tWn
+tWn
+sXL
+ydb
+qjy
+qAm
+rEd
+jyy
+pPR
+kNl
+tSE
+gDB
+iIU
 aaa
 aaa
 aaa
@@ -100187,21 +100438,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-tZW
-tWn
-tWn
-tWn
-tZW
-aaB
-aaB
-aaB
-aaa
-aaa
-aaa
+sXL
+gIj
+gIj
+gIj
+sXL
+ttD
+ttD
+loK
+sXL
+tWD
+tWD
+tWD
+tWD
+tWD
+iIU
 aaa
 aaa
 aaa
@@ -100493,12 +100744,12 @@ aaa
 aaa
 aaa
 aaa
-tZW
-tWn
-tWn
-tWn
-tZW
-aaB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100795,11 +101046,11 @@ aaa
 aaa
 aaa
 aaa
-tZW
-pJC
-pJC
-pJC
-tZW
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
[ENHANCEMENT] [MAPPING] [SCIENCE] 
## About the PR
Completely transforms toxins on Mushroom to contain all the features necessary for.. toxins reasearch (TTV Making, heating up/cooling down gases)
This is my first mapping change to more significantly affect a station, even if one that isn't often seen in rotation.

Old:
![dreamseeker_SiVrQEDkWB](https://github.com/goonstation/goonstation/assets/27376947/2868116b-14cd-4ee7-a2b4-0d7a31106143)

New:
![dreamseeker_oZetgrtGSC](https://github.com/goonstation/goonstation/assets/27376947/ce09e882-75b1-45b8-b526-6e069b27d3f2)

## Why's this needed?
Currently, toxins in Mushroom is so old that it does not have the usual features seen in other toxins maps. The cooling and heating loops are completely absent from the map, and toxins storage spawns with air canisters, for some reason. Remapping toxins lets it be usuable, and if I've done it right, it'll look better too.