### PR TITLE
Sets mesons to later (higher priority) in sight.dm

### DIFF
--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -140,6 +140,12 @@
 				owner.see_infrared = 1
 			owner.render_special.set_centerlight_icon("thermal", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
 
+
+		if (HAS_ATOM_PROPERTY(owner, PROP_MOB_NIGHTVISION))
+			owner.render_special.set_centerlight_icon("nightvision", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
+		else if (HAS_ATOM_PROPERTY(owner, PROP_MOB_NIGHTVISION_WEAK))
+			owner.render_special.set_centerlight_icon("thermal", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
+
 		if (HAS_ATOM_PROPERTY(owner, PROP_MOB_MESONVISION))
 			if(T && !isrestrictedz(T.z))
 				owner.sight |= SEE_TURFS
@@ -149,12 +155,6 @@
 			owner.render_special.set_centerlight_icon("meson", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255), wide = (owner.client?.widescreen))
 			if (owner.see_invisible < INVIS_INFRA)
 				owner.see_invisible = INVIS_INFRA
-
-
-		if (HAS_ATOM_PROPERTY(owner, PROP_MOB_NIGHTVISION))
-			owner.render_special.set_centerlight_icon("nightvision", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
-		else if (HAS_ATOM_PROPERTY(owner, PROP_MOB_NIGHTVISION_WEAK))
-			owner.render_special.set_centerlight_icon("thermal", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255))
 
 		if (human_owner)////Glasses handled separately because i dont have a fast way to get glasses on any mob type
 			if (istype(human_owner.glasses, /obj/item/clothing/glasses/construction) && (T && !isrestrictedz(T.z)))


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets mesons to later (higher priority) in sight.dm, so that its effects and center tile light apply over the less powerful nightvision one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #13261
- fixes #8908

