### PR TITLE
Fixes #16377 Plush Toys Spawning with Nectar Perspiration 

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2189,7 +2189,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-		// Deactivate any gene that was activated by
+
+		// Deactivate any gene that was activated by Mildly mutated trait
 		M.bioHolder.DeactivateAllPoolEffects()
 		M.critterize(/mob/living/critter/small_animal/plush/cryptid)
 
@@ -2202,6 +2203,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
+		// Deactivate any gene that was activated by Mildly mutated trait
 		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/mouse/remy)
 		C.flags = null
@@ -2214,6 +2216,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
+
+		// Deactivate any gene that was activated by Mildly mutated trait
 		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/spider/nice)
 		C.flags = null
@@ -2227,6 +2231,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
+		// Deactivate any gene that was activated by Mildly mutated trait
 		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/bird/crow)
 		C.flags = null

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2189,6 +2189,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
+		M.bioHolder.RemoveEffect("buzz")
 		M.critterize(/mob/living/critter/small_animal/plush/cryptid)
 
 /datum/job/special/halloween/critter/remy

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2189,7 +2189,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-		M.bioHolder.RemoveEffect("buzz")
+		// Deactivate any gene that was activated by
+		M.bioHolder.DeactivateAllPoolEffects()
 		M.critterize(/mob/living/critter/small_animal/plush/cryptid)
 
 /datum/job/special/halloween/critter/remy
@@ -2200,6 +2201,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
+
+		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/mouse/remy)
 		C.flags = null
 
@@ -2211,6 +2214,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
+		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/spider/nice)
 		C.flags = null
 
@@ -2222,6 +2226,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
+
+		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/bird/crow)
 		C.flags = null
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2197,7 +2197,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-
 		M.critterize(/mob/living/critter/small_animal/plush/cryptid)
 
 /datum/job/special/halloween/critter/remy
@@ -2208,7 +2207,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/mouse/remy)
 		C.flags = null
 
@@ -2220,7 +2218,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/spider/nice)
 		C.flags = null
 
@@ -2232,7 +2229,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		..()
 		if (!M)
 			return
-
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/bird/crow)
 		C.flags = null
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2180,6 +2180,14 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	slot_card = null
 	slot_back = list()
 
+	special_setup(var/mob/living/carbon/human/M)
+		if (!M)
+			return
+
+		..()
+		// Deactivate any gene that was activated by Mildly mutated trait
+		M.bioHolder.DeactivateAllPoolEffects()
+
 /datum/job/special/halloween/critter/plush
 	name = "Plush Toy"
 	mentor_only = FALSE
@@ -2190,8 +2198,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
-		// Deactivate any gene that was activated by Mildly mutated trait
-		M.bioHolder.DeactivateAllPoolEffects()
 		M.critterize(/mob/living/critter/small_animal/plush/cryptid)
 
 /datum/job/special/halloween/critter/remy
@@ -2203,8 +2209,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
-		// Deactivate any gene that was activated by Mildly mutated trait
-		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/mouse/remy)
 		C.flags = null
 
@@ -2217,8 +2221,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
-		// Deactivate any gene that was activated by Mildly mutated trait
-		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/spider/nice)
 		C.flags = null
 
@@ -2231,8 +2233,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 
-		// Deactivate any gene that was activated by Mildly mutated trait
-		M.bioHolder.DeactivateAllPoolEffects()
 		var/mob/living/critter/C = M.critterize(/mob/living/critter/small_animal/bird/crow)
 		C.flags = null
 

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -424,6 +424,50 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		..()
 
+	proc/OutputGainOrLoseMsg(var/datum/bioEffect/E, var/gain = TRUE)
+		if (!E)
+			return
+
+		if (gain == TRUE)
+			if (length(E.msgGain) > 0)
+				if (E.isBad)
+					boutput(owner, "<span class='alert'>[E.msgGain]</span>")
+				else
+					boutput(owner, "<span class='notice'>[E.msgGain]</span>")
+		else
+			if (length(E.msgLose) > 0)
+				if (E.isBad)
+					boutput(owner, "<span class='notice'>[E.msgLose]</span>")
+				else
+					boutput(owner, "<span class='alert'>[E.msgLose]</span>")
+
+		return
+
+	/// Deactivate effects that were activated from effectsPool and putting them back into effectsPool
+	proc/DeactivateAllPoolEffects()
+		if (length(src.effects) == 0)
+			return
+
+		for (var/datum/bioEffect/curr as anything in src.effects)
+			var/datum/bioEffect/E = src.effects[curr]
+			if (E.activated_from_pool == 1)
+				DeactivatePoolEffect(E)
+
+		return
+
+	/// Deactivates a gene effect and inserts it back into the pool
+	proc/DeactivatePoolEffect(var/datum/bioEffect/E)
+		if (!E)
+			return 0
+		src.effects.Remove(E.id)
+		src.effectPool[E.id] = E
+		E.owner = null
+		E.holder = null
+		E.activated_from_pool = 0
+		E.OnRemove()
+
+		src.OutputGainOrLoseMsg(E, FALSE)
+
 	proc/ActivatePoolEffect(var/datum/bioEffect/E, var/overrideDNA = 0, var/grant_research = 1)
 		if(!E || !effectPool[E.id] || (!E.dnaBlocks.sequenceCorrect() && !overrideDNA) || HasEffect(E.id))
 			return 0
@@ -444,11 +488,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		E.holder = src
 		E.activated_from_pool = 1
 		E.OnAdd()
-		if(length(E.msgGain) > 0)
-			if (E.isBad)
-				boutput(owner, "<span class='alert'>[E.msgGain]</span>")
-			else
-				boutput(owner, "<span class='notice'>[E.msgGain]</span>")
+		DeactivateAllPoolEffects(E, TRUE)
 
 		mobAppearance.UpdateMob()
 		return E
@@ -712,11 +752,9 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 				src.genetic_stability -= newEffect.stability_loss
 				src.genetic_stability = max(0,src.genetic_stability)
-			if(owner && length(newEffect.msgGain) > 0)
-				if (newEffect.isBad)
-					boutput(owner, "<span class='alert'>[newEffect.msgGain]</span>")
-				else
-					boutput(owner, "<span class='notice'>[newEffect.msgGain]</span>")
+			if(owner)
+				OutputGainOrLoseMsg(newEffect, TRUE)
+
 			mobAppearance.UpdateMob()
 			logTheThing(LOG_COMBAT, owner, "gains the [newEffect] mutation at [log_loc(owner)].")
 			return newEffect
@@ -756,11 +794,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			src.genetic_stability -= BE.stability_loss
 			src.genetic_stability = max(0,src.genetic_stability)
 
-		if(length(BE.msgGain) > 0)
-			if (BE.isBad)
-				boutput(owner, "<span class='alert'>[BE.msgGain]</span>")
-			else
-				boutput(owner, "<span class='notice'>[BE.msgGain]</span>")
+		OutputGainOrLoseMsg(BE, TRUE)
 		mobAppearance.UpdateMob()
 		logTheThing(LOG_COMBAT, owner, "gains the [BE] mutation at [log_loc(owner)].")
 		return BE
@@ -780,11 +814,9 @@ var/list/datum/bioEffect/mutini_effects = list()
 				src.genetic_stability = max(0,src.genetic_stability)
 			D.activated_from_pool = 0 //Fix for bug causing infinitely exploitable stability gain / loss
 
-			if (owner && length(D.msgLose) > 0)
-				if (D.isBad)
-					boutput(owner, "<span class='notice'>[D.msgLose]</span>")
-				else
-					boutput(owner, "<span class='alert'>[D.msgLose]</span>")
+			if (owner)
+				OutputGainOrLoseMsg(D, FALSE)
+
 			if (mobAppearance)
 				mobAppearance.UpdateMob()
 			logTheThing(LOG_COMBAT, owner, "loses the [D] mutation at [log_loc(owner)].")

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -488,7 +488,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		E.holder = src
 		E.activated_from_pool = 1
 		E.OnAdd()
-		DeactivateAllPoolEffects(E, TRUE)
+		OutputGainOrLoseMsg(E, TRUE)
 
 		mobAppearance.UpdateMob()
 		return E


### PR DESCRIPTION
[Bug] [Critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Small fix to remove Nectar Perspiration if they spawn with it, fixes #16377 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It has little counterplay as plush toys aren't going to find it easy to get mutadone, or even attention from doctors most of the time and the normal bee cloud effect doesn't seem to render on their sprites.
