### PR TITLE
Adds a reliable way to quickly stop a securitron.

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -288,6 +288,11 @@
 		Status: <A href='?src=\ref[src];power=1'>[src.on ? "On" : "Off"]</A><BR>
 		Behaviour controls are [src.locked ? "locked" : "unlocked"]"}
 
+		if(!src.emagged)
+			if(src.allowed(user))
+				if (user.a_intent == INTENT_DISARM || user.a_intent == INTENT_GRAB)
+					src.KillPathAndGiveUp(KPAGU_CLEAR_ALL)
+
 		if(!src.locked)
 			dat += {"<hr>
 			Check for Unauthorised Equipment: <A href='?src=\ref[src];operation=idcheck'>[src.idcheck ? "Yes" : "No"]</A><BR>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If you have access, clicking a securitron while on disarm or grab intent will stop it from moving for a few seconds. This could be seen as buff to antagonists with AA, though securitrons rarely go after people with AA.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now, the onclick menu for securitrons is useless, as they just move away before you can use it. The only way to stop them is through the slow PDA app. See this forum thread: https://forum.ss13.co/showthread.php?tid=21854&pid=198161#pid198161

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Froggit Dogget
(+) If you have security access, you can click on a securitron using grab or disarm intent to make it temporarily stop moving/chasing its target.
```
