### PR TITLE
Allows musicians to change their names

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2757,6 +2757,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	items_in_backpack = list(/obj/item/instrument/saxophone,/obj/item/instrument/guitar,/obj/item/instrument/bagpipe,/obj/item/instrument/fiddle)
+	change_name_on_spawn = 1
 
 /datum/job/battler
 	name = "Battler"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Small pr that lets musicians choose their own stagename


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Musicians often have theatrical stagenames to fit the aesthetic they are trying to portray (ringo starr is not infact called ringo starr)