### PR TITLE
Adds dialysis machines to rotation maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -14017,6 +14017,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aUb" = (
+/obj/machinery/dialysis,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "aUc" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -32908,6 +32908,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 28
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -38538,6 +38538,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "cvD" = (
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -54002,6 +54002,7 @@
 	pixel_x = -10
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -48355,6 +48355,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11067,6 +11067,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/blood,
 /turf/simulated/floor/blackwhite/side{
 	dir = 1
 	},
@@ -65336,8 +65338,7 @@
 /turf/space,
 /area/space)
 "ufs" = (
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/blood,
+/obj/machinery/dialysis,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "ufw" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -15970,6 +15970,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 10
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -10998,6 +10998,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -4185,6 +4185,7 @@
 	icon_state = "line1"
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/machinery/dialysis,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "anZ" = (

--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -328,6 +328,7 @@
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line2"
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/white,
 /area/devzone)
 "fs" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDICAL][OBJECTS][FEAT][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Introduces dialysis machines to most rotation maps. They should be located in the operating room or close by if not possible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allowing people to use new features is cool and good.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DisturbHerb
(*)The latest advances in hemodialysis technology have been harnessed by your local medical bay. Clean your blood, today!
```
