### PR TITLE
Steals sec's crematorium access on RP

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -205,7 +205,7 @@
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_crematorium, access_kitchen, access_robotics, access_cargo, access_supply_console,
+						access_kitchen, access_robotics, access_cargo, access_supply_console,
 						access_research, access_hydro, access_ranch, access_mail, access_ai_upload, access_pathology, access_researchfoyer,
 						access_telesci, access_teleporter)
 		if("Head of Security")
@@ -253,12 +253,12 @@
 
 		///////////////////////////// Security
 		if("Security Officer")
-#ifdef RP_MODE // trying out giving them more access for RP
+#ifdef RP_MODE
 			return list(access_security, access_brig, access_forensics_lockers, access_armory,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_emergency_storage, access_chapel_office, access_kitchen,
-				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
+				access_bar, access_janitor, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
 				access_tech_storage, access_engineering_storage, access_engineering_eva,
 				access_engineering_power, access_engineering_engine, access_mining_shuttle,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
yoink
Also takes away the HoP's access on both servers because cmon they don't need that

There's already a thread so no feedback tag:
https://forum.ss13.co/showthread.php?tid=21785
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i am game balancer

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)aloe
(+)Removed security's access to the crematorium on the RP servers.
```
