### PR TITLE
Fix fuel tanks saying "Nothing in it." when there is in fact something in it

### DIFF
--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -15,12 +15,11 @@
 	amount_per_transfer_from_this = 25
 	incompatible_with_chem_dispensers = 1
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | ACCEPTS_MOUSEDROP_REAGENTS
-	rc_flags = RC_SCALE
+	rc_flags = RC_SPECTRO | RC_FULLNESS
 	initial_volume = 400
 	can_recycle = FALSE
 	can_chug = 0
 	initial_reagents = "fuel"
-	rc_flags = RC_SPECTRO
 
 /obj/item/reagent_containers/food/drinks/fueltank/empty
 	initial_reagents = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a bug wherein fuel tanks would say nothing in it on examine because they only had the flag to make reagents viewable with spectroscopic goggles, and none like RC_VISIBLE, RC_SCALE, RC_FULLNESS to give basic information on contents.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I dumped 800u of welding fuel on the floor of engineering last round because I thought they were empty and now I'm embarrassed 
