### PR TITLE
The Reappearing Cake (fixes cake self-deletion)

### DIFF
--- a/code/modules/food_and_drink/cakes.dm
+++ b/code/modules/food_and_drink/cakes.dm
@@ -34,7 +34,7 @@
 	icon = 'icons/obj/foodNdrink/food_dessert.dmi'
 	icon_state = "cake1-base_custom"
 	inhand_image_icon = 'icons/mob/inhand/hand_food.dmi'
-	bites_left = 0
+	bites_left = 12
 	heal_amt = 2
 	fill_amt = 20 //2 per slice
 	use_bite_mask = FALSE
@@ -492,8 +492,9 @@
 			frost_cake(W,user)
 			return
 		else if(istype(W,/obj/item/reagent_containers/food/snacks/cake))
-			stack_cake(W,user)
-			return
+			if(!(src == W))
+				stack_cake(W,user)
+				return
 		else if(cake_candle.len && !(litfam) && (W.firesource))
 			src.ignite()
 			W.firesource_interact()

--- a/code/modules/food_and_drink/cakes.dm
+++ b/code/modules/food_and_drink/cakes.dm
@@ -492,7 +492,7 @@
 			frost_cake(W,user)
 			return
 		else if(istype(W,/obj/item/reagent_containers/food/snacks/cake))
-			if(!(src == W))
+			if(src != W)
 				stack_cake(W,user)
 				return
 		else if(cake_candle.len && !(litfam) && (W.firesource))


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- gives cakes 12 bites because no food should have 0 bites left imo and that's what the cake batter has
- stops cakes from being able to be stacked on top of itself (which deletes it)
- 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- fixes #10548
