### PR TITLE
Pronoun usage in various vampire messages

### DIFF
--- a/code/modules/antagonists/vampire/abilities/cancel_stun.dm
+++ b/code/modules/antagonists/vampire/abilities/cancel_stun.dm
@@ -34,7 +34,7 @@
 
 		if (message_type == 3)
 			violent_standup_twitch(M)
-			M.visible_message("<span class='alert'><B>[M] contorts their body and judders upright!</B></span>")
+			M.visible_message("<span class='alert'><B>[M] contorts [his_or_her(M)] body and judders upright!</B></span>")
 			playsound(M.loc, 'sound/effects/bones_break.ogg', 60, 1)
 		else if (message_type == 2)
 			boutput(M, "<span class='notice'>You feel your flesh knitting itself back together.</span>")

--- a/code/modules/antagonists/vampire/abilities/enthrall.dm
+++ b/code/modules/antagonists/vampire/abilities/enthrall.dm
@@ -104,7 +104,7 @@
 			return
 
 		if(istype(M))
-			M.visible_message("<span class='alert'><B>[M] stabs [target] with their sharp fingers!</B></span>")
+			M.visible_message("<span class='alert'><B>[M] stabs [target] with [his_or_her(M)] sharp fingers!</B></span>")
 			boutput(M, "<span class='notice'>You begin to pump your [pick("polluted","spooky","bad","gross","icky","evil","necrotic")] blood into [target]'s chest.</span>")
 			boutput(target, "<span class='alert'>You feel cold . . .</span>")
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -52,7 +52,7 @@
 		return FALSE
 
 	if (check_target_immunity(target) == 1)
-		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce their skin!</B></span>")
+		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce [his_or_her(target)] skin!</B></span>")
 		return FALSE
 
 	if (isnpcmonkey(target))
@@ -214,7 +214,7 @@
 		return 0
 
 	if (check_target_immunity(target) == 1)
-		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce their skin!</B></span>")
+		target.visible_message("<span class='alert'><B>[M] bites [target], but fails to even pierce [his_or_her(target)] skin!</B></span>")
 		return 0
 
 	if (isnpcmonkey(target))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replace usages of they with pronoun procs in certain vampire-related messages

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

parity, ah ah ah
