### PR TITLE
Increase blob respawn time period

### DIFF
--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -71,6 +71,8 @@
 	var/spawn_time = 0
 	var/respawned = FALSE
 
+	var/random_event_spawn = FALSE
+
 	var/last_blob_life_tick = 0 //needed for mult to properly work for blob abilities
 
 	var/admin_override = FALSE //for sudo blobs
@@ -209,7 +211,8 @@
 		. = ..()
 
 		//if within grace period, respawn
-		if (!src.respawned && (TIME - src.spawn_time <= 15 MINUTES))
+		var/respawn_time = !src.random_event_spawn ? 15 MINUTES : 7 MINUTES
+		if (!src.respawned && (TIME - src.spawn_time <= respawn_time))
 			src.respawned = TRUE
 			src.reset()
 			boutput(src, "<span class='notice'><b>In a desperate act of self preservation you avoid your untimely death by concentrating what energy you had left! You feel ready to try again!</b></span>")

--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -68,10 +68,8 @@
 	var/debuff_duration = 1200 //deciseconds. 1200 = 2 minutes
 
 	//give blobs who get rekt soon after starting another chance
-	var/current_try = 1
-	var/extra_tries_max = 2
-	var/extra_try_period = 3000 //3000 = 5 minutes
-	var/extra_try_timestamp = 0
+	var/spawn_time = 0
+	var/respawned = FALSE
 
 	var/last_blob_life_tick = 0 //needed for mult to properly work for blob abilities
 
@@ -104,8 +102,7 @@
 		initial_material = getMaterial("blob")
 
 		//set start grace-period timestamp
-		var/extraGrace = rand(600, 1800) //add between 1 min and 3 mins extra
-		src.extra_try_timestamp = world.timeofday + extra_try_period + extraGrace
+		src.spawn_time = TIME
 
 		src.nucleus_overlay = image('icons/mob/blob.dmi', null, "reflective_overlay")
 		src.nucleus_overlay.alpha = 0
@@ -212,11 +209,10 @@
 		. = ..()
 
 		//if within grace period, respawn
-		if (src.current_try < src.extra_tries_max && world.timeofday <= src.extra_try_timestamp)
-			src.extra_try_timestamp = 0
-			src.current_try++
+		if (!src.respawned && (TIME - src.spawn_time <= 15 MINUTES))
+			src.respawned = TRUE
 			src.reset()
-			out(src, "<span class='notice'><b>In a desperate act of self preservation you avoid your untimely death by concentrating what energy you had left! You feel ready for round [src.current_try]!</b></span>")
+			boutput(src, "<span class='notice'><b>In a desperate act of self preservation you avoid your untimely death by concentrating what energy you had left! You feel ready to try again!</b></span>")
 
 		//no grace, go die scrub
 		else

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -216,6 +216,8 @@
 						mind.add_antagonist(ROLE_BLOB, do_relocate = FALSE, source = ANTAGONIST_SOURCE_RANDOM_EVENT)
 						role = ROLE_BLOB
 						M3 = mind.current
+						var/mob/living/intangible/blob_overmind/blob = M3
+						blob.random_event_spawn = TRUE
 					else
 						failed = 1
 


### PR DESCRIPTION
[GAME MODES][BALANCE][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR increases the blob respawn time. Proposed time is 15 minutes, which may be a bit high, but just a number for the moment. Tried to set it at a good number where it's a bit higher than the time most blobs die, but high enough that a good blob player won't respawn.

Random event blobs have their time set just to 7 minutes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Couple reasons
-Currently it's randomized between 6 and 8 minutes. Don't think randomization is good for respawn time.
-Getting blob is very rare, and often blobs will die somewhere close to 10 minutes. Think it would be nice to have a higher respawn time for how often you get it, especially with the difficulty of it
-In the case blobs die earlier, helps the round keep going a little longer instead of ending really early
-An argument could be made that respawn time shouldn't be increased, because it's a blob issue, like them not making enough special tiles. Regardless, increased respawn timer helps newer blobs and those who aren't much used to blob

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(*)Roundstart blob respawn time increased to 15 minutes. Random event blobs will now have a 7 minute respawn time.
```
