### PR TITLE
Empowered coprolalia gives bold maptext

### DIFF
--- a/code/mob/living/carbon/human/test.dm
+++ b/code/mob/living/carbon/human/test.dm
@@ -9,7 +9,7 @@
 		src.AddComponent(/datum/component/health_maptext)
 
 
-	say(message, ignore_stamina_winded)
+	say(message, ignore_stamina_winded, unique_maptext_style, maptext_animation_colors)
 		if(!shutup)
 			. = ..()
 

--- a/code/mob/living/carbon/human/test.dm
+++ b/code/mob/living/carbon/human/test.dm
@@ -9,7 +9,7 @@
 		src.AddComponent(/datum/component/health_maptext)
 
 
-	say(message, ignore_stamina_winded, unique_maptext_style, maptext_animation_colors)
+	say(message, ignore_stamina_winded)
 		if(!shutup)
 			. = ..()
 

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -135,7 +135,7 @@
 	reclaim_fail = 15
 	var/talk_prob = 10
 	var/list/talk_strings = list("PISS","FUCK","SHIT","DAMN","ARGH","WOOF","CRAP","HECK","FRICK","JESUS")
-	var/empowered_popup_style = "font-family: 'Comic Sans MS'; font-size: 8px;"
+	var/empowered_popup_style = "font-weight: bold;"
 	icon_state  = "bad"
 
 	OnLife(var/mult)

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -135,6 +135,7 @@
 	reclaim_fail = 15
 	var/talk_prob = 10
 	var/list/talk_strings = list("PISS","FUCK","SHIT","DAMN","ARGH","WOOF","CRAP","HECK","FRICK","JESUS")
+	var/empowered_maptext_style = "font-weight: bold;"
 	icon_state  = "bad"
 
 	OnLife(var/mult)
@@ -145,7 +146,11 @@
 		if (isdead(L))
 			return
 		if (probmult(talk_prob))
-			L.say(pick(talk_strings))
+			var/mob/living/carbon/human/H = L
+			if(istype(H) && src.power > 1)
+				H.say(pick(talk_strings), unique_maptext_style=empowered_maptext_style)
+			else
+				L.say(pick(talk_strings))
 
 /datum/bioEffect/shortsighted
 	name = "Diminished Optic Nerves"

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -135,7 +135,7 @@
 	reclaim_fail = 15
 	var/talk_prob = 10
 	var/list/talk_strings = list("PISS","FUCK","SHIT","DAMN","ARGH","WOOF","CRAP","HECK","FRICK","JESUS")
-	var/empowered_maptext_style = "font-weight: bold;"
+	var/empowered_popup_style = "font-family: 'Comic Sans MS'; font-size: 8px;"
 	icon_state  = "bad"
 
 	OnLife(var/mult)
@@ -146,11 +146,13 @@
 		if (isdead(L))
 			return
 		if (probmult(talk_prob))
-			var/mob/living/carbon/human/H = L
-			if(istype(H) && src.power > 1)
-				H.say(pick(talk_strings), unique_maptext_style=empowered_maptext_style)
-			else
+			if(src.power > 1)
+				var/original_speechpopupstyle = L.speechpopupstyle
+				L.speechpopupstyle += empowered_popup_style
 				L.say(pick(talk_strings))
+				L.speechpopupstyle = original_speechpopupstyle
+				return
+			L.say(pick(talk_strings))
 
 /datum/bioEffect/shortsighted
 	name = "Diminished Optic Nerves"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

empowering coprolalia gives your outbursts a bit more gusto by bolding their maptext.

tested with comic accent and megaphone.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
empowered genes should do something, so a minor effect for a minor gene :)