### PR TITLE
Fix missing button for Brig access on ID computer

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -423,6 +423,8 @@ var/list/access_name_lookup //Generated at round start.
 	switch(A)
 		if(access_cargo)
 			return "Cargo Bay"
+		if(access_brig)
+			return "Brig"
 		if(access_security)
 			return "Security"
 		if(access_forensics_lockers)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

At some point (possibly when TGUI ID computer got merged) there stopped being a button to toggle Brig access on IDs because it was missing an entry in get_access_desc()

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When I give myself all access I mean all access

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) The ID computer should now let you add/remove Brig access as normal.
```
