### PR TITLE
Add a link to the VSCode debugger guide to the Code Guideline

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -453,7 +453,7 @@ make sure it isn't being used as a verb somewhere else.
 # Useful Things
 
 ## VSCode Debugger
-//TODO
+You can check out a guide on using the debugger in the guide located in the [Developer Guide](https://hackmd.io/@goonstation/dev#How-to-use-the-VS-Code-Debugger).
 
 ## Debugging Overlays
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets people reading one guide about Code check out the debugging guide in the Developer Guide instead of being met with the 
// TODO

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It has been done for a while, this should really be linked
