### PR TITLE
Fixes #16290 - Black cannabis joint off-gassing

### DIFF
--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -148,7 +148,7 @@
 					boutput(user, "<span class='alert'>[target] is full.</span>")
 					return
 
-				if (target.is_open_container(TRUE) != 1 && !ismob(target) && !istype(target,/obj/item/reagent_containers/food) && !istype(target,/obj/item/reagent_containers/patch))
+				if (target.is_open_container(TRUE) != 1 && !ismob(target) && !istype(target,/obj/item/reagent_containers/food) && !istype(target,/obj/item/clothing/mask/cigarette/custom) && !istype(target,/obj/item/reagent_containers/patch))
 					boutput(user, "<span class='alert'>You cannot directly fill this object.</span>")
 					return
 

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -116,7 +116,7 @@
 					boutput(user, "<span class='alert'>The [src.name] is full.</span>")
 					return
 
-				if (!target.is_open_container() && !istype(target,/obj/reagent_dispensers))
+				if (!target.is_open_container() && (!istype(target,/obj/reagent_dispensers) && !istype(target,/obj/item/clothing/mask/cigarette/custom)))
 					boutput(user, "<span class='alert'>You cannot directly remove reagents from this object.</span>")
 					return
 

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -524,7 +524,7 @@
 		src.reagents.clear_reagents()
 
 	is_open_container()
-		return 1
+		return 0
 
 /* ================================================= */
 /* -------------------- Packets -------------------- */


### PR DESCRIPTION
[Bug] [Chemistry] [Hydroponics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so custom cigarettes (i.e. joints, reefers, doobies, spliffs) are no longer open containers. This is to prevent the scenario where reagents could off-gas out of the cigarette, which doesn't make much sense. This PR also seeks to maintain the old behaviour where custom cigarettes could have their reagents syringed out or new ones in. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16290 a bug where someone makes a death weed joint and accidentally gases everyone in the room with cyanide.