### PR TITLE
Cyborg teleport module draws cell charge just before teleporting

### DIFF
--- a/code/modules/robotics/robot/upgrade/teleporter.dm
+++ b/code/modules/robotics/robot/upgrade/teleporter.dm
@@ -3,7 +3,7 @@
 	desc = "A personal teleportation device that allows a cyborg to transport itself instantly to any teleporter beacon."
 	icon_state = "up-teleport"
 	active = TRUE
-	drainrate = 250
+	var/cell_drain_per_teleport = 250
 
 /obj/item/roboupgrade/teleport/upgrade_activate(var/mob/living/silicon/robot/user)
 	if (is_incapacitated(user))
@@ -61,6 +61,10 @@
 	if (!isturf(user.loc))
 		user.show_text("You can't teleport from inside a container.", "red")
 		return
+	if (user.cell.charge < src.cell_drain_per_teleport)
+		user.show_text("Your cell is too low.", "red")
+		return
 
+	user.cell.use(src.cell_drain_per_teleport)
 	showswirl_out(user, TRUE)
 	do_teleport(user, L[desc], 0)

--- a/code/modules/robotics/robot/upgrade/teleporter.dm
+++ b/code/modules/robotics/robot/upgrade/teleporter.dm
@@ -61,7 +61,7 @@
 	if (!isturf(user.loc))
 		user.show_text("You can't teleport from inside a container.", "red")
 		return
-	if (user.cell.charge < src.cell_drain_per_teleport)
+	if (!istype(user.cell) || (user.cell.charge < src.cell_drain_per_teleport))
 		user.show_text("Your cell is too low.", "red")
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

when using the teleport module, don't charge power against the cell unless the silicon can actually teleport

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
only charge for power that is used
fixes #10082
