### PR TITLE
Turn on life support for pilot trait pods

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -535,6 +535,7 @@ var/global/totally_random_jobs = FALSE
 						for(var/obj/critter/gunbot/drone/snappedDrone in V.loc)	//Spawning onto a drone doesn't sound fun so the spawn location gets cleaned up.
 							qdel(snappedDrone)
 						V.finish_board_pod(src)
+						V.life_support?.activate()
 
 				#undef MAX_ALLOWED_ITERATIONS
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[trait][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turn on life support for pilot trait pods on spawn

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #16059
