### PR TITLE
Furnaces emit light when on

### DIFF
--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -31,11 +31,11 @@ TYPEINFO(/obj/machinery/power/furnace)
 	New(new_loc)
 		..()
 		START_TRACKING
-		src.point_light.set_brightness(0.3)
+		src.point_light.set_brightness(0.5)
 		src.point_light.set_color(src.col_r, src.col_g, src.col_b)
 		src.point_light.attach(src)
 
-		src.cone_light.set_brightness(1)
+		src.cone_light.set_brightness(0.7)
 		src.cone_light.set_color(src.col_r, src.col_g, src.col_b)
 		src.cone_light.outer_angular_size = src.outer_angular_size
 		src.cone_light.inner_angular_size = src.inner_angular_size
@@ -57,7 +57,6 @@ TYPEINFO(/obj/machinery/power/furnace)
 			if(!src.fuel)
 				src.visible_message("<span class='alert'>[src] runs out of fuel and shuts down!</span>")
 				src.active = FALSE
-
 		else
 			on_inactive()
 

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -14,14 +14,33 @@ TYPEINFO(/obj/machinery/power/furnace)
 	var/maxfuel = 1000
 	var/genrate = 20000
 	var/stoked = 0 // engine ungrump
-	custom_suicide = 1
+	custom_suicide = TRUE
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
+
+	// lights
+	var/datum/light/cone/cone_light = new /datum/light/cone
+	var/datum/light/point/point_light = new /datum/light/point
+	var/col_r = 0.69
+	var/col_g = 0.23
+	var/col_b = 0.01
+	var/outer_angular_size = 90
+	var/inner_angular_size = 75
+	var/inner_radius = 2
 
 	New(new_loc)
 		..()
 		START_TRACKING
-		AddComponent(/datum/component/loctargeting/medium_directional_light, 255, 110, 135, 125, src.active)
+		src.point_light.set_brightness(0.3)
+		src.point_light.set_color(src.col_r, src.col_g, src.col_b)
+		src.point_light.attach(src)
+
+		src.cone_light.set_brightness(1)
+		src.cone_light.set_color(src.col_r, src.col_g, src.col_b)
+		src.cone_light.outer_angular_size = src.outer_angular_size
+		src.cone_light.inner_angular_size = src.inner_angular_size
+		src.cone_light.inner_radius = src.inner_radius
+		src.cone_light.attach(src)
 
 	disposing()
 		STOP_TRACKING
@@ -37,8 +56,8 @@ TYPEINFO(/obj/machinery/power/furnace)
 					stoked--
 			if(!src.fuel)
 				src.visible_message("<span class='alert'>[src] runs out of fuel and shuts down!</span>")
-				src.active = 0
-				SEND_SIGNAL(src, COMSIG_LIGHT_DISABLE)
+				src.active = FALSE
+
 		else
 			on_inactive()
 
@@ -57,8 +76,12 @@ TYPEINFO(/obj/machinery/power/furnace)
 				var/image/I = GetOverlayImage("active")
 				if(!I) I = image('icons/obj/power.dmi', "furn-burn")
 				UpdateOverlays(I, "active")
+				src.point_light.enable()
+				src.cone_light.enable()
 			else
 				UpdateOverlays(null, "active", 0, 1) //Keep it in cache for when it's toggled
+				src.point_light.disable()
+				src.cone_light.disable()
 
 		var/fuel_state = round(min((src.fuel / src.maxfuel) * 5, 4))
 		//At max fuel, the state will be 4, aka all bars, then it will lower / increase as fuel is added
@@ -75,13 +98,14 @@ TYPEINFO(/obj/machinery/power/furnace)
 
 
 	was_deconstructed_to_frame(mob/user)
-		src.active = 0
+		src.active = FALSE
+		src.point_light.disable()
+		src.cone_light.disable()
 
 	attack_hand(var/mob/user)
 		if (!src.fuel) boutput(user, "<span class='alert'>There is no fuel in the furnace!</span>")
 		else
 			src.active = !src.active
-			src.active ? SEND_SIGNAL(src, COMSIG_LIGHT_ENABLE) : SEND_SIGNAL(src, COMSIG_LIGHT_DISABLE)
 			boutput(user, "You switch [src.active ? "on" : "off"] the furnace.")
 
 	attackby(obj/item/W, mob/user)

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -21,6 +21,7 @@ TYPEINFO(/obj/machinery/power/furnace)
 	New(new_loc)
 		..()
 		START_TRACKING
+		AddComponent(/datum/component/loctargeting/medium_directional_light/, 255, 110, 135, 125, src.active)
 
 	disposing()
 		STOP_TRACKING
@@ -37,6 +38,7 @@ TYPEINFO(/obj/machinery/power/furnace)
 			if(!src.fuel)
 				src.visible_message("<span class='alert'>[src] runs out of fuel and shuts down!</span>")
 				src.active = 0
+				SEND_SIGNAL(src, COMSIG_LIGHT_DISABLE)
 		else
 			on_inactive()
 
@@ -79,6 +81,7 @@ TYPEINFO(/obj/machinery/power/furnace)
 		if (!src.fuel) boutput(user, "<span class='alert'>There is no fuel in the furnace!</span>")
 		else
 			src.active = !src.active
+			src.active ? SEND_SIGNAL(src, COMSIG_LIGHT_ENABLE) : SEND_SIGNAL(src, COMSIG_LIGHT_DISABLE)
 			boutput(user, "You switch [src.active ? "on" : "off"] the furnace.")
 
 	attackby(obj/item/W, mob/user)

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -21,7 +21,7 @@ TYPEINFO(/obj/machinery/power/furnace)
 	New(new_loc)
 		..()
 		START_TRACKING
-		AddComponent(/datum/component/loctargeting/medium_directional_light/, 255, 110, 135, 125, src.active)
+		AddComponent(/datum/component/loctargeting/medium_directional_light, 255, 110, 135, 125, src.active)
 
 	disposing()
 		STOP_TRACKING


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Give furnaces a point and cone light so they're properly hearth-y.

single
<img width="705" alt="image" src="https://github.com/goonstation/goonstation/assets/91498627/76363556-b4b4-435f-8f4e-fbd32ec6cb40">

all
<img width="703" alt="image" src="https://github.com/goonstation/goonstation/assets/91498627/4ec5b565-27c1-4eae-bdf3-302737ec75a4">

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11527