### PR TITLE
Finer definition control for requisition food entries

### DIFF
--- a/_std/defines/economy.dm
+++ b/_std/defines/economy.dm
@@ -9,6 +9,10 @@
 #define AID_CONTRACT 2
 #define SCI_CONTRACT 3
 
+#define FOOD_REQ_BY_ITEM 0
+#define FOOD_REQ_BY_BITE 1
+#define FOOD_REQ_INTACT 2
+
 #define REQ_RETURN_NOSALE 0
 #define REQ_RETURN_SALE 1
 #define REQ_RETURN_FULLSALE 2

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -263,7 +263,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/food/any
 	name = "solid food, preferably nutritious"
 	typepath = /obj/item/reagent_containers/food/snacks
-	must_be_whole = FALSE
+	food_integrity = FOOD_REQ_BY_ITEM
 	feemod = PAY_TRADESMAN
 
 /datum/rc_entry/reagent/water
@@ -400,6 +400,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "slices' worth of pizza"
 	commodity = /datum/commodity/
 	typepath = /obj/item/reagent_containers/food/snacks/pizza
+	food_integrity = FOOD_REQ_BY_BITE
 	feemod = PAY_UNTRAINED
 
 /datum/rc_entry/reagent/cola


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reworks food requisition entries' handling of bites_left to use a set of three options with defines - by item (an item is one count regardless of bites left), by bite (one bites_left is one count, regardless of how many items provide the bites_left), or intact (an item is one count if its bites left equal initial bites left).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

After #16078, it was brought to my attention that the lowered sensitivity on the "any solid food" requisition entry made it behave oddly, counting each bites_left on a food as one fulfilled food item. This makes these requisitions much easier to fulfill, and not in an intentional or intuitive way.

This puts in a system to make that behave better, in a way that should be much more comprehensible to myself and others going forward.