### PR TITLE
Change API format query params to correct format for Laravel

### DIFF
--- a/code/modules/goonhub/api/routes/apiRoute.dm
+++ b/code/modules/goonhub/api/routes/apiRoute.dm
@@ -19,14 +19,17 @@
 
 
 /// Formats a given parameter associated list into a urlstring format
-/// E.g. `list("ckey"="zewaka") to `?&ckey=zewaka` and `list("x"=list("a", "b"))` to `?&x=a,b`
+/// E.g. `list("ckey"="zewaka") to `?&ckey=zewaka` and `list("x"=list("a" = "foo", "b" = "bar"))` to `?&x[a]=foo&x[b]=bar`
 /datum/apiRoute/proc/formatQueryParams()
 	if (length(src.queryParams))
-		var/paramListClone = src.queryParams.Copy()
-		for (var/key in paramListClone)
-			if (islist(paramListClone[key])) // Do we need to encode the value?
-				paramListClone[key] = jointext(paramListClone[key], ",") // lists become csvs by convention
-		. = list2params(.)
+		var/list/ret = list()
+		for (var/key in src.queryParams)
+			if (islist(src.queryParams[key])) // Do we need to encode the value?
+				for (var/subKey in src.queryParams[key])
+					ret["[key]\[[subKey]\]"] = src.queryParams[key][subKey]
+			else
+				ret[key] = src.queryParams[key]
+		. = list2params(ret)
 
 /// Formats a given parameter list into a route-append format
 /// E.g. `list("tuesday", "wednesday")` to `tuesday/wednesday`

--- a/code/modules/goonhub/api/routes/apiRoute.dm
+++ b/code/modules/goonhub/api/routes/apiRoute.dm
@@ -22,14 +22,14 @@
 /// E.g. `list("ckey"="zewaka") to `?&ckey=zewaka` and `list("x"=list("a" = "foo", "b" = "bar"))` to `?&x[a]=foo&x[b]=bar`
 /datum/apiRoute/proc/formatQueryParams()
 	if (length(src.queryParams))
-		var/list/ret = list()
+		. = list()
 		for (var/key in src.queryParams)
 			if (islist(src.queryParams[key])) // Do we need to encode the value?
 				for (var/subKey in src.queryParams[key])
-					ret["[key]\[[subKey]\]"] = src.queryParams[key][subKey]
+					.["[key]\[[subKey]\]"] = src.queryParams[key][subKey]
 			else
-				ret[key] = src.queryParams[key]
-		. = list2params(ret)
+				.[key] = src.queryParams[key]
+		. = list2params(.)
 
 /// Formats a given parameter list into a route-append format
 /// E.g. `list("tuesday", "wednesday")` to `tuesday/wednesday`


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Previous method formatted nested lists to a CSV structure. Laravel instead expects array parameters as foo[bar]=val