### PR TITLE
Use Spatial Mapping to ensure distance of placed Flora/Fauna in Biomes

### DIFF
--- a/_std/spatial_hashing.dm
+++ b/_std/spatial_hashing.dm
@@ -135,12 +135,12 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
 			return list()
 
 		// if the range is higher than cell size, we can miss cells!
-		range = min(range, cellsize)
+		range = min(range, src.cellsize)
 
 		. = list()
 		for (var/id in get_atom_id(A, range))
 			if(length(hashmap[id]))
-				. += hashmap[id]
+				. += src.hashmap[id]
 
 /datum/spatial_hashmap/clients
 	cellsize = 30 // 300x300 -> 10x10

--- a/code/modules/worldgen/mapgen/MarsGenerator.dm
+++ b/code/modules/worldgen/mapgen/MarsGenerator.dm
@@ -5,13 +5,15 @@
 	turf_type = /turf/unsimulated/floor/setpieces/martian/station_duststorm
 
 	flora_types = list(/obj/machinery/light/beacon=10)
-	flora_density = 0.8
+	flora_density = 2
+	minimum_flora_distance = 10
 
 /datum/biome/mars/martian_area
 	turf_type = /turf/unsimulated/floor/setpieces/martian/station_duststorm
 
 	fauna_types = list(/mob/living/critter/martian=50, /mob/living/critter/martian/soldier=10, /mob/living/critter/martian/mutant=1, /mob/living/critter/martian/initiate=5, /mob/living/critter/martian/warrior=10)
 	fauna_density = 1
+	minimum_fauna_distance = 3
 
 /datum/biome/mars/martian_rock
 	turf_type = /turf/unsimulated/wall/setpieces/martian/auto

--- a/code/modules/worldgen/mapgen/biomes/_biome.dm
+++ b/code/modules/worldgen/mapgen/biomes/_biome.dm
@@ -4,14 +4,29 @@
 	var/turf_type
 	///Chance of having a structure from the flora types list spawn
 	var/flora_density = 0
+	var/minimum_flora_distance = 0
 	///Chance of having a mob from the fauna types list spawn
 	var/fauna_density = 0
+	var/minimum_fauna_distance = 0
 	///list of type paths of objects that can be spawned when the turf spawns flora. Syntax: list(type = weight)
 	var/list/flora_types = list(/obj/tree = 100)
 	///list of type paths of mobs that can be spawned when the turf spawns fauna. Syntax: list(type = weight)
 	var/list/fauna_types = list()
 
+	var/datum/spatial_hashmap/manual/fauna_hashmap
+	var/datum/spatial_hashmap/manual/flora_hashmap
+
+
 var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
+
+/datum/biome/New()
+	. = ..()
+	if(minimum_fauna_distance)
+		fauna_hashmap = new(cs=minimum_fauna_distance)
+		fauna_hashmap.update_cooldown = INFINITY
+	if(minimum_flora_distance)
+		flora_hashmap = new(cs=minimum_flora_distance)
+		flora_hashmap.update_cooldown = INFINITY
 
 ///This proc handles the creation of a turf of a specific biome type
 /datum/biome/proc/generate_turf(var/turf/gen_turf, flags=0)
@@ -19,8 +34,10 @@ var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
 
 	if((flags & MAPGEN_IGNORE_FAUNA) == 0)
 		if(length(fauna_types) && prob(fauna_density))
-			var/mob/fauna = weighted_pick(fauna_types)
-			new fauna(gen_turf)
+			if(!fauna_hashmap || !length(fauna_hashmap.get_nearby(gen_turf, src.minimum_fauna_distance)))
+				var/mob/fauna = weighted_pick(fauna_types)
+				fauna = new fauna(gen_turf)
+				fauna_hashmap?.add_weakref(fauna)
 
 	// Skip areas where flora generation can be problematic due to introduction of dense anchored objects
 	if((gen_turf.z == Z_LEVEL_STATION || isgenplanet(gen_turf)) && ((flags & MAPGEN_IGNORE_BUILDABLE) == 0))
@@ -35,8 +52,10 @@ var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
 
 	if((flags & MAPGEN_IGNORE_FLORA) == 0)
 		if(length(flora_types) && prob(flora_density))
-			var/obj/structure/flora = weighted_pick(flora_types)
-			new flora(gen_turf)
+			if(!flora_hashmap || !length(flora_hashmap.get_nearby(gen_turf, src.minimum_flora_distance)))
+				var/obj/flora = weighted_pick(flora_types)
+				flora = new flora(gen_turf)
+				flora_hashmap?.add_weakref(flora)
 
 	var/area/A = get_area(gen_turf)
 	A.store_biome(gen_turf, src.type)
@@ -60,7 +79,7 @@ var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
 
 /datum/biome/snow
 	turf_type = /turf/unsimulated/floor/auto/snow
-	flora_types = list(/obj/stone/snow/random = 100, /obj/decal/fakeobjects/smallrocks = 100, /obj/shrub/snow/random{override_default_behaviour=1} = 100, /obj/stone/random = 5)
+	flora_types = list(/obj/stone/snow/random = 100, /obj/decal/fakeobjects/smallrocks = 100, /obj/shrub/snow/random{last_use=INFINITY} = 100, /obj/stone/random = 5)
 	flora_density = 2
 
 /datum/biome/snow/rocky
@@ -69,7 +88,7 @@ var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
 	flora_density = 5
 
 /datum/biome/snow/forest
-	flora_types = list(/obj/tree/snow_random = 50, /obj/shrub/snow/random{override_default_behaviour=1} = 100, /obj/stone/snow/random = 10, /obj/decal/fakeobjects/smallrocks = 5)
+	flora_types = list(/obj/tree/snow_random = 50, /obj/shrub/snow/random{last_use=INFINITY} = 100, /obj/stone/snow/random = 10, /obj/decal/fakeobjects/smallrocks = 5)
 	flora_density = 20
 
 /datum/biome/snow/forest/thick
@@ -82,42 +101,46 @@ var/list/area/blacklist_flora_gen = list(/area/shuttle, /area/mining)
 
 /datum/biome/plains
 	turf_type = /turf/unsimulated/floor/auto/grass/swamp_grass
-	flora_types = list(/obj/tree/elm_random = 50, /obj/shrub/random{override_default_behaviour=1} = 100, /obj/stone/random = 100, /obj/decal/fakeobjects/smallrocks = 100)
+	flora_types = list(/obj/tree/elm_random = 50, /obj/shrub/random{last_use=INFINITY} = 100, /obj/stone/random = 100, /obj/decal/fakeobjects/smallrocks = 100)
 	flora_density = 15
 
 /datum/biome/forest
 	turf_type = /turf/unsimulated/floor/grasslush/thin
-	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 75, /obj/tree/elm_random=1, /obj/shrub/random{override_default_behaviour=1} = 50)
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 75, /obj/tree/elm_random=1, /obj/shrub/random{last_use=INFINITY} = 50)
 	flora_density = 20
+	minimum_flora_distance = 2
 
 	fauna_types = list(/mob/living/critter/small_animal/firefly/ai_controlled = 5, /mob/living/critter/small_animal/firefly/pyre/ai_controlled = 1, /mob/living/critter/small_animal/firefly/lightning/ai_controlled = 1, /mob/living/critter/bear=5, /mob/living/critter/small_animal/bird/crow=5)
 	fauna_density = 0.2
 
 /datum/biome/forest/dense
 	turf_type = /turf/unsimulated/floor/grasslush/thinner
-	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 75, /obj/tree/elm_random=1, /obj/shrub/random{override_default_behaviour=1} = 5, /obj/machinery/plantpot/bareplant/tree = 5)
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 75, /obj/tree/elm_random=1, /obj/shrub/random{last_use=INFINITY} = 5, /obj/machinery/plantpot/bareplant/tree = 5)
 	flora_density = 35
+	minimum_flora_distance = 1
 
 	fauna_types = list(/mob/living/critter/small_animal/dragonfly/ai_controlled = 20, /mob/living/critter/bear=1, /mob/living/critter/small_animal/frog=5, /mob/living/critter/small_animal/bird/owl=5)
 
 /datum/biome/forest/thin
 	turf_type = /turf/unsimulated/floor/grasslush
-	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 5, /obj/tree/elm_random=5, /obj/shrub/random{override_default_behaviour=1} = 150, /obj/machinery/plantpot/bareplant/tree = 5, /obj/machinery/plantpot/bareplant/flower = 50)
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 5, /obj/tree/elm_random=5, /obj/shrub/random{last_use=INFINITY} = 150, /obj/machinery/plantpot/bareplant/tree = 5, /obj/machinery/plantpot/bareplant/flower = 50)
 	flora_density = 10
+	minimum_flora_distance = 3
 
 	fauna_types = list(/mob/living/critter/small_animal/mouse=5, /mob/living/critter/small_animal/pig=1, /mob/living/critter/small_animal/snake=1, /mob/living/critter/small_animal/bird/crow=1)
 	fauna_density = 0.5
 
 /datum/biome/forest/clearing
 	turf_type = /turf/unsimulated/floor/grasslush
-	flora_types = list(/obj/shrub/random{override_default_behaviour=1} = 150, /obj/machinery/plantpot/bareplant/flower = 50)
+	flora_types = list(/obj/shrub/random{last_use=INFINITY} = 150, /obj/machinery/plantpot/bareplant/flower = 50)
 	flora_density = 5
+	minimum_flora_distance = 4
 
 	fauna_types = list(/mob/living/critter/small_animal/mouse=10, /mob/living/critter/small_animal/snake=1)
 
 /datum/biome/jungle
 	turf_type = /turf/unsimulated/floor/auto/grass/leafy
-	flora_types = list(/obj/tree/elm_random = 75, /obj/shrub/random{override_default_behaviour=1} = 150, /obj/stone/random = 10, /obj/decal/fakeobjects/smallrocks = 10, /obj/machinery/plantpot/bareplant/swamp_flora = 1)
+	flora_types = list(/obj/tree/elm_random = 75, /obj/shrub/random{last_use=INFINITY} = 150, /obj/stone/random = 10, /obj/decal/fakeobjects/smallrocks = 10, /obj/machinery/plantpot/bareplant/swamp_flora = 1)
 	flora_density = 40
 
 	fauna_types = list(/mob/living/critter/small_animal/dragonfly/ai_controlled = 50, /mob/living/critter/small_animal/firefly/ai_controlled = 10, /mob/living/critter/small_animal/firefly/lightning/ai_controlled = 2, /mob/living/critter/small_animal/firefly/pyre/ai_controlled = 1, /mob/living/critter/small_animal/iguana = 3)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a more reliable means of spacing out flora and fauna instead of custom code or praying to the pseudorandom number generator.

Provides much better distributions of elements:
* Forest
* Mars

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improved tools for procedural generation.
