### PR TITLE
Add crystal bazaar to RDir pda: fix #16063

### DIFF
--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -136,6 +136,7 @@ TYPEINFO(/obj/item/disk/data/cartridge/syndicate)
 			src.root.add_file( new /datum/computer/file/pda_program/signaler(src))
 			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portasci(src))
+			src.root.add_file( new /datum/computer/file/pda_program/pressure_crystal_shopper(src))
 			src.read_only = 1
 
 	medical_director


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the program to RDir pda (they didn't get it, only scientists did). Fixes #16063


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oopsie I forgot


