### PR TITLE
Admin verb to spawn all of a type

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2529,4 +2529,4 @@ var/list/fun_images = list()
 	for (var/type as anything in spawn_matches)
 		new type(T)
 		total++
-	boutput(src, "Created [total] types.")
+	boutput(src, "Created [length(spawn_matches)] types.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2515,18 +2515,21 @@ var/list/fun_images = list()
 	set name = "Spawn All Of A Type"
 	set desc = "Creates one of every subtype instance of a type at your loc."
 	ADMIN_ONLY
-	var/total = 0
-	var/spawn_input = input("Enter path", "Enter Path") as null|text
+	var/spawn_input = input(src, "Enter path", "Enter Path") as null|text
 	var/spawn_path = get_one_match(spawn_input, /atom/movable, FALSE)
 	if (!spawn_path)
 		return
 	var/list/spawn_matches = concrete_typesof(spawn_path)
 	if (!length(spawn_matches))
 		return
+	if (length(spawn_matches) > 99)
+		var/response = input(src, "High number of types: [length(spawn_matches)] - Type YES to continue", "Caution!") as null|text
+		if (lowertext(response) != "yes")
+			return
 	var/turf/T = get_turf(usr)
 	if (!T)
 		return
 	for (var/type as anything in spawn_matches)
 		new type(T)
-		total++
+	logTheThing(LOG_ADMIN, src, "Created [length(spawn_matches)] types of: [spawn_path] at ([log_loc(usr)]")
 	boutput(src, "Created [length(spawn_matches)] types.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2526,8 +2526,7 @@ var/list/fun_images = list()
 	var/turf/T = get_turf(usr)
 	if (!T)
 		return
-	for (var/i = 1; i <= spawn_matches.len; i++)
-		var/obj/item/I = spawn_matches[i]
-		new I(T)
+	for (var/type as anything in spawn_matches)
+		new type(T)
 		total++
 	boutput(src, "Created [total] types.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -414,6 +414,7 @@ var/list/admin_verbs = list(
 		/client/proc/debug_image_deletions_clear,
 #endif
 		/client/proc/distribute_tokens,
+		/client/proc/spawn_all_type
 		),
 
 	7 = list(
@@ -2508,3 +2509,25 @@ var/list/fun_images = list()
 				client.set_antag_tokens(client.antag_tokens + 1)
 				break
 	boutput(src, "Roundstart antags given tokens: [total]")
+
+/client/proc/spawn_all_type()
+	SET_ADMIN_CAT(ADMIN_CAT_PLAYERS)
+	set name = "Spawn All Of A Type"
+	set desc = "Creates one of every subtype instance of a type at your loc."
+	ADMIN_ONLY
+	var/total = 0
+	var/spawn_input = input("Enter path", "Enter Path") as null|text
+	var/spawn_path = get_one_match(spawn_input, /atom/movable, FALSE)
+	if (!spawn_path)
+		return
+	var/list/spawn_matches = concrete_typesof(spawn_path)
+	if (!spawn_matches.len)
+		return
+	var/turf/T = get_turf(usr)
+	if (!T)
+		return
+	for (var/i = 1; i <= spawn_matches.len; i++)
+		var/obj/item/I = spawn_matches[i]
+		new I(T)
+		total++
+	boutput(src, "Created [total] types.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2516,6 +2516,8 @@ var/list/fun_images = list()
 	set desc = "Creates one of every subtype instance of a type at your loc."
 	ADMIN_ONLY
 	var/spawn_input = input(src, "Enter path", "Enter Path") as null|text
+	if (spawn_input == "")
+		return
 	var/spawn_path = get_one_match(spawn_input, /atom/movable, FALSE)
 	if (!spawn_path)
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2521,7 +2521,7 @@ var/list/fun_images = list()
 	if (!spawn_path)
 		return
 	var/list/spawn_matches = concrete_typesof(spawn_path)
-	if (!spawn_matches.len)
+	if (!length(spawn_matches))
 		return
 	var/turf/T = get_turf(usr)
 	if (!T)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)fri sep 29 23
+(u)Flappybat
+(*)New verb Spawn-All-Of-A-Type that creates all of a type.<br>Primarily intended for debugging, please exercise caution on a live server!
 (t)sat sep 23 23
 (u)pali
 (*)New verb Replace-Type that lets you replace a type with another type globally across the whole world.<br>Stuff just on the ground should work fine. Should also work ok for stuff like equipment and storage but other stuff like globally replacing organs or limbs is not yet fully supported.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add admin command to spawn all concrete subtypes of a type.
![image](https://github.com/goonstation/goonstation/assets/70909958/5d34c80c-1ac5-49eb-b3d2-dfa875ec1eb3)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly for testing purposes.
PR'd for sanity checking