### PR TITLE
Fix orwell's lying state to not be george's

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -957,6 +957,7 @@ TYPEINFO(/mob/living/critter/small_animal/cat/jones)
 /mob/living/critter/small_animal/dog/george/orwell
 	name = "Orwell"
 	icon_state = "corgi"
+	icon_state_dead = "corgi-lying"
 	dogtype = "corgi"
 
 /* ============================================== */


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
OOP moment, /mob/living/critter/small_animal/dog/george/orwell inherits george's lying state and sets its own icon state, but not its lying state, so when it lies down it turns into George.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16178
