### PR TITLE
fix custom soups runtiming

### DIFF
--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -12,7 +12,7 @@
 	icon_state = "bowl"
 	name = null
 	desc = "Ah, the, uh, wonders of the kitchen stove."
-	bites_left = null
+	bites_left = 6
 	heal_amt = null
 	initial_volume = null
 	initial_reagents = null


### PR DESCRIPTION
[catering][bug][]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds an initial bites_left amount to custom soup. This stops custom soup from runtiming and makes custom soup able to fill the stomach of people.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Runtimes are bad. This fixes #16569
