### PR TITLE
fix wood sheets in map editor

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -499,7 +499,7 @@ MATERIAL
 
 /obj/item/sheet/wood
 	item_state = "sheet-metal"
-	icon_state = "sheet-m_5$wood"
+	icon_state = "sheet-m_5$$wood"
 	default_material = "wood"
 	amount = 10
 	var/wall_type = /obj/structure/woodwall
@@ -512,9 +512,9 @@ MATERIAL
 			return ..()
 		actions.start(new /datum/action/bar/icon/build(src, wall_type, 5, src.material, 1, 'icons/ui/actions.dmi', "working", "a barricade", null, spot = target), user)
 
-	zwood
-		amount = 5
-		wall_type = /obj/structure/woodwall/anti_zombie
+/obj/item/sheet/wood/zwood
+	amount = 5
+	wall_type = /obj/structure/woodwall/anti_zombie
 
 /obj/item/sheet/bamboo
 	item_state = "sheet-metal"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix wood sheets in the map editor. absolute path for zwood sheet.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bad bug

