### PR TITLE
Use IMMUNE_TRENCH_WARP for atoms that shouldn't fall to z5 via seafloor hole

### DIFF
--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -63,6 +63,8 @@
 /// overrides the click drag mousedrop pickup QOL kinda stuff
 #define NO_MOUSEDROP_QOL			(1 << 10)
 #define MOVE_NOCLIP 				(1 << 11)
+/// Atom won't get warped to z5 via floor holes on underwater maps
+#define IMMUNE_TRENCH_WARP			(1 << 12)
 
 
 //THROW flags (what kind of throw, we can have ddifferent kinds of throws ok)

--- a/code/WorkInProgress/ISNStuff2.dm
+++ b/code/WorkInProgress/ISNStuff2.dm
@@ -135,6 +135,7 @@
 	density = 1
 	opacity = 0
 	anchored = ANCHORED
+	event_handler_flags = IMMUNE_TRENCH_WARP
 	var/has_processing_loop = 0
 
 	New(var/turf/loc)

--- a/code/WorkInProgress/missile_latejoin.dm
+++ b/code/WorkInProgress/missile_latejoin.dm
@@ -11,7 +11,7 @@
 	bound_width = 32
 	bound_height = 64
 	layer = 30
-	flags = IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY
+	event_handler_flags = IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY | IMMUNE_TRENCH_WARP
 	dir = NORTH
 	var/move_dir = NORTH
 	var/moved_on_flooring = 0

--- a/code/datums/components/afterimage.dm
+++ b/code/datums/components/afterimage.dm
@@ -82,7 +82,7 @@ TYPEINFO(/datum/component/afterimage)
 /obj/afterimage
 	mouse_opacity = FALSE
 	plane = PLANE_NOSHADOW_BELOW
-	anchored = 2
+	anchored = ANCHORED_ALWAYS
 	var/correct_alpha = 120
 	var/appearance_ref = null
 	var/active = FALSE

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -1,6 +1,6 @@
 /mob/dead
 	stat = STAT_DEAD
-	event_handler_flags =  IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY
+	event_handler_flags =  IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY | IMMUNE_TRENCH_WARP
 	pass_unstable = FALSE
 	///Our corpse, if one exists
 	var/mob/living/corpse

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -7,7 +7,7 @@
 	blinded = 0
 	anchored = ANCHORED
 	throws_can_hit_me = FALSE
-	event_handler_flags =  IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY | MOVE_NOCLIP
+	event_handler_flags =  IMMUNE_MANTA_PUSH | IMMUNE_SINGULARITY | IMMUNE_TRENCH_WARP | MOVE_NOCLIP
 	canbegrabbed = FALSE
 
 	New()

--- a/code/mob/living/silicon/ai/holograms.dm
+++ b/code/mob/living/silicon/ai/holograms.dm
@@ -182,6 +182,7 @@
 	density = 0
 	alpha = 0		//animates to 180 in New
 	// plane = PLANE_HUD
+	event_handler_flags = IMMUNE_TRENCH_WARP
 	var/duration = 30 SECONDS
 	var/mob/living/silicon/ai/owner
 	var/hologram_value = 1

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -390,6 +390,7 @@ TYPEINFO(/obj/machinery/fluid_canister)
 	desc = "A deployable sea ladder that will allow you to descend to and ascend from the trench."
 	icon = 'icons/obj/fluid.dmi'
 	icon_state = "ladder_on"
+	event_handler_flags = IMMUNE_TRENCH_WARP
 
 	var/obj/sea_ladder_deployed/linked_ladder
 	var/obj/item/sea_ladder/og_ladder_item = 0

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -342,6 +342,8 @@
 
 	Entered(var/atom/movable/AM)
 		. = ..()
+		if (istype(AM, /datum/projectile/))
+			return
 		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return
 		if (locate(/obj/lattice) in src)
@@ -542,6 +544,8 @@
 		return
 
 	Entered(atom/movable/AM as mob|obj)
+		if (istype(AM, /datum/projectile/))
+			return
 		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return ..()
 		var/turf/T = pick_landmark(LANDMARK_FALL_SEA)

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -342,8 +342,6 @@
 
 	Entered(var/atom/movable/AM)
 		. = ..()
-		if (istype(AM, /datum/projectile/))
-			return
 		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return
 		if (locate(/obj/lattice) in src)

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -346,7 +346,7 @@
 			return
 		if (locate(/obj/lattice) in src)
 			return
-		if (AM.anchored == 2)
+		if (AM.anchored == ANCHORED_ALWAYS)
 			return
 		if (ismob(AM))
 			var/mob/M = AM
@@ -541,19 +541,19 @@
 	ex_act(severity)
 		return
 
-	Entered(atom/movable/A as mob|obj)
-		if (istype(A, /obj/overlay/tile_effect) || istype(A, /mob/dead) || istype(A, /mob/living/intangible))
+	Entered(atom/movable/AM as mob|obj)
+		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return ..()
 		var/turf/T = pick_landmark(LANDMARK_FALL_SEA)
 		if (isturf(T))
-			visible_message("<span class='alert'>[A] falls down [src]!</span>")
-			if (ismob(A))
-				var/mob/M = A
+			visible_message("<span class='alert'>[AM] falls down [src]!</span>")
+			if (ismob(AM))
+				var/mob/M = AM
 				random_brute_damage(M, 25)
 				M.changeStatus("weakened", 5 SECONDS)
 				M.emote("scream")
 				playsound(M.loc, 'sound/impact_sounds/Flesh_Break_1.ogg', 50, 1)
-			A.set_loc(T)
+			AM.set_loc(T)
 			return
 		else ..()
 

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -342,7 +342,7 @@
 
 	Entered(var/atom/movable/AM)
 		. = ..()
-		if (istype(AM,/mob/dead) || istype(AM,/mob/living/intangible) || istype(AM, /obj/lattice) || istype(AM, /obj/cable/reinforced) || istype(AM,/obj/torpedo_targeter) || istype(AM,/obj/overlay) || istype (AM, /obj/arrival_missile) || istype(AM, /obj/sea_ladder_deployed) || istype(AM, /obj/forcefield) || istype(AM, /obj/linked_laser))
+		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return
 		if (locate(/obj/lattice) in src)
 			return

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -342,7 +342,7 @@
 
 	Entered(var/atom/movable/AM)
 		. = ..()
-		if (istype(AM,/mob/dead) || istype(AM,/mob/living/intangible) || istype(AM, /obj/lattice) || istype(AM, /obj/cable/reinforced) || istype(AM,/obj/torpedo_targeter) || istype(AM,/obj/overlay) || istype (AM, /obj/arrival_missile) || istype(AM, /obj/sea_ladder_deployed))
+		if (istype(AM,/mob/dead) || istype(AM,/mob/living/intangible) || istype(AM, /obj/lattice) || istype(AM, /obj/cable/reinforced) || istype(AM,/obj/torpedo_targeter) || istype(AM,/obj/overlay) || istype (AM, /obj/arrival_missile) || istype(AM, /obj/sea_ladder_deployed) || istype(AM, /obj/forcefield) || istype(AM, /obj/linked_laser))
 			return
 		if (locate(/obj/lattice) in src)
 			return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -87,6 +87,7 @@
 	icon_state = "0-1-thick"
 	iconmod = "-thick"
 	color = "#075C90"
+	event_handler_flags = IMMUNE_TRENCH_WARP
 
 	condcutor_default = "pharosium"
 	insulator_default = "synthblubber"

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -650,11 +650,10 @@ TYPEINFO(/obj/laser_sink/splitter)
 /obj/linked_laser
 	icon = 'icons/obj/power.dmi'
 	icon_state = "ptl_beam"
-	anchored = 2
+	anchored = ANCHORED_ALWAYS
 	density = 0
 	luminosity = 1
 	mouse_opacity = 0
-	event_handler_flags = IMMUNE_TRENCH_WARP
 	///How many laser segments are behind us
 	var/length = 0
 	///Maximum number of segments in the beam, this exists to prevent nerds from blowing up the server

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -654,6 +654,7 @@ TYPEINFO(/obj/laser_sink/splitter)
 	density = 0
 	luminosity = 1
 	mouse_opacity = 0
+	event_handler_flags = IMMUNE_TRENCH_WARP
 	///How many laser segments are behind us
 	var/length = 0
 	///Maximum number of segments in the beam, this exists to prevent nerds from blowing up the server

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -15,6 +15,7 @@
 	layer = EFFECTS_LAYER_BASE
 	anchored = ANCHORED
 	animate_movement = FALSE
+	event_handler_flags = IMMUNE_TRENCH_WARP
 
 	/// Projectile data; almost all specific projectile information and functionality lives here
 	var/datum/projectile/proj_data = null

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -324,7 +324,7 @@
 	pass_unstable = FALSE
 	mat_changename = 0
 	mat_changedesc = 0
-	event_handler_flags = IMMUNE_MANTA_PUSH
+	event_handler_flags = IMMUNE_MANTA_PUSH | IMMUNE_TRENCH_WARP
 	density = 0
 
 	updateHealth()

--- a/code/obj/effect.dm
+++ b/code/obj/effect.dm
@@ -1,6 +1,7 @@
 /obj/effect
 	name = "" // for some reason mouse_opacity itself doesn't work for hiding this from rightclick, empty name works though
 	mouse_opacity = 0
+	event_handler_flags = IMMUNE_TRENCH_WARP
 
 /obj/effect/distort
 	icon = 'icons/effects/distort.dmi'

--- a/code/obj/lattice.dm
+++ b/code/obj/lattice.dm
@@ -9,6 +9,7 @@
 	anchored = ANCHORED
 	layer = LATTICE_LAYER
 	plane = PLANE_FLOOR
+	event_handler_flags = IMMUNE_TRENCH_WARP
 	//	flags = CONDUCT
 	text = "<font color=#333>+"
 	/// bitmask of directions it connects to.

--- a/code/obj/torpedoes.dm
+++ b/code/obj/torpedoes.dm
@@ -89,7 +89,7 @@
 	density = 0
 	layer = 10
 	alpha = 200
-	event_handler_flags = IMMUNE_MANTA_PUSH
+	event_handler_flags = IMMUNE_MANTA_PUSH | IMMUNE_TRENCH_WARP
 
 	var/image/trgImage = null
 	var/obj/machinery/torpedo_console/master = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds two new exceptions to the list of things that get warped to the trench on a surface hole: forcefields and lasers

maybe a "floating" object property makes sense at this point idk?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

* oshan 'meteors' can sink forcefield segments :|||||
* it's a little silly that energy manifestations have physical gravity 

## TODO
- [x] Double-check laser interactions
- [x] make it a property