### PR TITLE
Update factions with new neutral faction and updates

### DIFF
--- a/_std/macros/factions.dm
+++ b/_std/macros/factions.dm
@@ -1,22 +1,34 @@
 //Faction bitmasks, for setting what teams mobs/critters are on. Barebones atm.
 
+/// Faction which is not targeted by default
+#define FACTION_NEUTRAL			(1<<0)
+/// Generic faction for groups you don't want killing eachother
+#define FACTION_GENERIC			(1<<1)
 /// Wraith critters and summons
-#define FACTION_WRAITH			(1<<0)
-/// Maneaters, Tomatoes, Wasps and Plasmaspores
-#define FACTION_BOTANY			(1<<1)
+#define FACTION_WRAITH			(1<<2)
+/// Maneaters, Tomatoes, Wasps, Plasmaspores and Botanists
+#define FACTION_BOTANY			(1<<3)
 /// Trench and Ocean mobs
-#define FACTION_AQUATIC			(1<<2)
+#define FACTION_AQUATIC			(1<<4)
 /// Robots and Drones
-#define FACTION_SYNDICATE		(1<<3)
+#define FACTION_SYNDICATE		(1<<5)
 /// NT persons of interest and assets
-#define FACTION_NANOTRASEN		(1<<4)
+#define FACTION_NANOTRASEN		(1<<6)
 /// Wizard & summons
-#define FACTION_WIZARD			(1<<5)
+#define FACTION_WIZARD			(1<<7)
 /// Sponge capsule spawns
-#define FACTION_SPONGE			(1<<6)
+#define FACTION_SPONGE			(1<<8)
 /// Ice moon critters
-#define FACTION_ICEMOON			(1<<7)
+#define FACTION_ICEMOON			(1<<9)
 /// Clowns and other clown like entities
-#define FACTION_CLOWN			(1<<8)
+#define FACTION_CLOWN			(1<<10)
 /// Void stuff / disaster portal / old robots
-#define FACTION_DERELICT		(1<<9)
+#define FACTION_DERELICT		(1<<11)
+
+/// Returns TRUE if ourguy is enemies with otherguy FALSE otherwise
+proc/faction_check(var/mob/ourguy, var/mob/otherguy, var/attack_neutral)
+	if (ourguy.faction & otherguy.faction) // Same faction
+		return FALSE
+	if ((otherguy.faction & FACTION_NEUTRAL) && !attack_neutral) // If neutral and we don't want to attack them, don't attack
+		return FALSE
+	return TRUE // No faction / Differing faction / attacking neutral

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -95,6 +95,8 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 
 	var/pull_w_class = W_CLASS_SMALL
 
+	///Whether or not we attack mobs with the neutral faction flag
+	var/ai_attacks_neutral = FALSE
 	///If the mob has an ai, turn this to TRUE if you want it to fight back upon being attacked
 	var/ai_retaliates = FALSE
 	///If the mob has an ai, and ai_retaliates is TRUE, how many attacks should we endure before attacking back?
@@ -1346,8 +1348,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health)
 		if (isintangible(C)) return FALSE
 		if (isdead(C)) return FALSE
 		if (istype(C, src.type)) return FALSE
+		if (isghostcritter(C) || isghostdrone(C)) return FALSE
 		if (C in src.friends) return FALSE
-		return !src.faction || !(C.faction & src.faction) //if we don't have a faction we hate everyone
+		return faction_check(src, C, src.ai_attacks_neutral)
 
 	/// Used for generic critter mobAI - targets returned from this proc will be chased and scavenged. Return a list of potential targets, one will be picked based on distance.
 	proc/seek_scavenge_target(var/range = 5)

--- a/code/mob/living/critter/aberration.dm
+++ b/code/mob/living/critter/aberration.dm
@@ -113,8 +113,8 @@
 		Br?.TakeDamage(damage)
 
 	valid_target(var/mob/living/C)
-		if (istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
+		if (istype(C, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = C
 			if (istype(H.head, /obj/item/clothing/head/void_crown))
 				return FALSE
 		..()

--- a/code/mob/living/critter/aberration.dm
+++ b/code/mob/living/critter/aberration.dm
@@ -24,6 +24,7 @@
 	canbegrabbed = FALSE
 	throws_can_hit_me = FALSE
 	reagent_capacity = 0
+	faction = FACTION_DERELICT
 	blood_id = null
 	can_bleed = FALSE
 	metabolizes = FALSE
@@ -111,20 +112,12 @@
 		var/datum/healthHolder/Br = src.get_health_holder("brute")
 		Br?.TakeDamage(damage)
 
-	seek_target(range = 7)
-		. = list()
-		for (var/mob/living/M in hearers(range, src))
-			if (isintangible(M))
-				continue
-			if (isdead(M))
-				continue
-			if (istype(M, src.type))
-				continue
-			if (istype(M, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if (istype(H.head, /obj/item/clothing/head/void_crown))
-					continue
-			. += M
+	valid_target(var/mob/living/C)
+		if (istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if (istype(H.head, /obj/item/clothing/head/void_crown))
+				return FALSE
+		..()
 
 	Cross(atom/movable/mover)
 		if (!istype(mover, /mob))

--- a/code/mob/living/critter/firefly.dm
+++ b/code/mob/living/critter/firefly.dm
@@ -23,6 +23,7 @@ TYPEINFO(/mob/living/critter/small_animal/firefly)
 	health_brute = 10
 	health_burn = 10
 
+	faction = FACTION_NEUTRAL
 	flags = TABLEPASS
 	fits_under_table = 1
 	base_move_delay = 1.5

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -135,6 +135,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 	speechverb_ask = "squeaks"
 	health_brute = 8
 	health_burn = 8
+	faction = FACTION_NEUTRAL
 	ai_type = /datum/aiHolder/mouse
 	ai_retaliate_patience = 0 //retaliate when hit immediately
 	ai_retaliate_persistence = RETALIATE_ONCE //but just hit back once
@@ -240,6 +241,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 	health_burn = 2
 
 /mob/living/critter/small_animal/mouse/mad
+	faction = null
 	ai_type = /datum/aiHolder/mouse/mad
 	var/list/disease_types = list(/datum/ailment/disease/space_madness, /datum/ailment/disease/berserker)
 
@@ -1723,6 +1725,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	health_brute = 5
 	health_burn = 5
 	flags = TABLEPASS | DOORPASS
+	faction = FACTION_NEUTRAL
 	fits_under_table = 1
 	ai_type = /datum/aiHolder/roach
 	ai_retaliates = FALSE
@@ -2752,6 +2755,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	icon_state_dead = "floateye-dead"
 	health_brute = 10
 	health_burn = 10
+	faction = FACTION_NEUTRAL
 	isFlying = TRUE
 
 	setup_hands()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new faction faction` FACTION_NEUTRAL` mobs with this faction aren't attacked by default.
Applied to cockroaches, non angry mice, firelies and float eyes for now. Since these are common "decorative" mobs.

Adds a new generic faction `FACTION_GENERIC` for generic groups that don't need a unique one.

Update abberation with a faction and update it to use `valid_target()` so it doesn't kill void mobs.

Prevents targeting of ghost critters and ghost drones by mob AI, since these roles should have minimal round impact they shouldn't be targeted by mobs.

Adds a global `proc/faction_check()` which takes mob A, mob B and whether A attacks neutral mobs. Returns` TRUE` if A attacks B `FALSE` otherwise.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While its funny for places to turn into blood baths before you even get there, mobs that are intended for flavour should stay as decoration and not get killed by hostile mobs. Likewise mobs in the same areas should ideally not attack eachother.



