### PR TITLE
Fix small click-drag bug with storages

### DIFF
--- a/code/modules/storage/bible.dm
+++ b/code/modules/storage/bible.dm
@@ -19,7 +19,7 @@ var/global/list/bible_contents = list()
 		W.tooltip_rebuild = TRUE
 
 /datum/storage/bible/add_contents(obj/item/I, mob/user = null, visible = TRUE)
-	if (user?.equipped() == I)
+	if (I in user?.equipped_list())
 		user.u_equip(I)
 	for_by_tcl(bible, /obj/item/bible)
 		bible.storage.stored_items += I

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -334,7 +334,7 @@
 
 /// when adding an item in
 /datum/storage/proc/add_contents(obj/item/I, mob/user = null, visible = TRUE)
-	if (user?.equipped() == I)
+	if (I in user?.equipped_list())
 		user.u_equip(I)
 	src.stored_items += I
 	I.set_loc(src.linked_item, FALSE)


### PR DESCRIPTION
[GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where click dragging an item to a storage, while on the hand that isn't holding that item, would break the storage a little


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix

Fixes #15347