### PR TITLE
Remove ability for AI Eye to swap borg cells

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -977,6 +977,8 @@ TYPEINFO(/obj/machinery/recharge_station)
 			if (user == src.occupant)
 				boutput(user, "<span class='alert'>You can't modify your own power cell!</span>")
 				return
+			if (isintangible(user))
+				boutput(user, "<span class='alert'>You have to be physically present for this!</span>")
 			var/mob/living/silicon/robot/R = src.occupant
 			var/cellRef = params["cellRef"]
 			if(cellRef)

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -977,7 +977,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			if (user == src.occupant)
 				boutput(user, "<span class='alert'>You can't modify your own power cell!</span>")
 				return
-			if (isintangible(user))
+			if (isAIeye(user))
 				boutput(user, "<span class='alert'>You have to be physically present for this!</span>")
 				return
 			var/mob/living/silicon/robot/R = src.occupant
@@ -1000,6 +1000,9 @@ TYPEINFO(/obj/machinery/recharge_station)
 			. = TRUE
 		if("cell-remove")
 			if (!isrobot(src.occupant))
+				return
+			if (isAIeye(user))
+				boutput(user, "<span class='alert'>You have to be physically present for this!</span>")
 				return
 			if (user == src.occupant)
 				boutput(user, "<span class='alert'>You can't modify your own power cell!</span>")

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -979,6 +979,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 				return
 			if (isintangible(user))
 				boutput(user, "<span class='alert'>You have to be physically present for this!</span>")
+				return
 			var/mob/living/silicon/robot/R = src.occupant
 			var/cellRef = params["cellRef"]
 			if(cellRef)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Intangible AI eyes can no longer swap cells for cyborgs in docking stations.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15851 by ensuring cells swappers are not intangble.
