### PR TITLE
Prevents active secbots from being pulled and makes them unable to scan while not on turfs

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -64,6 +64,9 @@ TYPEINFO(/atom)
 	/// Storage for items
 	var/datum/storage/storage = null
 
+	/// Which mob is pulling this atom currently
+	var/mob/pulled_by = null
+
 /* -------------------- name stuff -------------------- */
 	/*
 	to change names: either add or remove something with the appropriate proc(s) and then call atom.UpdateName()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -54,7 +54,6 @@
 	var/other_mobs = null
 	var/memory = ""
 	var/atom/movable/pulling = null
-	var/mob/pulled_by = null
 	var/stat = STAT_ALIVE
 	var/next_click = 0
 	var/transforming = null
@@ -1129,10 +1128,7 @@
 			return
 
 	src.pulling = A
-
-	if(ismob(src.pulling))
-		var/mob/M = src.pulling
-		M.pulled_by = src
+	A.pulled_by = src
 
 	//robust grab : a dirty DIRTY trick on mbc's part. When I am being chokeholded by someone, redirect pulls to the captor.
 	//this is so much simpler than pulling the victim and invoking movment on the captor through that chain of events.
@@ -1147,9 +1143,8 @@
 	pull_particle(src,pulling)
 
 /mob/proc/remove_pulling()
-	if(ismob(pulling))
-		var/mob/M = pulling
-		M.pulled_by = null
+	if(src.pulling)
+		src.pulling.pulled_by = null
 	src.pulling = null
 
 // less icon caching maybe?!

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -271,6 +271,12 @@
 			message = capitalize(ckeyEx(message))
 		. = ..()
 
+	pull(mob/user)
+		if (src.on)
+			boutput(user,"<span class='alert'><b>[src] resists being pulled around! Maybe deactivate it first.</b></span>")
+			return 1
+		..()
+
 	Move(var/turf/NewLoc, direct)
 		var/oldloc = src.loc
 		. = ..()
@@ -318,6 +324,8 @@
 			src.on = !src.on
 			if (src.on)
 				add_simple_light("secbot", list(255, 255, 255, 0.4 * 255))
+				if (src.pulled_by)
+					src.pulled_by.remove_pulling()
 			else
 				remove_simple_light("secbot")
 			src.KillPathAndGiveUp(KPAGU_CLEAR_ALL)
@@ -813,6 +821,8 @@
 	// look for a criminal in range of the bot
 	proc/look_for_perp()
 		src.anchored = UNANCHORED
+		if (!isturf(src.loc)) //no active searching while in lockers and stuff
+			return
 		for(var/mob/living/carbon/C in view(7, get_turf(src))) //Let's find us a criminal
 			if ((C.stat) || (C.hasStatus("handcuffed")))
 				continue

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -388,6 +388,8 @@
 			boutput(user, "<span class='alert'>[src] refuses your authority!</span>")
 			return
 		src.on = !src.on
+		if (src.on && src.pulled_by)
+			src.pulled_by.remove_pulling()
 		src.KillPathAndGiveUp(KPAGU_CLEAR_ALL)
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
@@ -404,6 +406,8 @@
 
 			src.emagged++
 			src.on = 1
+			if (src.pulled_by)
+				src.pulled_by.remove_pulling()
 			src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-wild" : null]"
 			src.KillPathAndGiveUp(KPAGU_CLEAR_PATH)
 
@@ -444,6 +448,8 @@
 			src.emagged = 1
 			src.visible_message("<span class='alert'><B>[src] buzzes oddly!</B></span>")
 			src.on = 1
+			if (src.pulled_by)
+				src.pulled_by.remove_pulling()
 		else
 			src.explode()
 		return

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -75,7 +75,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 
 	else if (istype(AM, /obj/machinery/bot))
 		var/obj/machinery/bot/B = AM
-		if (src.check_access(B.botcard))
+		if (src.check_access(B.botcard) && !B.pulled_by) //no more dragging bots onto doors for makeshift AA
 			if (src.density)
 				src.open()
 


### PR DESCRIPTION
[player actions][bug][balance][critters]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces a few changes to bots on the station, most notable secbots.

Firstly, this PR changes `mob.pulled_by` to be located on `atom/moveable` instead. This means items and other atoms track which mob is pulling them.

This new behaviour was used in multiple areas.
Firstly, trying to pull a bot into a door it has access to won't open the door anymore. This fixes #9057.

Secondly, active securitrons cannot be pulled anymore while they are active. To pull them around, you need to deactivate them.

Lastly, securitrons won't search for targets to arrest anymore while they are not on a turf, this means securitrons in lockers/crates won't jump out to capture anybody if they were idling there.  Ordering them to move somewhere/patrol will still make them leave lockers/crates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Firstly, dragging ducks or securitrons for cheap AA is a bad idea.

Secondly, with the introduction of the securitron whistle to the brobocop module in #16260, we saw a massive uptick in borgs roleplaying as security by dragging around securitrons and using the whistle to actively persecute crimers. 

Since secborgs was a thing that was very intentionally removed from the game because of all the problem it brought with validhunting and imbalance between antags/security, this is a behaviour that should not be incentivized.
This PR prevents many of the means of actively hunting people with securitrons. You still are able to move inactive securitrons, move them in a crate and release them or order securitrons onto an area, but these changes add delays into that behaviour that makes it much more predictable and open a bigger window of opportunity to react.

On the other hand, this changes how to deal with securitrons. They need a crate/locker to be moved out of an area, which makes it a little more harder and obvious for antags to move the securitron somewhere so you can crime in an area. On the other hand, this prevents surprise-securitrons from jumping out of lockers on their own.

On the antag side, emagged securitrons are easier to transport, since they only jump out of lockers if they are already trying to baton someone (most likely you).

In general, these changes should highly diminish the active patrolling of borgs with securitrons and should make securitrons slightly more harder to move away from an area they should guard.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Activated securitrons cannot be pulled anymore.
(+)Securitrons don't search for targets while in a locker. They still move out of they are patrolling/chasing someone.
```
