### PR TITLE
No UI Wizard Teleport Computer

### DIFF
--- a/code/modules/antagonists/wizard/abilities/teleport.dm
+++ b/code/modules/antagonists/wizard/abilities/teleport.dm
@@ -93,7 +93,7 @@
 				return 0
 
 		if (2)
-			var/obj/machinery/computer/pod/comp_check = item_to_check
+			var/obj/machinery/computer/comp_check = item_to_check
 			if (!comp_check || !istype(comp_check))
 				src.show_text("The computer appears to have been destroyed.", "red")
 				return 0

--- a/code/obj/machinery/computer/wizard_teleport_computer.dm
+++ b/code/obj/machinery/computer/wizard_teleport_computer.dm
@@ -7,6 +7,9 @@
 	light_b = 0.1
 
 /obj/machinery/computer/wizard_teleport_computer/attack_hand(var/mob/user)
+	if(..())
+		return
+
 	if (!iswizard(user))
 		user.show_text("The [src.name] doesn't respond to your inputs.", "red")
 		return

--- a/code/obj/machinery/computer/wizard_teleport_computer.dm
+++ b/code/obj/machinery/computer/wizard_teleport_computer.dm
@@ -1,0 +1,14 @@
+/obj/machinery/computer/wizard_teleport_computer
+	name = "Magix System IV"
+	desc = "An arcane artifact that holds much magic. Running E-Knock 2.2: Sorceror's Edition"
+	icon_state = "wizard"
+	light_r = 0.6
+	light_g = 1
+	light_b = 0.1
+
+/obj/machinery/computer/wizard_teleport_computer/attack_hand(var/mob/user)
+	if (!iswizard(user))
+		user.show_text("The [src.name] doesn't respond to your inputs.", "red")
+		return
+
+	usr.teleportscroll(1, 2, src)

--- a/code/obj/machinery/computer/wizard_teleport_computer.dm
+++ b/code/obj/machinery/computer/wizard_teleport_computer.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/wizard_teleport_computer
-	name = "Magix System IV"
-	desc = "An arcane artifact that holds much magic. Running E-Knock 2.2: Sorceror's Edition"
+	name = "Magix System V"
+	desc = "An arcane artifact overflowing with teleportation magic. Running E-Knock 3.1: Sorceror's Edition"
 	icon_state = "wizard"
 	light_r = 0.6
 	light_g = 1

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1963,6 +1963,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\machinery\computer\security.dm"
 #include "code\obj\machinery\computer\shuttle.dm"
 #include "code\obj\machinery\computer\teleporter.dm"
+#include "code\obj\machinery\computer\wizard_teleport_computer.dm"
 #include "code\obj\machinery\computer\workstation.dm"
 #include "code\obj\machinery\computer\security\riot.dm"
 #include "code\obj\machinery\computer\security\sec_camera_move.dm"

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -74619,7 +74619,11 @@
 	dir = 1
 	},
 /obj/table/wood/auto,
-/obj/machinery/computer/pod/old/swf{
+/obj/machinery/door_control/podbay{
+	id = "hangar_wizard";
+	pixel_x = -21
+	},
+/obj/machinery/computer/wizard_teleport_computer{
 	id = "hangar_wizard";
 	pixel_x = -4;
 	pixel_y = 8
@@ -77725,7 +77729,7 @@ oUi
 oUi
 oUi
 lRx
-tGW
+lRx
 lNz
 lNz
 tGW


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the `/obj/machinery/computer/pod/old/swf` that's in the wizard's den with a button and a computer that skips straight to `usr.teleportscroll()` upon being used. `usr.teleportscroll()` prompts you for which area to teleport to, and you can cancel out if you want, so it's fit for purpose.
Screenshot of the button and the UI that opens after clicking the new computer:
![tsaa6v](https://github.com/goonstation/goonstation/assets/6396368/15229653-26cc-4e1c-9afc-f5e13b3dca23)
Old UI:
![261907773-7aa6c5e1-5d86-4c90-81ff-7ab7f8ac6d7a](https://github.com/goonstation/goonstation/assets/6396368/58bfb207-604a-456c-a0ee-54ac1f9c0426)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`/obj/machinery/computer/pod` is some ancient technology with like mass driver and pod airlock features that's not used anywhere in modern map building. Instead of revamping the UI, this seemed better.

[Rework][UI][Mapping]