### PR TITLE
Removes securitron whistle from the brobocop module

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -23,7 +23,7 @@
 		/obj/item/dice/robot,
 		/obj/item/device/light/zippo/borg,
 		/obj/item/device/prisoner_scanner,
-		/obj/item/instrument/whistle/security,
+		/obj/item/instrument/whistle,
 		/obj/item/item_box/assorted/stickers/robot,
 		// TODO: security grenade fabricator?!
 		// /obj/item/handcuffs/tape_roll/crappy,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[objects] [balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes securitron whistle from the brobocop module, replaces it with a normal one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not being able to drag securitrons while they are active anymore, borgs just began dragging them around with the securitron off, and quickly turning it on and whistling when an arrest needs to be made. This is annoying to see both as  security and antags, since it shifts the scale unevenly towards security. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

I am unsure whether one is needed or not.
