### PR TITLE
Don't trigger action bar for Pod Eject Occupants if no occupants in pod cabin

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1077,7 +1077,7 @@
 	actions.start(new/datum/action/bar/icon/eject_pod(src,usr), usr)
 	return
 
-/obj/machinery/vehicle/proc/eject_pod(mob/user, dead_only=FALSE)
+/obj/machinery/vehicle/proc/eject_pod(var/mob/user, var/dead_only = 0)
 	for(var/mob/M in src) // nobody likes losing a pod to a dead pilot
 		if (!dead_only)
 			leave_pod(M)
@@ -1086,7 +1086,6 @@
 			if(M.stat || !M.client)
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You pull [M] out of [src].</span>")
-
 			else if(!isliving(M))
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You scrape [M] out of [src].</span>")
@@ -1101,6 +1100,7 @@
 		boutput(user, "<span class='alert'>You [pick("scrape","scrub","clean")] [O] out of [src].</span>")
 		var/floor = get_turf(src)
 		O.set_loc(floor)
+
 
 /datum/action/bar/board_pod
 	duration = 20

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1077,23 +1077,31 @@
 	actions.start(new/datum/action/bar/icon/eject_pod(src,usr), usr)
 	return
 
-/obj/machinery/vehicle/proc/eject_pod(var/mob/user, var/dead_only = 0)
+/obj/machinery/vehicle/proc/eject_pod(mob/user, dead_only=FALSE)
+	var/ejected_something = FALSE
 	for(var/mob/M in src) // nobody likes losing a pod to a dead pilot
 		if (!dead_only)
 			leave_pod(M)
 			boutput(user, "<span class='alert'>You yank [M] out of [src].</span>")
+			ejected_something = TRUE
 		else
 			if(M.stat || !M.client)
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You pull [M] out of [src].</span>")
+				ejected_something = TRUE
 			else if(!isliving(M))
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You scrape [M] out of [src].</span>")
+				ejected_something = TRUE
 
 	for(var/obj/decal/cleanable/O in src)
 		boutput(user, "<span class='alert'>You [pick("scrape","scrub","clean")] [O] out of [src].</span>")
 		var/floor = get_turf(src)
 		O.set_loc(floor)
+		ejected_something = TRUE
+
+	if (!ejected_something)
+		boutput(user, "<span class='alert'>Nothing was inside the cabin of [src]!</span>")
 
 
 /datum/action/bar/board_pod

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1078,31 +1078,29 @@
 	return
 
 /obj/machinery/vehicle/proc/eject_pod(mob/user, dead_only=FALSE)
-	var/ejected_something = FALSE
 	for(var/mob/M in src) // nobody likes losing a pod to a dead pilot
 		if (!dead_only)
 			leave_pod(M)
 			boutput(user, "<span class='alert'>You yank [M] out of [src].</span>")
-			ejected_something = TRUE
 		else
 			if(M.stat || !M.client)
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You pull [M] out of [src].</span>")
-				ejected_something = TRUE
+
 			else if(!isliving(M))
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You scrape [M] out of [src].</span>")
-				ejected_something = TRUE
+
+	var/obj/item/shipcomponent/secondary_system/cargo/hold = src.sec_system
+	if(istype(hold))
+		for(var/mob/M in hold.load)
+			hold.unload(M, user.loc)
+			boutput(user, "<span class='alert'>You dump [M] out from the [hold] of [src].</span>")
 
 	for(var/obj/decal/cleanable/O in src)
 		boutput(user, "<span class='alert'>You [pick("scrape","scrub","clean")] [O] out of [src].</span>")
 		var/floor = get_turf(src)
 		O.set_loc(floor)
-		ejected_something = TRUE
-
-	if (!ejected_something)
-		boutput(user, "<span class='alert'>Nothing was inside the cabin of [src]!</span>")
-
 
 /datum/action/bar/board_pod
 	duration = 20

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1074,8 +1074,11 @@
 		boutput(usr, "<span class='alert'>[src] is locked!</span>")
 		return
 
-	actions.start(new/datum/action/bar/icon/eject_pod(src,usr), usr)
-	return
+	for(var/mob/M in src)
+		actions.start(new/datum/action/bar/icon/eject_pod(src,usr), usr)
+		return
+
+	boutput(usr, "<span class='alert'>No one is in [src].</span>")
 
 /obj/machinery/vehicle/proc/eject_pod(var/mob/user, var/dead_only = 0)
 	for(var/mob/M in src) // nobody likes losing a pod to a dead pilot
@@ -1089,12 +1092,6 @@
 			else if(!isliving(M))
 				leave_pod(M)
 				boutput(user, "<span class='alert'>You scrape [M] out of [src].</span>")
-
-	var/obj/item/shipcomponent/secondary_system/cargo/hold = src.sec_system
-	if(istype(hold))
-		for(var/mob/M in hold.load)
-			hold.unload(M, user.loc)
-			boutput(user, "<span class='alert'>You dump [M] out from the [hold] of [src].</span>")
 
 	for(var/obj/decal/cleanable/O in src)
 		boutput(user, "<span class='alert'>You [pick("scrape","scrub","clean")] [O] out of [src].</span>")

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1074,7 +1074,7 @@
 		boutput(usr, "<span class='alert'>[src] is locked!</span>")
 		return
 
-	for(var/mob/M in src)
+	if(locate(/mob) in src.contents)
 		actions.start(new/datum/action/bar/icon/eject_pod(src,usr), usr)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

when completing the eject occupants action bar, in addition to the driver/passenger ejection, check if the secondary system of the pod is storage, and if so unload any mobs in the direct load list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #7425
it's a pretty long action bar for it to do nothing if the intent is to empty people