### PR TITLE
Fixes #15888 - Parallax Signal Registration Now Uses Outermost Movable To Determine Location

### DIFF
--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -41,13 +41,15 @@
 	src.on_turf_change(thing, previous_loc)
 
 /datum/component/complexsignal/outermost_movable/proc/on_turf_change(atom/movable/thing, atom/previous_loc)
+	var/atom/movable/outermost_movable = src.get_outermost_movable()
+
 	var/turf/old_turf = get_turf(previous_loc)
-	var/turf/new_turf = get_turf(parent)
+	var/turf/new_turf = get_turf(outermost_movable)
 	if (old_turf != new_turf)
 		SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_TURF_CHANGED, old_turf, new_turf)
 
 		var/turf/old_area = get_area(previous_loc)
-		var/area/new_area = get_area(parent)
+		var/area/new_area = get_area(outermost_movable)
 		if (old_area != new_area)
 			SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_AREA_CHANGED, old_area, new_area)
 

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -128,7 +128,6 @@
 	. = ..()
 	src.toggle_parallax()
 
-
 /mob/Login()
 	. = ..()
 	src.register_parallax_signals()
@@ -138,23 +137,28 @@
 	. = ..()
 
 /mob/proc/register_parallax_signals()
-	if (src.client?.parallax_controller)
-		RegisterSignal(src, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(update_parallax))
-		RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(update_area_parallax))
-		RegisterSignal(src, XSIG_MOVABLE_Z_CHANGED, PROC_REF(update_parallax_z))
-		RegisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED, PROC_REF(update_outermost_movable))
+	if (!src.client?.parallax_controller)
+		return
 
-		var/datum/component/complexsignal/outermost_movable/C = src.GetComponent(/datum/component/complexsignal/outermost_movable)
-		src.client.parallax_controller.outermost_movable = C.get_outermost_movable()
-		src.update_area_parallax(null, get_area(src.client.parallax_controller.previous_turf), get_area(src))
-		src.update_parallax_z(null, src.client.parallax_controller.previous_turf?.z, src.z)
+	RegisterSignal(src, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(update_parallax))
+	RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(update_area_parallax))
+	RegisterSignal(src, XSIG_MOVABLE_Z_CHANGED, PROC_REF(update_parallax_z))
+	RegisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED, PROC_REF(update_outermost_movable))
+
+	var/datum/component/complexsignal/outermost_movable/C = src.GetComponent(/datum/component/complexsignal/outermost_movable)
+	var/atom/movable/outermost_movable = C.get_outermost_movable()
+	src.client.parallax_controller.outermost_movable = outermost_movable
+	src.update_area_parallax(null, get_area(src.client.parallax_controller.previous_turf), get_area(outermost_movable))
+	src.update_parallax_z(null, src.client.parallax_controller.previous_turf?.z, outermost_movable.z)
 
 /mob/proc/unregister_parallax_signals()
-	if (src.GetComponent(/datum/component/complexsignal/outermost_movable))
-		UnregisterSignal(src, XSIG_MOVABLE_TURF_CHANGED)
-		UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
-		UnregisterSignal(src, XSIG_MOVABLE_Z_CHANGED)
-		UnregisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED)
+	if (!src.GetComponent(/datum/component/complexsignal/outermost_movable))
+		return
+
+	UnregisterSignal(src, XSIG_MOVABLE_TURF_CHANGED)
+	UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
+	UnregisterSignal(src, XSIG_MOVABLE_Z_CHANGED)
+	UnregisterSignal(src, XSIG_OUTERMOST_MOVABLE_CHANGED)
 
 /mob/proc/update_parallax(datum/component/component, turf/old_turf, turf/new_turf)
 	src.client?.parallax_controller?.update_parallax_layers(old_turf, new_turf)


### PR DESCRIPTION
[Internal] [Bug]


## About The PR:
Fixes #15888 by ensuring that parallax signal registration utilises a mob's outermost movable in order to determine area and z-level.