### PR TITLE
make see_face use TRUE and FALSE defines

### DIFF
--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -90,7 +90,7 @@
 	name = "Cyalume Knight Helmet"
 	desc = "An ominous armored article of clothing."
 	icon_state = "cknight_hood"
-	see_face = 0
+	see_face = FALSE
 
 /atom/movable/screen/ability/topBar/cyalume_knight
 	clicked(params)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -998,7 +998,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 	desc = "Spookier!"
 	icon_state = "pumpkin"
 	c_flags = COVERSEYES | COVERSMOUTH
-	see_face = 0
+	see_face = FALSE
 	item_state = "pumpkin"
 
 	attackby(obj/item/W, mob/user)
@@ -1040,7 +1040,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 	desc = "Cute!"
 	icon_state = "pumpkinlatte"
 	c_flags = COVERSEYES | COVERSMOUTH
-	see_face = 0
+	see_face = FALSE
 	item_state = "pumpkinlatte"
 
 	attackby(obj/item/W, mob/user)

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -4,7 +4,7 @@ ABSTRACT_TYPE(/obj/item/clothing)
 	//var/obj/item/clothing/master = null
 	w_class = W_CLASS_SMALL
 
-	var/see_face = 1
+	var/see_face = TRUE
 	///Makes it so the item doesn't show up upon examining, currently only applied for gloves
 	var/nodescripition = FALSE
 

--- a/code/obj/item/clothing/cardboard.dm
+++ b/code/obj/item/clothing/cardboard.dm
@@ -6,7 +6,7 @@
 	icon_state = "c_box"
 	item_state = "c_box"
 	density = 1
-	see_face = 0
+	see_face = FALSE
 	over_hair = 1
 	wear_layer = MOB_LAYER_OVER_FUCKING_EVERYTHING_LAYER
 	c_flags = COVERSEYES | COVERSMOUTH

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -19,7 +19,7 @@
 	icon_state = "hunter"
 	item_state = "helmet"
 	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
-	see_face = 0
+	see_face = FALSE
 	item_function_flags = IMMUNE_TO_ACID
 
 	New()
@@ -58,7 +58,7 @@
 	item_state = "santahat"
 	hides_from_examine = C_EARS
 	c_flags = null
-	see_face = 1
+	see_face = TRUE
 
 	noslow
 		setupProperties()
@@ -85,7 +85,7 @@
 	desc = "Twoooo!"
 	icon_state = "owl"
 	item_state = "owl_mask"
-	see_face = 0
+	see_face = FALSE
 
 	equipped(var/mob/user)
 		..()
@@ -151,7 +151,7 @@
 	name = "Smiling Face"
 	desc = ":)"
 	icon_state = "smiles"
-	see_face = 0
+	see_face = FALSE
 
 TYPEINFO(/obj/item/clothing/under/gimmick/waldo)
 	mat_appearances_to_ignore = list("jean")
@@ -356,7 +356,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	item_state = "bl_suit"
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | MASKINTERNALS //The bat respirator is a real thing. See also: Batman can breathe in space.
 	hides_from_examine = C_EARS
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/head/helmet/batman
 	name = "batcowl"
@@ -365,7 +365,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	item_state = "batcowl"
 	c_flags = COVERSEYES | COVERSMOUTH
 	hides_from_examine = C_EARS
-	see_face = 0
+	see_face = FALSE
 
 // see procitizen.dm for batman verbs
 
@@ -652,7 +652,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	desc = "Hold hostages, rob a bank, shoot up an airport, the primitive yet flexible balaclava does it all!"
 	icon_state = "balaclava"
 	item_state = "balaclava"
-	see_face = 0
+	see_face = FALSE
 
 // Sweet Bro and Hella Jeff
 
@@ -681,7 +681,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	desc = "WARNING: Provides no protection from falling bricks."
 	icon_state = "spiderman"
 	item_state = "bogloves"
-	see_face = 0
+	see_face = FALSE
 	hides_from_examine = C_GLASSES|C_EARS
 
 /obj/item/clothing/under/gimmick/spiderman
@@ -696,7 +696,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	icon_state = "horse"
 	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
 	hides_from_examine = C_GLASSES|C_EARS
-	see_face = 0
+	see_face = FALSE
 
 	cursed
 		cant_drop = 1
@@ -720,7 +720,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	name = "birdman helmet"
 	desc = "bird bird bird"
 	icon_state = "birdman"
-	see_face = 0
+	see_face = FALSE
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | MASKINTERNALS //FACT: space birds can breathe in space
 	hides_from_examine = C_EARS
 
@@ -764,7 +764,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	hides_from_examine = C_EARS|C_GLASSES|C_MASK
 	c_flags = COVERSEYES | COVERSMOUTH
 	seal_hair = 1
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/suit/power
 	name = "unpainted cardboard space marine armor"
@@ -890,7 +890,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	icon = 'icons/obj/items/organs/skull.dmi'
 	icon_state = "skull"
 	item_state = "death"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/suit/robuddy
 	name = "guardbuddy costume"
@@ -935,21 +935,21 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	desc = "An eerily realistic mask of 20th century film actor Nicolas Cage."
 	icon_state = "niccage"
 	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/waltwhite
 	name = "meth scientist mask"
 	desc = "A crappy looking mask that you swear you've seen a million times before. 'Spook*Corp Costumes' is embedded on the side of it."
 	icon_state = "waltwhite"
 	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS //| SPACEWEAR Walter White is like Batman in many ways. Breathing in space is not one of them.
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/mmyers
 	name = "murderer mask"
 	desc = "This looks strangely like another mask you've seen somewhere else, but painted white. Huh."
 	icon_state = "mmyers"
 	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
-	see_face = 0
+	see_face = FALSE
 
 
 /obj/item/clothing/suit/gimmick
@@ -966,7 +966,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	wear_layer = MOB_FULL_SUIT_LAYER
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_MASK|C_GLASSES|C_EARS
 	over_hair = TRUE
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/under/gimmick/utena //YJHTGHTFH's utena suit
 	name = "revolutionary suit"
@@ -1003,7 +1003,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	c_flags = COVERSMOUTH | COVERSEYES
 	hides_from_examine = C_GLASSES|C_EARS|C_MASK
 	seal_hair = 1
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/suit/armor/sneaking_suit
 	name = "sneaking suit"
@@ -1094,7 +1094,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	name = "mime mask"
 	desc = "The charming mask of the mime. Very emotive! Wait, isn't this usually face-paint?"
 	icon_state = "mime"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/under/misc/mime
 	name = "mime suit"
@@ -1823,7 +1823,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 	c_flags = COVERSMOUTH | COVERSEYES
 	hides_from_examine = C_EARS|C_GLASSES|C_MASK
 	seal_hair = 1
-	see_face = 0
+	see_face = FALSE
 
 
 //sock hats

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -770,7 +770,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "Good god, this thing STINKS. Is that mold on the inner lining? Ugh."
 	icon_state = "wizardnec"
 	item_state = "wizardnec"
-	see_face = 0
+	see_face = FALSE
 	seal_hair = 1
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
@@ -784,7 +784,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "It's a paper hat!"
 	icon_state = "paper"
 	item_state = "lgloves"
-	see_face = 1
+	see_face = TRUE
 	body_parts_covered = HEAD
 
 /obj/item/paper_hat/attackby(obj/item/W, mob/user)
@@ -807,14 +807,14 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "A white towel folded all into a fancy hat. NOT a turban!" // @;)
 	icon_state = "towelhat"
 	item_state = "lgloves"
-	see_face = 1
+	see_face = TRUE
 	body_parts_covered = HEAD
 
 /obj/item/clothing/head/crown
 	name = "crown"
 	desc = "Yeah, big deal, you got a fancy crown, what does that do for you against the <b>HORRORS OF SPACE</b>, tough guy?"
 	icon_state = "crown"
-	see_face = 1
+	see_face = TRUE
 	body_parts_covered = HEAD
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -19,7 +19,7 @@
 	name = "space helmet"
 	icon_state = "space"
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
-	see_face = 0
+	see_face = FALSE
 	item_state = "s_helmet"
 	desc = "Helps protect against vacuum."
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
@@ -48,7 +48,7 @@
 	icon_state = "espace0"
 	uses_multiple_icon_states = 1
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH
-	see_face = 0
+	see_face = FALSE
 	item_state = "s_helmet"
 	var/on = 0
 
@@ -271,7 +271,7 @@
 	desc = "A lightweight space helmet."
 	icon_state = "spacelight-e" // if I add more light suits/helmets change this to nuetral suit/helmet
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
-	see_face = 0
+	see_face = FALSE
 	item_state = "s_helmet"
 	hides_from_examine = C_EARS|C_MASK // Light space suit helms have transparent fronts
 	seal_hair = 1
@@ -340,7 +340,7 @@
 		icon_state = "syndie_commander"
 		desc = "A terrifyingly tall, black & red cap, typically worn by a Syndicate Nuclear Operative Commander. Maybe they're trying to prove something to the Head of Security?"
 		seal_hair = 0
-		see_face = 1
+		see_face = TRUE
 		team_num = TEAM_SYNDICATE
 
 		setupProperties()
@@ -390,7 +390,7 @@
 			icon_state = "syndie_specialist"
 			item_state = "syndie_specialist"
 			c_flags = SPACEWEAR | COVERSEYES
-			see_face = 0
+			see_face = FALSE
 			protective_temperature = 1300
 			abilities = list(/obj/ability_button/nukie_meson_toggle)
 			var/on = 0
@@ -932,7 +932,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/siren)
 	item_state = "nthelm"
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
-	see_face = 0
+	see_face = FALSE
 	setupProperties()
 		..()
 		setProperty("meleeprot_head", 8)

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -104,7 +104,7 @@
 	icon_state = "gas_mask"
 	c_flags =  COVERSMOUTH | COVERSEYES | MASKINTERNALS | BLOCKSMOKE
 	w_class = W_CLASS_NORMAL
-	see_face = 0
+	see_face = FALSE
 	item_state = "gas_mask"
 	color_r = 0.8 // green tint
 	color_g = 1
@@ -147,7 +147,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 	desc = "Nobody will know who you are if you put this on. Nobody."
 	icon_state = "moustache"
 	item_state = "moustache"
-	see_face = 0
+	see_face = FALSE
 	w_class = W_CLASS_TINY
 	c_flags = null
 	is_syndicate = 1
@@ -162,14 +162,14 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 	desc = "Almost as good as a REAL fake moustache."
 	icon_state = "moustache"
 	item_state = "moustache"
-	see_face = 1
+	see_face = TRUE
 
 /obj/item/clothing/mask/moustache/Italian
 	name = "fake Italian moustache"
 	desc = "For those who can't cut the lasagna."
 	icon_state = "moustache-i"
 	item_state = "moustache-i"
-	see_face = 1
+	see_face = TRUE
 
 
 /obj/item/clothing/mask/gas/emergency
@@ -185,7 +185,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		icon_state = "slasher_mask"
 		item_state = "slasher_mask"
 		item_function_flags = IMMUNE_TO_ACID
-		see_face = 1
+		see_face = TRUE
 		setupProperties()
 			..()
 			setProperty("meleeprot_head", 6)
@@ -206,7 +206,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		desc = "A close-fitting sealed gas mask, from the looks of it, it's well over a hundred years old."
 		icon_state = "slasher_mask"
 		item_state = "slasher_mask"
-		see_face = 1
+		see_face = TRUE
 		setupProperties()
 			..()
 			setProperty("movespeed", 0.2)
@@ -343,7 +343,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	desc = "A mask depicting the grinning facial expression of a prototypical clown. There's a place to tuck the attached wig in if you don't want it interfering with your own hair."
 	icon_state = "clown"
 	item_state = "clown_hat"
-	see_face = 0
+	see_face = FALSE
 
 	var/spam_flag = 0
 	var/spam_timer = 100
@@ -567,7 +567,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	desc = "A little mask, made of paper."
 	icon_state = "domino"
 	item_state = "domino"
-	see_face = 0
+	see_face = FALSE
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 1
@@ -584,7 +584,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	desc = "Haven't seen that fellow in a while."
 	icon_state = "melons"
 	item_state = "melons"
-	see_face = 0
+	see_face = FALSE
 
 TYPEINFO(/obj/item/clothing/mask/wrestling)
 	random_subtypes = list(/obj/item/clothing/mask/wrestling,
@@ -596,7 +596,7 @@ TYPEINFO(/obj/item/clothing/mask/wrestling)
 	desc = "A mask that will greatly enhance your wrestling prowess! Not, like, <i>physically</i>, but mentally. In your heart. In your soul. Something like that."
 	icon_state = "silvermask"
 	item_state = "silvermask"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/wrestling/black
 	icon_state = "blackmask"
@@ -615,7 +615,7 @@ TYPEINFO(/obj/item/clothing/mask/wrestling)
 	desc = "Looking at this thing gives you the heebie-jeebies. And a weird urge to go rob a bank, for some reason."
 	icon_state = "anime"
 	item_state = "anime"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/gas/plague
 	name = "plague doctor mask"
@@ -632,35 +632,35 @@ TYPEINFO(/obj/item/clothing/mask/wrestling)
 	desc = "Just your ordinary chicken mask that induces no violent feelings towards anyone or anything."
 	icon_state = "chicken"
 	item_state = "chicken"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/jester
 	name = "jester's mask"
 	desc = "The mask of a not-so-funny-clown."
 	icon_state = "jester"
 	item_state = "jester"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/hastur
 	name = "cultist mask"
 	desc = "The mask of a cultist who has seen the yellow sign and answered its call.."
 	icon_state = "hasturmask"
 	item_state = "hasturmask"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/kitsune
 	name = "kitsune mask"
 	desc = "The mask of a mythical fox creature from folklore."
 	icon_state = "kitsune"
 	item_state = "kitsune"
-	see_face = 0
+	see_face = FALSE
 
 /obj/item/clothing/mask/blossommask
 	name = "cherryblossom mask"
 	desc = "A mask. Specifically for masquerades."
 	icon_state = "cherryblossom"
 	item_state = "cherryblossom"
-	see_face = 0
+	see_face = FALSE
 	c_flags = null
 
 /obj/item/clothing/mask/peacockmask
@@ -668,14 +668,14 @@ TYPEINFO(/obj/item/clothing/mask/wrestling)
 	desc = "A mask. Specifically for masquerades."
 	icon_state = "peacock"
 	item_state = "peacock"
-	see_face = 0
+	see_face = FALSE
 	c_flags = null
 
 ABSTRACT_TYPE(/obj/item/clothing/mask/bandana)
 /obj/item/clothing/mask/bandana
 	name = "bandana"
 	desc = "The desperado's choice."
-	see_face = 0
+	see_face = FALSE
 	var/is_pulled_down = FALSE
 	var/obj/item/cloth/handkerchief/handkerchief = null
 

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1622,7 +1622,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
 	icon_state = "cultist"
 	item_state = "cultist"
-	see_face = 0
+	see_face = FALSE
 	magical = 1
 	over_hair = TRUE
 	wear_layer = MOB_FULL_SUIT_LAYER
@@ -1663,7 +1663,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
 	icon_state = "flockcultist"
 	item_state = "flockcultistt"
-	see_face = 0
+	see_face = FALSE
 	wear_layer = MOB_FULL_SUIT_LAYER
 	c_flags = COVERSEYES | COVERSMOUTH
 	body_parts_covered = TORSO|LEGS|ARMS


### PR DESCRIPTION
[QUALITY] [INTERNAL]
## About the PR
Minor code cleanup: i noticed see_face used `= 0` instead of `= FALSE` a lot (and the same for `= 1`). This makes it so they all use `TRUE` and `FALSE` defines instead.

## Why's this needed?
Cleaner code is better. Stuff that behaves like booleans should use the defines.