### PR TITLE
Mark corpse spawned humans as NPCs

### DIFF
--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -109,6 +109,7 @@
 		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
 		H.death(FALSE)
 		H.traitHolder.addTrait("puritan")
+		H.is_npc = TRUE
 
 		if (src.no_decomp)
 			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets `is_npc = TRUE` on corpse humans


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not players. Prevents antags bumping up their numbers from space, etc.

