### PR TITLE
Add more ashtrays and cigarette vendors to bar.

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7170,7 +7170,6 @@
 	dir = 4
 	},
 /obj/decal/stage_edge,
-/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "aCv" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7170,6 +7170,7 @@
 	dir = 4
 	},
 /obj/decal/stage_edge,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "aCv" = (
@@ -7760,6 +7761,7 @@
 "aEy" = (
 /obj/table/wood/auto,
 /obj/item/card_box/plain,
+/obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fpurple1"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -10531,7 +10531,6 @@
 /area/station/crew_quarters/kitchen)
 "aDw" = (
 /obj/table/reinforced/bar/auto,
-/obj/item/decoration/ashtray,
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
 	},
@@ -11072,6 +11071,7 @@
 "aES" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/card_box/plain,
+/obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet{
 	icon_state = "fpurple1"
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -32886,6 +32886,7 @@
 	pixel_y = 7
 	},
 /obj/item/clothing/mask/cigarette/propuffs,
+/obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -44740,6 +44741,11 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"sse" = (
+/obj/machinery/light/incandescent,
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "ssf" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/horizontal,
@@ -75209,7 +75215,7 @@ aCy
 mmb
 azU
 bgH
-bjs
+sse
 ygD
 bwR
 bjo

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -45246,6 +45246,7 @@
 	layer = 3.1;
 	name = "Bar Shutter"
 	},
+/obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 8
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -42442,7 +42442,6 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/vending/cigarette,
 /turf/simulated/floor/black/corner{
 	dir = 1
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -42442,6 +42442,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/black/corner{
 	dir = 1
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -39876,10 +39876,6 @@
 /obj/machinery/navbeacon/mule/hydroponics_north,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"lpX" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/specialroom/bar,
-/area/station/crew_quarters/bar)
 "lqc" = (
 /obj/decal/fakeobjects/skeleton,
 /obj/item/mining_tool/powerhammer,
@@ -82272,7 +82268,7 @@ nyX
 cLa
 aQl
 dwx
-lpX
+biB
 bjh
 bjX
 bjX

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -18879,6 +18879,7 @@
 /area/station/crew_quarters/bar)
 "bmz" = (
 /obj/table/reinforced/bar/auto,
+/obj/item/decoration/ashtray,
 /turf/simulated/floor/carpet/blue/fancy/narrow/se,
 /area/station/crew_quarters/bar)
 "bmA" = (
@@ -39875,6 +39876,10 @@
 /obj/machinery/navbeacon/mule/hydroponics_north,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"lpX" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/bar)
 "lqc" = (
 /obj/decal/fakeobjects/skeleton,
 /obj/item/mining_tool/powerhammer,
@@ -82267,7 +82272,7 @@ nyX
 cLa
 aQl
 dwx
-biB
+lpX
 bjh
 bjX
 bjX


### PR DESCRIPTION
[MAPPING] [QOL]
## About the PR
It was noticed that the donut2 bar doesn't have an ashtray nor a nearby cigarette vendor. I decided to make sure every bar had an ashtray, and a cigarette machine reasonably close by.

## Why's this needed?
Let smokers rp. Also map consistency is nice.

## Changelog
```changelog
(u)Tyrant
(+)All bars now have an ashtray and a nearby cigarette vendor.
```