### PR TITLE
makes plantpots open containers for the purposes of inputting chems

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -216,7 +216,7 @@ TYPEINFO(/obj/machinery/plantpot)
 	density = 1
 	event_handler_flags = null
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
-	flags = NOSPLASH|ACCEPTS_MOUSEDROP_REAGENTS
+	flags = NOSPLASH | ACCEPTS_MOUSEDROP_REAGENTS | OPENCONTAINER
 	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS
 	power_usage = 25
@@ -365,6 +365,9 @@ TYPEINFO(/obj/machinery/plantpot)
 		..()
 		src.do_update_water_icon = 1
 		src.update_water_level()
+
+	is_open_container(input = FALSE)
+		. = input && ..()
 
 	power_change()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #16073

This was not an issue before due to the botanical mister check having a bug until 3724ac5267825ed62b657954daadbd734cca1c25 fixed it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So that the botanical mister works on plant trays again.
This shouldn't have any balance issues due to not being able to remove chems with this, only put them in. (hopefully)