### PR TITLE
Fix improperly rotated firedoor on Clarion bridge enterance

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -20305,7 +20305,6 @@
 	icon_state = "2-4"
 	},
 /obj/mapping_helper/access/heads,
-/obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner{
 	pixel_y = -10
 	},
@@ -20324,6 +20323,7 @@
 /obj/machinery/door/airlock/pyro/command{
 	name = "Bridge"
 	},
+/obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/blue,
 /area/station/bridge)
 "edo" = (


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![dreamseeker_nUZYcAKPiJ](https://github.com/goonstation/goonstation/assets/27376947/9ae3b8ee-34e4-4e2d-9f9b-1ef85130fcbc)
![dreamseeker_D7jFDzvzOI](https://github.com/goonstation/goonstation/assets/27376947/15ab9934-ebe9-455a-9faa-f27203e99494)
The reason this occurs is because the dir on the helper is overriden by the blast door, which has a dir of 4 to be horizontal instead of 2, making the firedoor become vertical.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's probably okay to replace a helper with a firedoor instead of adding code to every helper ever to check if the door its on is a blast door and handle that separately and it fixes #15994