### PR TITLE
Fix a map vote bug

### DIFF
--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -459,6 +459,7 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 
 /obj/mapVoteLink
 	name = "<span style='color: green; text-decoration: underline;'>Map Vote</span>"
+	flags = NOSPLASH
 
 	Click()
 		var/client/C = usr.client


### PR DESCRIPTION
[SECRET] [UI]
## About the PR
Adds the NOSPLASH flag to the `obj/mapVoteLink`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11582. Previously the reagent being poured onto the ui could get used up and therefore fail to vote for the intended map. This way the reagent stays in the container and can be detected by the map vote. Allowing you to vote for mushroom and pamgoc.