### PR TITLE
Make glowsticks easier to put in reactor

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -535,8 +535,8 @@
 			glowstick_mat.setColor(rgb(stick.col_r*255, stick.col_g*255, stick.col_b*255))
 			var/obj/item/reactor_component/fuel_rod/glowsticks/result_rod = new /obj/item/reactor_component/fuel_rod/glowsticks(glowstick_mat)
 			src.component_grid[x][y]=result_rod
+			result_rod.set_loc(src)
 			user.u_equip(equipped)
-			equipped.set_loc(src)
 			qdel(equipped)
 		else
 			src.component_grid[x][y]=equipped

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -515,7 +515,7 @@
 					if(!equipped)
 						return
 
-					if(!istype(equipped,/obj/item/reactor_component))
+					if(!istype(equipped,/obj/item/reactor_component) && !istype(equipped,/obj/item/device/light/glowstick))
 						ui.user.visible_message("<span class='alert'>[ui.user] tries to shove \a [equipped] into the reactor. Silly [ui.user]!</span>", "<span class='alert'>You try to put \a [equipped] into the reactor. You feel very foolish.</span>")
 						return
 
@@ -528,9 +528,20 @@
 	proc/insert_comp_callback(var/x,var/y,var/mob/user,var/obj/item/reactor_component/equipped)
 		if(src.component_grid[x][y])
 			return FALSE
-		src.component_grid[x][y]=equipped
-		user.u_equip(equipped)
-		equipped.set_loc(src)
+		if(istype(equipped,/obj/item/device/light/glowstick))
+			var/obj/item/device/light/glowstick/stick = equipped
+			var/datum/material/glowstick_mat = getMaterial("glowstick")
+			glowstick_mat = glowstick_mat.getMutable()
+			glowstick_mat.setColor(rgb(stick.col_r*255, stick.col_g*255, stick.col_b*255))
+			var/obj/item/reactor_component/fuel_rod/glowsticks/result_rod = new /obj/item/reactor_component/fuel_rod/glowsticks(glowstick_mat)
+			src.component_grid[x][y]=result_rod
+			user.u_equip(equipped)
+			equipped.set_loc(src)
+			qdel(equipped)
+		else
+			src.component_grid[x][y]=equipped
+			user.u_equip(equipped)
+			equipped.set_loc(src)
 		playsound(src, 'sound/machines/law_insert.ogg', 80)
 		logTheThing(LOG_STATION, user, "[constructName(user)] <b>inserts</b> component into nuclear reactor([src]): [equipped] at slot [x],[y]")
 		user.visible_message("<span class='alert'>[user] slides \a [equipped] into the reactor</span>", "<span class='alert'>You slide the [equipped] into the reactor.</span>")

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -246,7 +246,7 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 
 /obj/item/reactor_component/fuel_rod/glowsticks
 	name = "makeshift fuel rod"
-	desc = "A fuel rod fo- hey this is just a bundle of glowsticks!"
+	desc = "A fuel rod fo- hey this is just a squashed glowstick!"
 	melting_point = T0C+400 //plastic glowsticks melt easy
 
 	New(material)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you put glowsticks straight in the reactor


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Usability


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(*)You can now put glowsticks directly into the reactor.
```
