### PR TITLE
Cyborg cell cables usable on other cyborgs

### DIFF
--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -200,9 +200,8 @@
 			if (jumper.positive)
 				donor_cell = silicon_user.cell
 				recipient_cell = silicon_target.cell
-			else if (!silicon_user.emagged) // don't let us drain other cyborgs unless we're emagged
+			else if (!silicon_user.emagged)
 				boutput(user, "<span class='alert'>A core law submodule limits you from draining the power of other cyborgs!</span>")
-				// also hint to the user that being emagged removes this restriction
 				..()
 				interrupt(INTERRUPT_ALWAYS)
 				return
@@ -235,14 +234,12 @@
 						"<span class='notice'>You transfer [overspill] charge. [target] is now fully charged.</span>",
 						"<span class='notice'>[user] transfers [overspill] power to you!</span>"
 					)
-					//user.visible_message("<span class='notice'>[user] transfers some of their power to [silicon_target]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
 				else
 					user.tri_message(target,
 						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
 						"<span class='notice'>You siphon [overspill] charge. You are now fully charged.</span>",
 						"<span class='alert'>[user] siphons [overspill] power from you!</span>"
 					)
-					//user.visible_message("<span class='notice'>[user] transfers some of the power from [silicon_target] to themselves!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
 					logTheThing(LOG_STATION, user, "drains [overspill] power from [target] now [100*silicon_target.cell.charge/silicon_target.cell.maxcharge]% [log_loc(target)]")
 			else
 				donor_cell.use(jumper.charge_amount)
@@ -253,17 +250,14 @@
 						"<span class='notice'>You transfer [jumper.charge_amount] charge.</span>",
 						"<span class='notice'>[user] transfers [jumper.charge_amount] power to you!</span>"
 					)
-					//user.visible_message("<span class='notice'>[user] transfers some of their power to [silicon_target]!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
 				else
 					user.tri_message(target,
 						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
 						"<span class='notice'>You siphon [jumper.charge_amount] charge.</span>",
 						"<span class='alert'>[user] siphons [jumper.charge_amount] power from you!</span>"
 					)
-					//user.visible_message("<span class='notice'>[user] transfers some of the power from [silicon_target] to yourself!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
 					logTheThing(LOG_STATION, user, "drains [jumper.charge_amount] power from [target] now [100*silicon_target.cell.charge/silicon_target.cell.maxcharge]% [log_loc(silicon_target)]")
 				restart = TRUE
-			//silicon_target.charging = silicon_target.chargemode
 
 			if (prob(35))
 				playsound(owner.loc, 'sound/effects/electric_shock_short.ogg', 20, TRUE, -2, pitch = 0.7)

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -18,9 +18,6 @@
 		boutput(user, "<span class='alert'>The jumper cables will now transfer charge [positive ? "from you to the other device" : "from the other device to you"].</span>")
 
 	afterattack(var/atom/target, mob/user, flag)
-		/* if (!isobj(target))
-			..()
-			return */
 		if(istype(target,/obj/machinery/power/apc))
 			actions.start(new/datum/action/bar/private/icon/robojumper(user, target), user)
 		else if (istype(target, /mob/living/silicon/))

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -197,14 +197,11 @@
 			if (jumper.positive)
 				donor_cell = silicon_user.cell
 				recipient_cell = silicon_target.cell
-			else if (!silicon_user.emagged)
-				boutput(user, "<span class='alert'>A core law submodule limits you from draining the power of other cyborgs!</span>")
+			else
+				boutput(user, "<span class='alert'>You can't drain power from other cyborgs.</span>")
 				..()
 				interrupt(INTERRUPT_ALWAYS)
 				return
-			else
-				donor_cell = silicon_target.cell
-				recipient_cell = silicon_user.cell
 
 			if (isnull(donor_cell))
 				boutput(user, "<span class='alert'>You have no cell installed!</span>")

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -224,13 +224,13 @@
 				recipient_cell.charge += overspill
 				if (jumper.positive)
 					user.tri_message(target,
-						"[user] transfers some of their power to [target].",
+						"[user] transfers some of [his_or_her(user)] power to [target].",
 						"<span class='notice'>You transfer [overspill] charge. [target] is now fully charged.</span>",
 						"<span class='notice'>[user] transfers [overspill] power to you!</span>"
 					)
 				else
 					user.tri_message(target,
-						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
+						"<span class='alert'>[user] siphons some of the power from [target] to [himself_or_herself(user)]!</span>",
 						"<span class='notice'>You siphon [overspill] charge. You are now fully charged.</span>",
 						"<span class='alert'>[user] siphons [overspill] power from you!</span>"
 					)
@@ -240,13 +240,13 @@
 				recipient_cell.charge += jumper.charge_amount
 				if (jumper.positive)
 					user.tri_message(target,
-						"[user] transfers some of their power to [target].",
+						"[user] transfers some of [his_or_her(user)] power to [target].",
 						"<span class='notice'>You transfer [jumper.charge_amount] charge.</span>",
 						"<span class='notice'>[user] transfers [jumper.charge_amount] power to you!</span>"
 					)
 				else
 					user.tri_message(target,
-						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
+						"<span class='alert'>[user] siphons some of the power from [target] to [himself_or_herself(user)]!</span>",
 						"<span class='notice'>You siphon [jumper.charge_amount] charge.</span>",
 						"<span class='alert'>[user] siphons [jumper.charge_amount] power from you!</span>"
 					)

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -9,6 +9,9 @@
 	var/positive = TRUE //boolean, if positive, then you will charge an APC with your cell, if negative, you will take charge from apc
 	var/charge_amount = 250
 
+	attack(mob/M, mob/user)
+		return
+
 	attack_self(var/mob/user as mob)
 		positive = !positive
 		icon_state = "robojumper-[positive? "plus": "minus"]"
@@ -200,6 +203,8 @@
 			else if (!silicon_user.emagged) // don't let us drain other cyborgs unless we're emagged
 				boutput(user, "<span class='alert'>A core law submodule limits you from draining the power of other cyborgs!</span>")
 				// also hint to the user that being emagged removes this restriction
+				..()
+				interrupt(INTERRUPT_ALWAYS)
 				return
 			else
 				donor_cell = silicon_target.cell
@@ -233,8 +238,8 @@
 					//user.visible_message("<span class='notice'>[user] transfers some of their power to [silicon_target]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
 				else
 					user.tri_message(target,
-						"<span class='alert'>[user] transfers some of the power from [target] to themselves!</span>",
-						"<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>",
+						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
+						"<span class='notice'>You siphon [overspill] charge. You are now fully charged.</span>",
 						"<span class='alert'>[user] siphons [overspill] power from you!</span>"
 					)
 					//user.visible_message("<span class='notice'>[user] transfers some of the power from [silicon_target] to themselves!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
@@ -251,8 +256,8 @@
 					//user.visible_message("<span class='notice'>[user] transfers some of their power to [silicon_target]!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
 				else
 					user.tri_message(target,
-						"<span class='alert'>[user] transfers some of the power from [target] to themselves!</span>",
-						"<span class='notice'>You transfer [jumper.charge_amount] charge.</span>",
+						"<span class='alert'>[user] siphons some of the power from [target] to themselves!</span>",
+						"<span class='notice'>You siphon [jumper.charge_amount] charge.</span>",
 						"<span class='alert'>[user] siphons [jumper.charge_amount] power from you!</span>"
 					)
 					//user.visible_message("<span class='notice'>[user] transfers some of the power from [silicon_target] to yourself!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -142,7 +142,7 @@
 
 /datum/action/bar/private/icon/robojumper_to_silicon
 	duration = 1 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED | INTERRUPT_ACTION | INTERRUPT_ACT
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_ACT
 	id = "robojumper_to_silicon"
 	icon = 'icons/mob/hud_robot.dmi'
 	icon_state = "robocable_charge"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Cyborg cell cables can now donate charge to other /mob/living/silicon.
* You cannot siphon power from silicons.
* It's a copy of the original's action bar with adjusted messages, and removed interrupt_flag INTERRUPT_ATTACKED to allow for silly business.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Has some niche usage in off-station ops, like azones. Also, sensible that jumper cables would work on anything with a cell.


Silly Business:
![dreamseeker_SFqIFGTCvG](https://github.com/goonstation/goonstation/assets/40084056/0d717f77-442f-4d10-a820-d5c13fdd1650)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(+)Cyborg cell cables can now be used on other cyborgs.
```
