### PR TITLE
Pouches can no longer hold storage items (prevents recursive storage)

### DIFF
--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -2,7 +2,6 @@
 	Can fit in pockets allowing folks to carry more ammo at the expense of taking a little longer to acces it.
 	Less messy than having people spawn with 5 magazines in their backpack.	*/
 
-
 /obj/item/storage/pouch
 	name = "ammo pouch"
 	icon_state = "ammopouch"
@@ -13,6 +12,7 @@
 	slots = 5
 	opens_if_worn = TRUE
 	can_hold = list(/obj/item/ammo)
+	prevent_holding = list(/obj/item/storage)
 
 	assault_rifle
 		name = "rifle magazine pouch"
@@ -117,6 +117,7 @@
 	slots = 6
 	can_hold = list(/obj/item/old_grenade, /obj/item/chem_grenade)
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 
 	frag
 		name = "frag grenade pouch"
@@ -178,6 +179,7 @@
 	opens_if_worn = TRUE
 	spawn_contents = list(/obj/item/reagent_containers/mender/brute/high_capacity,
 	/obj/item/reagent_containers/mender/burn/high_capacity)
+	prevent_holding = list(/obj/item/storage)
 
 /obj/item/storage/security_pouch
 	name = "security pouch"
@@ -191,6 +193,7 @@
 	/obj/item/device/flash,\
 	/obj/item/reagent_containers/food/snacks/donut,\
 	/obj/item/instrument/whistle)
+	prevent_holding = list(/obj/item/storage)
 
 	empty
 		spawn_contents = list()
@@ -209,10 +212,12 @@
 	w_class = W_CLASS_SMALL
 	slots = 5
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/handcuffs/ = 1,
 	/obj/item/handcuffs/guardbot = 2,
 	/obj/item/device/flash,
 	/obj/item/reagent_containers/food/snacks/candy/candyheart)
+
 
 	ntso
 		spawn_contents = list(/obj/item/gun/kinetic/clock_188/boomerang/ntso,
@@ -226,6 +231,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 5
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/old_grenade/emp = 5)
 
 /obj/item/storage/tactical_grenade_pouch
@@ -236,6 +242,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 7
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/chem_grenade/incendiary = 2,\
 	/obj/item/chem_grenade/shock,\
 	/obj/item/old_grenade/smoke = 1,\
@@ -251,6 +258,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 6
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/old_grenade/sonic = 5,\
 	/obj/item/clothing/ears/earmuffs/earplugs)
 
@@ -262,6 +270,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 6
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/old_grenade/energy_concussion = 5)
 
 /obj/item/storage/banana_grenade_pouch
@@ -272,6 +281,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 7 //bonus two slots for the banana grenade kit
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/old_grenade/spawner/banana = 5)
 
 /obj/item/storage/beartrap_pouch
@@ -281,6 +291,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 4
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/beartrap = 4)
 
 /obj/item/storage/landmine_pouch
@@ -290,6 +301,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 3
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	var/static/list/possible_contents = list(/obj/item/mine/radiation, /obj/item/mine/incendiary, /obj/item/mine/stun, /obj/item/mine/blast)
 
 	make_my_stuff()
@@ -316,6 +328,7 @@
 	w_class = W_CLASS_SMALL
 	slots = 4
 	opens_if_worn = TRUE
+	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(
 		/obj/item/old_grenade/sawfly/firsttime = 3,
 		/obj/item/remote/sawflyremote


### PR DESCRIPTION



<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- adds storages to the list of prevented types for pouches
- at some point someone needs to run through these all and standardize them

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #8672
- prevents pouches from holding storage items
