### PR TITLE
Fix landmark paths on pamgoc so map compiles

### DIFF
--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -1504,7 +1504,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "acU" = (
@@ -2937,7 +2937,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /obj/stool/chair/office{
 	dir = 8
 	},
@@ -2947,7 +2947,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "afK" = (
@@ -5253,7 +5253,7 @@
 /obj/stool/chair/yellow{
 	dir = 1
 	},
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
@@ -5719,7 +5719,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment,
-/obj/landmark/start/janitor,
+/obj/landmark/start/job/janitor,
 /turf/simulated/floor,
 /area/station/janitor/supply)
 "aml" = (
@@ -9095,14 +9095,14 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/cyborg,
+/obj/landmark/start/job/cyborg,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "asW" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/medical_director,
+/obj/landmark/start/job/medical_director,
 /obj/stool/chair/office/red{
 	dir = 8
 	},
@@ -9112,7 +9112,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
 	},
@@ -9974,7 +9974,7 @@
 /obj/stool/chair/office{
 	dir = 1
 	},
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -11525,7 +11525,7 @@
 /area/station/maintenance/west)
 "ayZ" = (
 /obj/decal/cleanable/dirt,
-/obj/landmark/start/clown,
+/obj/landmark/start/job/clown,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "aza" = (
@@ -16735,7 +16735,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/landmark/start/AI,
+/obj/landmark/start/job/AI,
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
@@ -17088,7 +17088,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/landmark/start/security_assistant,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -23487,7 +23487,7 @@
 /turf/simulated/floor/yellow/side,
 /area/station/science/lobby)
 "bbQ" = (
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /obj/stool/chair/office/red,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -24499,7 +24499,7 @@
 /turf/space,
 /area/space)
 "beg" = (
-/obj/landmark/start/bartender,
+/obj/landmark/start/job/bartender,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bek" = (
@@ -24515,11 +24515,11 @@
 	},
 /area/station/crew_quarters/captain)
 "bel" = (
-/obj/landmark/start/chef,
+/obj/landmark/start/job/chef,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bem" = (
-/obj/landmark/start/cyborg,
+/obj/landmark/start/job/cyborg,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
@@ -24527,25 +24527,25 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "ben" = (
-/obj/landmark/start/cyborg,
+/obj/landmark/start/job/cyborg,
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "beo" = (
-/obj/landmark/start/cyborg,
+/obj/landmark/start/job/cyborg,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bep" = (
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "beq" = (
-/obj/landmark/start/head_of_personnel,
+/obj/landmark/start/job/head_of_personnel,
 /obj/stool/chair/comfy,
 /obj/cable{
 	icon_state = "1-4"
@@ -24575,18 +24575,18 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "beu" = (
-/obj/landmark/start/miner,
+/obj/landmark/start/job/miner,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bev" = (
-/obj/landmark/start/miner,
+/obj/landmark/start/job/miner,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bew" = (
-/obj/landmark/start/quartermaster,
+/obj/landmark/start/job/quartermaster,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -24596,7 +24596,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bex" = (
-/obj/landmark/start/quartermaster,
+/obj/landmark/start/job/quartermaster,
 /obj/stool/chair/yellow,
 /obj/cable{
 	icon_state = "1-8"
@@ -24607,29 +24607,29 @@
 /turf/simulated/floor/neutral/side,
 /area/station/quartermaster/office)
 "bey" = (
-/obj/landmark/start/quartermaster,
+/obj/landmark/start/job/quartermaster,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bez" = (
-/obj/landmark/start/quartermaster,
+/obj/landmark/start/job/quartermaster,
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "beA" = (
-/obj/landmark/start/research_director,
+/obj/landmark/start/job/research_director,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred5"
 	},
 /area/station/crew_quarters/hor)
 "beB" = (
-/obj/landmark/start/roboticist,
+/obj/landmark/start/job/roboticist,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "beC" = (
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /obj/stool/chair/office,
 /obj/cable{
 	icon_state = "4-8"
@@ -24637,12 +24637,12 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "beD" = (
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /obj/stool/chair/office,
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "beE" = (
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /obj/stool/chair/office{
 	dir = 1
 	},
@@ -24651,7 +24651,7 @@
 	},
 /area/station/science/chemistry)
 "beF" = (
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -29439,7 +29439,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/landmark/start/roboticist,
+/obj/landmark/start/job/roboticist,
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "bqV" = (
@@ -33205,7 +33205,7 @@
 /obj/item/storage/toilet{
 	dir = 8
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -33216,12 +33216,12 @@
 /obj/item/storage/toilet{
 	dir = 8
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "bCl" = (
 /obj/machinery/door/window/westright,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/item/storage/toilet/random{
 	dir = 8;
 	pixel_x = 8
@@ -33231,7 +33231,7 @@
 /area/station/crew_quarters/bathroom)
 "bCm" = (
 /obj/machinery/door/window/westright,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -41194,7 +41194,7 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "bSS" = (
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /obj/stool/chair/comfy/blue{
 	dir = 1
 	},
@@ -44390,7 +44390,7 @@
 	icon_state = "bedsheet-captain";
 	name = "special bedsheet"
 	},
-/obj/landmark/start/captain,
+/obj/landmark/start/job/captain,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred6"
@@ -44450,7 +44450,7 @@
 /area/station/engine/engineering/ce)
 "bZR" = (
 /obj/stool/bed,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -44459,7 +44459,7 @@
 /area/station/crew_quarters/quartersB)
 "bZS" = (
 /obj/stool/bed,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -44468,7 +44468,7 @@
 /area/station/crew_quarters/quartersA)
 "bZT" = (
 /obj/stool/bed,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/window/cubicle{
 	dir = 2
 	},
@@ -44480,7 +44480,7 @@
 /area/station/crew_quarters/quartersB)
 "bZU" = (
 /obj/stool/bed,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /obj/window/cubicle{
 	dir = 2
 	},
@@ -44525,7 +44525,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/landmark/start/security_assistant,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -44555,7 +44555,7 @@
 /area/station/hallway/primary/central)
 "cab" = (
 /obj/stool/chair,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -44650,7 +44650,7 @@
 /obj/disposalpipe/segment{
 	dir = 8
 	},
-/obj/landmark/start/head_of_security,
+/obj/landmark/start/job/head_of_security,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "cas" = (
@@ -44885,7 +44885,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 8
 	},
-/obj/landmark/start/botanist,
+/obj/landmark/start/job/botanist,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -45002,7 +45002,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/landmark/start/geneticist,
+/obj/landmark/start/job/geneticist,
 /obj/landmark/gps_waypoint{
 	name = "Cloning"
 	},
@@ -45014,7 +45014,7 @@
 /obj/stool/chair/office/red{
 	dir = 1
 	},
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -45024,7 +45024,7 @@
 /obj/stool/chair/office/red{
 	dir = 8
 	},
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "cbm" = (
@@ -45131,7 +45131,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/landmark/start/miner,
+/obj/landmark/start/job/miner,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -45165,7 +45165,7 @@
 /obj/item/device/radio/intercom{
 	dir = 8
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -45174,7 +45174,7 @@
 /obj/stool/chair{
 	dir = 1
 	},
-/obj/landmark/start/chaplain,
+/obj/landmark/start/job/chaplain,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -45184,7 +45184,7 @@
 /obj/stool/chair{
 	dir = 1
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "cbC" = (
@@ -45215,7 +45215,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/landmark/start/security_assistant,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor,
 /area/station/security/main)
 "cbG" = (
@@ -45285,7 +45285,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -45305,7 +45305,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/landmark/start/janitor,
+/obj/landmark/start/job/janitor,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -45315,14 +45315,14 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "cbP" = (
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "red2"
@@ -45332,7 +45332,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "cbS" = (
@@ -45495,7 +45495,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/security_assistant,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "ccl" = (
@@ -45518,7 +45518,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "ccn" = (
@@ -45590,14 +45590,14 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "cct" = (
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/scientist,
+/obj/landmark/start/job/scientist,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -45606,7 +45606,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -45619,7 +45619,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -45635,7 +45635,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -45645,7 +45645,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /obj/disposalpipe/segment{
 	dir = 8
 	},
@@ -45658,7 +45658,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/security_officer,
+/obj/landmark/start/job/security_officer,
 /obj/machinery/door_control{
 	id = "interrogation";
 	name = "Interrogation Room Door Control";
@@ -45672,7 +45672,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "ccA" = (
@@ -58163,7 +58163,7 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "fJV" = (
@@ -59261,7 +59261,7 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "hXo" = (
-/obj/landmark/start/botanist,
+/obj/landmark/start/job/botanist,
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "hXV" = (
@@ -59374,7 +59374,7 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ilK" = (
-/obj/landmark/start/security_assistant,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor,
 /area/station/security/main)
 "ilX" = (
@@ -59549,7 +59549,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "iGR" = (
-/obj/landmark/start/botanist,
+/obj/landmark/start/job/botanist,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -59633,7 +59633,7 @@
 /area/station/crew_quarters/captain)
 "iIS" = (
 /obj/stool/chair/office/red,
-/obj/landmark/start/geneticist,
+/obj/landmark/start/job/geneticist,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "iJv" = (
@@ -60089,7 +60089,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "jAA" = (
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -61602,7 +61602,7 @@
 	dir = 4
 	},
 /obj/landmark/bill_spawn,
-/obj/landmark/start/assistant,
+/obj/landmark/start/job/assistant,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "mIk" = (
@@ -61923,7 +61923,7 @@
 /turf/space,
 /area/space)
 "nod" = (
-/obj/landmark/start/botanist,
+/obj/landmark/start/job/botanist,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "npi" = (
@@ -63472,7 +63472,7 @@
 /obj/stool/chair/comfy/blue{
 	dir = 4
 	},
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
 "rqG" = (
@@ -64064,7 +64064,7 @@
 /obj/stool/chair/green{
 	dir = 8
 	},
-/obj/landmark/start/rancher,
+/obj/landmark/start/job/rancher,
 /obj/railing/orange/reinforced{
 	dir = 4
 	},
@@ -64140,7 +64140,7 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
-/obj/landmark/start/chief_engineer,
+/obj/landmark/start/job/chief_engineer,
 /turf/simulated/floor,
 /area/station/engine/engineering/ce)
 "sLK" = (
@@ -64166,7 +64166,7 @@
 /area/station/medical/medbay/psychiatrist)
 "sMF" = (
 /obj/stool/chair/yellow,
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "sOG" = (
@@ -64677,7 +64677,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/staff)
 "tTL" = (
-/obj/landmark/start/engineer,
+/obj/landmark/start/job/engineer,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/cable{
 	icon_state = "0-8"
@@ -66091,7 +66091,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/landmark/start/medical_doctor,
+/obj/landmark/start/job/medical_doctor,
 /obj/stool/chair/office/blue{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Updates /obj/landmark/start paths to /obj/landmark/start/job because they were broken

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pamgoc can be voted for on live servers and thus should properly compile
