### PR TITLE
Fix captain gloves medal rewards

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -859,7 +859,7 @@
 					M.name = "commander's gloves"
 					M.real_name = "commander's gloves"
 					M.desc = "A pair of formal gloves that are electrically insulated and quite heat-resistant. (Base Item: [prev])"
-					H.set_clothing_icon_dirty()
+					H.update_gloves(H.mutantrace.hand_offset)
 					succ = TRUE
 
 			if (H.head)
@@ -1030,7 +1030,7 @@
 					M.name = "CentCom gloves"
 					M.real_name = "CentCom gloves"
 					M.desc = "A pair of formal gloves that are electrically insulated and quite heat-resistant. (Base Item: [prev])"
-					H.set_clothing_icon_dirty()
+					H.update_gloves(H.mutantrace.hand_offset)
 					succ = TRUE
 
 			if (H.head)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -850,6 +850,18 @@
 					H.set_clothing_icon_dirty()
 					succ = TRUE
 
+			if (H.gloves)
+				var/obj/item/clothing/gloves/M = H.gloves
+				if (istype(M, /obj/item/clothing/gloves/swat/captain))
+					var/prev = M.name
+					M.icon_state = "centcomgloves"
+					M.item_state = "centcomgloves"
+					M.name = "commander's gloves"
+					M.real_name = "commander's gloves"
+					M.desc = "A pair of formal gloves that are electrically insulated and quite heat-resistant. (Base Item: [prev])"
+					H.set_clothing_icon_dirty()
+					succ = TRUE
+
 			if (H.head)
 				var/obj/item/clothing/M = H.head
 				if (istype(M, /obj/item/clothing/head/caphat))
@@ -1006,6 +1018,18 @@
 					M.item_state = "spacecap-red"
 					M.name = "\improper CentCom space suit"
 					M.desc = "A suit that protects against low pressure environments. It is made specifically for CENTCOM executives. (Base Item: [prev])"
+					H.set_clothing_icon_dirty()
+					succ = TRUE
+
+			if (H.gloves)
+				var/obj/item/clothing/gloves/M = H.gloves
+				if (istype(M, /obj/item/clothing/gloves/swat/captain))
+					var/prev = M.name
+					M.icon_state = "centcomredgloves"
+					M.item_state = "centcomredgloves"
+					M.name = "CentCom gloves"
+					M.real_name = "CentCom gloves"
+					M.desc = "A pair of formal gloves that are electrically insulated and quite heat-resistant. (Base Item: [prev])"
 					H.set_clothing_icon_dirty()
 					succ = TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the redeemable centcom and commander armor variants for the captain gloves.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15950
