### PR TITLE
Requisition adjustment oct23-01 (new pod-based civ requisition + some fixes)

### DIFF
--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -528,7 +528,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "wooden sheet"
 	typepath = /obj/item/sheet
 	mat_id = "wood"
-	feemod = PAY_UNTRAINED
+	feemod = PAY_UNTRAINED/2
 
 /datum/rc_entry/reagent/acetone
 	name = "acetone"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -524,9 +524,10 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	chem_ids = "silicate"
 	feemod = PAY_DOCTORATE/10
 
-/datum/rc_entry/item/sheet
+/datum/rc_entry/stack/sheet
 	name = "wooden sheet"
-	typepath = /obj/item/sheet/wood
+	typepath = /obj/item/sheet
+	mat_id = "wood"
 	feemod = PAY_UNTRAINED
 
 /datum/rc_entry/reagent/acetone

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -510,7 +510,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "rock"
 	commodity = /datum/commodity/ore
 	typepath = /obj/item/raw_material/rock
-	feemod = PAY_TRADESMAN
+	feemod = PAY_UNTRAINED
 
 /datum/rc_entry/seed/grass
 	name = "grass seed"
@@ -526,10 +526,8 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/rc_entry/item/sheet
 	name = "wooden sheet"
-	commodity = /datum/commodity/sheet
 	typepath = /obj/item/sheet/wood
-	exactpath = TRUE
-	feemod = PAY_IMPORTANT
+	feemod = PAY_UNTRAINED
 
 /datum/rc_entry/reagent/acetone
 	name = "acetone"
@@ -660,3 +658,133 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "proximity sensor"
 	typepath = /obj/item/device/prox_sensor
 	feemod = PAY_TRADESMAN
+
+/datum/req_contract/civilian/pod
+	//name = "Space Hogg"
+	payout = PAY_TRADESMAN*5
+	var/list/namevary = list("Back in the Shop","Vehicular Teardown","Rebuild Assistance","Nuts and Bolts")
+	var/list/flavor_descs = list(
+		"I'm overhauling my daily driver and my usual suppliers are giving me a lead time of weeks. Get everything together and I'll pay way too much.",
+		"Commercial hangar seeking components for rebuild of a client's personal vessel. Timely, well-secured delivery is required.",
+		"goddamn console says i have to fill this shit in GET ME MY PARTS",
+		"HELLO, FELLOW HUMANS. I SEEK VEHICULAR COMPONENTS FOR LEGITIMATE PURPOSES. I WILL REWARD YOU WITH MANY OF THESE CREDITS WE SO DEEPLY CHERISH.",
+		"Private hangar requesting expedited shipment of specified parts. Please use gloves when loading; any fingerprints will be scanned and recorded for later punitive action.",
+		"Transport service requesting parts for overhaul of a passenger vessel. Please be aware any 'mismatched' requests are not erroneous.",
+		"rick says hi",
+		"LF parts for a total overhaul. Used is fine, as long as I can't tell from the stains. Or smell. Peace out")
+
+	New()
+		src.name = pick(namevary)
+		src.flavor_desc = pick(flavor_descs)
+		src.payout += rand(0,40) * 10
+
+		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/engine_component,1)
+		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_engine,1)
+		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_circuitry,1)
+		if(prob(70) || length(src.rc_entries) < 2) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_armor,1)
+		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_control,1)
+		if(prob(60) || length(src.rc_entries) < 4) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_tool,1)
+		if(prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_secondary,1)
+
+		..()
+
+/datum/rc_entry/item/engine_component
+	name = "any pod-compatible engine but you shouldn't see this particular name for it"
+
+	New()
+		switch(rand(1, 10))
+			if(1 to 6)
+				name = "any pod-compatible engine"
+				typepath = /obj/item/shipcomponent/engine
+				feemod = PAY_TRADESMAN
+			if(7 to 9)
+				name = "Helios Mark-II engine"
+				typepath = /obj/item/shipcomponent/engine/helios
+				feemod = PAY_TRADESMAN*5
+			if(10)
+				name = "Hermes Mark-III engine"
+				typepath = /obj/item/shipcomponent/engine/hermes
+				feemod = PAY_DOCTORATE*5
+		..()
+
+/datum/rc_entry/item/pod_engine
+	name = "pod engine manifold"
+	typepath = /obj/item/pod/engine
+	feemod = PAY_TRADESMAN*2
+
+	New()
+		src.feemod += rand(0,20) * 10
+		..()
+
+/datum/rc_entry/item/pod_circuitry
+	name = "pod circuitry kit"
+	typepath = /obj/item/pod/boards
+	feemod = PAY_TRADESMAN
+
+	New()
+		src.feemod += rand(0,20) * 10
+		..()
+
+/datum/rc_entry/item/pod_armor
+	name = "pod armor but you shouldn't see this particular name for it"
+
+	New()
+		switch(rand(1, 10))
+			if(1 to 6)
+				name = "any pod armor"
+				typepath = /obj/item/podarmor
+				feemod = PAY_TRADESMAN*2
+			if(7 to 9)
+				name = "heavy pod armor"
+				typepath = /obj/item/podarmor/armor_heavy
+				feemod = PAY_TRADESMAN*5
+			if(10)
+				name = "industrial pod armor"
+				typepath = /obj/item/podarmor/armor_industrial
+				feemod = PAY_DOCTORATE*5
+		..()
+
+/datum/rc_entry/item/pod_control
+	name = "pod control interface"
+	typepath = /obj/item/pod/control
+	feemod = PAY_TRADESMAN
+
+	New()
+		src.feemod += rand(0,20) * 10
+		..()
+
+/datum/rc_entry/item/pod_tool
+	name = "youshouldn'tseemium cannon"
+
+	New()
+		switch(rand(1,20))
+			if(1 to 11)
+				name = "Mk 1.5 light phaser"
+				typepath = /obj/item/shipcomponent/mainweapon/phaser
+				feemod = PAY_TRADESMAN*2
+			if(12 to 19)
+				name = "plasma cutter system"
+				typepath = /obj/item/shipcomponent/mainweapon/mining
+				feemod = PAY_TRADESMAN*5
+			if(20)
+				name = "Mk.2 scout laser"
+				typepath = /obj/item/shipcomponent/mainweapon/laser
+				feemod = (PAY_DONTBUYIT*2) + (PAY_DOCTORATE * rand(3,6))
+		..()
+
+/datum/rc_entry/item/pod_secondary
+	name = "youshouldn'tseemium dongle"
+	feemod = PAY_TRADESMAN
+
+	New()
+		switch(rand(1, 10))
+			if(1 to 4)
+				name = "cargo hold"
+				typepath = /obj/item/shipcomponent/secondary_system/cargo
+			if(5 to 7)
+				name = "pod locking mechanism"
+				typepath = /obj/item/shipcomponent/secondary_system/lock
+			if(8 to 10)
+				name = "ship positioning system"
+				typepath = /obj/item/shipcomponent/secondary_system/gps
+		..()

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -786,6 +786,6 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 				name = "pod locking mechanism"
 				typepath = /obj/item/shipcomponent/secondary_system/lock
 			if(8 to 10)
-				name = "ship positioning system"
+				name = "ship's navigation GPS"
 				typepath = /obj/item/shipcomponent/secondary_system/gps
 		..()

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -662,7 +662,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/req_contract/civilian/pod
 	//name = "Space Hogg"
-	payout = PAY_TRADESMAN*5
+	payout = PAY_TRADESMAN*10
 	var/list/namevary = list("Back in the Shop","Vehicular Teardown","Rebuild Assistance","Nuts and Bolts")
 	var/list/flavor_descs = list(
 		"I'm overhauling my daily driver and my usual suppliers are giving me a lead time of weeks. Get everything together and I'll pay way too much.",

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -477,7 +477,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 			if("window treatment")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10*req_quant)
 			if("wood")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/sheet,rand(5,12)*req_quant)
+				src.rc_entries += rc_buildentry(/datum/rc_entry/stack/woodsheet,rand(5,12)*10*req_quant)
 			if("solvent")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10*req_quant)
 			if("detailing metal")
@@ -495,7 +495,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 				if("window treatment")
 					src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10)
 				if("wood")
-					src.rc_entries += rc_buildentry(/datum/rc_entry/item/sheet,rand(5,12))
+					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/woodsheet,rand(5,12)*10)
 				if("solvent")
 					src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10)
 				if("detailing metal")
@@ -524,7 +524,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	chem_ids = "silicate"
 	feemod = PAY_DOCTORATE/10
 
-/datum/rc_entry/stack/sheet
+/datum/rc_entry/stack/woodsheet
 	name = "wooden sheet"
 	typepath = /obj/item/sheet
 	mat_id = "wood"

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -150,10 +150,13 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		if(prob(60)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/fruit,rand(1,3))
 		if(!length(src.rc_entries) || prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/crop,rand(1,3))
 		if(length(src.rc_entries) == 1 || prob(30)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/veg,rand(1,3))
-		if(length(src.rc_entries) == 3) src.item_rewarders += new /datum/rc_itemreward/strange_seed
+		if(length(src.rc_entries) == 3) src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 		src.payout += 8000 * length(src.rc_entries)
 
-		src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
+		if(prob(80))
+			src.item_rewarders += new /datum/rc_itemreward/strange_seed
+		else
+			src.item_rewarders += new /datum/rc_itemreward/uv_lamp_frame
 		..()
 
 /datum/rc_entry/seed/scientific

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -153,7 +153,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		if(length(src.rc_entries) == 3) src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 		src.payout += 8000 * length(src.rc_entries)
 
-		if(prob(80))
+		if(prob(70))
 			src.item_rewarders += new /datum/rc_itemreward/strange_seed
 		else
 			src.item_rewarders += new /datum/rc_itemreward/uv_lamp_frame
@@ -202,3 +202,15 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 	build_reward()
 		var/seed = new /obj/item/seed/alien
 		return seed
+
+/datum/rc_itemreward/uv_lamp_frame
+	name = "ultraviolet botanical lamp"
+
+	build_reward()
+		var/obj/item/electronics/frame/F = new
+		F.store_type = /obj/machinery/hydro_growlamp
+		F.name = "UV Grow Lamp frame"
+		F.viewstat = 2
+		F.secured = 2
+		F.icon_state = "dbox"
+		return F


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Another set of improvements and fixes for requisitions.

- Introduces a new Civilian requisition for a set of pod components. These will most commonly be readily accessible components, but can sometimes require slightly or significantly rarer counterparts, which boosts the payout in kind.
- The Scientific requisition that requires specific seeds has had its rewards altered to be more appealing for botanists; instead of always rewarding a GardenGear refill cartridge and rewarding a strange seed for 3-requirement contracts, it now has a 70% chance to reward a strange seed and a 30% chance to reward a UV lamp frame, with the refill cartridge becoming the 3-requirement reward.
- Fixed the wood sheet requisition to use new material sheets (it was designed when wood sheets were a distinct unstackable item and apparently not fixed since then).
- Wood and rock requirements in requisitions now pay out less outlandish amounts of credits (wood in particular was vastly over-rewarded). As wood can now be purchased from the shipping market, quantities in the associated requisition have been increased tenfold to match.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes requisitions better and adds another variant for variety. Wood change fixes #16192.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Introduced an additional new civilian requisition centering around pod components and adjusted the seed requisition item rewards.
```
