### PR TITLE
Allows laundry machines to be scanned with a mechscanner

### DIFF
--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -5,6 +5,9 @@
 #define CYCLE_TIME_MOB_INSIDE 5
 #define CYCLE_TIME 10
 
+TYPEINFO(/obj/submachine/laundry_machine)
+	mats = 20
+
 /obj/submachine/laundry_machine
 	name = "laundry machine"
 	desc = "A combined washer/dryer unit used for cleaning clothes."

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -739,6 +739,9 @@ TYPEINFO(/obj/item/device/geiger)
 		. = ..()
 
 //DIRTY DIRTY PLAYERS
+TYPEINFO(/obj/submachine/laundry_machine/portable)
+	mats = list("telecrystal" = 5, "MET-2" = 15, "CON-1" = 10)
+
 /obj/submachine/laundry_machine/portable
 	name = "Port-A-Laundry"
 	desc = "Don't ask."

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -740,7 +740,7 @@ TYPEINFO(/obj/item/device/geiger)
 
 //DIRTY DIRTY PLAYERS
 TYPEINFO(/obj/submachine/laundry_machine/portable)
-	mats = list("telecrystal" = 5, "MET-2" = 15, "CON-1" = 10)
+	mats = 0
 
 /obj/submachine/laundry_machine/portable
 	name = "Port-A-Laundry"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets mechscanners scan laundry machines(20 mats)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Other machinery is scannable, its weird that laundry machines are an exception


## Changelog 
```changelog
(u)UnfunnyPerson
(+)Laundry machines can now be scanned with a mechscanner
```
