### PR TITLE
Makes the stealth storage more stealthy

### DIFF
--- a/code/modules/storage/no_hud.dm
+++ b/code/modules/storage/no_hud.dm
@@ -21,7 +21,7 @@
 	var/cur_weight = 0
 
 /datum/storage/no_hud/New(atom/storage_item, list/spawn_contents, list/can_hold, list/can_hold_exact, list/prevent_holding, check_wclass, max_wclass,
-		slots, sneaky, opens_if_worn, list/params)
+		slots, sneaky, stealthy_storage, opens_if_worn, list/params)
 	..()
 	src.use_inventory_counter = params["use_inventory_counter"] || initial(src.use_inventory_counter)
 	src.show_count = params["show_count"] || initial(src.show_count)

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -6,12 +6,12 @@
 
 /// add storage to an atom
 /atom/proc/create_storage(storage_type, list/spawn_contents = list(), list/can_hold = list(), list/can_hold_exact = list(), list/prevent_holding = list(),
-		check_wclass = FALSE, max_wclass = W_CLASS_SMALL, slots = 7, sneaky = FALSE, opens_if_worn = FALSE, list/params = list())
+		check_wclass = FALSE, max_wclass = W_CLASS_SMALL, slots = 7, sneaky = FALSE, stealthy_storage = FALSE, opens_if_worn = FALSE, list/params = list())
 	var/list/previous_storage = list()
 	for (var/obj/item/I as anything in src.storage?.get_contents())
 		previous_storage += I
 	src.remove_storage()
-	src.storage = new storage_type(src, spawn_contents, can_hold, can_hold_exact, prevent_holding, check_wclass, max_wclass, slots, sneaky, opens_if_worn, params)
+	src.storage = new storage_type(src, spawn_contents, can_hold, can_hold_exact, prevent_holding, check_wclass, max_wclass, slots, sneaky, stealthy_storage, opens_if_worn, params)
 	for (var/obj/item/I as anything in previous_storage)
 		src.storage.add_contents(I)
 
@@ -34,6 +34,8 @@
 	var/datum/hud/storage/hud = null
 	/// Don't print a visible message on use
 	var/sneaky = FALSE
+	/// Don't show the contents of the storage on its description
+	var/stealthy_storage = FALSE
 	/// Prevent accessing storage when clicked when worn, ex. in pocket
 	var/opens_if_worn = FALSE
 	/// Maximum w_class that can be held
@@ -48,7 +50,7 @@
 	var/list/stored_items = null
 
 /datum/storage/New(atom/storage_item, list/spawn_contents, list/can_hold, list/can_hold_exact, list/prevent_holding, check_wclass, max_wclass, \
-		slots, sneaky, opens_if_worn, list/params)
+		slots, sneaky, stealthy_storage, opens_if_worn, list/params)
 	..()
 	src.stored_items = list()
 
@@ -61,6 +63,7 @@
 	src.max_wclass = max_wclass
 	src.slots = slots
 	src.sneaky = sneaky
+	src.stealthy_storage = stealthy_storage
 	src.opens_if_worn = opens_if_worn
 
 	if (istype(src.linked_item, /obj/item))
@@ -396,7 +399,8 @@
 
 /// return outputtable capacity
 /datum/storage/proc/get_capacity_string()
-	return "<br>Holding [length(src.get_contents())]/[src.slots] objects"
+	if (!src.stealthy_storage)
+		return "<br>Holding [length(src.get_contents())]/[src.slots] objects"
 
 /// storage is full or not
 /datum/storage/proc/is_full()

--- a/code/modules/storage/unholdable.dm
+++ b/code/modules/storage/unholdable.dm
@@ -8,7 +8,7 @@
 	/// Should this thing do the storage rustle when we use it?
 	var/rustle = FALSE
 
-/datum/storage/unholdable/New(atom/storage_item, list/spawn_contents, list/can_hold, list/can_hold_exact, list/prevent_holding, check_wclass, max_wclass, slots, sneaky, opens_if_worn, list/params)
+/datum/storage/unholdable/New(atom/storage_item, list/spawn_contents, list/can_hold, list/can_hold_exact, list/prevent_holding, check_wclass, max_wclass, slots, sneaky, stealthy_storage, opens_if_worn, list/params)
 	. = ..()
 	src.rustle = params["rustle"]
 

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -15,6 +15,7 @@
 	var/check_wclass = 0
 	var/datum/hud/storage/hud
 	var/sneaky = 0
+	var/stealthy_storage = FALSE
 	var/opens_if_worn = FALSE
 	var/max_wclass = W_CLASS_SMALL
 	var/slots = 7
@@ -31,7 +32,7 @@
 	health = 10
 
 	New()
-		src.create_storage(/datum/storage, spawn_contents, can_hold, can_hold_exact, prevent_holding, check_wclass, max_wclass, slots, sneaky, opens_if_worn)
+		src.create_storage(/datum/storage, spawn_contents, can_hold, can_hold_exact, prevent_holding, check_wclass, max_wclass, slots, sneaky, stealthy_storage, opens_if_worn)
 		src.make_my_stuff()
 		..()
 

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -273,6 +273,7 @@
 	desc = "Can take on the appearance of another item. Creates a small dimensional rift in space-time, allowing it to hold multiple items."
 	icon_state = "box"
 	sneaky = 1
+	stealthy_storage = TRUE
 	var/cloaked = 0
 	flags = FPRINT | TABLEPASS | NOSPLASH
 	w_class = W_CLASS_SMALL
@@ -282,7 +283,7 @@
 		..()
 		src.cloaked = 0
 		src.create_storage(/datum/storage, prevent_holding = list(/obj/item/storage/box), max_wclass = src.max_wclass, slots = src.slots, sneaky = src.sneaky,
-			opens_if_worn = TRUE)
+			stealthy_storage = src.stealthy_storage, opens_if_worn = TRUE)
 
 	UpdateName()
 		src.name = "[name_prefix(null, 1)][src.real_name][name_suffix(null, 1)]"


### PR DESCRIPTION
[internal][game objects][balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces the stealthy_storage variable for the storage datum.

Setting this variable to true will hide the tooltip that says how many items a storage can and is containing.

This was used to make stealth storage hide it's contents on the tooltip.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Stealth storages are far too easy to make out due to their tooltip being a dead giveaway that you are not holding an item but a stealth storage. This change will make it harder to distinguish the storage from normal items and makes it more likely that the storage won't be revealed on a search by security

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Stealth storages have become a little bit more stealthy.
```
