### PR TITLE
Fix beakers staying closed after being swapped with another one directly from the chem dispenser

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -133,11 +133,12 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 			B.reagents.handle_reactions()
 			return
 		*/
-		var/ejected_beaker = null
+		var/obj/item/reagent_containers/glass/ejected_beaker = null
 		if (src.beaker?.loc == src)
-			beaker.reagents?.handle_reactions()
+			src.beaker.reagents?.handle_reactions()
 			ejected_beaker = src.beaker
 			user.put_in_hand_or_drop(ejected_beaker)
+			REMOVE_ATOM_PROPERTY(ejected_beaker, PROP_ITEM_IN_CHEM_DISPENSER, src)
 
 		src.beaker = B
 		APPLY_ATOM_PROPERTY(B, PROP_ITEM_IN_CHEM_DISPENSER, src)


### PR DESCRIPTION
[chemistry][game objects][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes the `PROP_ITEM_IN_CHEM_DISPENSER` property from beakers that get ejected from chem dispensers when you swap them with another beaker by directly using the other beaker on the chem dispenser.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was possible to have beakers be permanently closed by adding a beaker into a chem dispenser and swapping it by using another beaker on the dispenser without ejecting the first one.

This is most likely the reason for #16189 and #15992.