### PR TITLE
Fix sponges wiping down ability buttons

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -592,6 +592,9 @@ TRASH BAG
 	if (!src.reagents)
 		return ..()
 
+	if (istype(target, /obj/ability_button))
+		return
+
 	var/list/choices = src.get_action_options(target)
 
 	if (!length(choices))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #12798 with a type check on sponge `afterattack`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

/obj/ability_button my beloathed
