### PR TITLE
Meat Friends and Meat Things

### DIFF
--- a/code/datums/abilities/critter/boilgib.dm
+++ b/code/datums/abilities/critter/boilgib.dm
@@ -5,7 +5,7 @@
 	name = "Blood Boil"
 	desc = "Expend all of your energy to self-destruct and spray boiling changeling blood on nearby targets."
 	cooldown = 0
-	start_on_cooldown = 0
+	start_on_cooldown = FALSE
 	icon_state = "blood_boil"
 
 	cast(atom/target)
@@ -13,8 +13,9 @@
 			return 1
 		var/mob/ow = holder.owner
 
-		if(tgui_alert(ow, "This will destroy your body to scald all nearby targets! Are you sure?", "Blood boil", list("Yes","No")) != "Yes")
-			return
+		if(ow.client)
+			if(tgui_alert(ow, "This will destroy your body to scald all nearby targets! Are you sure?", "Blood boil", list("Yes","No")) != "Yes")
+				return
 
 		for (var/turf/splat in view(2,ow.loc))
 			if (prob(50))
@@ -26,7 +27,8 @@
 		var/dmg = 20
 		//Increase the power of the boilgib if we have collected DNA!
 		if (istype(holder.owner, /mob/living/critter/changeling/handspider))
-			dmg += holder.owner:absorbed_dna * 3.3
+			var/mob/living/critter/changeling/handspider/H = holder.owner
+			dmg += H.absorbed_dna * 3.3
 		for (var/mob/M in view(3,ow.loc))
 			if(iscarbon(M))
 				if (ishuman(M))

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -313,6 +313,9 @@
 		hivemind_owner.insert_into_hivemind(src)
 		qdel(src)
 
+/mob/living/critter/changeling/handspider/ai_controlled
+	ai_type = /datum/aiHolder/aggressive
+	is_npc = TRUE
 
 ///////////////////////////
 // EYESPIDER

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -167,6 +167,17 @@
 		UnregisterSignal(src, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED))
 		..()
 
+	critter_ability_attack(var/mob/target)
+		for (var/ability_path in list(/datum/targetable/critter/dna_gnaw, /datum/targetable/critter/boilgib))
+			var/datum/targetable/critter/A = src.abilityHolder?.getAbility(ability_path)
+			if(istype(A))
+				if(istype(A, /datum/targetable/critter/boilgib))
+					if(prob(src.get_health_percentage() * 100))
+						continue
+				if (!A.disabled && A.cooldowncheck())
+					A.handleCast(target)
+					return TRUE
+
 	proc/stop_sprint()
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_CANTSPRINT, src.type)
 
@@ -360,6 +371,17 @@
 		// EYE CAN SEE FOREVERRRR
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_XRAYVISION, src)
 
+	critter_ability_attack(var/mob/target)
+		for (var/ability_path in list(/datum/targetable/critter/shedtears, /datum/targetable/critter/boilgib))
+			var/datum/targetable/critter/A = src.abilityHolder?.getAbility(ability_path)
+			if(istype(A))
+				if(istype(A, /datum/targetable/critter/boilgib))
+					if(prob(src.get_health_percentage() * 100))
+						continue
+				if (!A.disabled && A.cooldowncheck())
+					A.handleCast(target)
+					return TRUE
+
 	// a slight breeze will kill these guys, such is life as a squishy li'l eye
 	setup_healths()
 		add_hh_flesh(3, 1)
@@ -404,6 +426,10 @@
 			SPAWN(3 SECONDS)
 				src.client?.images -= arrow
 				qdel(arrow)
+
+/mob/living/critter/changeling/eyespider/ai_controlled
+	ai_type = /datum/aiHolder/aggressive
+	is_npc = TRUE
 
 ///////////////////////////
 // LEGWORM
@@ -492,6 +518,16 @@
 		add_hh_flesh_burn(5, 1.25)
 		add_health_holder(/datum/healthHolder/toxin)
 
+	critter_ability_attack(var/mob/target)
+		for (var/ability_path in list(/datum/targetable/critter/powerkick, /datum/targetable/critter/writhe, /datum/targetable/critter/boilgib))
+			var/datum/targetable/critter/A = src.abilityHolder?.getAbility(ability_path)
+			if(istype(A))
+				if(istype(A, /datum/targetable/critter/boilgib))
+					if(prob(src.get_health_percentage() * 100))
+						continue
+				if (!A.disabled && A.cooldowncheck())
+					A.handleCast(target)
+					return TRUE
 
 	return_to_master()
 		if (ishuman(hivemind_owner.owner))
@@ -519,6 +555,10 @@
 		hivemind_owner.points += (dna_gain)
 		hivemind_owner.insert_into_hivemind(src)
 		qdel(src)
+
+/mob/living/critter/changeling/legworm/ai_controlled
+	ai_type = /datum/aiHolder/aggressive
+	is_npc = TRUE
 
 
 ///////////////////////////
@@ -566,7 +606,13 @@
 		add_hh_flesh(16, 1)
 		add_hh_flesh_burn(5, 1.25)
 
-
+	critter_ability_attack(var/mob/target)
+		for (var/ability_path in list(/datum/targetable/changeling/sting/fartonium, /datum/targetable/changeling/sting/simethicone))
+			var/datum/targetable/critter/A = src.abilityHolder?.getAbility(ability_path)
+			if(istype(A))
+				if (!A.disabled && A.cooldowncheck())
+					A.handleCast(target)
+					return TRUE
 
 	return_to_master()
 		if (ishuman(hivemind_owner.owner))
@@ -585,6 +631,10 @@
 		hivemind_owner.points += (dna_gain)
 		hivemind_owner.insert_into_hivemind(src)
 		qdel(src)
+
+/mob/living/critter/changeling/buttcrab/ai_controlled
+	ai_type = /datum/aiHolder/aggressive
+	is_npc = TRUE
 
 
 

--- a/code/modules/worldgen/mapgen/StorehouseGenerator.dm
+++ b/code/modules/worldgen/mapgen/StorehouseGenerator.dm
@@ -287,16 +287,14 @@
 #ifdef HALLOWEEN
 						else if(prob(5) + (meaty*5))
 							if(prob(1))
-								meat_friend = new /mob/living/critter/changeling/buttcrab(T)
+								meat_friend = new /mob/living/critter/changeling/buttcrab/ai_controlled(T)
 							else if(prob(20))
-								meat_friend = new /mob/living/critter/changeling/eyespider(T)
+								meat_friend = new /mob/living/critter/changeling/eyespider/ai_controlled(T)
 							else if(prob(50))
-								meat_friend = new /mob/living/critter/changeling/legworm(T)
+								meat_friend = new /mob/living/critter/changeling/legworm/ai_controlled(T)
 							else
-								meat_friend = new /mob/living/critter/changeling/handspider(T)
+								meat_friend = new /mob/living/critter/changeling/handspider/ai_controlled(T)
 							C = meat_friend
-							C.is_npc = TRUE
-							C.ai = new /datum/aiHolder/aggressive(C)
 #endif
 						else
 							if(prob(90))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expansion of #16416

Adds the addition of changeling critters to the Meat Rooms Generator during Halloween.

AI controlled variants and Ability support for the following:

- /mob/living/critter/changeling/eyespider
- /mob/living/critter/changeling/legworm
- /mob/living/critter/changeling/buttcrab
- /mob/living/critter/changeling/handspider

Bloodboil can now be used by AI mobs!

Visual improvement to depiction of stomach turfs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spooktober! Spooktober! Spooktober! Spooktober!

