### PR TITLE
Fix clarion fishing research pool not being portable subtype

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27045,7 +27045,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/fishing_pool,
+/obj/fishing_pool/portable,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #15882, also contestant for smallest PR ever. Might need an XXXS tag for this one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fishing pool subtypes should be consistent across maps, and even with the adjacent machinery.
