### PR TITLE
cyborg clothing checks for wear_state

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2826,7 +2826,10 @@
 				var/image/clothed_image = U.wear_image
 				if (!clothed_image)
 					continue
-				clothed_image.icon_state = U.icon_state
+				if (U.wear_state)
+					clothed_image.icon_state = U.wear_state
+				else
+					clothed_image.icon_state = U.icon_state
 				//under_image.layer = MOB_CLOTHING_LAYER
 				clothed_image.alpha = U.alpha
 				clothed_image.color = U.color


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
when "clothing" cyborgs, check for wear_state on the item as it is occasionally used

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15825