### PR TITLE
Makes syndicate thermals require a syndicate scanner

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -285,6 +285,7 @@ TYPEINFO(/obj/item/clothing/glasses/thermal)
 	color_g = 0.75 // slightly more red?
 	color_b = 0.75
 	upgraded = TRUE
+	is_syndicate = TRUE
 
 /obj/item/clothing/glasses/thermal/orange
 	name = "orange-tinted glasses"


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds is_syndicate = TRUE to traitor thermals, this makes it so you need a syndie scanner to scan them


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad
