### PR TITLE
Allows You To Pour Cut Open IV Bags on Pustules

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -894,6 +894,22 @@ proc/ui_describe_reagents(atom/A)
 		..()
 
 	attackby(var/obj/item/W, mob/user)
+		if(istype(W, /obj/item/reagent_containers/iv_drip))
+			var/obj/item/reagent_containers/iv_drip/iv = W
+			if(!iv.slashed)
+				boutput(user, "<span class='alert'>The [iv.name] needs to be cut open first!</span>")
+				return
+			else if (reagents.total_volume >= reagents.maximum_volume)
+				boutput(user, "<span class='alert'>The [src] is too full!</span>")
+				return
+			else if (!iv.reagents.total_volume)
+				boutput(user, "<span class='alert'>The [iv.name] is empty!</span>")
+				return
+			else
+				user.visible_message("<span class = 'alert'>[user.name] splashes all the reagent in the [iv.name] onto the [src.name].</span>")
+				iv.reagents.reaction(src,TOUCH)
+				iv.reagents.clear_reagents()
+
 		if(istype(W, /obj/item/organ))
 			var/obj/item/organ/organ = W
 			if(organ.material.getMaterialFlags() & MATERIAL_ORGANIC)


### PR DESCRIPTION
[CHEMISTRY]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR lets you pour cut open IV bags (including blood bags) on synthflesh pustules. It pours the whole thing in one go. This is equivalent to pouring a beaker, so if there's things that won't go into pustules in the bag, it won't go into the pustule.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Qol! It's useful to use blood bags on pustules but clicking a beaker 10 times to fill it up and then splashing on the pustule is annoying, and there's already a built-in delay to how much synthflesh you can make per second anyways so it's not like there's a real balance reason you should have to click that much. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flaborized
(+)You can now directly pour into synthflesh pustules from cut open blood bags.
```
