### PR TITLE
Chameleon outfit fixes

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -82,7 +82,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_jumpsuit_pattern
@@ -383,7 +383,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.seal_hair = T.seal_hair
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_hat_pattern
@@ -632,7 +632,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_suit_pattern
@@ -954,7 +954,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_glasses_pattern
@@ -1090,7 +1090,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.step_sound = T.step_sound
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_shoes_pattern
@@ -1279,7 +1279,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.material_prints = T.print_type
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_gloves_pattern
@@ -1436,7 +1436,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_belt_pattern
@@ -1603,7 +1603,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = 1
+			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_backpack_pattern

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -48,13 +48,13 @@
 			boutput(M, "<span class='alert'><B>Your chameleon jumpsuit malfunctions!</B></span>")
 			src.name = "psychedelic jumpsuit"
 			src.desc = "Groovy!"
+			src.icon_state = "psyche"
+			src.item_state = "psyche"
 			icon = 'icons/obj/clothing/uniforms/item_js_gimmick.dmi'
 			wear_image_icon = 'icons/mob/clothing/jumpsuits/worn_js_gimmick.dmi'
 			inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js_gimmick.dmi'
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
-			src.icon_state = "psyche"
-			src.item_state = "psyche"
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -348,11 +348,11 @@
 			boutput(M, "<span class='alert'><B>Your chameleon hat malfunctions!</B></span>")
 			src.name = "hat"
 			src.desc = "A knit cap in...what the hell?"
+			src.icon_state = "psyche"
+			src.item_state = "bgloves"
 			src.hides_from_examine = null
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
-			src.icon_state = "psyche"
-			src.item_state = "bgloves"
 			src.seal_hair = FALSE
 			M.set_clothing_icon_dirty()
 
@@ -595,13 +595,13 @@
 			boutput(M, "<span class='alert'><B>Your chameleon suit malfunctions!</B></span>")
 			src.name = "hoodie"
 			src.desc = "A comfy jacket that's hard on the eyes."
-			src.hides_from_examine = null
-			wear_image = image(wear_image_icon)
-			inhand_image = image(inhand_image_icon)
 			src.icon_state = "hoodie-psyche"
 			src.item_state = "hoodie-psyche"
-			src.icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
-			src.wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
+			src.hides_from_examine = null
+			src.icon = 'icons/obj/clothing/overcoats/hoods/hoodies.dmi'
+			src.wear_image_icon = 'icons/mob/clothing/overcoats/hoods/worn_hoodies.dmi'
+			wear_image = image(wear_image_icon)
+			inhand_image = image(inhand_image_icon)
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -923,10 +923,10 @@
 			boutput(M, "<span class='alert'><B>Your chameleon glasses malfunction!</B></span>")
 			src.name = "glasses"
 			src.desc = "A pair of glasses. They seem to be broken, though."
-			wear_image = image(wear_image_icon)
-			inhand_image = image(inhand_image_icon)
 			src.icon_state = "psyche"
 			src.item_state = "psyche"
+			wear_image = image(wear_image_icon)
+			inhand_image = image(inhand_image_icon)
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -1058,9 +1058,10 @@
 			boutput(M, "<span class='alert'><B>Your chameleon shoes malfunction!</B></span>")
 			src.name = "shoes"
 			src.desc = "A pair of shoes. Maybe they're those light up kind you had as a kid?"
+			src.icon_state = "psyche"
+			src.item_state = "psyche"
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
-			src.icon_state = "psyche"
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -1245,10 +1246,10 @@
 			boutput(M, "<span class='alert'><B>Your chameleon gloves malfunction!</B></span>")
 			src.name = "gloves"
 			src.desc = "A pair of gloves. Something seems off about them..."
-			wear_image = image(wear_image_icon)
-			inhand_image = image(inhand_image_icon)
 			src.icon_state = "psyche"
 			src.item_state = "psyche"
+			wear_image = image(wear_image_icon)
+			inhand_image = image(inhand_image_icon)
 			src.material_prints = "high-tech rainbow flashing nanofibers"
 			M.set_clothing_icon_dirty()
 
@@ -1404,10 +1405,10 @@
 			boutput(M, "<span class='alert'><B>Your chameleon belt malfunctions!</B></span>")
 			src.name = "belt"
 			src.desc = "A flashing belt. Looks like you can still put things in it, though."
-			wear_image = image(wear_image_icon)
-			inhand_image = image(inhand_image_icon)
 			src.icon_state = "psyche"
 			src.item_state = "psyche"
+			wear_image = image(wear_image_icon)
+			inhand_image = image(inhand_image_icon)
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -1571,10 +1572,10 @@
 			boutput(M, "<span class='alert'><B>Your chameleon backpack malfunctions!</B></span>")
 			src.name = "backpack"
 			src.desc = "A flashing backpack. Looks like you can still put things in it, though."
-			wear_image = image(wear_image_icon)
-			inhand_image = image(inhand_image_icon)
 			src.icon_state = "psyche_backpack"
 			src.item_state = "psyche_backpack"
+			wear_image = image(wear_image_icon)
+			inhand_image = image(inhand_image_icon)
 			M.set_clothing_icon_dirty()
 
 	verb/change()

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1143,6 +1143,13 @@
 		item_state = "swat"
 		step_sound = "step_military"
 
+	caps_boots
+		name = "captain's boots"
+		desc = "A set of formal shoes with a protective layer underneath."
+		icon_state = "capboots"
+		item_state = "capboots"
+		step_sound = "step_military"
+
 	galoshes
 		name = "galoshes"
 		desc = "Rubber boots that prevent slipping on wet surfaces."
@@ -1821,7 +1828,7 @@
 		hat_type = new/datum/chameleon_hat_pattern/caphat
 		suit_type = new/datum/chameleon_suit_pattern/captain_armor
 		glasses_type = new/datum/chameleon_glasses_pattern/sunglasses
-		shoes_type = new/datum/chameleon_shoes_pattern/swat
+		shoes_type = new/datum/chameleon_shoes_pattern/caps_boots
 		gloves_type = new/datum/chameleon_gloves_pattern/caps_gloves
 		belt_type = null
 		backpack_type = new/datum/chameleon_backpack_pattern/captain

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -82,6 +82,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_jumpsuit_pattern
@@ -382,6 +383,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.seal_hair = T.seal_hair
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_hat_pattern
@@ -630,6 +632,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_suit_pattern
@@ -951,6 +954,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_glasses_pattern
@@ -1085,6 +1089,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.step_sound = T.step_sound
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_shoes_pattern
@@ -1266,6 +1271,7 @@
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
 			src.material_prints = T.print_type
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_gloves_pattern
@@ -1422,6 +1428,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_belt_pattern
@@ -1588,6 +1595,7 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			src.tooltip_rebuild = 1
 			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_backpack_pattern

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -245,6 +245,12 @@
 		icon_state = "detective"
 		item_state = "detective"
 
+	rank/captain
+		name = "captain's uniform"
+		desc = "Would you believe terrorists actually want to steal this jumpsuit? It's true!"
+		icon_state = "captain"
+		item_state = "captain"
+
 	rank/head_of_personnel
 		name = "head of personnel's uniform"
 		desc = "Rather bland and inoffensive. Perfect for vanishing off the face of the universe."
@@ -1325,6 +1331,15 @@
 		hide_prints = TRUE
 		scramble_prints = FALSE
 
+	caps_gloves
+		name = "captain's gloves"
+		desc = "A pair of formal gloves that are electrically insulated and quite heat-resistant. The high-quality materials help you in blocking attacks."
+		icon_state = "capgloves"
+		item_state = "capgloves"
+		print_type = "high-quality synthetic fibers"
+		hide_prints = TRUE
+		scramble_prints = FALSE
+
 /obj/item/storage/belt/chameleon
 	name = "utility belt"
 	desc = "Can hold various small objects."
@@ -1794,11 +1809,12 @@
 
 	captain
 		name = "Captain"
-		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank
+		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/captain
 		hat_type = new/datum/chameleon_hat_pattern/caphat
 		suit_type = new/datum/chameleon_suit_pattern/captain_armor
 		glasses_type = new/datum/chameleon_glasses_pattern/sunglasses
 		shoes_type = new/datum/chameleon_shoes_pattern/swat
+		gloves_type = new/datum/chameleon_gloves_pattern/caps_gloves
 		belt_type = null
 		backpack_type = new/datum/chameleon_backpack_pattern/captain
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bulk discount PR for a few chameleon outfit things, fixes #14006, fixes #16481, makes change_outfit() set tooltip_rebuild, and adds the captain's gloves and boots to the outfit.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

While the captain may be a staff assistant in spirit they _do_ have a special jumpsuit
