### PR TITLE
Fix Sleeper Messaging being you-focused if the thing you're trying to fit in it can't fit in it

### DIFF
--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -97,9 +97,6 @@ TYPEINFO(/obj/machinery/genetics_scanner)
 		if(!iscarbon(target) )
 			boutput(M, "<span class='alert'><B>The scanner supports only carbon based lifeforms.</B></span>")
 			return 0
-		if (src.occupant)
-			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
-			return 0
 		if (src.locked)
 			boutput(M, "<span class='alert'><B>You need to unlock the scanner first.</B></span>")
 			return 0

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -545,33 +545,35 @@ TYPEINFO(/obj/machinery/sleeper)
 				move_inside()
 			else
 				return
-		else if (can_operate(user))
+		else if (can_operate(user,target))
 			var/previous_user_intent = user.a_intent
 			user.set_a_intent(INTENT_GRAB)
 			user.drop_item()
 			target.Attackhand(user)
 			user.set_a_intent(previous_user_intent)
 			SPAWN(user.combat_click_delay + 2)
-				if (can_operate(user))
+				if (can_operate(user,target))
 					if (istype(user.equipped(), /obj/item/grab))
 						src.Attackby(user.equipped(), user)
 
-	proc/can_operate(var/mob/M)
-		if (!(BOUNDS_DIST(src, M) == 0))
+	proc/can_operate(var/mob/M, var/mob/living/target)
+		if (!isalive(M))
+			return FALSE
+		if (BOUNDS_DIST(src, M) > 0)
 			return FALSE
 		if (istype(M) && is_incapacitated(M))
 			return FALSE
 		if (src.occupant)
-			boutput(M, "<span class='notice'><B>The scanner is already occupied!</B></span>")
+			boutput(M, "<span class='notice'><B>\The [src] is already occupied!</B></span>")
 			return FALSE
-		if (!ishuman(M))
-			boutput(usr, "<span class='alert'>You can't seem to fit into \the [src].</span>")
+		if(ismobcritter(target))
+			boutput(M, "<span class='alert'><B>\The [src] doesn't support this body type.</B></span>")
 			return FALSE
-		if (src.occupant)
-			usr.show_text("The [src.name] is already occupied!", "red")
+		if (!ishuman(target))
+			boutput(usr, "<span class='alert'>\The [src] only accepts humanoid lifeforms.</span>")
 			return FALSE
 
-		. = TRUE
+		.= TRUE
 
 	verb/move_inside()
 		set src in oview(1)
@@ -579,7 +581,7 @@ TYPEINFO(/obj/machinery/sleeper)
 
 		if (!src) return
 
-		if (!can_operate(usr)) return
+		if (!can_operate(usr,usr)) return
 
 		usr.remove_pulling()
 		usr.set_loc(src)
@@ -596,7 +598,7 @@ TYPEINFO(/obj/machinery/sleeper)
 		eject_occupant(user)
 
 	mouse_drop(mob/user as mob)
-		if (can_operate(user))
+		if (can_operate(user,user))
 			eject_occupant(user)
 		else
 			..()


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- fix weird double occupancy check on scanners

- fix sleepers giving weird messages if you're not able to use it but the thing you're trying to shove in could technically fit


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- weird messages confusing people

- Fixes #8992
