### PR TITLE
Fix hunter spear having an incorrect help message.

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -867,6 +867,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	throw_range = 10
 	makemeat = 0
 	var/hunter_key = "" // The owner of this spear.
+	HELP_MESSAGE_OVERRIDE({"Throw the spear at someone for a guaranteed short stun."})
 
 	New()
 		..()


### PR DESCRIPTION
[GAME OBJECTS] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The hunter spear previously had a help message saying it could butcher dead bodies into meat but the hunter spear cant do that. This changes the description to be correct.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad
