### PR TITLE
adds isbool()

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -148,6 +148,7 @@
 #include "macros\transfers.dm"
 #include "macros\turf.dm"
 #include "macros\twitch_sbill.dm"
+#include "macros\vars.dm"
 #include "macros\vehicles.dm"
 #include "address.dm"
 #include "color.dm"

--- a/_std/macros/vars.dm
+++ b/_std/macros/vars.dm
@@ -1,0 +1,5 @@
+// Macros for checking details of vars
+
+// Some are built into dm: islist(), istext(), isnum(), istext(), ispath(). Some are not.
+
+#define isbool(x)	(x == TRUE || x == FALSE)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,6 +30,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\macros\vars.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,7 +30,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
-#include "_std\macros\vars.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"


### PR DESCRIPTION
[INTERNAL] [QOL]
## About the PR
Adds a definition for `isbool(x)`. Puts it in `_std/macros/vars.dm`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We have checks for lists, paths, text, numbers, infinity, obj, pointers, movable, null, loc... all built straight into DM. But not `isbool()`. Apparently they expected you to just use truthiness, but what if you need to check it properly and not truthy?