### PR TITLE
Make Rocko Count for Noah's Shuttle Medal

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -526,6 +526,7 @@ var/global/current_state = GAME_STATE_INVALID
 		else if(ismobcritter(pet))
 			var/mob/living/critter/P = pet
 			if(isalive(P) && in_centcom(P)) pets_rescued++
+		else if(istype(pet, /obj/item/rocko) && in_centcom(pet)) pets_rescued++
 
 	//logTheThing(LOG_DEBUG, null, "Zamujasa: [world.timeofday] Processing end-of-round generic medals")
 	var/list/all_the_baddies = ticker.mode.traitors + ticker.mode.token_players + ticker.mode.Agimmicks + ticker.mode.former_antagonists


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDAL] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds special handling for Rocko in the code counting pets rescued for Noah's Shuttle, because Rocko is an obj not a critter

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Rocko counts as a command pet in the post-round score and the original PR that added Rocko (#4229) incremented the required pets for the medal by 1, meaning Rocko's exclusion from the count is a bug.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)Rocko should now count as a pet for the Noah's Shuttle medal.
```
