### PR TITLE
Makes tinfoil hats prevent artifact hallucinations

### DIFF
--- a/code/obj/artifacts/artifact_machines/madness.dm
+++ b/code/obj/artifacts/artifact_machines/madness.dm
@@ -349,8 +349,8 @@
 			var/turf/T = get_turf(O)
 			T.visible_message("<b>[O]</b> shimmers briefly!")
 
-		for (var/mob/living/L in range(range,O))
-			if (!L.client) //no point hallucinating if there's nobody to see it
+		for (var/mob/living/carbon/human/L in range(range,O))
+			if (!L.client || istype(L.head, /obj/item/clothing/head/tinfoil_hat)) //no point hallucinating if there's nobody to see it
 				continue
 
 			for(var/list/comp_args_tuple in src.madness_effects[src.effect_type])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE][FEATURE][CLOTHING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes #16411's madness artifact's hallucination effect ignore people with tinfoil hats.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I believe this to be a neat gimmick, and another use for the tinfoil hats, that, as of now, only block weak martian psyblasts.
This PR also adds a **potential** counter to the hallucinations, although I don't think the hats can be aquired without having
the conspirator trait.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Tinfoil hats now block artifact hallucinations.
```
