### PR TITLE
fix give returning early for alive target mobs

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1398,7 +1398,7 @@
 			L.give_to(src)
 
 /mob/living/proc/give_to(var/mob/living/M)
-	if (!M || M == src || isalive(M))
+	if (!M || M == src || !isalive(M))
 		return
 
 #ifdef TWITCH_BOT_ALLOWED


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
grabs are early returning for alive players and not dead ones

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I fucked up
fixes #16489 
