### PR TITLE
Add new traitor item "Reflective Glasses"

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1011,7 +1011,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 
 /datum/syndicate_buylist/traitor/sunglasses
 	name = "Reflective Glasses"
-	desc = "A randomly selected pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
+	desc = "A customizable pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
 	item = /obj/item/clothing/glasses/sunglasses/reflective
 	cost = 1
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP | UPLINK_HEAD_REV

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1009,6 +1009,13 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	not_in_crates = TRUE
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
+/datum/syndicate_buylist/traitor/sunglasses
+	name = "Reflective glasses"
+	desc = "A randomly selected pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
+	item = /obj/item/clothing/glasses/sunglasses/reflective
+	cost = 1
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP | UPLINK_HEAD_REV
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1013,7 +1013,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Reflective Glasses"
 	desc = "A randomly selected pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
 	item = /obj/item/clothing/glasses/sunglasses/reflective
-	cost = 2
+	cost = 1
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP | UPLINK_HEAD_REV
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1013,7 +1013,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Reflective Glasses"
 	desc = "A randomly selected pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
 	item = /obj/item/clothing/glasses/sunglasses/reflective
-	cost = 1
+	cost = 2
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP | UPLINK_HEAD_REV
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1010,7 +1010,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
 /datum/syndicate_buylist/traitor/sunglasses
-	name = "Reflective glasses"
+	name = "Reflective Glasses"
 	desc = "A randomly selected pair of glasses, with built-in sun and flash protection, covered by their 100%, one-way reflective shine!"
 	item = /obj/item/clothing/glasses/sunglasses/reflective
 	cost = 1

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -183,7 +183,10 @@ TYPEINFO(/obj/item/clothing/glasses/sunglasses/tanning)
 	mats = 4
 
 /obj/item/clothing/glasses/sunglasses/reflective
+	correct_bad_vision = TRUE
 	allow_blind_sight = TRUE
+	is_syndicate = TRUE
+
 	var/appearance_chosen = FALSE
 	var/static/list/possible_appearances = list(
 		"Spectro goggles" = /obj/item/clothing/glasses/spectro,

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -184,16 +184,39 @@ TYPEINFO(/obj/item/clothing/glasses/sunglasses/tanning)
 
 /obj/item/clothing/glasses/sunglasses/reflective
 	allow_blind_sight = TRUE
-	var/static/list/possible_appearances = list(/obj/item/clothing/glasses/meson, /obj/item/clothing/glasses/thermal, /obj/item/clothing/glasses/visor,
-		/obj/item/clothing/glasses/healthgoggles, /obj/item/clothing/glasses/spectro)
+	var/appearance_chosen = FALSE
+	var/static/list/possible_appearances = list(
+		"Spectro goggles" = /obj/item/clothing/glasses/spectro,
+		"Health goggles" = /obj/item/clothing/glasses/healthgoggles,
+		"Meson goggles" = /obj/item/clothing/glasses/meson,
+		"Thermal goggles" = /obj/item/clothing/glasses/thermal,
+		"VISOR goggles" = /obj/item/clothing/glasses/visor)
 
 	New()
-		var/obj/item/clothing/glasses/picked_type = pick(src.possible_appearances)
+		var/obj/item/clothing/glasses/initial_type = /obj/item/clothing/glasses/regular
+		src.name = initial(initial_type.name)
+		src.desc = initial(initial_type.desc)
+		src.icon_state = initial(initial_type.icon_state)
+		src.item_state = initial(initial_type.item_state)
+		..()
+
+
+	attack_self(mob/user)
+		..()
+		if (src.appearance_chosen)
+			return
+		var/choice = tgui_input_list(user, "Choose the appearance of the glasses. Can only be done once.", "Set appearance", src.possible_appearances)
+		if (!choice)
+			return
+
+		var/obj/item/clothing/glasses/picked_type = src.possible_appearances[choice]
 		src.name = initial(picked_type.name)
 		src.desc = initial(picked_type.desc)
-		src.icon = initial(picked_type.icon)
 		src.icon_state = initial(picked_type.icon_state)
-		..()
+		src.item_state = initial(picked_type.item_state)
+
+		src.appearance_chosen = TRUE
+		src.tooltip_rebuild = TRUE
 
 /obj/item/clothing/glasses/sunglasses/tanning
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. This pair has a label that says: \"For tanning use only.\""

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -182,6 +182,19 @@ TYPEINFO(/obj/item/clothing/glasses/meson)
 TYPEINFO(/obj/item/clothing/glasses/sunglasses/tanning)
 	mats = 4
 
+/obj/item/clothing/glasses/sunglasses/reflective
+	allow_blind_sight = TRUE
+	var/static/list/possible_appearances = list(/obj/item/clothing/glasses/meson, /obj/item/clothing/glasses/thermal, /obj/item/clothing/glasses/visor,
+		/obj/item/clothing/glasses/healthgoggles, /obj/item/clothing/glasses/spectro)
+
+	New()
+		var/obj/item/clothing/glasses/picked_type = pick(src.possible_appearances)
+		src.name = initial(picked_type.name)
+		src.desc = initial(picked_type.desc)
+		src.icon = initial(picked_type.icon)
+		src.icon_state = initial(picked_type.icon_state)
+		..()
+
 /obj/item/clothing/glasses/sunglasses/tanning
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. This pair has a label that says: \"For tanning use only.\""
 	color_b = 0.95

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -174,11 +174,21 @@ TYPEINFO(/obj/item/device/flash)
 		eye_damage = src.eye_damage_mod + rand(0, (1 * flash_power))
 
 	// We're flashing somebody directly, hence the 100% chance to disrupt cloaking device at the end.
-	var/blind_success = M.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
+	var/blind_success
+	var/flash_reflected = FALSE
+	var/previous_user = user
+	var/mob/living/carbon/human/H = M
+	if (istype(H) && istype(H.glasses, /obj/item/clothing/glasses/sunglasses/reflective))
+		flash_reflected = TRUE
+		M = user
+	blind_success = M.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
 	if (src.emagged)
 		user.apply_flash(animation_duration, weakened, 0, 0, eye_blurry, eye_damage, 0, burning, 100, stamina_damage = 70 * flash_power, disorient_time = 30)
 
-	convert(M,user)
+	if (!flash_reflected)
+		convert(M, user)
+	else
+		convert(M, previous_user)
 
 	// Log entry.
 	var/blind_msg_target = "!"
@@ -186,7 +196,11 @@ TYPEINFO(/obj/item/device/flash)
 	if (!blind_success)
 		blind_msg_target = " but your eyes are protected!"
 		blind_msg_others = " but [his_or_her(M)] eyes are protected!"
-	M.visible_message("<span class='alert'>[user] blinds [M] with \the [src][blind_msg_others]</span>", "<span class='alert'>[user] blinds you with \the [src][blind_msg_target]</span>")
+	if (M != user)
+		M.visible_message("<span class='alert'>[user] blinds [M] with \the [src][blind_msg_others]</span>", "<span class='alert'>[user] blinds you with \the [src][blind_msg_target]</span>")
+	else
+		M.visible_message("<span class='alert'>[user] blinds themselves with \the [src][blind_msg_others]</span>", "<span class='alert'>A bright light blinds you[blind_msg_target]</span>")
+
 	logTheThing(LOG_COMBAT, user, "blinds [constructTarget(M,"combat")] with [src] at [log_loc(user)].")
 	if (src.emagged)
 		logTheThing(LOG_COMBAT, user, "blinds themself with [src] at [log_loc(user)].")


### PR DESCRIPTION
[GAME OBJECTS][GAME MODES][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new 1 TC traitor item, Reflective Glasses.

Reflective glasses act just like sunglasses, initially appearing as prescription glasses. They can have their appearance set once by using them in-hand, and they redirect flashes and flash cell assembly burning effects back at the flasher. Doesn't count area flashes, and it doesn't recurse if the attacker has reflective glasses too.

They can also be bought by Revheads. If someone tries to flash a Revhead wearing them, and they don't have eye protection themselves, they will be converted to a Revolutionary.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This gives a defensive traitor option against a common stun option the crew has, while also being offensive and having some gimmicky-ness. Helps traitors and Revheads survive some more and gives them some resistance against being arrested.

While you can find sunglasses around the station, or use welding masks, this would be an available option that isn't hindering like welding masks and provides more utility than either.

Not sure if this is too similar to anything currently available for antagonists, defensive options like this aren't a traitor thing, or if this isn't a good solution for stun protection

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(*)Added a new 1 TC traitor item - Reflective Glasses. They reflect incoming flashes at attackers, and their appearance can be set once by using them in-hand. Also available for Revheads, where reflected flashes will convert attackers to Revolutionaries if they aren't wearing eye protection.
```