### PR TITLE
RecordTraks no longer redact existing fingerprint records

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -804,9 +804,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 				R["sex"] = M.gender
 				R["pronouns"] = M.get_pronouns().name
 				R["age"] = M.bioHolder.age
-				if (M.gloves)
-					R["fingerprint"] = "Unknown"
-				else
+				if (!M.gloves)
 					R["fingerprint"] = M.bioHolder.fingerprints
 				R["p_stat"] = "Active"
 				R["m_stat"] = "Stable"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, scanning someone wearing gloves with a recordtrak purges their fingerprints from the record. This PR makes it so that that _doesn't_ happen, but if they don't have gloves, it'll still try to update their fingerprints.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #15876 because this probably should not be the current behavior. Why would a forensic tool give you LESS forensic information..?