### PR TITLE
Fix lingering reference to human from inventory datum

### DIFF
--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -8,6 +8,10 @@
 	..()
 	human = H
 
+/datum/humanInventory/disposing()
+	src.human = null
+	..()
+
 /datum/humanInventory/ui_state(mob/user)
 	return tgui_physical_state
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -534,6 +534,11 @@
 	if (organHolder)
 		organHolder.dispose()
 		organHolder = null
+
+	if (src.inventory)
+		src.inventory.dispose()
+		src.inventory = null
+
 	..()
 
 	//blah, this might not be effective for ref clearing but ghost observers inside me NEED this list to be populated in base mob/disposing


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disposes the inventory datum when dispoing a human, along with clearing the human reference in the inventory when its disposed. I checked and if you have the UI open when a human is deleted it just closes so no issues there.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its stopping human GC


