### PR TITLE
Fixes vending machine pizza giving you food poisoning

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -89,6 +89,8 @@
 			w_class = W_CLASS_TINY
 
 		src.setMaterial(getMaterial("pizza"), appearance = 0, setname = 0)
+		// this is a funny workaround for the fact that any pizza not made by cooking will have quality reset to 0 from the above call
+		src.quality = 1
 		if (prob(1))
 			SPAWN( rand(300, 900) )
 				src.visible_message("<b>[src]</b> <i>says, \"I'm pizza.\"</i>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MATERIALS] [CATERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an explicit quality = 1 to New() of pizza because the setMaterial call resets quality to 0, meaning it will taste horrible and give you food poisoning. This will not impact player-cooked pizza because the quality for that is set elsewhere, after New().

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Vending machine and admin-spawned pizza should at the bare minimum not poison you I think

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Pizza made at the pizza vending machine should no longer taste horrible and make you sick.
```
