### PR TITLE
Fixes #16054 - Pod Seeking Launchers Now May Target Minisubs, Cars, And Similar

### DIFF
--- a/code/datums/components/smartgun_homing.dm
+++ b/code/datums/components/smartgun_homing.dm
@@ -37,7 +37,7 @@
 	type_to_target = /obj
 
 /datum/component/holdertargeting/smartgun/homing/pod/is_valid_target(mob/user, atom/A)
-	return ((istype(A, /obj/critter/gunbot/drone) || istype(A, /obj/machinery/vehicle/miniputt) || istype(A, /obj/machinery/vehicle/pod_smooth)) && !A.invisibility)
+	return ((istype(A, /obj/critter/gunbot/drone) || istype(A, /obj/machinery/vehicle/miniputt) || istype(A, /obj/machinery/vehicle/pod_smooth) || istype(A, /obj/machinery/vehicle/tank)) && !A.invisibility)
 
 /datum/component/holdertargeting/smartgun/homing/pod/track_targets(mob/user)
 	set waitfor = 0

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1544,7 +1544,7 @@ datum/projectile/bullet/autocannon
 				boutput(M, pod.ship_message(message))
 
 	on_hit(atom/hit)
-		if (istype(hit, /obj/critter/gunbot/drone) || istype(hit, /obj/machinery/vehicle/miniputt) || istype(hit, /obj/machinery/vehicle/pod_smooth))
+		if (istype(hit, /obj/critter/gunbot/drone) || istype(hit, /obj/machinery/vehicle/miniputt) || istype(hit, /obj/machinery/vehicle/pod_smooth)|| istype(hit, /obj/machinery/vehicle/tank))
 			explosion_new(null, get_turf(hit), 12)
 
 			if(istype(hit, /obj/machinery/vehicle))


### PR DESCRIPTION
[Bug] [Game Objects]


## About The PR:
Fixes #16054 by permitting pod seeking launchers and missiles to target objects of type `/obj/machinery/vehicle/tank`.