### PR TITLE
fix 10171, also fixes moving anchored lockers

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -191,12 +191,21 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 		src.last_relaymove_time = world.time
 
 		if (src.legholes)
-			step(src,user.dir)
-			return
+			if (!src.anchored)
+				step(src,user.dir)
+				return
+			else
+				user.show_text("You try moving, but [src] seems to be stuck to the floor!", "red")
+				return
+
 
 		if (!src.open(user=user))
 			if (!src.is_short && src.legholes)
-				step(src, pick(alldirs))
+				if (!src.anchored)
+					step(src, pick(alldirs))
+				else
+					user.show_text("You try moving, but [src] seems to be stuck to the floor!", "red")
+
 			if (!src.jiggled)
 				src.jiggled = 1
 				user.show_text("You kick at [src], but it doesn't budge!", "red")

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -198,7 +198,6 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 				user.show_text("You try moving, but [src] seems to be stuck to the floor!", "red")
 				return
 
-
 		if (!src.open(user=user))
 			if (!src.is_short && src.legholes)
 				if (!src.anchored)

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -204,7 +204,6 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 					step(src, pick(alldirs))
 				else
 					user.show_text("You try moving, but [src] seems to be stuck to the floor!", "red")
-
 			if (!src.jiggled)
 				src.jiggled = 1
 				user.show_text("You kick at [src], but it doesn't budge!", "red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes the current ability to poke holes in an anchored locker with a welder, and then move around the station in an immovable object.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

jank needs fixing

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

