### PR TITLE
Adds support for syndicate items with different weights and changes not_in_crates/vr_allowed to use TRUE/FALSE

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -105,9 +105,9 @@
 				continue
 
 			if (S.cost <= value_high && S.cost >= value_low)
-				possible_items += S
+				possible_items[S] = S.surplus_weight
 
-		reward = pick(possible_items)
+		reward = weighted_pick(possible_items)
 
 	proc/spawn_reward(var/mob/user,var/obj/item/device/pda2/hostpda)
 		if (reward_was_spawned) return

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -49,6 +49,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist)
 
 	/**
 	 * Runs on the purchase of the buylist datum
+	 *
 	 * Arguments:
 	 * `item`, the item you're expecting
 	 * `owner`, the person who bought the item

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -312,7 +312,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Syndicates in Pipebomb"
 	item = /obj/item/pipebomb/bomb/miniature_syndicate
 	cost = 3
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A rather volatile pipe bomb packed with miniature syndicate troops."
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -373,7 +373,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Mind Hack implant"
 	item = /obj/item/implanter/mindhack
 	cost = 3
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "Temporarily place an injected victim under your complete control! Faster and more effective than hypnotism! Warning: Implant effects are NOT indefinite. Will not work on anyone protected by those pesky security issue mind-protection implants."
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -381,7 +381,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Deluxe Mind Hack implant"
 	item = /obj/item/implanter/super_mindhack
 	cost = 6
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "Place an injected victim under your complete control! Enhanced cyberneurostimulators make this version last virtually indefinitely! Will not work on anyone protected by those pesky security issue mind-protection implants."
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -389,7 +389,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Microbomb Implant"
 	item = /obj/item/implanter/uplink_microbomb
 	cost = 1
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "This miniaturized explosive packs a decent punch and will detonate upon the unintentional death of the host. Do not swallow and keep out of reach of children."
 
 /datum/syndicate_buylist/traitor/lightbreaker
@@ -419,7 +419,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Pickpocket Gun"
 	item = /obj/item/gun/energy/pickpocket
 	cost = 3
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A stealthy claw gun capable of stealing and planting items, and severely messing with people."
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -428,7 +428,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Surplus Crate"
 	item = /obj/storage/crate/syndicate_surplus
 	cost = 12
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A crate containing 18-24 credits worth of whatever junk we had lying around."
 	can_buy = UPLINK_TRAITOR
 
@@ -449,7 +449,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 1
 	desc = "Allows you to track the IDs of your assassination targets, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
 	not_in_crates = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	objective = /datum/objective/regular/assassinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY | UPLINK_HEAD_REV
 
@@ -461,7 +461,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/pinpointer/idtracker/spy
 	cost = 1
 	desc = "Allows you to track the IDs of all other antagonists, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
-	vr_allowed = 0
+	vr_allowed = FALSE
 	not_in_crates = TRUE
 	objective = /datum/objective/spy_theft/assasinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
@@ -486,7 +486,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Clown Car"
 	item = /obj/vehicle/clowncar/surplus
 	cost = 5
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A funny-looking car designed for circus events. Seats 30, very roomy! Can be loaded with banana peels. Comes with an extra set of clown clothes."
 	job = list("Clown")
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV | UPLINK_SPY_THIEF
@@ -495,7 +495,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Boom Boots"
 	item = /obj/item/clothing/shoes/cowboy/boom
 	cost = 12
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
 	not_in_crates = TRUE
@@ -505,7 +505,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Clown Mask"
 	item = /obj/item/clothing/mask/gas/syndie_clown
 	cost = 5
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")
 	not_in_crates = TRUE
@@ -523,7 +523,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Chameleon Bomb Case"
 	item = /obj/item/storage/box/chameleonbomb
 	cost = 3
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "2 questionable mixtures of a chameleon projector and a bomb. Scan an object to take on its appearance, arm the bomb, and then explode the face(s) of whoever tries to touch it."
 	br_allowed = TRUE
 	job = list("Clown")
@@ -544,7 +544,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 1
 	desc = "We understand it can be difficult to carry out some of our missions. Here is some spiritual counsel in a small package."
 	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Chaplain", "Clown")
-	vr_allowed = 0
+	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/traitor/contract
@@ -554,7 +554,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	desc = "Comes complete with three soul binding contracts, three extra-pointy pens, and one suit provided by Lucifer himself."
 	job = list("Chaplain")
 	not_in_crates = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
 	run_on_spawn(var/obj/item/storage/briefcase/satan/Q,var/mob/living/owner, in_surplus_crate)
@@ -586,7 +586,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/kudzuseed
 	cost = 4
 	desc = "Syndikudzu. Interesting. Plant on the floor to grow."
-	vr_allowed = 0
+	vr_allowed = FALSE
 	job = list("Botanist", "Staff Assistant")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -657,7 +657,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 4
 	desc = "Identical in appearance to an ordinary trash cart, this beauty is capable of compacting (1) laying person placed inside at a time. It was originally supposed to only compact nonliving things, but a serendipitous design mistake resulted in 1500 units with a reversed safety unit."
 	not_in_crates = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	job = list("Janitor")
 	can_buy = UPLINK_TRAITOR
 
@@ -691,7 +691,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Syndicate Device Analyzer"
 	item = /obj/item/electronics/scanner/syndicate
 	cost = 4
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "The shell of a standard Nanotrasen mechanic's analyzer with cutting-edge Syndicate internals. This baby can scan almost anything!"
 	job = list("Engineer", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
@@ -733,7 +733,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Poison Bottle"
 	item = /obj/item/reagent_containers/glass/bottle/poison
 	cost = 1
-	vr_allowed = 0 //rat poison
+	vr_allowed = FALSE //rat poison
 	desc = "A bottle of poison. Which poison? Who knows."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -742,7 +742,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Poison Bottle Bundle"
 	item = /obj/item/storage/box/poison
 	cost = 7
-	vr_allowed = 0 //rat poison
+	vr_allowed = FALSE //rat poison
 	desc = "A box filled with seven random poison bottles."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -762,7 +762,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 2
 	desc = "A cyborg shell crafted from the finest recycled steel and reverse-engineered microelectronics. A cyborg crafted from this will see only Syndicate operatives (Such as yourself!) as human. Cyborg also comes preloaded with popular game \"Angry About the Bird\" and is compatible with most headphones."
 	not_in_crates = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	job = list("Roboticist")
 	can_buy = UPLINK_TRAITOR
 
@@ -770,7 +770,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Conversion Chamber"
 	item = /obj/machinery/recharge_station/syndicate
 	cost = 8
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A modified standard-issue cyborg recharging station that will automatically convert any human placed inside into a cyborg. Cyborgs created this way will follow a syndicate lawset making them loyal to you."
 	job = list("Roboticist")
 	not_in_crates = TRUE
@@ -912,7 +912,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Syndicate Cargo Transporter"
 	item = /obj/item/cargotele/traitor
 	cost = 3
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A modified cargo transporter which welds containers shut and sells their contents directly to the black market, swipe your ID to set the account. Any hapless crewmembers sold will be teleported to a random point in space and will reward cash bonuses based on their job."
 	job = list("Quartermaster","Miner","Engineer","Chief Engineer")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -921,7 +921,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Teleport Gun"
 	item = /obj/item/gun/energy/teleport
 	cost = 7
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "An experimental hybrid between a hand teleporter and a directed-energy weapon. Probably a very bad idea. Note -- Only works in conjunction with a stationary teleporter."
 	job = list("Research Director")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -939,7 +939,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Barrel-O-Monkeys"
 	item = /obj/storage/monkey_barrel
 	cost = 6
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A barrel of bloodthirsty apes. Careful!"
 	br_allowed = TRUE
 	job = list("Staff Assistant","Test Subject","Geneticist","Pathologist")
@@ -948,7 +948,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Mindhack Cloning Module"
 	item = /obj/item/cloneModule/mindhack_module
 	cost = 6
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "An add on to the genetics cloning pod that make anyone cloned loyal to whoever installed it."
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
 
@@ -956,7 +956,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Deluxe Mindhack Cloning Module Kit"
 	item = /obj/item/storage/box/mindhack_module_kit
 	cost = 10 //  Always leave them 1tc so they can buy the moustache. Style is key.
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A Deluxe Mindhack Cloning Kit. Contains a mindhack cloning module and a cloning lab in a box!"
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
 
@@ -964,7 +964,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Guardbuddy Ammo Replicator"
 	item = /obj/item/device/guardbot_module/ammofab
 	cost = 1
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A device that allows PR-6S Guardbuddy units to use their internal charge to replenish kinetic ammunition."
 	job = list("Research Director")
 
@@ -973,7 +973,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/device/radio_upgrade
 	cost = 3
 	desc = "A small device that may be installed in a headset to grant access to all station channels, along with one reserved for Syndicate operatives."
-	vr_allowed = 0
+	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/traitor/tape
@@ -986,7 +986,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Controlled Syndicate Scuttlebot"
 	item = /obj/item/clothing/head/det_hat/folded_scuttlebot
 	cost = 4
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A sneaky robot armed with a camera disguised as a hat, used to spy on people. Comes with it's own remote controlling glasses. Can lift small items and has a disabling flash."
 	job = list("Detective")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
@@ -1002,7 +1002,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Chicken Grenade"
 	item = /obj/item/old_grenade/chicken
 	cost = 1
-	vr_allowed = 0
+	vr_allowed = FALSE
 	desc = "A grenade that holds up to 5 chicken eggs. Uses syndicate brainwashing to turn the chickens into hardened warriors immediately on detonation. Normally passive chickens will become aggressive. Use a wrench to unload it."
 	job = list("Rancher")
 	not_in_crates = TRUE
@@ -1264,7 +1264,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	desc = "A pure Telecrystal, orignating from plasma giants. Used as currency in Syndicate Uplinks."
 
 	telecrystal = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV | UPLINK_NUKE_OP
 
@@ -1281,7 +1281,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	cost = 1
 	desc = "A small, highly volatile explosive designed to look like a pure Telecrystal."
 	telecrystal = TRUE
-	vr_allowed = 0
+	vr_allowed = FALSE
 	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV
 
@@ -1309,7 +1309,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	cost = 0
 	desc = "Maybe paint a really insulting picture of your foe? To be honest, we have no idea what is even in these or where they came from, a huge crate of them just showed up at our warehouse around a month ago. We're sure it's something very handy, though!"
 	job = list("Chaplain")
-	vr_allowed = 0
+	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/traitor/lawndarts
@@ -1336,7 +1336,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	item = /obj/item/device/flash/revolution
 	cost = 5
 	desc = "This flash never runs out and will convert susceptible crew when a rev head uses it. It will also allow the rev head to break counter-revolutionary implants."
-	vr_allowed = 0
+	vr_allowed = FALSE
 	not_in_crates = TRUE
 
 /datum/syndicate_buylist/generic/head_rev/revflashbang

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1086,10 +1086,9 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 	spy
-		cost = 3
+		cost = 5
 		vr_allowed = FALSE
 		not_in_crates = TRUE
-		surplus_weight = 25 // so this remains rare in spy
 		can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/surplus/akm

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -48,7 +48,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist)
 	var/can_buy
 
 	/**
-	 *
+	 * Runs on the purchase of the buylist datum
 	 * Arguments:
 	 * `item`, the item you're expecting
 	 * `owner`, the person who bought the item

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -38,15 +38,14 @@ ABSTRACT_TYPE(/datum/syndicate_buylist)
 	var/vr_allowed = TRUE
 	/// If the item can be created as loot in Battle Royale
 	var/br_allowed = FALSE
-	/// If the item should show up in surplus crates or not
-	var/not_in_crates = FALSE
+	/// How often should this should show up in a surplus crate? Set this to 0 if you want the item to never appear in a crate
+	var/surplus_weight = 50
 	/// The category of the item, currently unused (somewhat used in the Nukeop Commander uplink)
 	var/category
 	/// Bitflags for what uplinks can buy this item (see `_std/defines/uplink.dm` for flags)
 	var/can_buy
 
 	/**
-	 * Runs on the purchase of the buylist datum
 	 *
 	 * Arguments:
 	 * `item`, the item you're expecting
@@ -88,7 +87,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/storage/box/shotgun
 	cost = 8
 	desc = "Not exactly stealthy, but it'll certainly make an impression."
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/generic/radbow
@@ -163,7 +162,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/implanter/signaler
 	cost = 1
 	desc = "An implant that can send configurable signals. Can be used while stunned or handcuffed."
-	not_in_crates = 1
+	surplus_weight = 0
 	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR
 
@@ -184,7 +183,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/device/powersink
 	cost = 5
 	desc = "Lights too bright? Airlocks too automatic? Alarms too functional? Or maybe just nostalgic about the good ol' days before electricity came along? The XL-100 Power Sink addresses all these ills and more. Simply screw to the nearest exposed wiring and flip the switch, and this little wonder will get to work on draining all of that nasty power."
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/generic/detomatix
@@ -239,7 +238,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/sword
 	cost = 7
 	desc = "A powerful melee weapon, crafted using the latest in applied photonics! When inactive, it is small enough to fit in a pocket!"
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 	run_on_spawn(obj/item/sword/stabby, mob/living/owner, in_surplus_crate=FALSE) //Nukies get red ones
@@ -280,7 +279,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/clothing/head/bighat/syndicate
 	cost = 12
 	desc = "Think you're tough shit buddy?"
-	not_in_crates = 1 //see /datum/syndicate_buylist/surplus/bighat
+	surplus_weight = 0 //see /datum/syndicate_buylist/surplus/bighat
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY
 
@@ -297,7 +296,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Cloaking Device"
 	item = /obj/item/cloaking_device
 	cost = 6
-	//not_in_crates = 1
+	//surplus_weight = 0
 	desc = "Hides you from normal sight. AI and Cyborgs will still see you and so will any human with thermals so be careful how you use it."
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -315,14 +314,6 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	desc = "A rather volatile pipe bomb packed with miniature syndicate troops."
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
-
-	run_on_spawn(obj/item, mob/living/owner, in_surplus_crate, obj/item/uplink/uplink)
-		. = ..()
-		if(in_surplus_crate && prob(5))
-			if(prob(20))
-				new /obj/machinery/nuclearbomb/event/micronuke/defended(item.loc)
-			else
-				new /obj/machinery/nuclearbomb/event/micronuke(item.loc)
 
 /datum/syndicate_buylist/traitor/champrojector
 	name = "Chameleon Projector"
@@ -455,7 +446,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/pinpointer/idtracker
 	cost = 1
 	desc = "Allows you to track the IDs of your assassination targets, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
-	not_in_crates = 1
+	surplus_weight = 0
 	vr_allowed = 0
 	objective = /datum/objective/regular/assassinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY | UPLINK_HEAD_REV
@@ -469,7 +460,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 1
 	desc = "Allows you to track the IDs of all other antagonists, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
 	vr_allowed = 0
-	not_in_crates = 1
+	surplus_weight = 0
 	objective = /datum/objective/spy_theft/assasinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
@@ -484,7 +475,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 0
 	desc = "A crate containing a Nuke Ops Class Loadout, this one is generic and you shouldn't see it."
 	objective = /datum/objective/specialist/nuclear
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_NUKE_OP
 
 //////////////////////////////////////////////// Job-specific items  ////////////////////////////////////////////////////
@@ -505,7 +496,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV
 
 /datum/syndicate_buylist/traitor/clown_mask
@@ -515,7 +506,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR
 
 /datum/syndicate_buylist/traitor/fake_revolver
@@ -542,7 +533,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 3
 	desc = "Disguised as a screwdriver, this stealthy device can be loaded with dna injectors which will be injected into the target instantly and stealthily. The dna injector will be altered when inserted so that there will be a ten second delay before the gene manifests in the victim."
 	job = list("Geneticist")
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
 /datum/syndicate_buylist/traitor/minibible
@@ -560,7 +551,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 8
 	desc = "Comes complete with three soul binding contracts, three extra-pointy pens, and one suit provided by Lucifer himself."
 	job = list("Chaplain")
-	not_in_crates = 1
+	surplus_weight = 0
 	vr_allowed = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
@@ -584,7 +575,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/device/chargehacker
 	cost = 4
 	desc = "A tool designed to hack mining charges so that they will attach to any surface, disguised as a geological scanner."
-	not_in_crates = 1
+	surplus_weight = 0
 	job = list("Miner")
 	can_buy = UPLINK_TRAITOR
 
@@ -602,7 +593,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/seed/maneater
 	cost = 1
 	desc = "A boon for the green-thumbed agent! Simply plant and nurture to raise your own faithful guard-plant! Feed me, Seymour!"
-	not_in_crates = 1
+	surplus_weight = 0
 	job = list("Botanist")
 	can_buy = UPLINK_TRAITOR
 
@@ -611,7 +602,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/saw/syndie
 	cost = 7
 	desc = "This old earth beauty is made by hand with strict attention to detail. Unlike today's competing botanical chainsaw, it actually cuts things!"
-	not_in_crates = 1
+	surplus_weight = 0
 	job = list("Botanist")
 	can_buy = UPLINK_TRAITOR
 
@@ -663,7 +654,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/storage/cart/trash/syndicate
 	cost = 4
 	desc = "Identical in appearance to an ordinary trash cart, this beauty is capable of compacting (1) laying person placed inside at a time. It was originally supposed to only compact nonliving things, but a serendipitous design mistake resulted in 1500 units with a reversed safety unit."
-	not_in_crates = 1
+	surplus_weight = 0
 	vr_allowed = 0
 	job = list("Janitor")
 	can_buy = UPLINK_TRAITOR
@@ -724,7 +715,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/clothing/gloves/powergloves
 	cost = 6
 	desc = "These marvels of modern technology employ nanites and space science to draw energy from nearby cables to zap things. BZZZZT!"
-	not_in_crates = 1
+	surplus_weight = 0
 	job = list("Engineer", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -758,7 +749,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Chemicompiler"
 	item = /obj/item/device/chemicompiler
 	cost = 5
-	not_in_crates = 1
+	surplus_weight = 0
 	desc = "A handheld version of the Chemicompiler machine in Chemistry."
 	job = list("Research Director", "Scientist")
 	can_buy = UPLINK_TRAITOR
@@ -768,7 +759,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/parts/robot_parts/robot_frame/syndicate
 	cost = 2
 	desc = "A cyborg shell crafted from the finest recycled steel and reverse-engineered microelectronics. A cyborg crafted from this will see only Syndicate operatives (Such as yourself!) as human. Cyborg also comes preloaded with popular game \"Angry About the Bird\" and is compatible with most headphones."
-	not_in_crates = 1
+	surplus_weight = 0
 	vr_allowed = 0
 	job = list("Roboticist")
 	can_buy = UPLINK_TRAITOR
@@ -780,7 +771,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A modified standard-issue cyborg recharging station that will automatically convert any human placed inside into a cyborg. Cyborgs created this way will follow a syndicate lawset making them loyal to you."
 	job = list("Roboticist")
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR
 
 	run_on_spawn(var/obj/item)
@@ -829,7 +820,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/knife/butcher
 	cost = 7
 	desc = "An extremely sharp knife with a weighted handle for accurate throwing. Caution: May cause extreme bleeding if the cutting edge comes into contact with human flesh."
-	not_in_crates = 1
+	surplus_weight = 0
 	job = list("Chef")
 	can_buy = UPLINK_TRAITOR
 
@@ -838,7 +829,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/storage/cart/hotdog/syndicate
 	cost = 4
 	desc = "A sinister hotdog cart which traps people inside and squishes them into, you guessed it, hot dogs."
-	not_in_crates = TRUE
+	surplus_weight = 0
 	vr_allowed = FALSE //i don't know why this is here but it's on the trash compactor cart so w/e
 	job = list("Chef", "Sous-Chef", "Waiter")
 	can_buy = UPLINK_TRAITOR
@@ -937,7 +928,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Port-a-Puke"
 	item = /obj/machinery/portapuke
 	cost = 7
-	not_in_crates = 1
+	surplus_weight = 0
 	desc = "An experimental torture chamber that will make any human placed inside puke until they die!"
 	job = list("Janitor")
 	can_buy = UPLINK_TRAITOR
@@ -1012,7 +1003,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A grenade that holds up to 5 chicken eggs. Uses syndicate brainwashing to turn the chickens into hardened warriors immediately on detonation. Normally passive chickens will become aggressive. Use a wrench to unload it."
 	job = list("Rancher")
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR
 
 /datum/syndicate_buylist/traitor/fishing_rod
@@ -1028,7 +1019,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/aiModule/ability_expansion/laser
 	cost = 6
 	vr_allowed = FALSE
-	not_in_crates = TRUE
+	surplus_weight = 0
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
@@ -1039,7 +1030,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/megaphone/syndicate
 	cost = 5
 	vr_allowed = FALSE // no
-	not_in_crates = TRUE
+	surplus_weight = 0
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
@@ -1093,7 +1084,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 
 	spy
 		cost = 5
-		not_in_crates = TRUE
+		surplus_weight = 0
 		can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/surplus/akm
@@ -1139,6 +1130,22 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	cost = 2
 	desc = "An advanced self-charging power cell, the ideal upgrade for an energy weapon!"
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
+
+/datum/syndicate_buylist/surplus/micronuke
+	name = "Micronuke"
+	item = /obj/machinery/nuclearbomb/event/micronuke
+	desc = "A miniaturized version of the nuclear bomb given to our nuclear operative teams. Blow (a small portion) of the station to smithereens!"
+	cost = 7
+	surplus_weight = 5
+	vr_allowed = FALSE
+	can_buy = UPLINK_TRAITOR
+
+	defended
+		name = "Defended Micronuke"
+		item = /obj/machinery/nuclearbomb/event/micronuke/defended
+		desc = "A miniaturized version of the nuclear bomb given to our nuclear operative teams. Now with minature nuclear operatives!"
+		cost = 9
+		surplus_weight = 1
 
 // Why not, I guess? Cleaned up the old mine code, might as well use it (Convair880).
 /datum/syndicate_buylist/surplus/landmine
@@ -1188,7 +1195,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	name = "You shouldn't see me!"
 	cost = 0
 	desc = "You shouldn't see me!"
-	not_in_crates = TRUE
+	surplus_weight = 0
 	can_buy = UPLINK_NUKE_COMMANDER // Fun story here, I made the shit mistake of assuming that surplus crates and spy bounties couldn't roll this, leading to this shit https://imgur.com/a/uMaM0oV
 
 /datum/syndicate_buylist/commander/reinforcement
@@ -1254,7 +1261,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 
 	telecrystal = TRUE
 	vr_allowed = 0
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV | UPLINK_NUKE_OP
 
 	New()
@@ -1271,7 +1278,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	desc = "A small, highly volatile explosive designed to look like a pure Telecrystal."
 	telecrystal = TRUE
 	vr_allowed = 0
-	not_in_crates = 1
+	surplus_weight = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV
 
 	New()
@@ -1316,7 +1323,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	name = "Head Rev Buylist Parent"
 	cost = 0
 	desc = "You shouldn't see me!"
-	not_in_crates = TRUE
+	surplus_weight = 0
 	vr_allowed = FALSE
 	can_buy = UPLINK_HEAD_REV
 
@@ -1326,7 +1333,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	cost = 5
 	desc = "This flash never runs out and will convert susceptible crew when a rev head uses it. It will also allow the rev head to break counter-revolutionary implants."
 	vr_allowed = 0
-	not_in_crates = 1
+	surplus_weight = 0
 
 /datum/syndicate_buylist/generic/head_rev/revflashbang
 	name = "Revolutionary Flashbang"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -38,7 +38,9 @@ ABSTRACT_TYPE(/datum/syndicate_buylist)
 	var/vr_allowed = TRUE
 	/// If the item can be created as loot in Battle Royale
 	var/br_allowed = FALSE
-	/// How often should this should show up in a surplus crate? Set this to 0 if you want the item to never appear in a crate
+	/// If the item should show up in surplus crates or not
+	var/not_in_crates = FALSE
+	/// How often should this show up in a surplus crate/spy bounty?
 	var/surplus_weight = 50
 	/// The category of the item, currently unused (somewhat used in the Nukeop Commander uplink)
 	var/category
@@ -87,7 +89,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/storage/box/shotgun
 	cost = 8
 	desc = "Not exactly stealthy, but it'll certainly make an impression."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/generic/radbow
@@ -162,7 +164,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/implanter/signaler
 	cost = 1
 	desc = "An implant that can send configurable signals. Can be used while stunned or handcuffed."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR
 
@@ -183,7 +185,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/device/powersink
 	cost = 5
 	desc = "Lights too bright? Airlocks too automatic? Alarms too functional? Or maybe just nostalgic about the good ol' days before electricity came along? The XL-100 Power Sink addresses all these ills and more. Simply screw to the nearest exposed wiring and flip the switch, and this little wonder will get to work on draining all of that nasty power."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/generic/detomatix
@@ -238,7 +240,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/sword
 	cost = 7
 	desc = "A powerful melee weapon, crafted using the latest in applied photonics! When inactive, it is small enough to fit in a pocket!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 	run_on_spawn(obj/item/sword/stabby, mob/living/owner, in_surplus_crate=FALSE) //Nukies get red ones
@@ -279,7 +281,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/clothing/head/bighat/syndicate
 	cost = 12
 	desc = "Think you're tough shit buddy?"
-	surplus_weight = 0 //see /datum/syndicate_buylist/surplus/bighat
+	not_in_crates = TRUE //see /datum/syndicate_buylist/surplus/bighat
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY
 
@@ -296,7 +298,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Cloaking Device"
 	item = /obj/item/cloaking_device
 	cost = 6
-	//surplus_weight = 0
+	//not_in_crates = TRUE
 	desc = "Hides you from normal sight. AI and Cyborgs will still see you and so will any human with thermals so be careful how you use it."
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -446,7 +448,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/pinpointer/idtracker
 	cost = 1
 	desc = "Allows you to track the IDs of your assassination targets, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = 0
 	objective = /datum/objective/regular/assassinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY | UPLINK_HEAD_REV
@@ -460,7 +462,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 1
 	desc = "Allows you to track the IDs of all other antagonists, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
 	vr_allowed = 0
-	surplus_weight = 0
+	not_in_crates = TRUE
 	objective = /datum/objective/spy_theft/assasinate
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
@@ -475,7 +477,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 0
 	desc = "A crate containing a Nuke Ops Class Loadout, this one is generic and you shouldn't see it."
 	objective = /datum/objective/specialist/nuclear
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_NUKE_OP
 
 //////////////////////////////////////////////// Job-specific items  ////////////////////////////////////////////////////
@@ -496,7 +498,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV
 
 /datum/syndicate_buylist/traitor/clown_mask
@@ -506,7 +508,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR
 
 /datum/syndicate_buylist/traitor/fake_revolver
@@ -533,7 +535,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 3
 	desc = "Disguised as a screwdriver, this stealthy device can be loaded with dna injectors which will be injected into the target instantly and stealthily. The dna injector will be altered when inserted so that there will be a ten second delay before the gene manifests in the victim."
 	job = list("Geneticist")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
 /datum/syndicate_buylist/traitor/minibible
@@ -551,7 +553,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	cost = 8
 	desc = "Comes complete with three soul binding contracts, three extra-pointy pens, and one suit provided by Lucifer himself."
 	job = list("Chaplain")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = 0
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY
 
@@ -575,7 +577,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/device/chargehacker
 	cost = 4
 	desc = "A tool designed to hack mining charges so that they will attach to any surface, disguised as a geological scanner."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Miner")
 	can_buy = UPLINK_TRAITOR
 
@@ -593,7 +595,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/seed/maneater
 	cost = 1
 	desc = "A boon for the green-thumbed agent! Simply plant and nurture to raise your own faithful guard-plant! Feed me, Seymour!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Botanist")
 	can_buy = UPLINK_TRAITOR
 
@@ -602,7 +604,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/saw/syndie
 	cost = 7
 	desc = "This old earth beauty is made by hand with strict attention to detail. Unlike today's competing botanical chainsaw, it actually cuts things!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Botanist")
 	can_buy = UPLINK_TRAITOR
 
@@ -654,7 +656,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/storage/cart/trash/syndicate
 	cost = 4
 	desc = "Identical in appearance to an ordinary trash cart, this beauty is capable of compacting (1) laying person placed inside at a time. It was originally supposed to only compact nonliving things, but a serendipitous design mistake resulted in 1500 units with a reversed safety unit."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = 0
 	job = list("Janitor")
 	can_buy = UPLINK_TRAITOR
@@ -715,7 +717,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/clothing/gloves/powergloves
 	cost = 6
 	desc = "These marvels of modern technology employ nanites and space science to draw energy from nearby cables to zap things. BZZZZT!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Engineer", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
@@ -749,7 +751,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Chemicompiler"
 	item = /obj/item/device/chemicompiler
 	cost = 5
-	surplus_weight = 0
+	not_in_crates = TRUE
 	desc = "A handheld version of the Chemicompiler machine in Chemistry."
 	job = list("Research Director", "Scientist")
 	can_buy = UPLINK_TRAITOR
@@ -759,7 +761,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/parts/robot_parts/robot_frame/syndicate
 	cost = 2
 	desc = "A cyborg shell crafted from the finest recycled steel and reverse-engineered microelectronics. A cyborg crafted from this will see only Syndicate operatives (Such as yourself!) as human. Cyborg also comes preloaded with popular game \"Angry About the Bird\" and is compatible with most headphones."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = 0
 	job = list("Roboticist")
 	can_buy = UPLINK_TRAITOR
@@ -771,7 +773,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A modified standard-issue cyborg recharging station that will automatically convert any human placed inside into a cyborg. Cyborgs created this way will follow a syndicate lawset making them loyal to you."
 	job = list("Roboticist")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR
 
 	run_on_spawn(var/obj/item)
@@ -820,7 +822,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/knife/butcher
 	cost = 7
 	desc = "An extremely sharp knife with a weighted handle for accurate throwing. Caution: May cause extreme bleeding if the cutting edge comes into contact with human flesh."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Chef")
 	can_buy = UPLINK_TRAITOR
 
@@ -829,7 +831,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/storage/cart/hotdog/syndicate
 	cost = 4
 	desc = "A sinister hotdog cart which traps people inside and squishes them into, you guessed it, hot dogs."
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = FALSE //i don't know why this is here but it's on the trash compactor cart so w/e
 	job = list("Chef", "Sous-Chef", "Waiter")
 	can_buy = UPLINK_TRAITOR
@@ -928,7 +930,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Port-a-Puke"
 	item = /obj/machinery/portapuke
 	cost = 7
-	surplus_weight = 0
+	not_in_crates = TRUE
 	desc = "An experimental torture chamber that will make any human placed inside puke until they die!"
 	job = list("Janitor")
 	can_buy = UPLINK_TRAITOR
@@ -1003,7 +1005,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = 0
 	desc = "A grenade that holds up to 5 chicken eggs. Uses syndicate brainwashing to turn the chickens into hardened warriors immediately on detonation. Normally passive chickens will become aggressive. Use a wrench to unload it."
 	job = list("Rancher")
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR
 
 /datum/syndicate_buylist/traitor/fishing_rod
@@ -1019,7 +1021,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/aiModule/ability_expansion/laser
 	cost = 6
 	vr_allowed = FALSE
-	surplus_weight = 0
+	not_in_crates = TRUE
 	desc = "An AI module that upgrades any AI connected to the installed law rack access to the lasers installed in the cameras."
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
@@ -1030,7 +1032,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/megaphone/syndicate
 	cost = 5
 	vr_allowed = FALSE // no
-	surplus_weight = 0
+	not_in_crates = TRUE
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
@@ -1083,8 +1085,10 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 	spy
-		cost = 5
-		surplus_weight = 0
+		cost = 3
+		vr_allowed = FALSE
+		not_in_crates = TRUE
+		surplus_weight = 25 // so this remains rare in spy
 		can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/surplus/akm
@@ -1195,7 +1199,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	name = "You shouldn't see me!"
 	cost = 0
 	desc = "You shouldn't see me!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_NUKE_COMMANDER // Fun story here, I made the shit mistake of assuming that surplus crates and spy bounties couldn't roll this, leading to this shit https://imgur.com/a/uMaM0oV
 
 /datum/syndicate_buylist/commander/reinforcement
@@ -1261,7 +1265,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 
 	telecrystal = TRUE
 	vr_allowed = 0
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV | UPLINK_NUKE_OP
 
 	New()
@@ -1278,7 +1282,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 	desc = "A small, highly volatile explosive designed to look like a pure Telecrystal."
 	telecrystal = TRUE
 	vr_allowed = 0
-	surplus_weight = 0
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_HEAD_REV
 
 	New()
@@ -1323,7 +1327,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	name = "Head Rev Buylist Parent"
 	cost = 0
 	desc = "You shouldn't see me!"
-	surplus_weight = 0
+	not_in_crates = TRUE
 	vr_allowed = FALSE
 	can_buy = UPLINK_HEAD_REV
 
@@ -1333,7 +1337,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	cost = 5
 	desc = "This flash never runs out and will convert susceptible crew when a rev head uses it. It will also allow the rev head to break counter-revolutionary implants."
 	vr_allowed = 0
-	surplus_weight = 0
+	not_in_crates = TRUE
 
 /datum/syndicate_buylist/generic/head_rev/revflashbang
 	name = "Revolutionary Flashbang"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1140,7 +1140,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	name = "Micronuke"
 	item = /obj/machinery/nuclearbomb/event/micronuke
 	desc = "A miniaturized version of the nuclear bomb given to our nuclear operative teams. Blow (a small portion) of the station to smithereens!"
-	cost = 7
+	cost = 5
 	surplus_weight = 5
 	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -318,7 +318,7 @@
 				if(!isnull(owner_uplink) && !(S.can_buy & owner_uplink.purchase_flags)) //You can get anything (not usually excluded from surplus crates) from any gamemode if you spawn this without an uplink
 					continue
 
-				if (S.surplus_weight)
+				if (!S.not_in_crates)
 					possible_items[S] = S.surplus_weight
 
 		if (islist(possible_items) && length(possible_items))

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -318,13 +318,13 @@
 				if(!isnull(owner_uplink) && !(S.can_buy & owner_uplink.purchase_flags)) //You can get anything (not usually excluded from surplus crates) from any gamemode if you spawn this without an uplink
 					continue
 
-				if (!S.not_in_crates)
-					possible_items += S
+				if (S.surplus_weight)
+					possible_items[S] = S.surplus_weight
 
 		if (islist(possible_items) && length(possible_items))
 			var/list/crate_contents = list()
 			while(telecrystals < 18)
-				var/datum/syndicate_buylist/item_datum = pick(possible_items)
+				var/datum/syndicate_buylist/item_datum = weighted_pick(possible_items)
 				crate_contents += item_datum.name
 				if(telecrystals + item_datum.cost > 24) continue
 				var/obj/item/I = new item_datum.item(src)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes surplus crates/spy bounties use weighted lists to pick items.
Makes vr_allowed/not_in_crates use TRUE and FALSE defines

Items have 50 weight by default.

Removes the 1/20 chance for syndicate in pipebombs to come with a mininuke or defended mininuke
Adds a surplus micronuke with 5 weight and 5 tc cost, Also adds a defended micronuke with 1 weight and 9 tc cost

Minor but adds vr_blacklist to the spy ohr to prevent 2 ohr's from appearing in the vr uplink

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows cool items that shouldn't be an every round occurrence to exist such as the micronukes in surplus crates.  In addition, having an item with a 1/20 chance to come with a different rarer item felt weird to me.

