### PR TITLE
"Show Credits" verb appears at round end

### DIFF
--- a/code/datums/crew_credits/crew_credits_debug.dm
+++ b/code/datums/crew_credits/crew_credits_debug.dm
@@ -28,13 +28,6 @@
 	var/has_head = FALSE
 	var/what_role = ""
 
-	while (length(src.crew_tab_data[CREW_TAB_SECTION_ANTAGONIST]) < 4)
-		src.crew_tab_data[CREW_TAB_SECTION_ANTAGONIST] += src.generate_fake_crew_member(
-			real_name = src.fake_carbon_name(),
-			role = pick("Vampire", "Werewolf", "Changeling", "Legworm", "Handspider", "Eyespider", "Traitor", "Spy-thief", "Blob", "Flockmind", "Flockbit", "Omnitraitor", "Nuclear Operative", "Hard-mode Traitor"),
-			dead = prob(50),
-		)
-
 	while (length(src.crew_tab_data[CREW_TAB_SECTION_CAPTAIN]) < 1)
 		src.crew_tab_data[CREW_TAB_SECTION_CAPTAIN] += src.generate_fake_crew_member(
 			real_name = src.fake_carbon_name(),

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -808,6 +808,7 @@ var/global/current_state = GAME_STATE_INVALID
 		//logTheThing(LOG_DEBUG, null, "Zamujasa: [world.timeofday] displaying tickets and scores")
 		for(var/mob/E in mobs)
 			if(E.client)
+				E.verbs += /mob/proc/show_credits
 				if (E.client.preferences.view_tickets)
 					//logTheThing(LOG_DEBUG, null, "Zamujasa: [world.timeofday] sending tickets to [E.ckey]")
 					E.showtickets()

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -19,6 +19,8 @@ var/global/current_state = GAME_STATE_INVALID
 
 	var/datum/ai_rack_manager/ai_law_rack_manager = new /datum/ai_rack_manager()
 
+	var/datum/crewCredits/creds = null
+
 	var/skull_key_assigned = 0
 
 	var/tmp/last_try_dilate = 0
@@ -802,7 +804,7 @@ var/global/current_state = GAME_STATE_INVALID
 
 	SPAWN(0)
 		//logTheThing(LOG_DEBUG, null, "Zamujasa: [world.timeofday] creds/new")
-		var/datum/crewCredits/creds = new
+		creds = new /datum/crewCredits
 		//logTheThing(LOG_DEBUG, null, "Zamujasa: [world.timeofday] displaying tickets and scores")
 		for(var/mob/E in mobs)
 			if(E.client)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1526,6 +1526,16 @@
 	if (!isliving(src))
 		src.sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF | SEE_BLACKNESS
 
+/mob/proc/show_credits()
+	set name = "Show Credits"
+	set desc = "Open the crew credits window"
+	set category = "Commands"
+
+	if(isnull(ticker.creds))
+		boutput(src, "<span class='notice'>The credits have not been generated yet!</span>")
+		return
+	ticker.creds.ui_interact(src)
+
 /mob/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
 		return !projCanHit(mover:proj_data)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ui][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the crew credits datum up to a ticker-level variable, which can then be targeted by a new verb added to mobs with clients at round end.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You can re-open the end-game credits window if you close it, but want to go back and check something.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)You can re-open the end-game crew credits window by using the "Show Credits" verb.
```
