### PR TITLE
fix emergency shuttle takeoff sounds

### DIFF
--- a/_std/defines/landmarks.dm
+++ b/_std/defines/landmarks.dm
@@ -20,6 +20,7 @@
 // shuttle landmarks
 #define LANDMARK_SHUTTLE_CENTCOM "shuttle-centcom"
 #define LANDMARK_SHUTTLE_TRANSIT "shuttle-transit"
+#define LANDMARK_SHUTTLE_SOUND "shuttle-subwoofer"
 
 // nukies
 #define LANDMARK_SYNDICATE "Syndicate-Spawn"

--- a/code/area.dm
+++ b/code/area.dm
@@ -964,11 +964,6 @@ ABSTRACT_TYPE(/area/shuttle_particle_spawn)
 	icon_state = "shuttle_transit_stars_w"
 	star_dir = "_w"
 
-/area/shuttle_sound_spawn
-	name = "Shuttle Subwoofers"
-	icon_state = "shuttle_transit_sound"
-	teleport_blocked = TRUE
-	requires_power = FALSE
 
 // zewaka - actual areas below //
 

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -201,16 +201,19 @@ datum/shuttle_controller
 						announcement_done = 1
 
 					else if (announcement_done < 2 && timeleft < 30)
-						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/ship_charge.ogg', 100)
+						if (istype(src.sound_turf))
+							playsound(src.sound_turf, 'sound/effects/ship_charge.ogg', 100)
 						announcement_done = 2
 
 					else if (announcement_done < 3 && timeleft < 4)
-						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/ship_engage.ogg', 100)
+						if (istype(src.sound_turf))
+							playsound(src.sound_turf, 'sound/effects/ship_engage.ogg', 100)
 						announcement_done = 3
 
 					else if (announcement_done < 4 && timeleft < 1)
-						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/explosion_new4.ogg', 75)
-						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/flameswoosh.ogg', 75)
+						if (istype(src.sound_turf))
+							playsound(src.sound_turf, 'sound/effects/explosion_new4.ogg', 75)
+							playsound(src.sound_turf, 'sound/effects/flameswoosh.ogg', 75)
 						announcement_done = 4
 						if (src.airbridges.len)
 							for (var/obj/machinery/computer/airbr/S in src.airbridges)

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -14,7 +14,7 @@ datum/shuttle_controller
 	var/map_turf = /turf/space //Set in New() by map settings
 	var/transit_turf = /turf/space/no_replace //Not currently modified
 	var/centcom_turf = /turf/unsimulated/floor/shuttlebay //Not currently modified
-
+	var/turf/sound_turf = null //!where to play takeoff sounds, defined by landmark
 
 	// call the shuttle
 	// if not called before, set the endtime to T+600 seconds
@@ -82,7 +82,14 @@ datum/shuttle_controller
 				if (S.emergency && !(S in src.airbridges))
 					src.airbridges += S
 			map_turf = map_settings.shuttle_map_turf
-
+			src.sound_turf = pick_landmark(LANDMARK_SHUTTLE_SOUND)
+			if (!istype(src.sound_turf))
+				logTheThing(LOG_DEBUG, null, "Shuttle sound landmark not found, trying station shuttle area turfs")
+				var/area/start_location = locate(map_settings ? map_settings.escape_station : /area/shuttle/escape/station)
+				for (var/turf/new_target in start_location)
+					if(istype(new_target))
+						src.sound_turf = new_target
+						break
 		process()
 			if (!online)
 				return
@@ -194,19 +201,16 @@ datum/shuttle_controller
 						announcement_done = 1
 
 					else if (announcement_done < 2 && timeleft < 30)
-						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
-						playsound(sound_location, 'sound/effects/ship_charge.ogg', 100)
+						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/ship_charge.ogg', 100)
 						announcement_done = 2
 
 					else if (announcement_done < 3 && timeleft < 4)
-						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
-						playsound(sound_location, 'sound/effects/ship_engage.ogg', 100)
+						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/ship_engage.ogg', 100)
 						announcement_done = 3
 
 					else if (announcement_done < 4 && timeleft < 1)
-						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
-						playsound(sound_location, 'sound/effects/explosion_new4.ogg', 75)
-						playsound(sound_location, 'sound/effects/flameswoosh.ogg', 75)
+						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/explosion_new4.ogg', 75)
+						if (istype(src.sound_turf)) playsound(src.sound_turf, 'sound/effects/flameswoosh.ogg', 75)
 						announcement_done = 4
 						if (src.airbridges.len)
 							for (var/obj/machinery/computer/airbr/S in src.airbridges)

--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -194,17 +194,17 @@ datum/shuttle_controller
 						announcement_done = 1
 
 					else if (announcement_done < 2 && timeleft < 30)
-						var/area/sound_location = locate(/area/shuttle_sound_spawn)
+						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
 						playsound(sound_location, 'sound/effects/ship_charge.ogg', 100)
 						announcement_done = 2
 
 					else if (announcement_done < 3 && timeleft < 4)
-						var/area/sound_location = locate(/area/shuttle_sound_spawn)
+						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
 						playsound(sound_location, 'sound/effects/ship_engage.ogg', 100)
 						announcement_done = 3
 
 					else if (announcement_done < 4 && timeleft < 1)
-						var/area/sound_location = locate(/area/shuttle_sound_spawn)
+						var/turf/sound_location = pick_landmark(LANDMARK_SHUTTLE_SOUND)
 						playsound(sound_location, 'sound/effects/explosion_new4.ogg', 75)
 						playsound(sound_location, 'sound/effects/flameswoosh.ogg', 75)
 						announcement_done = 4

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -318,6 +318,12 @@ var/global/list/job_start_locations = list()
 /obj/landmark/shuttle_transit
 	name = LANDMARK_SHUTTLE_TRANSIT
 
+///emergency shuttle launch sound origin
+/obj/landmark/shuttle_subwoofer
+	name = LANDMARK_SHUTTLE_SOUND
+	icon = 'icons/turf/areas.dmi'
+	icon_state = "shuttle_transit_sound"
+
 /obj/landmark/telesci // Allowed turf marker for telesci
 	name = LANDMARK_TELESCI
 	icon_state = "telesci"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -7548,8 +7548,9 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "ayX" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "ayZ" = (
 /obj/machinery/conveyor/SN{
 	id = "outbound";

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1980,8 +1980,9 @@
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/storage/primary)
 "ajO" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "ajR" = (
 /turf/simulated/floor/black,
 /area/station/hangar/sec)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -36532,9 +36532,6 @@
 "coU" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
-"coX" = (
-/turf/space,
-/area/shuttle_sound_spawn)
 "cpa" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -51469,6 +51466,10 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/medsci)
+"mvt" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space,
+/area/space)
 "mvL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -68019,7 +68020,7 @@ adC
 adC
 adC
 adC
-adC
+mvt
 adC
 adC
 adC
@@ -113249,7 +113250,7 @@ kXL
 uLB
 adC
 adC
-coX
+mvt
 kgh
 kgh
 kgh

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -46688,8 +46688,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "cEK" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "cEL" = (
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 4

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -3198,9 +3198,6 @@
 	dir = 4
 	},
 /area/station/quartermaster/office)
-"aoJ" = (
-/turf/space,
-/area/shuttle_sound_spawn)
 "aoK" = (
 /obj/storage/closet/wardrobe/mixed,
 /obj/random_item_spawner/dressup/one_or_zero,
@@ -36530,6 +36527,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"mYd" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space,
+/area/space)
 "mYz" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9;
@@ -56753,7 +56754,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mYd
 aaa
 aaa
 aaa
@@ -75036,7 +75037,7 @@ ani
 ani
 ani
 ani
-aoJ
+mYd
 aaa
 aaa
 dRI

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -53874,6 +53874,13 @@
 "qyH" = (
 /turf/simulated/floor/plating/jen,
 /area/station/crew_quarters/arcade/dungeon)
+"qyJ" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/obj/landmark/shuttle_subwoofer,
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/exit)
 "qyQ" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -61190,6 +61197,10 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"sOJ" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space,
+/area/space)
 "sOZ" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
@@ -85033,7 +85044,7 @@ rdj
 rdj
 rdj
 rdj
-rdj
+sOJ
 rdj
 rdj
 rdj
@@ -139562,7 +139573,7 @@ qRB
 qRB
 qRB
 qRB
-xDL
+qyJ
 wQk
 sdZ
 xCY

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -40450,6 +40450,10 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/science/bot_storage)
+"jxG" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space,
+/area/space)
 "jyD" = (
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4
@@ -65781,7 +65785,7 @@ ciD
 ciD
 ciM
 ciD
-aaa
+jxG
 aaa
 aaa
 aaa
@@ -132123,7 +132127,7 @@ wzw
 wzw
 wzw
 aaa
-aaa
+jxG
 wzw
 wzw
 wzw

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -30065,6 +30065,10 @@
 	dir = 4
 	},
 /area/station/quartermaster/cargooffice)
+"mOT" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/unsimulated/wall/trench,
+/area/space)
 "mPl" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/caution/corner/ne,
@@ -39939,6 +39943,10 @@
 	dir = 6
 	},
 /area/station/ai_monitored/armory)
+"rse" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space/fluid/acid/clear,
+/area/space)
 "rsn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -62370,7 +62378,7 @@ oeA
 oeA
 oeA
 oeA
-oeA
+mOT
 oeA
 oeA
 oeA
@@ -117208,7 +117216,7 @@ rJg
 iMT
 iMT
 iMT
-rJg
+rse
 rJg
 rJg
 iMT

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -34839,6 +34839,10 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/science/chemistry)
+"eLI" = (
+/obj/landmark/shuttle_subwoofer,
+/turf/space/fluid,
+/area/space)
 "eLJ" = (
 /obj/machinery/door/airlock/pyro/alt{
 	name = "Sauna"
@@ -54858,7 +54862,7 @@ aqn
 aqn
 aqn
 aqn
-aqn
+eLI
 aTs
 aTs
 aqn
@@ -109137,7 +109141,7 @@ aqn
 bFU
 bFU
 bFU
-aqn
+eLI
 aqn
 aqn
 bFU

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -56569,8 +56569,9 @@
 /turf/space,
 /area/shuttle/mining/station)
 "cCV" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "cCW" = (
 /turf/space,
 /area/supply/sell_point)

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -36411,11 +36411,12 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
+/obj/landmark/shuttle_subwoofer,
 /turf/simulated/floor/shuttlebay{
 	desc = " It is made of steel.";
 	name = "steel shuttle bay plating"
 	},
-/area/shuttle_sound_spawn)
+/area/shuttle/arrival/station)
 "dVi" = (
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4

--- a/maps/unused/crash_gimmick_2.dmm
+++ b/maps/unused/crash_gimmick_2.dmm
@@ -309,11 +309,12 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
+/obj/landmark/shuttle_subwoofer,
 /turf/simulated/floor/shuttlebay{
 	desc = " It is made of steel.";
 	name = "steel shuttle bay plating"
 	},
-/area/shuttle_sound_spawn)
+/area/shuttle/arrival/station)
 "nn" = (
 /obj/cable{
 	icon_state = "0-4"

--- a/maps/unused/density.dmm
+++ b/maps/unused/density.dmm
@@ -4782,8 +4782,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "lc" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "ld" = (
 /obj/machinery/computer/genetics{
 	dir = 1;

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -2396,8 +2396,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "akj" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "akk" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/navbeacon{

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -52339,8 +52339,9 @@
 	},
 /area/station/janitor/office)
 "mpY" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "mqh" = (
 /obj/disposalpipe/segment/cargo{
 	dir = 4

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -23193,8 +23193,9 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "bzF" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "bzL" = (
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -27431,8 +27431,9 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "lXt" = (
+/obj/landmark/shuttle_subwoofer,
 /turf/space,
-/area/shuttle_sound_spawn)
+/area/space)
 "lXv" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace area-based sound with landmarks, and updates/adds landmark to all in-rotation maps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Better cues for emergency shuttle takeoff