### PR TITLE
Makes Rad and Wasp crossbow's cells unswappable

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -319,7 +319,7 @@ TYPEINFO(/obj/item/gun/energy/crossbow)
 	is_syndicate = 1
 	silenced = 1 // No conspicuous text messages, please (Convair880).
 	hide_attack = ATTACK_FULLY_HIDDEN
-	custom_cell_max_capacity = 100 // Those self-charging ten-shot radbows were a bit overpowered (Convair880)
+	can_swap_cell = FALSE
 	muzzle_flash = null
 	uses_charge_overlay = TRUE
 	charge_icon_state = "crossbow"
@@ -1589,7 +1589,7 @@ TYPEINFO(/obj/item/gun/energy/wasp)
 	projectiles = null
 	is_syndicate = 1
 	silenced = 1
-	custom_cell_max_capacity = 100
+	can_swap_cell = FALSE
 
 	New()
 		set_current_projectile(new/datum/projectile/special/spreader/quadwasp)


### PR DESCRIPTION
[GAME OBJECTS] [BALANCE] 

## About the PR 
Makes you unable to swap radiation and wasp crossbow's powercells


## Why's this needed? 
You can put extra fast recharging 100pu cell from sec vendor in it (which is actually pretty easy to get) and just spam the crossbows. Not nice considering the damage wasp and rad crossbows can do. 
And a lot of people assumed it was unswappable anyway....

## Changelog 
```changelog
(u)Sian
(+)Radiation and Wasp crossbow's powercells are now unswappable.
```
