### PR TITLE
Choking prevents the inhalation of smoke or smoking reactions

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -49,7 +49,7 @@
 #define isnewplayer(x) (istype(x, /mob/new_player))
 
 /// Returns true if this mob immune to breathing in smoke?
-#define issmokeimmune(x) (!isliving(x) || isintangible(x) || issilicon(x) || ((x?.wear_mask && (x.wear_mask.c_flags & BLOCKSMOKE || (x.wear_mask.c_flags & MASKINTERNALS && x.internal))) || ischangeling(x) || HAS_ATOM_PROPERTY(x, PROP_MOB_REBREATHING) || HAS_ATOM_PROPERTY(x, PROP_MOB_BREATHLESS) || isdead(x)))
+#define issmokeimmune(x) (!isliving(x) || isintangible(x) || issilicon(x) || ((x?.wear_mask && (x.wear_mask.c_flags & BLOCKSMOKE || (x.wear_mask.c_flags & MASKINTERNALS && x.internal))) || ischangeling(x) || HAS_ATOM_PROPERTY(x, PROP_MOB_REBREATHING) || HAS_ATOM_PROPERTY(x, PROP_MOB_BREATHLESS) || isdead(x) || x?.losebreath > 0))
 
 /// This is for objects which have some sort of prerequisite for people to use them. Allows you to bypass those checks if
 /// the user is the possessed version of the object being interacted with


### PR DESCRIPTION
[CHEMISTRY][INPUT WANTED][BALANCE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR prevents inhaling smoked chemicals while losebreath is higher than 0. This means smoke won't be inhaled when you cannot breath due to choking from chems/strangulation.
It applies to reactions that makes you inhale without a gas mask, like meth, as well.

Keep in mind this does not apply to asphixiation due to spaced enviroment.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It kinda makes no sense that you are to breath in smoke while actively choking and struggling to breath. This mostly affects chemicals which makes you struggling to breath e.g. cyanide. Also, this makes dying people in smoke not continue to suck of chemicals out of the smoke. 

This will make perfluorodecalin able to make you walk through non-skinpen smoke without problems, but since gas masks are fairly aquireable, this shouldn't be much of a problem. It enables perfluorodecalin to be an emergency tool for sudden smoking, though.

This PR enables additional mechanics and design space, like improving what stuff like what #15908 tries to achieve.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Choking makes you unable to breath in chemsmoke.
```
