### PR TITLE
Supply console can print trader/requisition barcodes directly

### DIFF
--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1252,7 +1252,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 					</li>
 					"}
 
-			bottomText += {"</ul>"}
+			bottomText += {"</ul><br><em>To sell goods to this trader, print a barcode for <strong>[T.name]</strong>, attach it to a crate containing the goods, and send the crate out the 'sell' mass driver.</em>"}
 
 		if ("selling")
 			bottomText += "<h3>Goods For Sale</h3><ul class='shoplist'>"

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1144,13 +1144,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		B.name = "Barcode Sticker ([to_name])"
 		B.destination = destination
 
-/obj/machinery/computer/supplycomp/proc/print_trader_barcode(datum/trader/trader)
-	playsound(src.loc, 'sound/machines/printer_cargo.ogg', 60, 0)
-	if (!ON_COOLDOWN(src, "print", SUPPLY_PRINT_COOLDOWN))
-		var/obj/item/sticker/barcode/B = new/obj/item/sticker/barcode(src.loc)
-		B.name = "Barcode Sticker ([trader.name])"
-		B.destination = trader.crate_tag
-
 /obj/machinery/computer/supplycomp/proc/trader_dialogue_update(var/dialogue,var/datum/trader/T)
 	if (!dialogue || !T)
 		return

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -127,7 +127,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	var/hacked = 0
 	var/tradeamt = 1
 	var/in_dialogue_box = 0
-	var/printing = 0
 	var/obj/item/card/id/scan = null
 	var/list/datum/supply_pack
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

In the cargo supply console, add links to easily print a single barcode for traders and requisitions. These new print options share a 2 second cooldown on the machine, which also includes the existing requisition print list option.

The barcode machine has bulk print and wage-split tagging as unique features; this does not intend to replace it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Easier for new cargo players to start working on requisitions and trades. Less trouble with duplicate name definitions in requisitions.