### PR TITLE
Fix hobo wine not containing any random reagents

### DIFF
--- a/code/modules/food_and_drink/alcohol.dm
+++ b/code/modules/food_and_drink/alcohol.dm
@@ -67,7 +67,7 @@
 	alt_filled_state = 1
 	var/safe = 0
 	initial_volume = 100
-	initial_reagents = list("wine"=80,"ethanol"=20)
+	initial_reagents = list("wine"=60,"ethanol"=20)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CHEMISTRY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15591 by lowering wine from 80u to 60u so there's 20u of empty space available for the later reagents to be added.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

At some point the amounts of ethanol/wine on this were tweaked which resulted in the bottles spawning 100% full, meaning all the code in New() to add random reagents would always fail. 
