### PR TITLE
Make regular and wall emergency lockers contain the same loot

### DIFF
--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -38,15 +38,18 @@ TYPEINFO(/obj/item/storage/wall)
 			src.storage.add_contents(new /obj/item/storage/firstaid/oxygen(src))
 		if (prob(10))
 			src.storage.add_contents(new /obj/item/tank/air(src))
-		if (prob(2))
+		if (prob(4))
 			src.storage.add_contents(new /obj/item/tank/oxygen(src))
 		if (prob(2))
 			src.storage.add_contents(new /obj/item/clothing/mask/gas/emergency(src))
 		for (var/i=rand(2,3), i>0, i--)
+			src.storage.add_contents(new /obj/item/tank/emergency_oxygen(src))
 			if (prob(40))
 				src.storage.add_contents(new /obj/item/tank/mini_oxygen(src))
 			if (prob(40))
 				src.storage.add_contents(new /obj/item/clothing/mask/breath(src))
+
+		return 1
 
 /obj/item/storage/wall/fire
 	name = "firefighting supplies"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Emergency wall lockers do not currently contain the newer pocket oxygen within them. This change makes it so they uh, do.
Also makes the chance for an oxy tank (+the rest of the loot) the same as closets.
The reason for this is that Clarion has ONLY wall lockers (23), and Cog1 has ONLY regular closets (18). Syncing the loot means a more unified experience for recieving emergency oxygen.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15958
