### PR TITLE
Make melee attack messages use pronouns

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -130,7 +130,7 @@
 		if (target.lying)
 			src.visible_message("<span class='notice'>[src] shakes [target], trying to wake [him_or_her(target)] up!</span>")
 		else if(target.hasStatus("shivering"))
-			src.visible_message("<span class='alert'><B>[src] shakes [target], trying to warm up!</B></span>")
+			src.visible_message("<span class='alert'><B>[src] shakes [target], trying to warm [him_or_her(target)] up!</B></span>")
 			target.changeStatus("shivering", -2 SECONDS)
 		else
 			if (ishuman(target) && ishuman(src))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -31,7 +31,7 @@
 		else if (ishuman(M))
 			src.administer_CPR(M)
 		else
-			src.visible_message("<span class='notice'>[src] shakes [M], trying to wake them up!</span>")
+			src.visible_message("<span class='notice'>[src] shakes [M], trying to wake [him_or_her(M)] up!</span>")
 			hit_twitch(M)
 	else if (M.is_bleeding())
 		src.staunch_bleeding(M)
@@ -88,17 +88,17 @@
 		if (P)
 			if (P.barbed == FALSE)
 				SETUP_GENERIC_ACTIONBAR(src, target, 1 SECOND, /mob/living/proc/pull_out_implant, list(target, P), P.icon, P.icon_state, \
-					src.visible_message("<span class='alert'><B>[src] pulls a [P.pull_out_name] out of themselves!</B></span>"), \
+					src.visible_message("<span class='alert'><B>[src] pulls a [P.pull_out_name] out of [himself_or_herself(src)]!</B></span>"), \
 					INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
 			else
-				src.visible_message("<span class='alert'><B>[src] tries to pull a [P.pull_out_name] out of themselves, but it's stuck in!</B></span>")
+				src.visible_message("<span class='alert'><B>[src] tries to pull a [P.pull_out_name] out of [himself_or_herself(src)], but it's stuck in!</B></span>")
 			return
 
 		var/obj/stool/S = (locate(/obj/stool) in src.loc)
 		if (S)
 			S.buckle_in(src,src)
 		if(src.hasStatus("shivering"))
-			src.visible_message("<span class='alert'><B>[src] shakes themselves, trying to warm up!</B></span>")
+			src.visible_message("<span class='alert'><B>[src] shakes [himself_or_herself(src)], trying to warm up!</B></span>")
 			src.changeStatus("shivering", -1 SECONDS)
 		else if(istype(src.wear_mask,/obj/item/clothing/mask/moustache))
 			src.visible_message("<span class='alert'><B>[src] twirls [his_or_her(src)] moustache and laughs [pick("diabolically","madly","evilly","strangely","scarily","awkwardly","excitedly","hauntingly","ominously","nonchalantly","gloriously","hairily")]!</B></span>")
@@ -111,7 +111,7 @@
 				var/v = pick("tidies","adjusts","brushes off", "flicks a piece of lint off", "tousles", "fixes", "readjusts","fusses with", "sweeps off")
 				src.visible_message("<span class='notice'>[src] [v] [his_or_her(src)] [item]!</span>")
 			else
-				src.visible_message("<span class='notice'>[src] pats themselves on the back. Feel better, [src].</span>")
+				src.visible_message("<span class='notice'>[src] pats [himself_or_herself(src)] on the back. Feel better, [src].</span>")
 
 	else
 		var/mob/living/M = target
@@ -128,7 +128,7 @@
 			return
 
 		if (target.lying)
-			src.visible_message("<span class='notice'>[src] shakes [target], trying to wake them up!</span>")
+			src.visible_message("<span class='notice'>[src] shakes [target], trying to wake [him_or_her(target)] up!</span>")
 		else if(target.hasStatus("shivering"))
 			src.visible_message("<span class='alert'><B>[src] shakes [target], trying to warm up!</B></span>")
 			target.changeStatus("shivering", -2 SECONDS)
@@ -165,7 +165,7 @@
 				var/mob/living/critter/C = target
 				C.on_pet(src)
 			else
-				src.visible_message("<span class='notice'>[src] shakes [target], trying to grab their attention!</span>")
+				src.visible_message("<span class='notice'>[src] shakes [target], trying to grab [his_or_her(target)] attention!</span>")
 	hit_twitch(target)
 
 /mob/living/proc/pull_out_implant(var/mob/living/user, var/obj/item/implant/dart)
@@ -738,7 +738,7 @@
 				if (BORG.part_head.ropart_take_damage(rand(20,40),0) == 1)
 					BORG.compborg_lose_limb(BORG.part_head)
 				if (!BORG.anchored && prob(30))
-					user.visible_message("<span class='alert'><B>...and sends them flying!</B></span>")
+					user.visible_message("<span class='alert'><B>...and sends [him_or_her(BORG)] flying!</B></span>")
 					send_flying = 2
 
 	else if (isAI(target))
@@ -751,7 +751,7 @@
 		playsound(user.loc, 'sound/impact_sounds/Metal_Clang_3.ogg', 50, 1)
 		damage = 10
 		if (!target.anchored && prob(30))
-			user.visible_message("<span class='alert'><B>...and sends them flying!</B></span>")
+			user.visible_message("<span class='alert'><B>...and sends [him_or_her(target)] flying!</B></span>")
 			send_flying = 2
 
 	if (send_flying == 2)
@@ -1141,7 +1141,7 @@
 		msgs.show_message_self("<span class='alert'>You drunkenly throw a brutal punch!</span>")
 	//wrestlers have a 2/3 chance of a big hit
 	if (src != msgs.target && iswrestler(src) && prob(66))
-		msgs.base_attack_message = "<span class='alert'><B>[src]</b> winds up and delivers a backfist to [msgs.target], sending them flying!</span>"
+		msgs.base_attack_message = "<span class='alert'><B>[src]</b> winds up and delivers a backfist to [msgs.target], sending [him_or_her(msgs.target)] flying!</span>"
 		. += 4
 		msgs.after_effects += /proc/wrestler_backfist
 
@@ -1288,7 +1288,7 @@
 
 			var/turf/throw_to = get_edge_target_turf(H, H.dir)
 			if (isturf(throw_to))
-				H.visible_message("<span class='alert'><B>[H] savagely punches [T], sending them flying!</B></span>")
+				H.visible_message("<span class='alert'><B>[H] savagely punches [T], sending [him_or_her(T)] flying!</B></span>")
 				T.throw_at(throw_to, 10, 2)
 
 /mob/proc/attack_finished(var/mob/target)
@@ -1322,7 +1322,7 @@
 			if (prob(50))
 				step_away(M, src, 15)
 			else
-				src.visible_message("<span class='alert'><B>[src] parries [M]'s attack, knocking them to the ground!</B></span>")
+				src.visible_message("<span class='alert'><B>[src] parries [M]'s attack, knocking [him_or_her(M)] to the ground!</B></span>")
 				M.changeStatus("weakened", 4 SECONDS)
 				M.force_laydown_standup()
 		playsound(src.loc, 'sound/impact_sounds/kendo_parry_1.ogg', 65, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

replace thems and theys with pronoun proc calls (also adds a missing word in a message I noticed)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity
