### PR TITLE
fixes clowns and mimes losing their genes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1007,11 +1007,8 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		if (!M)
 			return
 
-		// Yaaaaaay!
-		M.AddComponent(/datum/component/death_confetti)
 
-		M.bioHolder.AddEffect("clumsy", magical=1)
-		M.bioHolder.AddEffect("accent_comic", magical=1)
+		M.traitHolder.addTrait("training_clown")
 
 // AI and Cyborgs
 
@@ -1130,8 +1127,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		..()
 		if (!M)
 			return
-		M.bioHolder.AddEffect("mute", magical=1)
-		M.bioHolder.AddEffect("blankman", magical=1)
+		M.traitHolder.addTrait("training_mime")
 
 /datum/job/special/attorney
 	name = "Attorney"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -632,8 +632,8 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "training_mime"
 
 	onAdd(var/mob/owner)
-		owner.bioHolder.AddEffect("mute", magical=1)
-		owner.bioHolder.AddEffect("blankman", magical=1)
+		owner.bioHolder.AddEffect("mute", magical = TRUE)
+		owner.bioHolder.AddEffect("blankman", magical = TRUE)
 
 // Stats - Undetermined Border
 /datum/trait/athletic

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -616,6 +616,25 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "Sometimes you drink on the job, sometimes drinking is the job."
 	id = "training_drinker"
 
+/datum/trait/job/clown
+	name = "Clown Training"
+	desc = "Subject is trained at being a clumsy buffoon."
+	id = "training_clown"
+
+	onAdd(var/mob/owner)
+		owner.AddComponent(/datum/component/death_confetti)
+		owner.bioHolder?.AddEffect("accent_comic", magical = TRUE)
+		owner.bioHolder?.AddEffect("clumsy", magical = TRUE)
+
+/datum/trait/job/mime
+	name = "Mime Training"
+	desc = "..."
+	id = "training_mime"
+
+	onAdd(var/mob/owner)
+		owner.bioHolder.AddEffect("mute", magical=1)
+		owner.bioHolder.AddEffect("blankman", magical=1)
+
 // Stats - Undetermined Border
 /datum/trait/athletic
 	name = "Athletic"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -632,8 +632,8 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "training_mime"
 
 	onAdd(var/mob/owner)
-		owner.bioHolder.AddEffect("mute", magical = TRUE)
-		owner.bioHolder.AddEffect("blankman", magical = TRUE)
+		owner.bioHolder?.AddEffect("mute", magical = TRUE)
+		owner.bioHolder?.AddEffect("blankman", magical = TRUE)
 
 // Stats - Undetermined Border
 /datum/trait/athletic


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title says it all. Traits now apply genes upon being added, so clowns and mimes don't lose their funny genes after being cloned!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This fixes a major bug that I myself reported in #11935 almost a year ago!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NewyearnewmeUwu
(+)Fixed clowns and mimes losing their career genes after cloning.
```
