### PR TITLE
move a light on clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16054,13 +16054,6 @@
 /obj/lattice,
 /turf/space,
 /area/space)
-"bCK" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/storage)
 "bCQ" = (
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
@@ -38705,6 +38698,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"sNj" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/quartermaster/storage)
 "sOc" = (
 /obj/item/device/radio/beacon,
 /obj/landmark/gps_waypoint,
@@ -78700,8 +78700,8 @@ gck
 bzk
 fho
 bBB
-bCK
-rpX
+buG
+sNj
 bFo
 roW
 jkc


### PR DESCRIPTION
[Mapping] [Fix] [Trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move light that was left on a door onto the lower wall

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pretty sure this is my fault, I mighta goofed up and missed this light when mapping mining
Doesn't look right over the door