### PR TITLE
Prevent kudzu from spreading through walls with doors on their tile

### DIFF
--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -232,6 +232,8 @@
 	var/dogrowth = 1
 	if (!istype(Vspread, /turf/simulated/floor) || isfeathertile(Vspread))
 		dogrowth = 0
+		return
+		
 	for (var/obj/O in Vspread)
 
 		if (istype(O, /obj/window) || istype(O, /obj/forcefield) || istype(O, /obj/blob) || istype(O, /obj/spacevine) || istype(O, /obj/kudzu_marker))


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
One-liner to return if the tile isn't simulated floor.
I would make it so you can't do this in the first place, but there's argument to be made about it being a feature and/or balance discussion (Personally I'd be for it though)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16085, kudzu should not spread through walls just because there is a door on the tile