### PR TITLE
Wasp related items in surplus crates come with a wasp implant

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -624,15 +624,22 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	job = list("Botanist", "Apiculturist")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
+	run_on_spawn(obj/item/our_item, mob/living/owner, in_surplus_crate)
+		if(in_surplus_crate)
+			new /obj/item/implanter/wasp(our_item.loc)
+
 /datum/syndicate_buylist/traitor/wasp_crossbow
 	name = "Wasp Crossbow"
 	item = /obj/item/gun/energy/wasp
 	cost = 6
 	desc = "Become the member of the Space Cobra Unit you always wanted to be! Spread pain and fear far and wide using this scattershot wasp egg launcher! Through the power of sheer wasp-y fury, this crossbow will slowly recharge between shots and is guaranteed to light up your day with maniacal joy and to bring your enemies no end of sorrow."
-	not_in_crates = 1 //the value of the item goes down significantly for non-botanists since only botanists are treated kindly by wasps
 	vr_allowed = FALSE
 	job = list("Botanist", "Apiculturist")
 	can_buy = UPLINK_TRAITOR
+
+	run_on_spawn(obj/item/our_item, mob/living/owner, in_surplus_crate)
+		if(in_surplus_crate)
+			new /obj/item/implanter/wasp(our_item.loc)
 
 /datum/syndicate_buylist/traitor/fakegrenade
 	name = "Fake Cleaner Grenades"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -706,6 +706,35 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			src.owner?.elecgib()
 		. = ..()
 
+/obj/item/implant/revenge/wasp
+	name = "wasp implant"
+	big_message = " buzzes, what?"
+	small_message = "buzzes loudly, uh oh!"
+	power = 4
+	/// did we change our user's faction? this is in case a botanist gets this implant then gets it removed
+	var/changed_faction = FALSE
+
+	implanted(var/mob/M, mob/I)
+		..()
+		if (istype(M) && M.faction != FACTION_BOTANY)
+			M.faction = FACTION_BOTANY
+			changed_faction = TRUE
+
+	on_remove(var/mob/M)
+		..()
+		if (istype(M) && changed_faction == TRUE)
+			M.faction = 0
+			changed_faction = FALSE
+
+	do_effect(power)
+		// enjoy your wasps
+		for (var/i in 1 to power)
+			new /mob/living/critter/small_animal/wasp/angry(get_turf(src))
+
+		SPAWN(1)
+			src.owner?.gib()
+		. = ..()
+
 
 /obj/item/implant/robotalk
 	name = "machine translator implant"
@@ -1667,6 +1696,16 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 
 	New()
 		src.imp = new /obj/item/implant/revenge/zappy(src)
+		..()
+
+/obj/item/implanter/wasp
+	name = "wasp implanter"
+	icon_state = "implanter1-g"
+	sneaky = TRUE
+	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, they will explode into a cloud of angry wasps. Suiciding will cause no cloud of wasps to appear. This implant will also make wasps friendly to the user."})
+
+	New()
+		src.imp = new /obj/item/implant/revenge/wasp(src)
 		..()
 
 /* ================================================================ */

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -729,7 +729,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	do_effect(power)
 		// enjoy your wasps
 		for (var/i in 1 to power)
-			new /mob/living/critter/small_animal/wasp/angry(get_turf(src))
+			var/mob/living/critter/small_animal/wasp/W = new /mob/living/critter/small_animal/wasp/angry(get_turf(src))
+			W.lying = TRUE // So wasps dont hit other wasps when being flung
+			W.throw_at(get_edge_target_turf(get_turf(src), pick(alldirs)), rand(1,3 + round(power / 16)), 2)
+			SPAWN(1 SECOND)
+				W.lying = FALSE
 
 		SPAWN(1)
 			src.owner?.gib()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -711,20 +711,16 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	big_message = " buzzes, what?"
 	small_message = "buzzes loudly, uh oh!"
 	power = 8
-	/// did we change our user's faction? this is in case a botanist gets this implant then gets it removed
-	var/changed_faction = FALSE
 
 	implanted(var/mob/M, mob/I)
 		..()
-		if (istype(M) && M.faction != FACTION_BOTANY)
-			M.faction = FACTION_BOTANY
-			changed_faction = TRUE
+		if (istype(M))
+			M.faction |= FACTION_BOTANY
 
 	on_remove(var/mob/M)
 		..()
-		if (istype(M) && changed_faction == TRUE)
-			M.faction = 0
-			changed_faction = FALSE
+		if (istype(M))
+			M.faction &= ~FACTION_BOTANY
 
 	do_effect(power)
 		// enjoy your wasps

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -710,7 +710,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	name = "wasp implant"
 	big_message = " buzzes, what?"
 	small_message = "buzzes loudly, uh oh!"
-	power = 4
+	power = 8
 	/// did we change our user's faction? this is in case a botanist gets this implant then gets it removed
 	var/changed_faction = FALSE
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If wasp grenades are rolled in a surplus crate they come with a wasp implant. Wasp implants give the user the botany faction which prevents wasps from attacking them. Wasp implants also cause the user to explode into 8 wasps on death.
Additionally enables the wasp crossbow in surplus crates and adds a wasp implant when that is rolled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wasp grenades are significantly less useful when rolled in a surplus crate because the user lacks botany's wasp immunity. The implant allows this item to be used to its full potential. 
I added the crossbow to crates cause I noticed a comment about it being disabled due to issues with wasps killing their summoners but that shouldn't an issue because of the implant.

The user exploding into wasps on death is meant to be a fun little bonus when you get one of these items in a surplus.

## Changelog 

```changelog
(u)UnfunnyPerson
(+)Added the wasp crossbow to surplus crates.
(+)Wasp related items in surplus crates come with a wasp implant. The wasp implant will cause wasps to ignore the user and for the user to explode into wasps on death.
```
