### PR TITLE
Enables the sort-imports ESLint rule for tgui

### DIFF
--- a/tgui/.eslintrc.yml
+++ b/tgui/.eslintrc.yml
@@ -567,7 +567,7 @@ rules:
   ## Enforce spacing between rest and spread operators and their expressions
   # rest-spread-spacing: error
   ## Enforce sorted import declarations within modules
-  # sort-imports: error
+  sort-imports: [error, { ignoreCase: true, ignoreDeclarationSort: true }]
   ## Require symbol descriptions
   # symbol-description: error
   ## Require or disallow spacing around embedded expressions of template

--- a/tgui/packages/tgui-panel/audio/hooks.js
+++ b/tgui/packages/tgui-panel/audio/hooks.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { useSelector, useDispatch } from 'common/redux';
+import { useDispatch, useSelector } from 'common/redux';
 import { selectAudio } from './selectors';
 
 export const useAudio = context => {

--- a/tgui/packages/tgui-panel/chat/ChatTabs.js
+++ b/tgui/packages/tgui-panel/chat/ChatTabs.js
@@ -5,8 +5,8 @@
  */
 
 import { useDispatch, useSelector } from 'common/redux';
-import { Box, Tabs, Flex, Button } from 'tgui/components';
-import { changeChatPage, addChatPage } from './actions';
+import { Box, Button, Flex, Tabs } from 'tgui/components';
+import { addChatPage, changeChatPage } from './actions';
 import { selectChatPages, selectCurrentChatPage } from './selectors';
 import { openChatSettings } from '../settings/actions';
 

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -5,7 +5,7 @@
  */
 
 import { createUuid } from 'common/uuid';
-import { MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL } from './constants';
+import { MESSAGE_TYPE_INTERNAL, MESSAGE_TYPES } from './constants';
 
 export const canPageAcceptType = (page, type) => (
   type.startsWith(MESSAGE_TYPE_INTERNAL) || page.acceptedTypes[type]

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { addChatPage, changeChatPage, loadChat, removeChatPage, toggleAcceptedType, updateChatPage, updateMessageCount, changeScrollTracking } from './actions';
+import { addChatPage, changeChatPage, changeScrollTracking, loadChat, removeChatPage, toggleAcceptedType, updateChatPage, updateMessageCount } from './actions';
 import { canPageAcceptType, createMainPage } from './model';
 
 const mainPage = createMainPage();

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -7,7 +7,7 @@
 import { EventEmitter } from 'common/events';
 import { classes } from 'common/react';
 import { createLogger } from 'tgui/logging';
-import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MAX_VISIBLE_MESSAGES, MESSAGE_PRUNE_INTERVAL, MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN } from './constants';
+import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MAX_VISIBLE_MESSAGES, MESSAGE_PRUNE_INTERVAL, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN, MESSAGE_TYPES } from './constants';
 import { canPageAcceptType, createMessage, isSameMessage } from './model';
 import { highlightNode, linkifyNode } from './replaceInTextNode';
 

--- a/tgui/packages/tgui-panel/settings/hooks.js
+++ b/tgui/packages/tgui-panel/settings/hooks.js
@@ -5,7 +5,7 @@
  */
 
 import { useDispatch, useSelector } from 'common/redux';
-import { updateSettings, toggleSettings } from './actions';
+import { toggleSettings, updateSettings } from './actions';
 import { selectSettings } from './selectors';
 
 export const useSettings = context => {

--- a/tgui/packages/tgui/components/Input.js
+++ b/tgui/packages/tgui/components/Input.js
@@ -7,7 +7,7 @@
 import { classes } from 'common/react';
 import { Component, createRef } from 'inferno';
 import { Box } from './Box';
-import { KEY_ESCAPE, KEY_ENTER, KEY_UP, KEY_DOWN } from 'common/keycodes';
+import { KEY_DOWN, KEY_ENTER, KEY_ESCAPE, KEY_UP } from 'common/keycodes';
 
 export const toInputValue = value => (
   typeof value !== 'number' && typeof value !== 'string'

--- a/tgui/packages/tgui/components/ProgressBar.js
+++ b/tgui/packages/tgui/components/ProgressBar.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { clamp01, scale, keyOfMatchingRange, toFixed } from 'common/math';
+import { clamp01, keyOfMatchingRange, scale, toFixed } from 'common/math';
 import { classes, pureComponentHooks } from 'common/react';
 import { computeBoxClassName, computeBoxProps } from './Box';
 import { CSS_COLORS } from '../constants';

--- a/tgui/packages/tgui/interfaces/AIRack.js
+++ b/tgui/packages/tgui/interfaces/AIRack.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { BlockQuote, Button, Collapsible, Box, Section } from '../components';
+import { BlockQuote, Box, Button, Collapsible, Section } from '../components';
 import { Window } from '../layouts';
 
 export const AIRack = (props, context) => {

--- a/tgui/packages/tgui/interfaces/AirVendor.tsx
+++ b/tgui/packages/tgui/interfaces/AirVendor.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from "../backend";
-import { LabeledList, NumberInput, Button, Section, Dimmer } from "../components";
+import { Button, Dimmer, LabeledList, NumberInput, Section } from "../components";
 import { Window } from '../layouts';
 import { VendorCashTable } from './common/VendorCashTable';
 import { GasTankInfo } from './GasTank';

--- a/tgui/packages/tgui/interfaces/Airlock.js
+++ b/tgui/packages/tgui/interfaces/Airlock.js
@@ -8,7 +8,7 @@
 import { Fragment } from "inferno";
 import { useBackend, useLocalState } from "../backend";
 import { truncate } from '../format';
-import { Button, LabeledList, Section, Modal, Flex, Tabs, Box, NoticeBox, Divider, ProgressBar } from "../components";
+import { Box, Button, Divider, Flex, LabeledList, Modal, NoticeBox, ProgressBar, Section, Tabs } from "../components";
 import { Window } from "../layouts";
 
 export const uiCurrentUserPermissions = data => {

--- a/tgui/packages/tgui/interfaces/Apc/util.ts
+++ b/tgui/packages/tgui/interfaces/Apc/util.ts
@@ -6,7 +6,7 @@
  */
 
 import { BooleanLike } from 'common/react';
-import type { ApcData, ApcInterfaceData, ApcAccessPanelData } from './types';
+import type { ApcAccessPanelData, ApcData, ApcInterfaceData } from './types';
 import { InterfaceType } from './types';
 
 export const formatWatts = (watts: number | undefined) => `${isNaN(watts) ? 0 : Math.floor(watts)} W`;

--- a/tgui/packages/tgui/interfaces/ArtifactPaper.js
+++ b/tgui/packages/tgui/interfaces/ArtifactPaper.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Button, Section, Flex, TextArea } from '../components';
+import { Button, Flex, Section, TextArea } from '../components';
 import { Window } from '../layouts';
 
 export const ArtifactPaper = (props, context) => {

--- a/tgui/packages/tgui/interfaces/AutoInjector.js
+++ b/tgui/packages/tgui/interfaces/AutoInjector.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from "../backend";
-import { Button, Section, Slider, Dropdown, Box } from "../components";
+import { Box, Button, Dropdown, Section, Slider } from "../components";
 import { Window } from '../layouts';
 import { ReagentGraph, ReagentList } from './common/ReagentInfo';
 

--- a/tgui/packages/tgui/interfaces/BarcodeComputer.js
+++ b/tgui/packages/tgui/interfaces/BarcodeComputer.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { Button, NumberInput, Section, Box, Stack } from '../components';
+import { Box, Button, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 const BarcodeComputerSection = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Boardgame/Components/board/index.tsx
+++ b/tgui/packages/tgui/interfaces/Boardgame/Components/board/index.tsx
@@ -1,5 +1,5 @@
 import { HorizontalNotations, VerticalNotations } from '../';
-import { Flex, Box } from '../../../../components';
+import { Box, Flex } from '../../../../components';
 import { BoardgameData } from '../../utils';
 import { useBackend } from '../../../../backend';
 import { useActions } from '../../utils';

--- a/tgui/packages/tgui/interfaces/Boardgame/Components/common/TitleBar.tsx
+++ b/tgui/packages/tgui/interfaces/Boardgame/Components/common/TitleBar.tsx
@@ -1,7 +1,7 @@
 import { useBackend } from '../../../../backend';
 import { Box, Button } from '../../../../components';
 import { ButtonConfirm } from './ButtonConfirm';
-import { useActions, useStates, BoardgameData } from '../../utils';
+import { BoardgameData, useActions, useStates } from '../../utils';
 
 export const TitleBar = (props, context) => {
   const { act } = useBackend<BoardgameData>(context);

--- a/tgui/packages/tgui/interfaces/Boardgame/index.tsx
+++ b/tgui/packages/tgui/interfaces/Boardgame/index.tsx
@@ -3,8 +3,8 @@ import { useBackend } from '../../backend';
 import { adjustSizes, handleEvents } from './utils/window';
 import { Component } from 'inferno';
 
-import { Icon, Box, Dimmer } from '../../components';
-import { useStates, BoardgameData } from './utils';
+import { Box, Dimmer, Icon } from '../../components';
+import { BoardgameData, useStates } from './utils';
 import { TitleBar } from './Components/common/TitleBar';
 import { HeldPieceRenderer } from './Components/common/HeldPieceRenderer';
 import { BoardgameContents } from './Components/common/BoardgameContents';

--- a/tgui/packages/tgui/interfaces/Boardgame/utils/useStates.ts
+++ b/tgui/packages/tgui/interfaces/Boardgame/utils/useStates.ts
@@ -1,5 +1,5 @@
 import { useLocalState } from '../../../backend';
-import { XYType, TileSizeType, PalleteExpandType } from '.';
+import { PalleteExpandType, TileSizeType, XYType } from '.';
 
 export const DEFAULT_STATES = {
   // TODO: add more default states here

--- a/tgui/packages/tgui/interfaces/BugReportForm.js
+++ b/tgui/packages/tgui/interfaces/BugReportForm.js
@@ -5,7 +5,7 @@
  */
 
 import { useBackend, useLocalState } from '../backend';
-import { Flex, Section, Input } from '../components';
+import { Flex, Input, Section } from '../components';
 import { ButtonCheckbox } from '../components/Button';
 import { Window } from '../layouts';
 

--- a/tgui/packages/tgui/interfaces/CAViewer.js
+++ b/tgui/packages/tgui/interfaces/CAViewer.js
@@ -4,7 +4,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Button, Flex, Section, Dropdown, NumberInput } from '../components';
+import { Box, Button, Dropdown, Flex, NumberInput, Section } from '../components';
 import { Window } from '../layouts';
 
 export const CAViewer = (props, context) => {

--- a/tgui/packages/tgui/interfaces/ChemChute/index.tsx
+++ b/tgui/packages/tgui/interfaces/ChemChute/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../../backend';
-import { Flex, Box, Section } from '../../components';
+import { Box, Flex, Section } from '../../components';
 import { Window } from '../../layouts';
 import { ChemChuteData } from './type';
 

--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -6,10 +6,10 @@
 */
 
 import { BooleanLike } from "common/react";
-import { useBackend, useSharedState, useLocalState } from "../backend";
-import { AnimatedNumber, Button, NumberInput, Section, Box, Table, Icon, Tabs, Input, Modal } from "../components";
+import { useBackend, useLocalState, useSharedState } from "../backend";
+import { AnimatedNumber, Box, Button, Icon, Input, Modal, NumberInput, Section, Table, Tabs } from "../components";
 import { Window } from "../layouts";
-import { ReagentGraph, ReagentContainer, Reagent, ReagentList, MatterStateIconMap } from "./common/ReagentInfo";
+import { MatterStateIconMap, Reagent, ReagentContainer, ReagentGraph, ReagentList } from "./common/ReagentInfo";
 import { getTemperatureColor, getTemperatureIcon } from './common/temperatureUtils';
 
 type ChemDispenserData = {

--- a/tgui/packages/tgui/interfaces/ChemHeater.js
+++ b/tgui/packages/tgui/interfaces/ChemHeater.js
@@ -9,7 +9,7 @@ import { classes } from 'common/react';
 import { useBackend } from "../backend";
 import { AnimatedNumber, Box, Button, Dimmer, Icon, Knob, Section, SectionEx, Stack } from '../components';
 import { Window } from '../layouts';
-import { freezeTemperature, getTemperatureColor, getTemperatureIcon, getTemperatureChangeName } from './common/temperatureUtils';
+import { freezeTemperature, getTemperatureChangeName, getTemperatureColor, getTemperatureIcon } from './common/temperatureUtils';
 import { NoContainer, ReagentGraph, ReagentList } from './common/ReagentInfo';
 
 export const ChemHeater = (props, context) => {

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -6,10 +6,10 @@
  */
 
 import { useBackend } from "../backend";
-import { LabeledControls, Input, Box, NumberInput, Button, Dimmer, Image, SectionEx, Stack, Modal } from '../components';
+import { Box, Button, Dimmer, Image, Input, LabeledControls, Modal, NumberInput, SectionEx, Stack } from '../components';
 import { Window } from '../layouts';
 import { NoContainer, ReagentGraph, ReagentList } from './common/ReagentInfo';
-import { useSharedState, useLocalState } from "../backend";
+import { useLocalState, useSharedState } from "../backend";
 
 const ICON_LIST_PILLS = 0;
 const ICON_LIST_BOTTLES = 1;

--- a/tgui/packages/tgui/interfaces/ChemRequestReceiver.js
+++ b/tgui/packages/tgui/interfaces/ChemRequestReceiver.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend, useLocalState } from '../backend';
-import { Button, Section, Flex, Box, Stack, Tabs, Icon } from '../components';
+import { Box, Button, Flex, Icon, Section, Stack, Tabs } from '../components';
 import { Window } from '../layouts';
 
 import { capitalize } from '../../common/string';

--- a/tgui/packages/tgui/interfaces/ChemRequester.js
+++ b/tgui/packages/tgui/interfaces/ChemRequester.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend, useLocalState } from '../backend';
-import { Button, Input, Section, Stack, NumberInput, LabeledList } from '../components';
+import { Button, Input, LabeledList, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { capitalize } from '../../common/string';
 import { ListSearch } from './common/ListSearch';

--- a/tgui/packages/tgui/interfaces/ClothingBooth/index.tsx
+++ b/tgui/packages/tgui/interfaces/ClothingBooth/index.tsx
@@ -1,6 +1,6 @@
 import { classes } from 'common/react';
 import { useBackend, useLocalState } from '../../backend';
-import { Box, Button, Divider, Dropdown, Section, Stack, Image } from '../../components';
+import { Box, Button, Divider, Dropdown, Image, Section, Stack } from '../../components';
 import { Window } from '../../layouts';
 import { ClothingBoothData } from './type';
 

--- a/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
+++ b/tgui/packages/tgui/interfaces/ColorMatrixEditor.tsx
@@ -8,7 +8,7 @@
 
 import { useBackend } from '../backend';
 import { toFixed } from 'common/math';
-import { Box, Stack, Section, ByondUi, NumberInput, Button } from '../components';
+import { Box, Button, ByondUi, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 interface ColorMatrixEditorData {

--- a/tgui/packages/tgui/interfaces/ColorPickerModal.tsx
+++ b/tgui/packages/tgui/interfaces/ColorPickerModal.tsx
@@ -6,7 +6,7 @@
 
 import { Loader } from './common/Loader';
 import { useBackend, useLocalState } from '../backend';
-import { Autofocus, Box, Flex, Section, Stack, Pointer, NumberInput, Tooltip } from '../components';
+import { Autofocus, Box, Flex, NumberInput, Pointer, Section, Stack, Tooltip } from '../components';
 import { Window } from '../layouts';
 import { clamp } from 'common/math';
 import { hexToHsva, HsvaColor, hsvaToHex, hsvaToHslString, hsvaToRgba, rgbaToHsva, validHex } from 'common/color';

--- a/tgui/packages/tgui/interfaces/ContributorRewards.js
+++ b/tgui/packages/tgui/interfaces/ContributorRewards.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Button, Collapsible, Box, Section } from '../components';
+import { Box, Button, Collapsible, Section } from '../components';
 import { Window } from '../layouts';
 
 export const ContributorRewards = (_props, context) => {

--- a/tgui/packages/tgui/interfaces/CryoCell.js
+++ b/tgui/packages/tgui/interfaces/CryoCell.js
@@ -6,11 +6,11 @@
  */
 
 import { useBackend } from "../backend";
-import { Button, Box, Icon, AnimatedNumber, Section, LabeledList, ProgressBar, Dimmer } from "../components";
+import { AnimatedNumber, Box, Button, Dimmer, Icon, LabeledList, ProgressBar, Section } from "../components";
 import { Window } from '../layouts';
 import { getTemperatureColor, getTemperatureIcon } from './common/temperatureUtils';
 import { ReagentGraph, ReagentList } from './common/ReagentInfo';
-import { HealthStat, damageNum } from './common/HealthStat';
+import { damageNum, HealthStat } from './common/HealthStat';
 import { MobStatuses } from './common/MobStatus';
 import { KeyHealthIndicators } from './common/KeyHealthIndicators/index';
 

--- a/tgui/packages/tgui/interfaces/DJPanel.js
+++ b/tgui/packages/tgui/interfaces/DJPanel.js
@@ -8,7 +8,7 @@
 import { toFixed } from 'common/math';
 import { truncate } from '../format.js';
 import { useBackend } from '../backend';
-import { Button, Divider, NoticeBox, Section, Box, Knob, LabeledControls, Icon, NumberInput } from '../components';
+import { Box, Button, Divider, Icon, Knob, LabeledControls, NoticeBox, NumberInput, Section } from '../components';
 import { Window } from '../layouts';
 
 export const DJPanel = (props, context) => {

--- a/tgui/packages/tgui/interfaces/DyeDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/DyeDispenser.tsx
@@ -7,9 +7,9 @@
 
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Stack, Button, Dimmer, ColorBox } from '../components';
+import { Button, ColorBox, Dimmer, Stack } from '../components';
 import { ColorSelector } from './ColorPickerModal';
-import { HsvaColor, hexToHsva, hsvaToHex } from 'common/color';
+import { hexToHsva, HsvaColor, hsvaToHex } from 'common/color';
 
 type DyeDispenserParams = {
   bottle: boolean,

--- a/tgui/packages/tgui/interfaces/Elevator.tsx
+++ b/tgui/packages/tgui/interfaces/Elevator.tsx
@@ -7,7 +7,7 @@
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
-import { Section, Button } from '../components';
+import { Button, Section } from '../components';
 
 type ElevatorParams = {
   location: string,

--- a/tgui/packages/tgui/interfaces/EngineStats.js
+++ b/tgui/packages/tgui/interfaces/EngineStats.js
@@ -6,10 +6,10 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Chart, Modal, Section, Stack, Button } from '../components';
+import { Box, Button, Chart, Modal, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { formatSiUnit } from '../format';
-import { processStatsData, getStatsMax } from './common/graphUtils';
+import { getStatsMax, processStatsData } from './common/graphUtils';
 
 /**
  * Generates stack items of labeled charts for display

--- a/tgui/packages/tgui/interfaces/EspressoMachine.js
+++ b/tgui/packages/tgui/interfaces/EspressoMachine.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Button, Flex, Section, Box, NoticeBox, Tooltip } from '../components';
+import { Box, Button, Flex, NoticeBox, Section, Tooltip } from '../components';
 import { Window } from '../layouts';
 
 export const DrinksList = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Flamethrower.js
+++ b/tgui/packages/tgui/interfaces/Flamethrower.js
@@ -1,8 +1,8 @@
 import { useBackend } from '../backend';
 import { PortableHoldingTank } from './common/PortableAtmos';
-import { Button, Stack, Knob, Box, Icon, AnimatedNumber, Section, NumberInput } from '../components';
+import { AnimatedNumber, Box, Button, Icon, Knob, NumberInput, Section, Stack } from '../components';
 import { ReagentBar } from './common/ReagentInfo';
-import { getTemperatureColor, getTemperatureIcon, freezeTemperature } from './common/temperatureUtils';
+import { freezeTemperature, getTemperatureColor, getTemperatureIcon } from './common/temperatureUtils';
 import { Window } from '../layouts';
 
 const PilotLight = (props, context) => {

--- a/tgui/packages/tgui/interfaces/FlockPanel.js
+++ b/tgui/packages/tgui/interfaces/FlockPanel.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend, useLocalState } from "../backend";
-import { Tooltip, Button, Stack, Tabs, Icon, Box, Section, Dropdown } from "../components";
+import { Box, Button, Dropdown, Icon, Section, Stack, Tabs, Tooltip } from "../components";
 import { Window } from '../layouts';
 
 const FlockPartitions = (props, context) => {

--- a/tgui/packages/tgui/interfaces/FlockStructures.js
+++ b/tgui/packages/tgui/interfaces/FlockStructures.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Section, Image, Stack } from '../components';
+import { Image, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const FlockStructures = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Freezer.tsx
+++ b/tgui/packages/tgui/interfaces/Freezer.tsx
@@ -1,6 +1,6 @@
 import { useBackend } from '../backend';
 import { getTemperatureColor, getTemperatureIcon } from './common/temperatureUtils';
-import { Box, Button, Knob, Section, Stack, Icon, AnimatedNumber } from '../components';
+import { AnimatedNumber, Box, Button, Icon, Knob, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { formatPressure } from '../format';
 

--- a/tgui/packages/tgui/interfaces/GimmickObject.js
+++ b/tgui/packages/tgui/interfaces/GimmickObject.js
@@ -4,7 +4,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Button, Flex, NumberInput, LabeledList, Input, Section, Tooltip } from '../components';
+import { Box, Button, Flex, Input, LabeledList, NumberInput, Section, Tooltip } from '../components';
 import { Window } from '../layouts';
 
 export const GimmickObject = (props, context) => {

--- a/tgui/packages/tgui/interfaces/IDComputer.js
+++ b/tgui/packages/tgui/interfaces/IDComputer.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from "../backend";
-import { Button, Tabs, Section, NoticeBox, LabeledList, Image, Box, Divider, Stack } from "../components";
+import { Box, Button, Divider, Image, LabeledList, NoticeBox, Section, Stack, Tabs } from "../components";
 import { Window } from '../layouts';
 
 const DeptBox = (props, context) => {

--- a/tgui/packages/tgui/interfaces/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputModal.tsx
@@ -8,7 +8,7 @@
 import { Loader } from './common/Loader';
 import { InputButtons } from './common/InputButtons';
 import { Button, Input, Section, Stack } from '../components';
-import { KEY_A, KEY_DOWN, KEY_ESCAPE, KEY_ENTER, KEY_UP, KEY_Z, KEY_PAGEUP, KEY_PAGEDOWN, KEY_END, KEY_HOME, KEY_TAB } from 'common/keycodes';
+import { KEY_A, KEY_DOWN, KEY_END, KEY_ENTER, KEY_ESCAPE, KEY_HOME, KEY_PAGEDOWN, KEY_PAGEUP, KEY_TAB, KEY_UP, KEY_Z } from 'common/keycodes';
 import { Window } from '../layouts';
 import { useBackend, useLocalState } from '../backend';
 

--- a/tgui/packages/tgui/interfaces/LocalGenerator/index.tsx
+++ b/tgui/packages/tgui/interfaces/LocalGenerator/index.tsx
@@ -7,7 +7,7 @@
 
 import { useBackend } from '../../backend';
 import { Window } from '../../layouts';
-import { Section, Stack, Button, Box, ProgressBar } from '../../components';
+import { Box, Button, ProgressBar, Section, Stack } from '../../components';
 import { PortableHoldingTank } from '../common/PortableAtmos';
 import { LocalGeneratorData } from './type';
 

--- a/tgui/packages/tgui/interfaces/MechanicalDropper.js
+++ b/tgui/packages/tgui/interfaces/MechanicalDropper.js
@@ -4,10 +4,10 @@ import { ReagentBar } from './common/ReagentInfo';
 import { clamp, round } from 'common/math';
 
 import {
-  Stack,
   Button,
   Section,
   Slider,
+  Stack,
   Tabs,
 } from '../components';
 

--- a/tgui/packages/tgui/interfaces/NuclearReactor.js
+++ b/tgui/packages/tgui/interfaces/NuclearReactor.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Button, Knob, Box, Section, Table, RoundGauge } from '../components';
+import { Box, Button, Knob, RoundGauge, Section, Table } from '../components';
 import { Window } from '../layouts';
 import { Flex } from '../components';
 import { capitalize } from './common/stringUtils';

--- a/tgui/packages/tgui/interfaces/ObserverMenu.tsx
+++ b/tgui/packages/tgui/interfaces/ObserverMenu.tsx
@@ -1,6 +1,6 @@
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Button, Input, Section, Collapsible, BlockQuote, Flex } from '../components';
+import { BlockQuote, Button, Collapsible, Flex, Input, Section } from '../components';
 
 
 type Observable = {

--- a/tgui/packages/tgui/interfaces/OperatingComputer/index.tsx
+++ b/tgui/packages/tgui/interfaces/OperatingComputer/index.tsx
@@ -1,25 +1,25 @@
 
 import { useBackend, useSharedState } from '../../backend';
-import { Box, ColorBox, Chart, Section, Stack, Tabs, Table } from '../../components';
+import { Box, Chart, ColorBox, Section, Stack, Table, Tabs } from '../../components';
 import { Window } from '../../layouts';
 import { HealthStat } from '../common/HealthStat';
 import { COLORS } from '../../constants';
 import { ReagentGraph } from '../common/ReagentInfo';
-import { processStatsData, getStatsMax } from '../common/graphUtils';
+import { getStatsMax, processStatsData } from '../common/graphUtils';
 import { capitalize, spaceUnderscores } from '../common/stringUtils';
 import { KeyHealthIndicators } from '../common/KeyHealthIndicators/index';
 import {
+  DisplayAnatomicalAnomoliesProps,
+  DisplayBloodstreamContentProps,
+  DisplayGeneticAnalysisProps,
+  DisplayLimbProps,
+  DisplayLimbsProps,
+  DisplayOrgansProps,
+  LimbData,
   OperatingComputerData,
   OperatingComputerDisplayTitleProps,
-  PatientSummaryProps,
-  DisplayBloodstreamContentProps,
-  DisplayAnatomicalAnomoliesProps,
-  DisplayGeneticAnalysisProps,
   OrganData,
-  DisplayLimbsProps,
-  DisplayLimbProps,
-  LimbData,
-  DisplayOrgansProps,
+  PatientSummaryProps,
 } from './type';
 
 export const OperatingComputer = (props, context) => {

--- a/tgui/packages/tgui/interfaces/OperatingComputer/type.ts
+++ b/tgui/packages/tgui/interfaces/OperatingComputer/type.ts
@@ -1,5 +1,5 @@
 import { BooleanLike } from 'common/react';
-import { EmbeddedObjects, DisplayOccupiedProps, BrainDamageData } from '../common/KeyHealthIndicators/type';
+import { BrainDamageData, DisplayOccupiedProps, EmbeddedObjects } from '../common/KeyHealthIndicators/type';
 export interface OperatingComputerData {
   occupied: BooleanLike
 

--- a/tgui/packages/tgui/interfaces/PaperSheet.js
+++ b/tgui/packages/tgui/interfaces/PaperSheet.js
@@ -10,7 +10,7 @@ import { resolveAsset } from '../assets';
 import { Component } from 'inferno';
 import marked from 'marked';
 import { useBackend } from '../backend';
-import { Box, Flex, Tabs, TextArea, Table } from '../components';
+import { Box, Flex, Table, Tabs, TextArea } from '../components';
 import { Window } from '../layouts';
 import { clamp } from 'common/math';
 import { sanitizeText } from '../sanitize';

--- a/tgui/packages/tgui/interfaces/Phone/index.tsx
+++ b/tgui/packages/tgui/interfaces/Phone/index.tsx
@@ -9,7 +9,7 @@ import { useBackend } from '../../backend';
 import { Button, Collapsible, Dimmer, LabeledList, Section, Stack } from '../../components';
 import { capitalize } from '../common/stringUtils';
 import { Window } from '../../layouts';
-import { PhoneData, Phonebook } from './type';
+import { Phonebook, PhoneData } from './type';
 
 const CategoryColors = [
   { department: 'bridge', color: 'green' },

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend, useLocalState } from '../backend';
-import { Button, Section, Stack, Box, NumberInput, Image } from '../components';
+import { Box, Button, Image, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const PipeDispenser = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Plantmaster.js
+++ b/tgui/packages/tgui/interfaces/Plantmaster.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend, useLocalState } from "../backend";
-import { Button, Dimmer, Divider, Flex, NumberInput, Section, Box, Tabs, SectionEx, Table } from '../components';
+import { Box, Button, Dimmer, Divider, Flex, NumberInput, Section, SectionEx, Table, Tabs } from '../components';
 import { Window } from '../layouts';
 import { Fragment } from 'inferno';
 import { NoContainer, ReagentGraph, ReagentList } from './common/ReagentInfo';

--- a/tgui/packages/tgui/interfaces/PlayerPanel/Header.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPanel/Header.tsx
@@ -6,7 +6,7 @@
  */
 
 import { InfernoNode } from 'inferno';
-import { Stack, Icon } from '../../components';
+import { Icon, Stack } from '../../components';
 import { SortDirection } from './constant';
 
 interface HeaderProps {

--- a/tgui/packages/tgui/interfaces/PortablePump.js
+++ b/tgui/packages/tgui/interfaces/PortablePump.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Button, NumberInput, LabeledList, Divider } from '../components';
+import { Button, Divider, LabeledList, NumberInput } from '../components';
 import { Window } from '../layouts';
 import { PortableBasicInfo, PortableHoldingTank } from './common/PortableAtmos';
 

--- a/tgui/packages/tgui/interfaces/PortableScrubber.js
+++ b/tgui/packages/tgui/interfaces/PortableScrubber.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Button, NumberInput, LabeledList, Divider, Section } from '../components';
+import { Button, Divider, LabeledList, NumberInput, Section } from '../components';
 import { Window } from '../layouts';
 import { PortableBasicInfo, PortableHoldingTank } from './common/PortableAtmos';
 import { ReagentGraph } from './common/ReagentInfo';

--- a/tgui/packages/tgui/interfaces/Precipitation.js
+++ b/tgui/packages/tgui/interfaces/Precipitation.js
@@ -5,7 +5,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Button, NumberInput, Tooltip, Section } from '../components';
+import { Box, Button, NumberInput, Section, Tooltip } from '../components';
 import { Window } from '../layouts';
 import { ReagentList } from './common/ReagentInfo';
 

--- a/tgui/packages/tgui/interfaces/ReagentExtractor.js
+++ b/tgui/packages/tgui/interfaces/ReagentExtractor.js
@@ -5,7 +5,7 @@
  * @license ISC
  */
 
-import { useBackend, useSharedState, useLocalState } from "../backend";
+import { useBackend, useLocalState, useSharedState } from "../backend";
 import { Button, Dimmer, Divider, Flex, NumberInput, Section, SectionEx, Stack } from '../components';
 import { Window } from '../layouts';
 import { Fragment } from 'inferno';

--- a/tgui/packages/tgui/interfaces/Rockbox.js
+++ b/tgui/packages/tgui/interfaces/Rockbox.js
@@ -1,6 +1,6 @@
 import { Fragment } from 'inferno';
 import { useBackend, useLocalState } from '../backend';
-import { Button, Box, Divider, NumberInput, Section, Stack, Tooltip, Table } from '../components';
+import { Box, Button, Divider, NumberInput, Section, Stack, Table, Tooltip } from '../components';
 import { ButtonCheckbox } from '../components/Button';
 import { Window } from '../layouts';
 

--- a/tgui/packages/tgui/interfaces/SecureSafe.js
+++ b/tgui/packages/tgui/interfaces/SecureSafe.js
@@ -7,7 +7,7 @@
 
 
 import { useBackend } from '../backend';
-import { Stack, Box, Section, Flex, Button } from '../components';
+import { Box, Button, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 import { capitalize, glitch } from './common/stringUtils';

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Button, Flex, Icon, LabeledList, Knob, ProgressBar, Section, TimeDisplay } from '../components';
+import { Box, Button, Flex, Icon, Knob, LabeledList, ProgressBar, Section, TimeDisplay } from '../components';
 import { Window } from '../layouts';
 import { formatTime } from '../format';
 import { HealthStat } from './common/HealthStat';

--- a/tgui/packages/tgui/interfaces/SpendSpacebux.js
+++ b/tgui/packages/tgui/interfaces/SpendSpacebux.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { BlockQuote, Box, Button, Divider, Flex, Stack, Section } from '../components';
+import { BlockQuote, Box, Button, Divider, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 const SBPurchaseEntry = (props) => {

--- a/tgui/packages/tgui/interfaces/TEG.js
+++ b/tgui/packages/tgui/interfaces/TEG.js
@@ -6,7 +6,7 @@
  */
 
 import { useBackend } from '../backend';
-import { Box, Chart, LabeledList, Section, Divider } from '../components';
+import { Box, Chart, Divider, LabeledList, Section } from '../components';
 import { formatPower, formatSiUnit } from '../format';
 import { Window } from '../layouts';
 

--- a/tgui/packages/tgui/interfaces/Terminal/InputAndButtonsSection.tsx
+++ b/tgui/packages/tgui/interfaces/Terminal/InputAndButtonsSection.tsx
@@ -7,7 +7,7 @@
 
 import { useBackend } from '../../backend';
 import { TerminalData } from './types';
-import { Section, Flex, Input, Tooltip, Button } from '../../components';
+import { Button, Flex, Input, Section, Tooltip } from '../../components';
 
 export const InputAndButtonsSection = (_props, context) => {
   const { act, data } = useBackend<TerminalData>(context);

--- a/tgui/packages/tgui/interfaces/Terminal/PheripheralsSection.tsx
+++ b/tgui/packages/tgui/interfaces/Terminal/PheripheralsSection.tsx
@@ -7,7 +7,7 @@
 
 import { useBackend } from '../../backend';
 import { TerminalData } from './types';
-import { Section, Button } from '../../components';
+import { Button, Section } from '../../components';
 
 export const PheripheralsSection = (_props, context) => {
   const { act, data } = useBackend<TerminalData>(context);

--- a/tgui/packages/tgui/interfaces/Terminal/TerminalOutputSection.tsx
+++ b/tgui/packages/tgui/interfaces/Terminal/TerminalOutputSection.tsx
@@ -7,7 +7,7 @@
 
 import { useBackend } from '../../backend';
 import { TerminalData, TerminalOutputSectionProps } from './types';
-import { Section, Box } from '../../components';
+import { Box, Section } from '../../components';
 
 export const TerminalOutputSection = (props: TerminalOutputSectionProps, context) => {
   const { data } = useBackend<TerminalData>(context);

--- a/tgui/packages/tgui/interfaces/TransitShuttle.js
+++ b/tgui/packages/tgui/interfaces/TransitShuttle.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Section, Divider, Button, Table, BlockQuote } from '../components';
+import { BlockQuote, Button, Divider, Section, Table } from '../components';
 import { Window } from '../layouts';
 
 export const TransitShuttle = (props, context) => {

--- a/tgui/packages/tgui/interfaces/TrscArray.js
+++ b/tgui/packages/tgui/interfaces/TrscArray.js
@@ -6,10 +6,10 @@ import {
   Button,
   Divider,
   Flex,
-  Slider,
-  Section,
   Image,
   ProgressBar,
+  Section,
+  Slider,
 } from '../components';
 import { formatPower } from '../format';
 

--- a/tgui/packages/tgui/interfaces/TurbineControl.js
+++ b/tgui/packages/tgui/interfaces/TurbineControl.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Chart, LabeledList, Stack, NumberInput } from '../components';
+import { Chart, LabeledList, NumberInput, Stack } from '../components';
 import { formatPower } from '../format';
 import { Window } from '../layouts';
 

--- a/tgui/packages/tgui/interfaces/TurretControl.js
+++ b/tgui/packages/tgui/interfaces/TurretControl.js
@@ -1,6 +1,6 @@
 import { Window } from '../layouts';
 import { useBackend } from '../backend';
-import { Button, Section, Box, Stack } from '../components';
+import { Box, Button, Section, Stack } from '../components';
 import { randInt } from './common/mathUtils';
 import { glitch } from './common/stringUtils';
 

--- a/tgui/packages/tgui/interfaces/Vendors.js
+++ b/tgui/packages/tgui/interfaces/Vendors.js
@@ -1,6 +1,6 @@
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
-import { Box, Button, Section, Image } from 'tgui/components';
+import { Box, Button, Image, Section } from 'tgui/components';
 import { Collapsible, Divider, Flex, LabeledList, Stack } from '../components';
 import { VendorCashTable } from './common/VendorCashTable';
 

--- a/tgui/packages/tgui/interfaces/common/HealthStat.js
+++ b/tgui/packages/tgui/interfaces/common/HealthStat.js
@@ -7,7 +7,7 @@
 
 import { classes } from 'common/react';
 import { COLORS } from '../../constants';
-import { computeBoxClassName, Box } from '../../components/Box';
+import { Box, computeBoxClassName } from '../../components/Box';
 
 /*
  * A box that applies a color to its contents depending on the damage type.

--- a/tgui/packages/tgui/interfaces/common/KeyHealthIndicators/index.tsx
+++ b/tgui/packages/tgui/interfaces/common/KeyHealthIndicators/index.tsx
@@ -1,10 +1,10 @@
-import { Table, Box } from "../../../components";
+import { Box, Table } from "../../../components";
 import { pluralize } from '../stringUtils';
 import {
-  DisplayTempImplantRowProps,
-  DisplayTemperatureProps,
   DisplayBloodPressureProps,
   DisplayBrainProps,
+  DisplayTemperatureProps,
+  DisplayTempImplantRowProps,
 } from './type';
 
 export const KeyHealthIndicators = props => {

--- a/tgui/packages/tgui/interfaces/common/ReagentInfo.tsx
+++ b/tgui/packages/tgui/interfaces/common/ReagentInfo.tsx
@@ -5,7 +5,7 @@
  * @license ISC
  */
 
-import { Box, ColorBox, Flex, Icon, NoticeBox, Section, Tooltip, Stack, ProgressBar } from '../../components';
+import { Box, ColorBox, Flex, Icon, NoticeBox, ProgressBar, Section, Stack, Tooltip } from '../../components';
 import { freezeTemperature } from './temperatureUtils';
 import { BoxProps } from '../../components/Box';
 import { BooleanLike } from 'common/react';

--- a/tgui/packages/tgui/interfaces/common/ReleaseValve.js
+++ b/tgui/packages/tgui/interfaces/common/ReleaseValve.js
@@ -5,7 +5,7 @@
 * @license MIT
 */
 
-import { NumberInput, LabeledList, Button } from '../../components';
+import { Button, LabeledList, NumberInput } from '../../components';
 
 export const ReleaseValve = props => {
 

--- a/tgui/packages/tgui/interfaces/common/VendorCashTable.tsx
+++ b/tgui/packages/tgui/interfaces/common/VendorCashTable.tsx
@@ -5,7 +5,7 @@
  * @license ISC
  */
 
-import { Table, Button } from '../../components';
+import { Button, Table } from '../../components';
 
 interface VendorCashTableProps {
   cardname: string,


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables the [sort-imports](https://eslint.org/docs/latest/rules/sort-imports) rule to lets us validate and automatically fix imports in alphabetical order.
After having enabled the rule with `ignoreCase` and ran a `tgui.bat --fix`, most of the files corrected were ours (not upstream code,) which seems to indicate to me that this is a good idea.
`ignoreDeclarationSort` is set to true because import declaration sorting errors don't get automatically fixed and they would be a pain to fix everywhere, *and* are plentiful in upstream code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Better code quality, looking at #15993 made me realize that alphabetically sorted imports were preferred over just winging it.

[Internal][Code Quality]