### PR TITLE
Fix RP handwashing not cleaning blood below 50% hygiene

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -77,19 +77,19 @@ TYPEINFO(/obj/submachine/chef_sink)
 				H.set_clothing_icon_dirty()
 			else
 				if(H.sims)
-					if (H.sims.getValue("Hygiene") < SIMS_HYGIENE_THRESHOLD_MESSY)
-						playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
-						user.show_text("You're too messy for handwashing to be useful. You need a shower or a bath.", "red")
-					else
+					if (H.sims.getValue("Hygiene") >= SIMS_HYGIENE_THRESHOLD_MESSY)
 						user.visible_message("<span class='notice'>[user] starts washing [his_or_her(user)] hands.</span>")
 						actions.start(new/datum/action/bar/private/handwashing(user,src),user)
-				else //simpler handwashing if hygiene isn't a concern
-					playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
-					user.visible_message("<span class='notice'>[user] washes [his_or_her(user)] hands.</span>")
-					H.blood_DNA = null
-					H.blood_type = null
-					H.forensics_blood_color = null
-					H.set_clothing_icon_dirty()
+						return ..()
+					else
+						user.show_text("You're too messy to improve your hygiene this way, you need a shower or a bath.", "red")
+				//simpler handwashing if hygiene isn't a concern
+				playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
+				user.visible_message("<span class='notice'>[user] washes [his_or_her(user)] hands.</span>")
+				H.blood_DNA = null
+				H.blood_type = null
+				H.forensics_blood_color = null
+				H.set_clothing_icon_dirty()
 		..()
 
 /datum/action/bar/private/handwashing


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RP]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16610 by reorganizing checks so being below hygiene threshold gives a more specific message about not being able to improve your hygiene at the sink, but still allows you to wash your hands regardless.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
