### PR TITLE
Lowers the Maximum Players for Atlas to be in Rotation from 30 to 20

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -29,7 +29,7 @@ var/global/list/mapNames = list(
 	"Donut 2" =				list("id" = "DONUT2",		"settings" = "donut2",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 80),
 	"Donut 3" =				list("id" = "DONUT3",		"settings" = "donut3",			"playerPickable" = TRUE, 	"MinPlayersAllowed" = 40),
 	"Kondaru" =				list("id" = "KONDARU",		"settings" = "kondaru",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 80),
-	"Atlas" =				list("id" = "ATLAS",		"settings" = "atlas",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 30),
+	"Atlas" =				list("id" = "ATLAS",		"settings" = "atlas",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 20),
 	"Clarion" =				list("id" = "CLARION",		"settings" = "destiny/clarion", "playerPickable" = TRUE,	"MaxPlayersAllowed" = 60),
 	"Oshan Laboratory"= 	list("id" = "OSHAN",		"settings" = "oshan",			"playerPickable" = TRUE),
 	"Nadir" =				list("id" = "NADIR",		"settings" = "nadir",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 70),


### PR DESCRIPTION
[player actions] [balance]
## About the PR 
Bumps the pop threshold where the map Atlas can be voted for down to 20 players or less, from 30 players or less.

## Why's this needed? 
Atlas is evidently not built to support 30 players at the same time. I am making this PR right after experiencing an Atlas round with 30+ people on it, and I think player experience would greatly benefit from narrowing the probability of this happening again.

