### PR TITLE
Planet Generation Runtimes

### DIFF
--- a/code/WorkInProgress/artemis/GeneratePlanets.dm
+++ b/code/WorkInProgress/artemis/GeneratePlanets.dm
@@ -309,6 +309,10 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 			var/stop = 0
 			var/count= 0
 			var/maxTries = (P.required ? 200:80)
+
+			if(region.bottom_left.x+AST_MAPBORDER >= maxX || region.bottom_left.y+AST_MAPBORDER >= maxY)
+				continue
+
 			while (!stop && count < maxTries && failsafe-- > 0) //Kinda brute forcing it. Dumb but whatever.
 				var/turf/target = locate(rand(region.bottom_left.x+AST_MAPBORDER, maxX), rand(region.bottom_left.y+AST_MAPBORDER,maxY), region.bottom_left.z)
 				if(!P.check_biome_requirements(target))
@@ -379,6 +383,7 @@ var/global/datum/planetManager/PLANET_LOCATIONS = new /datum/planetManager()
 	message_admins("Planet region generated at [log_loc(region.bottom_left)] with [generator].")
 
 	return turfs
+
 /datum/map_generator/asteroids
 	clear_turf_type = /turf/space
 

--- a/code/modules/events/gimmick/generate_planet.dm
+++ b/code/modules/events/gimmick/generate_planet.dm
@@ -97,7 +97,7 @@
 					break
 
 				var/turf/T = pick(turfs)
-				if(checkTurfPassable(T))
+				if(!checkTurfPassable(T))
 					maxTries--
 					continue
 

--- a/code/modules/worldgen/GenerateMining.dm
+++ b/code/modules/worldgen/GenerateMining.dm
@@ -177,6 +177,9 @@ var/list/miningModifiers = list()
 
 		var/list/used = list()
 		for(var/s in 0 to 19)
+			if(!length(src.generated - used))
+				break
+
 			var/turf/TU = pick(generated - used)
 			var/list/L = list()
 			for(var/turf/simulated/wall/auto/asteroid/A in orange(5,TU))

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1069,7 +1069,8 @@ TYPEINFO_NEW(/turf/simulated/wall/auto/asteroid)
 			src.color = src.stone_color
 		else
 			SPAWN(1)
-				space_overlays()
+				if(istype(src, /turf/simulated/wall/auto/asteroid))
+					space_overlays()
 
 	generate_worldgen()
 		. = ..()
@@ -1473,7 +1474,8 @@ TYPEINFO(/turf/simulated/floor/plating/airless/asteroid)
 		worldgenCandidates += src
 		if(current_state > GAME_STATE_PREGAME)
 			SPAWN(1)
-				space_overlays()
+				if(istype(src, /turf/simulated/floor/plating/airless/asteroid))
+					space_overlays()
 
 	generate_worldgen()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolve runtime where there are no turfs to place a prefab.
Resolve runtime where there are insufficient turfs in an asteroid chunk.
Resolve Planet Events sending you to a spot you can't normally access....


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves runtimes and incorrect generation where the crew is erased from existence!