### PR TITLE
Replace Martian mutant gibstare ability with radiation blast

### DIFF
--- a/code/datums/abilities/critter/radiation_blast.dm
+++ b/code/datums/abilities/critter/radiation_blast.dm
@@ -1,0 +1,17 @@
+/datum/targetable/critter/radiationblast
+	name = "Radiation Blast"
+	desc = "Focus your psychic powers to unleash a concentrated blast of radiation at a spot."
+	cooldown = 100
+	disabled = FALSE
+	targeted = TRUE
+	target_anything = TRUE
+
+/datum/targetable/critter/radiationblast/cast(atom/target)
+	if (..())
+		return 1
+	if (disabled)
+		return
+	var/turf/T = get_turf(target)
+	if (isturf(T))
+		var/pulse_lifespan = rand(20,40)
+		new /obj/anomaly/radioactive_burst(T,lifespan = pulse_lifespan)

--- a/code/mob/living/critter/martian.dm
+++ b/code/mob/living/critter/martian.dm
@@ -215,18 +215,18 @@
 
 	New()
 		..()
-		abilityHolder.addAbility(/datum/targetable/critter/gibstare)
+		abilityHolder.addAbility(/datum/targetable/critter/radiationblast)
 		abilityHolder.addAbility(/datum/targetable/critter/telepathy)
 
 	critter_attack(var/mob/target)
-		var/datum/targetable/critter/gibstare/gib = src.abilityHolder.getAbility(/datum/targetable/critter/gibstare)
-		if (!gib.disabled && gib.cooldowncheck())
-			gib.handleCast(target)
+		var/datum/targetable/critter/radiationblast/rads = src.abilityHolder.getAbility(/datum/targetable/critter/radiationblast)
+		if (!rads.disabled && rads.cooldowncheck())
+			rads.handleCast(target)
 			return TRUE
 
 	can_critter_attack()
-		var/datum/targetable/critter/gibstare/gib = src.abilityHolder.getAbility(/datum/targetable/critter/gibstare)
-		return ..() && !gib.disabled
+		var/datum/targetable/critter/radiationblast/rads = src.abilityHolder.getAbility(/datum/targetable/critter/radiationblast)
+		return ..() && !rads.disabled
 
 /mob/living/critter/martian/initiate
 	name = "martian initiate"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -159,6 +159,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\abilities\critter\ocean.dm"
 #include "code\datums\abilities\critter\powerkick.dm"
 #include "code\datums\abilities\critter\psyblast.dm"
+#include "code\datums\abilities\critter\radiation_blast.dm"
 #include "code\datums\abilities\critter\scuttlebot.dm"
 #include "code\datums\abilities\critter\shedtears.dm"
 #include "code\datums\abilities\critter\singularity.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the gibstare on Martian Mutants with the ability to cause radiation blasts (from rad storm).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think having standard critters gib (not just kill) is a bit much.
Players learning about these critters have to get used to a very dangerous ability, this ability is also unique in that it gibs at range and all martians are carrying a 7 second stun retaliation ability.
The radiation blasts keep a "zone control" mechanic to the martians without being as lethal. Radiation is still fairly bad for you!

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(+)Martian Mutants gib ability has been swapped out for a radiation blast.
```
