### PR TITLE
Gun holster buff

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -880,6 +880,7 @@
 ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 /obj/item/storage/belt/gun
 	var/gun_type
+	check_wclass = TRUE
 
 	New()
 		..()
@@ -905,7 +906,6 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	icon_state = "revolver_belt"
 	item_state = "revolver_belt"
 	slots = 6
-	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/revolver
 	can_hold = list(/obj/item/gun/kinetic/revolver)
 	spawn_contents = list(/obj/item/gun/kinetic/revolver, /obj/item/ammo/bullets/a357 = 2, /obj/item/ammo/bullets/a357/AP)
@@ -916,7 +916,6 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	icon_state = "pistol_belt"
 	item_state = "pistol_belt"
 	slots = 6
-	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/pistol
 	can_hold = list(/obj/item/gun/kinetic/pistol)
 	spawn_contents = list(/obj/item/gun/kinetic/pistol, /obj/item/ammo/bullets/bullet_9mm = 4)
@@ -927,7 +926,6 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	icon_state = "smartgun_belt"
 	item_state = "smartgun_belt"
 	slots = 6
-	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/pistol/smart/mkII
 	can_hold = list(/obj/item/gun/kinetic/pistol/smart/mkII)
 	spawn_contents = list(/obj/item/gun/kinetic/pistol/smart/mkII, /obj/item/ammo/bullets/bullet_22/smartgun = 4)

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -904,11 +904,10 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	desc = "A stylish leather belt for holstering a revolver and it's ammo."
 	icon_state = "revolver_belt"
 	item_state = "revolver_belt"
-	slots = 4
+	slots = 6
 	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/revolver
-	can_hold = list(/obj/item/ammo/bullets/a357)
-	can_hold_exact = list(/obj/item/gun/kinetic/revolver)
+	can_hold = list(/obj/item/gun/kinetic/revolver)
 	spawn_contents = list(/obj/item/gun/kinetic/revolver, /obj/item/ammo/bullets/a357 = 2, /obj/item/ammo/bullets/a357/AP)
 
 /obj/item/storage/belt/gun/pistol
@@ -916,11 +915,10 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	desc = "A rugged belt fitted with a pistol holster and some magazine pouches."
 	icon_state = "pistol_belt"
 	item_state = "pistol_belt"
-	slots = 5
+	slots = 6
 	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/pistol
-	can_hold = list(/obj/item/ammo/bullets/bullet_9mm)
-	can_hold_exact = list(/obj/item/gun/kinetic/pistol)
+	can_hold = list(/obj/item/gun/kinetic/pistol)
 	spawn_contents = list(/obj/item/gun/kinetic/pistol, /obj/item/ammo/bullets/bullet_9mm = 4)
 
 /obj/item/storage/belt/gun/smartgun
@@ -928,11 +926,10 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 	desc = "A rugged belt fitted with a smart pistol holster and some magazine pouches."
 	icon_state = "smartgun_belt"
 	item_state = "smartgun_belt"
-	slots = 5
+	slots = 6
 	check_wclass = 0
 	gun_type = /obj/item/gun/kinetic/pistol/smart/mkII
-	can_hold = list(/obj/item/ammo/bullets/bullet_22/smartgun)
-	can_hold_exact = list(/obj/item/gun/kinetic/pistol/smart/mkII)
+	can_hold = list(/obj/item/gun/kinetic/pistol/smart/mkII)
 	spawn_contents = list(/obj/item/gun/kinetic/pistol/smart/mkII, /obj/item/ammo/bullets/bullet_22/smartgun = 4)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects] [balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the amount of slots all gun belts have to 6 and allows more than just the gun and ammo to fit in there. This should make nukies want to use them more often.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When you play nuke ops you tend to see these belts all over the floor as they are just kinda worse than a fanny pack or a utility belt thanks to their limited selection of things it can hold as well as having a low amount of slots as well. This should make them more of a sidegrade as they can hold a pistol but also hold one less item than a normal belt.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DimWhat
(+)Made nukie pistol holsters hold more stuff, and more types of stuff.
```
