### PR TITLE
Declutter Clarion engineering control room

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14531,12 +14531,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
-"bsq" = (
-/obj/securearea{
-	name = "ENGINEERING ACCESS"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/engineering)
 "bss" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/storage)
@@ -26620,6 +26614,7 @@
 /obj/cable/orange{
 	icon_state = "0-4"
 	},
+/obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/white,
 /area/station/engine/engineering)
 "jbP" = (
@@ -35324,7 +35319,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/item/device/radio/intercom/engineering,
 /obj/machinery/power/data_terminal,
 /obj/noticeboard/persistent{
 	name = "Engineering persistent notice board";
@@ -77750,7 +77744,7 @@ bgz
 boQ
 hVf
 brc
-bsq
+bso
 yfR
 buC
 pCX
@@ -78264,7 +78258,7 @@ bgz
 lWI
 ebq
 brn
-bsq
+bso
 kow
 buC
 qLR


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Deletes signs and moves the intercom in the Clarion engineering control room.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Just look at it
![image](https://github.com/goonstation/goonstation/assets/70909958/f0fff2a8-66f9-4bdd-8f86-ec8ec3692677)