### PR TITLE
Fix Sulfuric Acid Smoke Clamp Issue and Slight Amount Tweak

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2609,7 +2609,7 @@
 		on_reaction(var/datum/reagents/holder)
 			var/location = get_turf(holder.my_atom)
 			if (holder.my_atom && holder.my_atom.is_open_container() || istype(holder,/datum/reagents/fluid_group))
-				var/smoke_to_create = clamp((holder.total_temperature - T20C), 0, 15) / 10 //for every degree over 20C, make .1u of smoke (up to 15u)...
+				var/smoke_to_create = clamp((holder.total_temperature - T20C)/20 , 0, 5)//for every degree over 20C, make .05u of smoke (up to 5u)...
 				if(smoke_to_create > 0)                                     //...but if under 20C, don't make any
 					var/datum/reagents/smokeContents = new/datum/reagents/
 					smokeContents.add_reagent("acid", smoke_to_create)


### PR DESCRIPTION
[BUG]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This was pointed out to me by Clarks Kents in the discord, so thank you Clarks.

When I wrote the sulfuric acid smoke code (where it makes smoke on-reaction), it was intended to make 0.1u of smoke per degree over 20C, capped at 15u. Instead, I made it divide *after* the clamp, so it would make 1u of smoke per degree over 20C, capped at 1.5. This was wrong!! However, it was wrong for so long into testing that I never actually tested the original amounts, and when fixing this and seeing it in-game, I think it made a bit *too* much smoke, so I dropped it down to making 0.05u of smoke per degree over 20C with a cap of 5u (per reaction, non-instant..) which feels more reasonable to me. It's still more smoke than it was before, so it's overall more dangerous, but not like, 15 times more smoke lol

So it's partially a bug fix and partially a balance tweak, but mostly just a one line change bringing it more where it's supposed to be.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I oopsed the math!! Fix
