### PR TITLE
Makes voting box use player pronouns in messages

### DIFF
--- a/code/obj/voting_box.dm
+++ b/code/obj/voting_box.dm
@@ -31,7 +31,7 @@
 				map_vote_holder.special_vote(C,map)
 				var/adv = pick("", "proudly", "confidently", "cautiously", "dismissively", "carelessly", "idly")
 				var/adj = pick("", "questionable", "decisive", "worthless", "important", "curious", "bizarre", "regrettable")
-				visible_message("<span class='notice'><strong>[user]</strong> [adv] [hadVoted ? "changes their" : "casts a"] [adj] vote [hadVoted ? "to" : "for"] <strong>[map]</strong>.</span>")
+				visible_message("<span class='notice'><strong>[user]</strong> [adv] [hadVoted ? "changes [his_or_her(user)]" : "casts a"] [adj] vote [hadVoted ? "to" : "for"] <strong>[map]</strong>.</span>")
 				playsound(src.loc, 'sound/machines/ping.ogg', 35)
 
 				if (user.real_name == bribeJerk)
@@ -71,10 +71,10 @@
 						if (user.real_name == bribeJerk)
 							// increase paid amount here
 							bribeAmount += S.amount
-							visible_message("<strong>[user] increases their bribe to [bribeAmount] credits!</strong>")
+							visible_message("<strong>[user] increases [his_or_her(user)] bribe to [bribeAmount] credits!</strong>")
 						else
 							// time to switch our vote.
-							visible_message("<strong>[user] has paid [S.amount] credits to swing the map vote in their favor!</strong>")
+							visible_message("<strong>[user] has paid [S.amount] credits to swing the map vote in [his_or_her(user)] favor!</strong>")
 							boutput(user, "<span class='notice'>You've puchased a vote for [chosen].</span>")
 							bribeAmount = S.amount
 							bribeJerk = user.real_name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes messages related to voting at the voting box use player pronouns instead of they

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity