### PR TITLE
Remove trailing comma-space on atmos scan for teleman

### DIFF
--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -966,7 +966,7 @@
 				var/list/success = signal_program(1, list("command"=DWAINE_COMMAND_DMSG, "target"=driver_id, "dcommand"="scan"))
 				if (istype(success))
 					#define _TELESCI_ATMOS_SCAN(GAS, _, NAME, ...) "[NAME]: [success[#GAS]], " +
-					message_user("Scan Results:|nAtmosphere: [APPLY_TO_GASES(_TELESCI_ATMOS_SCAN) " "][success["temp"]] Kelvin, [success["pressure"]] kPa, [(success["burning"])?("BURNING"):(null)]","multiline")
+					message_user("Scan Results:|nAtmosphere: [APPLY_TO_GASES(_TELESCI_ATMOS_SCAN) " "][success["temp"]] Kelvin, [success["pressure"]] kPa[(success["burning"])?(", BURNING"):(null)]","multiline")
 					// undefined at the end of the file because of https://secure.byond.com/forum/post/2072419
 
 				else if (istext(success))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][UI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes an unnecessary `, ` at the end of teleman scans when the target is not burning.

```
Scan Results:
Atmosphere: O2: 21.824, N2: 82.1031, CO2: 0.000833333, Plasma: 0, Farts: 0, Fallout: 0, N2O: 0, Oxygen Agent B: 0, 293.15 Kelvin, 101.325 kPa, 
```
to:
```
Scan Results:
Atmosphere: O2: 21.824, N2: 82.1031, CO2: 0.000833333, Plasma: 0, Farts: 0, Fallout: 0, N2O: 0, Oxygen Agent B: 0, 293.15 Kelvin, 101.325 kPa
```

I look forward to someone telling me how this horribly breaks some weird mechcomp/packet thing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Better strings good.

Slightly less major change than solving by setting everywhere on fire. 🔥🔥🔥🔥🔥