### PR TITLE
APIV2 split parameters into queryParams and routeParams

### DIFF
--- a/code/modules/goonhub/api/api.dm
+++ b/code/modules/goonhub/api/api.dm
@@ -88,7 +88,7 @@ var/global/datum/apiHandler/apiHandler
 			src.apiError("API Error: Cancelled query due to [!enabled ? "disabled apiHandler" : "missing route parameter"]", forceErrorException)
 			return
 
-		var/req_route = "[config.goonhub_api_endpoint]/[route.path]/?[route.formatParams()]"
+		var/req_route = "[config.goonhub_api_endpoint]/[route.path][route.routeParams ? "/[route.formatRouteParams()]" : ""]/?[route.formatQueryParams()]"
 
 		var/headers = list(
 			"Accept" = "application/json",

--- a/code/modules/goonhub/api/routes/apiRoute.dm
+++ b/code/modules/goonhub/api/routes/apiRoute.dm
@@ -8,8 +8,10 @@
 	var/method = null
 	/// Actual path of the api query, for example `/rounds`
 	var/path = null
-	/// Parameters for the call
-	var/list/parameters = null
+	/// Route parameters for the call, ie /rounds/{round_id}/
+	var/list/routeParams = null
+	/// Query parameters for the call, ie /rounds?&id=3
+	var/list/queryParams = null
 	/// Body of the request, invalid for GET
 	var/datum/apiBody/body = null
 	/// The expected type upon deserialization
@@ -18,10 +20,16 @@
 
 /// Formats a given parameter associated list into a urlstring format
 /// E.g. `list("ckey"="zewaka") to `?&ckey=zewaka` and `list("x"=list("a", "b"))` to `?&x=a,b`
-/datum/apiRoute/proc/formatParams()
-	if (length(src.parameters))
-		var/paramListClone = src.parameters.Copy()
+/datum/apiRoute/proc/formatQueryParams()
+	if (length(src.queryParams))
+		var/paramListClone = src.queryParams.Copy()
 		for (var/key in paramListClone)
 			if (islist(paramListClone[key])) // Do we need to encode the value?
 				paramListClone[key] = jointext(paramListClone[key], ",") // lists become csvs by convention
 		. = list2params(.)
+
+/// Formats a given parameter list into a route-append format
+/// E.g. `list("tuesday", "wednesday")` to `tuesday/wednesday`
+/datum/apiRoute/proc/formatRouteParams()
+	if (length(src.routeParams))
+		return jointext(src.routeParams, "/")

--- a/code/modules/goonhub/api/routes/apiRoute.dm
+++ b/code/modules/goonhub/api/routes/apiRoute.dm
@@ -8,7 +8,7 @@
 	var/method = null
 	/// Actual path of the api query, for example `/rounds`
 	var/path = null
-	/// Route parameters for the call, ie /rounds/{round_id}/
+	/// Route parameters for the call, ie /rounds/{round_id}/ - Must be in order
 	var/list/routeParams = null
 	/// Query parameters for the call, ie /rounds?&id=3
 	var/list/queryParams = null

--- a/code/modules/goonhub/api/routes/players/notes/GetPlayerNotes.dm
+++ b/code/modules/goonhub/api/routes/players/notes/GetPlayerNotes.dm
@@ -4,5 +4,5 @@
 /datum/apiRoute/players/notes/get
 	method = RUSTG_HTTP_METHOD_GET
 	path = "/players/notes"
-	parameters = list("filters", "sort_by", "descending", "per_page") // string, string, string, string
+	queryParams = list("filters", "sort_by", "descending", "per_page") // string, string, string, string
 	correct_response = "string"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splits the api route parameters into query and route params and adds handling for them in the route generation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Route params do exist
