### PR TITLE
Fix duplication on donut2 telesci pad

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -21980,16 +21980,6 @@
 /area/station/chapel/sanctuary)
 "cLH" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/networked/telepad,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/telepad,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -21998,6 +21988,7 @@
 	},
 /obj/cable,
 /mob/living/carbon/human/npc/monkey/albert,
+/obj/machinery/networked/telepad,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "cMe" = (


### PR DESCRIPTION
[MAPPING]
## About the PR
On the telescience pad, there were 2 sets of cables, data terminals, and teleport pad. Albert remains unaffected by mortal woes.

This pr removes the duplication
## Why's this needed?
B U G S    A R E    B A D