### PR TITLE
Mail chute funnelling

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -437,6 +437,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "abY" = (
@@ -1717,6 +1718,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal/mail,
+/obj/window/reinforced/east,
 /turf/simulated/floor/bluegreen/side,
 /area/station/hallway/secondary/exit)
 "aiz" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2927,6 +2927,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
+/obj/window/reinforced/north,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -10627,6 +10628,7 @@
 	},
 /obj/disposalpipe/trunk/ejection,
 /obj/machinery/power/apc/autoname_north,
+/obj/window/reinforced/east,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -14211,6 +14213,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aRB" = (
@@ -30994,6 +30997,7 @@
 	message = 1;
 	name = "mail chute-'Research'"
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bXH" = (
@@ -32783,6 +32787,7 @@
 	name = "mail chute-'Robotics'"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/window/reinforced/east,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "cdp" = (
@@ -54850,6 +54855,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "ppr" = (
@@ -58649,6 +58655,7 @@
 	mail_tag = "sortingroom";
 	name = "mail chute-'Sorting Room'"
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
 "sFS" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1859,6 +1859,7 @@
 "agb" = (
 /obj/machinery/disposal/mail/autoname/public/crewB,
 /obj/disposalpipe/trunk/mail/east,
+/obj/window/reinforced/west,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quartersB)
 "agc" = (
@@ -2845,6 +2846,7 @@
 "ajc" = (
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/autoname/security/detective,
+/obj/window/reinforced/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "ajd" = (
@@ -9009,6 +9011,7 @@
 "aAQ" = (
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/autoname/kitchen,
+/obj/window/reinforced/north,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aAR" = (
@@ -10900,8 +10903,11 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aFY" = (
-/obj/machinery/disposal,
+/obj/machinery/disposal/small/north{
+	pixel_y = 32
+	},
 /obj/disposalpipe/trunk,
+/obj/window/reinforced/east,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aFZ" = (
@@ -12389,6 +12395,8 @@
 /obj/machinery/disposal/mail/autoname/hydroponics,
 /obj/disposalpipe/trunk/mail/north,
 /obj/decal/stripe_caution,
+/obj/window/reinforced/east,
+/obj/window/reinforced/north,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "aKw" = (
@@ -14174,6 +14182,7 @@
 	},
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/autoname/public/crewA,
+/obj/window/reinforced/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
 "aPs" = (
@@ -18378,7 +18387,7 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/northeast)
 "bbt" = (
-/obj/machinery/disposal,
+/obj/machinery/disposal/small/south,
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
@@ -31219,6 +31228,7 @@
 "bLO" = (
 /obj/machinery/disposal/mail/autoname/engineering,
 /obj/disposalpipe/trunk/mail/north,
+/obj/window/reinforced/east,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -32816,6 +32826,7 @@
 /obj/machinery/status_display{
 	pixel_y = -30
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -33283,6 +33294,7 @@
 "bRm" = (
 /obj/machinery/disposal/mail/autoname/security,
 /obj/disposalpipe/trunk/mail,
+/obj/window/reinforced/west,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -41029,6 +41041,7 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -42835,6 +42848,7 @@
 "ctR" = (
 /obj/disposalpipe/trunk/mail/north,
 /obj/machinery/disposal/mail/autoname/qm/refinery,
+/obj/window/reinforced/east,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -44879,11 +44893,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/trunk/mail/east,
+/obj/machinery/disposal/mail/small/autoname/checkpoint/cargo/south,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "czL" = (
-/obj/disposalpipe/trunk/mail/south,
-/obj/machinery/disposal/mail/small/autoname/checkpoint/cargo/west,
+/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "czM" = (
@@ -45482,6 +45497,7 @@
 /obj/machinery/light,
 /obj/machinery/disposal/mail/autoname/mechanics,
 /obj/disposalpipe/trunk/mail/west,
+/obj/window/reinforced/east,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "cBB" = (
@@ -48297,6 +48313,7 @@
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/autoname/qm,
 /obj/decal/stripe_caution,
+/obj/window/reinforced/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "cJO" = (
@@ -48584,6 +48601,7 @@
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/autoname/research,
 /obj/decal/stripe_caution,
+/obj/window/reinforced/south,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "cKF" = (
@@ -51939,6 +51957,7 @@
 "cUg" = (
 /obj/disposalpipe/trunk/mail/west,
 /obj/machinery/disposal/mail/autoname/medbay/genetics,
+/obj/window/reinforced/east,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -52952,6 +52971,7 @@
 	icon_state = "2-8"
 	},
 /obj/landmark/start/job/security_officer,
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "cWX" = (
@@ -55788,6 +55808,7 @@
 /area/station/maintenance/solar/south)
 "deV" = (
 /obj/machinery/flasher/portable,
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "deW" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1238,6 +1238,7 @@
 	name = "mail chute-'Artifact Lab'"
 	},
 /obj/disposalpipe/trunk/mail/east,
+/obj/window/reinforced/south,
 /turf/simulated/floor/white/checker2{
 	dir = 8
 	},
@@ -1426,6 +1427,7 @@
 	name = "mail chute-'Chemistry'"
 	},
 /obj/disposalpipe/trunk/mail,
+/obj/window/reinforced/west,
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "agK" = (
@@ -3855,6 +3857,7 @@
 "arZ" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
+/obj/window/reinforced/west,
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster/office)
 "asb" = (
@@ -3995,6 +3998,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
+/obj/window/reinforced/south,
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "asG" = (
@@ -15918,6 +15922,7 @@
 /obj/machinery/recharger/wall/sticky{
 	dir = 1
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -59151,6 +59151,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
+/obj/window/reinforced/south,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "shi" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -4341,6 +4341,7 @@
 "apA" = (
 /obj/machinery/disposal/mail/autoname/public/podbay,
 /obj/disposalpipe/trunk/mail/west,
+/obj/window/reinforced/east,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -6923,6 +6924,7 @@
 "aAe" = (
 /obj/machinery/disposal/mail/autoname/chapel,
 /obj/disposalpipe/trunk/mail/east,
+/obj/window/reinforced/north,
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
 "aAf" = (
@@ -9288,6 +9290,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /obj/machinery/light,
+/obj/window/reinforced/west,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "aIX" = (
@@ -10373,6 +10376,7 @@
 	pixel_y = 21
 	},
 /obj/disposalpipe/trunk/south,
+/obj/window/reinforced/west,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -12008,7 +12012,6 @@
 "aVa" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
-/obj/machinery/disposal,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 16
@@ -13834,6 +13837,7 @@
 "bcX" = (
 /obj/machinery/disposal/mail/autoname/medbay,
 /obj/disposalpipe/trunk/mail/west,
+/obj/window/reinforced/south,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -18436,6 +18440,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
 "bwN" = (
@@ -22520,6 +22525,7 @@
 "bLJ" = (
 /obj/machinery/disposal/mail/autoname/research,
 /obj/disposalpipe/trunk/mail/north,
+/obj/window/reinforced/south,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bLK" = (
@@ -27971,6 +27977,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "chs" = (
@@ -33406,6 +33413,7 @@
 	pixel_y = 20
 	},
 /obj/machinery/firealarm/north,
+/obj/window/reinforced/east,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -36367,6 +36375,7 @@
 "gpE" = (
 /obj/machinery/disposal/mail/autoname/public/escape,
 /obj/disposalpipe/trunk/mail/west,
+/obj/window/reinforced/north,
 /turf/simulated/floor/escape/corner{
 	dir = 4
 	},
@@ -44748,6 +44757,7 @@
 	pixel_x = -12
 	},
 /obj/disposalpipe/trunk/east,
+/obj/window/reinforced/north,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "mLE" = (
@@ -54852,6 +54862,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /obj/machinery/firealarm/north,
+/obj/window/reinforced/east,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "uyR" = (
@@ -54927,6 +54938,7 @@
 	name = "Ranch"
 	},
 /obj/disposalpipe/trunk/mail/east,
+/obj/window/reinforced/west,
 /turf/simulated/floor/caution/misc{
 	dir = 4
 	},
@@ -58835,6 +58847,7 @@
 "xyz" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
+/obj/window/reinforced/south,
 /turf/simulated/floor/darkblue/checker,
 /area/station/crew_quarters/radio/news_office)
 "xzv" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -3625,6 +3625,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/disposalpipe/trunk/south,
+/obj/window/reinforced/west,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "bDH" = (
@@ -19129,6 +19130,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "ijX" = (
@@ -30573,6 +30575,7 @@
 /obj/sign_switch/east{
 	id = "kitchenopen"
 	},
+/obj/window/reinforced/south,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "mXd" = (
@@ -36081,6 +36084,7 @@
 	},
 /obj/disposalpipe/trunk/south,
 /obj/machinery/disposal,
+/obj/window/reinforced/east,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -47411,6 +47415,7 @@
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/window/reinforced/west,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay)
 "uwR" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -6630,6 +6630,7 @@
 /obj/machinery/disposal/mail/autoname{
 	mail_tag = "crew quarters"
 	},
+/obj/window/reinforced/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersA)
 "avK" = (
@@ -7437,6 +7438,7 @@
 	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
+/obj/window/reinforced/south,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "ayw" = (
@@ -13213,6 +13215,7 @@
 	mail_tag = "mechanics"
 	},
 /obj/machinery/light/incandescent/warm,
+/obj/window/reinforced/south,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -13335,6 +13338,7 @@
 	mail_tag = "escape"
 	},
 /obj/disposalpipe/trunk/mail/west,
+/obj/window/reinforced/north,
 /turf/simulated/floor/darkpurple/side{
 	dir = 8
 	},
@@ -16431,6 +16435,7 @@
 "bgn" = (
 /obj/disposalpipe/trunk/east,
 /obj/machinery/disposal,
+/obj/window/reinforced/west,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bgo" = (
@@ -24777,6 +24782,7 @@
 	tag = ""
 	},
 /obj/decal/stripe_delivery,
+/obj/window/reinforced/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bID" = (
@@ -27030,6 +27036,7 @@
 /obj/disposalpipe/trunk/east{
 	dir = 1
 	},
+/obj/window/reinforced/south,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},


### PR DESCRIPTION
[MAPPING] [QOL]
## About the PR
This PR finds all(?) of the mail chutes that are close to other pipe chutes and either moves the exit chute or places a thindow. This is to prevent mail from immediately going into the disposal chute and being missed by the recipient.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Missing out on mail just because a mail chute and disposal chute were put next to each other shouldn't really be a thing. It's been reported in discord as an issue as well.

## Changelog
```changelog
(u)Tyrant
(+)New barriers have been placed to stop mail from going straight into disposal chutes.
```