### PR TITLE
someone forgot to add `.name` for getting the subtype's name in mushroom cap random so here it is

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -2075,7 +2075,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/mushroomcap)
 	random
 		New()
 			var/obj/item/clothing/head/mushroomcap/rand_type = get_random_subtype(/obj/item/clothing/head/mushroomcap)
-			name = initial(rand_type)
+			name = initial(rand_type.name)
 			additional_desc = initial(rand_type.additional_desc)
 			icon_state = initial(rand_type.icon_state)
 			item_state = initial(rand_type.item_state)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #16270 which breaks because code doesn't use `initial(random_type.name)`, rather `initial(random_type)` which is `null`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix bug. Please tell me what to say here I genuinely don't wanna be someone who just puts "Bug Bad" on every one line fix I don't like doing it