### PR TITLE
Civilian pod parts requisition adjustment batch

### DIFF
--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -678,10 +678,11 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	New()
 		src.name = pick(namevary)
 		src.flavor_desc = pick(flavor_descs)
+		src.flavor_desc += "<br><i>REQHUB ADVISORY: MiniPutt or Minisub components not accepted</i>"
 		src.payout += rand(0,40) * 10
 
 		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/engine_component,1)
-		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_engine,1)
+		if(prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_engine,1)
 		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_circuitry,1)
 		if(prob(70) || length(src.rc_entries) < 2) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_armor,1)
 		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_control,1)
@@ -694,16 +695,12 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "any pod-compatible engine but you shouldn't see this particular name for it"
 
 	New()
-		switch(rand(1, 10))
-			if(1 to 6)
-				name = "any pod-compatible engine"
-				typepath = /obj/item/shipcomponent/engine
-				feemod = PAY_TRADESMAN
-			if(7 to 9)
+		switch(rand(1, 6))
+			if(1 to 5)
 				name = "Helios Mark-II engine"
 				typepath = /obj/item/shipcomponent/engine/helios
 				feemod = PAY_TRADESMAN*5
-			if(10)
+			if(6)
 				name = "Hermes Mark-III engine"
 				typepath = /obj/item/shipcomponent/engine/hermes
 				feemod = PAY_DOCTORATE*5
@@ -712,7 +709,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/pod_engine
 	name = "pod engine manifold"
 	typepath = /obj/item/pod/engine
-	feemod = PAY_TRADESMAN*2
+	feemod = PAY_TRADESMAN*3
 
 	New()
 		src.feemod += rand(0,20) * 10
@@ -721,7 +718,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/pod_circuitry
 	name = "pod circuitry kit"
 	typepath = /obj/item/pod/boards
-	feemod = PAY_TRADESMAN
+	feemod = PAY_TRADESMAN*2
 
 	New()
 		src.feemod += rand(0,20) * 10
@@ -735,21 +732,21 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 			if(1 to 6)
 				name = "any pod armor"
 				typepath = /obj/item/podarmor
-				feemod = PAY_TRADESMAN*2
+				feemod = PAY_TRADESMAN*4
 			if(7 to 9)
 				name = "heavy pod armor"
 				typepath = /obj/item/podarmor/armor_heavy
-				feemod = PAY_TRADESMAN*5
+				feemod = PAY_DOCTORATE*5
 			if(10)
 				name = "industrial pod armor"
 				typepath = /obj/item/podarmor/armor_industrial
-				feemod = PAY_DOCTORATE*5
+				feemod = PAY_TRADESMAN*12
 		..()
 
 /datum/rc_entry/item/pod_control
 	name = "pod control interface"
 	typepath = /obj/item/pod/control
-	feemod = PAY_TRADESMAN
+	feemod = PAY_TRADESMAN*3
 
 	New()
 		src.feemod += rand(0,20) * 10
@@ -776,7 +773,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/rc_entry/item/pod_secondary
 	name = "youshouldn'tseemium dongle"
-	feemod = PAY_TRADESMAN
+	feemod = PAY_TRADESMAN*2
 
 	New()
 		switch(rand(1, 10))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Set of legibility and balance adjustments for the new pod parts requisition.

- At the end of the requisition description text, a note from the requisitions hub now specifies that MiniPutt and Minisub counterparts for certain components (engine manifold, pod circuitry etc) are unacceptable.
- The entry for pod-compatible engines is now slightly rarer, and will only ask for Mark-2 and Mark-3 engines (as you apparently can't manufacture Mark-1 engines currently, you'd have to make a Mark-2 and swap it into an existing pod).
- Increased several per-item payouts across the board that were a bit undertuned relative to their material cost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes the pod parts requisition easier to interpret and more rewarding.