### PR TITLE
Update shuttles and shuttle floors for in rotation maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12132,8 +12132,8 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "aOc" = (
@@ -12150,8 +12150,8 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "aOf" = (
@@ -12261,8 +12261,8 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "aOD" = (
@@ -12273,8 +12273,8 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "aOF" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -17137,21 +17137,21 @@
 /area/listeningpost)
 "bLF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLG" = (
 /obj/rack,
 /obj/item/clothing/mask/gas/swat,
 /obj/item/clothing/mask/gas/swat,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLH" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLI" = (
@@ -17175,14 +17175,14 @@
 	desc = "This looks like a perfectly innocent weather satellite. It's locked up pretty tight to keep bath salts junkies from breaking in to steal the equipment.";
 	name = "Weather Satellite"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLM" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLN" = (
@@ -17190,8 +17190,8 @@
 	name = "E light switch";
 	pixel_x = 24
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLO" = (
@@ -17218,8 +17218,8 @@
 /area/listeningpost)
 "bLR" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "bLU" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -161,17 +161,13 @@
 /obj/indestructible/shuttle_corner{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aaL" = (
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aaN" = (
 /obj/machinery/mass_driver{
@@ -192,7 +188,9 @@
 	dir = 1;
 	icon_state = "alt_heater"
 	},
-/turf/simulated/shuttle/wall,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
 /area/shuttle/arrival/station)
 "aaT" = (
 /turf/simulated/shuttle/wall/cockpit/window{
@@ -303,9 +301,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "abM" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	name = "window"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "abS" = (
 /obj/machinery/atmospherics/pipe/simple{
@@ -39765,8 +39762,9 @@
 	},
 /area/listeningpost)
 "cAB" = (
-/obj/decal/fakeobjects/shuttlethruster{
-	dir = 4
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
 	},
 /turf/space,
 /area/abandonedship)
@@ -39870,34 +39868,24 @@
 	},
 /area/listeningpost)
 "cAR" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cAS" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cAT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
-/area/listeningpost)
-"cAU" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/obj/decal/fakeobjects/shuttlethruster{
+/turf/unsimulated/floor/shuttle/red{
 	dir = 4
 	},
-/turf/space,
-/area/abandonedship)
+/area/listeningpost)
 "cAX" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -39985,14 +39973,14 @@
 	dir = 4;
 	name = "Weather Satellite"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cBh" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cBi" = (
@@ -40055,8 +40043,8 @@
 /area/listeningpost)
 "cBr" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cBt" = (
@@ -41721,6 +41709,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/hangar/medical)
+"dGc" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/space,
+/area/shuttle/arrival/station)
 "dGl" = (
 /obj/machinery/door_timer/solitary{
 	pixel_x = -24
@@ -42463,11 +42457,7 @@
 	},
 /obj/landmark/start/latejoin,
 /obj/stool/chair/comfy/shuttle,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "emz" = (
 /obj/disposalpipe/segment/mail{
@@ -43583,12 +43573,9 @@
 	},
 /area/space)
 "fgR" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/obj/decal/fakeobjects/shuttleengine{
-	dir = 8
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
 	},
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/abandonedship)
@@ -43620,14 +43607,6 @@
 /obj/effects/background_objects/fortuna,
 /turf/space,
 /area/space)
-"fhL" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
-/area/shuttle/arrival/station)
 "fhM" = (
 /obj/submachine/seed_manipulator{
 	dir = 8
@@ -44759,12 +44738,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
-"gcg" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall/corner,
-/area/shuttle/arrival/station)
 "gci" = (
 /obj/decal/fakeobjects/airmonitor_broken,
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -45479,11 +45452,7 @@
 /area/space)
 "gKy" = (
 /obj/landmark/observer,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "gKO" = (
 /obj/cable,
@@ -45597,14 +45566,6 @@
 	dir = 5
 	},
 /area/station/medical/medbay/psychiatrist)
-"gNJ" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
-/area/shuttle/arrival/station)
 "gNP" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -46538,11 +46499,7 @@
 /area/station/engine/gas)
 "hGH" = (
 /obj/table/reinforced/auto,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "hHC" = (
 /obj/cable{
@@ -46911,11 +46868,7 @@
 	dir = 1;
 	icon_state = "alt_heater"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "hXV" = (
 /obj/cable{
@@ -47435,11 +47388,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "iyO" = (
 /obj/machinery/light{
@@ -48205,11 +48154,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "jqS" = (
 /obj/machinery/conveyor/EW{
@@ -49224,16 +49169,6 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/engine)
-"kic" = (
-/obj/decal/fakeobjects/shuttleengine{
-	dir = 8
-	},
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/unsimulated/wall/auto/adventure/shuttle/dark,
-/area/abandonedship)
 "kiI" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
@@ -49352,11 +49287,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "kqf" = (
 /obj/machinery/status_display,
@@ -52045,11 +51976,7 @@
 /area/station/engine/coldloop)
 "mWr" = (
 /obj/storage/closet/emergency,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/arrival/station)
 "mWz" = (
 /obj/table/auto,
@@ -53178,11 +53105,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/arrivals{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "nRZ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -56993,13 +56916,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engine/inner)
-"qXN" = (
-/obj/lattice,
-/obj/decal/fakeobjects/shuttleengine{
-	dir = 8
-	},
-/turf/unsimulated/wall/auto/adventure/shuttle/dark,
-/area/abandonedship)
 "qYs" = (
 /obj/grille/catwalk,
 /obj/cable/orange{
@@ -58356,16 +58272,6 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
-"slE" = (
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/obj/decal/fakeobjects/shuttleengine{
-	dir = 8
-	},
-/turf/unsimulated/wall/auto/adventure/shuttle/dark,
-/area/abandonedship)
 "slQ" = (
 /obj/machinery/firealarm/west,
 /obj/machinery/light{
@@ -58735,13 +58641,6 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"sFE" = (
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/turf/unsimulated/wall/auto/adventure/shuttle/dark,
-/area/abandonedship)
 "sFO" = (
 /obj/disposalpipe/trunk/mail{
 	dir = 1
@@ -60141,13 +60040,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"tSC" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/unsimulated/wall/auto/adventure/shuttle/dark,
-/area/abandonedship)
 "tSK" = (
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/maintenance/northeast)
@@ -60269,11 +60161,7 @@
 "tUY" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "tVf" = (
 /obj/grille/steel,
@@ -60608,11 +60496,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "ugg" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -61035,11 +60919,7 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "uwt" = (
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uwB" = (
 /turf/simulated/floor/bluewhite{
@@ -61191,11 +61071,7 @@
 /area/station/hallway/secondary/exit)
 "uCM" = (
 /obj/item/device/radio/beacon,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uCP" = (
 /obj/stool/bed/moveable,
@@ -61786,11 +61662,7 @@
 "vdx" = (
 /obj/landmark/start/latejoin,
 /obj/stool/chair/comfy/shuttle,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "vdC" = (
 /obj/reagent_dispensers/compostbin,
@@ -63615,11 +63487,7 @@
 	pixel_x = 3
 	},
 /obj/item/device/radio/intercom,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/arrival/station)
 "wFv" = (
 /obj/machinery/power/smes{
@@ -63792,11 +63660,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/arrivals{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "wQe" = (
 /obj/lattice{
@@ -64012,11 +63876,7 @@
 /area/station/engine/hotloop)
 "xbR" = (
 /obj/machinery/sleeper/compact,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/arrival/station)
 "xcW" = (
 /obj/disposalpipe/segment,
@@ -64710,6 +64570,12 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)
+"xKK" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space,
+/area/shuttle/arrival/station)
 "xKS" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -72554,7 +72420,7 @@ adC
 adC
 adC
 cAB
-cAU
+cAB
 adC
 adC
 cAB
@@ -72855,10 +72721,10 @@ adC
 adC
 adC
 adC
-slE
-qXN
+fgR
+fgR
 adC
-kic
+oct
 fgR
 cBQ
 cBQ
@@ -73157,11 +73023,11 @@ adC
 adC
 adC
 oct
-sFE
+oct
 uwL
 oct
 oct
-tSC
+oct
 oct
 cBQ
 cBQ
@@ -111013,7 +110879,7 @@ adC
 adC
 aaI
 aaP
-gcg
+xKK
 aak
 aaq
 hnF
@@ -111316,12 +111182,12 @@ aaJ
 aaL
 niO
 fYA
-gNJ
+abM
 niO
 niO
 wPo
 niO
-gcg
+xKK
 adC
 aam
 hnF
@@ -111624,7 +111490,7 @@ vdx
 uwt
 kqa
 hGH
-aaT
+xKK
 aaJ
 adC
 hnF
@@ -112832,7 +112698,7 @@ vdx
 uwt
 iyq
 tUY
-aaV
+dGc
 aaJ
 adC
 hnF
@@ -113128,12 +112994,12 @@ aaJ
 aaK
 niO
 nvq
-gNJ
+abM
 niO
 niO
 nRP
 niO
-fhL
+dGc
 adC
 aaf
 hnF
@@ -113429,7 +113295,7 @@ adC
 adC
 aaI
 aaP
-fhL
+dGc
 aak
 aaw
 hnF

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -10216,12 +10216,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/decal/poster/wallsign/stencil/left/a,
 /obj/decal/poster/wallsign/stencil/right/r,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "aDL" = (
 /obj/disposalpipe/segment/mail/vertical,
@@ -10465,12 +10460,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/decal/poster/wallsign/stencil/left/r,
 /obj/decal/poster/wallsign/stencil/right/v,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "aEt" = (
 /obj/cable,
@@ -10484,9 +10474,7 @@
 /area/station/hangar/arrivals)
 "aEu" = (
 /obj/indestructible/shuttle_corner,
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aEv" = (
 /obj/stool/chair/comfy/barber_chair{
@@ -10508,20 +10496,7 @@
 /area/shuttle/arrival/station)
 "aEA" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
-"aEC" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "aED" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -10728,19 +10703,6 @@
 	},
 /turf/space,
 /area/shuttle/arrival/station)
-"aFt" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-L"
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
-/area/shuttle/arrival/station)
 "aFu" = (
 /obj/machinery/light{
 	dir = 1
@@ -10748,22 +10710,16 @@
 /obj/machinery/sleeper/compact{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aFv" = (
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aFw" = (
@@ -10776,11 +10732,8 @@
 	dir = 4
 	},
 /obj/landmark/start/latejoin,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aFy" = (
@@ -10791,19 +10744,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
-"aFB" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aFD" = (
@@ -11347,35 +11289,16 @@
 	dir = 5
 	},
 /area/station/hallway/secondary/entry)
-"aHh" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-M"
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
-/area/shuttle/arrival/station)
 "aHi" = (
 /obj/table/auto,
 /obj/random_item_spawner/med_kit,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHj" = (
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHk" = (
@@ -11384,11 +11307,8 @@
 	opacity = 0;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHl" = (
@@ -11399,41 +11319,23 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
-"aHm" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHn" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHo" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio,
 /obj/item/device/radio,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aHq" = (
@@ -11952,28 +11854,12 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"aIM" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "alt_heater-R"
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
-/area/shuttle/arrival/station)
 "aIN" = (
 /obj/machinery/sleeper/compact{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aIO" = (
@@ -11993,35 +11879,23 @@
 	dir = 8;
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aIQ" = (
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
-	},
-/area/shuttle/arrival/station)
-"aIR" = (
-/turf/unsimulated/wall/generic{
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "wall";
-	opacity = 0
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aIS" = (
-/turf/simulated/shuttle/wall/corner{
+/obj/indestructible/shuttle_corner{
 	dir = 1
 	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aIT" = (
 /obj/table/wood/auto,
@@ -12452,19 +12326,8 @@
 /area/shuttle/arrival/station)
 "aKo" = (
 /obj/landmark/bill_spawn,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
-"aKp" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aKq" = (
@@ -12474,31 +12337,17 @@
 	opacity = 0;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aKr" = (
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aKs" = (
-/turf/unsimulated/wall/generic{
-	icon = 'icons/effects/160x160.dmi';
-	icon_state = "shuttlecock";
-	layer = 30;
-	name = "Cockpit";
-	opacity = 0;
-	pixel_x = -64;
-	pixel_y = -64
-	},
+/turf/simulated/shuttle/wall/cockpit,
 /area/shuttle/arrival/station)
 "aKt" = (
 /obj/reagent_dispensers/watertank/big,
@@ -12860,11 +12709,8 @@
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aLF" = (
@@ -12881,15 +12727,7 @@
 	dir = 8;
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
-	},
-/area/shuttle/arrival/station)
-"aLH" = (
-/turf/simulated/shuttle/wall/corner{
+/turf/unsimulated/floor/shuttle/yellow{
 	dir = 4
 	},
 /area/shuttle/arrival/station)
@@ -13384,11 +13222,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "aMW" = (
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aMX" = (
@@ -13397,21 +13232,15 @@
 	opacity = 0;
 	req_access_txt = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aMY" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aMZ" = (
@@ -13872,11 +13701,8 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aOm" = (
@@ -13885,19 +13711,14 @@
 	},
 /obj/landmark/start/latejoin,
 /obj/machinery/light,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aOn" = (
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
+/obj/machinery/door/airlock/pyro/reinforced/arrivals,
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aOo" = (
@@ -14362,7 +14183,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/corner,
+/turf/space,
 /area/shuttle/arrival/station)
 "aPA" = (
 /obj/machinery/light,
@@ -16242,11 +16063,8 @@
 	dir = 4
 	},
 /obj/machinery/bot/secbot,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aUR" = (
@@ -58701,21 +58519,21 @@
 /area/listeningpost)
 "dov" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "dow" = (
 /obj/rack,
 /obj/item/clothing/mask/gas/swat,
 /obj/item/clothing/mask/gas/swat,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "dox" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "doy" = (
@@ -58739,14 +58557,14 @@
 	dir = 4;
 	name = "Teleport Pad"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "doC" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "doD" = (
@@ -58754,8 +58572,8 @@
 	name = "E light switch";
 	pixel_x = 24
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "doE" = (
@@ -58782,8 +58600,8 @@
 /area/listeningpost)
 "doH" = (
 /obj/machinery/light,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost/syndicate_teleporter)
 "doK" = (
@@ -58865,15 +58683,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/escape)
-"dtU" = (
-/obj/machinery/door/airlock/pyro/reinforced/arrivals,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/arrival/station)
 "dux" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner{
@@ -59436,6 +59245,15 @@
 /obj/machinery/computer/transit_shuttle/mining,
 /turf/simulated/floor/plating/damaged2,
 /area/station/maintenance/southeast)
+"egI" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/arrival/station)
 "eht" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/specialroom/bar,
@@ -60133,7 +59951,7 @@
 /area/station/catwalk/south)
 "ffT" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("janitor","escape        checkpoint","mining","escape        hallway","mechanics","cargo        checkpoint","QM","refinery");
+	mail_tag = list("janitor","escape                checkpoint","mining","escape                hallway","mechanics","cargo                checkpoint","QM","refinery");
 	name = "mail junction (escape and cargo sectors)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -60251,11 +60069,6 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/crew_quarters/catering)
-"frm" = (
-/turf/unsimulated/floor/shuttle{
-	fullbright = 1
-	},
-/area/shuttle/research/outpost)
 "fsq" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
@@ -60862,12 +60675,7 @@
 	dir = 8;
 	icon_state = "alt_heater-M"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "goM" = (
 /obj/table/reinforced/auto,
@@ -61417,7 +61225,7 @@
 /area/station/hallway/secondary/exit)
 "gZy" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("medbay        lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
+	mail_tag = list("medbay                lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
 	name = "mail junction (medsci sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -62903,7 +62711,7 @@
 /area/station/medical/medbay)
 "iOr" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("chapel","chapel        checkpoint","crewA","arrivals        checkpoint");
+	mail_tag = list("chapel","chapel                checkpoint","crewA","arrivals                checkpoint");
 	name = "mail junction (arrivals sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -65317,6 +65125,11 @@
 	dir = 9
 	},
 /area/space)
+"lnj" = (
+/turf/unsimulated/floor/shuttle/green{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "lnJ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -65832,7 +65645,7 @@
 /area/station/engine/inner)
 "lTt" = (
 /obj/disposalpipe/switch_junction/left/north{
-	mail_tag = list("brig","customs        checkpoint","bridge","security");
+	mail_tag = list("brig","customs                checkpoint","bridge","security");
 	name = "mail junction (command sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -66251,10 +66064,6 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"mvu" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/research/outpost)
 "mww" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -66268,12 +66077,7 @@
 	dir = 8;
 	icon_state = "alt_heater-L"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "mwV" = (
 /obj/mapping_helper/firedoor_spawn,
@@ -68907,12 +68711,8 @@
 /turf/simulated/floor/caution/south,
 /area/station/science/lobby)
 "pPS" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/unsimulated/floor/shuttle{
-	fullbright = 1
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/unsimulated/floor/plating,
 /area/shuttle/research/outpost)
 "pQy" = (
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -69056,12 +68856,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
-"pZH" = (
-/obj/indestructible/shuttle_corner,
-/turf/unsimulated/floor/shuttle{
-	fullbright = 1
-	},
-/area/shuttle/research/outpost)
 "qak" = (
 /obj/table/wood/auto,
 /obj/machinery/firealarm/east,
@@ -69383,7 +69177,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical        booth");
+	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical                booth");
 	name = "mail junction (catering sector)"
 	},
 /turf/simulated/floor/grime,
@@ -71237,9 +71031,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "svA" = (
 /obj/lattice{
@@ -73203,7 +72995,7 @@
 /area/station/catwalk/south)
 "uNZ" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("engineering","podbay","podbay        checkpoint");
+	mail_tag = list("engineering","podbay","podbay                checkpoint");
 	name = "mail junction (engineering sector)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -74141,11 +73933,6 @@
 	dir = 4
 	},
 /area/station/catwalk/north)
-"wld" = (
-/obj/machinery/door/airlock/pyro/reinforced/arrivals,
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "wmv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/firealarm/north,
@@ -74365,12 +74152,7 @@
 	dir = 8;
 	icon_state = "alt_heater-R"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 8;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "wHp" = (
 /obj/machinery/power/terminal{
@@ -84636,7 +84418,7 @@ qDX
 kOo
 dRS
 pys
-mvu
+pPS
 pys
 gBo
 tHI
@@ -85242,7 +85024,7 @@ dwa
 nfB
 nfB
 hXM
-frm
+pPS
 rYU
 tHI
 aaa
@@ -85544,7 +85326,7 @@ jis
 vuG
 rYq
 dwa
-pZH
+pPS
 ibV
 aaa
 aaa
@@ -85844,7 +85626,7 @@ qDX
 qOn
 otl
 pys
-mvu
+pPS
 pys
 ibV
 aaa
@@ -138538,9 +138320,9 @@ aNN
 aaa
 aaa
 aKm
-aFt
-aHh
-aIM
+mwC
+goG
+wHl
 aKm
 mwC
 goG
@@ -139140,7 +138922,7 @@ axh
 aux
 aqF
 aaa
-aKm
+egI
 aEx
 aFv
 aHj
@@ -139150,7 +138932,7 @@ aLE
 aMW
 aLE
 aKm
-aKm
+egI
 aaa
 aFi
 aFi
@@ -139442,7 +139224,7 @@ axh
 aux
 arJ
 aaa
-aEC
+aIS
 aEy
 aFw
 aHk
@@ -139746,12 +139528,12 @@ arJ
 aaa
 aaa
 aKm
-aOn
-aOn
+lnj
+lnj
 aFx
 aIP
 aFx
-aOn
+lnj
 aFx
 aKm
 aaa
@@ -140048,12 +139830,12 @@ aAD
 aaS
 arR
 aEA
-aOn
-aOn
+lnj
+lnj
 aFx
 aFx
 aFx
-aOn
+lnj
 aFx
 aEA
 aag
@@ -140351,11 +140133,11 @@ arJ
 aDi
 aKm
 aFy
-aOn
+lnj
 aIO
-aKp
+aEA
 aLF
-aOn
+lnj
 aOm
 aKm
 aQR
@@ -140651,16 +140433,16 @@ aux
 kRn
 avX
 avX
-dtU
 aOn
-aOn
-aOn
+lnj
+lnj
+lnj
 aKo
+lnj
+lnj
+lnj
 aOn
-aOn
-aOn
-aOn
-wld
+aSi
 aSi
 rDA
 aGV
@@ -140953,16 +140735,16 @@ aux
 kRn
 aCa
 avX
-dtU
 aOn
+lnj
+lnj
+lnj
+lnj
+lnj
+lnj
+lnj
 aOn
-aOn
-aOn
-aOn
-aOn
-aOn
-aOn
-wld
+aSi
 aSj
 rDA
 gbM
@@ -141258,9 +141040,9 @@ aDi
 aKm
 aFy
 aFx
-aOn
-aOn
-aOn
+lnj
+lnj
+lnj
 aFx
 aOm
 aKm
@@ -141561,7 +141343,7 @@ aDK
 aFx
 aFx
 aFx
-aOn
+lnj
 aUQ
 aFx
 aFx
@@ -141863,7 +141645,7 @@ aEs
 aFx
 aFx
 aFx
-aOn
+lnj
 aFx
 aFx
 aFx
@@ -142162,13 +141944,13 @@ aAF
 aaa
 aaa
 aKm
-aOn
+lnj
 aFx
 aHl
-aOn
+lnj
 aFx
 aFx
-aOn
+lnj
 aKm
 aaa
 aaa
@@ -142463,13 +142245,13 @@ aqF
 aaI
 aaa
 aaa
-aEC
+aIS
 aDj
-aHm
+aEA
 aFw
 aKq
 aFw
-aHm
+aEA
 aDj
 svu
 aaa
@@ -142766,13 +142548,13 @@ arQ
 aaa
 aaa
 aaa
-aFB
+aEA
 aHn
 aIQ
 aKr
 aLG
 aMY
-aFB
+aEA
 aaa
 aaa
 aaa
@@ -143068,7 +142850,7 @@ aaa
 aaa
 aaa
 aaa
-aEC
+aIS
 aHo
 aIQ
 aIQ
@@ -143372,10 +143154,10 @@ aaa
 aaa
 aaa
 aIS
-aIR
-aIR
-aIR
-aLH
+aEA
+aEA
+aEA
+svu
 aaa
 aaa
 aaa
@@ -143674,9 +143456,9 @@ aaa
 aaa
 aaa
 hRi
-aIS
+hRi
 aKs
-aLH
+hRi
 hRi
 aaa
 aaa

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -536,8 +536,8 @@
 	},
 /area/listeningpost)
 "abN" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "abO" = (
@@ -551,8 +551,8 @@
 /area/station/crew_quarters/quarters)
 "abP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "abQ" = (
@@ -563,8 +563,8 @@
 /area/listeningpost)
 "abS" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "abT" = (
@@ -601,8 +601,8 @@
 /area/listeningpost)
 "abW" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "abZ" = (
@@ -1971,12 +1971,7 @@
 /area/station/science/lab)
 "aik" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/research/outpost)
 "ail" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -2135,7 +2130,7 @@
 	},
 /area/station/science/lab)
 "ajo" = (
-/obj/decal/fakeobjects/shuttleengine{
+/obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater"
 	},
 /turf/simulated/wall/auto/shuttle{
@@ -2314,7 +2309,7 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "ajW" = (
-/obj/decal/fakeobjects/shuttlethruster{
+/obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
 	},
 /turf/space,
@@ -2434,39 +2429,24 @@
 /area/shuttle/research/outpost)
 "aku" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/decal/fakeobjects/shuttleengine{
+/obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/research/outpost)
 "akv" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/decal/fakeobjects/shuttleengine{
+/obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-M"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/research/outpost)
 "akw" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/decal/fakeobjects/shuttleengine{
+/obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-R"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/research/outpost)
 "akx" = (
 /obj/indestructible/shuttle_corner{
@@ -2920,11 +2900,7 @@
 	dir = 1;
 	icon_state = "alt_heater-R"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "anl" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -2932,11 +2908,7 @@
 	dir = 1;
 	icon_state = "alt_heater-M"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "anm" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -2944,11 +2916,7 @@
 	dir = 1;
 	icon_state = "alt_heater-L"
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "ann" = (
 /obj/indestructible/shuttle_corner{
@@ -3012,11 +2980,7 @@
 /obj/cryotron{
 	layer = 3.9
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anY" = (
 /turf/simulated/wall/auto/shuttle{
@@ -3031,11 +2995,7 @@
 /obj/item/tank/emergency_oxygen,
 /obj/item/crowbar,
 /obj/item/crowbar,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoa" = (
 /obj/machinery/conveyor/WE{
@@ -3071,11 +3031,7 @@
 	network = "SS13";
 	tag = ""
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aol" = (
 /obj/machinery/light/emergency{
@@ -3116,28 +3072,16 @@
 /obj/storage/closet/wardrobe/mixed,
 /obj/machinery/light/incandescent,
 /obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aow" = (
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aox" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoy" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -3204,19 +3148,11 @@
 "aoK" = (
 /obj/storage/closet/wardrobe/mixed,
 /obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoL" = (
 /obj/machinery/light/incandescent,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoM" = (
 /obj/machinery/light/incandescent,
@@ -3241,14 +3177,6 @@
 "aoV" = (
 /turf/space,
 /area/supply/sell_point)
-"aoW" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
-/area/shuttle/arrival/station)
 "aoX" = (
 /obj/machinery/conveyor/SN{
 	id = "cargobelt_out";
@@ -3332,11 +3260,7 @@
 /area/station/hallway/secondary/researchshuttle)
 "apq" = (
 /obj/storage/closet/wardrobe/grey,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "apr" = (
 /obj/vehicle/tug,
@@ -3394,28 +3318,16 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
 /obj/item/device/radio,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "apE" = (
 /obj/stool/chair/comfy/shuttle/brown,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "apF" = (
 /obj/table/reinforced,
 /obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "apG" = (
 /turf/simulated/wall/auto/shuttle{
@@ -3618,9 +3530,8 @@
 	},
 /area/station/quartermaster/office)
 "aql" = (
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "13"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "aqm" = (
 /obj/cable{
@@ -11761,11 +11672,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aWr" = (
 /obj/machinery/computer/power_monitor,
@@ -13140,14 +13047,6 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"bbp" = (
-/turf/simulated/shuttle/wall/cockpit{
-	dir = 8;
-	icon_state = "shuttlecock";
-	layer = 2.8;
-	pixel_y = -32
-	},
-/area/shuttle/research/outpost)
 "bbq" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -23089,11 +22988,7 @@
 "doJ" = (
 /obj/machinery/light/incandescent,
 /obj/storage/closet/wardrobe/black,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "doQ" = (
 /obj/decal/cleanable/dirt/dirt5,
@@ -23297,11 +23192,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "duU" = (
 /obj/cable{
@@ -24971,8 +24862,8 @@
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "eDd" = (
@@ -25124,11 +25015,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
-"eKN" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall_space"
-	},
-/area/station/wreckage)
 "eKV" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor,
@@ -29171,6 +29057,12 @@
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
 /area/station/wreckage)
+"hQt" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/space,
+/area/space)
 "hQw" = (
 /obj/disposalpipe/segment,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -35153,17 +35045,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"meL" = (
-/obj/indestructible/shuttle_corner{
-	dir = 0
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/research/outpost)
 "meV" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -38291,6 +38172,11 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai_upload)
+"orA" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 8
+	},
+/area/space)
 "orH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38349,11 +38235,7 @@
 "otj" = (
 /obj/stool/chair/comfy/shuttle,
 /obj/landmark/start/latejoin,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "otq" = (
 /obj/disposalpipe/segment/mail{
@@ -42654,7 +42536,8 @@
 	dir = 1;
 	embed = 1;
 	icon_state = "shuttle-embed";
-	pixel_y = 25
+	pixel_y = 25;
+	layer = 31
 	},
 /turf/unsimulated/floor{
 	desc = "";
@@ -45792,8 +45675,8 @@
 	dir = 4;
 	name = "Weather Satellite"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "tAY" = (
@@ -46432,13 +46315,6 @@
 	dir = 8
 	},
 /area/station/hangar/arrivals)
-"uaD" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	dir = 1;
-	icon_state = "wall_space";
-	name = "window"
-	},
-/area/station/wreckage)
 "uaT" = (
 /obj/machinery/door/airlock/pyro/sci_alt,
 /obj/mapping_helper/firedoor_spawn,
@@ -46765,11 +46641,7 @@
 /area/station/security/hos)
 "umY" = (
 /obj/landmark/observer,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uns" = (
 /obj/disposalpipe/segment{
@@ -47848,17 +47720,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
-"vfw" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	dir = 2;
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor6"
-	},
-/area/shuttle/research/outpost)
 "vfW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -49204,6 +49065,12 @@
 	dir = 1
 	},
 /area/station/crew_quarters/quarters)
+"wff" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/space,
+/area/space)
 "wfj" = (
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
@@ -51572,12 +51439,6 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
-"xUj" = (
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "wall_space"
-	},
-/area/station/wreckage)
 "xUC" = (
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -78753,8 +78614,8 @@ apC
 apC
 apC
 apG
-aoW
-aoW
+aql
+aql
 apT
 apC
 apB
@@ -79352,7 +79213,7 @@ aaa
 aaa
 ajJ
 ank
-aoW
+aow
 anX
 otj
 aow
@@ -79654,7 +79515,7 @@ aaa
 aaa
 akk
 anl
-aoW
+aow
 aoL
 otj
 aow
@@ -79956,7 +79817,7 @@ aaa
 aaa
 akH
 anm
-aoW
+aow
 aow
 otj
 aow
@@ -80565,8 +80426,8 @@ apC
 apG
 aox
 apT
-aoW
-aoW
+aql
+aql
 apG
 aox
 apH
@@ -101552,14 +101413,14 @@ aaa
 aaa
 aaa
 aaa
-xUj
+aaa
 gIe
 gIe
 stQ
 stQ
 gIe
 gIe
-eKN
+aaa
 aaa
 aaa
 pSH
@@ -103363,8 +103224,8 @@ aaa
 smI
 acG
 tIu
-gIe
-uaD
+acG
+acG
 gIe
 uOI
 cZx
@@ -113761,7 +113622,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+wff
 agD
 agD
 aik
@@ -114063,7 +113924,7 @@ aaa
 aaa
 aaa
 aaa
-meL
+aik
 ahg
 aHz
 ahE
@@ -114364,8 +114225,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bbp
+orA
+aik
 rxN
 ahF
 ahF
@@ -114667,7 +114528,7 @@ aaa
 aaa
 aaa
 aaa
-vfw
+aik
 ahi
 aHA
 ahF
@@ -114969,7 +114830,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+hQt
 agD
 agD
 ail

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1150,7 +1150,9 @@
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-R"
 	},
-/turf/space,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
 /area/shuttle/asylum/medbay)
 "aoq" = (
 /obj/decal/fakeobjects/bookcase{
@@ -2244,8 +2246,8 @@
 /area/station/ai_monitored/armory)
 "aEf" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "aEC" = (
@@ -2866,14 +2868,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"aNW" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
-/area/shuttle/asylum/medbay)
 "aNY" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -3695,9 +3689,10 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "aZs" = (
-/turf/simulated/shuttle/wall/corner{
+/obj/indestructible/shuttle_corner{
 	dir = 1
 	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aZw" = (
 /obj/stool/chair/pew/fancy/center{
@@ -4041,7 +4036,9 @@
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
 	},
-/turf/simulated/wall/auto/shuttle,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
 /area/shuttle/asylum/medbay)
 "beH" = (
 /obj/submachine/chef_sink{
@@ -4204,15 +4201,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"bih" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8;
-	icon_state = "wall3_trans"
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
-/area/shuttle/asylum/medbay)
 "biw" = (
 /obj/stool/chair/comfy{
 	dir = 1
@@ -5194,10 +5182,8 @@
 	dir = 4
 	},
 /obj/landmark/start/latejoin,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "bwg" = (
@@ -9115,9 +9101,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "cDl" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
@@ -13659,7 +13643,9 @@
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
 	},
-/turf/space,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
 /area/shuttle/asylum/medbay)
 "ecM" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -15174,10 +15160,8 @@
 "eCP" = (
 /obj/storage/closet/wardrobe/black,
 /obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "eCQ" = (
@@ -18740,9 +18724,7 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "fId" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "fIf" = (
 /obj/decal/stripe_delivery,
@@ -19956,10 +19938,8 @@
 /area/station/crew_quarters/courtroom)
 "gcU" = (
 /obj/table/reinforced/auto,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "gcY" = (
@@ -20418,10 +20398,9 @@
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
 "gjo" = (
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "gjB" = (
@@ -20485,10 +20464,8 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "gkg" = (
@@ -21442,10 +21419,9 @@
 /area/station/maintenance/outer/north)
 "gyq" = (
 /obj/landmark/observer,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "gyy" = (
@@ -23252,10 +23228,8 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "hbY" = (
@@ -23897,11 +23871,8 @@
 "hlI" = (
 /obj/storage/closet/wardrobe/mixed,
 /obj/random_item_spawner/dressup/one_or_zero,
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "hlV" = (
@@ -26481,12 +26452,6 @@
 /obj/machinery/manufacturer/engineering,
 /turf/simulated/floor/yellowblack,
 /area/station/storage/primary)
-"idq" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "idA" = (
 /turf/simulated/wall/auto/reinforced/jen/blue{
 	icon_state = "R6"
@@ -26689,12 +26654,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
-"igF" = (
-/obj/indestructible/shuttle_corner,
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
-/area/shuttle/asylum/medbay)
 "igQ" = (
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -26702,9 +26661,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "ihb" = (
 /obj/cable{
@@ -27557,11 +27514,7 @@
 	icon_state = "alt_heater-L"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "iwJ" = (
 /obj/machinery/light,
@@ -32409,9 +32362,7 @@
 /obj/machinery/light/incandescent/cool{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/asylum/medbay)
 "jVO" = (
 /obj/mapping_helper/wingrille_spawn/auto,
@@ -32628,9 +32579,7 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/asylum/medbay)
 "jYw" = (
 /obj/decal/tile_edge/stripe/extra_big,
@@ -33051,9 +33000,7 @@
 "kgo" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/incandescent/cool,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "kgt" = (
 /obj/decal/cleanable/dirt/jen,
@@ -33604,9 +33551,7 @@
 /obj/machinery/door/airlock/pyro/medical/alt,
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/access/maint,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "kqI" = (
 /turf/simulated/floor/greenblack/corner{
@@ -34007,10 +33952,8 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "kxL" = (
@@ -36286,7 +36229,9 @@
 /area/station/maintenance/outer/nw)
 "ljE" = (
 /obj/indestructible/shuttle_corner,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "ljN" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -37987,7 +37932,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/corner,
+/turf/space,
 /area/shuttle/arrival/station)
 "lHb" = (
 /obj/table/reinforced/auto,
@@ -38320,9 +38265,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "lMP" = (
 /obj/submachine/chef_sink/chem_sink{
@@ -39473,8 +39416,8 @@
 "mbT" = (
 /obj/table/wood/auto,
 /obj/item/crowbar,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "mca" = (
@@ -46278,10 +46221,11 @@
 /area/station/science/lobby)
 "olM" = (
 /obj/machinery/computer/arcade,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "olP" = (
@@ -47235,14 +47179,6 @@
 /obj/mapping_helper/access/pathology,
 /turf/simulated/floor,
 /area/station/science/lobby)
-"ozb" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
-/area/shuttle/arrival/station)
 "ozs" = (
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
@@ -47264,10 +47200,8 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "ozN" = (
@@ -48259,11 +48193,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
-"oPx" = (
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
-/area/shuttle/arrival/station)
 "oPI" = (
 /obj/grille/steel,
 /obj/lattice,
@@ -49387,8 +49316,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/chapel/sanctuary)
 "phT" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "pif" = (
@@ -49641,13 +49570,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"plk" = (
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
-	},
-/area/shuttle/arrival/station)
 "plm" = (
 /obj/table/auto,
 /obj/item/wrench{
@@ -50292,13 +50214,8 @@
 /area/station/ai_monitored/armory)
 "pxg" = (
 /obj/machinery/computer/arcade,
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "pxu" = (
@@ -51197,10 +51114,8 @@
 /area/station/maintenance/inner/sw)
 "pJw" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "pJK" = (
@@ -51714,10 +51629,8 @@
 "pQX" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "pRd" = (
@@ -52073,11 +51986,7 @@
 	icon_state = "alt_heater-M"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "pXt" = (
 /obj/table/auto,
@@ -52223,8 +52132,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "qaz" = (
@@ -56434,11 +56343,10 @@
 	dir = 1;
 	embed = 1;
 	icon_state = "shuttle-embed";
-	pixel_y = 25
+	pixel_y = 25;
+	layer = 31
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
+/turf/unsimulated/floor/shuttle/yellow,
 /area/shuttle/asylum/medbay)
 "rnV" = (
 /turf/simulated/wall/auto/reinforced/jen,
@@ -56620,9 +56528,6 @@
 	dir = 6
 	},
 /area/station/bridge/customs)
-"rra" = (
-/turf/simulated/wall/auto/shuttle,
-/area/shuttle/asylum/medbay)
 "rrj" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -56707,10 +56612,9 @@
 /area/station/medical/dome)
 "rsK" = (
 /obj/machinery/sleeper/compact,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "rsN" = (
@@ -58403,10 +58307,8 @@
 /area/station/security/brig/north_side)
 "rVd" = (
 /obj/storage/closet/emergency,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "rVh" = (
@@ -60004,11 +59906,8 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "stQ" = (
-/obj/machinery/light/incandescent/netural,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "stS" = (
@@ -60988,9 +60887,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "sMf" = (
 /obj/cable{
@@ -61353,6 +61250,14 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
+"sTb" = (
+/obj/cryotron{
+	layer = 3.9
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "sTc" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment/transport,
@@ -61361,14 +61266,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"sTo" = (
-/obj/indestructible/shuttle_corner,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
-/area/shuttle/arrival/station)
 "sTy" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -61678,19 +61575,6 @@
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/maintenance/outer/se)
-"sWX" = (
-/obj/cryotron{
-	layer = 3.9
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
-/area/shuttle/arrival/station)
 "sWY" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -62635,11 +62519,7 @@
 	icon_state = "alt_heater-R"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "tnq" = (
 /obj/lattice{
@@ -63945,6 +63825,11 @@
 /mob/living/critter/small_animal/seal,
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
+"tIf" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "tIl" = (
 /obj/machinery/vending/pda,
 /turf/simulated/floor/greenwhite/other{
@@ -66555,6 +66440,14 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"uyF" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "uyL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -68128,15 +68021,6 @@
 /obj/table/auto,
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
-"uWU" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1;
-	icon_state = "wall3_trans"
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
-/area/shuttle/asylum/medbay)
 "uWW" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -70598,10 +70482,8 @@
 "vJd" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "vJI" = (
@@ -72567,10 +72449,11 @@
 "wmS" = (
 /obj/storage/closet/wardrobe/mixed,
 /obj/random_item_spawner/dressup/one_or_zero,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "wmV" = (
@@ -73845,10 +73728,8 @@
 	})
 "wGe" = (
 /obj/machinery/light/small/floor/netural,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "wGD" = (
@@ -73981,9 +73862,7 @@
 /turf/simulated/floor/stairs/wood2/wide,
 /area/station/crew_quarters/bar)
 "wIr" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/asylum/medbay)
 "wIu" = (
 /obj/shrub{
@@ -75539,8 +75418,7 @@
 /area/station/engine/engineering/ce)
 "xde" = (
 /turf/simulated/shuttle/wall/cockpit{
-	dir = 1;
-	icon_state = "shuttlecock_blu2"
+	dir = 8
 	},
 /area/shuttle/asylum/medbay)
 "xdn" = (
@@ -76177,11 +76055,7 @@
 /area/ghostdrone_factory)
 "xlS" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "xlW" = (
 /obj/decal/tile_edge/line/yellow{
@@ -76930,9 +76804,6 @@
 "xwE" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/security/checkpoint/escape)
-"xwL" = (
-/turf/space,
-/area/shuttle/asylum/medbay)
 "xwM" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -77534,9 +77405,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/medical,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor3"
-	},
+/turf/unsimulated/floor/shuttle/white,
 /area/shuttle/asylum/medbay)
 "xFr" = (
 /obj/disposalpipe/segment,
@@ -79182,10 +79051,8 @@
 /area/station/turret_protected/AIsat)
 "yff" = (
 /obj/storage/closet/wardrobe/pride,
-/turf/unsimulated/floor{
-	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+/turf/unsimulated/floor/shuttle{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "yfg" = (
@@ -103309,12 +103176,12 @@ rdj
 rdj
 qol
 vBJ
-sWX
-gjo
+tIf
+sTb
+hlI
 wmS
-wmS
-wmS
-wmS
+hlI
+hlI
 hlI
 vBJ
 qol
@@ -103609,14 +103476,14 @@ rdj
 rdj
 rdj
 rdj
-ozb
+aZs
 glO
-gjo
-gjo
-gjo
-gjo
-gjo
-gjo
+uyF
+tIf
+tIf
+tIf
+tIf
+tIf
 gjo
 hje
 sLK
@@ -103913,11 +103780,11 @@ rdj
 rdj
 rdj
 xlS
-gjo
-gjo
-gjo
-gjo
-gjo
+tIf
+tIf
+tIf
+tIf
+tIf
 yff
 eCP
 xlS
@@ -104217,9 +104084,9 @@ rdj
 hje
 xDf
 raQ
-gjo
-gjo
-gjo
+tIf
+tIf
+tIf
 gVW
 xDf
 glO
@@ -104518,11 +104385,11 @@ rdj
 rdj
 vBJ
 olM
-gjo
-gjo
-gjo
-gjo
-plk
+tIf
+tIf
+tIf
+tIf
+stQ
 rsK
 vBJ
 rdj
@@ -104820,11 +104687,11 @@ rdj
 rdj
 xlS
 pxg
-gjo
+tIf
 bvY
 bvY
 bvY
-plk
+stQ
 stQ
 vBJ
 rdj
@@ -105122,12 +104989,12 @@ rdj
 rdj
 xlS
 gcU
-gjo
-gjo
+tIf
+tIf
 gyq
-gjo
-gjo
-gjo
+tIf
+tIf
+tIf
 xlS
 cPY
 dne
@@ -105424,12 +105291,12 @@ rdj
 rdj
 xlS
 vJd
-gjo
+tIf
 bvY
 bvY
 bvY
-gjo
-gjo
+tIf
+tIf
 pJw
 qxT
 mbH
@@ -105726,12 +105593,12 @@ rdj
 rdj
 xlS
 gjU
-gjo
-gjo
-gjo
-gjo
-gjo
-gjo
+tIf
+tIf
+wGe
+tIf
+tIf
+tIf
 pJw
 qxT
 mbH
@@ -106028,11 +105895,11 @@ rdj
 rdj
 xlS
 rVd
-gjo
+tIf
 bvY
 bvY
 bvY
-gjo
+tIf
 rVd
 xlS
 cPY
@@ -106330,11 +106197,11 @@ rdj
 rdj
 vBJ
 ozv
-gjo
-gjo
-gjo
-gjo
-gjo
+tIf
+tIf
+tIf
+tIf
+tIf
 pQX
 vBJ
 rdj
@@ -106630,8 +106497,8 @@ rdj
 rdj
 rdj
 rdj
-ozb
-idq
+aZs
+hbR
 vJd
 bvY
 bvY
@@ -106933,12 +106800,12 @@ rdj
 rdj
 rdj
 rdj
-ozb
+aZs
 hbR
 wGe
 bvY
 wGe
-sTo
+ljE
 sLK
 rdj
 rdj
@@ -107237,10 +107104,10 @@ rdj
 rdj
 rdj
 aZs
-xDf
-xDf
-xDf
-oPx
+xlS
+xlS
+xlS
+sLK
 rdj
 rdj
 rdj
@@ -122397,7 +122264,7 @@ xLs
 rdj
 rdj
 rdj
-igF
+buU
 uLS
 opv
 tIo
@@ -122698,7 +122565,7 @@ rdj
 vVp
 rdj
 rdj
-bih
+buU
 lMN
 kgo
 qQs
@@ -122999,8 +122866,8 @@ rdj
 rdj
 qJK
 rdj
-xwL
-rra
+rdj
+tIo
 fId
 fId
 kGW
@@ -123302,7 +123169,7 @@ rdj
 vVp
 rdj
 xde
-rra
+tIo
 rnS
 fId
 kqE
@@ -123603,8 +123470,8 @@ rdj
 rdj
 qJK
 rdj
-xwL
-rra
+rdj
+tIo
 fId
 fId
 ksF
@@ -123906,7 +123773,7 @@ xqF
 ldn
 rdj
 rdj
-uWU
+moS
 iha
 kgo
 qQs
@@ -124209,7 +124076,7 @@ aRr
 rdj
 rdj
 rdj
-aNW
+moS
 uLS
 wzE
 tIo

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -23,10 +23,11 @@
 /turf/space,
 /area/space)
 "aag" = (
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "wall3_space"
+/obj/indestructible/shuttle_corner{
+	icon_state = "wall3_trans";
+	dir = 8
 	},
+/turf/space,
 /area/space)
 "aah" = (
 /obj/decal/fakeobjects/airmonitor_broken,
@@ -44,6 +45,10 @@
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/space)
 "aal" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4;
+	icon_state = "wall3_trans"
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "aam" = (
@@ -150,6 +155,10 @@
 /turf/space,
 /area/space)
 "aaz" = (
+/obj/indestructible/shuttle_corner{
+	icon_state = "wall3_trans";
+	dir = 1
+	},
 /turf/simulated/floor/airless/damaged4,
 /area/space)
 "aaA" = (
@@ -178,9 +187,10 @@
 /turf/simulated/floor/airless/damaged3,
 /area/space)
 "aaD" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3_space"
+/obj/indestructible/shuttle_corner{
+	icon_state = "wall3_trans"
 	},
+/turf/space,
 /area/space)
 "aaF" = (
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -29687,21 +29697,21 @@
 	desc = "Seems to be a pretty sturdy door.";
 	name = "Listening Post"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cna" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cnb" = (
 /obj/table/wood/auto,
 /obj/item/crowbar,
 /obj/item/crowbar,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cnc" = (
@@ -29715,14 +29725,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cne" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cnf" = (
@@ -29791,8 +29801,8 @@
 /area/listeningpost)
 "cnk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
+/turf/unsimulated/floor/shuttle/red{
+	dir = 4
 	},
 /area/listeningpost)
 "cnl" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1320,9 +1320,8 @@
 /area/station/turret_protected/ai)
 "aDq" = (
 /obj/machinery/light/small/floor,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "aDu" = (
@@ -3066,9 +3065,8 @@
 /obj/indestructible/shuttle_corner{
 	dir = 1
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "bsw" = (
@@ -3828,9 +3826,8 @@
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "bIJ" = (
@@ -11117,9 +11114,8 @@
 "feM" = (
 /obj/table/auto,
 /obj/random_item_spawner/med_kit,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "feY" = (
@@ -14233,9 +14229,8 @@
 "guf" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/fire,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "guj" = (
@@ -19472,8 +19467,8 @@
 	dir = 4;
 	hardened = 1
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "ivh" = (
@@ -22447,9 +22442,8 @@
 /area/station/bridge)
 "jML" = (
 /obj/machinery/light/small/floor,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "jMP" = (
@@ -26543,9 +26537,7 @@
 	})
 "lrG" = (
 /obj/mapping_helper/wingrille_spawn/auto,
-/turf/unsimulated/floor/shuttle{
-	dir = 8
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "lrN" = (
 /obj/cable{
@@ -31669,9 +31661,8 @@
 "nBu" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "nBD" = (
@@ -32807,9 +32798,8 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/tank/air,
 /obj/item/clothing/mask/breath,
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "oaQ" = (
@@ -40063,9 +40053,8 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "rvC" = (
@@ -42329,6 +42318,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
+"swq" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/arrival/station)
 "swt" = (
 /obj/machinery/chem_master{
 	dir = 8
@@ -45306,9 +45304,8 @@
 /obj/machinery/sleeper/compact{
 	dir = 4
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "tJx" = (
@@ -47582,9 +47579,8 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "uJW" = (
@@ -47872,8 +47868,8 @@
 	hardened = 1;
 	name = "emergency chamber airlock"
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "uQU" = (
@@ -48607,6 +48603,15 @@
 "vmx" = (
 /turf/simulated/floor/yellowblack/corner,
 /area/station/hallway/secondary/east)
+"vmQ" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/arrival/station)
 "vmT" = (
 /obj/table/reinforced/chemistry/auto/clericalsup,
 /obj/item/paper/labdrawertips,
@@ -52006,9 +52011,8 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "wPO" = (
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor2"
+/turf/unsimulated/floor/shuttle/yellow{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "wPX" = (
@@ -53410,9 +53414,8 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
 "xwU" = (
-/turf/unsimulated/floor/shuttle{
-	dir = 8;
-	icon_state = "floor3"
+/turf/unsimulated/floor/shuttle/white{
+	dir = 4
 	},
 /area/shuttle/arrival/station)
 "xwY" = (
@@ -54658,9 +54661,7 @@
 "xYB" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/forcefield/energyshield/perma,
-/turf/unsimulated/floor/shuttle{
-	dir = 8
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "xYU" = (
 /obj/machinery/portableowl/attached{
@@ -55031,9 +55032,7 @@
 /obj/forcefield/energyshield/perma{
 	dir = 4
 	},
-/turf/unsimulated/floor/shuttle{
-	dir = 8
-	},
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "ykm" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -79754,7 +79753,7 @@ rJg
 rJg
 rJg
 rJg
-bJL
+vmQ
 uJL
 bIB
 bIB
@@ -79768,7 +79767,7 @@ rvz
 rvz
 rvz
 bsp
-cMR
+swq
 rJg
 rJg
 rJg

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -11890,15 +11890,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aNj" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aNk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aNm" = (
 /obj/machinery/power/smes{
@@ -11945,9 +11941,7 @@
 /obj/machinery/light/incandescent/greenish{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aNv" = (
 /obj/decal/cleanable/oil,
@@ -11964,17 +11958,13 @@
 /area/station/security/main)
 "aNy" = (
 /obj/submachine/syndicate_teleporter,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aNz" = (
 /obj/machinery/light/incandescent/greenish{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aNA" = (
 /turf/simulated/floor/plating/random,
@@ -12129,9 +12119,7 @@
 	desc = "This looks like a perfectly innocent weather satellite. It's locked up pretty tight to keep bath salts junkies from breaking in to steal the equipment.";
 	name = "Weather Satellite"
 	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/listeningpost)
 "aOj" = (
 /obj/cable{
@@ -21912,9 +21900,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
 "bzD" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bzE" = (
 /turf/simulated/floor/carpet{
@@ -22321,15 +22307,11 @@
 /obj/rack,
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/clothing/mask/medical,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bAL" = (
 /obj/machinery/light/small/floor/warm/very,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bAM" = (
 /obj/machinery/disposal/ore,
@@ -22698,9 +22680,7 @@
 /obj/item/clothing/shoes/black,
 /obj/item/clothing/gloves/swat,
 /obj/item/clothing/shoes/swat,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bBV" = (
 /obj/table/auto,
@@ -28089,9 +28069,7 @@
 /area/station/crew_quarters/lounge/port)
 "bTw" = (
 /obj/critter/gunbot/drone,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bTx" = (
 /obj/cable{
@@ -28864,9 +28842,7 @@
 /area/station/security/hos)
 "bWe" = (
 /obj/critter/gunbot/drone/heavydrone,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "bWf" = (
 /obj/cable{
@@ -35734,9 +35710,7 @@
 /area/station/maintenance/inner/central)
 "fWc" = (
 /obj/landmark/spawner/loot,
-/turf/simulated/floor/shuttle{
-	icon_state = "floor4"
-	},
+/turf/unsimulated/floor/shuttle/red,
 /area/space)
 "fWR" = (
 /obj/machinery/firealarm/east,

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -6495,12 +6495,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"cUd" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/space,
-/area/space)
 "cUu" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/supernorn,
@@ -47326,7 +47320,7 @@
 	},
 /area/station/solar/west)
 "uPn" = (
-/turf/simulated/floor/airbridge,
+/turf/unsimulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "uPq" = (
 /obj/cable{
@@ -103094,11 +103088,11 @@ vnX
 vnX
 vnX
 vnX
-dII
+vnX
 fHc
 fHc
 fHc
-dII
+vnX
 vnX
 vnX
 yaT
@@ -105810,7 +105804,7 @@ vnX
 vnX
 vnX
 vnX
-cUd
+aXX
 tTB
 amn
 ngU
@@ -107926,7 +107920,7 @@ vnX
 vnX
 vnX
 vnX
-cUd
+aXX
 eUs
 eUs
 eUs

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -577,7 +577,9 @@
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "aju" = (
 /obj/decal/cleanable/paper,
@@ -725,7 +727,9 @@
 "amm" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "amn" = (
 /obj/machinery/camera{
@@ -735,7 +739,9 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "amx" = (
 /obj/table/auto,
@@ -760,9 +766,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 8
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "anp" = (
 /turf/simulated/floor/caution/west,
@@ -879,7 +883,9 @@
 "apU" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "aqN" = (
 /obj/machinery/navbeacon/mule/ranch_north,
@@ -950,25 +956,11 @@
 	},
 /turf/simulated/grass,
 /area/station/garden/owlery)
-"asG" = (
-/obj/indestructible/shuttle_corner{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "asI" = (
 /obj/loudspeaker,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/research_outpost/protest)
-"asL" = (
-/obj/table/auto,
-/obj/machinery/light/incandescent{
-	dir = 8
-	},
-/obj/random_item_spawner/desk_stuff,
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "atc" = (
 /obj/grille/catwalk,
 /obj/cable{
@@ -1575,7 +1567,9 @@
 /obj/indestructible/shuttle_corner{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "aHg" = (
 /turf/space/asteroid,
@@ -2314,9 +2308,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "aYH" = (
 /obj/rack,
@@ -3714,14 +3706,6 @@
 /obj/mapping_helper/access/medical_director,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"bFy" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1
-	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 1
-	},
-/area/space)
 "bFL" = (
 /obj/table/auto,
 /obj/item/bee_egg_carton,
@@ -5834,7 +5818,9 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "cBu" = (
 /obj/table/auto,
@@ -6008,7 +5994,7 @@
 	dir = 1;
 	icon_state = "alt_heater"
 	},
-/turf/simulated/shuttle/wall,
+/turf/unsimulated/wall/auto/adventure/shuttle,
 /area/abandonedship{
 	name = "Crashed Limo"
 	})
@@ -6510,11 +6496,10 @@
 	},
 /area/station/hallway/primary/south)
 "cUd" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	dir = 1;
-	icon_state = "wall_space";
-	name = "window"
+/obj/indestructible/shuttle_corner{
+	dir = 1
 	},
+/turf/space,
 /area/space)
 "cUu" = (
 /obj/disposalpipe/segment/horizontal,
@@ -6589,7 +6574,7 @@
 /turf/space,
 /area/space)
 "cVC" = (
-/turf/simulated/shuttle/wall,
+/turf/unsimulated/wall/auto/adventure/shuttle,
 /area/abandonedship{
 	name = "Crashed Limo"
 	})
@@ -6601,7 +6586,7 @@
 /area/station/crew_quarters/fitness)
 "cVT" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
-/turf/simulated/floor/shuttle,
+/turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "cWe" = (
 /obj/machinery/disposal/morgue,
@@ -6724,7 +6709,9 @@
 /area/station/maintenance/east)
 "dae" = (
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "daf" = (
 /obj/lattice{
@@ -7105,7 +7092,9 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "diy" = (
 /turf/simulated/wall/auto/supernorn,
@@ -7523,7 +7512,9 @@
 /area/station/mining/cargo_staff_room)
 "drm" = (
 /obj/landmark/observer,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "drn" = (
 /obj/cable{
@@ -8404,7 +8395,7 @@
 /area/station/hallway/primary/south)
 "dJu" = (
 /obj/decal/cleanable/rust,
-/turf/simulated/shuttle/wall,
+/turf/unsimulated/wall/auto/adventure/shuttle,
 /area/abandonedship{
 	name = "Crashed Limo"
 	})
@@ -9148,11 +9139,6 @@
 /obj/cable,
 /turf/simulated/floor/specialroom/gym,
 /area/station/turret_protected/ai)
-"dZR" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	name = "window"
-	},
-/area/shuttle/arrival/station)
 "eah" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9729,12 +9715,15 @@
 /turf/simulated/floor/stairs/wide,
 /area/station/hallway/primary/west)
 "ejD" = (
-/obj/table/auto,
 /obj/machinery/light/incandescent{
 	dir = 8
 	},
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/shuttle,
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "ejR" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
@@ -10568,7 +10557,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/corner,
+/turf/space,
 /area/shuttle/arrival/station)
 "eBA" = (
 /obj/cable{
@@ -11074,7 +11063,11 @@
 /area/station/com_dish/comdish)
 "eQP" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/shuttle,
+/obj/table/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "eRc" = (
 /obj/table/auto,
@@ -11254,7 +11247,7 @@
 /area/space)
 "eUs" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "eUu" = (
 /obj/machinery/camera{
@@ -11788,7 +11781,9 @@
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "ffB" = (
 /obj/machinery/light/emergency{
@@ -12383,13 +12378,6 @@
 /obj/item/reagent_containers/glass/bottle/fruitful,
 /turf/simulated/floor/caution,
 /area/station/hydroponics/bay)
-"fvB" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	dir = 4;
-	icon_state = "wall_space";
-	name = "window"
-	},
-/area/shuttle/arrival/station)
 "fvC" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -12936,7 +12924,7 @@
 /area/station/crew_quarters/baroffice)
 "fHc" = (
 /obj/machinery/shuttle/engine/propulsion/burst{
-	dir = 4;
+	dir = 8;
 	icon_state = "alt_propulsion"
 	},
 /turf/space,
@@ -14088,9 +14076,7 @@
 /obj/indestructible/shuttle_corner{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/corner{
-	dir = 4
-	},
+/turf/space,
 /area/shuttle/arrival/station)
 "gef" = (
 /turf/simulated/floor/white,
@@ -17607,9 +17593,8 @@
 	dir = 8;
 	icon_state = "alt_heater"
 	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
 "hJH" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -17995,12 +17980,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"hTL" = (
-/obj/machinery/sleep_console{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "hTN" = (
 /obj/machinery/light/emergency{
 	dir = 1
@@ -20791,7 +20770,9 @@
 /area/station/maintenance/northeast)
 "jax" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
-/turf/simulated/floor/shuttle,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
 /area/shuttle/arrival/station)
 "jaM" = (
 /obj/machinery/light{
@@ -30035,6 +30016,11 @@
 "ngE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/research_director)
+"ngU" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "ngX" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -39563,6 +39549,16 @@
 	dir = 8
 	},
 /area/station/bridge)
+"rtA" = (
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
+/obj/table/auto,
+/obj/random_item_spawner/desk_stuff,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "rtE" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -42973,7 +42969,7 @@
 	icon_state = "alt_heater"
 	},
 /obj/decal/cleanable/rust,
-/turf/simulated/shuttle/wall,
+/turf/unsimulated/wall/auto/adventure/shuttle,
 /area/abandonedship{
 	name = "Crashed Limo"
 	})
@@ -45415,6 +45411,14 @@
 /area/abandonedship{
 	name = "Crashed Limo"
 	})
+"tTB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "tUM" = (
 /obj/stool/chair{
 	dir = 1
@@ -47322,7 +47326,7 @@
 	},
 /area/station/solar/west)
 "uPn" = (
-/turf/simulated/floor/shuttle,
+/turf/simulated/floor/airbridge,
 /area/shuttle/arrival/station)
 "uPq" = (
 /obj/cable{
@@ -53647,6 +53651,12 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"xvu" = (
+/obj/machinery/light/incandescent,
+/turf/unsimulated/floor/shuttle{
+	dir = 4
+	},
+/area/shuttle/arrival/station)
 "xvD" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -103689,8 +103699,8 @@ vnX
 amV
 hJv
 cBo
-asL
-uPn
+ejD
+ngU
 ejD
 aHc
 hJv
@@ -103989,12 +103999,12 @@ vnX
 vnX
 vnX
 afe
-ajr
-uPn
-hTL
-uPn
-hTL
-uPn
+rtA
+ngU
+ngU
+ngU
+ngU
+ngU
 eQP
 afe
 eDf
@@ -104291,13 +104301,13 @@ vnX
 vnX
 hGG
 eUs
-uPn
+ngU
 diw
 diw
-uPn
+ngU
 diw
 diw
-uPn
+ngU
 jax
 cVT
 aTk
@@ -104593,13 +104603,13 @@ vnX
 vnX
 hGG
 eUs
-uPn
-uPn
-uPn
-uPn
-uPn
-uPn
-uPn
+ngU
+ngU
+ngU
+ngU
+ngU
+ngU
+ngU
 jax
 cVT
 aTk
@@ -104896,12 +104906,12 @@ vnX
 vnX
 afe
 ajr
-uPn
-uPn
-uPn
-uPn
-uPn
-eQP
+ngU
+ngU
+ngU
+ngU
+ngU
+xvu
 afe
 bYH
 vpn
@@ -105200,7 +105210,7 @@ eUs
 amm
 diw
 diw
-uPn
+ngU
 diw
 diw
 apU
@@ -105500,11 +105510,11 @@ vnX
 hGG
 eUs
 apU
-uPn
-uPn
+ngU
+ngU
 dae
-uPn
-uPn
+ngU
+ngU
 amm
 eUs
 eDf
@@ -105800,13 +105810,13 @@ vnX
 vnX
 vnX
 vnX
-bFy
-asG
+cUd
+tTB
 amn
-uPn
+ngU
 drm
-uPn
-uPn
+ngU
+ngU
 ffv
 gec
 eDf
@@ -106104,11 +106114,11 @@ vnX
 vnX
 hGG
 eUs
-uPn
+ngU
 diw
 diw
 diw
-uPn
+ngU
 eUs
 say
 eDf
@@ -106407,10 +106417,10 @@ vnX
 vnX
 afe
 ajr
-uPn
-uPn
-uPn
-uPn
+ngU
+ngU
+ngU
+xvu
 afe
 lVt
 eDf
@@ -106708,11 +106718,11 @@ vnX
 vnX
 hGG
 eUs
-uPn
+ngU
 diw
 diw
 diw
-uPn
+ngU
 jax
 uPn
 cVT
@@ -107010,11 +107020,11 @@ vnX
 vnX
 hGG
 eUs
-uPn
-uPn
-uPn
-uPn
-uPn
+ngU
+ngU
+ngU
+ngU
+ngU
 jax
 uPn
 cVT
@@ -107316,7 +107326,7 @@ ajr
 diw
 diw
 diw
-eQP
+xvu
 afe
 lVt
 eDf
@@ -107614,10 +107624,10 @@ vnX
 vnX
 vnX
 aXX
-uPn
-uPn
-uPn
-uPn
+tTB
+ngU
+ngU
+ngU
 ffv
 gec
 iAO
@@ -107917,10 +107927,10 @@ vnX
 vnX
 vnX
 cUd
-dZR
-dZR
-dZR
-fvB
+eUs
+eUs
+eUs
+gec
 vnX
 iAO
 eDf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace icon varedits with the typed colours for shuttle floors.
Removes turf shuttle corners from all arrival shuttles.
Changes dir of shuttle floors to match arrival shuttle direction where it doesn't.
Puts plating under all windows in arrival shuttles.
Replace transparent broken walls with windows in shuttle cockpits.
Update wrestlemap arrival shutttle with compact sleepers.
Removed shuttle corners from the horizon ranch shuttle on donut 2.

Update the old heater in the cog 1 wreck to the newer ones:
![image](https://github.com/goonstation/goonstation/assets/113442598/e6bc1149-07d6-4037-9b7c-087f8e151ba0)

Slight moving around of the donut 3 arrival shuttle:
![image](https://github.com/goonstation/goonstation/assets/113442598/25d719fa-4596-4f90-a244-5f0e03988720)
(lights and cyro moved)

Removed the extra windows and extended the donut 2 arrival shuttle and area:
![image](https://github.com/goonstation/goonstation/assets/113442598/6c90a611-c55f-4286-818e-583b504b9d9f)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes and updates for shuttles. Good for consistency. Typed floors will be better if anyone changes the icon_state.

