### PR TITLE
Dark Forest

### DIFF
--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -52,6 +52,7 @@ var/datum/station_zlevel_repair/station_repair = new
 					var/obj/effects/E = locate(src.weather_effect) in T
 					if(!E)
 						new src.weather_effect(T)
+				T.UpdateOverlays(null, "foreground_parallax_occlusion_overlay")
 
 	proc/clean_up_station_level(replace_with_cars, add_sub, remove_parallax = TRUE)
 		mass_driver_fixup()
@@ -661,10 +662,26 @@ ABSTRACT_TYPE(/datum/terrainify)
 	additional_options = list("Mining"=list("None","Normal","Rich"))
 	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE)
 
+#ifdef HALLOWEEN
+	New()
+		..()
+		additional_toggles["Spooky"] = FALSE
+#endif
+
 	convert_station_level(params, datum/tgui/ui)
 		if(..())
-			var/const/ambient_light = "#222"
-			station_repair.station_generator = new/datum/map_generator/forest_generator
+			var/const/ambient_light = "#211"
+
+
+			if(params["Spooky"])
+#ifdef HALLOWEEN
+				station_repair.station_generator = new/datum/map_generator/forest_generator/dark
+#else
+				;
+#endif
+			else
+				station_repair.station_generator = new/datum/map_generator/forest_generator
+
 
 			if(params["Ambient Light Obj"])
 				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
@@ -688,6 +705,18 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS)
 			handle_mining(params, space)
+
+			if(params["Spooky"])
+				var/list/station_areas = get_accessible_station_areas()
+				for(var/area_name in station_areas)
+					var/area/A = station_areas[area_name]
+					A.occlude_foreground_parallax_layers = TRUE
+					for(var/turf/T in get_area_turfs(A))
+						if(T.z == Z_LEVEL_STATION)
+							T.update_parallax_occlusion_overlay()
+							LAGCHECK(LAG_MED)
+
+				ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/foreground/fog, 20 SECONDS)
 
 			logTheThing(LOG_ADMIN, ui.user, "turned space into a forest.")
 			logTheThing(LOG_DIARY, ui.user, "turned space into a forest.", "admin")
@@ -716,7 +745,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 /datum/terrainify/storehouse
 	name = "Storehouse"
 	desc = "Load some nearby storehouse (Run before other Generators!)"
-	additional_toggles = list("Fill Z-Level"=FALSE,"Meaty"=FALSE)
+	additional_toggles = list("Fill Z-Level"=FALSE, "Meaty"=FALSE)
 
 	convert_station_level(params, datum/tgui/ui)
 		if (!..())

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -707,14 +707,16 @@ ABSTRACT_TYPE(/datum/terrainify)
 			handle_mining(params, space)
 
 			if(params["Spooky"])
+				// The following should be removed iff Caustics Parallax #16477 is merged
 				var/list/station_areas = get_accessible_station_areas()
 				for(var/area_name in station_areas)
 					var/area/A = station_areas[area_name]
-					A.occlude_foreground_parallax_layers = TRUE
-					for(var/turf/T in get_area_turfs(A))
-						if(T.z == Z_LEVEL_STATION)
-							T.update_parallax_occlusion_overlay()
-							LAGCHECK(LAG_MED)
+					if(!A.occlude_foreground_parallax_layers)
+						A.occlude_foreground_parallax_layers = TRUE
+						for(var/turf/T in get_area_turfs(A))
+							if(T.z == Z_LEVEL_STATION)
+								T.update_parallax_occlusion_overlay()
+								LAGCHECK(LAG_MED)
 
 				ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/foreground/fog, 20 SECONDS)
 

--- a/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
@@ -181,6 +181,19 @@
 	parallax_value = 0.9
 	scroll_speed = 150
 
+/atom/movable/screen/parallax_render_source/foreground/fog
+	parallax_icon_state = "snow_dense"
+	color = list(
+		1, 0, 0, 0.4,
+		0, 1, 0, 0.4,
+		0, 0, 1, 0.4,
+		0, 0, 0, 1,
+		0, 0, 0, -1)
+	static_colour = TRUE
+	parallax_value = 0.8
+	scroll_speed = 5
+	scroll_angle = 180
+
 
 // Dust Storm Layers
 /atom/movable/screen/parallax_render_source/foreground/dust

--- a/code/modules/worldgen/mapgen/ForestGenerator.dm
+++ b/code/modules/worldgen/mapgen/ForestGenerator.dm
@@ -48,7 +48,6 @@
 
 		var/height = text2num(rustg_noise_get_at_coordinates("[height_seed]", "[drift_x]", "[drift_y]"))
 
-
 		var/datum/biome/selected_biome
 		if(height <= 0.85) //If height is less than 0.85, we generate biomes based on the heat and humidity of the area.
 			var/humidity = text2num(rustg_noise_get_at_coordinates("[humidity_seed]", "[drift_x]", "[drift_y]"))
@@ -77,6 +76,7 @@
 			selected_biome = possible_biomes[heat_level][humidity_level]
 		else //Over 0.85; It's a mountain
 			selected_biome = /datum/biome/mountain
+		selected_biome = adjust_biome(gen_turf, selected_biome)
 		selected_biome = biomes[selected_biome]
 		selected_biome.generate_turf(gen_turf, flags)
 
@@ -105,3 +105,49 @@
 					return
 
 #undef BIOME_RANDOM_SQUARE_DRIFT
+
+
+/datum/map_generator/forest_generator/proc/adjust_biome(turf/gen_turf, datum/biome/path)
+	. = path
+
+#ifdef HALLOWEEN
+
+/datum/biome/forest/dense/dark
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 5, /obj/tree/elm_random=25, /obj/shrub/random{last_use=INFINITY} = 5, /obj/machinery/plantpot/bareplant/swamp_flora = 1)
+	fauna_types = list(/mob/living/critter/changeling/eyespider/ai_controlled = 5, /mob/living/critter/changeling/legworm/ai_controlled = 5, /mob/living/critter/changeling/handspider/ai_controlled = 5, /mob/living/critter/bear=1, /mob/living/critter/small_animal/frog=5, /mob/living/critter/small_animal/bird/owl=1)
+
+/datum/biome/forest/thin/dark
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 5, /obj/tree/elm_random=5, /obj/shrub/random{last_use=INFINITY} = 50, /obj/machinery/plantpot/bareplant/tree = 5, /obj/machinery/plantpot/bareplant/swamp_flora = 50)
+	fauna_types = list(/mob/living/critter/small_animal/mouse=5, /mob/living/critter/small_animal/mouse/mad=1, /mob/living/critter/small_animal/snake=2, /mob/living/critter/small_animal/bird/crow=1)
+
+/datum/biome/forest/dark
+	flora_types = list(/obj/tree{layer = EFFECTS_LAYER_UNDER_1} = 5, /obj/tree/elm_random=30, /obj/shrub/random{last_use=INFINITY} = 50)
+	fauna_types = list(/mob/living/critter/small_animal/firefly/ai_controlled = 1, /mob/living/critter/small_animal/firefly/pyre/ai_controlled = 3, /mob/living/critter/small_animal/firefly/lightning/ai_controlled = 3, /mob/living/critter/bear=1, /mob/living/critter/small_animal/bird/crow=5)
+
+/datum/biome/forest/clearing/dark
+	flora_types = list(/obj/shrub/random{last_use=INFINITY} = 150, /obj/machinery/plantpot/bareplant/flower = 5, /obj/machinery/plantpot/bareplant/swamp_flora = 1 )
+	fauna_types = list(/mob/living/critter/small_animal/mouse=5, /mob/living/critter/small_animal/mouse/mad=1, /mob/living/critter/small_animal/snake=3)
+
+/datum/map_generator/forest_generator/dark
+	var/list/dark_region
+	var/static/list/dark_lookup = list(/datum/biome/forest/clearing=/datum/biome/forest/clearing/dark,
+						   /datum/biome/forest/thin=/datum/biome/forest/thin/dark,
+						   /datum/biome/forest=/datum/biome/forest/dark,
+						   /datum/biome/forest/dense=/datum/biome/forest/dense/dark)
+
+	New()
+		..()
+		if(!dark_region)
+			dark_region = rustg_dbp_generate("[rand(1,420)]", "5", "15", "[world.maxx]", "0.001", "0.9")
+
+/datum/map_generator/forest_generator/dark/adjust_biome(turf/gen_turf, datum/biome/path)
+	var/dark
+	var/index = gen_turf.x * world.maxx + gen_turf.y
+	if(index <= length(dark_region))
+		dark = text2num(dark_region[index])
+	if(dark && dark_lookup[path])
+		. = dark_lookup[path]
+	else
+		. = path
+
+#endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Utilizes batch Perlin Noise to identify a regions of a Forest Map to be re-defined as a Dark Forest. Attempts an experimental method of adding occlusion parallax to Z1.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spooktober! Spooktober! Spooktober!
