### PR TITLE
Clean up skeleton bone pieces in Critter Gauntlet

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -479,6 +479,8 @@
 				qdel(P)
 		for (var/obj/item/electronics/E in gauntlet)
 			qdel(E)
+		for(var/obj/item/material_piece/M in gauntlet)
+			qdel(M)
 
 		current_level++
 		current_waves.len = 0


### PR DESCRIPTION
[BUG] [TRIVIAL] [MOBS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bone material pieces in the gauntlet get cleaned along with the rest of stuff when waves end.

## Why's this needed?
Skeletons in the gauntlet gib with a LOT of bone pieces on death and it gets messy. There are a few miscellaneous items that also don't clean themselves but there's far more loot than such items.
