### PR TITLE
Revolutionary sign damage scales with number of nearby revs

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1319,7 +1319,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	name = "Revolutionary Sign"
 	item = /obj/item/revolutionary_sign
 	cost = 4
-	desc = "This large revolutionary sign will inspire all nearby revolutionaries and grant them small combat buffs. Additionally the sign will channel the fury of nearby revs to deal increased damage! Best used in conjunction with a horde of angry revolutionaries."
+	desc = "This large revolutionary sign will inspire all nearby revolutionaries and grant them small combat buffs. Additionally the sign will channel the fury of nearby revolutionaries to provide greater force when the sign is swung! Best used in conjunction with a horde of angry revolutionaries."
 
 /datum/syndicate_buylist/generic/head_rev/rev_dagger
 	name = "Sacrificial Dagger"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1319,7 +1319,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	name = "Revolutionary Sign"
 	item = /obj/item/revolutionary_sign
 	cost = 4
-	desc = "This large revolutionary sign will inspire all nearby revolutionaries and grant them small combat buffs. A rev head needs to be holding this sign for it to have any effect."
+	desc = "This large revolutionary sign will inspire all nearby revolutionaries and grant them small combat buffs. Additionally the sign will channel the fury of nearby revs to deal increased damage! Best used in conjunction with a horde of angry revolutionaries."
 
 /datum/syndicate_buylist/generic/head_rev/rev_dagger
 	name = "Sacrificial Dagger"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -544,6 +544,10 @@ THROWING DARTS
 			return
 		var/mob/living/carbon/human/H = src.owner
 		if (H.mind?.get_antagonist(ROLE_REVOLUTIONARY))
+			if (H.hasStatus("revspirit"))
+				if (prob(30))
+					H.show_text("<B>The presence of revolutionary leadership has temporarily allowed you to resist [src]!</B>", "blue")
+				return
 			H.TakeDamage("chest", 1.5*mult, 1.5*mult, 0)
 			if (H.health < 0)
 				H.changeStatus("paralysis", 5 SECONDS)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -544,10 +544,6 @@ THROWING DARTS
 			return
 		var/mob/living/carbon/human/H = src.owner
 		if (H.mind?.get_antagonist(ROLE_REVOLUTIONARY))
-			if (H.hasStatus("revspirit"))
-				if (prob(30))
-					H.show_text("<B>The presence of revolutionary leadership has temporarily allowed you to resist [src]!</B>", "blue")
-				return
 			H.TakeDamage("chest", 1.5*mult, 1.5*mult, 0)
 			if (H.health < 0)
 				H.changeStatus("paralysis", 5 SECONDS)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -653,11 +653,11 @@ TYPEINFO(/obj/item/sword/pink/angel)
 
 	attack(mob/living/target, mob/user)
 		if (isrevolutionary(user))
-			var/damage_tally = 0 // how much bonus damage we get on hit
+			var/nearby_revs = 0
 			for (var/mob/M in viewers(5, src.loc))
 				if (isrevolutionary(M))
-					damage_tally = min(25, damage_tally + 5)
-			random_brute_damage(target, damage_tally, TRUE)
+					nearby_revs++
+			random_brute_damage(target, min(25, nearby_revs * 5), TRUE)
 		..()
 
 	disposing()

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -639,7 +639,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	throwforce = 8
 	flags = FPRINT | TABLEPASS | CONDUCT
 	c_flags = EQUIPPED_WHILE_HELD
-	force = 7
+	force = 3
 	stamina_damage = 30
 	stamina_cost = 15
 	stamina_crit_chance = 10
@@ -650,6 +650,14 @@ TYPEINFO(/obj/item/sword/pink/angel)
 		src.setItemSpecial(/datum/item_special/swipe)
 		BLOCK_SETUP(BLOCK_LARGE)
 		processing_items.Add(src)
+
+	attack(mob/living/target, mob/user)
+		var/damage_tally = 0 // how much bonus damage we get on hit
+		for (var/mob/M in viewers(5, src.loc))
+			if (isrevolutionary(M))
+				damage_tally = min(25, damage_tally + 5)
+		random_brute_damage(target, damage_tally, TRUE)
+		..()
 
 	disposing()
 		..()

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -652,11 +652,12 @@ TYPEINFO(/obj/item/sword/pink/angel)
 		processing_items.Add(src)
 
 	attack(mob/living/target, mob/user)
-		var/damage_tally = 0 // how much bonus damage we get on hit
-		for (var/mob/M in viewers(5, src.loc))
-			if (isrevolutionary(M))
-				damage_tally = min(25, damage_tally + 5)
-		random_brute_damage(target, damage_tally, TRUE)
+		if (isrevolutionary(user))
+			var/damage_tally = 0 // how much bonus damage we get on hit
+			for (var/mob/M in viewers(5, src.loc))
+				if (isrevolutionary(M))
+					damage_tally = min(25, damage_tally + 5)
+			random_brute_damage(target, damage_tally, TRUE)
 		..()
 
 	disposing()


### PR DESCRIPTION
[BALANCE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Revsign damage scales with nearby revs in a 5 tile radius, Each rev is 5 extra damage up to a max of 25 damage(The user will count toward this)
Lowers base damage of the sign to 3
Non-revs do not gain the damage buff if they attack using the sign


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The revolutionary sign isn't a very good item in its current state. Its extremely loud, deals little damage, and the buff it gives isnt very good. Compared to the syndie dagger which has a very powerful stun ability and a cheaper cost, the revsign is a poor choice. This change is intended to make the revsign worth the 4 tc.


## Changelog

```changelog
(u)UnfunnyPerson
(+)Revolutionary sign damage scales depending on how many revs are nearby the user
```
