### PR TITLE
Introduction of the `uneaten_bites_left` variable to `reagent_containers/snacks`

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -155,7 +155,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	var/list/food_effects = list()
 	var/create_time = 0
 	var/bites_left = 3
-	var/uneaten_bites_left = 3
+	var/uneaten_bites_left = null
 
 	var/dropped_item = null
 
@@ -163,8 +163,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	var/meal_time_flags = 0
 
 	New()
+		if (!src.uneaten_bites_left)
+			src.uneaten_bites_left = initial(bites_left)
 		..()
-		src.uneaten_bites_left = initial(bites_left)
 		if (doants)
 			processing_items.Add(src)
 		create_time = world.time

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -155,6 +155,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	var/list/food_effects = list()
 	var/create_time = 0
 	var/bites_left = 3
+	var/uneaten_bites_left = 3
 
 	var/dropped_item = null
 
@@ -163,6 +164,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 
 	New()
 		..()
+		src.uneaten_bites_left = initial(bites_left)
 		if (doants)
 			processing_items.Add(src)
 		create_time = world.time
@@ -475,7 +477,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 						src.reagents.copy_to(eater.reagents, 3/max(src.reagents.total_volume, 3)) //copy up to 3u total, once per food per 15 seconds
 			else
 				var/obj/item/reagent_containers/food/snacks/bite/B = new /obj/item/reagent_containers/food/snacks/bite
-				B.fill_amt = src.fill_amt/initial(src.bites_left) //so all the bites add up to the full item fillness
+				B.fill_amt = src.fill_amt/src.uneaten_bites_left //so all the bites add up to the full item fillness
 				if(src.reagents)
 					B.reagents.maximum_volume = reagents.total_volume/((src.bites_left+1) || 1) //MBC : I copied this from the Eat proc. It doesn't really handle the reagent transfer evenly??
 					src.reagents.trans_to(B,B.reagents.maximum_volume,1,0)						//i'll leave it tho because i dont wanna mess anything up
@@ -490,8 +492,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				for (var/effect in src.food_effects)
 					L.add_food_bonus(effect, src)
 
-		if (use_bite_mask && initial(bites_left))
-			var/desired_mask = (bites_left / initial(bites_left)) * 5
+		if (use_bite_mask && src.uneaten_bites_left)
+			var/desired_mask = (bites_left / src.uneaten_bites_left) * 5
 			desired_mask = round(desired_mask)
 			desired_mask = max(1,desired_mask)
 			desired_mask = min(desired_mask, 5)

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -139,7 +139,7 @@ ABSTRACT_TYPE(/datum/rc_entry/food)
 		else if(!istype(eval_item,typepath)) return // Regular type evaluation
 		switch(food_integrity)
 			if(FOOD_REQ_INTACT)
-				if(eval_item.bites_left != initial(eval_item.bites_left)) return
+				if(eval_item.bites_left != eval_item.uneaten_bites_left) return
 				src.rollcount++
 			if(FOOD_REQ_BY_BITE)
 				src.rollcount += eval_item.bites_left

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -1016,6 +1016,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 					fryholder.icon = composite
 					fryholder.overlays = thing.overlays
 					fryholder.bites_left = 5
+					fryholder.uneaten_bites_left = fryholder.bites_left
 					if (ismob(thing))
 						fryholder.w_class = W_CLASS_BULKY
 					if(thing.reagents)

--- a/code/modules/food_and_drink/ice_cream.dm
+++ b/code/modules/food_and_drink/ice_cream.dm
@@ -35,7 +35,7 @@
 		src.food_color = src.reagents.get_master_color()
 		if (!src.cream_image)
 			src.cream_image = image(src.icon)
-		var/cream_level = (100 * round(bites_left/initial(bites_left),0.25))
+		var/cream_level = (100 * round(src.bites_left/src.uneaten_bites_left,0.25))
 		if (!src.food_color)
 			src.food_color = src.reagents.get_master_color()
 		src.cream_image.icon_state = "ice[cream_level]"

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -144,7 +144,7 @@
 			src.reagents.trans_to(P, src.reagents.total_volume/makeslices)
 			P.pixel_x = rand(-6, 6)
 			P.pixel_y = rand(-6, 6)
-			P.fill_amt = src.fill_amt / initial(src.bites_left)
+			P.fill_amt = src.fill_amt / src.uneaten_bites_left
 			. += P
 			makeslices--
 		qdel(src)

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -262,6 +262,7 @@ TYPEINFO(/obj/machinery/deep_fryer)
 		fryholder.w_class = item.w_class
 	else
 		fryholder.bites_left = 5
+	fryholder.uneaten_bites_left = fryholder.bites_left
 	if (ismob(thing))
 		fryholder.w_class = W_CLASS_BULKY
 	if(thing.reagents)

--- a/code/obj/machinery/shitty_grill.dm
+++ b/code/obj/machinery/shitty_grill.dm
@@ -320,6 +320,7 @@ TYPEINFO(/obj/machinery/shitty_grill)
 			shittysteak.bites_left = 5
 		else
 			shittysteak.bites_left = round(src.grillitem.w_class)
+		shittysteak.uneaten_bites_left = shittysteak.bites_left
 		shittysteak.reagents = src.grillitem.reagents
 		shittysteak.reagents.my_atom = shittysteak
 

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -1,6 +1,7 @@
 /datum/custom_soup
 	var/name
 	var/bites_left = 3
+	var/uneaten_bites_left = 3
 	var/heal_amt = 0
 	var/desc = null
 	var/initial_volume = 60
@@ -23,6 +24,9 @@
 		if(!S || !istype(S))
 			qdel(src)
 			return
+
+		..()
+
 		if (bowl)
 			src.icon = bowl.icon
 			src.icon_state = bowl.icon_state
@@ -32,6 +36,7 @@
 		src.fluid_image = bowl?.fluid_image || image("icon" = 'icons/obj/kitchen.dmi', "icon_state" = "bowl_fluid")
 		src.name = S.name
 		src.bites_left = S.bites_left
+		src.uneaten_bites_left = S.uneaten_bites_left
 		if(S.desc)
 			src.desc = S.desc
 		src.heal_amt = S.heal_amt
@@ -46,10 +51,6 @@
 				var/effect = pick(temp)
 				src.food_effects += effect
 				temp -= effect
-
-
-
-		..()
 
 		if(reagents.total_volume)
 			var/datum/color/average = reagents.get_average_color()
@@ -226,6 +227,7 @@ TYPEINFO(/obj/stove)
 						S.initial_reagents[id] = I.reagents.reagent_list[id].volume/pot.total_wclass
 
 		S.bites_left = max(1,round(S.bites_left))
+		S.uneaten_bites_left = S.bites_left
 
 		if(biggester)
 			if(biggest)

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -25,8 +25,6 @@
 			qdel(src)
 			return
 
-		..()
-
 		if (bowl)
 			src.icon = bowl.icon
 			src.icon_state = bowl.icon_state
@@ -51,6 +49,8 @@
 				var/effect = pick(temp)
 				src.food_effects += effect
 				temp -= effect
+
+		..()
 
 		if(reagents.total_volume)
 			var/datum/color/average = reagents.get_average_color()


### PR DESCRIPTION
[catering][internal][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces `var/uneaten_bites_left` to snack-objects. It is set to the amount of bites a food item has on calling of `New`. It is references whenever the codes need to know how many bites the item in question had before it was cut/bitten into. For custom items, like soups or fried food, it's manipulating the variable

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Since the gluttony rework, custom foods without bites_left defined initially as anything that isn't null or 0 tend to runtime, because it was calling initial(stuff.bites_left). This changes this to be referencing a variable that can be set dynamically.

This fixes #16569