### PR TITLE
Remove second armory locker from Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -25078,8 +25078,8 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "hBZ" = (
-/obj/storage/secure/closet/security/armory,
 /obj/machinery/light_switch/north,
+/obj/random_item_spawner/armory_breaching_supplies,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "hCf" = (
@@ -60113,17 +60113,6 @@
 /obj/item/breaching_hammer{
 	pixel_x = 3;
 	pixel_y = 3
-	},
-/obj/item/breaching_charge{
-	pixel_x = 8
-	},
-/obj/item/breaching_charge{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/breaching_charge{
-	pixel_x = 3;
-	pixel_y = -6
 	},
 /obj/machinery/light/incandescent/warm/very{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the second armory locker from Donut 3 and puts the armory charges in a secure crate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Match other armories.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(*)The second armory locker on Donut 3 has been removed. 
(*)The breaching charges in the Donut 3 armory have been put in a secure crate.
```
