### PR TITLE
Pod HUD shows X on portal icon more accurately

### DIFF
--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -91,8 +91,12 @@
 				wormhole.overlays.len = 0
 			else
 				engine.icon_state = "engine-off"
-				if (!wormhole.overlays.len)
-					wormhole.overlays += missing
+
+		if (master.engine?.active && master.sensors?.active)
+			wormhole.overlays.len = 0
+		else
+			if (!wormhole.overlays.len)
+				wormhole.overlays += missing
 
 		if (master.life_support)
 			if (master.life_support.active)

--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -88,7 +88,6 @@
 		if (master.engine)
 			if (master.engine.active)
 				engine.icon_state = "engine-on"
-				wormhole.overlays.len = 0
 			else
 				engine.icon_state = "engine-off"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][vehicle][ui]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

change the logic for the wormhole icon to show only if engine *and* sensors are online, matching how they work

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
portal button should be X'd out if you can't use it
does not change behavior just UI