### PR TITLE
Unify pool fluid spawning levels

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8905,7 +8905,7 @@
 /area/station/maintenance/inner/central)
 "aKo" = (
 /obj/fluid_spawner{
-	amount = 3600
+	amount = 4200
 	},
 /turf/simulated/floor/pool/no_animate,
 /area/station/crew_quarters/pool)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44825,7 +44825,7 @@
 /area/station/security/secwing)
 "mVi" = (
 /obj/fluid_spawner{
-	amount = 2100
+	amount = 3600
 	},
 /turf/simulated/floor/pool/no_animate,
 /area/station/crew_quarters/pool)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -16052,7 +16052,7 @@
 /area/station/science/hall)
 "hex" = (
 /obj/fluid_spawner{
-	amount = 2100
+	amount = 3000
 	},
 /turf/simulated/floor/pool/no_animate,
 /area/station/crew_quarters/pool)

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -41488,7 +41488,7 @@
 /area/station/hallway/primary/central)
 "sig" = (
 /obj/fluid_spawner{
-	amount = 2700
+	amount = 3000
 	},
 /turf/simulated/floor/pool/no_animate,
 /area/station/crew_quarters/pool)


### PR DESCRIPTION
[MAPPING]
## About the PR
Makes it so that the fluid spawners in the pools on each map spawn enough fluid that there is 150 units of water per tile.

## Why's this needed?
Parity is good. If the water level is above 210 per tile, it will spill out over the ladder, and if it's too low, then splashing around in the pool is not as fun.