### PR TITLE
Wasp crossbow projectiles ignore wasps

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -1003,6 +1003,11 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	window_pass = 0
 	typetospawn = /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/wasp/angry
 
+	on_pre_hit(atom/hit, angle, obj/projectile/O)
+		if (istype(hit, /mob/living/critter/small_animal/wasp))
+			return TRUE
+		. = ..()
+
 	on_hit(atom/hit, direction, projectile)
 		var/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/wasp/angry/W = ..()
 		if(istype(W))


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wasp eggs fired from the wasp crossbow will ignore wasps, This fixes wasps attacking the crossbow owner instead of other people.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15590
Fixes #15280
