### PR TITLE
Sets wear_image pixel offsets to initials in case they've changed

### DIFF
--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -179,6 +179,8 @@
 			if ("left_[icon_name]" in src.mutantrace?.clothing_icon_states?["hands"]) //checking if the wearer is a mutant, and if so swaps the left glove with the special sprite if there is one.
 				src.gloves.wear_image.icon = src.mutantrace.clothing_icons["hands"]
 				no_offset = TRUE
+				src.gloves.wear_image.pixel_x = initial(src.gloves.wear_image.pixel_x)
+				src.gloves.wear_image.pixel_y = initial(src.gloves.wear_image.pixel_y)
 			else
 				src.gloves.wear_image.icon = src.gloves.wear_image_icon
 			src.gloves.wear_image.icon_state = "left_[icon_name]"
@@ -193,6 +195,8 @@
 			if ("right_[icon_name]" in src.mutantrace?.clothing_icon_states?["hands"]) //above but right glove
 				src.gloves.wear_image.icon = src.mutantrace.clothing_icons["hands"]
 				no_offset = TRUE
+				src.gloves.wear_image.pixel_x = initial(src.gloves.wear_image.pixel_x)
+				src.gloves.wear_image.pixel_y = initial(src.gloves.wear_image.pixel_y)
 			else
 				src.gloves.wear_image.icon = src.gloves.wear_image_icon
 			src.gloves.wear_image.icon_state = "right_[icon_name]"
@@ -310,6 +314,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["back"]) //checks if they are a mutantrace with special back sprites and then replaces them if they do
 			src.back.wear_image.icon = src.mutantrace.clothing_icons["back"]
 			no_offset = TRUE
+			src.back.wear_image.pixel_x = initial(src.back.wear_image.pixel_x)
+			src.back.wear_image.pixel_y = initial(src.back.wear_image.pixel_y)
 		else
 			src.back.wear_image.icon = src.back.wear_image_icon
 		src.back.wear_image.icon_state = wear_state
@@ -343,6 +349,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["eyes"]) //checks for special glasses sprites for mutantraces and replaces the sprite with it if there is one.
 			src.glasses.wear_image.icon = src.mutantrace.clothing_icons["eyes"]
 			no_offset = TRUE
+			src.glasses.wear_image.pixel_x = initial(src.glasses.wear_image.pixel_x)
+			src.glasses.wear_image.pixel_y = initial(src.glasses.wear_image.pixel_y)
 		else
 			src.glasses.wear_image.icon = src.glasses.wear_image_icon
 		src.glasses.wear_image.icon_state = wear_state
@@ -372,6 +380,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["ears"]) //checks if they are a mutantrace with special earwear sprites and then replaces them if they do
 			src.ears.wear_image.icon = src.mutantrace.clothing_icons["ears"]
 			no_offset = TRUE
+			src.ears.wear_image.pixel_x = initial(src.ears.wear_image.pixel_x)
+			src.ears.wear_image.pixel_y = initial(src.ears.wear_image.pixel_y)
 		else
 			src.ears.wear_image.icon = src.ears.wear_image_icon
 		src.ears.wear_image.icon_state = wear_state
@@ -402,6 +412,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["mask"])
 			src.wear_mask.wear_image.icon = src.mutantrace.clothing_icons["mask"]
 			no_offset = TRUE
+			src.wear_mask.wear_image.pixel_x = initial(src.wear_mask.wear_image.pixel_x)
+			src.wear_mask.wear_image.pixel_y = initial(src.wear_mask.wear_image.pixel_y)
 		else
 			src.wear_mask.wear_image.icon = src.wear_mask.wear_image_icon
 		src.wear_mask.wear_image.icon_state = wear_state
@@ -434,6 +446,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["head"])
 			src.head.wear_image.icon = src.mutantrace.clothing_icons["head"]
 			no_offset = TRUE
+			src.head.wear_image.pixel_x = initial(src.head.wear_image.pixel_x)
+			src.head.wear_image.pixel_y = initial(src.head.wear_image.pixel_y)
 		else
 			src.head.wear_image.icon = src.head.wear_image_icon
 		src.head.wear_image.icon_state = wear_state
@@ -465,6 +479,8 @@
 		if (wear_state in src.mutantrace?.clothing_icon_states?["belt"]) //checks if they are a mutantrace with special belt sprites and then replaces them if they do
 			src.belt.wear_image.icon = src.mutantrace.clothing_icons["belt"]
 			no_offset = TRUE
+			src.belt.wear_image.pixel_x = initial(src.belt.wear_image.pixel_x)
+			src.belt.wear_image.pixel_y = initial(src.belt.wear_image.pixel_y)
 		else
 			src.belt.wear_image.icon = src.belt.wear_image_icon
 		src.belt.wear_image.icon_state = wear_state


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- if no_offset = TRUE on update icons, resets possible existing offsets to initials

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #8583
