### PR TITLE
"Meat Storehouse" Map Generator

### DIFF
--- a/_std/spatial_hashing.dm
+++ b/_std/spatial_hashing.dm
@@ -172,6 +172,22 @@ ABSTRACT_TYPE(/datum/spatial_hashmap/by_type)
 	update_cooldown = 5
 	type_to_track = /obj/shrub
 
+/datum/spatial_hashmap/manual/proc/add_target(atom/A)
+	var/turf/T = get_turf(A)
+	if (world.maxz > src.zlevels)
+		src.zlevels = world.maxz
+		src.hashmap.len = src.cols * src.rows * src.zlevels
+	if(T && !QDELETED(A))
+		ADD_TO_MAP(A, T)
+
+/datum/spatial_hashmap/manual/proc/add_weakref(atom/A)
+	var/turf/T = get_turf(A)
+	if (world.maxz > src.zlevels)
+		src.zlevels = world.maxz
+		src.hashmap.len = src.cols * src.rows * src.zlevels
+	if(T && !QDELETED(A))
+		ADD_TO_MAP(get_weakref(A), T)
+
 #undef CELL_POSITION
 #undef ADD_BUCKET
 #undef ADD_TO_MAP

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -716,7 +716,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 /datum/terrainify/storehouse
 	name = "Storehouse"
 	desc = "Load some nearby storehouse (Run before other Generators!)"
-	additional_toggles = list("Fill Z-Level"=FALSE)
+	additional_toggles = list("Fill Z-Level"=FALSE,"Meaty"=FALSE)
 
 	convert_station_level(params, datum/tgui/ui)
 		if (!..())
@@ -724,12 +724,17 @@ ABSTRACT_TYPE(/datum/terrainify)
 		var/list/turf/space = list()
 		for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 			space += S
-		var/datum/map_generator/storehouse_generator/generator = new/datum/map_generator/storehouse_generator
+		var/datum/map_generator/storehouse_generator/generator
+		if(params["Meaty"])
+			generator = new/datum/map_generator/storehouse_generator/meaty
+		else
+			generator = new/datum/map_generator/storehouse_generator
 		station_repair.station_generator = generator
 
 		if(params["Fill Z-Level"])
-			generator.wall_path = /turf/unsimulated/wall/auto/lead/gray
-			generator.floor_path = /turf/unsimulated/floor/industrial
+			if(!(params["Meaty"]))
+				generator.wall_path = /turf/unsimulated/wall/auto/lead/gray
+				generator.floor_path = /turf/unsimulated/floor/industrial
 			generator.fill_map()
 		else
 			generator.generate_map()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a variation on the Storehouse Map Generator themed around Meat Station.

Uses Perlin Noise to determine areas that should be more... meatlike.
Uses Worley Noise to make... acidic areas.

Uses spatial hashmaps to try to control distribution of critters and lighting.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spooktober! Spooktober! Spooktober! Spooktober! 