### PR TITLE
Fixes fires not processing on singletons

### DIFF
--- a/code/modules/atmospherics/FEA_fire.dm
+++ b/code/modules/atmospherics/FEA_fire.dm
@@ -72,16 +72,26 @@
 		if (parent?.group_processing)
 			parent.suspend_group_processing()
 
-		src.active_hotspot = new /obj/hotspot
-		src.active_hotspot.temperature = exposed_temperature
-		src.active_hotspot.volume = exposed_volume
-		src.active_hotspot.set_loc(src)
-		src.active_hotspot.set_real_color()
+		src.add_hotspot(exposed_temperature, exposed_volume)
 
 		src.active_hotspot.just_spawned = (current_cycle < air_master.current_cycle)
 		//remove just_spawned protection if no longer processing this cell
 
 	return igniting
+
+/// Adds a hotspot to self, deletes the previous if there was one. Sets processing to true also, since a fire kinda should be processed.
+/turf/proc/add_hotspot(temperature, volume)
+	src.active_hotspot?.dispose()
+	src.active_hotspot = new /obj/hotspot
+	src.active_hotspot.temperature = temperature
+	src.active_hotspot.volume = volume
+	src.active_hotspot.set_loc(src)
+	src.active_hotspot.set_real_color()
+	if (issimulatedturf(src))
+		var/turf/simulated/self = src
+		self.processing = TRUE
+		if(!self.parent)
+			air_master.active_singletons |= src
 
 /// The object that represents fire ingame. Very nice and warm.
 /obj/hotspot

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -344,7 +344,7 @@ var/global/list/turf/hotly_processed_turfs = list()
 
 		src.parent.length_space_border += src.length_space_border
 
-	if(src.air_check_directions)
+	if(src.air_check_directions || src.active_hotspot)
 		src.processing = TRUE
 		if(!src.parent)
 			air_master.active_singletons |= src
@@ -411,7 +411,7 @@ var/global/list/turf/hotly_processed_turfs = list()
 	else
 		src.active_hotspot?.catalyst_active = FALSE
 
-	if(src.active_hotspot && possible_fire_spreads)
+	if(src.active_hotspot)
 		src.active_hotspot.process(possible_fire_spreads)
 
 	if(src.air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)

--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -13,15 +13,10 @@
 		for(var/obj/kudzu_marker/M in T) qdel(M)
 //		for(var/obj/alien/weeds/V in T) qdel(V)
 
-		var/obj/hotspot/h = new /obj/hotspot
-		h.temperature = temp
-		h.volume = 400
-		h.set_real_color()
-		h.set_loc(T)
-		T.active_hotspot = h
-		hotspots += h
+		T.add_hotspot(temp, 400)
+		hotspots += T.active_hotspot
 
-		T.hotspot_expose(h.temperature, h.volume)
+		T.hotspot_expose(T.active_hotspot.temperature, T.active_hotspot.volume)
 /*// experimental thing to let temporary hotspots affect atmos
 		h.perform_exposure()
 */
@@ -101,15 +96,11 @@
 		var/need_expose = 0
 		var/expose_temp = 0
 		if (!existing_hotspot)
-			var/obj/hotspot/h = new /obj/hotspot
+			T.add_hotspot((temp - dist * falloff), 400)
 			need_expose = 1
-			h.temperature = temp - dist * falloff
-			expose_temp = h.temperature
-			h.volume = 400
-			h.set_loc(T)
-			T.active_hotspot = h
-			hotspots += h
-			existing_hotspot = h
+			expose_temp = T.active_hotspot.temperature
+			hotspots += T.active_hotspot
+			existing_hotspot = T.active_hotspot
 		else if (existing_hotspot.temperature < temp - dist * falloff)
 			expose_temp = (temp - dist * falloff) - existing_hotspot.temperature
 			prev_temp = existing_hotspot.temperature


### PR DESCRIPTION
[ATMOSPHERICS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes fires not processing on singletons by adding a proc that handles adding fires and making it so that an active fire causes the tile to be processed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is good that fires can process, not good that they can't.