### PR TITLE
Changelings do not get DNA from white hole bodies

### DIFF
--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -1092,13 +1092,13 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(istype(., /mob/living))
 			var/mob/living/L = .
-			L.is_npc = TRUE
 			if(ismobcritter(L))
 				L.TakeDamage("chest", rand(0, 15), rand(0, 15), rand(0, 15))
 			else
 				L.TakeDamage("chest", rand(0, 80), rand(0, 80), rand(0, 80))
 			if(ishuman(.))
 				var/mob/living/carbon/human/H = .
+				H.is_npc = TRUE
 				SPAWN(1)
 					var/list/limbs = list("l_arm", "r_arm", "l_leg", "r_leg")
 					shuffle_list(limbs)

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -1052,6 +1052,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 				if (bag_it)
 					var/obj/item/body_bag/bag = new(src.loc)
 					bag.UpdateIcon()
+					human.is_npc = TRUE // NPC is set for direct mob returns separately
 					human.set_loc(bag)
 					. = bag
 			if("geneinjector")
@@ -1091,6 +1092,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(istype(., /mob/living))
 			var/mob/living/L = .
+			L.is_npc = TRUE
 			if(ismobcritter(L))
 				L.TakeDamage("chest", rand(0, 15), rand(0, 15), rand(0, 15))
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mark white hole humans as NPCs, preventing changelings getting DNA (but letting them get appearance)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #15894
