### PR TITLE
Change Fishing Upload Terminal on Atlas to portable subtype

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18420,7 +18420,7 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "pkT" = (
-/obj/submachine/fishing_upload_terminal,
+/obj/submachine/fishing_upload_terminal/portable,
 /turf/simulated/floor,
 /area/station/ranch)
 "plm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Swaps the fishing upload terminal on atlas with the portable subtype that allows you to move it by wrench/screwdriver

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Every other map uses the portable subtype and even on Atlas itself the fish tank and the vendor are both the portable subtypes.