### PR TITLE
Fix contraband being flagged when equip_new_if_possible places an item in a backpack or belt

### DIFF
--- a/code/datums/components/contraband.dm
+++ b/code/datums/components/contraband.dm
@@ -20,7 +20,7 @@ TYPEINFO(/datum/component/contraband)
 	RegisterSignal(parent, COMSIG_MOVABLE_CONTRABAND_CHANGED, PROC_REF(visible_contraband_changed))
 	if (isitem(AM))
 		var/obj/item/I = AM
-		if (ismob(I.loc))
+		if (ismob(I.loc) && I.equipped_in_slot)
 			var/mob/M = I.loc
 			src.equipped(I, M, I.equipped_in_slot)
 		RegisterSignal(AM, COMSIG_ITEM_EQUIPPED, PROC_REF(equipped))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #16451


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
equip_new_if_possible spawns the bartender's shotgun inside them, then moves it to their backpack. This brief moment of internal firepower was the same moment that contraband for the shotgun was created.