### PR TITLE
Adds the TGUI Colour Picker to Docking Stations

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -641,7 +641,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 				boutput(user, "<span class='alert'>ERROR: Cannot find cyborg's decorations.</span>")
 				return
 			C.painted = TRUE
-			C.paint = input(user) as color
+			C.paint = tgui_color_picker(user, "Please select a color!","Chasis Color",C.paint)
 			R.update_appearance()
 			R.update_bodypart()
 			. = TRUE
@@ -669,7 +669,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			else
 				boutput(user, "<span class='alert'>ERROR: Cannot find cyborg's decorations.</span>")
 				return
-			C.paint = input(user) as color
+			C.paint = tgui_color_picker(user, "Please select a color!","Chasis Color",C.paint)
 			R.update_appearance()
 			R.update_bodypart("all")
 			. = TRUE
@@ -683,7 +683,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			else
 				boutput(user, "<span class='alert'>ERROR: Cannot find cyborg's decorations.</span>")
 				return
-			var/selected_color = input(user) as color
+			var/selected_color = tgui_color_picker(user, "Please select a color!","Eye Color",C.fx)
 			if(selected_color)
 				C.fx = hex_to_rgb_list(selected_color)
 				R.update_appearance()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the TGUI Colour Picker to the Cyborg Docking Stations for changing paint and eye colour. Simple as that, shouldn't effect anything else unless I've horribly biffed something

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Quality of life is nice! So is standardisation! 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)444explorer
(+)Cyborg Docking Stations now use the TGUI Colour Picker.
```
