### PR TITLE
Adds the "liquid code"-chem to the code-worm-fish and adds AI cores as additional fishing spot

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4076,6 +4076,18 @@ datum
 			transparency = 20
 			bioeffect_id = "accent_swedish"
 
+		fooddrink/temp_bioeffect/liquid_code
+			name = "liquid code"
+			id = "liquid_code"
+			description = "A tangy substance with numbers shimmering in it."
+			fluid_r = 50
+			fluid_g = 185
+			fluid_b = 120
+			transparency = 65
+			taste = list("spaghetti-like")
+			bioeffect_id = "accent_hacker"
+
+
 		fooddrink/temp_bioeffect/innitium
 			name = "innitium"
 			id = "innitium"

--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -503,6 +503,10 @@ Alien/mutant/other fish:
 		global.processing_items -= src
 		. = ..()
 
+	make_reagents()
+		..() //it still contains fish oil
+		src.reagents.add_reagent("liquid_code",10)
+
 	process()
 		if (prob(30))
 			src.hologram_effect(TRUE)

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -790,3 +790,13 @@ datum/fishing_spot/golden_toilet
 	/obj/item/disk/data/cartridge/clown = 15,\
 	/obj/item/disk/data/cartridge/ringtone_beepy = 5)
 
+//AI-core
+/datum/fishing_spot/ai_core
+	fishing_atom_type = /mob/living/silicon/ai
+	rod_tier_required = 3
+	fish_available = list(/obj/item/reagent_containers/food/fish/code_worm = 40,\
+	/obj/item/reagent_containers/food/fish/goldfish = 10, \
+	/obj/item/cable_coil/reinforced = 20,\
+	/obj/item/cell/shell_cell = 10, \
+	/obj/item/disk/data/cartridge/clown = 15,\
+	/obj/item/disk/data/cartridge/ringtone_beepy = 5)


### PR DESCRIPTION
[CHEMISTRY][SILICONS][GAME-OBJECTS][FEATURE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR enables anglers to fish in AI's. For this, a T3 fishing rod is required. Noteable loot contains reinforced cable coils and code worms.

Also, this PR adds the liquid code-chem. It can only be found in code worms (making it fishing-exclusive). It is a accent-chem that adds the Leetspeak-accent when injected into someone.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, rare fishes themselves need some mechanical rewards, and this PR provides a humorous chem to one. Since this is a rather rare accent, moving this behind a T3 fish makes sense.

Also, this PR adds a fishing spot where the fish in question can be aquired. The other fishing spot code worms can be found is the mainframe, which is an equal highly defended spot full of code, so the placing makes sense.

Also, i personally like the thought of doing RP with an AI while you pull fish out of its brain. The goldfish is added for this reason ("Memory of a goldfish").

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Master anglers are able to fish in AIs now!
(+)Code worms seem to be filled with a new chemical, liquid code.
```
