### PR TITLE
Handcuffs: small usage nerf

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -727,6 +727,27 @@
 
 		logTheThing(LOG_COMBAT, owner, "attempts to handcuff [constructTarget(target,"combat")] with [cuffs] at [log_loc(owner)].")
 
+		if (!is_incapacitated(target)) // same check in both onStart and onEnd.
+			if (target.a_intent == INTENT_HELP)
+				if (owner.dir != target.dir)
+					owner.tri_message(target,
+						"<span class='alert'><B>[owner] attempts to handcuff [target],</B> \
+							but [he_or_she(owner)] can't reach [target]'s back.</span>",
+						"<span class='alert'>[target]'s back isn't turned! Cuff them from behind.</span>",
+						"<span class='alert'><B>[owner] can't cuff you from this angle!</B> Turn your back to cooperate.</span>"
+					)
+					interrupt(INTERRUPT_ALWAYS)
+					return
+			else
+				owner.tri_message(target,
+					"<span class='alert'><B>[owner] attempts to handcuff [target]. \
+						[he_or_she(target)] dodge[target.get_pronouns().pluralize ? "s" : ""] away!</B></span>",
+					"<span class='alert'>[target] slips from your grasp! Pin or incapacitate them first.</span>",
+					"<span class='alert'><B>You evade [owner]'s handcuff attempt!</B> Use help intent and turn your back to cooperate.</span>"
+				)
+				interrupt(INTERRUPT_ALWAYS)
+				return
+
 		duration *= cuffs.apply_multiplier
 
 		if(ishuman(owner))
@@ -742,6 +763,27 @@
 		var/mob/ownerMob = owner
 		if(!istype(ownerMob) || !target || !cuffs || target.hasStatus("handcuffed") || cuffs != ownerMob.equipped() || BOUNDS_DIST(owner, target) != 0)
 			return
+
+		if (!is_incapacitated(target))
+			if (target.a_intent == INTENT_HELP)
+				if (owner.dir != target.dir)
+					owner.tri_message(target,
+						"<span class='alert'><B>[owner] attempts to handcuff [target],</B> \
+							but [he_or_she(owner)] can't reach [target]'s back.</span>",
+						"<span class='alert'>[target]'s back isn't turned! Cuff them from behind.</span>",
+						"<span class='alert'><B>[owner] can't cuff you from this angle!</B> Turn your back to cooperate.</span>"
+					)
+					interrupt(INTERRUPT_ALWAYS)
+					return
+			else
+				owner.tri_message(target,
+					"<span class='alert'><B>[owner] attempts to handcuff [target]. \
+						[he_or_she(target)] dodge[target.get_pronouns().pluralize ? "s" : ""] away!</B></span>",
+					"<span class='alert'>[target] slips from your grasp! Pin or incapacitate them first.</span>",
+					"<span class='alert'><B>You evade [owner]'s handcuff attempt!</B> Use help intent and turn your back to cooperate.</span>"
+				)
+				interrupt(INTERRUPT_ALWAYS)
+				return
 
 		if (initial(cuffs.amount) > 1)
 			if (cuffs.amount < 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The handcuff action bar now **requires one of** these conditions, both on start and on end, or else it fails:
* Target is incapacitated (stunned, knockdown, unconscious, or pinned).
* Target is on help intent, and has turned their back to the handcuffer.

Don't worry, this doesn't change much for Security - the baton+cuff combo works just the same.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Handcuffing doesn't have an interrupt flag for being attacked. So the only way to escape cuffing is getting distance - which isn't possible sometimes, e.g. very crowded or cramped areas. 

This PR stops such scenarios, because it feels really bad to get cuffed with no recourse. It also fights off getting cuffed while typing.

(I didn't simply add the flag for other reasons: e.g. someone automending you while cuffing would've canceled it)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(*)Handcuffing now requires the target to be incapacitated (pinned, stunned, asleep, etc) or cooperating (facing away from you on Help intent).
```
