### PR TITLE
Chem dispenser record button responsiveness

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -398,6 +398,7 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 					src.eject_card()
 					src.update_account()
 					update_static_data(usr,ui)
+					. = TRUE
 				else
 					var/obj/item/I = usr.equipped()
 					if (istype(I, /obj/item/card/id) || istype(I, /obj/item/card/data))
@@ -406,11 +407,14 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 						src.user_id = I
 						src.update_account()
 						update_static_data(usr,ui)
+						. = TRUE
 				return
 			if ("record")
 				src.recording_state = !src.recording_state
+				. = TRUE
 			if ("clear_recording")
 				src.recording_queue = list()
+				. = TRUE
 
 /obj/machinery/chem_dispenser/chemical
 	New()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Indicates that the UI should be updated after clicking the semi-recent Stop/Record/Clear ChemDispenser buttons
(ui_act comment: * return bool If the UI should be updated or not.)
https://github.com/goonstation/goonstation/assets/6396368/ddd09c66-273d-483b-b823-fd4ff41f3d3c

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Responsiveness good, it being slow made me think things weren't ready to record and that it was processing something big

[UI][QoL][Bug]
