### PR TITLE
Remove non-working 'togglepoint' keybind and related 'in_point_mode' checks

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -16,7 +16,6 @@
 	var/delete_on_logout = TRUE
 	var/delete_on_logout_reset = TRUE
 	var/obj/item/clothing/head/wig/wig = null
-	var/in_point_mode = FALSE
 	var/datum/hud/ghost_observer/hud
 	var/auto_tgui_open = TRUE
 	/// Observer menu TGUI datum. Can be null.
@@ -35,24 +34,10 @@
 
 	..()
 
-/mob/dead/observer/proc/toggle_point_mode(var/force_off = FALSE)
-	if (force_off)
-		src.in_point_mode = FALSE
-	else
-		src.in_point_mode = !(src.in_point_mode)
-	src.update_cursor()
-
-/mob/dead/observer/hotkey(name)
-	switch (name)
-		if ("togglepoint")
-			src.toggle_point_mode()
-		else
-			. = ..()
-
 /mob/dead/observer/update_cursor()
 	..()
 	if (src.client)
-		if (src.in_point_mode || src.client.check_key(KEY_POINT))
+		if (src.client.check_key(KEY_POINT))
 			src.set_cursor('icons/cursors/point.dmi')
 		else if (src.client.check_key(KEY_EXAMINE))
 			src.set_cursor('icons/cursors/examine.dmi')
@@ -60,10 +45,8 @@
 /mob/dead/observer/click(atom/target, params, location, control)
 	// If we have an ability active, skip all this and go straight to parent call.
 	if (!src.targeting_ability)
-		if (src.in_point_mode || (src.client && src.client.check_key(KEY_POINT)))
+		if (src.client && src.client.check_key(KEY_POINT))
 			src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
-			if (src.in_point_mode)
-				src.toggle_point_mode()
 			return
 		if (ismob(target) && !src.client.check_key(KEY_EXAMINE) && !istype(target, /mob/dead))
 			src.insert_observer(target)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -41,7 +41,6 @@
 	var/static/mutable_appearance/sleep_bubble = mutable_appearance('icons/mob/mob.dmi', "sleep")
 	var/image/silhouette
 	var/image/static_image = null
-	var/in_point_mode = 0
 	var/butt_op_stage = 0.0 // sigh
 	var/dna_to_absorb = 1
 
@@ -456,8 +455,6 @@
 				else
 					src.hasStatus("resting") ? src.delStatus("resting") : src.setStatus("resting", INFINITE_STATUS)
 					src.force_laydown_standup()
-		if ("togglepoint")
-			src.toggle_point_mode()
 		if ("say_radio")
 			src.say_radio()
 		else
@@ -481,10 +478,8 @@
 		src.examine_verb(target)
 		return
 
-	if (src.in_point_mode || (src.client && src.client.check_key(KEY_POINT)))
+	if (src.client && src.client.check_key(KEY_POINT))
 		src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
-		if (src.in_point_mode)
-			src.toggle_point_mode()
 		return
 
 	if (src.restrained())
@@ -576,7 +571,7 @@
 /mob/living/update_cursor()
 	..()
 	if (src.client)
-		if (src.in_point_mode || src.client.check_key(KEY_POINT))
+		if (src.client.check_key(KEY_POINT))
 			src.set_cursor('icons/cursors/point.dmi')
 			return
 
@@ -595,14 +590,6 @@
 /mob/living/key_up(key)
 	if (key == "alt" || key == "ctrl" || key == "shift")
 		update_cursor()
-
-/mob/living/proc/toggle_point_mode(var/force_off = 0)
-	if (force_off)
-		src.in_point_mode = 0
-		src.update_cursor()
-		return
-	src.in_point_mode = !(src.in_point_mode)
-	src.update_cursor()
 
 /mob/living/point_at(var/atom/target, var/pixel_x, var/pixel_y)
 	if (!isturf(src.loc) || !isalive(src) || src.restrained())

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -364,10 +364,8 @@
 			src.examine_verb(target) // in theory, usr should be us, this is shit though
 			return
 
-		if (src.in_point_mode || src.client?.check_key(KEY_POINT))
+		if (src.client?.check_key(KEY_POINT))
 			src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
-			if (src.in_point_mode)
-				src.toggle_point_mode()
 			return
 
 		if (GET_DIST(src, target) > 0) // temporary fix for cyborgs turning by clicking

--- a/code/modules/interface/action_associations.dm
+++ b/code/modules/interface/action_associations.dm
@@ -79,7 +79,6 @@ var/list/action_names = list(
 	"mentorhelp" = "Mentor Help",
 	"adminhelp" = "Admin Help",
 
-	"togglepoint" = "Toggle Pointing",
 	"refocus"   = "Refocus Window",
 	"mainfocus" = "Focus Main Window",
 
@@ -118,7 +117,6 @@ var/list/action_verbs = list(
 	"mentorhelp" = "mentorhelp",
 	"autoscreenshot" = ".xscreenshot auto",
 	"screenshot" = ".xscreenshot",
-	"togglepoint" = "togglepoint",
 	"refocus"   = ".winset \\\"mainwindow.input.focus=true;mainwindow.input.text=\\\"\\\"\\\"",
 	"mainfocus" = ".winset \"mainwindow.input.focus=false;mapwindow.map.focus=true;mainwindow.input.text=\"\"\"",
 	//"lazyfocus" = ".winset \\\"mainwindow.input.focus=true\\\"",

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -116,7 +116,6 @@ var/global/list/datum/keybind_style/keybind_styles = null
 	"P" = "pickup",
 	"F1" = "adminhelp",
 	"F3" = "mentorhelp",
-	"CTRL+P" = "togglepoint",
 	"F2" = "autoscreenshot",
 	"SHIFT+F2" = "screenshot",
 	"G" = "refocus",

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -99,7 +99,7 @@
 			return null
 
 	Click(location,control,params)
-		if(istype(usr, /mob/dead/observer) && usr.client && !usr.client.keys_modifier && !usr:in_point_mode)
+		if(istype(usr, /mob/dead/observer) && usr.client && !usr.client.keys_modifier)
 			var/mob/dead/observer/O = usr
 			if(src.pilot)
 				O.insert_observer(src.pilot)

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -130,7 +130,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 			src.eject_rider(crashed=FALSE, selfdismount=TRUE, ejectall=FALSE)
 
 	Click(location,control,params)
-		if(istype(usr, /mob/dead/observer) && usr.client && !usr.client.keys_modifier && !usr:in_point_mode)
+		if(istype(usr, /mob/dead/observer) && usr.client && !usr.client.keys_modifier)
 			var/mob/dead/observer/O = usr
 			if(src.rider)
 				O.insert_observer(src.rider)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The CTRL+P keybind for "togglepoint" hasn't been working for a while, and I'm not sure there's a need for it. Reviewed the code for mentor/admin mouse and changeling hivemind to confirm it wasn't using these, just in case.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fixes #8517

