### PR TITLE
Fixes teeny tiny typo in extended pocket tanks

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -473,7 +473,7 @@ TYPEINFO(/obj/item/tank/jetpack/micro)
 
 /obj/item/tank/emergency_oxygen/extended
 	name = "extended capacity pocket oxygen tank"
-	desc = "A an extended capacity version of the pocket emergency oxygen tank."
+	desc = "An extended capacity version of the pocket emergency oxygen tank."
 	icon_state = "ex_pocket_oxtank"
 
 	New()


### PR DESCRIPTION
[game objects] [bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the extended oxygen tank description respect proper grammar.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
:bug: