### PR TITLE
Remove version tracking api calls

### DIFF
--- a/browserassets/js/browserOutput.js
+++ b/browserassets/js/browserOutput.js
@@ -1008,7 +1008,7 @@ $(function() {
             '</div>');
     }
 
-    runByond('?action=ehjax&type=datum&datum=chatOutput&proc=doneLoading&param[ua]='+escaper(navigator.userAgent));
+    runByond('?action=ehjax&type=datum&datum=chatOutput&proc=doneLoading');
     if ($('#loading').is(':visible')) {
         $('#loading').remove();
     }

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -119,7 +119,7 @@ var/global
 		return
 
 /// Called on chat output done-loading by JS.
-/datum/chatOutput/proc/doneLoading(ua)
+/datum/chatOutput/proc/doneLoading()
 	if (src.owner && !src.loaded)
 		src.loaded = 1
 		winset(src.owner, "browseroutput", "is-disabled=false")
@@ -129,14 +129,6 @@ var/global
 			for (var/list/message in src.messageQueue)
 				boutput(src.owner, message["message"], message["group"])
 		src.messageQueue = null
-		if (ua)
-			//For persistent user tracking
-			apiHandler?.queryAPI("versions/add", list(
-				"ckey" = src.owner.ckey,
-				"userAgent" = ua,
-				"byondMajor" = src.owner.byond_version,
-				"byondMinor" = src.owner.byond_build
-			))
 
 		else
 			src.sendClientData()

--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -129,15 +129,13 @@ var/global
 			for (var/list/message in src.messageQueue)
 				boutput(src.owner, message["message"], message["group"])
 		src.messageQueue = null
-
-		else
-			src.sendClientData()
-			/* WIRE TODO: Fix this so the CDN dying doesn't break everyone
-			SPAWN(1 MINUTE) //60 seconds
-				if (!src.cookieSent) //Client has very likely futzed with their local html/js chat file
-					out(src.owner, "<div class='fatalError'>Chat file tampering detected. Closing connection.</div>")
-					del(src.owner)
-			*/
+		src.sendClientData()
+		/* WIRE TODO: Fix this so the CDN dying doesn't break everyone
+		SPAWN(1 MINUTE) //60 seconds
+			if (!src.cookieSent) //Client has very likely futzed with their local html/js chat file
+				out(src.owner, "<div class='fatalError'>Chat file tampering detected. Closing connection.</div>")
+				del(src.owner)
+		*/
 
 /// Called in update_admins()
 /datum/chatOutput/proc/loadAdmin()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

We never really used user agent tracking for anything useful, and byond version tracking is being moved to the player login call