### PR TITLE
Leave legs behind when using a teleport wand with magboots active

### DIFF
--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -85,4 +85,23 @@
 		for(var/atom/X in T.contents)
 			if (X.density)
 				return FALSE
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.shoes?.magnetic)
+				boutput(user, "<span class='alert'><b>The magnetic locks on [H.shoes] overload!</b></span>")
+				playsound(H, pick('sound/impact_sounds/Flesh_Stab_1.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Slimy_Hit_3.ogg'), 30)
+
+				var/obj/item/clothing/shoes/stay_behind = H.shoes
+				H.u_equip(stay_behind)
+				stay_behind.set_loc(H.loc)
+				stay_behind.dropped(H)
+				stay_behind.layer = initial(stay_behind.layer)
+
+				H.sever_limb("l_leg")
+				H.sever_limb("r_leg")
+				random_brute_damage(H, rand(15, 45))
+				take_bleeding_damage(H, null, 10, DAMAGE_CRUSH)
+
+				SPAWN(3 SECONDS) // womp womp
+					playsound(stay_behind, 'sound/items/miningtool_off.ogg', 30, 1)
 		return TRUE

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -20,6 +20,25 @@
 		//var/turf/T = get_turf(target)
 		if (A.activated)
 			if (A.can_teleport_here(U,user))
+				if(ishuman(user))
+					var/mob/living/carbon/human/H = user
+					if(H.shoes?.magnetic && istype(H.shoes, /obj/item/clothing/shoes/magnetic))
+						var/obj/item/clothing/shoes/magnetic/stay_behind = H.shoes
+
+						boutput(user, "<span class='alert'><b>The magnetic attractor on [stay_behind] overloads!</b></span>")
+						playsound(H, pick('sound/impact_sounds/Flesh_Stab_1.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Slimy_Hit_3.ogg'), 30)
+						H.u_equip(stay_behind)
+						stay_behind.set_loc(H.loc)
+						stay_behind.dropped(H)
+						stay_behind.layer = initial(stay_behind.layer)
+
+						H.sever_limb("l_leg")
+						H.sever_limb("r_leg")
+						random_brute_damage(H, rand(15, 45))
+						take_bleeding_damage(H, null, 10, DAMAGE_CRUSH)
+
+						SPAWN(3 SECONDS) // womp womp
+							stay_behind.deactivate()
 				A.effect_click_tile(src,user,U)
 			else
 				boutput(user, "<b>[src]</b> [A.error_phrase]")
@@ -85,23 +104,4 @@
 		for(var/atom/X in T.contents)
 			if (X.density)
 				return FALSE
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(H.shoes?.magnetic)
-				boutput(user, "<span class='alert'><b>The magnetic locks on [H.shoes] overload!</b></span>")
-				playsound(H, pick('sound/impact_sounds/Flesh_Stab_1.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Slimy_Hit_3.ogg'), 30)
-
-				var/obj/item/clothing/shoes/stay_behind = H.shoes
-				H.u_equip(stay_behind)
-				stay_behind.set_loc(H.loc)
-				stay_behind.dropped(H)
-				stay_behind.layer = initial(stay_behind.layer)
-
-				H.sever_limb("l_leg")
-				H.sever_limb("r_leg")
-				random_brute_damage(H, rand(15, 45))
-				take_bleeding_damage(H, null, 10, DAMAGE_CRUSH)
-
-				SPAWN(3 SECONDS) // womp womp
-					playsound(stay_behind, 'sound/items/miningtool_off.ogg', 30, 1)
 		return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Leave legs behind when using a teleport wand with magboots active. code change only affects teleport wands. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Magboots are supposed to stop teleportation