### PR TITLE
Attempts to put map correctness checks on random rooms

### DIFF
--- a/code/modules/worldgen/PrefabRuntimeChecker.dm
+++ b/code/modules/worldgen/PrefabRuntimeChecker.dm
@@ -32,6 +32,7 @@
 		var/dmm_suite/D = new/dmm_suite()
 		D.read_map(loaded,T.x,T.y,T.z,M.prefabPath, DMM_OVERWRITE_MOBS | DMM_OVERWRITE_OBJS)
 		boutput(world, "<span class='alert'>Prefab placement [M.type][M.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]")
+		check_map_correctness()
 		sleep(1 SECOND)
 		// cleanup
 		var/turf/other_corner = locate(T.x + M.prefabSizeX, T.y + M.prefabSizeY, T.z)

--- a/code/modules/worldgen/PrefabRuntimeChecker.dm
+++ b/code/modules/worldgen/PrefabRuntimeChecker.dm
@@ -32,7 +32,6 @@
 		var/dmm_suite/D = new/dmm_suite()
 		D.read_map(loaded,T.x,T.y,T.z,M.prefabPath, DMM_OVERWRITE_MOBS | DMM_OVERWRITE_OBJS)
 		boutput(world, "<span class='alert'>Prefab placement [M.type][M.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]")
-		check_map_correctness()
 		sleep(1 SECOND)
 		// cleanup
 		var/turf/other_corner = locate(T.x + M.prefabSizeX, T.y + M.prefabSizeY, T.z)

--- a/code/modules/worldgen/RandomRoomRuntimeChecker.dm
+++ b/code/modules/worldgen/RandomRoomRuntimeChecker.dm
@@ -32,6 +32,7 @@
 		var/dmm_suite/D = new/dmm_suite()
 		D.read_map(loaded, T.x, T.y, T.z, R.prefabPath, DMM_OVERWRITE_MOBS | DMM_OVERWRITE_OBJS)
 		boutput(world, "<span class='alert'>Prefab placement [R.type][R.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]")
+		check_map_correctness()
 		sleep(1 SECOND)
 		// cleanup
 		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)


### PR DESCRIPTION
[INTERNAL] [TOOLING]
## About the PR
Between each random room runtime check, run `check_map_correctness()`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Useful for checking if the random rooms violate map correctness such as having unsimmed turfs and objects in walls. The full list is:
```
check_missing_navbeacons()
check_apcs_wired()
check_objects_in_walls()
check_window_turfs()
check_door_turfs()
check_networked_data_terminals()
check_blinds_switches()
check_apcless_station_areas()
check_lightswitchless_station_areas()
check_unsimulated_station_turfs()
check_duplicate_area_names()
check_missing_material()
check_turf_underlays()
check_mass_drivers()
```