### PR TITLE
Ensure recipient of 'Give Item' is alive and not yourself

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1390,7 +1390,7 @@
 			L.give_to(src)
 
 /mob/living/proc/give_to(var/mob/living/M)
-	if (!M)
+	if (!M || M == src || M.stat != STAT_ALIVE)
 		return
 
 #ifdef TWITCH_BOT_ALLOWED

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1384,6 +1384,10 @@
 	set src in view(1)
 	set category = "Local"
 
+	if (usr == src)
+		boutput(usr,"<span class='alert'>You can't give items to yourself!</span>")
+		return
+
 	SPAWN(0.7 SECONDS) //secret spawn delay, so you can't spam this during combat for a free "stun"
 		if (usr && isliving(usr) && !issilicon(usr) && BOUNDS_DIST(src, usr) == 0)
 			var/mob/living/L = usr

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1390,7 +1390,7 @@
 			L.give_to(src)
 
 /mob/living/proc/give_to(var/mob/living/M)
-	if (!M || M == src || M.stat != STAT_ALIVE)
+	if (!M || M == src || isalive(M))
 		return
 
 #ifdef TWITCH_BOT_ALLOWED


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the ability to give yourself an item or to try and give someone under anesthetic/who is asleep/who is dead an item.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12973

TODO:

- [x] Remove Right-Click option to give yourself an item as well 
Cant give items to yourself but it still shows up cos verb sadly
- [x] Prevent people lying down/stunned from receiving items as well
(Not planned unless requested, unconscious is fine enough)
