### PR TITLE
Multiple Outputs for Condensers

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -730,17 +730,17 @@ proc/ui_describe_reagents(atom/A)
 			try_adding_container(over_object, usr)
 
 	set_loc(newloc, storage_check)
-		if (src.loc != newloc && src.connected_containers.len > 0)
+		if (src.loc != newloc && length(src.connected_containers))
 			src.remove_all_containers()
 		. = ..()
 
 	Move()
-		if(src.connected_containers.len > 0)
+		if(length(src.connected_containers))
 			src.remove_all_containers()
 		..()
 
 	attack_hand(var/mob/user)
-		if(src.connected_containers.len > 0)
+		if(length(src.connected_containers))
 			src.remove_all_containers()
 			boutput(user, "<span class='alert'>You remove all connections to the [src.name].</span>")
 		..()
@@ -770,7 +770,7 @@ proc/ui_describe_reagents(atom/A)
 		if (GET_DIST(container, src) > 1)
 			usr.show_text("The [src.name] is too far away from the [container.name]!", "red")
 			return
-		if(src.connected_containers.len >= src.max_amount_of_containers)
+		if(length(src.connected_containers) >= src.max_amount_of_containers)
 			boutput(user, "<span class='alert'>The [src.name] can only be connected to [max_amount_of_containers] containers!</span>")
 		else
 			boutput(user, "<span class='notice'>You hook the [container.name] up to the [src.name].</span>")
@@ -796,7 +796,7 @@ proc/ui_describe_reagents(atom/A)
 			remove_container(container)
 
 	proc/try_adding_reagents_to_container(reagent, amount, sdata, temp_new, donotreact, donotupdate) //called when a reaction occurs inside the condenser flagged with "chemical_reaction = TRUE"
-		if(src.connected_containers.len <= 0) //if we have no beaker, dump the reagents into condenser
+		if(length(src.connected_containers) <= 0) //if we have no beaker, dump the reagents into condenser
 			src.reagents.add_reagent(reagent, amount, sdata, temp_new, donotreact, donotupdate)
 		else
 			add_reagents_to_containers(reagent, amount, sdata, temp_new, donotreact, donotupdate)
@@ -806,17 +806,17 @@ proc/ui_describe_reagents(atom/A)
 		for(var/obj/container in connected_containers)
 			if(container.reagents.maximum_volume > container.reagents.total_volume) //don't bother with this if it's already full, move onto other containers
 				non_full_containers.Add(container)
-		if(non_full_containers.len <= 0)	//all full? backflow!!
+		if(!length(non_full_containers))	//all full? backflow!!
 			src.reagents.add_reagent(reagent, amount, sdata, temp_new, donotreact, donotupdate)
-		else
-			var/divided_amount = (amount / non_full_containers.len) //cut the reagents needed into chunks
-			for(var/obj/container in non_full_containers)
-				var/remaining_container_space = container.reagents.maximum_volume - container.reagents.total_volume
-				if(remaining_container_space < divided_amount) 																			//if there's more reagent to add than the beaker can hold...
-					container.reagents.add_reagent(reagent, remaining_container_space, sdata, temp_new, donotreact, donotupdate) //...add what we can to the beaker...
-					src.add_reagents_to_containers(reagent, divided_amount - remaining_container_space, sdata, temp_new, donotreact, donotupdate)  //...then run the whole proc again with the remaining reagent, evenly distributing to remaining containers
-				else
-					container.reagents.add_reagent(reagent, divided_amount, sdata, temp_new, donotreact, donotupdate)
+			return
+		var/divided_amount = (amount / length(non_full_containers)) //cut the reagents needed into chunks
+		for(var/obj/container in non_full_containers)
+			var/remaining_container_space = container.reagents.maximum_volume - container.reagents.total_volume
+			if(remaining_container_space < divided_amount) 																			//if there's more reagent to add than the beaker can hold...
+				container.reagents.add_reagent(reagent, remaining_container_space, sdata, temp_new, donotreact, donotupdate) //...add what we can to the beaker...
+				src.add_reagents_to_containers(reagent, divided_amount - remaining_container_space, sdata, temp_new, donotreact, donotupdate)  //...then run the whole proc again with the remaining reagent, evenly distributing to remaining containers
+			else
+				container.reagents.add_reagent(reagent, divided_amount, sdata, temp_new, donotreact, donotupdate)
 
 	disposing()
 		src.remove_container()

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -717,8 +717,9 @@ proc/ui_describe_reagents(atom/A)
 	object_flags = FPRINT | OPENCONTAINER | SUPPRESSATTACK
 	initial_volume = 100
 	accepts_lid = TRUE
-	var/obj/item/current_container = null //! the container currently attached to the condenser
+	var/list/connected_containers = list() //! the containers currently connected to the condenser
 	var/image/fluid_image = null
+	var/max_amount_of_containers = 4
 
 	mouse_drop(atom/over_object, src_location, over_location)
 		if(over_object == src)
@@ -729,19 +730,19 @@ proc/ui_describe_reagents(atom/A)
 			try_adding_container(over_object, usr)
 
 	set_loc(newloc, storage_check)
-		if (src.loc != newloc && src.current_container)
-			src.remove_container()
+		if (src.loc != newloc && src.connected_containers.len > 0)
+			src.remove_all_containers()
 		. = ..()
 
 	Move()
-		if (src.current_container)
-			src.remove_container()
+		if(src.connected_containers.len > 0)
+			src.remove_all_containers()
 		..()
 
 	attack_hand(var/mob/user)
-		if(current_container)
-			remove_container()
-			boutput(user, "<span class='alert'>You remove the connection to the [src.name].</span>")
+		if(src.connected_containers.len > 0)
+			src.remove_all_containers()
+			boutput(user, "<span class='alert'>You remove all connections to the [src.name].</span>")
 		..()
 
 	on_reagent_change()
@@ -769,8 +770,8 @@ proc/ui_describe_reagents(atom/A)
 		if (GET_DIST(container, src) > 1)
 			usr.show_text("The [src.name] is too far away from the [container.name]!", "red")
 			return
-		if(current_container)
-			boutput(user, "<span class='alert'>The [src.name] is already connected to the [current_container.name]!</span>")
+		if(src.connected_containers.len >= src.max_amount_of_containers)
+			boutput(user, "<span class='alert'>The [src.name] can only be connected to [max_amount_of_containers] containers!</span>")
 		else
 			boutput(user, "<span class='notice'>You hook the [container.name] up to the [src.name].</span>")
 			//this is a mess but we need it to disconnect if ANYTHING happens
@@ -780,27 +781,42 @@ proc/ui_describe_reagents(atom/A)
 			var/datum/lineResult/result = drawLine(src, container, "condenser", "condenser_end", src.pixel_x + 10, src.pixel_y, container.pixel_x, container.pixel_y + get_chemical_effect_position())
 			result.lineImage.pixel_x = -src.pixel_x
 			result.lineImage.pixel_y = -src.pixel_y
-			src.UpdateOverlays(result.lineImage, "tube")
-			current_container = container
+			src.UpdateOverlays(result.lineImage, "tube\ref[container]")
+			src.connected_containers.Add(container)
 
-	proc/remove_container()
-		src.UpdateOverlays(null, "tube")
-		UnregisterSignal(current_container, COMSIG_ATTACKHAND)
-		UnregisterSignal(current_container, XSIG_OUTERMOST_MOVABLE_CHANGED)
-		UnregisterSignal(current_container, COMSIG_MOVABLE_MOVED)
-		current_container = null
+	proc/remove_container(var/obj/container)
+		src.UpdateOverlays(null, "tube\ref[container]")
+		UnregisterSignal(container, COMSIG_ATTACKHAND)
+		UnregisterSignal(container, XSIG_OUTERMOST_MOVABLE_CHANGED)
+		UnregisterSignal(container, COMSIG_MOVABLE_MOVED)
+		src.connected_containers.Remove(container)
+
+	proc/remove_all_containers()
+		for(var/obj/container in src.connected_containers)
+			remove_container(container)
 
 	proc/try_adding_reagents_to_container(reagent, amount, sdata, temp_new, donotreact, donotupdate) //called when a reaction occurs inside the condenser flagged with "chemical_reaction = TRUE"
-		if(!current_container) //if we have no beaker, dump the reagents into condenser
+		if(src.connected_containers.len <= 0) //if we have no beaker, dump the reagents into condenser
 			src.reagents.add_reagent(reagent, amount, sdata, temp_new, donotreact, donotupdate)
 		else
-			var/remaining_container_space = current_container.reagents.maximum_volume - current_container.reagents.total_volume
-			if(remaining_container_space < amount) 																			//if there's more reagent to add than the beaker can hold...
-				current_container.reagents.add_reagent(reagent, remaining_container_space, sdata, temp_new, donotreact, donotupdate) //...add what we can to the beaker...
-				src.reagents.add_reagent(reagent, amount - remaining_container_space, sdata, temp_new, donotreact, donotupdate)  //...then backflow remaining chems into the condenser
+			add_reagents_to_containers(reagent, amount, sdata, temp_new, donotreact, donotupdate)
 
-			else
-				current_container.reagents.add_reagent(reagent, amount, sdata, temp_new, donotreact, donotupdate)
+	proc/add_reagents_to_containers(reagent, amount, sdata, temp_new, donotreact, donotupdate)
+		var/list/non_full_containers = list()
+		for(var/obj/container in connected_containers)
+			if(container.reagents.maximum_volume > container.reagents.total_volume) //don't bother with this if it's already full, move onto other containers
+				non_full_containers.Add(container)
+		if(non_full_containers.len <= 0)	//all full? backflow!!
+			src.reagents.add_reagent(reagent, amount, sdata, temp_new, donotreact, donotupdate)
+		else
+			var/divided_amount = (amount / non_full_containers.len) //cut the reagents needed into chunks
+			for(var/obj/container in non_full_containers)
+				var/remaining_container_space = container.reagents.maximum_volume - container.reagents.total_volume
+				if(remaining_container_space < divided_amount) 																			//if there's more reagent to add than the beaker can hold...
+					container.reagents.add_reagent(reagent, remaining_container_space, sdata, temp_new, donotreact, donotupdate) //...add what we can to the beaker...
+					src.add_reagents_to_containers(reagent, divided_amount - remaining_container_space, sdata, temp_new, donotreact, donotupdate)  //...then run the whole proc again with the remaining reagent, evenly distributing to remaining containers
+				else
+					container.reagents.add_reagent(reagent, divided_amount, sdata, temp_new, donotreact, donotupdate)
 
 	disposing()
 		src.remove_container()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[FEATURE] [CHEMISTRY}

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR lets you hook condensers up to (up to) four containers, instead of just one. It will distribute reagents evenly to all containers when outputting. If one output beaker is full, it'll distribute the overflow to remaining beakers. If *all* beakers are full, it'll backflow like it currently does. Picking up or moving one attached beaker will remove just it, but picking up or moving the condenser will remove all attachments as expected.

Behold: The spider condenser

![condenser_pr](https://github.com/goonstation/goonstation/assets/53125172/acafaaea-cf0d-4952-9efe-c7f274024964)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There's several useful applications for this which I think are Neat.

- If you want to harvest your output from a beaker, you can attach a second beaker to the condenser to catch product made while you remove the initial beaker. This is useful mainly for oil, and means you won't have to deal with a bit of oil getting stuck in the condenser every time you want to use some oil, and don't have a time pressure to replace the beaker ever.
- You can use this to set up larger buffers for reactions. If you can't use a barrel (don't have one?) but want to run a reaction that makes over 100u of product, now you can easily do that by just splitting it into multiple beakers. This is like a medium version of a barrel mix, when you need <400u of space but >100u.
- You can use this to balance reactions in chains of condensers. If the first reaction in a chain is four times as fast as the second reaction, you can split the reaction into four outputs (three buffer beakers? three other condensers doing their own reactions?) and then the speeds will be more comparable, which means you have less backflow issues.
- It looks kinda cool and I imagine there's some creative uses of this that I'm not seeing. You could make even weirder spider web patterns of glassware for fun.


Also thank you to Leah for helping me figure out how to setup the overlay ref stuff for this and the specific beaker disconnecting :beesleep:

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flaborized
(*)Chemical condensers can now be attached to up to four containers, splitting their output evenly through them.
```
