### PR TITLE
Fix creating negative amounts of sheet stacks

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -618,7 +618,7 @@ ABSTRACT_TYPE(/obj/item)
 		stackee = other
 	if (stacker != stackee && check_valid_stack(stackee))
 		if (src.amount + other.amount > max_stack)
-			if (max_stack - stacker.amount < 0)
+			if (max_stack - stacker.amount < 0) // if this is negative it means the stack amount is higher than max stack, so cancel all this shit
 				return added
 			added = max_stack - stacker.amount
 		else

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -602,6 +602,8 @@ ABSTRACT_TYPE(/obj/item)
 	var/added = 0
 	var/imrobot
 	var/imdrone
+	var/obj/item/stacker
+	var/obj/item/stackee
 	if(QDELETED(other))
 		return added
 	if((imrobot = isrobot(other.loc)) || (imdrone = isghostdrone(other.loc)) || istype(other.loc, /obj/item/magtractor))
@@ -609,21 +611,20 @@ ABSTRACT_TYPE(/obj/item)
 			max_stack = 300
 		else if (imdrone)
 			max_stack = 1000
-		if (other != src && check_valid_stack(src))
-			if (src.amount + other.amount > max_stack)
-				added = max_stack - other.amount
-			else
-				added = src.amount
-			src.change_stack_amount(-added)
-			other.change_stack_amount(added)
+		stacker = other
+		stackee = src
 	else
-		if (other != src && check_valid_stack(other))
-			if (src.amount + other.amount > max_stack)
-				added = max_stack - src.amount
-			else
-				added = other.amount
-			src.change_stack_amount(added)
-			other.change_stack_amount(-added)
+		stacker = src
+		stackee = other
+	if (stacker != stackee && check_valid_stack(stackee))
+		if (src.amount + other.amount > max_stack)
+			if (max_stack - stacker.amount < 0)
+				return added
+			added = max_stack - stacker.amount
+		else
+			added = stackee.amount
+		stacker.change_stack_amount(added)
+		stackee.change_stack_amount(-added)
 
 	return added
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -606,6 +606,7 @@ ABSTRACT_TYPE(/obj/item)
 	var/obj/item/stackee
 	if(QDELETED(other))
 		return added
+
 	if((imrobot = isrobot(other.loc)) || (imdrone = isghostdrone(other.loc)) || istype(other.loc, /obj/item/magtractor))
 		if (imrobot)
 			max_stack = 300
@@ -616,15 +617,19 @@ ABSTRACT_TYPE(/obj/item)
 	else
 		stacker = src
 		stackee = other
-	if (stacker != stackee && check_valid_stack(stackee))
-		if (stacker.amount + stackee.amount > max_stack)
-			if (max_stack - stacker.amount < 0) // if this is negative it means the stack amount is higher than max stack, so cancel all this shit
-				return added
-			added = max_stack - stacker.amount
-		else
-			added = stackee.amount
-		stacker.change_stack_amount(added)
-		stackee.change_stack_amount(-added)
+
+	if (stacker == stackee || !check_valid_stack(stackee))
+		return added
+
+	if (stacker.amount + stackee.amount > max_stack)
+		if (max_stack - stacker.amount < 0) // if this is negative it means the stack amount is higher than max stack, so cancel all this shit
+			return added
+		added = max_stack - stacker.amount
+	else
+		added = stackee.amount
+
+	stacker.change_stack_amount(added)
+	stackee.change_stack_amount(-added)
 
 	return added
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -617,7 +617,7 @@ ABSTRACT_TYPE(/obj/item)
 		stacker = src
 		stackee = other
 	if (stacker != stackee && check_valid_stack(stackee))
-		if (src.amount + other.amount > max_stack)
+		if (stacker.amount + stackee.amount > max_stack)
 			if (max_stack - stacker.amount < 0) // if this is negative it means the stack amount is higher than max stack, so cancel all this shit
 				return added
 			added = max_stack - stacker.amount

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -621,12 +621,7 @@ ABSTRACT_TYPE(/obj/item)
 	if (stacker == stackee || !check_valid_stack(stackee))
 		return added
 
-	if (stacker.amount + stackee.amount > max_stack)
-		if (max_stack - stacker.amount < 0) // if this is negative it means the stack amount is higher than max stack, so cancel all this shit
-			return added
-		added = max_stack - stacker.amount
-	else
-		added = stackee.amount
+	added = clamp(stackee.amount, 0, max_stack - stacker.amount)
 
 	stacker.change_stack_amount(added)
 	stackee.change_stack_amount(-added)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS] [MATERIALS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16303 by rewriting stack_item to reduce duplicate code and adding a check to prevent `added` being negative if the user has a stack that's already over `max_stack` (like a 200 stack from a crate)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
