### PR TITLE
Scale banana peel size to banana size

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -945,7 +945,14 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 			var/index = findtext(src.name, "unpeeled")
 			src.name = splicetext(src.name, index, index + 9)
 			src.icon_state = "banana-fruit"
-			new /obj/item/bananapeel(user.loc)
+			var/obj/item/bananapeel/droppeel = new /obj/item/bananapeel(user.loc)
+			// Scale peel size to banana size
+			// If banana 80% normal size or larger, directly copy banana's size for the peel
+			if (src.transform.a >= 0.8)
+				droppeel.transform = src.transform
+			// Cap at 80% size so no micro peel from rotten bananas
+			else
+				droppeel.transform = matrix(0.8,0,0,0,0.8,0)
 		else
 			..()
 


### PR DESCRIPTION
[A-Hydroponics][C-Feature]
## About the PR 
Use a banana's transform (size scaling) matrix to determine the size of the resulting peel after being opened. Minimum size of 80% to prevent micro peels in cases of very unloved rotting bananas. I'm not tied to the floor being 80%. This looked visually appealing to me, and I've been told it's hard to get the size very low. 

Current visuals below of a jumbo banana (top), normal banana (middle), and rotting banana (bottom)
![image](https://github.com/goonstation/goonstation/assets/5091297/5b82a9f2-01a7-4392-a331-dce526092386)

## Why's this needed? 
Getting a normal peel after botany worked hard to make a big banana seems counterintuitive. Also big peels are funny.

## Changelog 
```changelog
(u)spAAAce
(+)Banana peels now scale to banana size, within reason
```
