### PR TITLE
Use regular speech bubble for whispers

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1660,6 +1660,7 @@
 		if (isdead(M) && !(M in heard_a) && !istype(M, /mob/dead/target_observer) && !(M?.client?.preferences?.local_deadchat))
 			M.show_message(rendered, 2)
 
+	speech_bubble.icon_state = "speech"
 	show_speech_bubble(speech_bubble)
 
 /mob/living/carbon/human/u_equip(obj/item/W)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Whispering never sets a chat bubble icon state, so it used whatever the last one was. This explicitly sets the "speech" icon state when whispering.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16140