### PR TITLE
Fix donut2 south solar array not working

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -46174,7 +46174,7 @@
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "tNT" = (
-/obj/machinery/power/tracker,
+/obj/machinery/power/tracker/south,
 /obj/grille/catwalk{
 	dir = 6
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Despite starting fully wired up the south solar array on donut 2 won't automatically track the sun because the tracker on it is the base type instead of the /south subtype, you'd have to re-scan for equipment with a multitool which seems unintended given it's already fully hooked up.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Unlike the north solar that starts with cut wires the south solar is designed like it should work out of the box, but it doesn't
