### PR TITLE
Give Donut 3 QM and main hangar buttons

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -34239,6 +34239,12 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
+"kyV" = (
+/obj/machinery/door_control/podbay/qm{
+	pixel_y = 9
+	},
+/turf/simulated/wall/auto/reinforced/jen/yellow,
+/area/station/hangar/qm)
 "kyX" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -42644,6 +42650,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"ncb" = (
+/obj/machinery/door_control/podbay/mainpod2{
+	pixel_y = 1
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/hangar/main)
 "ncn" = (
 /obj/tree{
 	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
@@ -130175,7 +130187,7 @@ vcG
 vcG
 ocq
 cvl
-vYX
+kyV
 oag
 rah
 jIH
@@ -137690,7 +137702,7 @@ aeQ
 mxH
 aiP
 tSd
-tSd
+ncb
 xca
 aSO
 sNb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the qm hangar and the main station podbay hangar have buttons to open the blast doors
![Screenshot (287)](https://github.com/goonstation/goonstation/assets/73998720/610fdf2a-f9b7-48e5-b224-ee3b4f985155)
![Screenshot (288)](https://github.com/goonstation/goonstation/assets/73998720/8213054a-02b6-41c2-93d0-4c223f40c9c7)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i dont really know why they didn't before, its been bugging me for the longest time

