### PR TITLE
Fix macrophaser access

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -588,7 +588,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	cost = PAY_EXECUTIVE*2
 	containertype = /obj/storage/secure/crate/weapon
 	containername = "Weapons Crate - Macro Phaser (Cardlocked \[Armory Equipment])"
-	access = access_armory
+	access = access_maxsec
 
 /datum/supply_packs/evacuation
 	name = "Emergency Equipment"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game-Objects] [Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
From the[ wiki ](https://wiki.ss13.co/Quartermaster#Security_Department)it appears the Macro Phaser crate should be armory locked, and this PR fixes that access. 

From comments in https://github.com/goonstation/goonstation/blob/207966fde4ecec34957568ce2ca1c9fb94109a5a/_std/defines/access.dm#L8 it appears intended that that access_armory is no longer in use, and access_maxsec should be used instead. 

This change impacts the following roles, losing Macro Phaser crate opening access ONLY:
- Captain
- Head of Personnel 
- RP_MODE only Security Officer (non-RP mode stays the same as current with no access)
- /proc/get_all_accesses adjacent jobs:
  - Judge
  - Regional Director
  - Nanotrasen Special Operative
  - Nanotrasen Emergency Repair Technician
  - Nanotrasen Emergency Medic
  - NT-SO Rescue Worker
  - AI
  - Cyborgs
- Syndicate Special Operative via /proc/syndicate_spec_ops_access
- emag'd cards getting a chance for access_armory

**I'm unsure if folks now expect the roles above to be able to open this crate or not. I'd appreciate dev feedback on if we need community feedback before this change is made. If current access to the Macro Phaser crate is "working as intended", happy to close this and the bug report out as not needed.**
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes bug #16488 

