### PR TITLE
Fix icon not updating when swapping empty cell into a baton

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -97,6 +97,10 @@ TYPEINFO(/obj/item/baton)
 		if (!src || !istype(src))
 			return
 
+		// when swapping a zero charge cell into the baton
+		if (!(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE) & CELL_SUFFICIENT_CHARGE))
+			src.is_active = FALSE
+
 		if (src.is_active)
 			src.set_icon_state("[src.icon_on][src.flipped ? "-f" : ""]") //if flipped is true, attach -f to the icon state. otherwise leave it as normal
 			src.item_state = "[src.item_on][src.flipped ? "-f" : ""]"


### PR DESCRIPTION
[GAME OBJECTS][BUG][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where when swapping an empty power cell into a stun baton, its sprite does not update to show that it's off.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix