### PR TITLE
Make ATM ui_act use get_id_card

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -914,7 +914,7 @@
 				var/obj/item/card/id/ID = get_id_card(O)
 				if (istype(ID))
 					boutput(usr, "<span class='notice'>You swipe your ID card.</span>")
-					src.scan = O
+					src.scan = ID
 				. = TRUE
 			if("login_attempt")
 				if(!src.scan)

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -911,7 +911,8 @@
 				if (src.scan)
 					return TRUE
 				var/obj/O = usr.equipped()
-				if (istype(O, /obj/item/card/id))
+				var/obj/item/card/id/ID = get_id_card(O)
+				if (istype(ID))
 					boutput(usr, "<span class='notice'>You swipe your ID card.</span>")
 					src.scan = O
 				. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes clicking on login button of ATM use get_id_card instead of istype

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity