### PR TITLE
fix bald trait not updating hair properly

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -680,6 +680,7 @@ var/global/totally_random_jobs = FALSE
 		src.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
 		src.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
 		src.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+		src.update_colorful_parts()
 	else if (src.traitHolder && src.traitHolder.hasTrait("loyalist"))
 		trinket = new/obj/item/clothing/head/NTberet(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("petasusaphilic"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #15988 
this was caused by #15780

I am not 100% sure if update_colorful_parts() is the best thing to use here or if there is a lesser proc just for hair that should be used instead?
Also, the barber code seems to also call set_clothing_icon_dirty() after changing hair, but I am not sure if this is actually necessary?

Anyway, this seems to fix the bug with the hair still appearing.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the people demand baldness