### PR TITLE
Fix grasshopper being permanent

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1702,7 +1702,7 @@ datum
 
 			on_mob_life(var/mob/living/carbon/human/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				if(istype(M) && !M.mutantrace)
+				if(istype(M) && !(M.mutantrace.name == "roach"))
 					bioeffect_length++
 				..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CHEMISTRY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bugfix to make grasshopper work [as intended on the wiki](https://wiki.ss13.co/Chemicals#Grasshopper). Since human is a mutantrace, change the grasshopper conditional to count up as long as the mob isn't a roach already. 


**NOTE:** When de-roaching, you'll get the "You shed your roachy skin!x3" message. This is not a bug related to the fix for grasshopper, but seems to be a more general bug with how a mutantrace based trait added by a timed based bioEffect is removed. You can reproduce this bug with yee or by manually adding a bioeffect via admin panel and modifying the bioeffect's timeLeft to a number in seconds. In the spirit of atomizing commits, focus on only fixing grasshopper here. (Also I don't know if the larger bug is worth fixing since it touches the landmine of mutantraces, only occurs in a specific case, and doesn't ruin gameplay outside of a duplicate message....)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes https://github.com/goonstation/goonstation/issues/15494
I might not want to be a roach forever.