### PR TITLE
Small Animals can no longer break disposal pipes without flipping

### DIFF
--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -138,7 +138,8 @@
 		if(last_sound + 6 < world.time)
 			playsound(src.loc, 'sound/impact_sounds/Metal_Clang_1.ogg', 50, 0, 0)
 			last_sound = world.time
-			damage_pipe()
+			if(!istype(user,/mob/living/critter/small_animal))
+				damage_pipe()
 			if(prob(30))
 				slowed++
 


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- small animals cannot break disposal pipes without flipping

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #16151


