### PR TITLE
Recieve PDA messages when your cargo request is approved or denied

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -9,6 +9,7 @@
 	var/orderedby = null
 	var/comment = null
 	var/whos_id = null
+	var/address = null
 	var/console_location = null
 
 	proc/create(var/mob/orderer)

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1262,6 +1262,7 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 
 			O.object = P
 			O.orderedby = src.master.owner
+			O.address = src.master.net_id
 			O.console_location = get_area(src.master)
 			shippingmarket.supply_requests += O
 			src.temp = "Request sent to Supply Console. The Quartermasters will process your request as soon as possible.<BR>"

--- a/code/obj/machinery/computer/QM_order.dm
+++ b/code/obj/machinery/computer/QM_order.dm
@@ -149,6 +149,8 @@
 				else
 					account["current_money"] -= P.cost
 					O.object = P
+					if (account["pda_net_id"])
+						O.address = account["pda_net_id"]
 					O.orderedby = usr.name
 					O.console_location = src.console_location
 					var/obj/storage/S = O.create(usr)
@@ -165,6 +167,22 @@
 			else
 				O.object = P
 				O.orderedby = usr.name
+
+				var/list/pda_list = list()
+
+				// check visible PDAs
+				var/mob/living/carbon/human/H = usr
+				if(istype(H))
+					pda_list += H.get_slot(SLOT_L_HAND)
+					pda_list += H.get_slot(SLOT_R_HAND)
+					pda_list += H.get_slot(SLOT_WEAR_ID)
+					pda_list += H.get_slot(SLOT_BELT)
+
+				for (var/obj/item/device/pda2/pda in pda_list)
+					if (pda.host_program.message_on && pda.owner)
+						O.address = pda.net_id
+						break
+
 				O.console_location = src.console_location
 				shippingmarket.supply_requests += O
 				boutput(usr, "Request for [P.name] sent to Supply Console. The Quartermasters will process your request as soon as possible.")

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -141,7 +141,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 
 	New()
 		..()
-		MAKE_SENDER_RADIO_PACKET_COMPONENT(null, FREQ_STATUS_DISPLAY)
+		MAKE_SENDER_RADIO_PACKET_COMPONENT("pda", FREQ_PDA)
 
 /obj/machinery/computer/supplycomp/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	if(!hacked)
@@ -614,9 +614,12 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 					. = {"Request denied.<br>"}
 
 				if ("clear")
+					var/orderers = list()
 					for(var/datum/supply_order/order as anything in shippingmarket.supply_requests)
 						if (order.address)
-							src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
+							orderers += order.address
+					for(var/orderer in uniquelist(orderers))
+						src.send_pda_message(orderer, "Your orders have been denied.")
 					shippingmarket.supply_requests = null
 					shippingmarket.supply_requests = new/list()
 					. = {"All requests have been cleared.<br>"}
@@ -1306,6 +1309,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	newsignal.data["address_1"] = address
 	newsignal.data["sender"] = "00000000"
 
-	radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(newsignal)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, newsignal, null, "pda")
 
 #undef ORDER_LABEL_MAX_LEN

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -542,6 +542,8 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 							return .("list") // The user cancelled the order
 						O.comment = html_encode(O.comment)
 						wagesystem.shipping_budget -= P.cost
+						if (O.address)
+							src.send_pda_message(O.address, "Your order of [P.name] has been approved.")
 						var/obj/storage/S = O.create(usr)
 						shippingmarket.receive_crate(S)
 						logTheThing(LOG_STATION, usr, "ordered a [P.name] at [log_loc(src)].")
@@ -610,14 +612,20 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 				return .
 
 			if ("remove")
-				shippingmarket.supply_requests -= locate(href_list["what"])
-				// todo: fancy "your request got denied, doofus" message?
+				var/datum/supply_order/order = locate(href_list["what"]) in shippingmarket.supply_requests
+				if(!istype(order))
+					return
+				if (order.address)
+					src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
+				shippingmarket.supply_requests -= order
 				. = {"Request denied."}
 
 			if ("clear")
+				for(var/datum/supply_order/order as anything in shippingmarket.supply_requests)
+					if (order.address)
+						src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
 				shippingmarket.supply_requests = null
 				shippingmarket.supply_requests = new/list()
-				// todo: message people that their stuff's been denied?
 				. = {"All requests have been cleared."}
 
 		return .
@@ -1290,13 +1298,15 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		return 0
 	return 1
 
-/obj/machinery/computer/supplycomp/proc/post_signal(var/command)
-	var/datum/signal/status_signal = get_free_signal()
-	status_signal.source = src
-	status_signal.transmission_method = 1
-	status_signal.data["command"] = command
-	status_signal.data["address_tag"] = "STATDISPLAY"
+/obj/machinery/computer/supplycomp/proc/send_pda_message(address, message)
+	var/datum/signal/newsignal = get_free_signal()
+	newsignal.source = src
+	newsignal.data["command"] = "text_message"
+	newsignal.data["sender_name"] = "CARGO-MAILBOT"
+	newsignal.data["message"] = message
+	newsignal.data["address_1"] = address
+	newsignal.data["sender"] = "00000000"
 
-	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, status_signal, null, FREQ_STATUS_DISPLAY)
+	radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(newsignal)
 
 #undef ORDER_LABEL_MAX_LEN

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -603,22 +603,22 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 
 	requests(subaction, href_list)
 		if (!isnull(subaction))
-		switch (subaction)
-			if ("remove")
-				var/datum/supply_order/order = locate(href_list["what"]) in shippingmarket.supply_requests
-				if(!istype(order))
-					return
-				if (order.address)
-					src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
-				shippingmarket.supply_requests -= order
-					. = {"Request denied.<br>"}
-
-			if ("clear")
-				for(var/datum/supply_order/order as anything in shippingmarket.supply_requests)
+			switch (subaction)
+				if ("remove")
+					var/datum/supply_order/order = locate(href_list["what"]) in shippingmarket.supply_requests
+					if(!istype(order))
+						return
 					if (order.address)
 						src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
-				shippingmarket.supply_requests = null
-				shippingmarket.supply_requests = new/list()
+					shippingmarket.supply_requests -= order
+					. = {"Request denied.<br>"}
+
+				if ("clear")
+					for(var/datum/supply_order/order as anything in shippingmarket.supply_requests)
+						if (order.address)
+							src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
+					shippingmarket.supply_requests = null
+					shippingmarket.supply_requests = new/list()
 					. = {"All requests have been cleared.<br>"}
 
 		. += "<h2>Current Requests</h2><br><a href='[topicLink("requests", "clear")]'>Clear all</a><br><ul>"

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -602,15 +602,8 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 
 
 	requests(subaction, href_list)
+		if (!isnull(subaction))
 		switch (subaction)
-			if (null, "list")
-				. = "<h2>Current Requests</h2><br><a href='[topicLink("requests", "clear")]'>Clear all</a><br><ul>"
-				for(var/datum/supply_order/SO in shippingmarket.supply_requests)
-					. += "<li>[SO.object.name], requested by [SO.orderedby] from [SO.console_location]. Price: [SO.object.cost] <a href='[topicLink("order", "buy", list(what = "\ref[SO]"))]'>Approve</a> <a href='[topicLink("requests", "remove", list(what = "\ref[SO]"))]'>Deny</a></li>"
-
-				. += {"</ul>"}
-				return .
-
 			if ("remove")
 				var/datum/supply_order/order = locate(href_list["what"]) in shippingmarket.supply_requests
 				if(!istype(order))
@@ -618,7 +611,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 				if (order.address)
 					src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
 				shippingmarket.supply_requests -= order
-				. = {"Request denied."}
+					. = {"Request denied.<br>"}
 
 			if ("clear")
 				for(var/datum/supply_order/order as anything in shippingmarket.supply_requests)
@@ -626,7 +619,13 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 						src.send_pda_message(order.address, "Your order of [order.object.name] has been denied.")
 				shippingmarket.supply_requests = null
 				shippingmarket.supply_requests = new/list()
-				. = {"All requests have been cleared."}
+					. = {"All requests have been cleared.<br>"}
+
+		. += "<h2>Current Requests</h2><br><a href='[topicLink("requests", "clear")]'>Clear all</a><br><ul>"
+		for(var/datum/supply_order/SO in shippingmarket.supply_requests)
+			. += "<li>[SO.object.name], requested by [SO.orderedby] from [SO.console_location]. Price: [SO.object.cost] <a href='[topicLink("order", "buy", list(what = "\ref[SO]"))]'>Approve</a> <a href='[topicLink("requests", "remove", list(what = "\ref[SO]"))]'>Deny</a></li>"
+
+		. += {"</ul>"}
 
 		return .
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][station-systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The Cargo Request PDA app and Supply Request Console will tag your supply order with your associated PDA address, if possible. On approve or deny, PDA messages are sent to the associated PDA address.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Make cargo requests feel more integrated into other game systems.

PDA requests feel like they should have PDA feedback.

Something scannable/spoofable with packets for mechanics.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)When approving or denying cargo requests, PDA Messages are sent to the requestor.
```
