### PR TITLE
Fix die a glorious death failing if respawned in afterlife bar

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1146,8 +1146,8 @@ proc/create_fluff(datum/mind/target)
 	check_completion()
 		if(isghostdrone(owner.current))
 			return 1
-		
-		if(!owner.current || isdead(owner.current) || isVRghost(owner.current))
+
+		if(!owner.current || isdead(owner.current) || isVRghost(owner.current) || inafterlifebar(owner.current))
 			return 1
 
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #13529 by adding check for afterlife bar in check_completion()

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
