### PR TITLE
Small refactor of custom pies to fix their attack not working

### DIFF
--- a/code/modules/food_and_drink/pies.dm
+++ b/code/modules/food_and_drink/pies.dm
@@ -201,23 +201,22 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pieslice)
 	use_bite_mask = FALSE
 
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
-		if (ismob(hit_atom))
-			var/atom/movable/random_content
-			if(length(src.contents) >= 1)
-				random_content = pick(contents)
-			else
-				random_content = src
+		var/atom/movable/random_content = src
+		if(length(src.contents) >= 1)
+			random_content = pick(src.contents)
+		if(random_content && thr.user && istype(random_content, /obj/item))
+			var/obj/item/randomed_item = random_content
 			playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 100, 1)
-			var/mob/hit_mob = hit_atom
-			//For custom pie attack behaviour, we check if we found an item to attack, if it's an item at all and if we got a valid attacker
-			if (random_content && thr.user && istype(random_content, /obj/item))
-				var/obj/item/randomed_item = random_content
-				hit_mob.Attackby(randomed_item, thr.user)
+			//for Attackby, we specifically need any atom as target (TIL ID-pies to open doors are a thing and it fills me with joy)
+			hit_atom.Attackby(randomed_item, thr.user)
+			if (ismob(hit_atom))
+				var/mob/hit_mob = hit_atom
+				//for AfterAttack, we specifically need a mob as target
 				randomed_item.AfterAttack(hit_mob, thr.user)
-			if (hit_mob == thr.user)
-				src.visible_message("<span class='alert'>[thr.user] fumbles and smacks the [src] into their own face!</span>")
-			else
-				src.visible_message("<span class='alert'>[src] smacks into [hit_mob]!</span>")
+				if (hit_mob == thr.user)
+					src.visible_message("<span class='alert'>[thr.user] fumbles and smacks the [src] into their own face!</span>")
+				else
+					src.visible_message("<span class='alert'>[src] smacks into [hit_mob]!</span>")
 		else
 			..()
 

--- a/code/modules/food_and_drink/pies.dm
+++ b/code/modules/food_and_drink/pies.dm
@@ -201,27 +201,25 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pieslice)
 	use_bite_mask = FALSE
 
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
-		if (contents)
+		if (ismob(hit_atom))
 			var/atom/movable/random_content
-			if (length(contents) >= 1)
+			if(length(src.contents) >= 1)
 				random_content = pick(contents)
 			else
 				random_content = src
-
- 			hit_atom.Attackby(random_content, thr?.user)
-			//for afterattack, we want to filter out mobs since pies hit also the turf the person is standing on. Also, we need to call it on an actual item
-			if (hit_atom && random_content && istype(random_content, /obj/item) && ismob(hit_atom))
+			playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 100, 1)
+			var/mob/hit_mob = hit_atom
+			//For custom pie attack behaviour, we check if we found an item to attack, if it's an item at all and if we got a valid attacker
+			if (random_content && thr.user && istype(random_content, /obj/item))
 				var/obj/item/randomed_item = random_content
-				randomed_item.AfterAttack(hit_atom, thr?.user)
-
-
-			if (ismob(hit_atom))
-				playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 100, 1)
-				var/mob/M = hit_atom
-				if (M == thr.user)
-					src.visible_message("<span class='alert'>[thr.user] fumbles and smacks the [src] into their own face!</span>")
-				else
-					src.visible_message("<span class='alert'>[src] smacks into [M]!</span>")
+				hit_mob.Attackby(randomed_item, thr.user)
+				randomed_item.AfterAttack(hit_mob, thr.user)
+			if (hit_mob == thr.user)
+				src.visible_message("<span class='alert'>[thr.user] fumbles and smacks the [src] into their own face!</span>")
+			else
+				src.visible_message("<span class='alert'>[src] smacks into [hit_mob]!</span>")
+		else
+			..()
 
 	Exited(atom/movable/Obj, newloc)
 		. = ..()


### PR DESCRIPTION
[catering][game objects][bug][code quality]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR refactors custom pie's `throw_impact` proc so it properly applies items backed into it onto mobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I want to throw chainsaws in pies at people.

Fixes #16036

Although i am completely honest that i got no idea why it didn't called `hit_atom.Attackby` before properly (it simply skipped the proc for absolutely no apparent reason). This PR fixes this while making the proc in general a bit cleaner.

