### PR TITLE
Appendicitis event filters mobs before picking victims

### DIFF
--- a/code/modules/events/minor/appendicitis_event.dm
+++ b/code/modules/events/minor/appendicitis_event.dm
@@ -15,8 +15,8 @@
 			if (!H.organHolder?.appendix) continue // with appendix
 			if (H.organHolder?.appendix?.robotic) continue // that isn't robotic
 			potential_victims += H
-		if (potential_victims.len)
+		if (length(potential_victims))
 			var/num = rand(2, 4)
-			for (var/i = 0, i < num, i++)
+			for (var/i = 0, i < min(num, length(potential_victims)), i++)
 				var/mob/living/carbon/human/patient = pick(potential_victims)
 				patient?.contract_disease(/datum/ailment/disease/appendicitis,null,null,1)

--- a/code/modules/events/minor/appendicitis_event.dm
+++ b/code/modules/events/minor/appendicitis_event.dm
@@ -1,19 +1,22 @@
 /datum/random_event/minor/appendicitis
 	name = "Appendicitis Contraction"
-	centcom_headline = "Medical Data Inbound"
-	centcom_message = "The NanoTrasen Personnel Records Department has informed us that some crew members have the genetic indicators that they will very likely contract Appendicitis, they should report to medbay before their condition worsens."
+	centcom_headline = "Medical Records Notice"
+	centcom_message = "The NanoTrasen Personnel Records Department has informed us that some crew members have genetic indicators of increased Appendicitis risk and should seek medical care before their condition worsens."
 	weight = 10
 
 	event_effect(var/source)
 		..()
 		var/list/potential_victims = list()
-		for (var/mob/living/carbon/human/H in mobs)
-			if (isdead(H))
-				continue
+
+		for_by_tcl(H, /mob/living/carbon/human)
+			if (isdead(H)) continue // alive
+			if (isnpc(H)) continue // player
+			//TODO: in medical records
+			if (!H.organHolder?.appendix) continue // with appendix
+			if (H.organHolder?.appendix?.robotic) continue // that isn't robotic
 			potential_victims += H
 		if (potential_victims.len)
 			var/num = rand(2, 4)
 			for (var/i = 0, i < num, i++)
 				var/mob/living/carbon/human/patient = pick(potential_victims)
-				if (!(isnpcmonkey(patient)) && patient.organHolder && patient.organHolder.appendix && !patient.organHolder.appendix.robotic)
-					patient.contract_disease(/datum/ailment/disease/appendicitis,null,null,1)
+				patient?.contract_disease(/datum/ailment/disease/appendicitis,null,null,1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Use for_by_tcl to get mob list
* Filter mobs up front
* Tweak wording

This will make the event have slightly greater impact on the round as there will be much fewer "whiffs" on the 2-4 attempts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fix #8123 (isnpcmonkey -> isnpc check)
* Event effect should be consistent with intent
