### PR TITLE
Fix out of order proc def `/mob/proc/keys_changed`

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -10,7 +10,8 @@
 			return controller.hotkey(src, name)
 	return ..()
 
-/mob/keys_changed(keys, changed)
+/mob/proc/keys_changed(keys, changed)
+	set waitfor = 0
 	if (changed & KEY_EXAMINE && src.client)
 		if (keys & KEY_EXAMINE)
 			if (HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES))

--- a/code/modules/interface/input.dm
+++ b/code/modules/interface/input.dm
@@ -301,11 +301,6 @@ var/list/dirty_keystates = list()
 
 /mob
 
-	proc/keys_changed(keys, changed)
-		set waitfor = 0
-		//SHOULD_NOT_SLEEP(TRUE) // prevent shitty code from locking up the main input loop - commenting out for now because out of scope
-		// stub
-
 	proc/recheck_keys()
 		keys_changed(src.client?.key_state, 0xFFFF) //ZeWaka: Fix for null.key_state
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Breaks OD, should warn but doesn't.