### PR TITLE
Fix bodies with embalming fluid still rotting in unpowered morgue trays

### DIFF
--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -26,7 +26,7 @@
 
 			if (istype(owner.loc, /obj/machinery/traymachine/morgue)) //Morgues require power now
 				var/obj/machinery/traymachine/morgue/stinkbox = owner.loc
-				suspend_rot = !(stinkbox.status & NOPOWER)
+				suspend_rot = suspend_rot || !(stinkbox.status & NOPOWER)
 
 			if (H.decomp_stage >= DECOMP_STAGE_SKELETONIZED)
 				return ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15626 by making the suspend_rot assignment OR with the old value instead of overwriting it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug