### PR TITLE
fixes photophosphide not decaying under 1u

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3018,7 +3018,7 @@
 	photophosphide_decay //decays in low amounts
 		name = "Photophosphide Decay"
 		id = "photophosphide_decay"
-		required_reagents = list("photophosphide" = 1)
+		required_reagents = list("photophosphide" = 0)
 		instant = FALSE
 		result_amount = 1
 		reaction_speed = 3
@@ -3029,6 +3029,9 @@
 				return TRUE
 			else
 				return FALSE
+
+		on_reaction(var/datum/reagents/holder, var/created_volume)
+			holder.remove_reagent("photophosphide", src.reaction_speed)
 
 	styptic_powder // COGWERKS CHEM REVISION PROJECT: no idea, probably a magic drug
 		name = "Styptic Powder"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [BUG][CHEMISTRY] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes photophosphide not decaying under 1u


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
making a near unlimited amount of light activated bombs using just a mechanical dropper should not be possible