### PR TITLE
soda cans react properly when opened

### DIFF
--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -333,6 +333,7 @@
 		var/drop_this_shit = 0 //i promise this is useful
 		if (src.is_sealed)
 			is_sealed = 0
+			src.set_open_container(TRUE)
 			can_chug = 1
 			splash_all_contents = TRUE
 			incompatible_with_chem_dispensers = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX][CHEMISTRY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
soda cans now react properly to being opened


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
soda cans can be cracked open and not react, counting as closed
