### PR TITLE
Makes cyborg extingushers normal sized

### DIFF
--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -221,7 +221,7 @@
 	name = "fire extinguisher XL"
 	initial_volume = 300
 
-/obj/item/extinguisher/large/cyborg // because borgs can't replace their extinguishers
+/obj/item/extinguisher/cyborg // because borgs can't replace their extinguishers
 	reinforced = TRUE
 	New()
 		..()

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -52,14 +52,14 @@
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/large,
-		/obj/item/extinguisher/large/cyborg,
+		/obj/item/extinguisher/cyborg,
 		/obj/item/device/gps, // Let's them assist with telesci
 	)
 
 // botanist. chef. janitor.
 /datum/robot/module_tool_creator/recursive/module/civilian
 	definitions = list(
-		/obj/item/extinguisher/large/cyborg,
+		/obj/item/extinguisher/cyborg,
 		/obj/item/pen, // TODO: make more versatile version
 		/obj/item/seedplanter,
 		/obj/item/plantanalyzer,
@@ -112,7 +112,7 @@
 		/obj/item/electronics/soldering,
 		/obj/item/room_planner,
 		/obj/item/room_marker,
-		/obj/item/extinguisher/large/cyborg,
+		/obj/item/extinguisher/cyborg,
 		/obj/item/rcd,
 		/obj/item/deconstructor/borg,
 		/datum/robot/module_tool_creator/item_type/amount/steel_tile,
@@ -126,7 +126,7 @@
 /datum/robot/module_tool_creator/recursive/module/engineering
 	definitions = list(
 		/obj/item/atmosporter,
-		/obj/item/extinguisher/large/cyborg,
+		/obj/item/extinguisher/cyborg,
 		/obj/item/weldingtool,
 		/obj/item/device/t_scanner,
 		/obj/item/electronics/scanner,
@@ -182,7 +182,7 @@
 		/obj/item/oreprospector,
 		/obj/item/satchel/mining/large,
 		/obj/item/satchel/mining/large,
-		/obj/item/extinguisher/large/cyborg,
+		/obj/item/extinguisher/cyborg,
 		/obj/item/device/gps,
 		/obj/item/device/appraisal,
 		/obj/item/device/matanalyzer,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cyborg extingushers now store the normal amount of chemicals (100) compared to the previous amounts of 300. This doesnt impact any other special behavior that borgs have (such as being reinforced)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The insane capacity of borg extingushers leads to them being used by chemborg for some pretty whacky and bad hijinks. There's no meaningful utility of them having insane sized extingushers outside of this, as borgs are fireproof thus they already have a significant edge when it comes to dealing with fires. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)Borg extingushers are now normal sized.
```
