### PR TITLE
Fix lingering human ref in head organ

### DIFF
--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -156,7 +156,7 @@
 				if(thing in holder.vars && holder.vars[thing] == src) // organ holders suck, refactor when they no longer suck
 					holder.vars[thing] = null
 
-
+		donor_original = null
 		donor = null
 
 		if (bones)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix head organ lingering ref:
Found in Nitara Highlands's head, type being/obj/item/organ/head, with ref [0x2001597] which is at loc nullspace - var: donor_original


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Things should GC, one of the three refs stopping human GC.

