### PR TITLE
Fixes Glaucus fishing rod not respecting sanctuary + offhand

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -592,14 +592,16 @@ TYPEINFO(/obj/item/syndie_fishing_rod)
 		..()
 
 	throw_impact(mob/hit_atom, datum/thrown_thing/thr)
-		if (isliving(hit_atom) && hit_atom.equipped() == src.rod)
-			return
-		else
+		if (istype(hit_atom))
 			src.try_embed(hit_atom, FALSE)
+			return
 		return ..()
 
 	proc/try_embed(mob/M, do_weaken = TRUE)
-		if (istype(M) && isliving(M) && !M.nodamage)
+		if (istype(M) && isliving(M))
+			var/area/AR = get_area(M)
+			if (AR?.sanctuary || M.nodamage || (src.rod in M.equipped_list(check_for_magtractor = 0)))
+				return TRUE
 			if (do_weaken)
 				M.changeStatus("weakened", 5 SECONDS)
 				M.TakeDamage(M.hand == LEFT_HAND ? "l_arm": "r_arm", 15, 0, 0, DAMAGE_STAB)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Game Objects] [C-Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #16055
The lure's try_embed() will now return TRUE but do nothing (thus preventing further behavior) when picked up, rolled over, hit with, pulled, etc. if the target is in a sanctuary or holding the lure's connected fishing rod in either hand.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad, no-damage sanctuaries are a thing and I forgot that.
