### PR TITLE
Update NTSO Industrial Armor Icon State

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1526,8 +1526,8 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
 
 /obj/item/clothing/suit/space/industrial/nt_specialist
 	name = "NT industrial space armor"
-	item_state = "indus_specialist"
-	icon_state = "indus_specialist"
+	item_state = "indus-nt"
+	icon_state = "ntso_specialist-heavy"
 
 	setupProperties()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CLOTHING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16518 (fixes inhand sprite cuz that had the wrong state too)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

ya
