### PR TITLE
Assign girder material when RCDs build stuff

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -254,6 +254,7 @@ TYPEINFO(/obj/item/rcd)
 						var/turf/simulated/wall/T = A:ReplaceWithWall()
 						T.inherit_area()
 						T.setMaterial(getMaterial(material_name))
+						T.girdermaterial = getMaterial(material_name)
 						log_construction(user, "builds a wall ([T])")
 						return
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
RCDs don't set girder material when they build full walls and that's definitely not good

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bug that fixes #15892, which was likely never noticed since most RCDs make steel girders.