### PR TITLE
Simplifies neurodepressant's and solipsizine's recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3167,7 +3167,7 @@
 		name = "neurodepressant"
 		id = "neurodepressant"
 		result = "neurodepressant"
-		required_reagents = list("acid" = 1, "neurotoxin" = 1)
+		required_reagents = list("acid" = 1, "neurotoxin" = 1, "acetone" = 0.1)
 		result_amount = 1
 		min_temperature = T0C + 450
 		mix_phrase = "The neurotoxin breaks down, bubbling violently."

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3167,8 +3167,8 @@
 		name = "neurodepressant"
 		id = "neurodepressant"
 		result = "neurodepressant"
-		required_reagents = list("acid" = 1, "neurotoxin" = 1, "acetone" = 0.1)
-		result_amount = 1
+		required_reagents = list("acid" = 1, "neurotoxin" = 2, "acetone" = 1)
+		result_amount = 2
 		min_temperature = T0C + 450
 		mix_phrase = "The neurotoxin breaks down, bubbling violently."
 		mix_sound = 'sound/misc/drinkfizz.ogg'

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3167,8 +3167,8 @@
 		name = "neurodepressant"
 		id = "neurodepressant"
 		result = "neurodepressant"
-		required_reagents = list("acid" = 1, "neurotoxin" = 2, "acetone" = 1)
-		result_amount = 2
+		required_reagents = list("acid" = 1, "neurotoxin" = 1)
+		result_amount = 1
 		min_temperature = T0C + 450
 		mix_phrase = "The neurotoxin breaks down, bubbling violently."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
@@ -3177,7 +3177,7 @@
 		name = "Solipsizine"
 		id = "solipsizine"
 		result = "solipsizine"
-		required_reagents = list("antihistamine" = 2, "neurodepressant" = 1, "LSD" = 1, "haloperidol" = 1)
+		required_reagents = list("neurodepressant" = 1, "LSD" = 1, "haloperidol" = 1)
 		result_amount = 3
 
 	mutadone // // COGWERKS CHEM REVISION PROJECT: magic bullshit drug, make it involve mutagen


### PR DESCRIPTION
[LABEL][chemistry][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the recipe of Neurodepressant, and the only chem that also requires it as a precursor to be produced, solipsizine. It does it by removing diphenhydramine from solipsizine's recipe, and swapping the acetone in the neurodepressant recipe with another part of sulfuric acid.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The chemistry recipe update has made a lot of changes, and a few chemicals that were already hard to made were made even more so, particularly neurodepressant and solipsizine(partly on account of needing the former as a precursor).

Neurodepressant currently needs both acetone and sulfuric acid, the first being significantly harder to produce now, and the second being quite volatile to work with. Neurodepressant is still not close to being easy to make, and overall more dangerous considering the sulfuric acid offgass, however it should be closer to how time and resource consuming it was originally to make.


```changelog
(u)Colossusqw
(+)Solipsizine's recipe no longer requires diphenhydramine.
```
