### PR TITLE
Use Standard tgui UI for Sillicon Paper

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -123,19 +123,9 @@
 		qdel(src)
 
 /obj/item/paper/attack_ai(var/mob/AI as mob)
-	var/mob/living/silicon/ai/user
-	if (isAIeye(AI))
-		var/mob/living/intangible/aieye/E = AI
-		user = E.mainframe
-	else
-		user = AI
-	if (!isAI(user) || (user.current && GET_DIST(src, user.current) < 2)) //Wire: fix for undefined variable /mob/living/silicon/robot/var/current
-		var/font_junk = ""
-		for (var/i in src.fonts)
-			font_junk += "<link href='http://fonts.googleapis.com/css?family=[i]' rel='stylesheet' type='text/css'>"
-		usr.Browse("<HTML><HEAD><TITLE>[src.name]</TITLE>[font_junk]</HEAD><BODY><TT>[src.info]</TT></BODY></HTML>", "window=[src.name]")
-		onclose(usr, "[src.name]")
-	return
+	//Papers can be alt+click inspected from anywhere, let's give attack_ai the same freedom
+	//	instead of doing dubious /mob/living/silicon/ai.current checks
+	ui_interact(AI)
 
 /obj/item/paper/proc/stamp(x, y, r, stamp_png, icon_state)
 	if(length(stamps) < PAPER_MAX_STAMPS)
@@ -351,6 +341,8 @@
 	src.field_counter++
 	return {"\[<input type="text" style="font:'12x Georgia';color:'null';min-width:[pixel_width]px;max-width:[pixel_width]px;" id="paperfield_[field_counter]" maxlength=[length] size=[length] />\]"}
 
+/obj/item/paper/proc/show_through_camera(mob/living/user)
+	return ui_interact(user)
 
 /obj/item/paper/thermal
 	name = "thermal paper"

--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -265,7 +265,7 @@
 			var/obj/item/portable_typewriter/typewriter = src.loc
 			if(istype(typewriter.pen, /obj/item/pen))
 				O = typewriter.pen
-	if(istype(O, /obj/item/pen))
+	if(istype(O, /obj/item/pen) && in_interact_range(src, user))
 		var/obj/item/pen/PEN = O
 		. += list(
 			"penFont" = PEN.font,
@@ -274,7 +274,7 @@
 			"isCrayon" = FALSE,
 			"stampClass" = "FAKE",
 		)
-	else if(istype(O, /obj/item/stamp))
+	else if(istype(O, /obj/item/stamp) && in_interact_range(src, user))
 		var/obj/item/stamp/stamp = O
 		stamp.current_state = stamp_assets[STAMP_IDS[stamp.current_mode]]
 		. += list(
@@ -340,9 +340,6 @@
 	var/pixel_width = (14 + (12 * (length-1)))
 	src.field_counter++
 	return {"\[<input type="text" style="font:'12x Georgia';color:'null';min-width:[pixel_width]px;max-width:[pixel_width]px;" id="paperfield_[field_counter]" maxlength=[length] size=[length] />\]"}
-
-/obj/item/paper/proc/show_through_camera(mob/living/user)
-	return ui_interact(user)
 
 /obj/item/paper/thermal
 	name = "thermal paper"

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -298,14 +298,14 @@
 		for(var/mob/O in mobs)
 			if (isAI(O))
 				boutput(O, "[user] holds a paper up to one of your cameras ...")
-				X.show_through_camera(O)
+				X.ui_interact(O)
 				logTheThing(LOG_STATION, user, "holds up a paper to a camera at [log_loc(src)], forcing [constructTarget(O,"station")] to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
 			else
 				var/obj/machinery/computer/security/S = O.using_dialog_of_type(/obj/machinery/computer/security)
 				if (S)
 					if (S.current == src)
 						boutput(O, "[user] holds a paper up to one of the cameras ...")
-						X.show_through_camera(O)
+						X.ui_interact(O)
 						logTheThing(LOG_STATION, user, "holds up a paper to a camera at [log_loc(src)], forcing [constructTarget(O,"station")] to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
 
 //Return a working camera that can see a given mob

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -298,14 +298,14 @@
 		for(var/mob/O in mobs)
 			if (isAI(O))
 				boutput(O, "[user] holds a paper up to one of your cameras ...")
-				O.Browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", X.name, X.info), text("window=[]", X.name))
+				X.show_through_camera(O)
 				logTheThing(LOG_STATION, user, "holds up a paper to a camera at [log_loc(src)], forcing [constructTarget(O,"station")] to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
 			else
 				var/obj/machinery/computer/security/S = O.using_dialog_of_type(/obj/machinery/computer/security)
 				if (S)
 					if (S.current == src)
 						boutput(O, "[user] holds a paper up to one of the cameras ...")
-						O.Browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", X.name, X.info), text("window=[]", X.name))
+						X.show_through_camera(O)
 						logTheThing(LOG_STATION, user, "holds up a paper to a camera at [log_loc(src)], forcing [constructTarget(O,"station")] to read it. <b>Title:</b> [X.name]. <b>Text:</b> [adminscrub(X.info)]")
 
 //Return a working camera that can see a given mob


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When an AI gets shown a paper through a camera, or when sillicons left click papers, it used to be shown by an html popup with the paper's contents plugged inside. This change makes it so that we just open the paper's tgui window for them.
Other small change: fixes a bug where silicons could edit notes from afar.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes sense to only have 1 paper viewing technique, probably fixes a font bug with the AI camera, might fix href exploits if there are any, and is also what https://github.com/tgstation/tgstation/pull/68612 did anyways (no need to port the whole refactor for this, just pointing out it's how they solved a "showing the paper to AI cameras" problem)

Paper to camera AI PoV:
![image](https://github.com/goonstation/goonstation/assets/6396368/7e00107c-7e86-4672-99fe-17500b62ce50)
Borg left clicking paper:
![image](https://github.com/goonstation/goonstation/assets/6396368/729de258-0001-4a19-b619-54d49c44e527)

How they would see it before:
![266410142-277b2244-e0ba-4178-8fae-15939d0b6137](https://github.com/goonstation/goonstation/assets/6396368/d0a903e4-034f-4b49-9775-c5a4dd0bc510)

Edit while in range, with a pen selected, yes:
![image](https://github.com/goonstation/goonstation/assets/6396368/97060329-a938-4e27-bbcb-c116062f41ae)

Edit while out of range, with a pen selected, no:
![image](https://github.com/goonstation/goonstation/assets/6396368/2bf5dab2-c633-4c9d-8c46-b172e590959b)

[UI][Bug]