### PR TITLE
Makes beakers seperate visually based on states of matter

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -374,7 +374,6 @@
 			skin_target.desc = "A large round-bottom flask, for all your chemistry needs. (Base Item: [prev])"
 			skin_target.icon_style = "flask"
 			skin_target.item_state = "flask"
-			skin_target.fluid_image = image(skin_target.icon, "fluid-flask")
 			skin_target.UpdateIcon()
 			activator.set_clothing_icon_dirty()
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chemicals with different states of matter will now seperate into different layers. Solids will go on the bottom, liquids will overlay ontop of solids, and gases will overlay behind everything. 
![image](https://github.com/goonstation/goonstation/assets/73148980/c9673239-9728-47c1-97a2-9cedda10ed51)
![image](https://github.com/goonstation/goonstation/assets/73148980/b4793cbe-4ade-48c2-9c98-7796c501bcb2)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks neat + could potientally be useful for some future gameplay stuff.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Different states of matter will now visually seperate in beakers.
```
