### PR TITLE
Unify Fire alarm offsets

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -242,9 +242,7 @@
 "abd" = (
 /obj/stool/chair/comfy,
 /obj/landmark/start/job/detective,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "abf" = (
@@ -1244,9 +1242,7 @@
 	},
 /area/station/quartermaster/office)
 "aed" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/cart/mechcart,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
@@ -1275,9 +1271,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aeh" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/cart/medcart,
 /obj/item/reagent_containers/syringe/haloperidol,
 /turf/simulated/floor/bluewhite{
@@ -2056,9 +2050,7 @@
 /area/station/crew_quarters/kitchen)
 "agy" = (
 /obj/submachine/foodprocessor,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "agz" = (
@@ -2433,9 +2425,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
 "ahP" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -3265,9 +3255,7 @@
 /obj/machinery/chem_dispenser/soda,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/light_switch/auto,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
@@ -3633,9 +3621,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 2
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -4511,9 +4497,7 @@
 /area/station/engine/core)
 "apg" = (
 /obj/machinery/atmospherics/unary/furnace_connector,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/furnace/thermo,
 /turf/simulated/floor/red,
 /area/station/engine/core)
@@ -4529,9 +4513,7 @@
 /obj/item/clothing/suit/space,
 /obj/item/clothing/head/helmet/space,
 /obj/item/clothing/mask/breath,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/orangeblack,
 /area/station/storage/eva)
 "apm" = (
@@ -4567,9 +4549,7 @@
 /area/station/hallway/primary/east)
 "apr" = (
 /obj/machinery/teleport/portal_ring,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/purple,
 /area/station/teleporter)
 "aps" = (
@@ -6953,9 +6933,7 @@
 	},
 /area/station/engine/elect)
 "awS" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
@@ -7306,9 +7284,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blueblack,
 /area/station/bridge/customs)
 "axN" = (
@@ -7464,9 +7440,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "ayo" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/submachine/chef_sink{
 	name = "bathroom sink"
 	},
@@ -7919,9 +7893,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine,
 /area/station/engine/coldloop)
 "azK" = (
@@ -8498,9 +8470,7 @@
 "aBJ" = (
 /obj/table/auto,
 /obj/bedsheetbin,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
 "aBK" = (
@@ -8965,9 +8935,7 @@
 	},
 /area/station/science/chemistry)
 "aDg" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/glass_recycler/chemistry{
 	pixel_y = 14
 	},
@@ -10043,9 +10011,7 @@
 	},
 /area/station/science/teleporter)
 "aGa" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs{
 	dir = 8
 	},
@@ -12704,10 +12670,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -12943,9 +12906,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aPY" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
@@ -14134,9 +14095,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
@@ -14999,9 +14958,8 @@
 /area/station/hallway/primary/east)
 "aWf" = (
 /obj/machinery/plantpot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/firealarm/west{
+	pixel_y = 11
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
@@ -15076,9 +15034,7 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/heads)
 "aWq" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aWr" = (
@@ -15160,9 +15116,7 @@
 "aWE" = (
 /obj/table/reinforced/auto,
 /obj/item/spraybottle/cleaner,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "aWF" = (
@@ -16268,9 +16222,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 2
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -19780,9 +19732,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -166,10 +166,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/garden/aviary)
 "aaX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "aaZ" = (
@@ -209,11 +206,7 @@
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "abf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "abg" = (
@@ -392,11 +385,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/northeast)
 "abI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
@@ -668,10 +657,7 @@
 /area/station/maintenance/northwest)
 "acE" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "acM" = (
@@ -709,10 +695,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -735,11 +718,7 @@
 	})
 "adc" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/bot/cleanbot,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
@@ -917,10 +896,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "aeg" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/bluegreen/side{
 	dir = 1
@@ -1985,11 +1961,7 @@
 /area/station/hangar/sec)
 "ajy" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -2038,12 +2010,7 @@
 /obj/shrub{
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 4;
-	pixel_x = 4;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black/side{
 	dir = 5
 	},
@@ -2064,10 +2031,7 @@
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/storage/primary)
 "ajL" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/storage/primary)
@@ -2189,10 +2153,7 @@
 	name = "Locker Room"
 	})
 "akB" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom{
@@ -2893,10 +2854,7 @@
 	},
 /area/station/hallway/primary/north)
 "amU" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -3332,10 +3290,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/crew_quarters/bathroom{
 	name = "Locker Room"
@@ -3458,10 +3413,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "aph" = (
-/obj/machinery/firealarm{
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
@@ -3483,11 +3435,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
 /obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -10;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -3619,10 +3567,7 @@
 /area/station/crew_quarters/arcade)
 "apC" = (
 /obj/submachine/claw_machine,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "apE" = (
@@ -3726,11 +3671,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/auxillary)
 "aqa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/storage/auxillary)
@@ -4071,10 +4012,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -4140,10 +4078,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arn" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -4202,10 +4137,7 @@
 	},
 /area/station/hallway/primary/central)
 "arw" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arx" = (
@@ -4668,10 +4600,7 @@
 /area/station/chapel/funeral_parlor)
 "atu" = (
 /obj/stool/chair/wooden,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -4825,11 +4754,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "atY" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_x = 5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "atZ" = (
@@ -4991,11 +4916,7 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "auD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/crate,
 /obj/item/storage/box/beakerbox,
 /obj/item/device/reagentscanner,
@@ -5015,11 +4936,7 @@
 /area/station/ranch)
 "auG" = (
 /obj/railing/orange/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/closet/civilian/ranch,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
@@ -5346,10 +5263,7 @@
 	},
 /area/station/chapel/funeral_parlor)
 "avG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -5464,11 +5378,7 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "avX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/line/green{
 	dir = 6;
 	icon_state = "line2"
@@ -5894,10 +5804,7 @@
 	},
 /area/station/security/detectives_office)
 "axG" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -6144,10 +6051,7 @@
 	name = "Community Center"
 	})
 "ayJ" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/item/instrument/large/organ,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -6389,10 +6293,7 @@
 	},
 /area/station/crew_quarters/bar)
 "azy" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/table/round,
 /obj/item/reagent_containers/food/drinks/bottle/soda/bottledwater{
 	pixel_y = 16
@@ -7324,18 +7225,11 @@
 /area/station/crew_quarters/clown)
 "aCS" = (
 /obj/reagent_dispensers/heliumtank,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown)
 "aCW" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aCY" = (
@@ -7504,10 +7398,7 @@
 /area/station/crew_quarters/bar)
 "aDv" = (
 /obj/submachine/chem_extractor,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "aDw" = (
@@ -8491,10 +8382,7 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aHJ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -8525,10 +8413,7 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "aHP" = (
-/obj/machinery/firealarm{
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/fire,
 /obj/item/clothing/glasses/sunglasses,
@@ -8794,11 +8679,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/science/lobby)
 "aIO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/item/storage/toilet/random{
 	dir = 1
 	},
@@ -8823,10 +8704,7 @@
 	},
 /area/station/science/lobby)
 "aIR" = (
-/obj/machinery/firealarm{
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/cards,
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -10255,10 +10133,7 @@
 	},
 /area/station/science/lab)
 "aQq" = (
-/obj/machinery/firealarm{
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -10786,11 +10661,7 @@
 /area/station/hallway/secondary/central)
 "aSX" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair,
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -11059,10 +10930,7 @@
 	},
 /area/station/bridge/hos)
 "aUj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "aUk" = (
@@ -11279,11 +11147,7 @@
 /obj/machinery/light,
 /obj/storage/closet/office,
 /obj/machinery/light/emergency,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = -5
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -11415,11 +11279,7 @@
 	},
 /area/station/science/lobby)
 "aVX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -11786,10 +11646,7 @@
 	pixel_y = 4;
 	switchon = 1
 	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
@@ -11850,10 +11707,7 @@
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/captain)
 "aYq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/computer/telescope{
 	dir = 4
 	},
@@ -11923,10 +11777,7 @@
 /turf/space,
 /area/space)
 "aYK" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/door/window/westleft,
 /obj/machinery/shower{
 	dir = 4;
@@ -12027,9 +11878,7 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
+/obj/machinery/firealarm/west{
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
@@ -12129,10 +11978,7 @@
 	name = "Head of Personnel's Quarters"
 	})
 "aZA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/computer/announcement{
 	dir = 8;
 	tag = "icon-comm (WEST)"
@@ -12662,10 +12508,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bbT" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment,
 /obj/table/wood/auto,
 /obj/item/card/id/captains_spare,
@@ -12872,10 +12715,7 @@
 	},
 /area/station/bridge/captain)
 "bdf" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -13116,11 +12956,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/science/teleporter)
 "bex" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair/office/purple{
 	dir = 8
 	},
@@ -13307,11 +13143,7 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "bfV" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/table/reinforced/auto,
 /obj/item/device/audio_log,
 /obj/item/audio_tape{
@@ -13535,10 +13367,7 @@
 	},
 /area/station/science/chemistry)
 "bhL" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/disposal/chemlink,
 /obj/disposalpipe/trunk/mail{
 	dir = 8
@@ -13973,11 +13802,7 @@
 /turf/simulated/floor/damaged4,
 /area/station/science/artifact)
 "bkC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/table/reinforced/auto,
 /obj/item/storage/box/tapebox,
 /obj/item/disk/data/tape{
@@ -14364,10 +14189,7 @@
 	},
 /area/station/science/chemistry)
 "bmT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -14846,11 +14668,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light,
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/heads{
@@ -15057,10 +14875,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bqD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/table/auto,
 /obj/item/peripheral/printer,
 /obj/item/peripheral/network/radio/locked,
@@ -15475,10 +15290,7 @@
 	},
 /area/station/engine/elect)
 "bsY" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -15524,10 +15336,7 @@
 	},
 /area/station/crew_quarters/ce)
 "bte" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot/safety,
 /obj/machinery/power/data_terminal,
@@ -15706,10 +15515,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "btL" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light_switch/east{
 	pixel_x = 32;
 	pixel_y = -5
@@ -16213,10 +16019,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bwd" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/computer/ordercomp{
 	dir = 4
 	},
@@ -16599,10 +16402,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "byd" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grime,
 /area/station/quartermaster/storage)
 "byg" = (
@@ -17394,10 +17194,7 @@
 	},
 /obj/storage/secure/closet/engineering/mining,
 /obj/item/device/radio/intercom/cargo,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -17537,11 +17334,7 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bHf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
 "bHD" = (
@@ -18597,10 +18390,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/atmospherics/pipe/tank/air_repressurization{
 	dir = 4
 	},
@@ -19478,11 +19268,7 @@
 /area/station/quartermaster/storage)
 "cre" = (
 /obj/machinery/vending/medical,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/redwhite{
 	dir = 6
 	},
@@ -19830,11 +19616,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "cGn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cGz" = (
@@ -20854,10 +20636,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "dEi" = (
@@ -23233,10 +23012,7 @@
 /area/station/science/bot_storage)
 "fPd" = (
 /obj/storage/secure/closet/medical/chemical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fblue2"
@@ -24428,11 +24204,7 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "gSK" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -24974,10 +24746,7 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "hry" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -26609,10 +26378,7 @@
 	print_id = "Security"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -27740,11 +27506,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood/two,
 /area/station/medical/medbay/lobby)
 "jwm" = (
@@ -27844,10 +27606,7 @@
 /area/station/engine/core/nuclear)
 "jAP" = (
 /obj/machinery/vending/janitor,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "jAS" = (
@@ -28081,10 +27840,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "jKn" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -28545,10 +28301,7 @@
 	pixel_y = -4
 	},
 /obj/rack,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -19
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "kgG" = (
@@ -28627,10 +28380,8 @@
 	pixel_x = 2;
 	pixel_y = 8
 	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_x = -5;
-	pixel_y = 28
+/obj/machinery/firealarm/north{
+	pixel_x = -5
 	},
 /obj/machinery/light_switch/south{
 	pixel_x = 10;
@@ -28956,10 +28707,7 @@
 /area/station/hallway/primary/east)
 "kxS" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/escape{
 	dir = 6
 	},
@@ -30657,11 +30405,7 @@
 	pixel_y = 3;
 	switchon = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fblue2"
@@ -31025,10 +30769,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "mgz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white/checker2{
 	dir = 5
 	},
@@ -31145,11 +30886,7 @@
 /area/station/engine/engineering/ce/private)
 "miz" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_delivery,
 /obj/vehicle/forklift,
 /turf/simulated/floor,
@@ -31543,11 +31280,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "mAt" = (
@@ -32024,10 +31757,7 @@
 	},
 /area/station/medical/head)
 "mQG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "mRx" = (
@@ -33869,11 +33599,7 @@
 /area/station/medical/medbay/lobby)
 "oFt" = (
 /obj/machinery/camera,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/navbeacon/mule/medbay_north/east,
 /obj/decal/stripe_caution,
 /turf/simulated/floor/bluewhite{
@@ -34428,11 +34154,7 @@
 	name = "Entry Hallway"
 	})
 "oZm" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black{
 	pixel_x = 4;
@@ -35053,10 +34775,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "pDY" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/tile_edge/line/green{
 	dir = 10;
 	icon_state = "line1"
@@ -35643,10 +35362,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen)
 "pWc" = (
@@ -36175,10 +35891,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "qqQ" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -36255,10 +35968,7 @@
 	},
 /area/station/hangar/sec)
 "qvr" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/stairs{
 	dir = 10;
 	icon_state = "quiltystair"
@@ -36302,10 +36012,7 @@
 	name = "Entry Hallway"
 	})
 "qxa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/crate/weapon/armory/phaser,
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -37581,11 +37288,7 @@
 /area/station/quartermaster/office)
 "rwV" = (
 /obj/rack,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/item/storage/box/health_upgrade_kit{
 	pixel_x = 9;
 	pixel_y = 7
@@ -37732,10 +37435,7 @@
 	dir = 1;
 	pixel_y = 30
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/unsimulated/floor/orangeblack/side{
 	dir = 5
 	},
@@ -38879,11 +38579,7 @@
 /obj/submachine/cargopad{
 	name = "Robotics Workshop Pad"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/landmark/start/job/cyborg,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -40471,11 +40167,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "tUK" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black{
 	pixel_x = 4;
@@ -40796,10 +40488,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -41621,21 +41310,14 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "uKZ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "uLK" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/secure/closet/engineering/engineer,
 /obj/cable/brown{
 	icon_state = "4-8"
@@ -42762,11 +42444,7 @@
 /obj/item/body_bag,
 /obj/item/body_bag,
 /obj/storage/cart/medcart,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "vOq" = (
@@ -42803,11 +42481,7 @@
 	pixel_y = 3;
 	switchon = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fpurple2"
@@ -43120,10 +42794,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/start/job/security_assistant,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/caution/east{
 	dir = 8
 	},
@@ -43244,10 +42915,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/central)
 "wiz" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -43283,10 +42951,7 @@
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "wlU" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/deep_fryer,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -43782,10 +43447,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fpurple2"
@@ -44899,11 +44561,7 @@
 	},
 /area/station/medical/medbay/cloner)
 "xIr" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/stool/chair/comfy/wheelchair,
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -45406,10 +45064,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/research_director)
 "ydW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/landmark/start/job/engineer,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -308,11 +308,7 @@
 	},
 /area/shuttle/arrival/station)
 "abR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
 "abS" = (
@@ -497,9 +493,7 @@
 	dir = 9;
 	level = 2
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
@@ -1031,9 +1025,7 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -1138,10 +1130,7 @@
 	status = 1
 	},
 /obj/decal/cleanable/cobweb,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction2)
 "aeJ" = (
@@ -2754,10 +2743,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "ajI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -2781,10 +2767,7 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersB)
 "ajK" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/window/cubicle{
 	dir = 2
 	},
@@ -3177,9 +3160,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "alh" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -3644,10 +3625,7 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
 "amX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -3790,9 +3768,7 @@
 	name = "Catering Hangar"
 	})
 "anq" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/table/auto,
 /obj/item/wrapping_paper,
 /obj/item/scissors,
@@ -3814,9 +3790,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "anx" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "any" = (
@@ -4587,10 +4561,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/wreckage)
 "aqu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "aqw" = (
@@ -4723,10 +4694,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aqN" = (
@@ -6983,10 +6951,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -6999,9 +6964,7 @@
 "axJ" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
@@ -7131,9 +7094,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/stool/chair,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "ayj" = (
@@ -7223,10 +7184,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/secwing)
 "ayz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -7237,9 +7195,7 @@
 /area/station/crew_quarters/barber_shop)
 "ayB" = (
 /obj/submachine/laundry_machine,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -7996,9 +7952,7 @@
 /area/station/storage/emergency)
 "aAy" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -8912,9 +8866,7 @@
 	},
 /area/station/hallway/primary/central)
 "aCS" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -8984,9 +8936,7 @@
 	},
 /area/station/hallway/primary/central)
 "aDa" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -9042,10 +8992,7 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
@@ -9272,11 +9219,7 @@
 	dir = 8;
 	level = 2
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aDs" = (
@@ -9351,9 +9294,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -9481,11 +9422,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/security/main)
@@ -10087,11 +10024,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
@@ -10294,9 +10227,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/medical_public,
 /obj/machinery/light/emergency{
 	dir = 8
@@ -10948,9 +10879,7 @@
 	},
 /area/station/security/secwing)
 "aHU" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -12064,11 +11993,7 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "aKM" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
@@ -12297,9 +12222,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "aLo" = (
@@ -12413,11 +12336,7 @@
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aLC" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/table/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -12572,10 +12491,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aMf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-10"
@@ -12854,10 +12770,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aMU" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -13591,10 +13504,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "aOP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -13689,10 +13599,7 @@
 	},
 /area/station/security/main)
 "aPa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -14150,9 +14057,7 @@
 /area/station/crew_quarters/juryroom)
 "aQf" = (
 /obj/stool/chair,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "aQg" = (
@@ -14626,9 +14531,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aRA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/carpet/grime,
@@ -14677,11 +14580,7 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aRI" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aRJ" = (
@@ -14871,11 +14770,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aSh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/rack,
 /obj/item/crowbar{
 	pixel_x = -5;
@@ -15267,9 +15162,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/chair/couch{
 	dir = 4
 	},
@@ -16180,9 +16073,7 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -16385,10 +16276,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aWj" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "aWk" = (
@@ -17204,11 +17092,7 @@
 /area/station/hallway/primary/central)
 "aYl" = (
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/central)
 "aYm" = (
@@ -17484,11 +17368,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -17605,11 +17485,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aZi" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/courtroom)
 "aZj" = (
@@ -17803,10 +17679,7 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aZP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
@@ -17933,9 +17806,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/station/teleporter)
@@ -18024,9 +17895,7 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "baB" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "baC" = (
@@ -18471,9 +18340,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -18561,9 +18428,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -19459,9 +19324,7 @@
 	},
 /area/station/janitor/office)
 "beE" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -19697,9 +19560,7 @@
 /obj/stool/chair/couch{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -19833,9 +19694,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/emergency{
 	dir = 4
 	},
@@ -20079,9 +19938,7 @@
 /area/station/maintenance/disposal)
 "bgs" = (
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgt" = (
@@ -22489,11 +22346,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bnY" = (
@@ -22624,10 +22477,7 @@
 	},
 /area/station/crew_quarters/stockex)
 "boA" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -22804,11 +22654,7 @@
 	pixel_x = -9;
 	pixel_y = -24
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -22824,11 +22670,7 @@
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/market)
 "bpf" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/light,
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/market)
@@ -22878,10 +22720,7 @@
 /area/station/ai_monitored/storage/eva)
 "bpj" = (
 /obj/machinery/space_heater,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/ai_monitored/storage/eva)
 "bpk" = (
@@ -23172,10 +23011,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bqb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/emergency,
 /obj/machinery/light{
@@ -23632,10 +23468,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bsa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bsd" = (
@@ -23692,11 +23525,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bsy" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bsz" = (
@@ -23895,10 +23724,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -24339,9 +24165,7 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -25521,11 +25345,7 @@
 	pixel_x = 5;
 	pixel_y = 10
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -26063,11 +25883,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bCW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -26323,10 +26139,7 @@
 /area/station/turret_protected/Zeta)
 "bEf" = (
 /obj/table/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/item/storage/box/tapebox{
 	pixel_x = -5;
 	pixel_y = 9
@@ -26605,11 +26418,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
 "bFX" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/item/slag_shovel{
 	pixel_x = 7;
 	pixel_y = 6
@@ -26917,9 +26726,7 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bHy" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -27691,9 +27498,7 @@
 /turf/simulated/floor/stairs,
 /area/station/hallway/primary/south)
 "bKo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -28035,10 +27840,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bLq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "bLr" = (
@@ -28170,9 +27972,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bLL" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/atmospherics/binary/valve{
 	high_risk = 1;
 	name = "Air Reserve (Escape Hallway)"
@@ -28266,10 +28066,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bMr" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -28476,9 +28273,7 @@
 /area/station/science/teleporter)
 "bMV" = (
 /obj/item/device/radio/beacon,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "Stairs_wide"
@@ -28852,9 +28647,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -30091,10 +29884,7 @@
 /obj/decal/cleanable/desk_clutter{
 	pixel_x = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/paper_bin{
 	pixel_x = 7;
 	pixel_y = 6
@@ -30332,11 +30122,7 @@
 	},
 /area/station/crew_quarters/hor)
 "bSB" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -30577,11 +30363,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bTu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bTv" = (
@@ -30682,11 +30464,7 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "bTG" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/light/small,
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -30863,11 +30641,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUd" = (
@@ -31042,9 +30816,7 @@
 	},
 /area/station/hallway/primary/south)
 "bUC" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -31335,9 +31107,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/switch_junction{
 	desc = "An underfloor mail pipe.";
 	dir = 8;
@@ -31579,10 +31349,7 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bWv" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -31864,9 +31631,7 @@
 	},
 /area/station/mining/staff_room)
 "bXo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -32622,10 +32387,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/hookups/east)
 "bZN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/shrub{
 	dir = 8;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -32767,11 +32529,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "cap" = (
@@ -33650,10 +33408,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "ccX" = (
@@ -34926,10 +34681,7 @@
 /area/station/maintenance/southwest)
 "chc" = (
 /obj/machinery/light/emergency,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -35744,10 +35496,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "cjx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cjy" = (
@@ -36247,11 +35996,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "cld" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "clf" = (
@@ -36667,10 +36412,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "cmn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/closet/command/medical_director,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
@@ -37476,9 +37218,7 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -37624,10 +37364,7 @@
 /turf/space,
 /area/shuttle_sound_spawn)
 "coY" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cpa" = (
@@ -38002,11 +37739,7 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cpT" = (
@@ -38678,10 +38411,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -38722,10 +38452,7 @@
 /area/station/medical/medbay)
 "csx" = (
 /obj/storage/secure/closet/medical/anesthetic,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -38865,9 +38592,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fred2"
@@ -38880,9 +38605,7 @@
 	},
 /obj/machinery/glass_recycler/chemistry,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/table/reinforced/chemistry/auto/basicsup,
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -40302,11 +40025,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/purple/side,
 /area/station/janitor/supply)
 "cxj" = (
@@ -41813,10 +41532,7 @@
 /area/station/maintenance/disposal)
 "cFh" = (
 /obj/storage/secure/closet/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cFm" = (
@@ -42670,10 +42386,7 @@
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "dwz" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/window/reinforced{
 	dir = 2
 	},
@@ -44319,11 +44032,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "eLF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -47728,9 +47437,7 @@
 	icon_state = "xtra_bigstripe-edge2"
 	},
 /obj/disposalpipe/trunk/produce,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/ranch)
@@ -47832,10 +47539,7 @@
 	},
 /area/space)
 "hRo" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
@@ -48933,9 +48637,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/vending/alcohol/with_ammo,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "iWb" = (
@@ -48967,10 +48669,7 @@
 	},
 /area/station/mining/staff_room)
 "iWR" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "iWW" = (
@@ -49114,10 +48813,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side,
 /area/station/engine/inner)
 "jeE" = (
@@ -50611,10 +50307,7 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "kwK" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -53249,9 +52942,7 @@
 /turf/simulated/floor,
 /area/station/engine/elect)
 "nfF" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/chair/couch{
 	dir = 4;
 	icon_state = "chair_couch-blue";
@@ -54345,9 +54036,7 @@
 /area/station/mining/staff_room)
 "obR" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "obY" = (
@@ -54955,11 +54644,7 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "oFv" = (
@@ -56135,9 +55820,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
 "pNf" = (
@@ -56254,10 +55937,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -56306,11 +55986,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
@@ -56399,10 +56075,7 @@
 /turf/simulated/floor,
 /area/station/routing/medsci)
 "pZI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/fluid_canister,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
@@ -56430,11 +56103,7 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "qbv" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "qci" = (
@@ -56610,10 +56279,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -57173,10 +56839,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/main)
@@ -58461,10 +58124,7 @@
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
 "rQy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
 "rQC" = (
@@ -58598,9 +58258,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-10"
 	},
@@ -59568,10 +59226,7 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "sMX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating/jen,
 /area/station/engine/inner)
 "sNo" = (
@@ -59916,10 +59571,7 @@
 "sZA" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/decal/stripe_caution,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/engine/gas)
 "tag" = (
@@ -61196,9 +60848,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -61789,11 +61439,7 @@
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -62651,10 +62297,7 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "vsb" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/medical)
 "vsM" = (
@@ -64378,10 +64021,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "wSz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
@@ -64867,9 +64507,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "xtD" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "xtF" = (
@@ -65286,10 +64924,7 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "xPJ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)
 "xPS" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -646,11 +646,7 @@
 	pixel_y = 5;
 	print_id = "AI"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/turret_protected/ai)
@@ -1146,11 +1142,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/crate/clown,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
@@ -1960,10 +1952,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "agl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "agm" = (
@@ -2285,11 +2274,7 @@
 	name = "Television";
 	network = "Zeta"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -2334,11 +2319,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersB)
 "ahx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -2832,11 +2813,7 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/catering)
 "aiR" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "Stairs_wide"
@@ -3678,9 +3655,7 @@
 /obj/item/body_bag,
 /obj/item/body_bag,
 /obj/item/body_bag,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "alz" = (
@@ -3994,11 +3969,7 @@
 /area/station/crew_quarters/catering)
 "amp" = (
 /obj/machinery/atmospherics/portables_connector,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "amq" = (
@@ -4033,10 +4004,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "amv" = (
@@ -4393,11 +4361,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
 "ant" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "anu" = (
@@ -4535,11 +4499,7 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "anY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "anZ" = (
@@ -4755,11 +4715,7 @@
 /obj/item/pen,
 /obj/item/storage/box/cocktail_umbrellas,
 /obj/item/storage/box/cocktail_doodads,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aoF" = (
@@ -4775,11 +4731,7 @@
 	},
 /area/station/security/detectives_office)
 "aoI" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -4832,11 +4784,7 @@
 	},
 /area/station/security/detectives_office)
 "aoN" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/reagent_dispensers/watertank/fountain,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
@@ -4890,10 +4838,7 @@
 /area/station/crew_quarters/fitness)
 "aoW" = (
 /obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "aoX" = (
@@ -5038,11 +4983,7 @@
 /obj/item/storage/pill_bottle/cyberpunk{
 	layer = 2.4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating/scorched,
 /area/station/hallway/secondary/construction)
 "apw" = (
@@ -5430,11 +5371,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aqC" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aqD" = (
@@ -6467,11 +6404,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/breadloaf,
@@ -6828,11 +6761,7 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/arrivals)
 "aur" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/hangar/arrivals)
 "aus" = (
@@ -7104,11 +7033,7 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/item/extinguisher,
 /obj/item/reagent_containers/glass/oilcan,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -7247,11 +7172,7 @@
 	icon_state = "chair_couch-blue";
 	name = "ratty blue couch"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -7369,11 +7290,7 @@
 	},
 /area/station/chapel/sanctuary)
 "avH" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/chair/couch{
 	dir = 4;
 	icon_state = "chair_couch-blue";
@@ -7949,11 +7866,7 @@
 /obj/item/reagent_containers/glass/wateringcan{
 	pixel_y = 5
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -8107,11 +8020,7 @@
 /obj/item/clothing/head/chefhat,
 /obj/item/reagent_containers/food/drinks/milk,
 /obj/item/clothing/gloves/latex,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
@@ -8631,11 +8540,7 @@
 	name = "Net Cafe"
 	})
 "ayW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -9236,11 +9141,7 @@
 /turf/simulated/floor,
 /area/station/storage/emergency2)
 "aAv" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/standard,
 /turf/simulated/floor/orangeblack,
 /area/station/storage/emergency2)
@@ -9849,11 +9750,7 @@
 	},
 /area/station/chapel/sanctuary)
 "aBM" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/wood/auto,
 /obj/item/paper_bin,
 /obj/item/pen/marker,
@@ -10674,11 +10571,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aDO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair{
 	dir = 8
 	},
@@ -11113,11 +11006,7 @@
 /area/station/crew_quarters/cafeteria)
 "aFa" = (
 /obj/machinery/vending/medical_public,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
@@ -11355,11 +11244,7 @@
 	},
 /area/station/hydroponics/lobby)
 "aFS" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -11752,11 +11637,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "aHa" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/computer3,
 /turf/simulated/floor/neutral/side{
 	dir = 9
@@ -12560,11 +12441,7 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "aJd" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/table/auto,
 /obj/machinery/coffeemaker/botany,
 /turf/simulated/floor/caution/north,
@@ -13173,11 +13050,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/garden)
 "aKY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 10
@@ -13280,20 +13153,12 @@
 /turf/simulated/floor/green/side,
 /area/station/crew_quarters/garden)
 "aLo" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
 "aLp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/reagent_dispensers/watertank/big,
 /obj/cable{
 	icon_state = "1-2"
@@ -13655,11 +13520,7 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aMm" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/item/clothing/under/shorts/blue{
 	desc = "In space?";
 	name = "swimming trunks"
@@ -14460,11 +14321,7 @@
 	},
 /area/station/crew_quarters/arcade)
 "aOu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOv" = (
@@ -15263,11 +15120,7 @@
 "aQs" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/chapel)
 "aQt" = (
@@ -15393,11 +15246,7 @@
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
 /obj/item/device/audio_log,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
 	},
@@ -15535,11 +15384,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/barber_shop)
 "aRh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "1-2"
@@ -15613,10 +15458,7 @@
 "aRr" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/sleeper/compact{
 	dir = 8
 	},
@@ -16055,11 +15897,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aSD" = (
@@ -16408,10 +16246,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "aTz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -16634,11 +16469,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aUa" = (
@@ -16738,11 +16569,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aUn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/closet/dresser,
 /obj/item/clothing/suit/bathrobe,
 /obj/item/clothing/suit/bathrobe,
@@ -16770,11 +16597,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aUq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment,
 /obj/machinery/manufacturer/uniform,
 /turf/simulated/floor/sanitary,
@@ -16889,11 +16712,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "aUE" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -17097,11 +16916,7 @@
 "aVl" = (
 /obj/item/reagent_containers/emergency_injector/spaceacillin,
 /obj/storage/closet/biohazard,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -17383,11 +17198,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/arrivals)
 "aWb" = (
@@ -17487,10 +17298,7 @@
 	dir = 5
 	},
 /obj/stool/bench/red/auto,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/pool)
 "aWA" = (
@@ -17761,11 +17569,7 @@
 /obj/stool/chair/wooden{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
@@ -18221,10 +18025,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aYr" = (
@@ -18423,11 +18224,7 @@
 /area/station/crew_quarters/quartersA)
 "aYR" = (
 /obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -18739,11 +18536,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -19248,11 +19041,7 @@
 /area/station/maintenance/north)
 "baU" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/northeast)
 "baV" = (
@@ -19655,21 +19444,13 @@
 "bch" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
 "bci" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
 "bcj" = (
@@ -19892,21 +19673,13 @@
 	desc = "Ugh, gross.";
 	name = "fedora"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "bcS" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/luggable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "bcT" = (
@@ -19939,11 +19712,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "bcW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -20122,11 +19891,7 @@
 "bdr" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "bdu" = (
@@ -20806,11 +20571,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/catwalk/north)
 "bfP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -21171,10 +20932,7 @@
 	level = 2
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bhi" = (
@@ -21643,11 +21401,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "biB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -21670,10 +21424,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "biF" = (
@@ -21951,14 +21702,6 @@
 "bjD" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bjE" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -22487,10 +22230,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "bla" = (
@@ -22924,10 +22664,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "bmq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "bmr" = (
@@ -23124,10 +22861,7 @@
 /obj/cable/brown{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
 "bmV" = (
@@ -23350,11 +23084,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "bnB" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "bnC" = (
@@ -23445,11 +23175,7 @@
 /area/station/ai_monitored/storage/eva)
 "bnP" = (
 /obj/shrub,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -24154,10 +23880,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering)
 "bpH" = (
@@ -24322,11 +24045,7 @@
 	can_rupture = 0;
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/hotloop)
 "bqd" = (
@@ -24555,10 +24274,7 @@
 	icon_state = "4-8"
 	},
 /obj/storage/closet/wardrobe/orange,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
@@ -25132,10 +24848,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bso" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/south,
 /area/station/routing/security)
 "bsp" = (
@@ -25544,11 +25257,7 @@
 	},
 /area/station/engine/engineering)
 "btn" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -25666,11 +25375,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "btD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "btE" = (
@@ -25731,11 +25436,7 @@
 /area/station/engine/gas)
 "btL" = (
 /obj/machinery/atmospherics/portables_connector,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grime,
 /area/station/engine/gas)
 "btM" = (
@@ -26964,10 +26665,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack/side,
 /area/station/hangar/main)
 "bwY" = (
@@ -27540,11 +27238,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/computer/card/department/security{
 	dir = 8
 	},
@@ -27553,11 +27247,7 @@
 	},
 /area/station/security/hos)
 "byp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack,
 /area/station/ai_monitored/storage/eva)
 "byr" = (
@@ -27673,11 +27363,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/heads)
 "byD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "byF" = (
@@ -27758,11 +27444,7 @@
 	can_rupture = 0;
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "byV" = (
@@ -28136,11 +27818,7 @@
 /area/station/security/main)
 "bzT" = (
 /obj/shrub,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -28263,10 +27941,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/computer/ordercomp,
 /turf/simulated/floor/black,
 /area/station/hangar/main)
@@ -28844,11 +28519,7 @@
 	},
 /area/station/security/checkpoint/customs)
 "bBG" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -29574,10 +29245,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/item/device/prisoner_scanner,
@@ -30136,11 +29804,7 @@
 	name = "Engineering Control Room"
 	})
 "bEy" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -31661,11 +31325,7 @@
 /area/station/bridge)
 "bHV" = (
 /obj/shrub,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -32080,10 +31740,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/inner/central)
 "bIN" = (
@@ -33467,11 +33124,7 @@
 /obj/cable/brown{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bLI" = (
@@ -34828,10 +34481,7 @@
 /area/station/security/checkpoint/podbay)
 "bOI" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bOJ" = (
@@ -35073,11 +34723,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -35314,11 +34960,7 @@
 	},
 /area/station/security/checkpoint/customs)
 "bPT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/disposal/brig{
 	name = "ejection chute"
 	},
@@ -35477,11 +35119,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/transport{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -35526,11 +35164,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
@@ -35615,11 +35249,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grime,
 /area/station/routing/engine)
 "bQF" = (
@@ -35948,11 +35578,7 @@
 /area/station/storage/emergency)
 "bRt" = (
 /obj/shrub,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -36026,10 +35652,7 @@
 "bRH" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/submachine/poster_creator,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -36595,17 +36218,11 @@
 /turf/simulated/floor/grime,
 /area/station/security/main)
 "bSY" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/east)
 "bSZ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purple,
 /area/station/teleporter)
 "bTa" = (
@@ -36725,11 +36342,7 @@
 	},
 /area/station/crew_quarters/captain)
 "bTm" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bTn" = (
@@ -37055,11 +36668,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bUh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "bUi" = (
@@ -37461,11 +37070,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/coldloop)
 "bVn" = (
@@ -37938,10 +37543,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/podbay)
 "bWA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
@@ -38324,11 +37926,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/main)
 "bXC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -38606,11 +38204,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "corner_east"
@@ -39121,11 +38715,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
 "bZE" = (
@@ -39169,11 +38759,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -39796,11 +39382,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "cbQ" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -40031,10 +39613,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ccF" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ccG" = (
@@ -40711,10 +40290,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "ceP" = (
@@ -40754,11 +40330,7 @@
 	dir = 8;
 	setup_os_string = "ZETA_MAINFRAME"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -40771,11 +40343,7 @@
 	name = "Dead plant";
 	pixel_y = 10
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "ceW" = (
@@ -41013,11 +40581,7 @@
 /area/station/storage/tech)
 "cfF" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -41580,11 +41144,7 @@
 /area/station/storage/tech)
 "chB" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/east)
 "chC" = (
@@ -41853,21 +41413,13 @@
 "cit" = (
 /obj/table/auto,
 /obj/random_item_spawner/med_tool,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "ciu" = (
 /obj/table/auto,
 /obj/random_item_spawner/medicine,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "civ" = (
@@ -42049,10 +41601,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "cjf" = (
@@ -42106,11 +41655,7 @@
 	},
 /area/station/maintenance/southeast)
 "cjl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -42373,11 +41918,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
@@ -42881,11 +42422,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -43433,21 +42970,13 @@
 /obj/decal/cleanable/desk_clutter,
 /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip,
 /obj/machinery/light/lamp/green,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/stamp/rd,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "cmE" = (
 /obj/item/cigbutt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/stool/chair{
 	dir = 4
 	},
@@ -43730,11 +43259,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -43954,10 +43479,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/escape)
 "cof" = (
@@ -44324,11 +43846,7 @@
 /area/station/storage/warehouse)
 "cpc" = (
 /obj/machinery/manufacturer/general,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -44362,11 +43880,7 @@
 	},
 /area/station/quartermaster/refinery)
 "cph" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/bot/firebot,
 /obj/disposalpipe/segment/mineral{
 	icon_state = "pipe-c"
@@ -44783,11 +44297,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/camera/television/mobile{
 	c_tag = "research 2";
 	dir = 8;
@@ -45028,11 +44538,7 @@
 	},
 /area/station/quartermaster/refinery)
 "cqS" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/disposal)
 "cqT" = (
@@ -45338,11 +44844,7 @@
 /area/station/science/construction)
 "crQ" = (
 /obj/machinery/disposal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/teleporter)
@@ -45435,10 +44937,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "csi" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -46176,11 +45675,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "cum" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "cun" = (
@@ -46396,11 +45891,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/north,
 /area/station/science/bot_storage)
 "cuS" = (
@@ -46536,11 +46027,7 @@
 /obj/item/device/radio,
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/item/chem_grenade/cleaner,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
@@ -46689,11 +46176,7 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "cvN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/vending/jobclothing/research,
 /turf/simulated/floor/purple/side{
 	dir = 10
@@ -46830,10 +46313,7 @@
 	},
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/autoname/research/testchamber,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/poster/wallsign/poster_nt{
 	pixel_y = 28
 	},
@@ -47161,11 +46641,7 @@
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -47586,19 +47062,12 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "cyb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "cyc" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "cyd" = (
@@ -47814,11 +47283,7 @@
 	},
 /area/station/engine/elect)
 "cyC" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -47898,11 +47363,7 @@
 /area/station/science/lab)
 "cyR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "cyS" = (
@@ -48050,10 +47511,7 @@
 	},
 /area/station/medical/medbay/lobby)
 "czp" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/tile_edge/stripe{
 	dir = 6;
 	icon_state = "bot2"
@@ -48277,11 +47735,7 @@
 	},
 /area/station/engine/elect)
 "czX" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -49079,11 +48533,7 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cCq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/submachine/ATM{
 	pixel_y = 32
 	},
@@ -49243,11 +48693,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "cCH" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -49429,11 +48875,7 @@
 /area/station/science/lab)
 "cDi" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -49466,11 +48908,7 @@
 /area/station/science/lobby)
 "cDn" = (
 /obj/table/reinforced/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/chem_grenade/firefighting,
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/shieldgenerator/meteorshield,
@@ -49492,11 +48930,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/south,
 /area/station/science/lobby)
 "cDq" = (
@@ -50544,11 +49978,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/science/lab)
 "cGo" = (
@@ -50918,11 +50348,7 @@
 /area/station/crew_quarters/market)
 "cHy" = (
 /obj/shrub,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -51260,11 +50686,7 @@
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbay/lobby)
 "cIo" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/blue/side{
 	dir = 6
@@ -51290,10 +50712,7 @@
 "cIr" = (
 /obj/disposalpipe/segment/morgue,
 /obj/machinery/light_switch/east,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/market)
 "cIs" = (
@@ -51592,11 +51011,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "cJq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler,
 /obj/item/storage/box/beakerbox{
@@ -52207,10 +51622,7 @@
 	},
 /area/station/medical/medbay)
 "cLc" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "cLd" = (
@@ -52228,10 +51640,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cLg" = (
@@ -52557,11 +51966,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/chemistry)
 "cMi" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4
 	},
@@ -52835,11 +52240,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/medical/medbay/cloner)
@@ -53181,10 +52582,7 @@
 /area/station/medical/medbay)
 "cNT" = (
 /obj/vehicle/segway,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -53691,11 +53089,7 @@
 	},
 /area/station/medical/medbay)
 "cPj" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -54092,11 +53486,7 @@
 /area/station/hangar/escape)
 "cQk" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -54596,11 +53986,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_north"
 	},
@@ -54787,11 +54173,7 @@
 /turf/simulated/floor/plating/damaged1,
 /area/station/science/storage)
 "cSc" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -54799,11 +54181,7 @@
 /area/station/science/storage)
 "cSd" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating/damaged2,
 /area/station/science/storage)
 "cSe" = (
@@ -54834,10 +54212,7 @@
 "cSh" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -55162,11 +54537,7 @@
 /turf/simulated/floor/caution/south,
 /area/station/mining/staff_room)
 "cTl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mineral{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -55412,11 +54783,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/secure/closet/medical/chemical,
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -55626,11 +54993,7 @@
 "cUl" = (
 /obj/table/auto,
 /obj/item/pen,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/item/clothing/head/helmet/hardhat,
 /obj/item/staple_gun,
 /obj/item/reagent_containers/hypospray,
@@ -55661,11 +55024,7 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/south)
 "cUq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -55744,11 +55103,7 @@
 /area/station/quartermaster/office)
 "cUE" = (
 /obj/storage/cart,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -56537,11 +55892,7 @@
 "cWH" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grime,
 /area/station/storage/auxillary)
 "cWI" = (
@@ -56585,11 +55936,7 @@
 /area/station/hangar/qm)
 "cWM" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -57230,10 +56577,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "cYz" = (
@@ -57297,11 +56641,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "cYI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4
@@ -57665,11 +57005,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purplewhite{
 	dir = 10
 	},
@@ -57789,11 +57125,7 @@
 /obj/stool/chair/office{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -57887,11 +57219,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cZW" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/closet/fridge/pathology{
 	req_access_txt = "5"
 	},
@@ -57905,11 +57233,7 @@
 /obj/table/auto,
 /obj/item/clipboard,
 /obj/item/storage/pill_bottle/mutadone,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -58549,11 +57873,7 @@
 /turf/simulated/floor,
 /area/station/hangar/science)
 "dbG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
@@ -58798,11 +58118,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/stairs{
 	dir = 4;
@@ -59040,11 +58356,7 @@
 	},
 /area/station/medical/cdc)
 "dcZ" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -59176,10 +58488,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "ddv" = (
@@ -59981,10 +59290,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/medbay)
 "dgf" = (
@@ -60331,10 +59637,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "dhp" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "dhq" = (
@@ -60644,11 +59947,7 @@
 /turf/simulated/floor/black,
 /area/research_outpost)
 "diy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/device/radio/intercom,
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -60757,10 +60056,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost)
 "diP" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/furnace,
 /obj/cable{
 	icon_state = "0-8"
@@ -60805,10 +60101,7 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "diU" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -60859,11 +60152,7 @@
 /area/research_outpost)
 "dja" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/research_outpost)
 "djb" = (
@@ -61196,10 +60485,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purple/side{
 	dir = 5
 	},
@@ -61351,10 +60637,7 @@
 	},
 /area/research_outpost/chamber)
 "dkq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_east"
 	},
@@ -61609,11 +60892,7 @@
 	},
 /area/research_outpost/hangar)
 "dkW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/westeast,
 /area/research_outpost)
 "dkX" = (
@@ -61855,11 +61134,7 @@
 "dlH" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
 /area/research_outpost)
@@ -61939,11 +61214,7 @@
 	},
 /area/research_outpost)
 "dlQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood,
 /area/research_outpost)
 "dlR" = (
@@ -63371,11 +62642,7 @@
 /area/station/crew_quarters/market)
 "eoN" = (
 /obj/item/device/radio/intercom/science,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment,
 /obj/shrub,
@@ -64829,10 +64096,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "gQb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack,
 /area/station/security/checkpoint/podbay)
 "gQp" = (
@@ -65909,10 +65173,7 @@
 /turf/simulated/floor,
 /area/station/engine/coldloop)
 "ius" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/shuttlebay,
 /area/station/security/checkpoint/podbay)
 "iuC" = (
@@ -66623,11 +65884,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters_east)
 "jqe" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/plantpot{
 	anchored = 1
 	},
@@ -66732,11 +65989,7 @@
 	desc = "Caution! Construction Zone!";
 	name = "caution sign"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/item/storage/firstaid/oxygen{
 	pixel_y = -4
 	},
@@ -68052,11 +67305,7 @@
 /area/station/security/checkpoint/escape)
 "lcN" = (
 /mob/living/critter/small_animal/bird/owl,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "lei" = (
@@ -68391,11 +67640,7 @@
 /obj/item/storage/toilet/random,
 /obj/landmark/halloween,
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine/safe,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/security/brig)
 "lGH" = (
@@ -69238,10 +68483,7 @@
 /area/listeningpost)
 "mOe" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -69453,11 +68695,7 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/arrivals)
 "nhh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/crate,
 /obj/item/reagent_containers/food/drinks/bottle/soda,
 /obj/item/reagent_containers/food/drinks/bottle/soda,
@@ -72297,11 +71535,7 @@
 /area/station/engine/hotloop)
 "rFH" = (
 /obj/table/wood/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/device/camera_viewer,
 /obj/item/camera,
 /obj/item/device/audio_log,
@@ -72332,11 +71566,7 @@
 	},
 /area/space)
 "rJj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/purplewhite{
 	dir = 10
@@ -73559,11 +72789,7 @@
 /area/station/hangar/escape)
 "tur" = (
 /obj/machinery/atmospherics/binary/valve,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/research_outpost)
 "tuu" = (
@@ -73760,10 +72986,7 @@
 /area/station/catwalk/north)
 "tMI" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -74498,11 +73721,7 @@
 /obj/item/device/light/glowstick,
 /obj/item/extinguisher,
 /obj/item/reagent_containers/food/drinks/fueltank,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/solar/north)
 "vcx" = (
@@ -75954,11 +75173,7 @@
 	},
 /area/station/hydroponics/bay)
 "xHC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/table/wood/auto,
 /obj/item/pinpointer/teg_semi{
 	pixel_x = -4;
@@ -76035,11 +75250,7 @@
 /obj/item/storage/box/nerd_kit{
 	pixel_y = 5
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "blue5"
@@ -111553,7 +110764,7 @@ aaa
 bgA
 bgA
 bgA
-bjE
+ccF
 bli
 bjF
 boc

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1271,10 +1271,7 @@
 	},
 /area/station/science/lobby)
 "afO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -1534,11 +1531,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agO" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -1821,11 +1814,7 @@
 /obj/cable/brown{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -1887,10 +1876,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -2148,10 +2134,7 @@
 	},
 /area/station/science/lobby)
 "aiM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -2262,10 +2245,7 @@
 /obj/item/pen{
 	pixel_x = -7
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 9
 	},
@@ -2859,10 +2839,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "alT" = (
@@ -3471,10 +3448,7 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apy" = (
@@ -4282,10 +4256,7 @@
 /turf/simulated/floor/caution/south,
 /area/station/quartermaster/office)
 "arW" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/caution/south,
 /area/station/quartermaster/office)
 "arX" = (
@@ -4976,10 +4947,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "auE" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -5094,11 +5062,7 @@
 /turf/simulated/floor/grime,
 /area/station/hangar/arrivals)
 "auW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/grime,
 /area/station/hangar/arrivals)
 "auX" = (
@@ -5374,10 +5338,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "awl" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -5509,10 +5470,7 @@
 /obj/machinery/traymachine/morgue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "awN" = (
@@ -5778,10 +5736,7 @@
 /area/station/chapel/sanctuary)
 "axC" = (
 /obj/table/wood/auto,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/reagent_containers/food/drinks/bottle/wine{
 	pixel_x = -7;
 	pixel_y = 12
@@ -5973,10 +5928,7 @@
 /area/station/chapel/sanctuary)
 "ayg" = (
 /obj/machinery/space_heater,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -6256,10 +6208,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/stone,
 /turf/simulated/floor/dojo/sand/circle,
 /area/station/chapel/sanctuary)
@@ -6446,10 +6395,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azT" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azU" = (
@@ -6915,10 +6861,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -6985,10 +6928,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/central)
 "aBT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
@@ -7308,9 +7248,7 @@
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "aCQ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred2"
@@ -8197,10 +8135,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aFX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -8508,10 +8443,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aHl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -9408,10 +9340,7 @@
 	dir = 1;
 	icon_state = "ebulb1"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "aKV" = (
@@ -9955,10 +9884,7 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/arrivals)
 "aMW" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable/black{
 	icon_state = "4-8"
 	},
@@ -10168,10 +10094,7 @@
 	c_tag = "West Hallway North";
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
@@ -10249,6 +10172,7 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aOc" = (
@@ -10457,10 +10381,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aON" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -10934,11 +10855,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQP" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/storage/closet/office,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -10980,10 +10897,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aRa" = (
@@ -11050,10 +10964,7 @@
 "aRg" = (
 /obj/machinery/light/incandescent,
 /obj/storage/secure/closet/animal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/greenwhite{
 	dir = 9
 	},
@@ -11368,10 +11279,7 @@
 "aSu" = (
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
 /obj/shrub/captainshrub,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aSw" = (
@@ -11404,10 +11312,7 @@
 	tag = "null"
 	},
 /obj/machinery/light/incandescent,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 9
 	},
@@ -11767,10 +11672,7 @@
 	},
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/blood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -11915,10 +11817,7 @@
 	},
 /area/station/hallway/primary/east)
 "aUs" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -11951,10 +11850,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "aUA" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/vending/player/chemicals,
 /obj/disposalpipe/trunk/mail{
 	dir = 4
@@ -12372,10 +12268,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "red2"
@@ -12728,10 +12621,7 @@
 	dir = 4;
 	icon_state = "ebulb1"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aXu" = (
@@ -13934,10 +13824,7 @@
 	},
 /area/station/medical/medbay)
 "bbi" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -14190,10 +14077,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bbY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -14309,11 +14193,7 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bcA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/black,
@@ -14800,10 +14680,7 @@
 "beu" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fgreen6"
@@ -15201,10 +15078,7 @@
 /obj/machinery/camera{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bgh" = (
@@ -15775,11 +15649,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "biH" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -15811,11 +15681,7 @@
 /obj/stool/chair/red{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/blind_switch/area/west{
 	pixel_y = -6
 	},
@@ -16018,10 +15884,7 @@
 /area/station/maintenance/inner/central)
 "bjz" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bjA" = (
@@ -16322,10 +16185,7 @@
 "blm" = (
 /obj/rack,
 /obj/item/clothing/mask/horse_mask,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/market)
 "bln" = (
@@ -17494,10 +17354,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "bqh" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/chair,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -17940,11 +17797,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bso" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
 "bsq" = (
@@ -18145,11 +17998,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bte" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -18574,10 +18423,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
 "bvu" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -19135,10 +18981,7 @@
 	},
 /area/station/engine/engineering)
 "bxN" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/vending/jobclothing/engineering,
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -19582,10 +19425,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -19826,10 +19666,7 @@
 /area/station/engine/elect)
 "bAO" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bAP" = (
@@ -20328,10 +20165,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bDa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -20429,10 +20263,7 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bDD" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bDE" = (
@@ -20897,10 +20728,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "bFs" = (
@@ -23597,11 +23425,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "cPh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -23663,10 +23487,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -23988,10 +23809,7 @@
 	},
 /area/station/science/teleporter)
 "dgv" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/closet/wardrobe/grey,
 /turf/simulated/floor/white/side{
 	dir = 1
@@ -24433,10 +24251,7 @@
 /area/station/turret_protected/ai_upload)
 "dvb" = (
 /obj/storage/closet/wardrobe/white,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -24635,10 +24450,7 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "dCo" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "dCE" = (
@@ -24951,18 +24763,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
-"dPY" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_x = 32;
-	pixel_y = 64;
-	text = "NF"
-	},
-/obj/landmark/start/job/assistant,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "dQM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25088,10 +24888,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "dWy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/camera{
 	c_tag = "Cargo Bay";
 	dir = 8
@@ -25779,11 +25576,7 @@
 /area/station/maintenance/disposal)
 "ete" = (
 /obj/mopbucket,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/purple/side,
 /area/station/janitor/supply)
 "eto" = (
@@ -25819,10 +25612,7 @@
 	dir = 5;
 	level = 2
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -26404,10 +26194,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
@@ -26440,10 +26227,7 @@
 /obj/machinery/computer3/generic/secure_data{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redblack,
 /area/station/security/checkpoint/research)
 "ePd" = (
@@ -26527,10 +26311,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "eTy" = (
@@ -26632,10 +26413,7 @@
 "eXf" = (
 /obj/mic_stand,
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "eXu" = (
@@ -26680,10 +26458,7 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "eYM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -27198,10 +26973,7 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "frp" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/vending/monkey/kitchen,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -29660,11 +29432,7 @@
 "htQ" = (
 /obj/stool/bar,
 /obj/landmark/start/job/assistant,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "htU" = (
@@ -29968,11 +29736,7 @@
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "hFy" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "hFZ" = (
@@ -30168,11 +29932,7 @@
 "hSd" = (
 /obj/machinery/light/emergency,
 /obj/stool/bench/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "hSi" = (
@@ -30332,10 +30092,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "hYn" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -31646,11 +31403,7 @@
 /obj/decal/stage_edge/alt,
 /obj/item/clothing/glasses/sunglasses/tanning,
 /obj/landmark/start/job/assistant,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment{
 	dir = 1
 	},
@@ -32234,10 +31987,7 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "jwx" = (
@@ -33010,10 +32760,7 @@
 /obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "jZP" = (
@@ -33882,10 +33629,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "kHI" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/maintenance/west)
 "kHZ" = (
@@ -35337,10 +35081,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "lFi" = (
@@ -35353,10 +35094,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "lFr" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/dispenser{
 	o2tanks = 5;
 	pltanks = 15
@@ -35587,10 +35325,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "lMX" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -37243,10 +36978,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -37355,10 +37087,7 @@
 /obj/machinery/plantpot{
 	anchored = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "nbM" = (
@@ -37425,10 +37154,7 @@
 	},
 /area/station/security/main)
 "nfm" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "nfo" = (
@@ -38066,10 +37792,7 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "nFD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/emergency{
 	dir = 8;
 	icon_state = "ebulb1"
@@ -38181,10 +37904,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "nJv" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "nJw" = (
@@ -39280,11 +39000,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -40716,10 +40432,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "pxT" = (
@@ -41786,11 +41499,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -41809,10 +41518,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -41829,10 +41535,7 @@
 /obj/machinery/camera/ranch{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "qrB" = (
@@ -41902,10 +41605,7 @@
 "qtB" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/disposal/small/west,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/greenwhite/other{
 	dir = 4
@@ -42374,11 +42074,7 @@
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 25;
-	pixel_y = 6
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "qIv" = (
@@ -42454,10 +42150,7 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "qMr" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "qME" = (
@@ -42557,10 +42250,7 @@
 	dir = 8
 	},
 /obj/landmark/start/job/botanist,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "qPC" = (
@@ -43305,10 +42995,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "rvd" = (
@@ -45618,10 +45305,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "sUu" = (
@@ -45971,10 +45655,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "tiL" = (
@@ -46107,10 +45788,7 @@
 /obj/machinery/chem_master{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -46223,10 +45901,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/landmark/start/job/assistant,
@@ -46701,10 +46376,7 @@
 /area/station/solar/south)
 "tNV" = (
 /obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
@@ -47314,10 +46986,7 @@
 "umW" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/donkpocket_kit,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "umY" = (
@@ -47354,10 +47023,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "uod" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -47906,10 +47572,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "uOE" = (
@@ -48080,10 +47743,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "uUG" = (
@@ -48507,10 +48167,7 @@
 	},
 /area/station/medical/robotics)
 "vlL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/restroom)
 "vlV" = (
@@ -48527,10 +48184,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "vmt" = (
@@ -49063,11 +48717,7 @@
 /area/space)
 "vHM" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/inner)
 "vIi" = (
@@ -49766,10 +49416,7 @@
 /area/station/hallway/primary/east)
 "wkO" = (
 /obj/machinery/computer/card/department/security,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "wkR" = (
@@ -49916,11 +49563,7 @@
 /area/station/medical/medbay)
 "wpU" = (
 /obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "wqf" = (
@@ -50666,10 +50309,7 @@
 /obj/decoration/decorativeplant/plant3{
 	pixel_y = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/greenwhite/other{
 	dir = 6
 	},
@@ -50867,10 +50507,7 @@
 	},
 /area/station/crew_quarters/locker)
 "xhh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "xhF" = (
@@ -51232,10 +50869,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "xtu" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable/blue{
 	icon_state = "2-8"
 	},
@@ -51568,10 +51202,7 @@
 /area/station/crew_quarters/locker)
 "xHC" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "xHH" = (
@@ -52190,10 +51821,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -52329,10 +51957,7 @@
 	message = "1";
 	name = "mail chute-'Toxins'"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
@@ -90580,7 +90205,7 @@ aJC
 aJC
 aNr
 wOT
-dPY
+hEQ
 pBy
 mTi
 hEQ

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -354,10 +354,7 @@
 /turf/simulated/grass,
 /area/station/crew_quarters/garden)
 "abP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/medical/breakroom)
 "abS" = (
@@ -2126,10 +2123,7 @@
 /area/station/bridge)
 "aCt" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light/small/sticky/harsh,
 /obj/machinery/conveyor/EW{
 	id = "toxins_n2o";
@@ -2291,10 +2285,7 @@
 /obj/stool/chair/comfy/blue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -2387,9 +2378,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aFQ" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "aFX" = (
@@ -2402,10 +2391,7 @@
 	},
 /area/station/science/lobby)
 "aGc" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -25
-	},
+/obj/machinery/firealarm/south,
 /obj/machinery/light/incandescent/cool{
 	dir = 1
 	},
@@ -2762,9 +2748,7 @@
 	},
 /area/station/hallway/primary/west)
 "aLr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
@@ -3136,9 +3120,7 @@
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -3431,10 +3413,7 @@
 	tag = ""
 	},
 /obj/disposalpipe/segment/brig,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -4349,11 +4328,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "bjv" = (
@@ -4423,10 +4398,7 @@
 /area/station/medical/medbay)
 "bkm" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -7376,11 +7348,7 @@
 	},
 /area/station/bridge)
 "cdn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
@@ -7676,10 +7644,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/security{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white,
 /area/station/security/main)
 "chW" = (
@@ -8797,10 +8762,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "cyO" = (
@@ -9050,11 +9012,7 @@
 	pixel_x = -5;
 	pixel_y = -2
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "cCh" = (
@@ -9903,10 +9861,7 @@
 /area/station/hallway/primary/southeast)
 "cQT" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "cRf" = (
@@ -10107,10 +10062,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
@@ -10596,10 +10548,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/security/beepsky)
 "ddq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -11594,10 +11543,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "dtM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
 	dir = 4;
@@ -12218,10 +12164,7 @@
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
 "dFo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/wood/six,
 /area/station/library/reading2)
 "dFM" = (
@@ -12869,11 +12812,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "dQj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -13715,10 +13654,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -25
-	},
+/obj/machinery/firealarm/south,
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /obj/decal/mule/beacon,
 /turf/simulated/floor/redwhite,
@@ -14450,10 +14386,7 @@
 /area/station/maintenance/inner/sw)
 "epd" = (
 /obj/disposalpipe/junction/right/north,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 4
 	},
@@ -15114,11 +15047,7 @@
 	},
 /area/station/storage/emergency)
 "ezW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
 "eAc" = (
@@ -15411,10 +15340,7 @@
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "eGk" = (
@@ -15979,11 +15905,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "ePB" = (
@@ -16487,11 +16409,7 @@
 /area/station/security/main)
 "eXg" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "eXi" = (
@@ -16868,10 +16786,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/escape{
 	dir = 10
@@ -16939,10 +16854,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
 "fdY" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -17567,9 +17479,7 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /obj/item/clothing/glasses/spectro{
 	pixel_x = 4;
 	pixel_y = -2
@@ -18357,10 +18267,7 @@
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "fCl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/creamer{
 	pixel_x = -8;
@@ -18503,10 +18410,7 @@
 /obj/stool/chair/couch/green{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/landmark/start/job/botanist,
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
@@ -19930,10 +19834,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/bot/guardbot/bootleg,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 24
@@ -20935,10 +20836,7 @@
 /area/station/crew_quarters/sauna)
 "goz" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction2)
 "goB" = (
@@ -21004,11 +20902,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
 "gpK" = (
-/obj/machinery/firealarm{
-	pixel_x = -4;
-	pixel_y = 28;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/submachine/seed_manipulator{
 	dir = 4
 	},
@@ -21389,11 +21283,7 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/crate,
 /obj/item/shipcomponent/secondary_system/tractor_beam{
 	pixel_x = -10;
@@ -21657,9 +21547,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
 "gza" = (
@@ -22098,10 +21986,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -22753,10 +22638,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
 "gRd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/cart/forensic,
 /obj/item/storage/box/body_bag,
 /obj/item/storage/box/evidence,
@@ -23051,10 +22933,7 @@
 	},
 /area/station/crew_quarters/hor)
 "gVp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -23887,10 +23766,7 @@
 /area/station/ai_monitored/storage/eva)
 "hjI" = (
 /obj/stool/bench/auto,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/west)
 "hjJ" = (
@@ -25552,11 +25428,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
 "hKF" = (
@@ -25813,11 +25685,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "hOR" = (
@@ -26613,9 +26481,7 @@
 /area/station/turret_protected/ai_upload)
 "idH" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
 "idR" = (
@@ -26954,10 +26820,7 @@
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -27846,10 +27709,7 @@
 /area/station/solar/west)
 "ixI" = (
 /obj/machinery/light/incandescent/warm,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/circuit/red,
 /area/station/security/hos)
 "ixQ" = (
@@ -28078,11 +27938,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
 "iBf" = (
@@ -28147,10 +28003,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "iBU" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment,
 /obj/machinery/plantpot{
 	anchored = 1
@@ -28522,9 +28375,7 @@
 	dir = 1
 	},
 /obj/machinery/drainage/big,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "iHL" = (
@@ -29406,10 +29257,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fblue2"
@@ -29832,10 +29680,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "jcF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/wood/six,
 /area/station/library/reading1)
 "jcT" = (
@@ -31013,9 +30858,7 @@
 	name = "Funeral Parlor"
 	})
 "jvp" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
@@ -31215,9 +31058,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "jxC" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "jxI" = (
@@ -31791,10 +31632,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -33372,11 +33210,7 @@
 	},
 /area/station/security/quarters)
 "kfN" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/incandescent/blueish{
 	dir = 1
 	},
@@ -33482,9 +33316,7 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -34352,10 +34184,7 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
 "kxq" = (
@@ -35266,10 +35095,7 @@
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "kMn" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -35944,10 +35770,7 @@
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
 "kWT" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
@@ -36872,10 +36695,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "lmW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -38849,10 +38669,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
 "lPi" = (
@@ -40087,10 +39904,7 @@
 	},
 /area/station/crew_quarters/bar)
 "mhs" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood/eight{
 	dir = 1
 	},
@@ -41709,10 +41523,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/brig,
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
@@ -41960,20 +41771,14 @@
 	},
 /area/space)
 "mPb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
 "mPj" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light/small/sticky/harsh,
 /obj/machinery/conveyor/EW{
 	id = "toxins_n2o";
@@ -42010,11 +41815,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/rack,
 /obj/item/clothing/suit/bio_suit/paramedic{
 	pixel_x = -5;
@@ -42620,10 +42421,7 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -43554,9 +43352,7 @@
 /obj/machinery/light/incandescent/blueish{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
@@ -43843,10 +43639,7 @@
 	pixel_x = -7;
 	pixel_y = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "nqy" = (
@@ -44192,9 +43985,7 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "nwn" = (
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "nwD" = (
@@ -44594,10 +44385,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/outer/east)
 "nCG" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "nCO" = (
@@ -44716,10 +44504,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
 "nEN" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -44875,9 +44660,7 @@
 /area/station/maintenance/outer/nw)
 "nHn" = (
 /obj/stool/bench/yellow/auto,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},
@@ -45176,9 +44959,7 @@
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
 "nNc" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -45771,10 +45552,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "nWH" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -46534,10 +46312,7 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "olL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light/small/greenish,
 /obj/machinery/computer/announcement{
 	dir = 8;
@@ -47486,9 +47261,7 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "ozs" = (
@@ -47612,10 +47385,7 @@
 /area/station/maintenance/outer/north)
 "oBu" = (
 /obj/item/instrument/large/piano/grand,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/landmark/bill_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
@@ -49560,10 +49330,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "phx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
@@ -50385,10 +50152,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
 "ptY" = (
@@ -51277,10 +51041,7 @@
 "pIe" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/emergency,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/west)
 "pIf" = (
@@ -51787,10 +51548,7 @@
 	dir = 10;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -25
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black/grime,
 /area/station/security/interrogation)
 "pPa" = (
@@ -52100,11 +51858,7 @@
 /turf/simulated/floor/white,
 /area/station/security/main)
 "pTo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 24
@@ -53043,10 +52797,7 @@
 	},
 /obj/machinery/disposal/mail/small/autoname/qm/refinery/south,
 /obj/disposalpipe/trunk/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "qip" = (
@@ -53213,10 +52964,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "qll" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/brig,
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -54331,10 +54079,7 @@
 /area/station/crew_quarters/arcade/dungeon)
 "qBB" = (
 /obj/machinery/light/incandescent/warm,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "qBC" = (
@@ -55250,10 +54995,7 @@
 "qPX" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/green,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "blue2"
@@ -55358,11 +55100,7 @@
 	id = "toxins_o2";
 	operating = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/small/sticky/harsh,
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
@@ -55522,10 +55260,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -55599,10 +55334,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "qVv" = (
@@ -56328,9 +56060,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/food,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -56554,10 +56284,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "rkW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -56817,10 +56544,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -57088,10 +56812,7 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "rtp" = (
@@ -57138,10 +56859,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/redblack,
 /area/station/security/main)
 "ruz" = (
@@ -57236,10 +56954,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/routing/depot)
 "rwh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/greenwhite/other,
 /area/station/crew_quarters/market)
 "rww" = (
@@ -58004,10 +57719,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/green/fancy/narrow/east,
 /area/station/crew_quarters/cafeteria)
 "rIs" = (
@@ -60104,9 +59816,7 @@
 /turf/simulated/floor/specialroom/freezer/white,
 /area/station/security/hos)
 "srJ" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/greenwhite/other{
 	dir = 1
 	},
@@ -60584,10 +60294,7 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "syv" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -61016,10 +60723,7 @@
 	},
 /area/station/hallway/primary/south)
 "sHx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/brig,
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -61305,10 +61009,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "sMH" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/landmark/antagonist/blob,
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
@@ -61549,10 +61250,7 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "sRk" = (
@@ -62106,11 +61804,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
 "sZR" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/cloner)
@@ -62496,11 +62190,7 @@
 	},
 /area/station/security/main)
 "thj" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -63249,11 +62939,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
 "ttX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/small/sticky/cool/very,
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending things directly to the crematorium.";
@@ -63267,10 +62953,7 @@
 /area/station/medical/morgue)
 "tud" = (
 /obj/machinery/bot/firebot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -63608,10 +63291,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/hallway/primary/east)
 "tyI" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -63687,10 +63367,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/incandescent/warm,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/escape)
 "tAo" = (
@@ -65946,10 +65623,7 @@
 	},
 /area/station/solar/west)
 "ukA" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -25
-	},
+/obj/machinery/firealarm/south,
 /obj/table/reinforced/chemistry/auto/drugs,
 /obj/machinery/glass_recycler/chemistry,
 /turf/simulated/floor/purpleblack/corner,
@@ -67638,10 +67312,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/west)
 "uKy" = (
@@ -67804,11 +67475,7 @@
 /area/station/security/hos)
 "uNA" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/small/sticky/harsh,
 /obj/machinery/conveyor/WE{
 	id = "toxins_plasma";
@@ -68307,11 +67974,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/north,
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -68529,9 +68192,7 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "vau" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "vaw" = (
@@ -70322,10 +69983,7 @@
 /area/station/security/brig/north_side)
 "vBz" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/escape{
 	dir = 5
 	},
@@ -71999,10 +71657,7 @@
 /turf/simulated/floor/sand,
 /area/station/engine/engineering/ce)
 "wag" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/escape{
 	dir = 6
 	},
@@ -72028,11 +71683,7 @@
 	icon_state = "bedsheet-red"
 	},
 /obj/landmark/start/job/security_officer,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred2"
@@ -72709,10 +72360,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "wlk" = (
@@ -72795,9 +72443,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
@@ -73414,10 +73060,7 @@
 	icon_state = "line1"
 	},
 /obj/stool/chair/blue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "wvW" = (
@@ -75321,10 +74964,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
@@ -75335,9 +74975,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -76230,10 +75868,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/medical/asylum/computer)
 "xjn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -76610,10 +76245,7 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
@@ -77478,11 +77110,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = -1
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fblue2"
@@ -79172,10 +78800,7 @@
 	icon_state = "line2"
 	},
 /obj/machinery/light/small/floor/warm,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "yaI" = (
@@ -79939,10 +79564,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ylf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-8"
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1977,10 +1977,7 @@
 "agv" = (
 /obj/table/auto,
 /obj/item/shipcomponent/mainweapon/phaser,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -2371,10 +2368,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "ahH" = (
@@ -2740,10 +2734,7 @@
 /obj/stool/chair/wooden{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey,
 /area/station/chapel/sanctuary)
 "aiW" = (
@@ -3041,11 +3032,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ajN" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "ajO" = (
@@ -3178,11 +3165,7 @@
 "aki" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/glass/bottle/holywater,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "akj" = (
@@ -3509,10 +3492,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "alt" = (
@@ -3831,9 +3811,7 @@
 	},
 /area/station/security/checkpoint/podbay)
 "amr" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/secure/closet/brig,
 /obj/cable{
 	icon_state = "2-8"
@@ -4121,10 +4099,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -4944,11 +4919,7 @@
 "aqc" = (
 /obj/machinery/disposal/morgue,
 /obj/machinery/light/small,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/trunk/morgue{
 	dir = 8
 	},
@@ -5043,10 +5014,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aqw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/darkblue/checker,
 /area/station/crew_quarters/radio/news_office)
 "aqx" = (
@@ -5185,11 +5153,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
 "aqZ" = (
@@ -5478,9 +5442,7 @@
 	},
 /area/station/hallway/primary/west)
 "arS" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arU" = (
@@ -5857,9 +5819,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aty" = (
@@ -6406,9 +6366,7 @@
 /area/station/teleporter)
 "avD" = (
 /obj/machinery/computer/teleporter,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
@@ -7069,10 +7027,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "ayC" = (
@@ -7265,9 +7220,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -7286,11 +7239,7 @@
 	name = "Book Nook"
 	})
 "azu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
 "azv" = (
@@ -8818,10 +8767,7 @@
 /area/station/security/detectives_office)
 "aEY" = (
 /obj/disposalpipe/segment/mail/bent/east,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -10546,10 +10492,7 @@
 	},
 /area/station/hallway/primary/north)
 "aLZ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -10810,9 +10753,7 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "aNi" = (
@@ -11044,9 +10985,7 @@
 /area/station/medical/dome)
 "aOB" = (
 /obj/monkeyplant,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/item/device/radio/intercom/medical{
 	dir = 4;
 	pixel_x = -21
@@ -11465,9 +11404,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending things directly to the crematorium.";
 	name = "crematorium chute"
@@ -12305,11 +12242,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 1
 	},
@@ -12849,9 +12782,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "aVj" = (
@@ -13597,10 +13528,7 @@
 /area/station/crew_quarters/pool)
 "aXW" = (
 /obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/emergency,
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
@@ -13767,10 +13695,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -14133,11 +14058,7 @@
 /area/station/crew_quarters/barber_shop)
 "bao" = (
 /obj/machinery/vending/snack,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "bap" = (
@@ -14491,9 +14412,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bca" = (
@@ -14526,10 +14445,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -14899,11 +14815,7 @@
 /area/station/storage/emergency)
 "bdJ" = (
 /obj/storage/secure/closet/personal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -16050,10 +15962,7 @@
 	},
 /area/station/quartermaster/cargobay)
 "biy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/autoname,
 /turf/simulated/floor/blueblack{
@@ -16209,10 +16118,7 @@
 /obj/submachine/chef_sink{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bjo" = (
@@ -16223,11 +16129,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bjq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/stairs/wood,
 /area/station/crew_quarters/cafeteria)
 "bjs" = (
@@ -16295,9 +16197,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -16998,9 +16898,7 @@
 /area/station/medical/medbay)
 "bms" = (
 /obj/table/auto,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/bedsheetbin,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/remote/porter/port_a_nanomed,
@@ -17490,9 +17388,7 @@
 /area/station/mining/refinery)
 "bnW" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -18912,10 +18808,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -19464,10 +19357,7 @@
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
 "bwM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/engine,
 /area/station/mining/refinery)
 "bwN" = (
@@ -20635,9 +20525,7 @@
 	pixel_y = 5;
 	print_id = "Research"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -20660,9 +20548,7 @@
 "bCe" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "bCf" = (
@@ -20775,9 +20661,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bCt" = (
@@ -21578,10 +21462,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -22690,9 +22571,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/darkblue/checker,
 /area/station/science/artifact)
 "bIQ" = (
@@ -23261,11 +23140,7 @@
 	},
 /obj/rack,
 /obj/machinery/light/small,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/storage/toolbox/emergency,
 /obj/item/extinguisher,
 /turf/simulated/floor/engine{
@@ -23533,10 +23408,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/bridge/hos)
 "bLt" = (
@@ -23757,11 +23629,7 @@
 /turf/simulated/floor/caution/west,
 /area/station/quartermaster/office)
 "bMa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -24749,10 +24617,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/escape{
 	dir = 8
 	},
@@ -25309,10 +25174,7 @@
 /obj/machinery/recharger,
 /obj/item/cargotele,
 /obj/item/cargotele,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -26217,10 +26079,7 @@
 	name = "Research Router"
 	})
 "bUS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -27178,10 +27037,7 @@
 	dir = 5
 	},
 /obj/disposalpipe/segment/transport,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orange/side{
 	dir = 8
 	},
@@ -27314,11 +27170,7 @@
 /area/station/science/lab)
 "cat" = (
 /obj/storage/closet/biohazard,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/white/grime,
 /area/station/science/lab)
 "cau" = (
@@ -27372,9 +27224,7 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "caD" = (
@@ -27566,9 +27416,7 @@
 "cbt" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -28270,9 +28118,7 @@
 /area/station/science/lab)
 "cdO" = (
 /obj/machinery/vending/standard,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -29016,11 +28862,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -31536,10 +31378,7 @@
 /area/station/security/main)
 "coD" = (
 /obj/machinery/vending/security,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -32132,10 +31971,7 @@
 	},
 /obj/item/suture,
 /obj/item/clothing/mask/surgical_shield,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "cvg" = (
@@ -32477,11 +32313,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "cJr" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/processor,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -32548,11 +32380,7 @@
 /obj/storage/secure/closet/command/medical_director,
 /obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/item/clipboard,
 /obj/item/pen,
 /turf/simulated/floor/black,
@@ -33577,9 +33405,7 @@
 /area/station/hallway/primary/south)
 "dwm" = (
 /obj/random_item_spawner/armory_breaching_supplies,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
@@ -33609,9 +33435,7 @@
 	id = "qmbelthell";
 	layer = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
@@ -33955,11 +33779,7 @@
 /area/station/crew_quarters/catering)
 "dIn" = (
 /obj/machinery/vending/computer3,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "dIN" = (
@@ -35747,10 +35567,7 @@
 /area/station/hallway/primary/south)
 "eVl" = (
 /obj/storage/secure/closet/security/equipment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -36292,11 +36109,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "fnu" = (
@@ -37932,9 +37745,7 @@
 "gDw" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -38124,11 +37935,7 @@
 "gNp" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "gNw" = (
@@ -38292,10 +38099,7 @@
 /obj/stool/chair{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -38573,11 +38377,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "haQ" = (
@@ -39022,9 +38822,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "hvN" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/green/corner{
 	dir = 1
@@ -39184,11 +38982,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "hzL" = (
@@ -39406,9 +39200,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "hNV" = (
@@ -40442,9 +40234,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light_switch/east,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -40631,10 +40421,7 @@
 	dir = 1
 	},
 /obj/railing/orange/reinforced,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "iMJ" = (
@@ -41042,10 +40829,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "jej" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -41444,9 +41228,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_east)
 "jrT" = (
@@ -41473,10 +41255,7 @@
 /area/station/hallway/primary/west)
 "jsY" = (
 /obj/machinery/plantpot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "juf" = (
@@ -42311,10 +42090,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "kcs" = (
@@ -42499,10 +42275,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/south,
 /area/station/quartermaster/cargobay)
 "knF" = (
@@ -42741,10 +42514,7 @@
 /obj/item/kitchen/food_box/donut_box{
 	pixel_y = 5
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -42754,18 +42524,12 @@
 /obj/item/reagent_containers/patch/mini/synthflesh,
 /obj/item/reagent_containers/patch/mini/synthflesh,
 /obj/item/storage/firstaid/oxygen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
 "kxY" = (
 /obj/machinery/atmospherics/binary/valve,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "kyy" = (
@@ -43054,11 +42818,7 @@
 /area/station/crew_quarters/catering)
 "kLW" = (
 /obj/stool/bench/blue/auto,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "kMi" = (
@@ -43153,9 +42913,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/blind_switch/area/north{
 	pixel_x = -13
 	},
@@ -44054,11 +43812,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
 "lya" = (
@@ -44929,11 +44683,7 @@
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "mkl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
 "mkA" = (
@@ -46313,10 +46063,7 @@
 /area/station/crew_quarters/cafeteria)
 "nqy" = (
 /obj/reagent_dispensers/watertank/fountain,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -48067,10 +47814,7 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
 "oRT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
 	},
@@ -48425,11 +48169,7 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -48860,11 +48600,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable,
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/science/research_director)
@@ -49892,11 +49628,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "qnV" = (
@@ -50079,11 +49811,7 @@
 "qsU" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light,
 /turf/simulated/floor/red/side{
 	dir = 6
@@ -51210,11 +50938,7 @@
 "rsk" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light_switch/north,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -51699,10 +51423,7 @@
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/atmospheric,
 /obj/item/wrench,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "rNZ" = (
@@ -51893,10 +51614,7 @@
 /obj/item/scissors,
 /obj/item/razor_blade,
 /obj/item/clothing/head/bald_cap,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "rUu" = (
@@ -52349,11 +52067,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -53131,11 +52845,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
@@ -53655,9 +53365,7 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -54210,10 +53918,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/wrench,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "tMy" = (
@@ -56794,10 +56499,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "vPM" = (
@@ -57050,11 +56752,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "wbB" = (
@@ -57241,11 +56939,7 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair{
 	dir = 8
 	},
@@ -57536,10 +57230,7 @@
 /obj/item/reagent_containers/glass/bottle/eyedrops,
 /obj/storage/crate,
 /obj/item/reagent_containers/dropper,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey,
 /area/station/hydroponics/bay)
 "wwF" = (
@@ -58461,9 +58152,7 @@
 /obj/shrub{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "xgg" = (
@@ -58971,9 +58660,7 @@
 	name = "News Office Bathroom"
 	})
 "xxz" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/submachine/laundry_machine,
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -59031,10 +58718,7 @@
 /obj/stool/chair/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -59254,9 +58938,7 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/ce)
 "xIe" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "xIu" = (
@@ -60083,17 +59765,11 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "ylt" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -44,9 +44,7 @@
 	},
 /area/station/security/main)
 "abk" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blackwhite{
 	dir = 5
 	},
@@ -1136,10 +1134,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair/red{
 	dir = 8
 	},
@@ -1495,10 +1490,7 @@
 "aHP" = (
 /obj/storage/closet/wardrobe/grey,
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -2321,10 +2313,7 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "bdy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/security/detectives_office)
 "bdB" = (
@@ -2426,9 +2415,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -2968,9 +2955,7 @@
 	dir = 10;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -4377,10 +4362,7 @@
 	pixel_x = 8;
 	pixel_y = 3
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "bVu" = (
@@ -5599,10 +5581,7 @@
 /area/space)
 "cBd" = (
 /obj/reagent_dispensers/watertank/big,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
 "cBo" = (
@@ -6215,10 +6194,7 @@
 	name = "Head of Personnel's Quarters"
 	})
 "cQI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/stool/chair{
 	dir = 8
 	},
@@ -7078,10 +7054,7 @@
 /obj/item/storage/toilet{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/small/harsh,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7143,10 +7116,7 @@
 /area/station/maintenance/inner/west)
 "dns" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/engine/caution/west,
 /area/station/crew_quarters/baroffice)
 "dnt" = (
@@ -7646,10 +7616,7 @@
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/cloner)
 "dys" = (
@@ -7879,10 +7846,7 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light/small,
 /turf/simulated/floor/blackwhite{
 	dir = 6
@@ -8241,9 +8205,7 @@
 	pixel_y = 2
 	},
 /obj/stool/chair/office,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
@@ -8460,10 +8422,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/xraymachine,
 /turf/simulated/floor/purpleblack/corner{
@@ -9207,9 +9166,7 @@
 "ejU" = (
 /obj/stool/chair/office,
 /obj/landmark/start/job/roboticist,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "ekF" = (
@@ -9374,10 +9331,7 @@
 	},
 /area/station/hallway/primary/northeast)
 "enx" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine/caution/east,
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
@@ -9400,10 +9354,7 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
 "eok" = (
@@ -9830,10 +9781,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/arcade/dungeon)
 "ezi" = (
@@ -9960,9 +9908,7 @@
 /area/listeningpost)
 "eCf" = (
 /obj/machinery/vehicle/tank/minisub/secsub,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine/caution/misc{
 	dir = 6
 	},
@@ -10057,9 +10003,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 5
 	},
@@ -12101,9 +12045,7 @@
 /turf/simulated/floor/redblack,
 /area/station/security/brig)
 "fxE" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
@@ -14424,10 +14366,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
 "gxk" = (
@@ -15115,10 +15054,7 @@
 	name = "Book Nook"
 	})
 "gKz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "gKQ" = (
@@ -15892,10 +15828,7 @@
 "hay" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/power/data_terminal,
 /obj/item/storage/box/cablesbox{
 	pixel_x = -10;
@@ -16014,10 +15947,7 @@
 "hcq" = (
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
 /obj/shrub/captainshrub,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
 "hct" = (
@@ -16414,10 +16344,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "hkz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -16874,10 +16801,7 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/light/small,
 /turf/simulated/floor/blackwhite{
 	dir = 4
@@ -18234,10 +18158,7 @@
 /area/station/hallway/primary/southeast)
 "hTZ" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blackwhite{
 	dir = 1
 	},
@@ -18595,10 +18516,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -19954,10 +19872,7 @@
 /area/station/crew_quarters/fitness)
 "iCA" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine/caution/west,
 /area/station/ai_monitored/armory)
 "iCT" = (
@@ -21576,10 +21491,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
 "jqn" = (
@@ -22889,10 +22801,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
 "jSq" = (
@@ -24498,9 +24407,7 @@
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = 14
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
 "kxH" = (
@@ -24882,9 +24789,7 @@
 	})
 "kFc" = (
 /obj/stool/chair/comfy,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/bridge)
 "kFd" = (
@@ -25713,10 +25618,7 @@
 /obj/submachine/ATM{
 	pixel_y = 32
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/engine/caution/corner,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -25757,10 +25659,7 @@
 /obj/stool/chair/office/purple{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/teleporter)
 "kYj" = (
@@ -25771,10 +25670,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
@@ -25917,10 +25813,7 @@
 /obj/item/instrument/harmonica{
 	pixel_y = -9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
 "lbm" = (
@@ -25972,10 +25865,7 @@
 /obj/storage/cart/forensic{
 	req_access_txt = "4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "lcQ" = (
@@ -26139,10 +26029,7 @@
 /obj/machinery/chem_master{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -26701,10 +26588,7 @@
 /turf/space/fluid/acid/clear,
 /area/space)
 "ltn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/vending/jobclothing/medical,
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -29655,9 +29539,7 @@
 	pixel_x = -2;
 	pixel_y = 7
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "mDv" = (
@@ -29799,10 +29681,7 @@
 /area/station/chapel/office)
 "mGe" = (
 /obj/machinery/traymachine/morgue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "mGk" = (
@@ -29950,10 +29829,7 @@
 /obj/item/storage/box/glassbox{
 	pixel_x = 14
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/grey/side{
 	dir = 10
 	},
@@ -30094,10 +29970,7 @@
 /obj/item/device/reagentscanner,
 /obj/item/clothing/glasses/spectro,
 /obj/item/reagent_containers/dropper/mechanical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/hydroponics{
 	do_not_irradiate = 1;
@@ -30703,10 +30576,7 @@
 /area/station/quartermaster/refinery)
 "nbS" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -30888,10 +30758,7 @@
 	name = "Drop Capsule"
 	})
 "nfV" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -31178,10 +31045,7 @@
 /area/station/engine/elect)
 "nmm" = (
 /obj/machinery/plantpot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "nmv" = (
@@ -32397,10 +32261,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/quarters_east)
 "nOs" = (
@@ -33888,10 +33749,7 @@
 /area/space)
 "ozi" = (
 /obj/vehicle/segway,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -34082,10 +33940,7 @@
 	icon_state = "0-4"
 	},
 /obj/item/device/net_sniffer,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "oDI" = (
@@ -35297,10 +35152,7 @@
 "pdH" = (
 /obj/table/reinforced/industrial/auto,
 /obj/item/storage/toolbox/emergency,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/minitiles/black,
 /area/station/engine/inner{
 	name = "Transception Array Control"
@@ -36109,9 +35961,7 @@
 /area/station/storage/tech)
 "pwy" = (
 /obj/machinery/nanofab/nuclear,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -36413,10 +36263,7 @@
 /turf/simulated/floor/plating,
 /area/station/ranch)
 "pFf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -36461,10 +36308,7 @@
 /obj/item/kitchen/food_box/donut_box{
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "pFB" = (
@@ -36802,10 +36646,7 @@
 "pPd" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/engine/caution/east,
 /area/station/crew_quarters/cafeteria)
 "pPs" = (
@@ -36923,10 +36764,7 @@
 /obj/item/clothing/mask/balaclava{
 	pixel_x = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_east)
 "pRY" = (
@@ -37478,10 +37316,7 @@
 	},
 /area/ghostdrone_factory)
 "qei" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/greenblack/corner,
 /area/station/turret_protected/Zeta)
 "qeu" = (
@@ -39949,10 +39784,7 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/quarters_east)
 "rpX" = (
@@ -39964,10 +39796,7 @@
 /obj/item/device/audio_log,
 /obj/item/camera,
 /obj/item/device/radio/headset/multifreq,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
@@ -40130,10 +39959,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/west)
 "rtS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "ruj" = (
@@ -40722,9 +40548,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "rJg" = (
@@ -40751,10 +40575,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
@@ -40785,10 +40606,7 @@
 	layer = 10;
 	name = "palm tree"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
 "rKn" = (
@@ -41147,10 +40965,7 @@
 /obj/item/stamp/hop{
 	pixel_x = -15
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"
@@ -42511,10 +42326,7 @@
 	},
 /area/station/hallway/primary/southwest)
 "suT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/tile_edge/line/orange{
 	dir = 9;
 	icon_state = "line2"
@@ -42614,10 +42426,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -42986,10 +42795,7 @@
 /obj/item/stamp/hos{
 	pixel_y = 18
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/reagent_containers/food/snacks/spaghetti/spicy,
 /obj/item/kitchen/utensil/fork{
 	pixel_x = 9;
@@ -43247,10 +43053,7 @@
 /area/station/engine/core/nuclear)
 "sLf" = (
 /obj/monkeyplant,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -44047,9 +43850,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/stool/chair/couch/purple{
 	dir = 8
 	},
@@ -44117,10 +43918,7 @@
 /area/station/hallway/primary/southeast)
 "tel" = (
 /obj/machinery/flasher/portable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -44685,10 +44483,7 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargooffice)
 "tpv" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -46436,18 +46231,13 @@
 "ubV" = (
 /obj/storage/secure/closet/courtroom,
 /obj/item/paper/book/from_file/space_law,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
 "ucD" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "ucO" = (
@@ -47541,10 +47331,7 @@
 	},
 /area/station/science/chemistry)
 "uBa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/tile_edge/line/orange{
 	dir = 5;
 	icon_state = "line2"
@@ -48654,9 +48441,7 @@
 /turf/simulated/floor,
 /area/pasiphae/bridge)
 "veU" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/trunk/mail/north,
 /obj/machinery/disposal/chemlink,
 /turf/simulated/floor/purpleblack{
@@ -49117,10 +48902,7 @@
 /obj/disposalpipe/trunk/mineral{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},
@@ -50176,10 +49958,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/storage/wall{
 	icon_state = "minipurple";
 	name = "siphon blueprint cache";
@@ -52014,9 +51793,7 @@
 /obj/item/device/multitool{
 	pixel_x = 14
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -53231,9 +53008,7 @@
 	},
 /area/station/storage/eva)
 "xnI" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/bridge/customs{
 	name = "Bridge Reception"
@@ -53332,9 +53107,7 @@
 /area/station/crew_quarters/lounge)
 "xqT" = (
 /obj/machinery/teleport/portal_generator,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -54274,10 +54047,7 @@
 /obj/machinery/traymachine/morgue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/blackwhite{
 	dir = 4
 	},
@@ -54492,10 +54262,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/submachine/seed_vendor,
 /turf/simulated/floor/greenblack{
 	dir = 4
@@ -54716,10 +54483,7 @@
 /obj/stool/chair/office/blue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "xVO" = (
@@ -55044,9 +54808,7 @@
 	icon_state = "chair_couch-blue";
 	name = "ratty blue couch"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
 "ydi" = (
@@ -55093,10 +54855,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -55276,10 +55035,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "yjm" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -207,10 +207,7 @@
 /area/station/hangar/engine)
 "aaP" = (
 /obj/table/auto,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
@@ -537,11 +534,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/power)
 "abF" = (
@@ -1330,11 +1323,7 @@
 /area/station/security/interrogation)
 "aef" = (
 /obj/blind_switch/area/east,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "aeg" = (
@@ -1916,11 +1905,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "agf" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agg" = (
@@ -2442,10 +2427,7 @@
 	dir = 2;
 	name = "crematorium pipe"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "ahV" = (
@@ -2536,11 +2518,7 @@
 "aik" = (
 /obj/storage/secure/closet/animal,
 /obj/landmark/spawner/inside/monkey,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/green,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -3037,11 +3015,7 @@
 /area/station/medical/medbay/surgery/storage)
 "ajR" = (
 /obj/machinery/vending/medical,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -3339,11 +3313,7 @@
 	icon_state = "line1"
 	},
 /obj/item/scissors/surgical_scissors,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "akK" = (
@@ -4665,11 +4635,7 @@
 	},
 /area/station/security/main)
 "aoY" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/wood/round/auto,
 /obj/machinery/computer3/generic/personal{
 	pixel_y = 6
@@ -4717,11 +4683,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
 "apf" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
@@ -5741,10 +5703,7 @@
 /area/research_outpost/toxins)
 "asf" = (
 /obj/machinery/light/incandescent/cool,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/closet/fire,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 1
@@ -5992,10 +5951,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake,
 /obj/item/reagent_containers/food/snacks/beefood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/wood,
 /area/station/science/research_director)
 "asS" = (
@@ -6152,10 +6108,7 @@
 /area/station/crew_quarters/lounge)
 "ato" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -6796,10 +6749,7 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/medical)
 "avr" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/clown)
 "avs" = (
@@ -6840,10 +6790,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
@@ -6953,11 +6900,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
 "avN" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
 "avO" = (
@@ -7299,11 +7242,7 @@
 /area/ghostdrone_factory)
 "awL" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -7383,11 +7322,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "awY" = (
@@ -7460,10 +7395,7 @@
 /area/ghostdrone_factory)
 "axn" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "axu" = (
@@ -7483,11 +7415,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "axx" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "axy" = (
@@ -7547,11 +7475,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/medical)
 "axF" = (
@@ -7700,10 +7624,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/warehouse)
 "ayb" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ayc" = (
@@ -7794,10 +7715,7 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ayt" = (
@@ -8378,11 +8296,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "azY" = (
@@ -8759,11 +8673,7 @@
 /area/station/hallway/primary/east)
 "aBf" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -9429,11 +9339,7 @@
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "aDt" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/computer/telescope,
 /turf/simulated/floor,
 /area/station/science/teleporter)
@@ -9612,10 +9518,7 @@
 	},
 /area/station/hallway/primary/west)
 "aDV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aDW" = (
@@ -10084,10 +9987,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
 "aFp" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
@@ -10124,10 +10024,7 @@
 /obj/item/item_box/assorted/stickers/stickers_limited{
 	pixel_y = 14
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade/dungeon)
 "aFx" = (
@@ -10136,10 +10033,7 @@
 /obj/item/sheet/glass/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/sheet/steel/reinforced/fullstack,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
@@ -10249,10 +10143,7 @@
 	dir = 4;
 	pixel_x = -2
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aFR" = (
@@ -10412,11 +10303,7 @@
 	dir = 8;
 	pixel_x = 2
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aGr" = (
@@ -10577,11 +10464,7 @@
 "aGO" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/light/incandescent/greenish,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -10768,11 +10651,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -11026,10 +10905,7 @@
 /obj/item/sponge,
 /obj/item/caution,
 /obj/item/caution,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "aIh" = (
@@ -11179,11 +11055,7 @@
 /area/station/storage/tech)
 "aIJ" = (
 /obj/item/device/net_sniffer,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -11243,11 +11115,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
@@ -11261,11 +11129,7 @@
 /area/station/science/chemistry)
 "aIU" = (
 /obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -11389,11 +11253,7 @@
 /turf/simulated/floor/wood,
 /area/station/science/lobby)
 "aJh" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -11818,11 +11678,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aKu" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aKv" = (
@@ -12169,10 +12025,7 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "aLH" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
@@ -13174,11 +13027,7 @@
 /area/listeningpost)
 "aPI" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -13272,10 +13121,7 @@
 /obj/table/wood/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/gun/russianrevolver,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
 "aPW" = (
@@ -13644,11 +13490,7 @@
 	},
 /area/research_outpost/toxins)
 "aRg" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/science)
@@ -13856,11 +13698,7 @@
 /obj/item/extinguisher,
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/plating/random,
 /area/station/storage/emergency2)
 "aRW" = (
@@ -14288,11 +14126,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
@@ -16876,10 +16710,7 @@
 /area/station/engine/gas)
 "beR" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -16943,11 +16774,7 @@
 /area/station/crew_quarters/data)
 "bfe" = (
 /obj/storage/crate/rcd/CE,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
 "bff" = (
@@ -17917,10 +17744,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bjj" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bjk" = (
@@ -17942,10 +17766,7 @@
 /obj/item/tank/air,
 /obj/item/chem_grenade/firefighting,
 /obj/item/chem_grenade/firefighting,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/storage/eeva)
@@ -18733,11 +18554,7 @@
 /area/station/storage/emergency)
 "bme" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bmf" = (
@@ -19123,11 +18940,7 @@
 	},
 /area/station/engine/elect)
 "bnn" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -19171,10 +18984,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/storage/secure/closet/engineering/welding,
 /turf/simulated/floor/black,
 /area/station/engine/inner)
@@ -19399,10 +19209,7 @@
 /area/station/engine/power)
 "bol" = (
 /obj/kitchenspike,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "bon" = (
@@ -19639,10 +19446,7 @@
 	},
 /area/station/crew_quarters/fitness)
 "boY" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/caution/north,
 /area/station/crew_quarters/fitness)
 "boZ" = (
@@ -19790,10 +19594,7 @@
 /area/station/crew_quarters/catering)
 "bpx" = (
 /obj/machinery/light/incandescent/cool/very,
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "bpy" = (
@@ -20552,10 +20353,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/observatory)
 "brL" = (
@@ -20887,11 +20685,7 @@
 /area/station/hallway/primary/east)
 "bsS" = (
 /obj/disposalpipe/segment/brig,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -21087,10 +20881,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "btA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/secure/closet/engineering/engineer,
 /obj/cable{
 	icon_state = "4-8"
@@ -21258,11 +21049,7 @@
 /obj/item/clothing/head/helmet/camera{
 	camera_tag = "Helmet Cam 1"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/table/round/auto,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -21641,11 +21428,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -21916,11 +21699,7 @@
 "bwg" = (
 /obj/shrub/captainshrub,
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/purple/standard/narrow/nw,
 /area/station/crew_quarters/captain)
 "bwh" = (
@@ -22003,11 +21782,7 @@
 /area/station/security/main)
 "bws" = (
 /obj/storage/secure/closet/command/hop,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -22041,11 +21816,7 @@
 "bwC" = (
 /obj/table/auto,
 /obj/machinery/recharger,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bwF" = (
@@ -22276,11 +22047,7 @@
 	},
 /area/station/crew_quarters/market)
 "bxn" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -22367,10 +22134,7 @@
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_triple,
 /area/station/crew_quarters/bar)
 "bxB" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/manufacturer/qm,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -22736,11 +22500,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -22815,11 +22575,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bzc" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon17,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -22912,10 +22668,7 @@
 	},
 /area/station/engine/engineering)
 "bzu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -23022,11 +22775,7 @@
 /area/station/bridge/customs)
 "bzN" = (
 /obj/stool/bench/green,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
 /area/station/bridge/customs)
 "bzO" = (
@@ -23419,11 +23168,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "bAQ" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -23535,10 +23280,7 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/customs)
 "bBk" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -23849,11 +23591,7 @@
 /turf/space/fluid,
 /area/space)
 "bCj" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "bCk" = (
@@ -24208,10 +23946,7 @@
 /obj/item/clothing/suit/space/diving/civilian,
 /obj/item/clothing/head/helmet/space/engineer/diving/civilian,
 /obj/item/clothing/mask/breath,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/item/clothing/shoes/flippers{
 	pixel_y = -12
 	},
@@ -24305,11 +24040,7 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bDG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/communications{
 	dir = 8
@@ -24566,10 +24297,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -24825,10 +24553,7 @@
 /obj/disposalpipe/trunk/south{
 	pixel_z = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
@@ -25208,20 +24933,13 @@
 	dir = 4
 	},
 /obj/shrub,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/crew_quarters/market)
 "bGC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/machinery/light/incandescent/netural,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
@@ -25433,10 +25151,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bHh" = (
@@ -25489,10 +25204,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bHq" = (
@@ -26385,10 +26097,7 @@
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bKm" = (
@@ -26434,10 +26143,7 @@
 /area/station/quartermaster/office)
 "bKr" = (
 /obj/machinery/vending/pizza,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "bKs" = (
@@ -26464,10 +26170,7 @@
 /area/station/crew_quarters/jazz)
 "bKw" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -26496,10 +26199,7 @@
 	},
 /area/station/quartermaster/refinery)
 "bKA" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mineral{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -27053,11 +26753,7 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bMq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -27098,11 +26794,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bMx" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bMy" = (
@@ -27144,11 +26836,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/oshan_arrivals)
 "bMG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/oshan_arrivals)
 "bMH" = (
@@ -27739,10 +27427,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/security/main)
 "bOF" = (
@@ -27806,10 +27491,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -28564,10 +28246,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bQT" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/hallway/secondary/oshan_arrivals)
 "bQU" = (
@@ -29049,10 +28728,7 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/electronics/scanner,
 /obj/item/device/analyzer/healthanalyzer,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/grime{
 	dir = 8
@@ -29097,10 +28773,7 @@
 /area/station/storage/warehouse)
 "bSs" = (
 /obj/machinery/vending/cola/blue,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "bSt" = (
@@ -29263,11 +28936,7 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bSW" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -29522,11 +29191,7 @@
 /area/station/maintenance/disposal)
 "bTJ" = (
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bTK" = (
@@ -29553,10 +29218,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/security/processing)
 "bTN" = (
@@ -29963,10 +29625,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "bVh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -33043,11 +32702,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "cfu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/south,
 /obj/table/wood/auto/desk,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
@@ -34326,10 +33981,7 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "clw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "clx" = (
@@ -34968,11 +34620,7 @@
 /turf/simulated/floor/plating/random,
 /area/diner/kitchen)
 "cSV" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -35348,11 +34996,7 @@
 /obj/item/clothing/shoes/brown,
 /obj/item/clothing/head/bald_cap,
 /obj/item/clothing/head/wig,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "dyC" = (
@@ -35777,10 +35421,7 @@
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade)
 "eec" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /obj/storage/secure/closet/civilian/bartender,
 /obj/item/hand_labeler,
 /turf/simulated/floor/carpet/grime,
@@ -35901,11 +35542,7 @@
 /area/station/engine/elect)
 "eiV" = (
 /obj/machinery/manufacturer/uniform,
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/blind_switch/area/east{
 	pixel_y = 4
 	},
@@ -36683,11 +36320,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/inner/central)
 "fsJ" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
 "fsN" = (
@@ -36890,9 +36523,7 @@
 /obj/item/clothing/suit/jacket/yellow,
 /obj/item/clothing/suit/jacket/plastic,
 /obj/item/clothing/under/misc/vice,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "fJb" = (
@@ -37333,10 +36964,7 @@
 "gtP" = (
 /obj/stool/chair,
 /obj/landmark/start/job/chaplain,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred2"
@@ -37413,10 +37041,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
 "gzQ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/decal/tile_edge/line/black{
 	dir = 8;
 	icon_state = "line1"
@@ -39670,11 +39295,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
 "kVp" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -40280,11 +39901,7 @@
 	},
 /area/station/medical/medbay/cloner)
 "lXd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/crew_quarters/quartersA)
@@ -41264,10 +40881,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "nAU" = (
@@ -41997,11 +41611,7 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "oPP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
+/obj/machinery/firealarm/east,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -42375,10 +41985,7 @@
 /obj/machinery/computer/arcade{
 	desc = "The VR representation of a popular computer game."
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "pxV" = (
@@ -42591,10 +42198,7 @@
 "pMt" = (
 /obj/machinery/light/incandescent/cool,
 /obj/storage/secure/closet/medical/cloning,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/white/checker2{
 	dir = 5
 	},
@@ -42710,10 +42314,7 @@
 	},
 /area/station/medical/dome)
 "pWz" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/west,
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
 /area/station/hangar/catering{
@@ -44493,11 +44094,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "tAS" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "tBo" = (
@@ -44703,10 +44300,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "tXn" = (
@@ -44921,11 +44515,7 @@
 	},
 /area/station/medical/medbay/surgery/storage)
 "uyg" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
+/obj/machinery/firealarm/north,
 /obj/storage/closet/fire,
 /turf/simulated/floor,
 /area/research_outpost/hangar)
@@ -46644,10 +46234,7 @@
 /area/station/crew_quarters/arcade/dungeon)
 "xAp" = (
 /mob/living/critter/small_animal/mouse/remy,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "xBl" = (


### PR DESCRIPTION
[MAPPING]
## About the PR
Replaces nearly every fire alarm in every rotation map with the new subtypes with built in pixel offsets. Doesn't change any that have both pixel x and pixel y, unless one is unneeded.

## Why's this needed?
A lot of southward alarms had the south facing sprite instead of the north facing. Similarly a lot (if not all) of east facing alarms used the west dir instead, as they sat on a west wall. Easy mistake to make, given that the "right way up" isn't terribly obvious. Those should be fixed now.
Also, there are multiple different offsets for the same direction, so the var edited pixel offsets could have multiple different ones. Now they are more uniform. Which I feel is better.
Also, by using subtypes instead of var editing, we have saved 3,283 lines of dmm files. Minor but still valid.