### PR TITLE
Make cyborgs use ladders

### DIFF
--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -1315,6 +1315,9 @@ ADMIN_INTERACT_PROCS(/obj/ladder/embed, proc/toggle_hidden)
 		return
 	src.climb(user)
 
+/obj/ladder/attack_ai(mob/user)
+	return src.attack_hand(user)
+
 /obj/ladder/attackby(obj/item/W, mob/user)
 	if (src.unclimbable) return
 	if (istype(W, /obj/item/grab))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15802 by adding attack_ai to ladders so cyborgs can use them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

They weren't implemented properly but borgs should probably be able to climb ladders.

note: wasn't sure whether to label this bug or addition cause it's hard to tell what's intended and what's not due to the nature of the change.