### PR TITLE
Introduces the COMSIG_MOB_EX_ACT signal and makes syringe implants remove on explosion of the mob

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -219,6 +219,8 @@
 	#define COMSIG_MOB_UPDATE_DAMAGE "mob_update_damage"
 	/// Sent when a mob resists, return TRUE to prevent other resist code from running
 	#define COMSIG_MOB_RESIST "mob_resist"
+	/// Sent when the mob is affected by an explosion
+	#define COMSIG_MOB_EXPLODES "mob_explosion"
 
 	// ---- cloaking device signal ----
 

--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -220,7 +220,7 @@
 	/// Sent when a mob resists, return TRUE to prevent other resist code from running
 	#define COMSIG_MOB_RESIST "mob_resist"
 	/// Sent when the mob is affected by an explosion
-	#define COMSIG_MOB_EXPLODES "mob_explosion"
+	#define COMSIG_MOB_EX_ACT "mob_explosion_act"
 
 	// ---- cloaking device signal ----
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -768,6 +768,7 @@
 
 // I moved the log entries from human.dm to make them global (Convair880).
 /mob/ex_act(severity, last_touched)
+	SEND_SIGNAL(src, COMSIG_MOB_EXPLODES, severity)
 	logTheThing(LOG_COMBAT, src, "is hit by an explosion (Severity: [severity]) at [log_loc(src)]. Explosion source last touched by [last_touched]")
 	return
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -768,7 +768,7 @@
 
 // I moved the log entries from human.dm to make them global (Convair880).
 /mob/ex_act(severity, last_touched)
-	SEND_SIGNAL(src, COMSIG_MOB_EXPLODES, severity)
+	SEND_SIGNAL(src, COMSIG_MOB_EX_ACT, severity)
 	logTheThing(LOG_COMBAT, src, "is hit by an explosion (Severity: [severity]) at [log_loc(src)]. Explosion source last touched by [last_touched]")
 	return
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1020,6 +1020,22 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				..()
 				implant_overlay = image(icon = 'icons/mob/human.dmi', icon_state = "syringe_stick_[rand(0, 4)]", layer = MOB_EFFECT_LAYER)
 
+			implanted(var/mob/receiving_mob, var/mob/implanting_mob)
+				..()
+				RegisterSignal(receiving_mob, COMSIG_MOB_EXPLODES, PROC_REF(on_explosion_reaction))
+
+			on_remove(var/mob/loosing_mob)
+				..()
+				UnregisterSignal(loosing_mob, COMSIG_MOB_EXPLODES)
+
+			proc/on_explosion_reaction(var/mob/exploding_mob, var/severity)
+				if (ishuman(exploding_mob))
+					var/mob/living/carbon/human/human_owner = exploding_mob
+					SPAWN(0.1 SECONDS)
+						src.on_remove(human_owner)
+						human_owner.implant.Remove(src)
+						qdel(src)
+
 			syringe_barbed
 				name = "barbed syringe round"
 				desc = "An empty syringe round, of the type that is fired from a syringe gun. It has a barbed tip. Nasty!"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1022,11 +1022,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 
 			implanted(var/mob/receiving_mob, var/mob/implanting_mob)
 				..()
-				RegisterSignal(receiving_mob, COMSIG_MOB_EXPLODES, PROC_REF(on_explosion_reaction))
+				RegisterSignal(receiving_mob, COMSIG_MOB_EX_ACT, PROC_REF(on_explosion_reaction))
 
-			on_remove(var/mob/loosing_mob)
+			on_remove(var/mob/losing_mob)
 				..()
-				UnregisterSignal(loosing_mob, COMSIG_MOB_EXPLODES)
+				UnregisterSignal(losing_mob, COMSIG_MOB_EX_ACT)
 
 			proc/on_explosion_reaction(var/mob/exploding_mob, var/severity)
 				if (ishuman(exploding_mob))


### PR DESCRIPTION
[Internal][Balance][Game Objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Introduces the `COMSIG_MOB_EX_ACT` signal. It is send on `ex_act` on a mob.

Also, this PR uses this signal to make syringe implants caused by the syringe gun to be removed when the mob carrying them suffers from an explosion.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pottassium+Ice in syringe guns proven to be far too effective for how little effort they need to set up. While it is nice to explode people with this combination, a single syringe could cause 4-5 explosions with this method.

By changing syringes to be removed on explosion of the mob, a single syringe can only explode the person at two times at maximum (due to delays) until the syringe+the chemicals are removed. 

In general, this makes getting hit with a PotIce syringe gun much more surviveable and severly diminishes their utility for crowd control while still keeping this mixture viable for the syringe gun. Get some better chem mixes, nerds.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Syringes, fired from the syringe gun, stuck in a human desintegrate when that human is affected by an explosion.
```
