### PR TITLE
Soda Water now quenches thirst

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1992,6 +1992,7 @@ datum
 			fluid_b = 250
 			description = "Carbonated water."
 			reagent_state = LIQUID
+			thirst_value = 0.8909
 			taste = "bubbly"
 
 		fooddrink/simplesyrup


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes Soda Water to now quench as much thirst as regular water


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Soda Water currently quenches no thirst, which makes it bad for making drinks
Also it just makes sense to have it quench thirst


