### PR TITLE
Make cigarette-related messages use character pronouns

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -173,7 +173,7 @@
 				src.light(user, "<span class='alert'><b>[user]</b> fumbles around with [W]; a small flame erupts from [src].</span>")
 				return
 			else if (istype(W, /obj/item/device/light/zippo) && W:on)
-				src.light(user, "<span class='alert'>With a single flick of their wrist, [user] smoothly lights [src] with [W]. Damn they're cool.</span>")
+				src.light(user, "<span class='alert'>With a single flick of [his_or_her(user)] wrist, [user] smoothly lights [src] with [W]. Damn [hes_or_shes(user)] cool.</span>")
 				return
 			else if ((istype(W, /obj/item/match) || istype(W, /obj/item/clothing/mask/cigarette) || istype(W, /obj/item/device/light/candle)) && W:on)
 				src.light(user, "<span class='alert'><b>[user]</b> lights [src] with [W].</span>")
@@ -246,7 +246,7 @@
 			if (prob(60))
 				switch(rand(1, 9))
 					if (1) message_append = " Ouch!"
-					if (2) message_append = " Are they just going to take that?"
+					if (2) message_append = " [capitalize(is_or_are(target))] [he_or_she(target)] just going to take that?"
 					if (3) message_append = " Whoa!"
 					if (4) message_append = " What a jerk!"
 					if (5) message_append = " That's bad-ass."
@@ -339,7 +339,7 @@
 			return ..()
 		else if (user.client)
 			if (!user.client.check_key(KEY_THROW)) //checks if player is in throw mode to avoid double messages
-				user.visible_message("<span class='alert'><b>[user]</b> drops [src]. Guess they've had enough for the day.</span>", group = "cig_drop")
+				user.visible_message("<span class='alert'><b>[user]</b> drops [src]. Guess [he_or_she(user)][ve_or_s(user)] had enough for the day.</span>", group = "cig_drop")
 				return ..()
 		else
 			return ..()

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -497,6 +497,10 @@
 /proc/has_or_have(var/mob/subject)
 	return subject.get_pronouns().pluralize ? "have" : "has"
 
+/// "they've had" vs "he's had"
+/proc/ve_or_s(var/mob/subject)
+	return subject.get_pronouns().pluralize ? "'ve" : "'s"
+
 /proc/himself_or_herself(var/mob/subject)
 	return subject.get_pronouns().reflexive
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change smoking related messages (dropping cigarettes, using zippo, blowing smoke in peoples faces) to check and use character pronouns instead of just assuming they. Also adds a pronoun proc for getting "'ve" or "'s" contraction based on pronouns.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

We have the technology
