### PR TITLE
Minor anvil fix

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2207,7 +2207,7 @@
 	src.emote("scream")
 	src.gib()
 
-/mob/proc/anvilgib(height = 7, use_shadow=TRUE, anvil_type=/obj/table/anvil)
+/mob/proc/anvilgib(height = 7, use_shadow=TRUE, anvil_type=/obj/table/anvil/gimmick)
 	logTheThing(LOG_COMBAT, src, "is anvil-gibbed at [log_loc(src)].")
 	src.transforming = TRUE
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_CANTMOVE, "anvilgib")

--- a/code/modules/admin/gibverbs.dm
+++ b/code/modules/admin/gibverbs.dm
@@ -201,7 +201,7 @@
 
 		M.buttgib()
 
-/client/proc/cmd_admin_anvilgib(mob/M as mob in world, height = 7 as num|null, anvil_type = /obj/table/anvil as text|null)
+/client/proc/cmd_admin_anvilgib(mob/M as mob in world, height = 7 as num|null, anvil_type = /obj/table/anvil/gimmick as text|null)
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	set name = "Anvil Gib"
 	set popup_menu = 0

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -499,10 +499,17 @@ Contents:
 	hulk_immune = TRUE
 
 	attackby(obj/item/W, mob/user, params)
-		if (istype(W) && src.place_on(W, user, params))
-			return
-		else
-			return ..()
+		if (istype(W))
+			src.place_on(W, user, params)
+
+/obj/table/anvil/gimmick
+	anchored = UNANCHORED
+	HELP_MESSAGE_OVERRIDE({"You can use a <b>welding tool</b> to slice it into sheets."})
+
+	attackby(obj/item/W, mob/user, params)
+		if (isweldingtool(W))
+			actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_DISASSEMBLE), user)
+		..()
 
 /obj/dojo_bellows
 	name = "bellows"

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -508,7 +508,7 @@ Contents:
 	HELP_MESSAGE_OVERRIDE({"You can use a <b>welding tool</b> on <span class='harm'>harm</span> intent to slice it into sheets."})
 	attackby(obj/item/W, mob/user, params)
 		if (isweldingtool(W) && user.a_intent == "harm")
-			SETUP_GENERIC_ACTIONBAR(user, src, 10 SECONDS, /obj/table/anvil/gimmick/deconstruct, null, W.icon, W.icon_state, "[user] finishes slicing \the [src] into sheets.",
+			SETUP_GENERIC_ACTIONBAR(user, src, 10 SECONDS, PROC_REF(deconstruct), null, W.icon, W.icon_state, "[user] finishes slicing \the [src] into sheets.",
 			INTERRUPT_ACT | INTERRUPT_ACTION | INTERRUPT_MOVE | INTERRUPT_ATTACKED | INTERRUPT_STUNNED)
 			return
 		..()

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -504,12 +504,21 @@ Contents:
 
 /obj/table/anvil/gimmick
 	anchored = UNANCHORED
-	HELP_MESSAGE_OVERRIDE({"You can use a <b>welding tool</b> to slice it into sheets."})
-
+	HELP_MESSAGE_OVERRIDE({"You can use a <b>welding tool</b> on <span class='harm'>harm</span> intent to slice it into sheets."})
 	attackby(obj/item/W, mob/user, params)
-		if (isweldingtool(W))
-			actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_DISASSEMBLE), user)
+		if (isweldingtool(W) && user.a_intent == "harm")
+			SETUP_GENERIC_ACTIONBAR(user, src, 10 SECONDS, /obj/table/anvil/gimmick/deconstruct, null, W.icon, W.icon_state, "[user] finishes slicing \the [src] into sheets.",
+			INTERRUPT_ACT | INTERRUPT_ACTION | INTERRUPT_MOVE | INTERRUPT_ATTACKED | INTERRUPT_STUNNED)
+			return
 		..()
+
+	deconstruct()
+		var/obj/item/sheet/sheet_stack = new /obj/item/sheet(src.loc)
+		sheet_stack.amount = 10
+		if (src.material)
+			sheet_stack.setMaterial(src.material)
+		sheet_stack.update_appearance()
+		qdel(src)
 
 /obj/dojo_bellows
 	name = "bellows"

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -497,6 +497,7 @@ Contents:
 	anchored = ANCHORED_ALWAYS
 	parts_type = null
 	hulk_immune = TRUE
+	HELP_MESSAGE_OVERRIDE("") // No, you can't wrench it
 
 	attackby(obj/item/W, mob/user, params)
 		if (istype(W))


### PR DESCRIPTION
[Secret] [Bugfix] [Player-Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tweaks azone anvil code to not be deconstructible by borgs (absolutely unintended), but makes anvilgib anvils able to be deconstructed into sheets with a weldingtool.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Borgs should not be able to disassemble the azone anvil into parts, but anvilgib anvils should certainly be deconstructible.
Also, fixes #15699
EDIT: Fixes #15874 
