### PR TITLE
Add a capsule machine to clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -36453,6 +36453,7 @@
 	dir = 8;
 	icon_state = "line1"
 	},
+/obj/machinery/vending/capsule,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "qSy" = (


### PR DESCRIPTION
[MAPPING]
## About the PR
Adds it to the central hallway as the arcade and north hallway is a bit full.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16200

## Changelog
```changelog
(u)Tyrant
(+)Clarion now has a capsule vending machine.
```