### PR TITLE
Fixes failing to cast ability still triggering cooldown

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -967,7 +967,7 @@
 				return CAST_ATTEMPT_FAIL_DO_COOLDOWN
 			if (!castcheck(target))
 				src.holder.locked = FALSE
-				return CAST_ATTEMPT_FAIL_DO_COOLDOWN
+				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 			var/datum/abilityHolder/localholder = src.holder
 			. = cast(target, params)
 			if(!QDELETED(localholder))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15609, fixes #15514, fixes #13662 by making castcheck() failing return CAST_ATTEMPT_FAIL_NO_COOLDOWN instead of CAST_ATTEMPT_FAIL_DO_COOLDOWN

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When abilities were being refactored some months ago the logic of cooldowns was changed such that the value that CAST_ATTEMPT_FAIL_DO_COOLDOWN was before (998) started triggering cooldowns when it previously did not.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)Using an ability while incapacitated or otherwise unable to will no longer trigger the cooldown anyways.
```
