### PR TITLE
visible messages for cyborg cell cables use pronoun procs

### DIFF
--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -105,17 +105,17 @@
 				donor_cell.use(overspill)
 				recipient_cell.charge += overspill
 				if (jumper.positive)
-					user.visible_message("<span class='notice'>[user] transfers some of their power to [apc]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of [his_or_her(user)] power to [apc]!</span>", "<span class='notice'>You transfer [overspill] charge. The APC is now fully charged.</span>")
 				else
-					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to themselves!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to [himself_or_herself(user)]!</span>", "<span class='notice'>You transfer [overspill] charge. You are now fully charged.</span>")
 					logTheThing(LOG_STATION, user, "drains [overspill] power from the APC [apc] now [100*apc.cell.charge/apc.cell.maxcharge]% [log_loc(apc)]")
 			else
 				donor_cell.use(jumper.charge_amount)
 				recipient_cell.charge += jumper.charge_amount
 				if (jumper.positive)
-					user.visible_message("<span class='notice'>[user] transfers some of their power to [apc]!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of [his_or_her(user)] power to [apc]!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
 				else
-					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to yourself!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
+					user.visible_message("<span class='notice'>[user] transfers some of the power from [apc] to [himself_or_herself(user)]!</span>", "<span class='notice'>You transfer [jumper.charge_amount] charge.</span>")
 					logTheThing(LOG_STATION, user, "drains [jumper.charge_amount] power from the APC [apc] now [100*apc.cell.charge/apc.cell.maxcharge]% [log_loc(apc)]")
 				restart = TRUE
 			apc.charging = apc.chargemode


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
updates the cyborg cell cables / 'robojumper' visible messages to use pronoun procs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
pronoun consistency