### PR TITLE
Adds banana juice to Honky Tonic recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1883,7 +1883,7 @@
 		name = "Honky Tonic"
 		id = "honky_tonic"
 		result = "honky_tonic"
-		required_reagents = list("tonic" = 1, "lube" = 1, "colors" = 1, "neurotoxin" = 1)
+		required_reagents = list("tonic" = 1, "lube" = 1, "colors" = 1, "neurotoxin" = 1, "juice_banana" = 1)
 		result_amount = 4
 		mix_phrase = "The drink honks at you! What the fuck?"
 		mix_sound = 'sound/misc/drinkfizz_honk.ogg'

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1883,7 +1883,7 @@
 		name = "Honky Tonic"
 		id = "honky_tonic"
 		result = "honky_tonic"
-		required_reagents = list("tonic" = 1, "lube" = 1, "colors" = 1, "neurotoxin" = 1, "juice_banana" = 1)
+		required_reagents = list("tonic" = 1, "lube" = 1, "neurotoxin" = 1, "juice_banana" = 1)
 		result_amount = 4
 		mix_phrase = "The drink honks at you! What the fuck?"
 		mix_sound = 'sound/misc/drinkfizz_honk.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Chemistry][Catering][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the new juice_banana reagent to the Honky Tonic recipe and
removes colored reagent from it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Honky Tonic is rather difficult to mix compared to other gimmick
drinks, this PR aims to make it a little easier by adding a botany exclusive
chem in the place of a (usually) chemistry exclusive one.
Also, it makes sense for a Clown-themed drink to include banana juice.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Banana juice has replaced colorful reagent in the Honky Tonic recipe.
```
