### PR TITLE
Makes cancelling record player title input not play the record

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -268,14 +268,11 @@
 		else if(is_music_playing())
 			boutput(user, "<span class='alert'>Music is already playing, it'd be rude to interrupt!</span>")
 		else
-			boutput(user, "You insert the record into the record player.")
-			var/inserted_record = W
-			src.visible_message("<span class='notice'><b>[user] inserts the record into the record player.</b></span>")
-			user.drop_item()
-			W.set_loc(src)
-			src.record_inside = W
-			src.has_record = TRUE
-			var/R = copytext(html_encode(tgui_input_text(user, "What is the name of this record?", "Record Name", src.record_inside.record_name)), 1, MAX_MESSAGE_LEN)
+			var/obj/item/record/inserted_record = W
+			var/R = copytext(html_encode(tgui_input_text(user, "What is the name of this record?", "Record Name", inserted_record.record_name)), 1, MAX_MESSAGE_LEN)
+			if(!R)
+				boutput(user, "<span class='notice'>You decide not to play this record.</span>")
+				return
 			if(!in_interact_range(src, user))
 				boutput(user, "You're out of range of the [src.name]!")
 				return
@@ -283,10 +280,13 @@
 				return
 			if(!inserted_record || (inserted_record != src.record_inside)) // record was removed/changed before input confirmation
 				return
-			if(R)
-				phrase_log.log_phrase("record", R)
-			if (!R)
-				R = record_inside.record_name ? record_inside.record_name : pick("rad tunes","hip jams","cool music","neat sounds","magnificent melodies","fantastic farts")
+			phrase_log.log_phrase("record", R)
+			boutput(user, "You insert the record into the record player.")
+			src.visible_message("<span class='notice'><b>[user] inserts the record into the record player.</b></span>")
+			user.drop_item()
+			W.set_loc(src)
+			src.record_inside = W
+			src.has_record = TRUE
 			user.client.play_music_radio(record_inside.song, R)
 			/// PDA message ///
 			var/datum/signal/pdaSignal = get_free_signal()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the behavior for the record player so that if the user cancels the input asking what the name of the record is, it doesn't play the record, instead of the current behavior of putting a random phrase in and playing it anyways.

Closes #13161 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Misclicks can and do happen, and given that playing a record has a multi-minute long cooldown, I feel like this behavior is both more intuitive and better for quality of life.