### PR TITLE
Add singing checks to non-spoken say procs (robot, thrall, ling, kudzu)

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -261,6 +261,7 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 	logTheThing(LOG_DIARY, src, ": [message]", "say")
 
 	message = trim(html_encode(message))
+	message = src.check_singing_prefix(message)
 
 	if (!message)
 		return

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -291,6 +291,10 @@
 	if (!hivemind_owner)
 		return
 
+	var/mob/living/L = src
+	if (istype(L))
+		message = L.check_singing_prefix(message)
+
 	//i guess this caused some real ugly text huh
 	//message = trim(copytext(html_encode(sanitize(message)), 1, MAX_MESSAGE_LEN))
 	if (!message)
@@ -349,6 +353,10 @@
 	if (!owner)
 		return
 
+	var/mob/living/L = src
+	if (istype(L))
+		message = L.check_singing_prefix(message)
+
 	if (!message)
 		return
 
@@ -380,6 +388,10 @@
 
 	if (!owner)
 		return
+
+	var/mob/living/L = src
+	if (istype(L))
+		message = L.check_singing_prefix(message)
 
 	if (!message)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add the same singing check that is in `say` to things that talk without speaking.

## TODO
- [x] robot talk
- [x] thrallsay
- [x] changeling hivemind 
- [x] kudzu hivemind

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16105
