### PR TITLE
Move TGUI ready to a script in body for OD

### DIFF
--- a/browserassets/tgui/tgui.html
+++ b/browserassets/tgui/tgui.html
@@ -595,7 +595,13 @@
 			<div>Please enable Javascript and restart the game.</div>
 		</div>
 	</noscript>
-
+	<script>
+		Byond.topic({
+			tgui: 1,
+			window_id: window.__windowId__,
+			type: 'ready',
+		});
+	</script>
 </body>
 
 </html>

--- a/browserassets/tgui/tgui.html
+++ b/browserassets/tgui/tgui.html
@@ -395,13 +395,6 @@
 		window.update = function (message) {
 			window.__updateQueue__.push(message);
 		};
-		window.onload = function () {
-			Byond.topic({
-				tgui: 1,
-				window_id: window.__windowId__,
-				type: 'ready',
-			});
-		};
 
 		// Necessary polyfill to make Webpack code splitting work on IE8
 		if (!Function.prototype.bind) (function () {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
CEF runs `window.onload` before the window load is completed. IE doesn't. Moving this is necessary for TGUI to work on OD.
