### PR TITLE
Fixes voting box taking money even when prompt cancelled

### DIFF
--- a/code/obj/voting_box.dm
+++ b/code/obj/voting_box.dm
@@ -79,18 +79,17 @@
 							bribeAmount = S.amount
 							bribeJerk = user.real_name
 							map_vote_holder.voting_box(src,chosen)
+						S.amount = 0
+						user.u_equip(S)
+						S.dropped(user)
+						qdel( S )
+						animate_storage_rustle(src)
+						playsound(src.loc, 'sound/machines/ping.ogg', 75)
+						SPAWN(1 SECOND)
+							playsound(src.loc, 'sound/machines/paper_shredder.ogg', 90, 1)
 				else
 					boutput(user, "<span class='alert'>You can't buy a vote when you haven't voted, doofus.</span>")
 					return
-
-			S.amount = 0
-			user.u_equip(S)
-			S.dropped(user)
-			qdel( S )
-			animate_storage_rustle(src)
-			playsound(src.loc, 'sound/machines/ping.ogg', 75)
-			SPAWN(1 SECOND)
-				playsound(src.loc, 'sound/machines/paper_shredder.ogg', 90, 1)
 			return
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16142 by moving the shred money logic to only run if chosen isn't null

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
