### PR TITLE
Fixes #16537: SMES Power Monitor was replaced by a broken Station Grid power monitor

### DIFF
--- a/code/modules/worldgen/prefab/engines.dm
+++ b/code/modules/worldgen/prefab/engines.dm
@@ -26,11 +26,11 @@ TYPEINFO(/datum/mapPrefab/engine_room)
 				comp1type = /obj/machinery/power/nuclear/reactor_control
 				comp2type = /obj/machinery/power/nuclear/turbine_control
 			if("TEG")
-				comp1type = /obj/machinery/computer/power_monitor
+				comp1type = /obj/machinery/computer/power_monitor/smes
 				comp2type = /obj/machinery/power/reactor_stats
 			if("singularity")
 				comp1type = /obj/machinery/computer3/generic/engine
-				comp2type = /obj/machinery/computer/power_monitor
+				comp2type = /obj/machinery/computer/power_monitor/smes
 			else
 				CRASH("Selected an unknown engine type - did you forget to put it here?")
 


### PR DESCRIPTION
[Bug] [Station Systems] [Mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #16537. Replaces broken APC power monitoring computer with SMES monitor that was there before cog1 engineering was upgraded with the engine prefab system.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The APC power monitor is broken and even if it wasn't it's duplicated by the same monitor on the left side of the room. This fixes this issue for both the TEG prefab and the Singulo engine prefab.