### PR TITLE
Adds the bass to the afterlife bar

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -57358,6 +57358,9 @@
 /obj/item/instrument/guitar{
 	pixel_y = 7
 	},
+/obj/item/instrument/bass{
+	pixel_y = 4
+	},
 /turf/unsimulated/floor/wood/two,
 /area/afterlife/bar)
 "eaz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the electric bass to the afterlife bar on the same table as the other guitar-like instruments


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More stuff to play around with in the ghost bar
