### PR TITLE
replacing emergency lights now respects shipalert status

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -1076,6 +1076,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 		var/state = !A.power_light || shipAlertState == SHIP_ALERT_BAD
 		seton(state)
 
+/obj/machinery/light/emergency/insert()
+	..()
+	power_change()
 
 // the light item
 // can be tube or bulb subtypes


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- replacing emergency lights now respects shipalert status

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #9055
