### PR TITLE
change amanitin to on_remove instead of moblifecomplete

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -213,6 +213,7 @@ datum
 				if (!istype(M)) return
 				M.take_toxin_damage(damage_counter)
 				logTheThing(LOG_COMBAT, M, "took [damage_counter] TOX damage from amanitin.")
+				damage_counter = 0
 
 
 		harmful/chemilin

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -207,11 +207,12 @@ datum
 					M = holder.my_atom
 				damage_counter += rand(2, 4) * mult * min(1, volume)
 				..()
-
-			on_mob_life_complete(mob/living/M)
-				if(M)
-					M.take_toxin_damage(damage_counter)
-					logTheThing(LOG_COMBAT, M, "took [damage_counter] TOX damage from amanitin.")
+			on_remove()
+				..()
+				var/mob/living/carbon/human/M = holder.my_atom
+				if (!istype(M)) return
+				M.take_toxin_damage(damage_counter)
+				logTheThing(LOG_COMBAT, M, "took [damage_counter] TOX damage from amanitin.")
 
 
 		harmful/chemilin


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes amanitin to use on_remove instead of onmoblifecomplete. Right now, if anything flushes amanitin out, it does zero damage. using on_remove still has amanitin do its damage after its been flushed out. One thing to keep in mind is that this includes adminhealing, which purges the amanitin causing it to do damage after the players been healed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Amanitin is kind of useless because when discovered it can be entirely negated. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Froggit Dogget
(+)Amanitin now does its damage when flushed out of the system.
```
