### PR TITLE
Fixes overlapping chem recipes causing chem duping and inhibitor changes

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -450,7 +450,10 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 						break
 				if(total_matching_reagents == C.required_reagents.len)
 					for (var/inhibitor in C.inhibitors)
-						if (src.has_reagent(inhibitor))
+						var/inhibitor_amount_to_check = 0
+						if (C.inhibitors[inhibitor])
+							inhibitor_amount_to_check = C.inhibitors[inhibitor]
+						if (src.has_reagent(inhibitor, inhibitor_amount_to_check))
 							continue reaction_loop
 
 					if(!C.does_react(src))

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -868,7 +868,7 @@
 		name = "sun tea"
 		id = "sun_tea"
 		result = "sun_tea"
-		required_reagents = list("tea" = 3, "juice_orange" = 1, "sugar" = 1)
+		required_reagents = list("tea" = 2, "juice_orange" = 1, "sweet_tea" = 2)
 		result_amount = 5
 		mix_phrase = "The tea takes on a sweet, summery smell."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
@@ -3991,6 +3991,7 @@
 		id = "ammonia"
 		result = "ammonia"
 		required_reagents = list("hydrogen" = 3, "nitrogen" = 1)
+		inhibitors = list("chlorine") //to prevent conflict with atrazine
 		result_amount = 3
 		mix_phrase = "The mixture bubbles, emitting an acrid reek."
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3991,7 +3991,7 @@
 		id = "ammonia"
 		result = "ammonia"
 		required_reagents = list("hydrogen" = 3, "nitrogen" = 1)
-		inhibitors = list("chlorine") //to prevent conflict with atrazine
+		inhibitors = list("chlorine" = 1) //to prevent conflict with atrazine
 		result_amount = 3
 		mix_phrase = "The mixture bubbles, emitting an acrid reek."
 
@@ -5041,7 +5041,7 @@
 		result_amount = 5 //14
 		mix_phrase = "The mixture of particles settles together with ease."
 		mix_sound = 'sound/misc/fuse.ogg'
-		inhibitors = list("sulfur")
+		inhibitors = list("sulfur" = 1)
 
 	okay_cement //lime, alumina, magnesia, iron (iii) oxide
 		name = "okay cement"
@@ -5051,7 +5051,7 @@
 		result_amount = 4 //13
 		mix_phrase = "The mixture of particles settles together complacently."
 		mix_sound = 'sound/misc/fuse.ogg'
-		inhibitors = list("gypsum")
+		inhibitors = list("gypsum" = 1)
 
 	poor_cement //lime, alumina, iron (iii) oxide
 		name = "poor cement"
@@ -5061,7 +5061,7 @@
 		result_amount = 2 //
 		mix_phrase = "The mixture of particles settles together... barely."
 		mix_sound = 'sound/misc/fuse.ogg'
-		inhibitors = list("magnesium")
+		inhibitors = list("magnesium" = 1)
 
 	perfect_concrete
 		name = "perfect concrete"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -868,7 +868,7 @@
 		name = "sun tea"
 		id = "sun_tea"
 		result = "sun_tea"
-		required_reagents = list("tea" = 2, "juice_orange" = 1, "sweet_tea" = 2)
+		required_reagents = list("tea" = 3, "juice_orange" = 1, "sugar" = 1)
 		result_amount = 5
 		mix_phrase = "The tea takes on a sweet, summery smell."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
@@ -879,6 +879,7 @@
 		id = "sweet_tea"
 		result = "sweet_tea"
 		required_reagents = list("sugar" = 1, "tea" = 1)
+		inhibitors = list("juice_orange" = 1)
 		result_amount = 2
 		mix_phrase = "The tea sweetens. Visually. Somehow."
 		mix_sound = 'sound/misc/drinkfizz.ogg'


### PR DESCRIPTION
[Internal][Chemistry][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Firstly, his PR changes so when a reaction removes chems from a container, it only updates the container AFTER all corresponding reagents have been removed, not after a single one has been removed. This bug causes the superconcrete recipe to create concrete despite it normally being impossible due to a set inhibitor. 

What was happening was that the inhibitor was removed first and then the container was updated and checked for reactions again. At that point, the other concrete recipe was able to proceed.

Also, this PR enables to have an amount of chem specified that is needed so the inhibitor works. That way it can be enabled that 0.5u of a chem in a container, that is otherwise unable to react due to minimum_amount, is not able to inhibit a reaction. This is used for the inhibitors in the concrete recipes.

Lastly, these changed were used to add chlorine, with at least 1u, as an inhibitor of the ammonia reaction. The same was done with orange juice with at least 1u in the sun tea recipe.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reactions that were in competition with each other caused the duping of reagents by creating more reagents than they actually should.

This fixes #15680 and fixes #14844

Also, this makes the corresponding recipes react more like you expect them to, priorizing the more complex recipe