### PR TITLE
Type trader/robot versions and automate trader_area

### DIFF
--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_disposal.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_disposal.dmm
@@ -213,11 +213,7 @@
 	name = "GLOMAR Salvager"
 	})
 "D" = (
-/obj/npc/trader/robot{
-	name = "Thrifty B.O.B.";
-	picture = "loungebuddy.png";
-	trader_area = "/area/evilreaver/storage/engineering"
-	},
+/obj/npc/trader/robot/robuddy/salvage,
 /obj/map/light/white,
 /turf/simulated/floor/plating/scorched,
 /area/evilreaver/storage/engineering{

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
@@ -25,15 +25,7 @@
 /turf/simulated/floor/damaged2,
 /area/prefab/sea_sketch)
 "ag" = (
-/obj/npc/trader/robot{
-	desc = "The robot equivelant of that guy back on Earth who tried to sell you stolen military gear and drugs in the bathroom of an old greasy spoon.";
-	greeting = "I got what you need.";
-	illegal = 1;
-	name = "Sketchy D-5";
-	picture = "loungebuddy.png";
-	productset = 1;
-	trader_area = "/area/prefab/sea_sketch"
-	},
+/obj/npc/trader/robot/robuddy/drugs,
 /turf/simulated/floor/grime,
 /area/prefab/sea_sketch)
 "ah" = (

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -1405,7 +1405,6 @@ var/list/owlery_sounds = list('sound/voice/animal/hoot.ogg','sound/ambience/owlz
 	picture = "robot.png"
 	name = "Greg"
 	desc = "Oh hey its Greg! Everyone loves him, but you don't seem to remember why."
-	trader_area = "/area/owlery/staffhall"
 
 	New()
 		..()

--- a/code/WorkInProgress/salvager.dm
+++ b/code/WorkInProgress/salvager.dm
@@ -471,7 +471,6 @@ var/datum/magpie_manager/magpie_man = new
 	icon = 'icons/obj/trader.dmi'
 	icon_state = "crate_dispenser"
 	picture = "generic.png"
-	trader_area = "/area/syndicate/salvager"
 	angrynope = "Unable to process request."
 	whotext = "I am the salvage reclamation and supply commissary.  In short I will provide goods in exchange for reclaimed materials and equipment."
 	barter = TRUE

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -34,7 +34,7 @@
 	var/list/failed_purchase_dialogue = null
 	var/pickupdialogue = null
 	var/pickupdialoguefailure = null
-	var/list/trader_area = "/area/trade_outpost/martian"
+	var/list/trader_area = null
 	var/doing_a_thing = 0
 	var/log_trades = TRUE
 
@@ -66,6 +66,7 @@
 
 	New()
 		dialogue = new/datum/dialogueMaster/traderGeneric(src)
+		src.trader_area = get_area(src)
 		..()
 
 	anger()
@@ -616,7 +617,6 @@
 /obj/npc/trader/random
 	icon_state = "welder"
 	picture = "generic.png"
-	trader_area = "/area/shuttle/merchant_shuttle/left"
 	angrynope = "Not right now..."
 	whotext = ""
 
@@ -728,7 +728,6 @@
 /obj/npc/trader/martian
 	icon_state = "martianP"
 	picture = "martian.png"
-	trader_area = "/area/martian_trader"
 	angrynope = "Not now, human."
 	whotext = "I am a simple martian, looking to trade."
 
@@ -790,205 +789,15 @@
 				P.set_loc(D.loc)
 				showswirl(P.loc)
 
-////////Robot
+////////Robot parent
+ABSTRACT_TYPE(/obj/npc/trader/robot)
 /obj/npc/trader/robot
-	icon = 'icons/obj/bots/robuddy/pr-1.dmi'
-	icon_state = "body"
-	picture = "robot.png"
-	trader_area = "/area/turret_protected/robot_trade_outpost"
-	var/productset = 0 // 0 is robots and salvage, 1 is podparts and drugs, 2 is produce. 3 is syndicate junk, 4 is medical stuff
 	angrynope = "Unable to process request."
 	whotext = "I am a trading unit. I have been authorized to engage in trade with you."
+	picture = "robot.png"
 
 	New()
 		..()
-		src.UpdateOverlays(image(src.icon, "face-happy"), "emotion")
-		src.UpdateOverlays(image(src.icon, "lights-on"), "lights")
-
-		switch(productset)
-			if(1) // drugs and pod stuff
-				src.goods_sell += new /datum/commodity/podparts/engine(src)
-				src.goods_sell += new /datum/commodity/podparts/laser(src)
-				src.goods_sell += new /datum/commodity/podparts/asslaser(src)
-				src.goods_sell += new /datum/commodity/podparts/blackarmor(src)
-				src.goods_sell += new /datum/commodity/podparts/skin_stripe_r(src)
-				src.goods_sell += new /datum/commodity/podparts/skin_stripe_b(src)
-				src.goods_sell += new /datum/commodity/podparts/skin_flames(src)
-				src.goods_sell += new /datum/commodity/contraband/ntso_uniform(src)
-				src.goods_sell += new /datum/commodity/contraband/ntso_beret(src)
-				src.goods_sell += new /datum/commodity/contraband/ntso_vest(src)
-				src.goods_sell += new /datum/commodity/contraband/swatmask(src)
-				src.goods_sell += new /datum/commodity/drugs/methamphetamine(src)
-				src.goods_sell += new /datum/commodity/drugs/crank(src)
-				//src.goods_sell += new /datum/commodity/drugs/bathsalts(src)
-				src.goods_sell += new /datum/commodity/drugs/catdrugs(src)
-				src.goods_sell += new /datum/commodity/drugs/morphine(src)
-				src.goods_sell += new /datum/commodity/drugs/krokodil(src)
-				src.goods_sell += new /datum/commodity/drugs/lsd(src)
-				src.goods_sell += new /datum/commodity/drug/lsd_bee(src)
-				src.goods_sell += new /datum/commodity/relics/bootlegfirework(src)
-				src.goods_sell += new /datum/commodity/pills/uranium(src)
-
-				src.goods_buy += new /datum/commodity/drugs/shrooms(src)
-				src.goods_buy += new /datum/commodity/drugs/cannabis(src)
-				src.goods_buy += new /datum/commodity/drugs/cannabis_mega(src)
-				src.goods_buy += new /datum/commodity/drugs/cannabis_white(src)
-				src.goods_buy += new /datum/commodity/drugs/cannabis_omega(src)
-
-			if(2) // diner attendant
-				src.goods_sell += new /datum/commodity/diner/mysteryburger(src)
-				src.goods_sell += new /datum/commodity/diner/monster(src)
-				src.goods_sell += new /datum/commodity/diner/sloppyjoe(src)
-				src.goods_sell += new /datum/commodity/diner/mashedpotatoes(src)
-				src.goods_sell += new /datum/commodity/diner/waffles(src)
-				src.goods_sell += new /datum/commodity/diner/pancake(src)
-				src.goods_sell += new /datum/commodity/diner/meatloaf(src)
-				src.goods_sell += new /datum/commodity/diner/slurrypie(src)
-				src.goods_sell += new /datum/commodity/diner/daily_special(src)
-
-				src.goods_buy += new /datum/commodity/produce/special/gmelon(src)
-				src.goods_buy += new /datum/commodity/produce/special/greengrape(src)
-				src.goods_buy += new /datum/commodity/produce/special/ghostchili(src)
-				src.goods_buy += new /datum/commodity/produce/special/chilly(src)
-				src.goods_buy += new /datum/commodity/produce/special/lashberry(src)
-				src.goods_buy += new /datum/commodity/produce/special/purplegoop(src)
-				src.goods_buy += new /datum/commodity/produce/special/glowfruit(src)
-
-			if(3) // syndicate bot
-				src.illegal = 1
-				var/carlsell = rand(1,10)
-				src.goods_illegal += new /datum/commodity/contraband/command_suit(src)
-				src.goods_illegal += new /datum/commodity/contraband/command_helmet(src)
-				src.goods_illegal += new /datum/commodity/contraband/disguiser(src)
-				if (carlsell <= 3)
-					src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
-				if (carlsell >= 2 && carlsell <= 6)
-					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
-				if (carlsell >= 5 && carlsell <= 8)
-					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
-				if (carlsell >= 9)
-					src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
-					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
-					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
-				src.goods_illegal += new /datum/commodity/contraband/birdbomb(src)
-				src.goods_illegal += new /datum/commodity/contraband/syndicate_headset(src)
-				src.goods_sell += new /datum/commodity/contraband/swatmask(src)
-				src.goods_sell += new /datum/commodity/contraband/spy_sticker_kit(src)
-				src.goods_sell += new /datum/commodity/contraband/flare(src)
-				src.goods_sell += new /datum/commodity/contraband/eguncell_highcap(src)
-				src.goods_sell += new /datum/commodity/podparts/cloak(src)
-				src.goods_sell += new /datum/commodity/podparts/redarmor(src)
-				src.goods_sell += new /datum/commodity/podparts/ballistic(src)
-				src.goods_sell += new /datum/commodity/podparts/artillery(src)
-				src.goods_sell += new /datum/commodity/contraband/artillery_ammo(src)
-				src.goods_sell += new /datum/commodity/contraband/ai_kit_syndie(src)
-#ifdef UNDERWATER_MAP
-				src.goods_sell += new /datum/commodity/HEtorpedo(src)
-#endif
-
-				src.goods_buy += new /datum/commodity/contraband/egun(src)
-				src.goods_buy += new /datum/commodity/contraband/secheadset(src)
-				src.goods_buy += new /datum/commodity/contraband/hosberet(src)
-				src.goods_buy += new /datum/commodity/contraband/spareid(src)
-				src.goods_buy += new /datum/commodity/contraband/captainid(src)
-				src.goods_buy += new /datum/commodity/goldbar(src)
-
-			if(4) // medical
-				src.goods_sell += new /datum/commodity/medical/injectorbelt(src)
-				src.goods_sell += new /datum/commodity/medical/strange_reagent(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidR(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidBr(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidB(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidT(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidO(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidN(src)
-				src.goods_sell += new /datum/commodity/medical/firstaidC(src)
-				src.goods_sell += new /datum/commodity/medical/injectorPent(src)
-				src.goods_sell += new /datum/commodity/medical/injectorPerf(src)
-				#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
-				src.goods_sell += new /datum/commodity/synthmodule/bacteria(src)
-				src.goods_sell += new /datum/commodity/synthmodule/virii(src)
-				src.goods_sell += new /datum/commodity/synthmodule/fungi(src)
-				src.goods_sell += new /datum/commodity/synthmodule/parasite(src)
-				src.goods_sell += new /datum/commodity/synthmodule/gmcell(src)
-				src.goods_sell += new /datum/commodity/synthmodule/vaccine(src)
-				src.goods_sell += new /datum/commodity/pathogensample(src)
-				#endif
-
-				src.goods_sell += new /datum/commodity/bodyparts/cyberheart(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberbutt(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_sunglass(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_sechud(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_thermal(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_meson(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_spectro(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_prodoc(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_camera(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_laser(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cybereye_ecto(src)
-				src.goods_sell += new /datum/commodity/bodyparts/l_cyberlung(src)
-				src.goods_sell += new /datum/commodity/bodyparts/r_cyberlung(src)
-				src.goods_sell += new /datum/commodity/bodyparts/l_cyberkidney(src)
-				src.goods_sell += new /datum/commodity/bodyparts/r_cyberkidney(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberliver(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberspleen(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberstomach(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberintestines(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberpancreas(src)
-				src.goods_sell += new /datum/commodity/bodyparts/cyberappendix(src)
-
-				src.goods_buy += new /datum/commodity/bodyparts/armL(src)
-				src.goods_buy += new /datum/commodity/bodyparts/armR(src)
-				src.goods_buy += new /datum/commodity/bodyparts/legL(src)
-				src.goods_buy += new /datum/commodity/bodyparts/legR(src)
-				src.goods_buy += new /datum/commodity/bodyparts/brain(src)
-				src.goods_buy += new /datum/commodity/bodyparts/synthbrain(src)
-				src.goods_buy += new /datum/commodity/bodyparts/aibrain(src)
-				src.goods_buy += new /datum/commodity/bodyparts/butt(src)
-				src.goods_buy += new /datum/commodity/bodyparts/synthbutt(src)
-				src.goods_buy += new /datum/commodity/bodyparts/heart(src)
-				src.goods_buy += new /datum/commodity/bodyparts/synthheart(src)
-				src.goods_buy += new /datum/commodity/bodyparts/l_eye(src)
-				src.goods_buy += new /datum/commodity/bodyparts/r_eye(src)
-				src.goods_buy += new /datum/commodity/bodyparts/syntheye(src)
-				src.goods_buy += new /datum/commodity/bodyparts/l_lung(src)
-				src.goods_buy += new /datum/commodity/bodyparts/r_lung(src)
-				src.goods_buy += new /datum/commodity/bodyparts/l_kidney(src)
-				src.goods_buy += new /datum/commodity/bodyparts/r_kidney(src)
-				src.goods_buy += new /datum/commodity/bodyparts/liver(src)
-				src.goods_buy += new /datum/commodity/bodyparts/spleen(src)
-				src.goods_buy += new /datum/commodity/bodyparts/stomach(src)
-				src.goods_buy += new /datum/commodity/bodyparts/intestines(src)
-				src.goods_buy += new /datum/commodity/bodyparts/pancreas(src)
-				src.goods_buy += new /datum/commodity/bodyparts/appendix(src)
-
-			else // salvage goods
-				src.goods_sell += new /datum/commodity/fuel(src)
-				src.goods_sell += new /datum/commodity/junk/horsemask(src)
-				src.goods_sell += new /datum/commodity/junk/batmask(src)
-				src.goods_sell += new /datum/commodity/junk/johnny(src)
-				src.goods_sell += new /datum/commodity/junk/buddy(src)
-				src.goods_sell += new /datum/commodity/junk/cowboy_boots(src)
-				src.goods_sell += new /datum/commodity/junk/cowboy_hat(src)
-				src.goods_sell += new /datum/commodity/medical/injectormask(src)
-				src.goods_sell += new /datum/commodity/contraband/briefcase(src)
-				src.goods_sell += new /datum/commodity/boogiebot(src)
-				src.goods_sell += new /datum/commodity/junk/voltron(src)
-				src.goods_sell += new /datum/commodity/junk/cloner_upgrade(src)
-				src.goods_sell += new /datum/commodity/junk/grinder_upgrade(src)
-				src.goods_sell += new /datum/commodity/junk/speedyclone(src)
-				src.goods_sell += new /datum/commodity/junk/efficientclone(src)
-				src.goods_sell += new /datum/commodity/podparts/goldarmor(src)
-
-				src.goods_buy += new /datum/commodity/salvage/scrap(src)
-				src.goods_buy += new /datum/commodity/salvage/machinedebris(src)
-				src.goods_buy += new /datum/commodity/salvage/robotdebris(src)
-				src.goods_buy += new /datum/commodity/relics/gnome(src)
-				src.goods_buy += new /datum/commodity/goldbar(src)
-
-		//src.name = pick( "Unit DX-495E", "Unit DX-495H", "Unit DX-575E", "Unit DX-485F", "Unit DX-385D", "Sketchy D", "Skeevy D")
-
 		greeting= {"[src.name]'s eyes light up, and he states, \"Salutations organic, welcome to my shop. Please browse my wares.\""}
 
 		portrait_setup = "<img src='[resource("images/traders/[src.picture]")]'><HR><B>[src.name]</B><HR>"
@@ -1022,6 +831,216 @@
 			for (var/obj/machinery/bot/guardbot/G in T)
 				G.turn_on()
 
+/obj/npc/trader/robot/medical
+	name = "D.O.C."
+	icon = 'icons/misc/evilreaverstation.dmi'
+	icon_state = "medibot0"
+
+	New()
+		..()
+		src.goods_sell += new /datum/commodity/medical/injectorbelt(src)
+		src.goods_sell += new /datum/commodity/medical/strange_reagent(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidR(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidBr(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidB(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidT(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidO(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidN(src)
+		src.goods_sell += new /datum/commodity/medical/firstaidC(src)
+		src.goods_sell += new /datum/commodity/medical/injectorPent(src)
+		src.goods_sell += new /datum/commodity/medical/injectorPerf(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberheart(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberbutt(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_sunglass(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_sechud(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_thermal(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_meson(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_spectro(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_prodoc(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_camera(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_laser(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cybereye_ecto(src)
+		src.goods_sell += new /datum/commodity/bodyparts/l_cyberlung(src)
+		src.goods_sell += new /datum/commodity/bodyparts/r_cyberlung(src)
+		src.goods_sell += new /datum/commodity/bodyparts/l_cyberkidney(src)
+		src.goods_sell += new /datum/commodity/bodyparts/r_cyberkidney(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberliver(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberspleen(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberstomach(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberintestines(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberpancreas(src)
+		src.goods_sell += new /datum/commodity/bodyparts/cyberappendix(src)
+
+		src.goods_buy += new /datum/commodity/bodyparts/armL(src)
+		src.goods_buy += new /datum/commodity/bodyparts/armR(src)
+		src.goods_buy += new /datum/commodity/bodyparts/legL(src)
+		src.goods_buy += new /datum/commodity/bodyparts/legR(src)
+		src.goods_buy += new /datum/commodity/bodyparts/brain(src)
+		src.goods_buy += new /datum/commodity/bodyparts/synthbrain(src)
+		src.goods_buy += new /datum/commodity/bodyparts/aibrain(src)
+		src.goods_buy += new /datum/commodity/bodyparts/butt(src)
+		src.goods_buy += new /datum/commodity/bodyparts/synthbutt(src)
+		src.goods_buy += new /datum/commodity/bodyparts/heart(src)
+		src.goods_buy += new /datum/commodity/bodyparts/synthheart(src)
+		src.goods_buy += new /datum/commodity/bodyparts/l_eye(src)
+		src.goods_buy += new /datum/commodity/bodyparts/r_eye(src)
+		src.goods_buy += new /datum/commodity/bodyparts/syntheye(src)
+		src.goods_buy += new /datum/commodity/bodyparts/l_lung(src)
+		src.goods_buy += new /datum/commodity/bodyparts/r_lung(src)
+		src.goods_buy += new /datum/commodity/bodyparts/l_kidney(src)
+		src.goods_buy += new /datum/commodity/bodyparts/r_kidney(src)
+		src.goods_buy += new /datum/commodity/bodyparts/liver(src)
+		src.goods_buy += new /datum/commodity/bodyparts/spleen(src)
+		src.goods_buy += new /datum/commodity/bodyparts/stomach(src)
+		src.goods_buy += new /datum/commodity/bodyparts/intestines(src)
+		src.goods_buy += new /datum/commodity/bodyparts/pancreas(src)
+		src.goods_buy += new /datum/commodity/bodyparts/appendix(src)
+
+/obj/npc/trader/robot/syndicate
+	name = "C.A.R.L."
+	icon = 'icons/mob/robots.dmi'
+	icon_state = "syndibot"
+	illegal = TRUE
+
+	New()
+		..()
+		var/carlsell = rand(1,10)
+		src.goods_illegal += new /datum/commodity/contraband/command_suit(src)
+		src.goods_illegal += new /datum/commodity/contraband/command_helmet(src)
+		src.goods_illegal += new /datum/commodity/contraband/disguiser(src)
+		src.goods_illegal += new /datum/commodity/contraband/birdbomb(src)
+		src.goods_illegal += new /datum/commodity/contraband/syndicate_headset(src)
+		if (carlsell <= 3)
+			src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
+		if (carlsell >= 2 && carlsell <= 6)
+			src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
+		if (carlsell >= 5 && carlsell <= 8)
+			src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
+		if (carlsell >= 9)
+			src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
+			src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
+			src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
+
+		src.goods_sell += new /datum/commodity/contraband/swatmask(src)
+		src.goods_sell += new /datum/commodity/contraband/spy_sticker_kit(src)
+		src.goods_sell += new /datum/commodity/contraband/flare(src)
+		src.goods_sell += new /datum/commodity/contraband/eguncell_highcap(src)
+		src.goods_sell += new /datum/commodity/podparts/cloak(src)
+		src.goods_sell += new /datum/commodity/podparts/redarmor(src)
+		src.goods_sell += new /datum/commodity/podparts/ballistic(src)
+		src.goods_sell += new /datum/commodity/podparts/artillery(src)
+		src.goods_sell += new /datum/commodity/contraband/artillery_ammo(src)
+		src.goods_sell += new /datum/commodity/contraband/ai_kit_syndie(src)
+#ifdef UNDERWATER_MAP
+		src.goods_sell += new /datum/commodity/HEtorpedo(src)
+#endif
+
+		src.goods_buy += new /datum/commodity/contraband/egun(src)
+		src.goods_buy += new /datum/commodity/contraband/secheadset(src)
+		src.goods_buy += new /datum/commodity/contraband/hosberet(src)
+		src.goods_buy += new /datum/commodity/contraband/spareid(src)
+		src.goods_buy += new /datum/commodity/contraband/captainid(src)
+		src.goods_buy += new /datum/commodity/goldbar(src)
+
+ABSTRACT_TYPE(/obj/npc/trader/robot/robuddy)
+/obj/npc/trader/robot/robuddy
+	icon = 'icons/obj/bots/robuddy/pr-1.dmi'
+	icon_state = "body"
+
+	New()
+		..()
+		src.UpdateOverlays(SafeGetOverlayImage("face", 'icons/obj/bots/robuddy/pr-1.dmi' ,"face-happy"), "face")
+		src.UpdateOverlays(SafeGetOverlayImage("lights", 'icons/obj/bots/robuddy/pr-1.dmi' ,"lights-on"), "lights")
+
+/obj/npc/trader/robot/robuddy/salvage
+	name = "Thrifty B.O.B.";
+	picture = "loungebuddy.png";
+
+	New()
+		..()
+		src.goods_sell += new /datum/commodity/fuel(src)
+		src.goods_sell += new /datum/commodity/junk/horsemask(src)
+		src.goods_sell += new /datum/commodity/junk/batmask(src)
+		src.goods_sell += new /datum/commodity/junk/johnny(src)
+		src.goods_sell += new /datum/commodity/junk/buddy(src)
+		src.goods_sell += new /datum/commodity/junk/cowboy_boots(src)
+		src.goods_sell += new /datum/commodity/junk/cowboy_hat(src)
+		src.goods_sell += new /datum/commodity/medical/injectormask(src)
+		src.goods_sell += new /datum/commodity/contraband/briefcase(src)
+		src.goods_sell += new /datum/commodity/boogiebot(src)
+		src.goods_sell += new /datum/commodity/junk/voltron(src)
+		src.goods_sell += new /datum/commodity/junk/cloner_upgrade(src)
+		src.goods_sell += new /datum/commodity/junk/grinder_upgrade(src)
+		src.goods_sell += new /datum/commodity/junk/speedyclone(src)
+		src.goods_sell += new /datum/commodity/junk/efficientclone(src)
+		src.goods_sell += new /datum/commodity/podparts/goldarmor(src)
+
+		src.goods_buy += new /datum/commodity/salvage/scrap(src)
+		src.goods_buy += new /datum/commodity/salvage/machinedebris(src)
+		src.goods_buy += new /datum/commodity/salvage/robotdebris(src)
+		src.goods_buy += new /datum/commodity/relics/gnome(src)
+		src.goods_buy += new /datum/commodity/goldbar(src)
+
+/obj/npc/trader/robot/robuddy/drugs
+	name = "Sketchy D-5"
+	desc = "The robot equivelant of that guy back on Earth who tried to sell you stolen military gear and drugs in the bathroom of an old greasy spoon."
+	picture = "loungebuddy.png"
+	greeting = "I got what you need."
+
+	New()
+		..()
+		src.goods_sell += new /datum/commodity/podparts/engine(src)
+		src.goods_sell += new /datum/commodity/podparts/laser(src)
+		src.goods_sell += new /datum/commodity/podparts/asslaser(src)
+		src.goods_sell += new /datum/commodity/podparts/blackarmor(src)
+		src.goods_sell += new /datum/commodity/podparts/skin_stripe_r(src)
+		src.goods_sell += new /datum/commodity/podparts/skin_stripe_b(src)
+		src.goods_sell += new /datum/commodity/podparts/skin_flames(src)
+		src.goods_sell += new /datum/commodity/contraband/ntso_uniform(src)
+		src.goods_sell += new /datum/commodity/contraband/ntso_beret(src)
+		src.goods_sell += new /datum/commodity/contraband/ntso_vest(src)
+		src.goods_sell += new /datum/commodity/contraband/swatmask(src)
+		src.goods_sell += new /datum/commodity/drugs/methamphetamine(src)
+		src.goods_sell += new /datum/commodity/drugs/crank(src)
+		src.goods_sell += new /datum/commodity/drugs/catdrugs(src)
+		src.goods_sell += new /datum/commodity/drugs/morphine(src)
+		src.goods_sell += new /datum/commodity/drugs/krokodil(src)
+		src.goods_sell += new /datum/commodity/drugs/lsd(src)
+		src.goods_sell += new /datum/commodity/drug/lsd_bee(src)
+		src.goods_sell += new /datum/commodity/relics/bootlegfirework(src)
+		src.goods_sell += new /datum/commodity/pills/uranium(src)
+
+		src.goods_buy += new /datum/commodity/drugs/shrooms(src)
+		src.goods_buy += new /datum/commodity/drugs/cannabis(src)
+		src.goods_buy += new /datum/commodity/drugs/cannabis_mega(src)
+		src.goods_buy += new /datum/commodity/drugs/cannabis_white(src)
+		src.goods_buy += new /datum/commodity/drugs/cannabis_omega(src)
+
+/obj/npc/trader/robot/robuddy/diner
+	name = "B.I.F.F."
+	desc = "The robot proprieter of the Diner. Deals in food that's to dine for!"
+	picture = "loungebuddy.png"
+
+	New()
+		..()
+		src.goods_sell += new /datum/commodity/diner/mysteryburger(src)
+		src.goods_sell += new /datum/commodity/diner/monster(src)
+		src.goods_sell += new /datum/commodity/diner/sloppyjoe(src)
+		src.goods_sell += new /datum/commodity/diner/mashedpotatoes(src)
+		src.goods_sell += new /datum/commodity/diner/waffles(src)
+		src.goods_sell += new /datum/commodity/diner/pancake(src)
+		src.goods_sell += new /datum/commodity/diner/meatloaf(src)
+		src.goods_sell += new /datum/commodity/diner/slurrypie(src)
+		src.goods_sell += new /datum/commodity/diner/daily_special(src)
+
+		src.goods_buy += new /datum/commodity/produce/special/gmelon(src)
+		src.goods_buy += new /datum/commodity/produce/special/greengrape(src)
+		src.goods_buy += new /datum/commodity/produce/special/ghostchili(src)
+		src.goods_buy += new /datum/commodity/produce/special/chilly(src)
+		src.goods_buy += new /datum/commodity/produce/special/lashberry(src)
+		src.goods_buy += new /datum/commodity/produce/special/purplegoop(src)
+		src.goods_buy += new /datum/commodity/produce/special/glowfruit(src)
 
 /// BZZZZZZZZZZZ
 
@@ -1030,7 +1049,6 @@
 	icon_state = "bee"
 	picture = "bee.png"
 	name = "Bombini" // like the tribe of bumblebees
-	trader_area = "/area/bee_trader"
 
 	New()
 		..()
@@ -1113,7 +1131,6 @@
 	icon_state = "exclown"
 	picture = "exclown.png"
 	name = "Geoff Honkington"
-	trader_area = "/area/hallway/secondary/entry"
 	angrynope = "HO--nngh. Leave me alone."
 	whotext = "Just an honest trader tryin' to make a living. Mind the banana peel, ya hear?"
 	var/honk = 0
@@ -1211,7 +1228,6 @@
 	icon_state = "skeleton"
 	picture = "skeleton.png"
 	name = "Clack Hat"
-	trader_area = "/area/skeleton_trader"
 	angrynope = "Not now."
 	whotext = "I am a trader."
 
@@ -1267,7 +1283,6 @@
 	icon_state = "chad"
 	picture = "chad.png"
 	name = "Chad"
-	trader_area = "/area/diner/hallway"
 	angrynope = "Piss off, bro!"
 	whotext = "What does it look like, man?"
 
@@ -1322,7 +1337,6 @@
 	icon_state = "hand"
 	picture = "hand.png"
 	name = "A hand sticking out from a toilet"
-	trader_area = "/area/diner/bathroom"
 
 	New()
 		..()
@@ -1388,7 +1402,6 @@
 	icon_state = "twins"
 	picture = "twins.png"
 	name = "Carol and Lynn"
-	trader_area = "/area/prefab/mobius"
 
 	bound_width = 64
 	bound_height = 32
@@ -1451,7 +1464,6 @@
 	icon_state = "flexx"
 	picture = "flexx.png"
 	name = "Flexx"
-	trader_area = "/area/flexx_trader"
 	angrynope = "Not cool, champ!"
 	whotext = "Yo, buddy, name's Flexx. Whaddup?"
 

--- a/code/obj/flock/trader.dm
+++ b/code/obj/flock/trader.dm
@@ -155,7 +155,6 @@ TYPEINFO(/turf/simulated/floor/shuttlebay/flock)
 	picture = "flocktrader.png"
 	name = "Flocktrader Sa.le"
 	desc = "Some sort of weird holographic image on some fancy totem thing. Seems like it wants to trade."
-	trader_area = "/area/flock_trader"
 	var/is_greeting = 0
 	var/grad_col_1 = "#3cb5a3"
 	var/grad_col_2 = "#124e43"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12040,14 +12040,7 @@
 /obj/stool/chair/office/red{
 	dir = 8
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5718,9 +5718,7 @@
 /area/station/maintenance/east)
 "ayB" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown)
 "ayD" = (
@@ -41188,14 +41186,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1256,9 +1256,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "afm" = (
@@ -39839,14 +39837,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1526,9 +1526,7 @@
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/generic,
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Clown's Quarters"
@@ -58679,14 +58677,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/cogwip/kappa.dmm
+++ b/maps/cogwip/kappa.dmm
@@ -7066,9 +7066,7 @@
 /area/space)
 "tW" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -2037,9 +2037,7 @@
 	},
 /area/space)
 "fT" = (
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/left_station"
-	},
+/obj/npc/trader/random,
 /obj/stool/chair/comfy,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -2082,9 +2080,7 @@
 /area/space)
 "ga" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -4538,11 +4534,7 @@
 /turf/space,
 /area/space)
 "mz" = (
-/obj/npc/trader/robot{
-	name = "Thrifty B.O.B.";
-	picture = "loungebuddy.png";
-	trader_area = "/area/evilreaver/storage/engineering"
-	},
+/obj/npc/trader/robot/robuddy/salvage,
 /obj/map/light/white,
 /turf/simulated/floor/plating/scorched,
 /area/space)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -501,14 +501,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -24487,9 +24480,7 @@
 /area/station/maintenance/inner/central)
 "enT" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -10880,9 +10880,7 @@
 	pixel_y = 24
 	},
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "djl" = (
@@ -15630,14 +15628,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "eIV" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "eJd" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1897,9 +1897,7 @@
 /area/space)
 "ahg" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
@@ -29287,14 +29285,7 @@
 /turf/simulated/floor/purpleblack,
 /area/research_outpost/indigo_rye)
 "clL" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -8297,13 +8297,7 @@
 /area/station/medical/medbay)
 "dNQ" = (
 /obj/stool/chair,
-/obj/npc/trader/robot{
-	icon_state = "medibot0";
-	name = "D.O.C.";
-	productset = 4;
-	trader_area = "/area/abandonedmedicalship/robot_trader";
-	icon = 'icons/misc/evilreaverstation.dmi'
-	},
+/obj/npc/trader/robot/medical,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "dOb" = (
@@ -21755,9 +21749,7 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "jvs" = (
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/stool/chair/syndicate,
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -28443,14 +28435,7 @@
 /turf/simulated/floor/minitiles/black,
 /area/station/bridge)
 "mdr" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1330,9 +1330,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "aek" = (
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -12829,14 +12827,7 @@
 	invisibility = 101;
 	name = "glow - WHITE"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /turf/simulated/floor/red,
 /area/listeningpost)
 "aQM" = (
@@ -21413,13 +21404,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 4
 	},
-/obj/npc/trader/robot{
-	icon_state = "medibot0";
-	name = "D.O.C.";
-	productset = 4;
-	trader_area = "/area/abandonedmedicalship/robot_trader";
-	icon = 'icons/misc/evilreaverstation.dmi'
-	},
+/obj/npc/trader/robot/medical,
 /obj/map/light/white,
 /obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/white/grime,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -5081,14 +5081,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -11474,9 +11467,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "ayR" = (

--- a/maps/setpieces/regina.dmm
+++ b/maps/setpieces/regina.dmm
@@ -48,9 +48,7 @@
 	},
 /area/space)
 "aQ" = (
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/left_station"
-	},
+/obj/npc/trader/random,
 /obj/stool/chair/comfy,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -270,9 +268,7 @@
 /area/shuttle/merchant_shuttle/diner_centcom)
 "gP" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -542,9 +538,7 @@
 /area/shuttle/merchant_shuttle/left_centcom/destiny)
 "kL" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -1204,9 +1198,7 @@
 /area/shuttle/merchant_shuttle/right_centcom/cogmap2)
 "wR" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -1624,9 +1616,7 @@
 /area/space)
 "Fc" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -1848,9 +1838,7 @@
 /area/regina)
 "Ki" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -2169,9 +2157,7 @@
 /turf/space,
 /area/regina)
 "Qf" = (
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /obj/stool/chair/comfy,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -2430,9 +2416,7 @@
 /area/regina)
 "Vv" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/left_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -2708,9 +2692,7 @@
 /area/shuttle/merchant_shuttle/diner_centcom)
 "ZW" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -32338,9 +32338,7 @@
 /area/russian/radiation)
 "dgf" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"

--- a/maps/unused/density.dmm
+++ b/maps/unused/density.dmm
@@ -1192,9 +1192,7 @@
 "cY" = (
 /obj/decal/cleanable/dirt,
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -14718,14 +14718,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -17361,9 +17354,7 @@
 /area/station/science/teleporter)
 "cGi" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/juggleplaque{
 	pixel_y = 32
 	},

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -12425,9 +12425,7 @@
 	})
 "Bc" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/carpet/arcade,
 /area/station/storage/tech)
 "Bd" = (
@@ -16264,14 +16262,7 @@
 /turf/simulated/floor/plating,
 /area/listeningpost)
 "Jn" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -21155,9 +21155,7 @@
 	pixel_x = 10
 	},
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
@@ -44059,14 +44057,7 @@
 /area/listeningpost/power)
 "cwF" = (
 /obj/decal/cleanable/dirt,
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -1728,12 +1728,7 @@
 /area/abandonedmedicalship/robot_trader)
 "agf" = (
 /obj/stool/chair,
-/obj/npc/trader/robot{
-	icon_state = "medibot0";
-	name = "D.O.C.";
-	productset = 4;
-	trader_area = "/area/abandonedmedicalship/robot_trader"
-	},
+/obj/npc/trader/robot/medical,
 /obj/map/light/white,
 /obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/white/grime,
@@ -3218,14 +3213,7 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "alp" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -39355,9 +39343,7 @@
 /area/station/medical/medbay/lobby)
 "rfE" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
 	pixel_y = 20

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -12686,14 +12686,7 @@
 	},
 /area/listeningpost)
 "bmy" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -14126,9 +14119,7 @@
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/generic,
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -69962,14 +69962,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/north)
 "sjJ" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /turf/simulated/floor,
 /area/listeningpost)
 "sjR" = (
@@ -71158,9 +71151,7 @@
 /turf/simulated/floor/grey,
 /area/ghostdrone_factory)
 "sxd" = (
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /obj/stool/chair,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
@@ -84826,7 +84817,7 @@
 "vJl" = (
 /obj/machinery/manufacturer/general/grody{
 	free_resource_amt = 2;
-
+	
 	},
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -22403,14 +22403,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
@@ -28577,9 +28570,7 @@
 /area/station/security/prison)
 "mlk" = (
 /obj/stool/chair/syndicate,
-/obj/npc/trader/exclown{
-	trader_area = "/area/station/crew_quarters/clown"
-	},
+/obj/npc/trader/exclown,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/south)
 "mlO" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -44956,14 +44956,7 @@
 	name = "Maintenance Shack"
 	})
 "tIR" = (
-/obj/npc/trader/robot{
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "syndibot";
-	illegal = 1;
-	name = "C.A.R.L.";
-	productset = 3;
-	trader_area = "/area/listeningpost"
-	},
+/obj/npc/trader/robot/syndicate,
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -49603,9 +49603,7 @@
 /area/shuttle/merchant_shuttle/right_centcom/cogmap2)
 "drV" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -49728,9 +49726,7 @@
 /area/hospital/underground)
 "dsu" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -50166,9 +50162,7 @@
 /area/crypt/sigma/lab)
 "dvi" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -58482,9 +58476,7 @@
 /area/centcom/offices/zamujasa)
 "eTR" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -60308,9 +60300,7 @@
 /area/centcom/lounge)
 "gZG" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -62996,9 +62986,7 @@
 	icon_state = "blue"
 	})
 "jRS" = (
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /obj/stool/chair/comfy,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -69916,9 +69904,7 @@
 /area/hospital)
 "raS" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/right_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -73111,9 +73097,7 @@
 /area/moon/museum/west)
 "uKz" = (
 /obj/stool/chair/comfy,
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/left_station"
-	},
+/obj/npc/trader/random,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -75041,9 +75025,7 @@
 /turf/unsimulated/grass,
 /area/owlery/owllock)
 "wLj" = (
-/obj/npc/trader/random{
-	trader_area = "/area/shuttle/merchant_shuttle/left_station"
-	},
+/obj/npc/trader/random,
 /obj/stool/chair/comfy,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -7064,11 +7064,7 @@
 /turf/space,
 /area/space)
 "aKG" = (
-/obj/npc/trader/robot{
-	name = "Thrifty B.O.B.";
-	picture = "loungebuddy.png";
-	trader_area = "/area/evilreaver/storage/engineering"
-	},
+/obj/npc/trader/robot/robuddy/salvage,
 /obj/map/light/white,
 /turf/simulated/floor/plating/scorched,
 /area/evilreaver/storage/engineering{
@@ -10843,13 +10839,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 4
 	},
-/obj/npc/trader/robot{
-	icon_state = "medibot0";
-	name = "D.O.C.";
-	productset = 4;
-	trader_area = "/area/abandonedmedicalship/robot_trader";
-	icon = 'icons/misc/evilreaverstation.dmi'
-	},
+/obj/npc/trader/robot/medical,
 /obj/map/light/white,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
@@ -17776,13 +17766,7 @@
 /turf/simulated/wall/auto/reinforced/old,
 /area/diner/kitchen)
 "iDz" = (
-/obj/npc/trader/robot{
-	desc = "The robot proprieter of the Diner. Deals in food that's to dine for!";
-	name = "B.I.F.F.";
-	picture = "loungebuddy.png";
-	productset = 2;
-	trader_area = "/area/diner/dining"
-	},
+/obj/npc/trader/robot/robuddy/diner,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/diner/dining)
@@ -18050,15 +18034,7 @@
 /turf/space,
 /area/diner/tug)
 "jiP" = (
-/obj/npc/trader/robot{
-	desc = "The robot equivelant of that guy back on Earth who tried to sell you stolen military gear and drugs in the bathroom of an old greasy spoon.";
-	greeting = "I got what you need.";
-	illegal = 1;
-	name = "Sketchy D-5";
-	picture = "loungebuddy.png";
-	productset = 1;
-	trader_area = "/area/diner/bathroom"
-	},
+/obj/npc/trader/robot/robuddy/drugs,
 /turf/simulated/floor/grime,
 /area/diner/bathroom)
 "jiQ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates subtypes for CARL, DOC, sketchy-D5, thrifty BOB and BIFF.
Automates setting `trader_area` instead of having it as a string on everything. I tested and traders should work as expected, buying puts the crates in the correct positions.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Varedited traders are a pain if one needs changing.


