### PR TITLE
Donut 2 QM Reinforced Table Fix

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -3364,7 +3364,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/researchshuttle)
 "aqi" = (
-/obj/table/reinforced,
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen/marker/blue,
@@ -3373,6 +3372,7 @@
 	pixel_x = -7
 	},
 /obj/item/stamp,
+/obj/table/reinforced/auto,
 /turf/simulated/floor/yellow/side,
 /area/station/quartermaster/office)
 "aqk" = (
@@ -27788,7 +27788,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "gTk" = (
-/obj/table/reinforced,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -27796,6 +27795,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/cargo,
+/obj/table/reinforced/auto,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "gTm" = (
@@ -50012,7 +50012,6 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "wqN" = (
-/obj/table/reinforced,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -50021,6 +50020,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/cargo,
 /obj/mapping_helper/firedoor_spawn,
+/obj/table/reinforced/auto,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "wrA" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Reinforced Tables at the QM's desk on Donut 2 with the auto connecting version
![image](https://github.com/goonstation/goonstation/assets/94804240/3ccb3d80-b152-4f0e-bc52-cabd3b0229f9)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks nicer

