### PR TITLE
Add the HoP's golden crayon to Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4962,6 +4962,10 @@
 	pixel_x = -15
 	},
 /obj/machinery/firealarm/east,
+/obj/item/pen/crayon/golden{
+	pixel_y = 7;
+	pixel_x = -6
+	},
 /turf/simulated/floor/black,
 /area/station/bridge/hos{
 	name = "Head of Personnel's Quarters"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a golden crayon to the HoP's room  

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #15066
map parity