### PR TITLE
Update human critters to paste their appearance onto the corpse they spawn

### DIFF
--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -5,8 +5,6 @@
 		. = ..()
 		randomize_look(src, !gender, 1, 1, 1, 1, 1, src)
 		src.gender = src.bioHolder?.mobAppearance?.gender
-		src.update_colorful_parts()
-		set_clothing_icon_dirty()
 
 /mob/living/carbon/human/normal/assistant
 	New()

--- a/code/mob/living/critter/humanoid/human.dm
+++ b/code/mob/living/critter/humanoid/human.dm
@@ -28,6 +28,8 @@ ABSTRACT_TYPE(/mob/living/critter/human)
 	var/corpse_spawner = null //Ex. var/corpse_spawner = /obj/mapping_helper/mob_spawn/corpse/human/random
 	/// Path of a human to copy appearance from should be a type of /mob/living/carbon/human.
 	var/human_to_copy = null //Ex. var/human_to_copy = /mob/living/carbon/human/normal/assistant
+	// A stored appearance which is set when stealing and applied to the corpse so the mobs look the same.
+	var/datum/bioHolder/stored_appearance = null
 
 	New()
 		..()
@@ -45,6 +47,8 @@ ABSTRACT_TYPE(/mob/living/critter/human)
 		..()
 		if (src.corpse_spawner)
 			var/obj/mapping_helper/mob_spawn/corpse/human/body = new src.corpse_spawner(get_turf(src))
+			body.appearance_override = src.stored_appearance
+			src.stored_appearance = null
 			body.decomp_stage = DECOMP_STAGE_NO_ROT
 			body.max_organs_removed = 0
 			src.ghostize()
@@ -66,8 +70,10 @@ ABSTRACT_TYPE(/mob/living/critter/human)
 			qdel(target.l_hand)
 		if (target.r_hand)
 			qdel(target.r_hand)
-		src.appearance = target
+		src.appearance = target.appearance
 		src.overlay_refs = target.overlay_refs?.Copy()
+		src.stored_appearance = new
+		src.stored_appearance.CopyOther(target.bioHolder, copyAppearance = 1, copyPool = 0, copyEffectBlocks = 0, copyActiveEffects = 0)
 		qdel(target)
 
 	proc/post_setup()

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -81,6 +81,8 @@
 	var/delete_id = FALSE
 	/// If TRUE we break the headset and make it unscannable after spawning
 	var/break_headset = FALSE
+	/// Sent in if we are spawned by a human critter that drops a spawner
+	var/datum/bioHolder/appearance_override = null
 
 	setup()
 		if (isnull(src.spawn_type))
@@ -160,6 +162,9 @@
 			var/obj/container = new container_type(src.loc)
 			H.set_loc(container)
 			container.update_icon()
+
+		if (src.appearance_override)
+			H.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
 
 	do_damage(var/mob/living/carbon/human/H) // Override if you want specific damage numbers / types
 		H.TakeDamage("all", brute = rand(100, 150), burn = rand(100, 150), tox = rand(40, 80), disallow_limb_loss = TRUE)

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -61,24 +61,23 @@
 
 	New()
 		..()
-		SPAWN(0)
-			if (src.donor)
-				if(!src.bones)
-					src.bones = new /datum/bone(src)
-				src.bones.donor = src.donor
-				src.bones.parent_organ = src.organ_name
-				src.bones.name = "skull"
-				if (src.donor?.bioHolder?.mobAppearance)
-					src.donor_appearance = src.donor.bioHolder.mobAppearance
-					src.UpdateIcon(/*makeshitup*/ 0)
-				else //The heck?
-					src.UpdateIcon(/*makeshitup*/ 1)
-				if (src.donor.eye != null)
-					src.donor.set_eye(null)
-			else
+		if (src.donor)
+			if(!src.bones)
+				src.bones = new /datum/bone(src)
+			src.bones.donor = src.donor
+			src.bones.parent_organ = src.organ_name
+			src.bones.name = "skull"
+			if (src.donor?.bioHolder?.mobAppearance)
+				src.donor_appearance = src.donor.bioHolder.mobAppearance
+				src.UpdateIcon(/*makeshitup*/ 0)
+			else //The heck?
 				src.UpdateIcon(/*makeshitup*/ 1)
-			if (!src.chat_text)
-				src.chat_text = new(null, src)
+			if (src.donor.eye != null)
+				src.donor.set_eye(null)
+		else
+			src.UpdateIcon(/*makeshitup*/ 1)
+		if (!src.chat_text)
+			src.chat_text = new(null, src)
 
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, mob/thrown_by, throw_type = 1,
 			allow_anchored = UNANCHORED, bonus_throwforce = 0, end_throw_callback = null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
FIxes human critters having incorrect head appearances by removing the SPAWN(0) on head organs.
Stores the appearance holder of the copied human and applies it to the corpse spawner so they look the same.
Removes unneeded calls from normal human bioholder init.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The fake guy you just killed should look the same as the real guy that they spawn.


