### PR TITLE
fix the north facing shuttle

### DIFF
--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -1111,15 +1111,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/outside)
-"Rf" = (
-/obj/indestructible/shuttle_corner{
-	dir = 0;
-	icon_state = "7"
-	},
-/turf/simulated/wall/auto/shuttle{
-	icon_state = "3"
-	},
-/area/shuttle/escape/centcom)
 "Rs" = (
 /turf/unsimulated/wall/generic{
 	icon = 'icons/misc/worlds.dmi';
@@ -1163,16 +1154,6 @@
 	},
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
-"SH" = (
-/obj/indestructible/shuttle_corner{
-	dir = 0
-	},
-/obj/indestructible/shuttle_corner{
-	dir = 0;
-	icon_state = "7"
-	},
-/turf/unsimulated/floor/shuttle,
-/area/shuttle/escape/centcom)
 "SW" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/decal/fakeobjects{
@@ -1463,7 +1444,7 @@ tt
 rR
 tt
 tt
-Rf
+rR
 jl
 Hm
 hi
@@ -1604,7 +1585,7 @@ Ih
 tt
 tt
 tt
-SH
+rR
 Zb
 Dz
 IG


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the north facing escape shuttle. It previously had two bugged spots where there were both wall and corner overlapping with broken sprites. It is now a T shaped wall.

The north facing escape shuttle is used on donut2, for context.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16534
