### PR TITLE
Nuclear Meltdowns Scale By Radioactive Material

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -374,20 +374,50 @@
 		world << alarm //ew
 		command_alert("A nuclear reactor aboard the station has catastrophically overloaded. Radioactive debris, nuclear fallout, and coolant fires are likely. Immediate evacuation of the surrounding area is strongly advised.", "NUCLEAR MELTDOWN")
 
-		logTheThing(LOG_STATION, src, "[src] CATASTROPHICALLY OVERLOADS (this is bad)")
+
 		//explode, throw radioactive components everywhere, dump rad gas, throw radioactive debris everywhere
 		src.melted = TRUE
+		var/meltdown_badness = 0
+		var/turf/epicentre = get_turf(src)
 		if(!src.current_gas)
 			src.current_gas = new/datum/gas_mixture()
-		src.current_gas.radgas += 6000
-		src.current_gas.temperature = src.temperature
+
+		//determine how bad this meltdown should be
+		//basically this is a points system, more points = worser
+		//at 49 fresh melted cerenkite rods, this is 490 (feasible, but difficult). at 49 fresh melted plutonium rods this is 1274 (basically upper limit - it would insane to reach this without admemes)
+		//at 3 fresh melted cerenkite rods this is 30 (most common meltdown due to pipeburn)
+		//total sum of radioactive junk
+		for(var/x=1 to REACTOR_GRID_WIDTH)
+			for(var/y=1 to REACTOR_GRID_HEIGHT)
+				if(src.component_grid[x][y])
+					var/obj/item/reactor_component/comp = src.component_grid[x][y]
+					//more radioactive material = higher score. Doubled if the component is already melted.
+					meltdown_badness += (comp.material.getProperty("radioactive") + comp.material.getProperty("n_radioactive")*2 + comp.material.getProperty("spent_fuel")*3) * (1 + comp.melted)
+					if(istype(comp, /obj/item/reactor_component/gas_channel))
+						var/obj/item/reactor_component/gas_channel/gascomp = comp
+						src.current_gas.merge(gascomp.air_contents) //grab all the gas in the channels and put it back in the reactor so it can be vented into engineering
+					if(prob(50))
+						var/obj/item/reactor_component/throwcomp = src.component_grid[x][y]
+						throwcomp.set_loc(epicentre)
+						throwcomp.throw_at(get_ranged_target_turf(epicentre,pick(alldirs),rand(1,20)),rand(1,20),rand(1,20))
+					else
+						qdel(src.component_grid[x][y])
+						var/obj/decal/cleanable/debris = make_cleanable(/obj/decal/cleanable/machine_debris/radioactive, epicentre)
+						debris.streak_cleanable(dist_upper=20)
+					src.component_grid[x][y] = null //get rid of the internal ref once we've thrown it out
+
+		src.current_gas.radgas += meltdown_badness*15
+		src.current_gas.temperature = max(src.temperature, src.current_gas.temperature)
 		var/turf/current_loc = get_turf(src)
 		current_loc.assume_air(current_gas)
 
 		for(var/i = 1 to rand(5,20))
 			shoot_projectile_XY(src, new /datum/projectile/bullet/wall_buster_shrapnel(), rand(-10,10), rand(-10,10))
 
-		explosion_new(src,current_loc,2500,1,0,360,TRUE)
+		logTheThing(LOG_STATION, src, "[src] CATASTROPHICALLY OVERLOADS (this is bad) meltdown badness: [meltdown_badness]")
+		qdel(src) //spawns the molten reactor, for cases where the explosion is too small to do so
+
+		explosion_new(src, current_loc, max(100, meltdown_badness*7), TRUE, 0, 360, TRUE)
 		SPAWN(15 SECONDS)
 			alarm.repeat = FALSE //haha this is horrendous, this cannot be the way to do this
 			alarm.status = SOUND_UPDATE
@@ -721,6 +751,14 @@
 					src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
 				else
 					src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("cerenkite")
+		..()
+
+/obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/insane
+	New()
+		for(var/x=1 to REACTOR_GRID_WIDTH)
+			for(var/y=1 to REACTOR_GRID_HEIGHT)
+				src.component_grid[x][y] = new /obj/item/reactor_component/fuel_rod("plutonium")
+				src.component_grid[x][y].melt()
 		..()
 
 /obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/glowstick

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -396,15 +396,6 @@
 					if(istype(comp, /obj/item/reactor_component/gas_channel))
 						var/obj/item/reactor_component/gas_channel/gascomp = comp
 						src.current_gas.merge(gascomp.air_contents) //grab all the gas in the channels and put it back in the reactor so it can be vented into engineering
-					if(prob(50))
-						var/obj/item/reactor_component/throwcomp = src.component_grid[x][y]
-						throwcomp.set_loc(epicentre)
-						throwcomp.throw_at(get_ranged_target_turf(epicentre,pick(alldirs),rand(1,20)),rand(1,20),rand(1,20))
-					else
-						qdel(src.component_grid[x][y])
-						var/obj/decal/cleanable/debris = make_cleanable(/obj/decal/cleanable/machine_debris/radioactive, epicentre)
-						debris.streak_cleanable(dist_upper=20)
-					src.component_grid[x][y] = null //get rid of the internal ref once we've thrown it out
 
 		src.current_gas.radgas += meltdown_badness*15
 		src.current_gas.temperature = max(src.temperature, src.current_gas.temperature)
@@ -415,7 +406,6 @@
 			shoot_projectile_XY(src, new /datum/projectile/bullet/wall_buster_shrapnel(), rand(-10,10), rand(-10,10))
 
 		logTheThing(LOG_STATION, src, "[src] CATASTROPHICALLY OVERLOADS (this is bad) meltdown badness: [meltdown_badness]")
-		qdel(src) //spawns the molten reactor, for cases where the explosion is too small to do so
 
 		explosion_new(src, current_loc, max(100, meltdown_badness*7), TRUE, 0, 360, TRUE)
 		SPAWN(15 SECONDS)

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -383,15 +383,15 @@
 
 		//determine how bad this meltdown should be
 		//basically this is a points system, more points = worser
-		//at 49 fresh melted cerenkite rods, this is 490 (feasible, but difficult). at 49 fresh melted plutonium rods this is 1274 (basically upper limit - it would insane to reach this without admemes)
-		//at 3 fresh melted cerenkite rods this is 30 (most common meltdown due to pipeburn)
+		//at 49 fresh melted cerenkite rods, this is 1080 (feasible, but difficult). at 49 fresh melted plutonium rods this is 3038 (basically upper limit - it would be insane to reach this without admemes)
+		//at 3 fresh melted cerenkite rods this is 60 (most common meltdown due to pipeburn)
 		//total sum of radioactive junk
 		for(var/x=1 to REACTOR_GRID_WIDTH)
 			for(var/y=1 to REACTOR_GRID_HEIGHT)
 				if(src.component_grid[x][y])
 					var/obj/item/reactor_component/comp = src.component_grid[x][y]
 					//more radioactive material = higher score. Doubled if the component is already melted.
-					meltdown_badness += (comp.material.getProperty("radioactive") + comp.material.getProperty("n_radioactive")*2 + comp.material.getProperty("spent_fuel")*3) * (1 + comp.melted)
+					meltdown_badness += (comp.material.getProperty("radioactive")*2 + comp.material.getProperty("n_radioactive")*5 + comp.material.getProperty("spent_fuel")*10) * (1 + comp.melted)
 					if(istype(comp, /obj/item/reactor_component/gas_channel))
 						var/obj/item/reactor_component/gas_channel/gascomp = comp
 						src.current_gas.merge(gascomp.air_contents) //grab all the gas in the channels and put it back in the reactor so it can be vented into engineering
@@ -406,7 +406,7 @@
 
 		logTheThing(LOG_STATION, src, "[src] CATASTROPHICALLY OVERLOADS (this is bad) meltdown badness: [meltdown_badness]")
 
-		explosion_new(src, current_loc, max(100, meltdown_badness*7), TRUE, 0, 360, TRUE)
+		explosion_new(src, current_loc, max(100, meltdown_badness*5), TRUE, 0, 360, TRUE)
 		SPAWN(15 SECONDS)
 			alarm.repeat = FALSE //haha this is horrendous, this cannot be the way to do this
 			alarm.status = SOUND_UPDATE

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -378,7 +378,6 @@
 		//explode, throw radioactive components everywhere, dump rad gas, throw radioactive debris everywhere
 		src.melted = TRUE
 		var/meltdown_badness = 0
-		var/turf/epicentre = get_turf(src)
 		if(!src.current_gas)
 			src.current_gas = new/datum/gas_mixture()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of a flat explosion + dump of fallout gas, meltdowns now scale from "little explosion that destroys the engine room" to "the station is utterly destroyed and everyone is dead" depending on the amount of nuclear fuel in the reactor. Gone are the days of pipeburns outclassing TTVs with zero effort.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently you can blow up a sizable chunk of the station by just starting a pipeburn in the reactor. That's not really in the spirit of what the meltdown mechanic was about.

Meltdown badness is now calculated as a weighted sum of radioactivity, neutron radioactivity, and spent fuel in each component. Melted component count for twice the badness.

To see some typical values, call `catastrophicOverload()` on 
- `prefilled/normal` 
- `prefilled/meltdown` 
- `prefilled/insane` (this one is the absolute  upper limit and is not achievable through normal gameplay)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(*)Nuclear meltdowns now scale with the amount of radioactive fuel in the reactor.
```
