### PR TITLE
Adds two artistic toolboxes to Donut 2

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -35761,6 +35761,7 @@
 	pixel_y = 7
 	},
 /obj/random_item_spawner/desk_stuff/few,
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/black/corner{
 	dir = 1
 	},
@@ -51261,6 +51262,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "xMi" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds two artistic toolboxes to Donut 2, one in crew lounge and one in the warehouse.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Map didn't have any and it's a nice thing to have.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)Two artistic toolboxes now spawn on Donut 2 in the crew lounge and warehouse.
```
