### PR TITLE
Cogmap1 Dining Chairs

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4920,7 +4920,7 @@
 /area/station/crew_quarters/cafeteria)
 "asg" = (
 /obj/disposalpipe/segment/mail,
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
@@ -4948,7 +4948,7 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "asi" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
@@ -5395,7 +5395,7 @@
 /area/station/crew_quarters/cafeteria)
 "atx" = (
 /obj/disposalpipe/segment/mail,
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
@@ -5443,7 +5443,7 @@
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/cafeteria)
 "atA" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
@@ -6260,7 +6260,7 @@
 /area/station/crew_quarters/cafeteria)
 "avX" = (
 /obj/disposalpipe/segment/mail,
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
@@ -6283,7 +6283,7 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "avZ" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/dining/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the chairs at the dining table in Cogmap1's bar from comfy brown chairs to wooden dining chairs
![image](https://github.com/goonstation/goonstation/assets/94804240/29bd312f-6f24-439a-9d39-1f227c87a445)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think it looks better, and the idea of sitting at a dining table in a sofa chair is very odd to me.


