### PR TITLE
New chemical: Capsizin

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4725,7 +4725,7 @@
 		result = "capsizin"
 		required_reagents = list("reversium" = 1, "capsaicin" = 4)
 		result_amount = 5
-		mix_phrase = "The solution begings to capsize. What does that even mean?"
+		mix_phrase = "The solution begins to capsize. What does that even mean?"
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 		hidden = TRUE
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4719,6 +4719,16 @@
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 		hidden = TRUE
 
+	capsizin
+		name = "capsizin"
+		id = "capsizin"
+		result = "capsizin"
+		required_reagents = list("reversium" = 1, "capsaicin" = 4)
+		result_amount = 5
+		mix_phrase = "The solution begings to capsize. What does that even mean?"
+		mix_sound = 'sound/misc/drinkfizz.ogg'
+		hidden = TRUE
+
 	transparium
 		name = "transparium"
 		id = "transparium"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2614,7 +2614,7 @@ datum
 				..()
 
 			do_overdose(var/severity, var/mob/M, var/mult = 1)
-					M.reagents.add_reagent("water", severity * mult)
+				M.reagents.add_reagent("water", severity * mult)
 
 		transparium
 			name = "transparium"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2587,6 +2587,34 @@ datum
 							M.visible_message("<span class='emote'><B>[M]</B> gives [some_idiot.name] the double deuce!</span>")
 				..()
 				return
+		capsizin
+			name = "capsizin"
+			id = "capsizin"
+			description = "This liquid doesn't seem to be self-righting..."
+			reagent_state = LIQUID
+			fluid_r = 23
+			fluid_g = 46
+			fluid_b = 111
+			transparency = 150
+			overdose = 30
+			threshold = THRESHOLD_INIT
+
+			cross_threshold_over()
+				if(ismob(holder?.my_atom))
+					var/mob/M = holder.my_atom
+					M.Turn(180)
+					boutput(M, "You capsize!")
+				..()
+
+			cross_threshold_under()
+				if(ismob(holder?.my_atom))
+					var/mob/M = holder.my_atom
+					M.Turn(180)
+					boutput(M, "You manage to right yourself!")
+				..()
+
+			do_overdose(var/severity, var/mob/M, var/mult = 1)
+					M.reagents.add_reagent("water", severity * mult)
 
 		transparium
 			name = "transparium"


### PR DESCRIPTION
[CHEMISTRY][FEATURE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a funny chemical that turns you upside down. It has standard depletion and decays into water when overdosed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Capsaicin sounds too much like capsizing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(*)New chemical: Capsizin. Makes you harmlessly capsize. Recipe: Reversium(1) + Capsaicin(4) = Capsizin(5)
```
