### PR TITLE
Add orbital shakers to maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4685,7 +4685,7 @@
 	pixel_y = 21
 	},
 /obj/table/reinforced/chemistry/auto/chemstorage,
-/obj/item/paper/labdrawertips,
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purplewhite{
 	dir = 9
 	},
@@ -16222,6 +16222,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/table/reinforced/chemistry/auto/allinone,
+/obj/item/paper/labdrawertips,
 /turf/simulated/floor/purplewhite{
 	dir = 5
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13965,6 +13965,7 @@
 /area/station/hallway/primary/east)
 "bpj" = (
 /obj/table/reinforced/chemistry/auto/drugs,
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purpleblack{
 	dir = 10
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -37713,6 +37713,7 @@
 	pixel_y = 32
 	},
 /obj/table/reinforced/chemistry/auto/firstaid,
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -60074,6 +60074,7 @@
 /area/research_outpost)
 "fas" = (
 /obj/table/reinforced/chemistry/auto,
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purplewhite{
 	dir = 6
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -43506,6 +43506,7 @@
 /area/station/security/checkpoint/research)
 "sht" = (
 /obj/table/reinforced/chemistry/auto,
+/obj/machinery/chem_shaker/large/chemistry,
 /obj/item/crowbar,
 /turf/simulated/floor/purplewhite{
 	dir = 9

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -65737,6 +65737,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33303,6 +33303,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
+/obj/machinery/chem_shaker/large/chemistry,
 /obj/item/paper/labdrawertips,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
@@ -37077,8 +37078,7 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "gRM" = (
-/obj/machinery/computer/barcode/qm{
-	},
+/obj/machinery/computer/barcode/qm,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
@@ -41148,8 +41148,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "jYt" = (
-/obj/machinery/computer/barcode{
-	},
+/obj/machinery/computer/barcode,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -50416,18 +50415,6 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"riM" = (
-/obj/machinery/computer/barcode/qm{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/quartermaster/office)
 "riU" = (
 /obj/shrub,
 /turf/simulated/floor/grass,
@@ -107105,7 +107092,7 @@ lTF
 bNf
 bOL
 bQb
-riM
+bZR
 bSW
 bJr
 cnU

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -30494,6 +30494,7 @@
 "mZj" = (
 /obj/table/reinforced/chemistry/auto/basicsup,
 /obj/machinery/light,
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "mZs" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -36328,6 +36328,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "gNp" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -22704,13 +22704,13 @@
 /area/station/medical/breakroom)
 "jQJ" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/machinery/chem_shaker/large/chemistry,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "jQL" = (
@@ -40972,6 +40972,7 @@
 /area/station/security/detectives_office)
 "rYQ" = (
 /obj/table/reinforced/chemistry/auto,
+/obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /turf/simulated/floor/specialroom/arcade,


### PR DESCRIPTION
[MAPPING] [FEATURE] [CHEM]
## About the PR
Adds one large chemistry orbital shaker to each rotation map, on top of a lab desk. Orbital shakers were merged 35 minutes ago in #15713

## Why's this needed?
They are cool and are meant to be used

## Changelog
```changelog
(u)DisturbHerb, Tyrant
(*)Added the new orbital shakers to Chemical Labs, which shake glassware around and apply physical force to them.
```