### PR TITLE
Fixes Flock Floors overwriting their atom flags instead of adding to them

### DIFF
--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -9,7 +9,6 @@ TYPEINFO(/turf/simulated/floor/feather)
 	var/flock_id = "Conduit"
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "floor"
-	flags = USEDELAY
 	mat_changename = FALSE
 	mat_changedesc = FALSE
 	default_material = "gnesis"
@@ -36,6 +35,7 @@ TYPEINFO(/turf/simulated/floor/feather)
 	light.attach(src)
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
 	src.AddComponent(/datum/component/flock_protection, report_unarmed=FALSE, report_thrown=FALSE, report_proj=FALSE)
+	flags |= USEDELAY
 
 /turf/simulated/floor/feather/special_desc(dist, mob/user)
 	if (!isflockmob(user))


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- fix flock floors overwriting their atom flags instead of adding to them

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #8947
- call your parents, flag edition

