### PR TITLE
Call power_change() on /obj/machinery when it moves to a new area

### DIFF
--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -393,6 +393,8 @@
 	if(A1 != A2)
 		if(A1) A1.machines -= src
 		if(A2) A2.machines += src
+		// call power_change on machine so it can check if the new area is powered and update it's status flag appropriately
+		src.power_change()
 
 /obj/machinery/Move(atom/target)
 	var/area/A1 = get_area(src)
@@ -401,6 +403,7 @@
 	if(A1 && A2 && A1 != A2)
 		A1.machines -= src
 		A2.machines += src
+		src.power_change()
 
 /datum/action/bar/icon/rotate_machinery
 	duration = 3 SECONDS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds code to call `power_change()` on machines when they change areas.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As far as I can tell this behavior is a side effect of `/obj/machinery` not being designed with machines that move in mind, but this manifests in bugs such as: you have a portable machine (like a disposal pipe dispenser cart), the APC for the room its in gets turned off, you can no longer open the interface for it because `NOPOWER` has been set on it, but if you drag it to a new area that is powered it still won't open. `NOPOWER` only gets updated when power_change() gets called, which would mean you'd need to flip the breaker off and on in this new room to get it working again. 
