### PR TITLE
Tiny fix to requisition info text formatting for seeds

### DIFF
--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -351,7 +351,7 @@ ABSTRACT_TYPE(/datum/req_contract)
 					if(length(rceed.gene_reqs))
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed with following traits:<br>"
 						for(var/index in rceed.gene_reqs)
-							src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or higher<br>"
+							src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or greater<br>"
 					else
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed<br>"
 			src.payout += rce.feemod * rce.count

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -351,7 +351,7 @@ ABSTRACT_TYPE(/datum/req_contract)
 					if(length(rceed.gene_reqs))
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed with following traits:<br>"
 						for(var/index in rceed.gene_reqs)
-							src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or greater<br>"
+							src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or higher<br>"
 					else
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed<br>"
 			src.payout += rce.feemod * rce.count

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -351,10 +351,7 @@ ABSTRACT_TYPE(/datum/req_contract)
 					if(length(rceed.gene_reqs))
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed with following traits:<br>"
 						for(var/index in rceed.gene_reqs)
-							if(index == "Maturation" || index == "Production")
-								src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or lower<br>"
-							else
-								src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or higher<br>"
+							src.requis_desc += "* [index]: [rceed.gene_reqs[index]] or higher<br>"
 					else
 						src.requis_desc += "[rce.count]x [rceed.cropname] seed<br>"
 			src.payout += rce.feemod * rce.count


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The front-end display of seed requisitions wasn't updated to match the fixed back-end behavior (higher maturation and production stats being better), incorrectly implying that lower is better for those stats. This fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Corrects small goof that inadvertently misled people about what some requisitions actually need. ty clover