### PR TITLE
Make latejoin antags not target VR people

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -49,6 +49,8 @@ ABSTRACT_TYPE(/datum/objective)
 					continue
 				if (!possible_target.current.client)
 					continue
+				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
+					continue
 				possible_targets += possible_target
 
 		if(length(possible_targets) > 0)
@@ -1175,7 +1177,7 @@ proc/create_fluff(datum/mind/target)
 					continue
 				if (!possible_target.current.client)
 					continue
-				if (istype(possible_target.current, /mob/living/carbon/human/virtual))
+				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
 					continue
 				possible_targets += possible_target
 
@@ -1385,6 +1387,8 @@ proc/create_fluff(datum/mind/target)
 				if (possible_target.current.mind && possible_target.current.mind.is_target) // Cannot read null.is_target
 					continue
 				if (!possible_target.current.client)
+					continue
+				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
 					continue
 				possible_targets += possible_target
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -49,7 +49,7 @@ ABSTRACT_TYPE(/datum/objective)
 					continue
 				if (!possible_target.current.client)
 					continue
-				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
+				if (isvirtual(possible_target) || istype(get_area(possible_target),/area/afterlife))
 					continue
 				possible_targets += possible_target
 
@@ -1177,7 +1177,7 @@ proc/create_fluff(datum/mind/target)
 					continue
 				if (!possible_target.current.client)
 					continue
-				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
+				if (isvirtual(possible_target) || istype(get_area(possible_target),/area/afterlife))
 					continue
 				possible_targets += possible_target
 
@@ -1388,7 +1388,7 @@ proc/create_fluff(datum/mind/target)
 					continue
 				if (!possible_target.current.client)
 					continue
-				if (isvirtual(H) || istype(get_area(H),/area/afterlife))
+				if (isvirtual(possible_target) || istype(get_area(possible_target),/area/afterlife))
 					continue
 				possible_targets += possible_target
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1175,6 +1175,8 @@ proc/create_fluff(datum/mind/target)
 					continue
 				if (!possible_target.current.client)
 					continue
+				if (istype(possible_target.current, /mob/living/carbon/human/virtual))
+					continue
 				possible_targets += possible_target
 
 		if(length(possible_targets) > 0)


### PR DESCRIPTION
[BUG] [VR] [GAMEMODE]
## About the PR
Adds a check that makes sure that the "possible targets" internal list doesn't include people who are currently inhabiting vr human bodies.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes  #10850