### PR TITLE
Adds some fishing-related mishaps for clowns!

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -92,6 +92,13 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
+		if (user.bioHolder.HasEffect("clumsy") && prob(25))
+			user.visible_message("<span class='alert'><b>[user]</b> fumbles with [src.rod] in [his_or_her(user)] haste and hits [himself_or_herself(user)] in the forehead with it!</span>", "<span class='alert'>You fumble with [src.rod] in your haste and hit yourself in the forehead with it!</span>")
+			user.changeStatus("weakened", 2 SECONDS)
+			playsound(user, 'sound/impact_sounds/tube_bonk.ogg', 50, 1)
+			interrupt(INTERRUPT_ALWAYS)
+			JOB_XP(user, "Clown", 1)
+			return
 
 		src.duration = max(0.5 SECONDS, rod.fishing_speed + (pick(1, -1) * (rand(0,40) / 10) SECONDS)) //translates to rod duration +- (0,4) seconds, minimum of 0.5 seconds
 		playsound(src.user, 'sound/items/fishing_rod_cast.ogg', 50, 1)

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -40,14 +40,32 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 
 /// called every time a fishing rod's action loop finishes. returns 0 if catching a fish failed, returns 1 if it succeeds
 /datum/fishing_spot/proc/try_fish(var/mob/user, var/obj/item/fishing_rod/fishing_rod, atom/target)
-	var/atom/movable/fish = src.generate_fish(user, fishing_rod, target)
-	if (!fish)
-		return 0
-	// ever put this much effort into the dumbest thing ever haha
-	user.visible_message("[user] [pick("reels in", "catches", "pulls in", "fishes up")] a \
-	[pick("big", "wriggly", "fat", "slimy", "fishy", "large", "high-quality", "nasty", "chompy", "real", "wily")] \
-	[prob(80) ? "[fish.name]" : pick("one", "catch", "chomper", "wriggler", "sunovagun", "sucker")]!")
-	user.put_in_hand_or_drop(fish)
+	if (user.bioHolder.HasEffect("clumsy") && prob(50))
+		var/mob/living/carbon/human/H = user
+		var/obj/picked_item
+		var/list/clothes_list = list()
+		if(H.shoes)
+			clothes_list.Add(H.shoes)
+		if(H.wear_mask)
+			clothes_list.Add(H.wear_mask)
+		if(clothes_list.len)
+			picked_item = pick(clothes_list)
+		else
+			return 0
+		user.visible_message("[user] [pick("reels in", "catches", "pulls in", "fishes up")] [picked_item]! Wait, how did that happen?")
+		user.u_equip(picked_item)
+		picked_item.set_loc(get_turf(user))
+		user.put_in_hand_or_drop(picked_item)
+		JOB_XP(user, "Clown", 1)
+	else
+		var/atom/movable/fish = src.generate_fish(user, fishing_rod, target)
+		if (!fish)
+			return 0
+		// ever put this much effort into the dumbest thing ever haha
+		user.visible_message("[user] [pick("reels in", "catches", "pulls in", "fishes up")] a \
+		[pick("big", "wriggly", "fat", "slimy", "fishy", "large", "high-quality", "nasty", "chompy", "real", "wily")] \
+		[prob(80) ? "[fish.name]" : pick("one", "catch", "chomper", "wriggler", "sunovagun", "sucker")]!")
+		user.put_in_hand_or_drop(fish)
 	playsound(user, 'sound/items/fishing_rod_reel.ogg', 50, TRUE)
 	playsound(user, 'sound/effects/fish_catch.ogg', 75, TRUE)
 	fishing_rod.last_fished = TIME //set the last fished time


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds a chance to fumble when fishing, both during the initial casting of the rod and with the result.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's funny and helps add more fumbles to things that clowns shouldn't be able to do without a chance of fail. And it's funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NewyearnewmeUwu
(*)Added some fishing related mishaps for clowns.
```
