### PR TITLE
Fix stacking colds

### DIFF
--- a/code/modules/medical/diseases/cold.dm
+++ b/code/modules/medical/diseases/cold.dm
@@ -42,4 +42,4 @@
 				boutput(affected_mob, "<span class='alert'>Mucous runs down the back of your throat.</span>")
 			if(probmult(0.5))
 				boutput(affected_mob, "<span class='alert'>Your cold feels even worse, somehow.</span>")
-				D.master = get_disease_from_path(/datum/ailment/disease/flu)
+				affected_mob.contract_disease(/datum/ailment/disease/flu)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the mechanism of giving a mob the flu once their cold has progressed to stage three to prevent stacking of "colds". 

Previously, the cold.dm code would modify the "master" of the current cold to the flu. Potentially this was intended to mutate that instance of disease to become a flu? In practice, you end up with a cold that has a "master" of the flu. When contract_disease checks if you have a cold in the section below, it thinks the mob has no cold since the master is the flu and the ailment is a cold, so it gives them another cold with a "master" of the cold. Colds should respect the max_stacks variable correctly now. 

https://github.com/goonstation/goonstation/blob/56e8c91b6aa3e43090dd010743e6af974ca4b4b9/code/datums/disease.dm#L357-L363

Fairly easily to replicate on devtest by spawning human mobs and adding 1u of mucus to one of them, starting the infection chain. Image below of having nine mobs stand close together for ~20 minutes and only contracting one cold and one flu each.

![image](https://github.com/goonstation/goonstation/assets/5091297/385ccfee-80ac-435e-94f9-9b5aaef528af)

I felt this approach to fixing colds had the smaller blast radius vs changing the disease.dm logic to check in a more sane way (touching a lot more code and otherwise diseases seem to be working as intended?). 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12599
Also gives the crew a chance to actually contract the flu from a cold, and a slightly better chance to cure the cold around the station before it goes too out of control as mobs won't have multiple instances of the same disease.