### PR TITLE
Sending out the rev tracker is no longer done via SPAWN

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -19,10 +19,15 @@
 	var/waittime = 0
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
+	/// Has the revolution announcement been sent out yet
 	var/waittimed = FALSE
+	/// The time to wait till we send out the tracker time
 	var/trackertime = 0
-	var/const/trackertime_min = 27 MINUTES //lower bound on time before intercept arrives (in tenths of seconds)
-	var/const/trackertime_max = 30 MINUTES //upper bound on time before intercept arrives (in tenths of seconds)
+	/// lower bound on time before intercept arrives (in tenths of seconds)
+	var/const/trackertime_min = 27 MINUTES
+	/// upper bound on time before intercept arrives (in tenths of seconds)
+	var/const/trackertime_max = 30 MINUTES
+	/// Has the tracker been sent out yet
 	var/trackertimed = FALSE
 	var/const/min_revheads = 3
 	var/const/max_revheads = 5
@@ -121,12 +126,12 @@
 	if (!istype(ticker.mode, /datum/game_mode/revolution/extended) && ticker.round_elapsed_ticks >= round_limit && !gibwave_started)
 		gibwave_started = TRUE
 		start_gibwave()
-	if (world.time > win_check_freq)
+	if (ticker.round_elapsed_ticks > win_check_freq)
 		win_check_freq += win_check_freq
 		check_win()
-	if (TIME >= waittime && !waittimed)
+	if (ticker.round_elapsed_ticks >= waittime && !waittimed)
 		send_intercept()
-	if (TIME >= trackertime && !trackertimed)
+	if (ticker.round_elapsed_ticks >= trackertime && !trackertimed)
 		send_tracker()
 #endif
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sending out the rev tracker is no longer sent out via SPAWN and is instead sent out by comparing to TIME, this should make the time it gets sent out much more consistent.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, should fix #11619


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Bug fix, not needed