### PR TITLE
N.A.R.C Turrets now check for access instead of icon_state

### DIFF
--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -498,15 +498,7 @@ ABSTRACT_TYPE(/obj/deployable_turret)
 		var/obj/item/card/id/I = C.get_id()
 		if(!istype(I))
 			return FALSE
-		switch(I.icon_state)
-			if("id_sec")
-				return TRUE
-			if("id_com")
-				return TRUE
-			if("gold")
-				return TRUE
-			else
-				return FALSE
+		. = (access_security in I.access) || (access_heads in I.access)
 
 /obj/deployable_turret/riot/active
 	anchored = ANCHORED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out originally N.A.R.C turrets checked for the icon_state of the ID, this changes it, meaning that it looks for access_security and access_heads instead.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents the turrets being avoided by just an Agent Card, should generally make plans for robbing the armoury just a tiny bit more interesting

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)444explorer
(+)NARC Turrets now make sure you have Security or Bridge access before firing, instead of ID band
```
