### PR TITLE
Fix antag banned players not getting non-antag respawn events

### DIFF
--- a/code/modules/admin/custom_spawn_event.dm
+++ b/code/modules/admin/custom_spawn_event.dm
@@ -67,7 +67,12 @@
 		if (src.ask_permission)
 			message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
-		var/list/datum/mind/candidates = dead_player_list(TRUE, src.ghost_confirmation_delay, text_messages, allow_dead_antags = TRUE, require_client = TRUE, do_popup = src.ask_permission)
+		var/list/datum/mind/candidates = dead_player_list(TRUE, src.ghost_confirmation_delay, text_messages,
+			allow_dead_antags = TRUE,
+			require_client = TRUE,
+			do_popup = src.ask_permission,
+			for_antag = !!src.antag_role
+		)
 
 		if (!length(candidates))
 			message_admins("No ghosts responded to spawn event: [src.get_mob_name()]")

--- a/code/modules/events/crew_spawn.dm
+++ b/code/modules/events/crew_spawn.dm
@@ -43,7 +43,7 @@
 
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
 		message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
-		var/list/datum/mind/candidates = dead_player_list(TRUE, src.ghost_confirmation_delay, text_messages, allow_dead_antags = TRUE, require_client = TRUE)
+		var/list/datum/mind/candidates = dead_player_list(TRUE, src.ghost_confirmation_delay, text_messages, allow_dead_antags = TRUE, require_client = TRUE, for_antag = FALSE)
 
 		for (var/i = 1 to src.num_crew)
 			if (!length(candidates))

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -78,7 +78,7 @@
 
 		// The proc takes care of all the necessary work (job-banned etc checks, confirmation delay).
 		message_admins("Sending offer to eligible ghosts. They have [src.ghost_confirmation_delay / 10] seconds to respond.")
-		var/list/datum/mind/candidates = dead_player_list(1, src.ghost_confirmation_delay, text_messages, allow_dead_antags = 0)
+		var/list/datum/mind/candidates = dead_player_list(1, src.ghost_confirmation_delay, text_messages, allow_dead_antags = 0, for_antag = FALSE)
 
 
 		if (candidates.len)

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -66,7 +66,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 		message_admins("[which_one == 0 ? "Santa Claus" : "Krampus"] respawn is sending offer to eligible ghosts. They have [confirmation_delay / 10] seconds to respond.")
 
 	// Select player.
-	var/list/datum/mind/candidates = dead_player_list(1, confirmation_delay, text_messages)
+	var/list/datum/mind/candidates = dead_player_list(1, confirmation_delay, text_messages, for_antag = which_one)
 	if (!islist(candidates) || length(candidates) <= 0)
 		message_admins("Couldn't set up [which_one == 0 ? "Santa Claus" : "Krampus"] respawn (no eligible candidates found).")
 		xmas_respawn_lock = 0

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1747,12 +1747,12 @@ proc/countJob(rank)
 	src.letter_overlay(letter, lcolor, text2dir(dir))
 
 /// Returns a list of eligible dead players that COULD choose to respawn or whatever
-/proc/eligible_dead_player_list(var/allow_dead_antags = 0, var/require_client = FALSE)
+/proc/eligible_dead_player_list(var/allow_dead_antags = 0, var/require_client = FALSE, var/for_antag = TRUE)
 	. = list()
 	for (var/datum/mind/M in ticker.minds)
 		if (M.current && M.current.client)
 			var/client/C = M.current.client
-			if (dead_player_list_helper(M.current, allow_dead_antags, require_client) != 1)
+			if (dead_player_list_helper(M.current, allow_dead_antags, require_client, for_antag) != 1)
 				continue
 			if (C.holder && !C.holder.ghost_respawns && !C.player_mode || !M.show_respawn_prompts)
 				continue
@@ -1760,8 +1760,9 @@ proc/countJob(rank)
 
 /// Returns a list of eligible dead players to be respawned as an antagonist or whatever (Convair880).
 /// Text messages: 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
+/// for_antag indicates that we are polling for an antag role and so should exclude antag-banned players
 /proc/dead_player_list(var/return_minds = 0, var/confirmation_spawn = 0, var/list/text_messages = list(), var/allow_dead_antags = 0,
-		var/require_client = FALSE, var/do_popup = TRUE)
+		var/require_client = FALSE, var/do_popup = TRUE, var/for_antag = TRUE)
 	var/list/candidates = list()
 	// Confirmation delay specified, so prompt eligible dead mobs and wait for response.
 	if (confirmation_spawn > 0)
@@ -1791,7 +1792,7 @@ proc/countJob(rank)
 		for (var/datum/mind/M in ticker.minds)
 			if (M.current && M.current.client)
 				var/client/C = M.current.client
-				if (dead_player_list_helper(M.current, allow_dead_antags, require_client) != 1)
+				if (dead_player_list_helper(M.current, allow_dead_antags, require_client, for_antag) != 1)
 					continue
 				if (C.holder && !C.holder.ghost_respawns && !C.player_mode || !M.show_respawn_prompts)
 					continue
@@ -1807,7 +1808,7 @@ proc/countJob(rank)
 						if (ghost_timestamp && (TIME > ghost_timestamp + confirmation_spawn))
 							if (M.current) boutput(M.current, text_chat_toolate)
 							return
-						if (dead_player_list_helper(M.current, allow_dead_antags, require_client) != 1)
+						if (dead_player_list_helper(M.current, allow_dead_antags, require_client, for_antag) != 1)
 							if (M.current) boutput(M.current, text_chat_failed)
 							return
 
@@ -1826,7 +1827,7 @@ proc/countJob(rank)
 		// Filter list again.
 		if (candidates.len)
 			for (var/datum/mind/M2 in candidates)
-				if (!M2.current || !ismob(M2.current) || dead_player_list_helper(M2.current, allow_dead_antags, require_client) != 1)
+				if (!M2.current || !ismob(M2.current) || dead_player_list_helper(M2.current, allow_dead_antags, require_client, for_antag) != 1)
 					candidates.Remove(M2)
 					continue
 
@@ -1851,7 +1852,7 @@ proc/countJob(rank)
 	candidates = list()
 
 	for (var/mob/O in mobs)
-		if (dead_player_list_helper(O, allow_dead_antags, require_client) != 1)
+		if (dead_player_list_helper(O, allow_dead_antags, require_client, for_antag) != 1)
 			continue
 		if (!(O in candidates))
 			candidates.Add(O.mind)
@@ -1889,7 +1890,7 @@ proc/countJob(rank)
 	logTheThing(LOG_ADMIN, mind.current, " was chosen to respawn as a random event [respawning_as][is_round_observer ? " after joining as an observer" : ""]. Source: [source ? "[source]" : "random"]")
 
 // So there aren't multiple instances of C&P code (Convair880).
-/proc/dead_player_list_helper(var/mob/G, var/allow_dead_antags = 0, var/require_client = FALSE)
+/proc/dead_player_list_helper(var/mob/G, var/allow_dead_antags = 0, var/require_client = FALSE, var/for_antag = TRUE)
 	if (!G?.mind || G.mind.get_player()?.dnr)
 		return 0
 	// if (!isobserver(G) && !(isliving(G) && isdead(G))) // if (NOT /mob/dead) AND NOT (/mob/living AND dead)
@@ -1900,7 +1901,7 @@ proc/countJob(rank)
 		return 0
 	if (istype(G, /mob/new_player) || G.respawning)
 		return 0
-	if (jobban_isbanned(G, "Syndicate"))
+	if (for_antag && jobban_isbanned(G, "Syndicate"))
 		return 0
 	if (jobban_isbanned(G, "Special Respawn"))
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I'm just PRing this so I can easily test it on the dev server :)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We have a separate special respawn jobban and this seems like an oversight.