### PR TITLE
Monkeys Stop Chasing Incorporeal Wraiths

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -324,6 +324,14 @@
 		// Dead monkeys can't hold a grude and stops emote
 		if(isdead(src) || T == src)
 			return ..()
+		if(isintangible(T))
+			if(!iswraith(T))
+				return ..()
+			else
+				if(!T.density)
+					return ..()
+		if(isobserver(T))
+			return ..()
 		if(ismonkey(T) && T:ai_active && prob(90))
 			return ..()
 		//src.ai_aggressive = 1
@@ -380,6 +388,22 @@
 	proc/done_with_you(var/atom/T as mob|obj)
 		if (!T)
 			return 0
+		if(isintangible(T))
+			if(!iswraith(T))
+				src.ai_state = 0
+				src.target = null
+				src.ai_target = null
+				src.ai_frustration = 0
+				walk_towards(src,null)
+				return 1
+			else
+				if(!T.density)
+					src.ai_state = 0
+					src.target = null
+					src.ai_target = null
+					src.ai_frustration = 0
+					walk_towards(src,null)
+					return 1
 		if (src.health <= 0 || (GET_DIST(src, T) >= 11))
 			if(src.health <= 0)
 				src.ai_state = AI_FLEEING


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- stops monkeys from trying to hit observers and intangible mobs (except corporeal wraiths)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #10150
