### PR TITLE
Fix GPS verb checking cooldown on path removal

### DIFF
--- a/code/modules/gps/gps.dm
+++ b/code/modules/gps/gps.dm
@@ -138,7 +138,7 @@
 	set name = "GPS"
 	set category = "Commands"
 	set desc = "Find your way around with ease!"
-	if(ON_COOLDOWN(src, "gps", 10 SECONDS))
+	if(ON_COOLDOWN(src, "gps", 10 SECONDS) && !client.GPS_Path)
 		boutput(src, "Verb on cooldown for [time_to_text(ON_COOLDOWN(src, "gps", 0))].")
 		return
 	DoGPS(src.get_id())
@@ -146,7 +146,7 @@
 	set name = "GPS"
 	set category = "Commands"
 	set desc = "Find your way around with ease!"
-	if(ON_COOLDOWN(src, "gps", 10 SECONDS))
+	if(ON_COOLDOWN(src, "gps", 10 SECONDS) && !client.GPS_Path)
 		boutput(src, "Verb on cooldown for [time_to_text(ON_COOLDOWN(src, "gps", 0 SECONDS))].")
 		return
 	DoGPS(src.botcard)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #11590 by making it only trigger the cooldown if you don't already have a GPS route set

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A cooldown to remove the path doesn't make sense

