### PR TITLE
Enables max_length on the wizard's name prompt

### DIFF
--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -12,7 +12,7 @@
 		. = ..()
 
 		SPAWN(0)
-			var/newname = tgui_input_text(src.owner.current, "You are a blob. Please choose a name for yourself, it will show in the form: <name> the Blob", "Name Change", max_length = 26)
+			var/newname = tgui_input_text(src.owner.current, "You are a blob. Please choose a name for yourself, it will show in the form: <name> the Blob", "Name Change", max_length = 25)
 			if (newname)
 				phrase_log.log_phrase("name-blob", newname, no_duplicates = TRUE)
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -73,7 +73,7 @@
 
 		if (!src.vr && !src.pseudo)
 			SPAWN(0)
-				var/newname = tgui_input_text(H, "You are a Wizard. Would you like to change your name to something else?", "Name change", randomname)
+				var/newname = tgui_input_text(H, "You are a Wizard. Would you like to change your name to something else?", "Name change", randomname, max_length = 25)
 				if(newname && newname != randomname)
 					phrase_log.log_phrase("name-wizard", randomname, no_duplicates = TRUE)
 


### PR DESCRIPTION
[BUG][UI]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the max_length arg to the tgui prompt for a wizard to choose their name. It also changes the max_length arg of the blob tgui name prompt to 25 characters, as it was one too long and would result in a single character being shaved off.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While accidentally naming myself 'Katherine, the Grand Ench' for my first wizard round and needing to ahelp for it to be fixed was pretty funny, we should probably let people know that they're going to go over the character limit in the future. Addditionally, blobs were always limited to a 25 character name, but max_length was set to 26, so this fixes that too.