### PR TITLE
Remove random floating light in cog1 escape

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -34734,21 +34734,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"cjH" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "cjK" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -115232,7 +115217,7 @@ uLB
 cgd
 chl
 ciC
-cjH
+cjL
 clr
 wfd
 uLB


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16450 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

No floating lightbulbs allowed
