### PR TITLE
Fix jean plated clothing losing special naming on UpdateName()

### DIFF
--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -60,7 +60,10 @@ ABSTRACT_TYPE(/obj/item/clothing)
 
 
 	UpdateName()
-		src.name = "[name_prefix(null, 1)][src.get_stains()][src.real_name ? src.real_name : initial(src.name)][name_suffix(null, 1)]"
+		src.name = src.real_name ? src.real_name : initial(src.name)
+		if(src.material?.usesSpecialNaming())
+			src.name = src.material.specialNaming(src)
+		src.name = "[name_prefix(null, 1)][src.get_stains()][src.name][name_suffix(null, 1)]"
 
 	proc/add_stain(var/stn)
 		if (!stn || !src.can_stain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CLOTHING] [MATERIALS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15959 by making UpdateName() on clothing apply any material-based special naming the item has.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently materials that do special naming (which I think rn is only jean) only apply that naming to src.name when SetMaterial is called, as soon as something else updates the name with real_name, it's lost
