### PR TITLE
update robot silhouette when appearance changes

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2839,6 +2839,7 @@
 			UpdateOverlays(src.i_clothes, "clothes")
 		else
 			UpdateOverlays(null, "clothes")
+		src.update_mob_silhouette()
 
 	proc/compborg_force_unequip(var/slot = 0)
 		src.module_active = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
update_body / update_clothing on /mob/living handle redrawing the static/silhouette mob overlay, but silicons have a special update_appearance proc that calls neither. This fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8313
