### PR TITLE
Remove some unused options from security weapons vendor

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -124,10 +124,7 @@
 		materiel_stock += new/datum/materiel/utility/morphineinjectors
 		materiel_stock += new/datum/materiel/utility/donuts
 		materiel_stock += new/datum/materiel/utility/flashbangs
-		materiel_stock += new/datum/materiel/utility/detscanner
 		materiel_stock += new/datum/materiel/utility/nightvisionsechudgoggles
-		materiel_stock += new/datum/materiel/utility/markerrounds
-		materiel_stock += new/datum/materiel/utility/prisonerscanner
 		materiel_stock += new/datum/materiel/ammo/medium
 		materiel_stock += new/datum/materiel/ammo/self_charging
 		materiel_stock += new/datum/materiel/assistant/basic


### PR DESCRIPTION
[GAME OBJECTS][REMOVAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just removes some options that are very rarely bought from the security weapons vendor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They are almost never bought, it just tends to be that the other utlities are more worth spending the points on.

Also,
Forensics scanner - Security PDAs already have enough forensics capability for nearly all forensics needs
Paint marker rounds - Need to land a direct hit to help track a target when they're escaping. Almost all the time, the target escapes and you can't track them already, or the AI can track them for you
RecordTrak - These already lie around security, there's never a need to buy a new one

Not really a situation warranting getting a security token from the armory just to get one of these things