### PR TITLE
Fix contraband not being halved in a backpack/pocket

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -936,6 +936,10 @@
 			if (!istype(perp_id))
 				perp_id = perp.get_id()
 
+			//Agent cards lower threat level
+			if(istype(perp_id, /obj/item/card/id/syndicate))
+				threatcount -= 2
+
 			if(perp_id) //Checking for targets and permits
 				var/list/contraband_returned = list()
 				if (SEND_SIGNAL(perp, COMSIG_MOVABLE_GET_CONTRABAND, contraband_returned, !(contraband_access in perp_id.access), !(weapon_access in perp_id.access)))
@@ -951,10 +955,6 @@
 		if(perp.traitHolder.hasTrait("stowaway") && perp.traitHolder.hasTrait("jailbird"))
 			if(isnull(data_core.security.find_record("name", perp.name)))
 				threatcount += 5
-
-		//Agent cards lower threat level
-		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))
-			threatcount -= 2
 
 		// we have grounds to make an arrest, don't bother with further analysis
 		if(threatcount >= 4)

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -232,21 +232,21 @@ TYPEINFO(/obj/machinery/secscanner)
 			if (istype(perp.l_store))
 				contraband_returned = list()
 				if(SEND_SIGNAL(perp.l_store, COMSIG_MOVABLE_GET_CONTRABAND, contraband_returned, !has_contraband_permit, !has_carry_permit))
-					threatcount += max(contraband_returned)
+					threatcount += max(contraband_returned) * 0.5
 
 			if (istype(perp.r_store))
 				contraband_returned = list()
 				if(SEND_SIGNAL(perp.r_store, COMSIG_MOVABLE_GET_CONTRABAND, contraband_returned, !has_contraband_permit, !has_carry_permit))
-					threatcount += max(contraband_returned)
+					threatcount += max(contraband_returned) * 0.5
 
 			if (istype(perp.back) && perp.back?.storage)
 				for(var/obj/item/item in perp.back.storage.get_contents())
 					contraband_returned = list()
 					if(SEND_SIGNAL(item, COMSIG_MOVABLE_GET_CONTRABAND, contraband_returned, !has_contraband_permit, !has_carry_permit))
-						threatcount += max(contraband_returned)
+						threatcount += max(contraband_returned) * 0.5
 
 		//Agent cards lower threatlevel
-		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))
+		if(istype(perp_id, /obj/item/card/id/syndicate))
 			threatcount -= 2
 
 		// we have grounds to make an arrest, don't bother with further analysis


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #16584 which was caused by me not applying a 0.5x multiplier in a couple places.
Also prevents re-finding the ID just to check if its an agent card when we already know where the ID is.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad
