### PR TITLE
allow matsci procs to use both typepaths and matid

### DIFF
--- a/code/modules/admin/atom_verbs.dm
+++ b/code/modules/admin/atom_verbs.dm
@@ -45,11 +45,11 @@ var/global/atom_emergency_stop = 0
 		if (!sleep_time)
 			return
 
-		if (!material_cache.len)
+		if (!material_cache_matid.len)
 			boutput(usr, "<span class='alert'>Error detected in material cache, attempting rebuild. Please try again.</span>")
 			buildMaterialCache()
 			return
-		var/mat = input(usr,"Select Material:","Material",null) in material_cache
+		var/mat = input(usr,"Select Material:","Material",null) in material_cache_matid
 		if(!mat)
 			return
 

--- a/code/modules/admin/buildmodes/meteor.dm
+++ b/code/modules/admin/buildmodes/meteor.dm
@@ -19,6 +19,6 @@ Ctrl-RMB on buildmode button = select material
 
 	click_mode_right(ctrl, alt, shift)
 		if (ctrl)
-			src.transmute_material = tgui_input_list(usr, "Pick material", "Meteor material", material_cache)
+			src.transmute_material = tgui_input_list(usr, "Pick material", "Meteor material", material_cache_matid)
 		else
 			src.meteor_type = tgui_input_list(usr, "Pick meteor type", "Meteor type", concrete_typesof(/obj/newmeteor)) || src.meteor_type

--- a/code/modules/admin/buildmodes/transmute.dm
+++ b/code/modules/admin/buildmodes/transmute.dm
@@ -9,11 +9,11 @@ Right Mouse Button on buildmode    = Set material ID<br>
 	var/mat_id = null
 
 	click_mode_right(var/ctrl, var/alt, var/shift)
-		if (!material_cache.len)
+		if (!material_cache_matid.len)
 			boutput(usr, "<span class='alert'>Error detected in material cache, attempting rebuild. Please try again.</span>")
 			buildMaterialCache()
 			return
-		var/mat = tgui_input_list(usr, "Select material: ", "Material", material_cache)
+		var/mat = tgui_input_list(usr, "Select material: ", "Material", material_cache_matid)
 		if(!mat)
 			return
 		mat_id = mat

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1551,7 +1551,7 @@
 	set popup_menu = 0
 
 	ADMIN_ONLY
-	var/matid = tgui_input_list(src, "Select material to transmute to:", "Set Material", material_cache)
+	var/matid = tgui_input_list(src, "Select material to transmute to:", "Set Material", material_cache_matid)
 	var/material_selected = getMaterial(matid)
 	if(!material_selected)
 		alert(src, "Invalid material selected: [matid]", "Invalid Material", "Ok")

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -49,7 +49,7 @@ var/global/meteor_shower_active = 0
 				if(prob(50))
 					transmute_material_instead = "jean"
 				else
-					transmute_material_instead = pick(material_cache)
+					transmute_material_instead = pick(material_cache_matid)
 			#endif
 		if(istext(transmute_material_instead))
 			transmute_material_instead = getMaterial(transmute_material_instead)
@@ -231,10 +231,10 @@ var/global/meteor_shower_active = 0
 
 		var/transmute_material_instead = null
 		if(tgui_alert(usr, "Do you want the meteor to transmute into a material instead of exploding?", "Meteor Shower", list("Yes", "No")) == "Yes")
-			var/matid = tgui_input_list(usr, "Select material to transmute to:", "Set Material", material_cache)
+			var/matid = tgui_input_list(usr, "Select material to transmute to:", "Set Material", material_cache_matid)
 			transmute_material_instead = getMaterial(matid)
 
-		src.event_effect(source,amtinput,dirinput,delinput,timinput,spdinput,  transmute_material_instead)
+		src.event_effect(source, amtinput, dirinput, delinput, timinput, spdinput, transmute_material_instead)
 		return
 
 ////////////////////////////////////////

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -201,8 +201,14 @@
 			prefix = "MYTHIC"
 
 	if(doMaterial)
-		var/list/material = pick(material_cache - list("cerenkite","ohshitium","plasmastone","koshmarite"))
-		I.setMaterial(material_cache[material], appearance = 1, setname = 1)
+		var/list/material = pick(material_cache_matid - list(
+			/datum/material/metal/cerenkite,
+			/datum/material/crystal/plasmastone,
+			/datum/material/organic/koshmarite
+			// the parent was in there too which is weird, since it shouldn't be in the cache
+			// hello reviewer. Tell me if it was correct to remove ohshitium and i'll remove these comments
+		))
+		I.setMaterial(material_cache_matid[material], appearance = 1, setname = 1)
 
 	I.name_prefix(prefix)
 

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -201,14 +201,11 @@
 			prefix = "MYTHIC"
 
 	if(doMaterial)
-		var/list/material = pick(material_cache_matid - list(
+		var/list/material = pick(material_cache_type - list(
 			/datum/material/metal/cerenkite,
 			/datum/material/crystal/plasmastone,
-			/datum/material/organic/koshmarite
-			// the parent was in there too which is weird, since it shouldn't be in the cache
-			// hello reviewer. Tell me if it was correct to remove ohshitium and i'll remove these comments
-		))
-		I.setMaterial(material_cache_matid[material], appearance = 1, setname = 1)
+			/datum/material/organic/koshmarite))
+		I.setMaterial(material_cache_type[material], appearance = 1, setname = 1)
 
 	I.name_prefix(prefix)
 

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -1,5 +1,8 @@
-
-var/global/list/material_cache
+// THESE TWO ARE THE SAME LIST
+/// the material cache, indexed by material id
+var/global/list/material_cache_matid
+/// the material cache, indexed by typepath
+var/global/list/material_cache_type
 
 /atom/var/datum/material/material = null
 /atom/var/material_amt = 1
@@ -13,14 +16,17 @@ var/global/list/material_cache
 /// Returns one of the base materials by id.
 /proc/getMaterial(mat)
 	#ifdef CHECK_MORE_RUNTIMES
-	if (!istext(mat))
-		CRASH("getMaterial() called with a non-text argument [mat].")
-	if (!(mat in material_cache))
-		CRASH("getMaterial() called with an invalid material id [mat].")
+	if (!ispath(mat) && !istext(mat))
+		CRASH("getMaterial() called with a non-typepath and non text argument [mat].")
+	if (!(mat in material_cache_matid) && !(mat in material_cache_type))
+		CRASH("getMaterial() called with an invalid material [mat].")
 	#endif
-	if(!istext(mat))
+	if(!ispath(mat) && !istext(mat))
 		return null
-	return material_cache?[mat]
+	if (istext(mat))
+		return material_cache_matid?[mat]
+	if (ispath(mat))
+		return material_cache_type?[mat]
 
 /proc/mergeProperties(var/list/leftProps, var/list/rightProps, var/rightBias=0.5)
 	var/leftBias = 1 - rightBias

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -83,7 +83,7 @@ var/global/list/material_cache_type
 		return
 	if(istext(mat1) && !mutable)
 		// cursed, but allows material ids to be used instead
-		mat1 = get_material(mat1)
+		mat1 = getMaterial(mat1)
 	else if (istext(mat1))
 		CRASH("mutable setMaterial() called with a string instead of a material datum.")
 	if(!mat1 ||!istype(mat1, /datum/material))

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -81,11 +81,8 @@ var/global/list/material_cache_type
 /atom/proc/setMaterial(datum/material/mat1 = null, appearance = TRUE, setname = TRUE, mutable = FALSE, use_descriptors = FALSE)
 	if (isnull(mat1))
 		return
-	if(istext(mat1) && !mutable)
-		// cursed, but allows material ids to be used instead
-		mat1 = getMaterial(mat1)
-	else if (istext(mat1))
-		CRASH("mutable setMaterial() called with a string instead of a material datum.")
+	if(istext(mat1))
+		CRASH("setMaterial() called with a string instead of a material datum.")
 	if(!mat1 ||!istype(mat1, /datum/material))
 		return
 	if(mutable)

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -13,7 +13,7 @@ var/global/list/material_cache_type
 
 
 
-/// Returns one of the base materials by id.
+/// Returns one of the base materials by id or by typepath.
 /proc/getMaterial(mat)
 	#ifdef CHECK_MORE_RUNTIMES
 	if (!ispath(mat) && !istext(mat))
@@ -78,9 +78,14 @@ var/global/list/material_cache_type
 
 
 /// Sets the material of an object. PLEASE USE THIS TO SET MATERIALS UNLESS YOU KNOW WHAT YOU'RE DOING.
-/atom/proc/setMaterial(datum/material/mat1, appearance = TRUE, setname = TRUE, mutable = FALSE, use_descriptors = FALSE)
-	if(istext(mat1))
-		CRASH("setMaterial() called with a string instead of a material datum.")
+/atom/proc/setMaterial(datum/material/mat1 = null, appearance = TRUE, setname = TRUE, mutable = FALSE, use_descriptors = FALSE)
+	if (isnull(mat1))
+		return
+	if(istext(mat1) && !mutable)
+		// cursed, but allows material ids to be used instead
+		mat1 = get_material(mat1)
+	else if (istext(mat1))
+		CRASH("mutable setMaterial() called with a string instead of a material datum.")
 	if(!mat1 ||!istype(mat1, /datum/material))
 		return
 	if(mutable)

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -89,7 +89,7 @@
 		if(mat)
 			src.setMaterial(mat)
 		else
-			src.setMaterial(material_cache_matid[/datum/material/metal/steel])
+			src.setMaterial(material_cache_type[/datum/material/metal/steel])
 		..()
 		START_TRACKING
 		src.UpdateIcon()

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -89,7 +89,7 @@
 		if(mat)
 			src.setMaterial(mat)
 		else
-			src.setMaterial(material_cache["steel"])
+			src.setMaterial(material_cache_matid[/datum/material/metal/steel])
 		..()
 		START_TRACKING
 		src.UpdateIcon()

--- a/code/world/initialization/0_preMapLoad.dm
+++ b/code/world/initialization/0_preMapLoad.dm
@@ -217,12 +217,14 @@
 	return
 
 /proc/buildMaterialCache()
-	material_cache = list()
+	material_cache_matid = list()
+	material_cache_type = list()
 	var/materialList = concrete_typesof(/datum/material)
 	for(var/datum/material/mat as anything in materialList)
 		if(initial(mat.cached))
 			var/datum/material/M = new mat()
-			material_cache[M.getID()] = M.getImmutable()
+			material_cache_matid[M.getID] = M.getImmutable()
+			material_cache_type[M.type] = M.getImmutable()
 
 #ifdef TRACY_PROFILER_HOOK
 /proc/prof_init()


### PR DESCRIPTION
[INTERNAL] [QUALITY] [MATERIAL]
## About the PR
set up a second material cache, indexed by type instead of by `getid()`. They're essentially the same list though. Renamed the original `material_cache` to `material_cache_matid`
let `get_material()` use typepaths.
let `set_material()` use matids in a horrible, no good way.

## Why's this needed?
More uniform code is better imo. It's weird that you have to use get_material inside of set_material. Second step is to switch everything over to using typepaths instead.