### PR TITLE
tiny bugfix for wall trophy runtime

### DIFF
--- a/code/obj/item/wall_trophy.dm
+++ b/code/obj/item/wall_trophy.dm
@@ -90,9 +90,10 @@ Subtypes:
 
 	//attaching trophy to the wall
 	afterattack(var/turf/simulated/wall/T, var/mob/user)
-		. = T.attach_item(user, src)
-		if (.)
-			playsound(src, 'sound/impact_sounds/Wood_Tap.ogg', 50, TRUE)
+		if (istype(T))
+			. = T.attach_item(user, src)
+			if (.)
+				playsound(src, 'sound/impact_sounds/Wood_Tap.ogg', 50, TRUE)
 		. = ..()
 
 	//unattaching the trophy from the wall


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes a runtime when you use a wall trophy on something that is not a wall


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bug bad
