### PR TITLE
ABCU: small bugfix for apc rebuilding

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -286,12 +286,13 @@
 		logTheThing(LOG_STATION, src, "[user] started ABCU build at [log_loc(src)], with blueprint [src.current_bp.name], authored by [src.current_bp.author]")
 
 	proc/end_build()
-		for (var/datum/objectinfo/N in src.apc_list)
-			var/atom/new_obj = new N.objecttype(src.apc_list[N])
-			new_obj.dir = N.direction
-			new_obj.pixel_x = N.px
-			new_obj.pixel_y = N.py
-		src.apc_list = new/list
+		SPAWN(2 SECONDS) // gotta wait for make_tile() to finish
+			for (var/datum/objectinfo/N in src.apc_list)
+				var/atom/new_obj = new N.objecttype(src.apc_list[N])
+				new_obj.dir = N.direction
+				new_obj.pixel_x = N.px
+				new_obj.pixel_y = N.py
+			src.apc_list = new/list
 
 		src.building = FALSE
 		UnsubscribeProcess()

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -287,7 +287,10 @@
 
 	proc/end_build()
 		for (var/datum/objectinfo/N in src.apc_list)
-			new N.objecttype(src.apc_list[N])
+			var/atom/new_obj = new N.objecttype(src.apc_list[N])
+			new_obj.dir = N.direction
+			new_obj.pixel_x = N.px
+			new_obj.pixel_y = N.py
 		src.apc_list = new/list
 
 		src.building = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fixes APCs getting built with the wrong offset. (this only happens to apcs that were mechscanned, built, then saved into a blueprint)
* Also adds a short delay with SPAWN so areas get assigned more properly-er


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
making things is hard

