### PR TITLE
Rename donut2 autolathe storage to auxilliary storage

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -16292,7 +16292,7 @@
 /area/station/engine/engineering)
 "brW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "brX" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
@@ -16509,34 +16509,34 @@
 "bsN" = (
 /obj/machinery/abcu,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsO" = (
 /obj/machinery/vending/book,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsP" = (
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/vending/pda,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsQ" = (
 /obj/machinery/camera{
 	c_tag = "Autolathe"
 	},
 /obj/machinery/vending/floppy,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsR" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/hand_labeler,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsS" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bsT" = (
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -16671,10 +16671,10 @@
 	},
 /obj/storage/crate/abcumarker,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "btM" = (
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "btN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16683,13 +16683,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "btO" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "btP" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -16699,7 +16699,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "btT" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
@@ -16855,7 +16855,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "buP" = (
 /obj/machinery/bot/firebot,
 /obj/disposalpipe/segment{
@@ -16863,24 +16863,24 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "buQ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "buR" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "buS" = (
 /obj/item/extinguisher{
 	pixel_y = 8
 	},
 /obj/storage/closet/fire,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "buU" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
@@ -17101,7 +17101,7 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bvW" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -17111,14 +17111,14 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bvX" = (
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "bvY" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -43555,7 +43555,7 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/storage/autolathe)
+/area/station/storage/auxillary)
 "rUL" = (
 /obj/stool/bench,
 /turf/simulated/floor/pool/no_animate,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes #16351, makes the room's area across from tool storage on donut2 be `/area/station/storage/auxilliary` instead of `/area/station/storage/autolathe`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

~~I hate soul~~ Confusing name for people who don't know what an autolathe is and for people who know an autolathe is a fabricator because the room doesn't even have a fabricator. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Autolathe storage on donut 2 has been renamed to auxilliary storage, and a team of scientists has been hired to research what exactly an autolathe is.
```
