### PR TITLE
No Cyborg Beaker Shattering

### DIFF
--- a/code/modules/chemistry/tools/beakers.dm
+++ b/code/modules/chemistry/tools/beakers.dm
@@ -182,8 +182,7 @@
 	initial_reagents = "silver_sulfadiazine"
 
 /obj/item/reagent_containers/glass/beaker/large/cyborg
-	shatter_chemically(var/projectiles = FALSE)
-		return FALSE
+	shatter_immune = TRUE
 
 /*  Now found in hydroponics.dm!
 

--- a/code/modules/chemistry/tools/beakers.dm
+++ b/code/modules/chemistry/tools/beakers.dm
@@ -181,6 +181,10 @@
 	icon_state = "largebottle-burn"
 	initial_reagents = "silver_sulfadiazine"
 
+/obj/item/reagent_containers/glass/beaker/large/cyborg
+	shatter_chemically(var/projectiles = FALSE)
+		return FALSE
+
 /*  Now found in hydroponics.dm!
 
 /obj/item/reagent_containers/glass/beaker/large/happy_plant //I have to test too many fucking plant-related issues atm so I'm adding this just to make my life less annoying

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -50,9 +50,9 @@
 		/obj/item/reagent_containers/dropper/mechanical,
 		// TODO: some sort of chem dispenser?
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
-		/obj/item/reagent_containers/glass/beaker/large,
-		/obj/item/reagent_containers/glass/beaker/large,
-		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/reagent_containers/glass/beaker/large/cyborg,
+		/obj/item/reagent_containers/glass/beaker/large/cyborg,
+		/obj/item/reagent_containers/glass/beaker/large/cyborg,
 		/obj/item/extinguisher/large/cyborg,
 		/obj/item/device/gps, // Let's them assist with telesci
 	)
@@ -168,8 +168,8 @@
 		/obj/item/scissors/surgical_scissors,
 		/obj/item/hemostat,
 		/obj/item/staple_gun,
-		/obj/item/reagent_containers/glass/beaker/large,
-		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/reagent_containers/glass/beaker/large/cyborg,
+		/obj/item/reagent_containers/glass/beaker/large/cyborg,
 		/obj/item/reagent_containers/dropper,
 	)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR gives cyborgs a new variant of beaker that cannot shatter. Both mediborgs and chemborgs. It's pathed at /obj/item/reagent_containers/glass/beaker/large/cyborg and is literally the only distinction between them and regular large beakers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #15777 , cyborg stuff isn't meant to break and I already implemented this for extinguishers, just forgot beakers. They can't get new ones, so they get shatter-proof stuff instead. Could possibly make it pour reagents on the ground or something if this is too lenient but most reactions that shatter beakers explode anyways so it's not like you *want* to blow yourself up. Shouldn't have to get a new module to replace this stuff imo.

