### PR TITLE
Fix respawned players not being clonescannable if old record still exists

### DIFF
--- a/code/datums/controllers/respawn_controls.dm
+++ b/code/datums/controllers/respawn_controls.dm
@@ -191,6 +191,13 @@ var/datum/respawn_controls/respawn_controller
 		//try to break all links with the previous body so we don't get pulled back by changeling absorb, cloning etc.
 		usr.mind = null
 
+		// remove old cloning records because they are tied to ckey/mind and can cause problems
+		for_by_tcl(C, /obj/machinery/computer/cloning)
+			var/datum/db_record/old = C.find_record(src.ckey)
+			if(!isnull(old))
+				C.records.Remove(old)
+				qdel(old)
+
 		var/mob/new_player/M = new()
 		M.adminspawned = 1
 		M.is_respawned_player = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15400 by adding code to delete cloning records of the previous character from consoles if the player is now respawning. The bug happens because clone records are looked up by ckey and thus trying to scan a player who was scanned in a previous life will still yield a record.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug