### PR TITLE
Prevents stacking of items onto QDeleted items and fixed some runtimes with the rockbox

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -602,6 +602,8 @@ ABSTRACT_TYPE(/obj/item)
 	var/added = 0
 	var/imrobot
 	var/imdrone
+	if(QDELETED(other))
+		return added
 	if((imrobot = isrobot(other.loc)) || (imdrone = isghostdrone(other.loc)) || istype(other.loc, /obj/item/magtractor))
 		if (imrobot)
 			max_stack = 300

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -664,7 +664,7 @@ ABSTRACT_TYPE(/obj/item)
 
 /obj/item/MouseDrop_T(atom/movable/O as obj, mob/user as mob)
 	..()
-	if (max_stack > 1 && src.loc == user && BOUNDS_DIST(O, user) == 0 && check_valid_stack(O))
+	if (!QDELETED(src) && max_stack > 1 && src.loc == user && BOUNDS_DIST(O, user) == 0 && check_valid_stack(O))
 		if ( src.amount >= max_stack)
 			failed_stack(O, user)
 			return
@@ -676,6 +676,9 @@ ABSTRACT_TYPE(/obj/item)
 		before_stack(O, user)
 
 		for(var/obj/item/other in view(1,user))
+			if (QDELETED(src))
+				//let's not try to stack items into items that are disposed but not deleted yet
+				return
 			stack_result = stack_item(other)
 			if (!stack_result)
 				continue

--- a/code/obj/mining_cloud_storage.dm
+++ b/code/obj/mining_cloud_storage.dm
@@ -138,7 +138,9 @@
 		user.visible_message("<span class='notice'>[user] begins quickly stuffing [O] into [src]!</span>")
 		var/staystill = user.loc
 		for(var/obj/item/raw_material/M in view(1,user))
-			if (!M)
+			if (QDELETED(M) || QDELETED(O))
+				continue
+			if (M == O)
 				continue
 			if (M.type != O.type)
 				continue
@@ -154,6 +156,10 @@
 			playsound(src, sound_load, 40, TRUE)
 			sleep(0.5)
 			if (user.loc != staystill) break
+		//we stuff the item we clickdragged with last so we keep all the information we want to reference during the stuffing process
+		if (!QDELETED(O))
+			src.load_item(O)
+			playsound(src, sound_load, 40, TRUE)
 		boutput(user, "<span class='notice'>You finish stuffing [O] into [src]!</span>")
 		return
 


### PR DESCRIPTION
[player actions][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR fixes two bugs that come from clickdragging items to move multiple.

Firstly, this fixes a runtime that results from quickly stuffing multiple items into a rockbox

Secondly, this prevents multiple attempts to stack items from deleting the stacked target.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It is very often encountered that trying to stack multiple stacks of cash results in getting your cash deleted entirely. That happened because it was attempted to stack items that were disposed, but not fully deleted. That resulted in your resulting stack being a disposed and subsequently deleted one.

Also, while testing i stumbled upon a runtime with the rockbox which also came from trying to handle qdeleted items, so this was fixed as well. 

This is a step to take care of #5836, but this does not fix all of the issues reported there.