### PR TITLE
Player Seals no longer have forced AI stuff

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2649,8 +2649,9 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 			if(findtext(W.name,"seal")) // for you, spacemarine9
 				src.visible_message("<span class='emote'><b>[src]</b> [pick("groans","yelps")]!</span>")
 				src.visible_message("<span class='notice'><b>[src]</b> gets frightened by [snack]!</span>")
-				src.ai.move_away(user, 10)
-				SPAWN(1 SECOND) walk(src,0)
+				if(src.is_npc)
+					src.ai.move_away(user, 10)
+					SPAWN(1 SECOND) walk(src,0)
 				return
 
 			if(prob(5))
@@ -2663,7 +2664,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 			src.HealDamage("all", 10, 10)
 		else
 			src.visible_message("<span class='emote'><b>[src]</b> [pick("groans","yelps")]!</span>")
-			src.ai.move_away(user, 10)
+			if(src.is_npc)
+				src.ai.move_away(user, 10)
 			return ..()
 
 	was_harmed(var/mob/M as mob, var/obj/item/weapon, var/special, var/intent)
@@ -2698,7 +2700,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		for (var/mob/living/critter/small_animal/seal/seal in view(7, src))
 			if (!(is_incapacitated(seal) && seal.ai?.enabled))
 				seal.visible_message("<span class='emote'><b>[seal]</b> [pick("groans","yelps")]!</span>")
-				seal.ai.move_away(src, 10)
+				if(seal.is_npc)
+					seal.ai.move_away(src, 10)
 
 		..()
 

--- a/code/modules/antagonists/wizard/abilities/animal.dm
+++ b/code/modules/antagonists/wizard/abilities/animal.dm
@@ -126,6 +126,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 			var/mob/living/critter/C = target.make_critter(pick(animal_spell_critter_paths))
 			C.real_name = "[target.real_name] the [C.real_name]"
 			C.name = C.real_name
+			C.is_npc = FALSE
 			logTheThing(LOG_COMBAT, M, "casts the Polymorph spell on [constructTarget(target,"combat")] turning them into [constructTarget(C,"combat")] at [log_loc(C)].")
 			C.butcherable = BUTCHER_ALLOWED // we would like the brain to be recoverable, please
 			if (istype(C, /mob/living/critter/small_animal/bee))


### PR DESCRIPTION



<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- wizard polymorph sets is_npc to FALSE
- stops seals from ignoring is_npc

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #16171