### PR TITLE
Make capsaicin stun use cooldowns

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2148,13 +2148,13 @@ datum
 				if(!M) M = holder.my_atom
 				if (holder.get_reagent_amount(src.id) >= 20)
 					M.stuttering += rand(0,5)
-					if(prob(19) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
+					if(prob(19) && !ON_COOLDOWN(M, "capsaicin_stun_life", 7 SECONDS))
 						M.emote(pick("choke","gasp","cough"))
 						M.setStatusMin("stunned", 1 SECOND * mult)
 						M.take_oxygen_deprivation(rand(0,10) * mult)
 						M.bodytemperature += rand(5,20) * mult
 				else
-					if(prob(10) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
+					if(prob(10) && !ON_COOLDOWN(M, "capsaicin_stun_life", 7 SECONDS))
 						M.emote(pick("cough"))
 						M.setStatusMin("stunned", 1 SECOND * mult)
 				M.stuttering += rand(0,2)

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2148,7 +2148,7 @@ datum
 				if(!M) M = holder.my_atom
 				if (holder.get_reagent_amount(src.id) >= 20)
 					M.stuttering += rand(0,5)
-					if(prob(15) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
+					if(prob(19) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
 						M.emote(pick("choke","gasp","cough"))
 						M.setStatusMin("stunned", 1 SECOND * mult)
 						M.take_oxygen_deprivation(rand(0,10) * mult)

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2148,16 +2148,18 @@ datum
 				if(!M) M = holder.my_atom
 				if (holder.get_reagent_amount(src.id) >= 20)
 					M.stuttering += rand(0,5)
-					if(prob(10))
+					if(prob(15) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
 						M.emote(pick("choke","gasp","cough"))
 						M.setStatusMin("stunned", 1 SECOND * mult)
 						M.take_oxygen_deprivation(rand(0,10) * mult)
 						M.bodytemperature += rand(5,20) * mult
+				else
+					if(prob(10) && !ON_COOLDOWN(M, "capsaicin_stun_life", 10 SECONDS))
+						M.emote(pick("cough"))
+						M.setStatusMin("stunned", 1 SECOND * mult)
 				M.stuttering += rand(0,2)
 				M.bodytemperature += rand(0,3) * mult
-				if(prob(10))
-					M.emote(pick("cough"))
-					M.setStatusMin("stunned", 1 SECOND * mult)
+
 				..()
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume_passed)
@@ -2191,13 +2193,14 @@ datum
 						return
 					else
 						M.reagents.add_reagent("capsaicin",round(volume_passed/5))
-						if(prob(50))
-							M.emote("scream")
-							boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
-							M.take_eye_damage(1, 1)
-						M.change_eye_blurry(3)
-						M.setStatusMin("stunned", 2 SECONDS)
-						M.change_misstep_chance(10)
+						if(!ON_COOLDOWN(M, "capsaicin_stun_touch", 3 SECONDS))
+							if(prob(50))
+								M.emote("scream")
+								boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
+								M.take_eye_damage(1, 1)
+							M.change_eye_blurry(3)
+							M.setStatusMin("stunned", 2 SECONDS)
+							M.change_misstep_chance(10)
 
 
 		fooddrink/el_diablo


### PR DESCRIPTION
[Balance][Chemistry]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces cooldowns to the stun of capsaicin:

7 second cooldown when stunned/coughing from capsaicin on life cycle
3 second cooldown when touching capsaicin without mask/glasses

When you are stunned by over 20u of capsaicin, it will always be the coughing/choking stun. The chance was changed accordingly to how it was before this PR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Capsaicin stuns were considered very annoying and especially capsaicin smoke was considered almost unescapeable.
This changes gives, especially with stun resistance, a bigger window of opportunity to escape capsaicin smoke. CC grenades will still make the area unsuitable to fight for anyone not wearing proper protection, since it only slightly opens up the window between stuns and people will still drop their items. Also, the misstep inflicted from capsaicin smoke is untouched.

The changes for the on-life effect makes the stun effect of capsaicin in mobs less spiky and more predictable.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Capsaicin has a cooldown between stuns now but high-dosage capsaicin stuns more often add oxygen deprivation.
```
