### PR TITLE
Adds scissors to Kondaru Medbooth

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44228,6 +44228,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/item/scissors/surgical_scissors,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds surgical scissors to the pile of tools in the medbooth on kondaru


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The medbooth starts with all basic medical tools except scissors, meaning anyone hoping to use it to remove an appendix in a rush will be unable to, i have added that since i felt it was missing

