### PR TITLE
donut2 camera reduction

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -25833,6 +25833,12 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light/incandescent,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/ptl)
 "geo" = (
@@ -32920,12 +32926,6 @@
 /area/station/bridge)
 "lmg" = (
 /obj/machinery/light_switch/east,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/item/device/radio/intercom/engineering{
 	dir = 8
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -14,12 +14,16 @@
 /turf/space/asteroid,
 /area/space)
 "aae" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir-b"
+/obj/pool/perspective{
+	dir = 4;
+	tag = "icon-pool (EAST)"
 	},
-/turf/space,
-/area/space)
+/obj/machinery/camera{
+	c_tag = "Emergency Storage";
+	dir = 10
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "aaf" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -33,9 +37,7 @@
 /area/space)
 "aah" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/communications_dish{
-	name = "Communications dish"
-	},
+/obj/machinery/communications_dish,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -266,8 +268,7 @@
 /area/space)
 "aaY" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
@@ -277,8 +278,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -344,7 +344,6 @@
 /area/listeningpost)
 "abl" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	dir = 8;
 	frequency = 1485;
 	name = "Security Intercom"
@@ -401,8 +400,7 @@
 /area/listeningpost)
 "abt" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/clothing/under/misc/syndicate,
@@ -442,8 +440,7 @@
 "abA" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
@@ -457,8 +454,7 @@
 /area/listeningpost)
 "abE" = (
 /obj/submachine/ATM{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -505,10 +501,8 @@
 /obj/decal/glow{
 	brightness = 3;
 	color_b = 0.35;
-	color_g = 0.35;
 	color_r = 0.35;
 	invisibility = 101;
-	luminosity = 0;
 	name = "glow - WHITE"
 	},
 /turf/simulated/floor/red,
@@ -527,8 +521,7 @@
 /area/listeningpost)
 "abM" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -567,7 +560,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/listeningpost)
@@ -711,12 +703,20 @@
 /turf/space,
 /area/space)
 "acG" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "acK" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
@@ -762,7 +762,6 @@
 /area/station/science/lobby)
 "adv" = (
 /obj/overlay{
-	anchored = 1;
 	icon = 'icons/misc/beach2.dmi';
 	icon_state = "palm1";
 	layer = 10;
@@ -860,8 +859,7 @@
 /area/station/science/chemistry)
 "adO" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/science/lobby)
@@ -948,8 +946,7 @@
 "aes" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -980,8 +977,7 @@
 "aeC" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -1107,8 +1103,7 @@
 /area/station/science/chemistry)
 "aff" = (
 /obj/stool/chair/office/purple{
-	dir = 8;
-	icon_state = "office_chair_purple"
+	dir = 8
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
@@ -1452,8 +1447,7 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -1521,8 +1515,7 @@
 "agX" = (
 /obj/landmark/spawner/artifact,
 /obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /obj/window/reinforced{
 	dir = 8
@@ -1532,8 +1525,7 @@
 "agY" = (
 /obj/landmark/spawner/artifact,
 /obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/hor)
@@ -1566,7 +1558,6 @@
 /obj/item/crowbar,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1576,7 +1567,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1678,7 +1668,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1686,7 +1675,6 @@
 "ahF" = (
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1697,7 +1685,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1713,15 +1700,13 @@
 /area/station/science/lobby)
 "ahI" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "ahJ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/purple/corner{
@@ -1731,8 +1716,7 @@
 "ahK" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -1749,13 +1733,11 @@
 "ahN" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
-	dir = 2;
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -1763,8 +1745,7 @@
 /area/station/science/lobby)
 "ahO" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/purple/corner{
@@ -1786,8 +1767,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -1797,8 +1777,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -1809,8 +1788,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -1824,8 +1802,7 @@
 	pixel_y = 32
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -1840,8 +1817,7 @@
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -1856,21 +1832,18 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 2;
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aic" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -1881,8 +1854,7 @@
 /area/station/science/lobby)
 "aid" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -1904,8 +1876,7 @@
 /area/station/chapel/sanctuary)
 "aif" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -1930,7 +1901,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -1985,8 +1955,7 @@
 /area/station/science/lobby)
 "aiD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/storage/crate/adventure,
 /turf/simulated/floor/green/corner,
@@ -2005,8 +1974,7 @@
 "aiI" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -2016,17 +1984,13 @@
 /area/station/science/lobby)
 "aiK" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
+/turf/simulated/floor/neutral/side,
 /area/station/science/lobby)
 "aiL" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -2253,7 +2217,6 @@
 /obj/stool/bed,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -2261,7 +2224,6 @@
 "ajY" = (
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -2272,7 +2234,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -2696,13 +2657,6 @@
 	desc = "A black countertop table for storing kitchen-y objects.";
 	name = "kitchen counter"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	network = "Armory Perimeter";
-	tag = ""
-	},
 /obj/random_item_spawner/snacks/one,
 /obj/random_item_spawner/snacks/maybe_few,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -2812,8 +2766,7 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "ann" = (
@@ -2855,9 +2808,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "anM" = (
 /turf/simulated/wall/auto/supernorn,
@@ -2880,8 +2831,7 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "anY" = (
@@ -2899,8 +2849,7 @@
 /obj/item/crowbar,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aoa" = (
@@ -2924,21 +2873,17 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aol" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/unsimulated/floor/arrival{
 	dir = 8
@@ -2973,8 +2918,7 @@
 "aow" = (
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aox" = (
@@ -2983,22 +2927,18 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aoy" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "aoz" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/researchshuttle)
@@ -3051,16 +2991,14 @@
 /obj/random_item_spawner/dressup/one_or_zero,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aoL" = (
 /obj/machinery/light/incandescent,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "aoM" = (
@@ -3143,9 +3081,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/space,
@@ -3403,8 +3339,7 @@
 /area/station/hangar/main)
 "aqw" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -3416,8 +3351,7 @@
 /area/station/hangar/main)
 "aqz" = (
 /obj/machinery/r_door_control{
-	id = "hangar_podbay1";
-	pixel_x = 0
+	id = "hangar_podbay1"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -3512,8 +3446,7 @@
 /area/station/hallway/secondary/exit)
 "aqO" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /turf/simulated/floor/escape{
 	dir = 5
@@ -3561,7 +3494,6 @@
 /obj/machinery/power/data_terminal,
 /obj/stool/chair/couch/green{
 	dir = 8;
-	icon_state = "chair_couch-green";
 	name = "ratty green couch"
 	},
 /turf/simulated/floor/plating,
@@ -3569,7 +3501,6 @@
 "aqW" = (
 /obj/stool/chair/couch/green{
 	dir = 4;
-	icon_state = "chair_couch-green";
 	name = "ratty green couch"
 	},
 /obj/submachine/GTM{
@@ -3670,8 +3601,7 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Bay West";
 	dir = 4;
-	name = "Security Camera";
-	network = "SS13"
+	name = "Security Camera"
 	},
 /obj/machinery/nanofab/refining,
 /obj/machinery/phone/wall{
@@ -3744,16 +3674,17 @@
 /turf/simulated/floor/stairs,
 /area/station/hangar/main)
 "arI" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
+	dir = 10;
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/purple/side,
+/area/station/hallway/primary/south)
 "arJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
@@ -3786,8 +3717,7 @@
 /area/station/maintenance/west)
 "arU" = (
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -3853,9 +3783,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/quartermaster/office)
 "ase" = (
 /obj/item/device/radio/intercom{
@@ -3879,8 +3807,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /turf/simulated/floor/scorched,
 /area/station/maintenance/north)
@@ -3912,8 +3839,7 @@
 /area/ghostdrone_factory)
 "ast" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -4049,14 +3975,6 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
-"ata" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room Maint";
-	c_tag_order = 999;
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "atb" = (
 /obj/stool/chair{
 	dir = 1
@@ -4072,8 +3990,7 @@
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4082,8 +3999,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -4098,8 +4014,7 @@
 "atg" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/escape/corner{
 	dir = 1
@@ -4108,8 +4023,7 @@
 "ath" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4128,7 +4042,6 @@
 	dir = 9
 	},
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -4222,14 +4135,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
+	pixel_x = 24
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4322,7 +4228,6 @@
 "auc" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "showerhead";
 	pixel_y = 6
 	},
 /turf/simulated/floor/sanitary,
@@ -4330,7 +4235,6 @@
 "auf" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "showerhead";
 	pixel_y = 6
 	},
 /turf/simulated/floor/sanitary,
@@ -4418,8 +4322,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4498,8 +4401,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4539,8 +4441,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -4565,8 +4466,7 @@
 "auY" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -4834,8 +4734,7 @@
 "awn" = (
 /obj/shrub,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -4885,8 +4784,7 @@
 /area/station/hangar/main)
 "awC" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5;
@@ -5132,7 +5030,6 @@
 /obj/table/wood/auto,
 /obj/decoration/floralarrangement,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
@@ -5205,8 +5102,7 @@
 "axB" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -5221,7 +5117,6 @@
 "axE" = (
 /obj/disposalpipe/segment{
 	dir = 4;
-	icon_state = "pipe-s";
 	name = "factory pipe"
 	},
 /turf/simulated/floor/plating/random,
@@ -5264,24 +5159,21 @@
 /area/station/hallway/primary/north)
 "axQ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axR" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axS" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -5301,8 +5193,7 @@
 /area/station/hallway/primary/north)
 "axW" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
@@ -5321,13 +5212,10 @@
 /area/station/hallway/primary/north)
 "axY" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/neutral/corner{
-	dir = 2
-	},
+/turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/north)
 "axZ" = (
 /obj/disposalpipe/switch_junction{
@@ -5340,8 +5228,7 @@
 /area/station/hallway/primary/north)
 "aya" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
@@ -5356,8 +5243,7 @@
 /area/station/hallway/primary/north)
 "ayc" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/neutral/side,
@@ -5507,7 +5393,6 @@
 "ayC" = (
 /obj/disposalpipe/segment{
 	dir = 4;
-	icon_state = "pipe-s";
 	name = "factory pipe"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -5682,8 +5567,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -5791,8 +5675,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/west)
 "azL" = (
@@ -5807,8 +5690,7 @@
 /area/station/hallway/primary/north)
 "azM" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -5817,8 +5699,7 @@
 /area/station/hallway/primary/north)
 "azN" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -5833,12 +5714,6 @@
 "azQ" = (
 /obj/cable{
 	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"azS" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance North"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -5920,10 +5795,6 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/hangar/main)
 "aAi" = (
-/obj/machinery/camera{
-	c_tag = "Crew Quarters";
-	dir = 1
-	},
 /obj/machinery/light/incandescent,
 /obj/rack,
 /obj/item/storage/belt/utility{
@@ -5943,8 +5814,7 @@
 	},
 /obj/item/device/light/flashlight,
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
@@ -5955,8 +5825,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /turf/simulated/floor/dojo/sand/circle,
 /area/station/chapel/sanctuary)
@@ -6052,10 +5921,6 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel East";
-	dir = 8
-	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "aAz" = (
@@ -6147,8 +6012,7 @@
 "aBa" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -6198,8 +6062,7 @@
 /area/station/maintenance/inner/central)
 "aBi" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -6270,8 +6133,7 @@
 "aBB" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -6288,8 +6150,7 @@
 /area/station/hallway/primary/north)
 "aBD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -6297,8 +6158,7 @@
 /area/station/hallway/primary/north)
 "aBF" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/neutral/side{
@@ -6316,8 +6176,7 @@
 /area/station/hallway/primary/north)
 "aBH" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -6444,7 +6303,6 @@
 "aCn" = (
 /obj/machinery/camera{
 	c_tag = "South Hallway East";
-	c_tag_order = 999;
 	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
@@ -6454,8 +6312,7 @@
 "aCo" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -6464,15 +6321,13 @@
 /area/station/hallway/primary/north)
 "aCp" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aCq" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -6698,8 +6553,7 @@
 /area/station/chapel/office)
 "aCU" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -6712,8 +6566,7 @@
 /area/station/chapel/office)
 "aCV" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -6804,8 +6657,7 @@
 "aDl" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -6816,8 +6668,7 @@
 "aDo" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -6887,15 +6738,13 @@
 /area/station/chapel/sanctuary)
 "aDv" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/chapel/sanctuary)
 "aDw" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -6941,7 +6790,6 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/office)
@@ -7003,8 +6851,7 @@
 /obj/machinery/camera{
 	c_tag = "West Maintenance External Access";
 	dir = 4;
-	name = "Security Camera";
-	network = "SS13"
+	name = "Security Camera"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -7090,8 +6937,7 @@
 	},
 /obj/machinery/light/small/floor,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red/decal/outercross,
 /area/station/chapel/sanctuary)
@@ -7103,8 +6949,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/office)
@@ -7114,8 +6959,7 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/office)
@@ -7269,7 +7113,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -7332,8 +7175,7 @@
 	location = "Chapel Hallway"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -7374,13 +7216,11 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
 "aFl" = (
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
@@ -7423,8 +7263,7 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/chapel/sanctuary)
@@ -7502,13 +7341,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
-"aFK" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aFT" = (
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -7565,7 +7397,6 @@
 "aGb" = (
 /obj/xmastree/ephemeral,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
@@ -7733,12 +7564,6 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/item/paper_bin,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -7750,8 +7575,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/chapel/sanctuary)
@@ -7767,8 +7591,7 @@
 /area/station/maintenance/northeast)
 "aGU" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northeast)
@@ -7839,10 +7662,6 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "aHx" = (
-/obj/machinery/camera{
-	c_tag = "Pool";
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -7856,7 +7675,6 @@
 /obj/machinery/light/incandescent,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -7868,15 +7686,13 @@
 /obj/machinery/light/incandescent,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
 /area/shuttle/research/outpost)
 "aHB" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /turf/simulated/floor/dojo/sand/horizontal,
 /area/station/chapel/sanctuary)
@@ -7941,8 +7757,7 @@
 	},
 /obj/item/cable_coil/cut,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/west)
 "aHT" = (
@@ -8128,15 +7943,13 @@
 /area/station/maintenance/west)
 "aIF" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "aIJ" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -8144,8 +7957,7 @@
 /area/station/hallway/primary/north)
 "aIK" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -8181,17 +7993,6 @@
 /obj/item/rubberduck,
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
-"aIS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "East Hallway North";
-	c_tag_order = 999;
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
 "aIT" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 4
@@ -8327,8 +8128,7 @@
 /area/station/hallway/primary/east)
 "aJA" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -8430,8 +8230,7 @@
 /area/station/maintenance/west)
 "aJX" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -8456,8 +8255,7 @@
 "aKf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/research)
@@ -8496,8 +8294,7 @@
 /area/station/hallway/primary/north)
 "aKr" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -8509,8 +8306,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -8570,9 +8366,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -8643,12 +8437,10 @@
 /area/station/medical/medbay/pharmacy)
 "aKV" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -8702,8 +8494,7 @@
 /area/station/crew_quarters/arcade)
 "aLm" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/corner{
 	dir = 4
@@ -8711,12 +8502,10 @@
 /area/station/hallway/primary/east)
 "aLn" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -8724,8 +8513,7 @@
 /area/station/hallway/primary/east)
 "aLo" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -8734,8 +8522,7 @@
 "aLp" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -8743,8 +8530,7 @@
 /area/station/hallway/primary/east)
 "aLq" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/arrival/corner{
 	dir = 1
@@ -8872,8 +8658,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -8899,15 +8684,13 @@
 	pixel_y = 9
 	},
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/item/storage/box/lglo_kit{
 	pixel_y = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -8925,8 +8708,7 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/chapel/sanctuary)
@@ -8951,8 +8733,7 @@
 /area/station/hallway/primary/east)
 "aMj" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -9006,8 +8787,7 @@
 /area/station/hallway/primary/west)
 "aMy" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
@@ -9198,8 +8978,7 @@
 /obj/item/pen,
 /obj/item/pen/fancy,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -9233,20 +9012,9 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
-"aNs" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance";
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aNt" = (
 /obj/machinery/camera{
 	c_tag = "East Hallway MidFore";
-	c_tag_order = 999;
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -9295,8 +9063,7 @@
 "aNL" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -9356,6 +9123,10 @@
 	pixel_x = -1;
 	pixel_y = 4
 	},
+/obj/machinery/camera{
+	c_tag = "East Hallway MidFore";
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -9394,8 +9165,7 @@
 "aOd" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -9410,15 +9180,13 @@
 	icon_state = "plant"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aOf" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -9476,7 +9244,6 @@
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "aOp" = (
-/obj/machinery/camera,
 /obj/decal/cleanable/dirt/dirt5,
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -9610,8 +9377,7 @@
 "aOR" = (
 /obj/landmark/start/job/detective,
 /obj/stool/chair/comfy/red{
-	dir = 8;
-	icon_state = "chair_comfy-red"
+	dir = 8
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet{
@@ -9721,7 +9487,6 @@
 /obj/decal/cleanable/desk_clutter,
 /obj/machinery/light/lamp/green,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
@@ -9825,11 +9590,6 @@
 /area/station/security/detectives_office)
 "aQb" = (
 /obj/storage/closet/fire,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -10004,8 +9764,7 @@
 /obj/machinery/power/apc/autoname_south,
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/vending/security,
 /turf/simulated/floor/carpet/grime,
@@ -10083,8 +9842,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -10117,8 +9875,7 @@
 "aRl" = (
 /obj/storage/secure/closet/medical/cloning,
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/decal/poster/wallsign/poster_human{
 	pixel_y = 30
@@ -10183,8 +9940,7 @@
 /area/station/hangar/science)
 "aRB" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -10221,9 +9977,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/red/side{
@@ -10265,8 +10019,7 @@
 "aRQ" = (
 /obj/critter/parrot/random,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -10364,17 +10117,6 @@
 "aSt" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
-"aSw" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
 "aSA" = (
 /obj/stool/chair/blue{
 	dir = 1
@@ -10517,8 +10259,7 @@
 /area/station/crew_quarters/captain)
 "aTm" = (
 /obj/shrub{
-	dir = 4;
-	icon_state = "shrub"
+	dir = 4
 	},
 /obj/decal/cleanable/dirt/dirt3,
 /obj/disposaloutlet{
@@ -10581,8 +10322,7 @@
 /area/space)
 "aTE" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -10681,8 +10421,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/restroom)
@@ -10763,8 +10502,7 @@
 /area/station/medical/morgue)
 "aUj" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -10797,9 +10535,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aUq" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance"
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -10824,8 +10559,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -10872,13 +10606,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/west,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
@@ -10906,8 +10633,7 @@
 /area/station/medical/medbay)
 "aUL" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet{
@@ -11090,8 +10816,7 @@
 /area/station/maintenance/inner/central)
 "aVG" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -11102,8 +10827,7 @@
 /area/station/maintenance/inner/central)
 "aVI" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -11182,8 +10906,7 @@
 /area/station/medical/medbay/surgery)
 "aWa" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/table/glass/auto,
 /obj/item/reagent_containers/food/snacks/plant/banana{
@@ -11240,7 +10963,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
@@ -11414,8 +11136,7 @@
 "aWT" = (
 /obj/machinery/disposal,
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/white,
@@ -11432,9 +11153,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/bluewhite{
@@ -11555,14 +11274,11 @@
 	name = "mail chute-'Medbay'"
 	},
 /obj/item/device/radio/intercom/medical,
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "aXD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -11570,8 +11286,7 @@
 /area/station/medical/medbay/lobby)
 "aXE" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
@@ -11593,8 +11308,7 @@
 "aXI" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -11619,8 +11333,7 @@
 /area/station/bridge)
 "aXY" = (
 /obj/machinery/camera{
-	c_tag = "Bridge Entrance";
-	dir = 2
+	c_tag = "Bridge Entrance"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -11632,8 +11345,7 @@
 /area/station/bridge)
 "aYb" = (
 /obj/stool/chair/comfy/blue{
-	dir = 4;
-	icon_state = "chair_comfy-blue"
+	dir = 4
 	},
 /obj/landmark/start/job/medical_director,
 /turf/simulated/floor/carpet{
@@ -11670,8 +11382,7 @@
 /area/station/bridge)
 "aYe" = (
 /obj/stool/chair/comfy/blue{
-	dir = 8;
-	icon_state = "chair_comfy-blue"
+	dir = 8
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/carpet{
@@ -11708,16 +11419,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"aYi" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aYj" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -11748,8 +11449,7 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -11798,9 +11498,7 @@
 	dir = 4;
 	level = -1
 	},
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "aYs" = (
 /obj/stool/chair/office/blue{
@@ -11835,16 +11533,6 @@
 "aYy" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/west)
-"aYz" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance West";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aYA" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -11854,9 +11542,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aYF" = (
-/obj/machinery/the_singularitygen{
-	bhole = 0
-	},
+/obj/machinery/the_singularitygen,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aYL" = (
@@ -11864,7 +11550,6 @@
 	charge = 5e+006;
 	chargelevel = 5000;
 	chargemode = 0;
-	online = 1;
 	output = 2500;
 	tag = ""
 	},
@@ -11876,7 +11561,6 @@
 "aYO" = (
 /obj/machinery/camera{
 	c_tag = "East Hallway Center";
-	c_tag_order = 999;
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -11890,8 +11574,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -11903,8 +11586,7 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -11922,8 +11604,7 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	dir = 4;
-	icon_state = "chair_comfy-blue"
+	dir = 4
 	},
 /obj/landmark/start/job/research_director,
 /turf/simulated/floor/carpet{
@@ -11953,8 +11634,7 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	dir = 8;
-	icon_state = "chair_comfy-blue"
+	dir = 8
 	},
 /obj/landmark/start/job/captain,
 /turf/simulated/floor/carpet{
@@ -11994,8 +11674,7 @@
 /obj/machinery/vending/port_a_nanomed,
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -12013,8 +11692,7 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
@@ -12026,17 +11704,13 @@
 	pixel_y = -20
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "aZi" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -12082,8 +11756,7 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	dir = 8;
-	icon_state = "chair_comfy-blue"
+	dir = 8
 	},
 /obj/landmark/start/job/head_of_security,
 /turf/simulated/floor/carpet{
@@ -12109,21 +11782,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"aZy" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/maintenance/west)
 "aZz" = (
 /obj/submachine/laundry_machine,
 /obj/item/sponge{
@@ -12166,8 +11824,7 @@
 /area/station/medical/medbay/lobby)
 "aZG" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -12195,7 +11852,6 @@
 	charge = 5e+006;
 	chargelevel = 5000;
 	chargemode = 0;
-	online = 1;
 	output = 2500;
 	tag = ""
 	},
@@ -12213,8 +11869,7 @@
 /area/station/engine/substation/east)
 "aZV" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -12226,8 +11881,7 @@
 /area/station/science/lobby)
 "aZW" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/table/reinforced/bar/auto{
 	name = "sturdy wooden table"
@@ -12251,15 +11905,12 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/bank_data,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
 "aZY" = (
-/obj/machinery/computer/security{
-	dir = 2
-	},
+/obj/machinery/computer/security,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -12579,7 +12230,6 @@
 /area/station/bridge)
 "bbc" = (
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/bridge)
@@ -12599,9 +12249,7 @@
 /area/station/bridge)
 "bbf" = (
 /obj/storage/closet/office,
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "bbj" = (
 /obj/item_dispenser/latex_gloves,
@@ -12631,8 +12279,7 @@
 /area/station/medical/staff)
 "bbm" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 10
@@ -12718,13 +12365,10 @@
 /area/station/medical/medbay/treatment)
 "bbE" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
+/turf/simulated/floor/neutral/side,
 /area/station/science/lobby)
 "bbF" = (
 /obj/cable{
@@ -12754,8 +12398,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -12763,8 +12406,7 @@
 /area/station/medical/medbay/treatment)
 "bbP" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -12792,8 +12434,7 @@
 /area/space)
 "bbT" = (
 /obj/stool/chair/couch{
-	dir = 8;
-	icon_state = "chair_couch-brown"
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -12812,8 +12453,7 @@
 /area/station/crew_quarters/jazz)
 "bbV" = (
 /obj/stool/chair/couch{
-	dir = 4;
-	icon_state = "chair_couch-brown"
+	dir = 4
 	},
 /obj/item/cigpacket/propuffs{
 	rand_pos = 0
@@ -12825,13 +12465,6 @@
 /area/station/crew_quarters/jazz)
 "bbW" = (
 /obj/storage/closet/welding_supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bbX" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance";
-	dir = 10
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bbZ" = (
@@ -12886,8 +12519,7 @@
 /area/station/engine/inner)
 "bcq" = (
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -12915,8 +12547,7 @@
 /area/station/crew_quarters/jazz)
 "bcu" = (
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -12926,8 +12557,7 @@
 "bcv" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
@@ -12982,9 +12612,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bcF" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen"
-	},
 /obj/shrub{
 	dir = 4;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -13041,16 +12668,13 @@
 /area/station/crew_quarters/jazz)
 "bdo" = (
 /obj/submachine/ATM{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -13061,7 +12685,6 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	dir = 4;
 	frequency = 1485;
 	name = "Station Intercom (Security)"
@@ -13078,8 +12701,7 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/machinery/camera{
 	c_tag = "Heads of Staff's Quarters";
-	dir = 6;
-	icon_state = "camera"
+	dir = 6
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -13171,8 +12793,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -13218,7 +12839,6 @@
 	name = "glow - YELLOW"
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred6"
 	},
 /area/station/crew_quarters/jazz)
@@ -13227,22 +12847,18 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/red/corner{
-	dir = 2
-	},
+/turf/simulated/floor/red/corner,
 /area/station/hallway/primary/east)
 "bdY" = (
 /obj/machinery/light/emergency,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
 "bdZ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
@@ -13311,11 +12927,9 @@
 "bev" = (
 /obj/storage/secure/closet/command/hop,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
@@ -13332,7 +12946,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
@@ -13361,7 +12974,6 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
@@ -13445,8 +13057,7 @@
 /area/station/maintenance/east)
 "beS" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/pharmacy)
@@ -13609,8 +13220,7 @@
 /area/station/maintenance/disposal)
 "bfS" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -13634,39 +13244,21 @@
 	},
 /area/station/hallway/primary/west)
 "bfZ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/carpet/blue/fancy/narrow/east,
 /area/station/medical/medbay/treatment1)
-"bgb" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "bgc" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/machinery/vending/snack,
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -13675,8 +13267,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/decal/poster/wallsign/chsl{
 	pixel_y = 30
@@ -13694,8 +13285,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -13708,7 +13298,6 @@
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance East Airlock";
 	dir = 6;
-	icon_state = "camera";
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -13786,8 +13375,7 @@
 /area/station/medical/staff)
 "bgE" = (
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -13945,7 +13533,6 @@
 /area/station/hallway/primary/west)
 "bhk" = (
 /obj/overlay{
-	anchored = 1;
 	icon = 'icons/misc/beach2.dmi';
 	icon_state = "palm1";
 	layer = 10;
@@ -13967,8 +13554,7 @@
 "bhu" = (
 /obj/machinery/light/incandescent,
 /obj/shrub{
-	dir = 6;
-	icon_state = "shrub"
+	dir = 6
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -13988,8 +13574,7 @@
 /area/station/hallway/primary/east)
 "bhy" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -14051,8 +13636,7 @@
 "bhN" = (
 /obj/machinery/camera{
 	c_tag = "Security West";
-	dir = 6;
-	icon_state = "camera"
+	dir = 6
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
@@ -14115,8 +13699,7 @@
 	max_lines = 350;
 	mode = 1;
 	name = "Security Recorder";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/item/remote/porter/port_a_brig{
 	pixel_x = 10
@@ -14158,8 +13741,7 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -14222,8 +13804,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/restroom)
@@ -14312,18 +13893,14 @@
 	pixel_y = 3
 	},
 /obj/item/plate,
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy{
-	name = "spaghetti arrabbiata"
-	},
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/hos)
 "biQ" = (
 /obj/stool/chair/comfy{
-	dir = 8;
-	icon_state = "chair_comfy"
+	dir = 8
 	},
 /obj/landmark/gps_waypoint,
 /obj/blind_switch/area/south{
@@ -14333,7 +13910,6 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/hos)
@@ -14343,7 +13919,6 @@
 	},
 /obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/hos)
@@ -14358,7 +13933,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/hos)
@@ -14385,8 +13959,7 @@
 /area/station/hallway/primary/west)
 "bjd" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -14397,9 +13970,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/bluewhite{
@@ -14423,19 +13994,9 @@
 	dir = 10
 	},
 /area/station/medical/medbay/cloner)
-"bjk" = (
-/obj/machinery/camera{
-	c_tag = "Medical Research East";
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/dirt5,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "bjl" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /obj/landmark/start/job/medical_doctor,
 /obj/machinery/light/incandescent/cool/very,
@@ -14596,8 +14157,7 @@
 /area/station/security/main)
 "bkv" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/recharger/wall/sticky{
 	dir = 1
@@ -14695,8 +14255,7 @@
 /area/station/security/processing)
 "bkJ" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door_timer/solitary2/new_walls/north,
 /turf/simulated/floor/redblack{
@@ -14806,22 +14365,18 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/red/corner{
-	dir = 2
-	},
+/turf/simulated/floor/red/corner,
 /area/station/hallway/primary/south)
 "blz" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "blA" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
@@ -14871,8 +14426,7 @@
 /area/station/security/main)
 "blI" = (
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -15030,7 +14584,6 @@
 "bmv" = (
 /obj/stool/chair/office/red{
 	dir = 8;
-	icon_state = "office_chair_red";
 	tag = "icon-office_chair_red (WEST)"
 	},
 /turf/simulated/floor,
@@ -15071,8 +14624,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -15099,8 +14651,7 @@
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
@@ -15109,8 +14660,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -15122,8 +14672,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
@@ -15135,8 +14684,7 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
@@ -15150,15 +14698,13 @@
 "bmK" = (
 /obj/disposalpipe/segment/ejection,
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
 "bmL" = (
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -15167,8 +14713,7 @@
 /area/station/security/processing)
 "bmM" = (
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
@@ -15208,8 +14753,7 @@
 /obj/machinery/door_control{
 	id = "store2";
 	name = "Door Toggle";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/stool,
 /obj/landmark/start/job/assistant,
@@ -15281,8 +14825,7 @@
 	pixel_x = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Security";
-	network = "SS13"
+	c_tag = "Security"
 	},
 /obj/item/storage/box/trackimp_kit{
 	pixel_x = -8
@@ -15465,8 +15008,7 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -15475,8 +15017,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -15488,8 +15029,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -15499,8 +15039,7 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -15545,7 +15084,6 @@
 "bon" = (
 /obj/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-j1";
 	name = "ejection pipe"
 	},
 /turf/simulated/floor/black,
@@ -15605,8 +15143,7 @@
 /area/station/crew_quarters/market)
 "boC" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -15714,8 +15251,7 @@
 /area/station/security/brig)
 "bpk" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -15822,8 +15358,7 @@
 "bpM" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
@@ -15848,7 +15383,6 @@
 /area/station/crew_quarters/courtroom)
 "bpT" = (
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -15939,8 +15473,7 @@
 "bqI" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -15961,20 +15494,15 @@
 /obj/machinery/light/incandescent,
 /obj/machinery/manufacturer/general,
 /obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "bqP" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Storage";
-	dir = 2
+	c_tag = "Engineering Storage"
 	},
 /obj/machinery/shieldgenerator/energy_shield,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "bqQ" = (
 /obj/machinery/shieldgenerator/energy_shield,
@@ -15985,8 +15513,7 @@
 /area/station/engine/storage)
 "bqS" = (
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/blue/side{
@@ -16009,8 +15536,7 @@
 /area/station/hallway/primary/south)
 "bqU" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16062,9 +15588,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /obj/shrub{
@@ -16089,9 +15613,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/space,
@@ -16128,9 +15650,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/space,
@@ -16216,9 +15736,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "brT" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -16230,9 +15748,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "brX" = (
 /turf/simulated/floor/orangeblack/corner{
@@ -16283,15 +15799,13 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bse" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -16371,8 +15885,7 @@
 /area/station/hallway/primary/south)
 "bsD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/south)
@@ -16470,12 +15983,10 @@
 /area/station/crew_quarters/courtroom)
 "btb" = (
 /obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /obj/stool/chair{
 	dir = 4
@@ -16773,8 +16284,7 @@
 /area/station/crew_quarters/juryroom)
 "bvd" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -16842,7 +16352,6 @@
 /area/space)
 "bvx" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -16921,8 +16430,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/yellow/side{
@@ -16931,8 +16439,6 @@
 /area/station/engine/engineering)
 "bvT" = (
 /obj/machinery/door_control/antagscanner{
-	id = "Sleeper_Access";
-	name = "Dubious Hand Scanner";
 	pixel_x = 32
 	},
 /turf/simulated/floor/grey/side{
@@ -16960,8 +16466,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white/checker{
 	dir = 4
@@ -17055,8 +16560,7 @@
 /area/station/maintenance/east)
 "bwn" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -17068,8 +16572,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -17078,15 +16581,13 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "bww" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -17104,15 +16605,13 @@
 /area/station/hallway/primary/south)
 "bwR" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bwS" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -17120,8 +16619,7 @@
 /area/station/hallway/primary/south)
 "bwT" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -17160,8 +16658,7 @@
 	dir = 9
 	},
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -17216,8 +16713,7 @@
 "bxg" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -17447,8 +16943,7 @@
 /area/station/turret_protected/ai_upload)
 "bym" = (
 /obj/shrub{
-	dir = 4;
-	icon_state = "shrub"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side{
@@ -17459,21 +16954,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "byo" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "byp" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "byq" = (
 /obj/machinery/light/incandescent,
@@ -17486,12 +16975,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/power_monitor{
-	dir = 4;
-	icon_state = "power"
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -17552,8 +17039,7 @@
 /area/station/maintenance/disposal)
 "byC" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -17575,15 +17061,13 @@
 "byG" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "byJ" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -17751,12 +17235,10 @@
 	icon_state = "1-2"
 	},
 /obj/stool/chair/office/yellow{
-	dir = 1;
-	icon_state = "office_chair_yellow"
+	dir = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
@@ -17782,8 +17264,7 @@
 /area/station/hallway/primary/south)
 "bAa" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -17795,8 +17276,7 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -17811,12 +17291,10 @@
 /area/station/hallway/primary/south)
 "bAd" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -17824,32 +17302,22 @@
 /area/station/hallway/primary/south)
 "bAe" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"bAf" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "bAh" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bAi" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/table/auto,
 /obj/item/storage/firstaid/regular{
@@ -18057,8 +17525,7 @@
 /area/station/maintenance/disposal)
 "bAY" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
@@ -18066,14 +17533,6 @@
 /obj/machinery/conveyor/WS{
 	id = "garbage";
 	move_lag = 15
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
 	},
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/plating,
@@ -18083,8 +17542,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -18161,15 +17619,13 @@
 /area/station/engine/elect)
 "bBz" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/corner,
 /area/station/hallway/primary/south)
 "bBB" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -18177,8 +17633,7 @@
 /area/station/hallway/primary/south)
 "bBC" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/item/caution{
 	desc = "Caution! Room full of death!";
@@ -18193,8 +17648,7 @@
 /area/station/hallway/primary/south)
 "bBD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/blue/side{
@@ -18203,8 +17657,7 @@
 /area/station/hallway/primary/south)
 "bBE" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/corner{
 	dir = 8
@@ -18212,8 +17665,7 @@
 /area/station/hallway/primary/south)
 "bBG" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
@@ -18239,8 +17691,7 @@
 /area/station/storage/tools)
 "bBK" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -18250,8 +17701,7 @@
 /area/station/storage/tools)
 "bBL" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/table/auto,
 /obj/item/crowbar,
@@ -18261,8 +17711,7 @@
 /area/station/storage/tools)
 "bBM" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/table/auto,
 /obj/item/storage/belt/utility,
@@ -18271,8 +17720,7 @@
 /area/station/storage/tools)
 "bBN" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -18405,8 +17853,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor,
 /area/station/storage/tools)
@@ -18696,8 +18143,7 @@
 /area/station/maintenance/disposal)
 "bDV" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -19120,15 +18566,12 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -19281,8 +18724,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/aisat)
 "bGr" = (
@@ -19295,8 +18737,7 @@
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
@@ -19343,9 +18784,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -19393,8 +18832,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/aisat)
 "bGK" = (
@@ -19414,9 +18852,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/space,
@@ -19507,7 +18943,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -19667,8 +19102,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/south)
 "bHO" = (
@@ -19676,8 +19110,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "bHP" = (
@@ -19688,8 +19121,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "bHQ" = (
@@ -19717,8 +19149,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "bHU" = (
@@ -19795,8 +19226,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/east)
 "bId" = (
@@ -19846,7 +19276,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -19896,8 +19325,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "bIl" = (
@@ -20001,8 +19429,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/mining/magnet)
 "bIA" = (
@@ -20049,8 +19476,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/south)
 "bID" = (
@@ -20175,8 +19601,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/mining/magnet)
 "bIT" = (
@@ -20220,7 +19645,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -20239,7 +19663,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -20290,8 +19713,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
@@ -20354,8 +19776,7 @@
 /area/station/quartermaster/office)
 "bMo" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable/blue{
 	icon_state = "4-8"
@@ -20368,16 +19789,14 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "bMF" = (
 /obj/machinery/firealarm/west,
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /turf/simulated/floor/escape{
 	dir = 8
@@ -20403,8 +19822,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -20423,8 +19841,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -20438,8 +19855,7 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
@@ -20633,8 +20049,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -20686,13 +20101,6 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bYJ" = (
@@ -20732,13 +20140,11 @@
 /area/station/science/lobby)
 "cav" = (
 /obj/shrub{
-	dir = 6;
-	icon_state = "shrub"
+	dir = 6
 	},
 /obj/decal/cleanable/dirt/dirt3,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -20819,8 +20225,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -20924,8 +20329,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -20934,8 +20338,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -21134,8 +20537,6 @@
 /area/station/crew_quarters/toilets)
 "cti" = (
 /obj/machinery/door_control/antagscanner{
-	id = "Sleeper_Access";
-	name = "Dubious Hand Scanner";
 	pixel_y = 25
 	},
 /turf/simulated/floor/stairs{
@@ -21155,8 +20556,7 @@
 /area/station/wreckage)
 "cvm" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -21282,8 +20682,7 @@
 /area/station/hallway/primary/south)
 "cAb" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /obj/storage/crate/adventure,
@@ -21318,7 +20717,6 @@
 /obj/cable/yellow,
 /obj/machinery/power/tracker/east,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -21354,13 +20752,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "cCj" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/barber_shop)
 "cCt" = (
@@ -21445,15 +20836,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "cEz" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -21466,13 +20854,11 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	dir = 4;
-	icon_state = "chair_comfy-blue"
+	dir = 4
 	},
 /obj/landmark/start/job/chief_engineer,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -21555,16 +20941,6 @@
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
-"cHY" = (
-/obj/cable/blue{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "cIh" = (
 /obj/machinery/hydro_growlamp,
 /obj/cable{
@@ -21655,7 +21031,6 @@
 	},
 /obj/machinery/secscanner{
 	dir = 4;
-	icon_state = "scanner_on";
 	pixel_x = -20
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
@@ -21736,8 +21111,7 @@
 /area/station/maintenance/east)
 "cNz" = (
 /obj/machinery/turret{
-	dir = 1;
-	icon_state = "grey_target_prism"
+	dir = 1
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
@@ -21865,8 +21239,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
@@ -21952,9 +21325,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
@@ -22035,8 +21406,7 @@
 /area/station/medical/morgue)
 "cYx" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -22058,9 +21428,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "cZm" = (
 /obj/indestructible/shuttle_corner{
@@ -22079,8 +21447,7 @@
 /area/station/hangar/science)
 "dag" = (
 /obj/machinery/computer/stockexchange{
-	dir = 8;
-	icon_state = "QMreq"
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -22259,8 +21626,7 @@
 /area/station/science/testchamber/bombchamber)
 "dio" = (
 /obj/stool/chair/comfy{
-	dir = 8;
-	icon_state = "chair_comfy"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/heads{
@@ -22296,16 +21662,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/central)
-"djY" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable/blue{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "dkd" = (
 /obj/storage/crate/freezer,
 /obj/item/reagent_containers/food/snacks/ingredient/meat{
@@ -22390,8 +21746,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -22486,8 +21841,7 @@
 /area/station/maintenance/west)
 "dnP" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -22499,8 +21853,7 @@
 /obj/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/landmark/start/job/clown,
 /obj/landmark/pest,
@@ -22521,8 +21874,7 @@
 /obj/machinery/light/incandescent,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "doQ" = (
@@ -22567,8 +21919,7 @@
 /area/station/crew_quarters/captain)
 "dqA" = (
 /obj/stool/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/item/clothing/suit/monkey,
 /turf/simulated/floor/grass/random,
@@ -22579,8 +21930,7 @@
 /area/station/crew_quarters/pool)
 "dqY" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -22634,8 +21984,7 @@
 /area/space)
 "dsa" = (
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
@@ -22865,8 +22214,6 @@
 "dzG" = (
 /obj/machinery/door_control/antagscanner{
 	entrance_scanner = 1;
-	id = "Sleeper_Access";
-	name = "Dubious Hand Scanner";
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating/airless{
@@ -22923,9 +22270,7 @@
 "dAS" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/arrival{
-	dir = 2
-	},
+/turf/simulated/floor/arrival,
 /area/station/crew_quarters/pool)
 "dAZ" = (
 /obj/cable{
@@ -22978,8 +22323,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -22992,20 +22336,11 @@
 "dEf" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "dEj" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/psychiatrist)
 "dEo" = (
@@ -23201,20 +22536,17 @@
 "dLB" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "dLJ" = (
 /obj/shrub{
-	dir = 8;
-	icon_state = "shrub"
+	dir = 8
 	},
 /obj/decal/cleanable/dirt/dirt5,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -23338,8 +22670,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -23409,12 +22740,10 @@
 /area/station/engine/substation/west)
 "dSS" = (
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -23474,8 +22803,7 @@
 "dVn" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/firealarm/west,
 /obj/stool/bed/moveable,
@@ -23518,8 +22846,7 @@
 /obj/machinery/door_control{
 	id = "dwaine_core";
 	name = "DWAINE Core Shield";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Computer Core";
@@ -23829,8 +23156,7 @@
 /area/station/engine/elect)
 "ege" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -23951,8 +23277,7 @@
 	location = "Engineering Storage"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
@@ -23986,8 +23311,7 @@
 	name = "crematorium pipe"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -24019,8 +23343,7 @@
 /area/station/medical/staff)
 "emT" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /turf/unsimulated/floor/arrival{
 	dir = 1
@@ -24037,8 +23360,7 @@
 /obj/disposalpipe/segment,
 /obj/item/clothing/glasses/sunglasses/tanning,
 /obj/stool/chair/comfy/blue{
-	dir = 8;
-	icon_state = "chair_comfy-blue"
+	dir = 8
 	},
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/plating,
@@ -24082,8 +23404,7 @@
 /area/station/janitor/office)
 "eol" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
@@ -24224,8 +23545,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -24237,8 +23557,7 @@
 /area/station/science/lobby)
 "euk" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/corner{
 	dir = 8
@@ -24270,8 +23589,7 @@
 /area/space)
 "euD" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -24375,8 +23693,7 @@
 "eyb" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/decal/cleanable/oil/streak,
 /turf/simulated/floor/grass/random,
@@ -24422,8 +23739,7 @@
 "eAb" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
@@ -24443,8 +23759,7 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -24464,8 +23779,7 @@
 /area/station/turret_protected/AIsat)
 "eCb" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/morgue{
@@ -24476,7 +23790,6 @@
 /area/station/medical/medbay)
 "eCh" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -24510,8 +23823,7 @@
 /area/station/engine/inner)
 "eDt" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/conveyor/NS{
 	id = "zetadisposals";
@@ -24521,8 +23833,7 @@
 /area/station/maintenance/scidisposal)
 "eDO" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/black/side{
@@ -24674,14 +23985,6 @@
 /obj/disposalpipe/junction{
 	icon_state = "pipe-j2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	network = "SS13";
-	tag = ""
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "eMi" = (
@@ -24723,22 +24026,17 @@
 	name = "Research Outpost Pad"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "eNh" = (
 /obj/decal/cleanable/cobweb,
-/obj/machinery/atmospherics/pipe/tank/sleeping_agent{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/tank/sleeping_agent,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "eNr" = (
-/obj/machinery/vending/pizza{
-	anchored = 1
-	},
+/obj/machinery/vending/pizza,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
@@ -24899,8 +24197,7 @@
 /area/station/quartermaster/refinery)
 "eTw" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -24914,8 +24211,7 @@
 /area/station/crew_quarters/hor)
 "eUb" = (
 /obj/machinery/computer/stockexchange{
-	dir = 8;
-	icon_state = "QMreq"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "West Electrical Substation";
@@ -24957,8 +24253,7 @@
 "eVm" = (
 /obj/landmark/start/job/assistant,
 /obj/stool/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/simulated/floor/black/side{
 	dir = 1
@@ -25018,8 +24313,7 @@
 /area/station/ranch)
 "eWI" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -25038,14 +24332,12 @@
 /obj/item/device/radio,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "eXu" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/black,
@@ -25270,8 +24562,7 @@
 "ffi" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -25338,7 +24629,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -25437,8 +24727,7 @@
 /area/station/medical/medbay/treatment1)
 "fkg" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable/blue{
 	icon_state = "4-8"
@@ -25507,9 +24796,6 @@
 /area/station/crew_quarters/locker)
 "flO" = (
 /obj/machinery/computer/robot_module_rewriter,
-/obj/machinery/camera{
-	c_tag = "Robotics"
-	},
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -25579,7 +24865,6 @@
 "fpK" = (
 /obj/machinery/shower{
 	dir = 4;
-	icon_state = "showerhead";
 	pixel_y = 6
 	},
 /obj/machinery/drainage,
@@ -25596,8 +24881,7 @@
 /area/station/hallway/secondary/researchshuttle)
 "fqv" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -25617,8 +24901,7 @@
 /area/station/hallway/secondary/exit)
 "fqZ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
@@ -25656,8 +24939,7 @@
 /area/station/crew_quarters/observatory)
 "ftm" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/shrub,
 /obj/machinery/status_display{
@@ -25695,7 +24977,6 @@
 /obj/machinery/light/small/floor,
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -25710,8 +24991,7 @@
 /area/station/ranch)
 "fvP" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -25775,8 +25055,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/machinery/emitter{
 	dir = 8
@@ -25805,8 +25084,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/ce)
@@ -25849,8 +25127,7 @@
 /area/station/medical/medbay/treatment)
 "fCw" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
@@ -25881,7 +25158,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -25930,7 +25206,6 @@
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -26030,8 +25305,7 @@
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -26089,7 +25363,6 @@
 /obj/mapping_helper/access/research,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -26103,15 +25376,12 @@
 /area/station/quartermaster/magnet)
 "fJi" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
+/turf/simulated/floor/neutral/side,
 /area/station/science/lobby)
 "fJk" = (
 /obj/machinery/traymachine/locking/crematorium{
@@ -26168,25 +25438,15 @@
 	},
 /obj/machinery/light_switch/west,
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/machinery/light/incandescent,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	network = "SS13";
-	tag = ""
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "fKO" = (
 /obj/machinery/light/incandescent,
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -26296,7 +25556,6 @@
 /area/station/quartermaster/magnet)
 "fQq" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/incandescent,
@@ -26325,8 +25584,7 @@
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -26342,7 +25600,6 @@
 /area/station/quartermaster/magnet)
 "fRR" = (
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "blue1"
 	},
 /area/station/crew_quarters/stockex)
@@ -26356,8 +25613,7 @@
 	req_access = null
 	},
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/mapping_helper/access/ai_upload,
 /obj/landmark/start/job/cyborg,
@@ -26591,8 +25847,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -26629,9 +25884,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "gfs" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "gfx" = (
 /obj/stool/chair{
@@ -26668,8 +25921,7 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -26711,8 +25963,7 @@
 /area/station/ranch)
 "ghP" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -26730,8 +25981,7 @@
 /area/station/medical/medbay/psychiatrist)
 "gjf" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/greenwhite/other{
 	dir = 4
@@ -26755,8 +26005,7 @@
 /obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -27217,9 +26466,7 @@
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "gEp" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -27269,7 +26516,6 @@
 /obj/stool/bar,
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -27287,15 +26533,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"gHE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance North West"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "gHR" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -27310,7 +26547,6 @@
 /area/station/maintenance/west)
 "gIb" = (
 /obj/overlay{
-	anchored = 1;
 	icon = 'icons/misc/beach2.dmi';
 	icon_state = "palm1";
 	layer = 10;
@@ -27318,8 +26554,7 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -27334,8 +26569,7 @@
 /area/station/turret_protected/ai_upload)
 "gIv" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -27362,8 +26596,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -27427,8 +26660,7 @@
 /area/station/ai_monitored/armory)
 "gMY" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/black/side{
 	dir = 9
@@ -27740,7 +26972,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -27751,8 +26982,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -27762,8 +26992,7 @@
 	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -28061,7 +27290,6 @@
 /area/space)
 "hlc" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -28091,8 +27319,7 @@
 "hmk" = (
 /obj/machinery/firealarm/south,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
@@ -28183,8 +27410,7 @@
 /obj/machinery/door_control{
 	id = "cloning_exit";
 	name = "Cloning Exit Door Control";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/cable{
 	icon_state = "0-8"
@@ -28219,9 +27445,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/yellow/side{
@@ -28238,8 +27462,7 @@
 /area/space)
 "hsk" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light_switch/south,
 /turf/simulated/floor,
@@ -28261,8 +27484,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -28275,7 +27497,6 @@
 	charge = 5e+006;
 	chargelevel = 5000;
 	chargemode = 0;
-	online = 1;
 	output = 2500;
 	tag = ""
 	},
@@ -28324,8 +27545,7 @@
 /area/station/bridge)
 "huT" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
@@ -28370,8 +27590,7 @@
 "hwa" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
@@ -28576,8 +27795,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -28589,10 +27807,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "hES" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room North";
-	dir = 10
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -28628,8 +27842,7 @@
 /area/station/crew_quarters/arcade/dungeon)
 "hFZ" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /turf/simulated/floor/greenwhite{
 	dir = 1
@@ -28660,8 +27873,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -28676,8 +27888,7 @@
 "hIR" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/shrub{
-	dir = 10;
-	icon_state = "shrub"
+	dir = 10
 	},
 /obj/cable,
 /turf/simulated/floor/carpet{
@@ -28724,7 +27935,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -28737,8 +27947,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28870,8 +28079,7 @@
 /area/station/maintenance/inner/central)
 "hQX" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/dirt2,
@@ -28897,8 +28105,7 @@
 /area/space)
 "hRG" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable/blue{
 	icon_state = "1-8"
@@ -28967,8 +28174,7 @@
 /area/station/security/processing)
 "hVI" = (
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door_timer/genpop/new_walls/south{
 	pixel_x = 10
@@ -29025,8 +28231,7 @@
 /area/station/turret_protected/ai)
 "hXa" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -29045,8 +28250,7 @@
 "hXn" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -29174,8 +28378,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -29201,8 +28404,7 @@
 /obj/mapping_helper/access/engineering,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -29283,8 +28485,7 @@
 /area/station/turret_protected/ai)
 "ifJ" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
@@ -29311,8 +28512,7 @@
 /area/station/maintenance/inner/central)
 "igq" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/kitchen{
-	current_temperature = 250;
-	dir = 2
+	current_temperature = 250
 	},
 /turf/simulated/floor/specialroom/freezer{
 	nitrogen = 105.86;
@@ -29398,8 +28598,7 @@
 /area/space)
 "ijm" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -29411,18 +28610,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
-"ikc" = (
-/obj/stool/bar,
-/obj/landmark/start/job/assistant,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "ike" = (
 /obj/machinery/hydro_mister,
 /turf/simulated/floor/grey,
@@ -29482,8 +28669,7 @@
 /area/station/crew_quarters/stockex)
 "inq" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/side,
 /area/station/science/lobby)
@@ -29512,8 +28698,7 @@
 /area/station/solar/aisat)
 "iov" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
@@ -29567,8 +28752,7 @@
 	level = 2
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -29671,7 +28855,6 @@
 /obj/item/device/radio/beacon,
 /obj/landmark/pest,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred3"
 	},
 /area/station/crew_quarters/jazz)
@@ -29815,7 +28998,6 @@
 /area/station/janitor/office)
 "iAv" = (
 /obj/disposalpipe/junction{
-	dir = 0;
 	icon_state = "pipe-y"
 	},
 /obj/machinery/navbeacon{
@@ -29839,7 +29021,6 @@
 "iBi" = (
 /obj/machinery/secscanner{
 	dir = 4;
-	icon_state = "scanner_on";
 	pixel_x = -20
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
@@ -29885,8 +29066,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
@@ -29930,7 +29110,6 @@
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -30133,8 +29312,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "iLe" = (
@@ -30246,9 +29424,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "iPp" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
@@ -30427,8 +29603,7 @@
 	panel_open = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -30444,7 +29619,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -30478,7 +29652,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -30492,7 +29665,6 @@
 	pictures_left = 30
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/security/detectives_office)
@@ -30550,7 +29722,6 @@
 "iZm" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -30565,15 +29736,13 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/comfy/blue{
-	dir = 4;
-	icon_state = "chair_comfy-blue"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "jab" = (
 /obj/stool/chair/couch/green{
 	dir = 8;
-	icon_state = "chair_couch-green";
 	name = "ratty green couch"
 	},
 /turf/simulated/floor,
@@ -30687,8 +29856,7 @@
 /area/station/crew_quarters/jazz)
 "jey" = (
 /obj/stool/chair/office/blue{
-	dir = 1;
-	icon_state = "office_chair_blue"
+	dir = 1
 	},
 /obj/landmark/start/job/roboticist,
 /turf/simulated/floor/black,
@@ -30811,9 +29979,7 @@
 /area/station/crew_quarters/quarters)
 "jjT" = (
 /obj/machinery/light/incandescent,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "jjW" = (
 /obj/machinery/door/airlock/pyro/command/alt{
@@ -30870,8 +30036,7 @@
 "jna" = (
 /obj/machinery/camera{
 	c_tag = "East Maintenance";
-	dir = 6;
-	icon_state = "camera"
+	dir = 6
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -30883,8 +30048,7 @@
 /obj/mapping_helper/access/maint,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -30963,8 +30127,7 @@
 /area/station/science/lobby)
 "jps" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/corner,
 /area/station/hallway/primary/south)
@@ -31009,8 +30172,7 @@
 "jrb" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -31091,8 +30253,7 @@
 /area/station/hallway/primary/south)
 "juJ" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/firealarm/north,
 /obj/machinery/light/incandescent,
@@ -31211,8 +30372,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -31318,8 +30478,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
@@ -31383,8 +30542,7 @@
 /area/station/science/lab)
 "jEI" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 10
@@ -31396,8 +30554,7 @@
 	},
 /obj/machinery/firealarm/north,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -31426,7 +30583,6 @@
 "jFs" = (
 /obj/stool/chair/office/red{
 	dir = 8;
-	icon_state = "office_chair_red";
 	tag = "icon-office_chair_red (WEST)"
 	},
 /obj/cable{
@@ -31436,8 +30592,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side{
@@ -31545,8 +30700,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -31579,8 +30733,7 @@
 /area/station/security/brig)
 "jKb" = (
 /obj/stool/chair/couch{
-	dir = 8;
-	icon_state = "chair_couch-brown"
+	dir = 8
 	},
 /obj/landmark/start/job/assistant,
 /obj/decal/poster/wallsign/landscape{
@@ -31612,8 +30765,7 @@
 /area/station/science/artifact)
 "jLw" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -31662,8 +30814,7 @@
 /area/station/crew_quarters/captain)
 "jMX" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -31861,14 +31012,6 @@
 /obj/stool/chair/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
-	},
 /mob/living/critter/small_animal/cockroach,
 /turf/simulated/floor/sanitary/white,
 /area/station/maintenance/west)
@@ -32047,8 +31190,7 @@
 /area/station/crew_quarters/toilets)
 "kdL" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -32134,8 +31276,7 @@
 /area/station/crew_quarters/pool)
 "kiY" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/lattice,
 /turf/space,
@@ -32250,8 +31391,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -32314,9 +31454,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /obj/indestructible/shuttle_corner{
@@ -32324,14 +31462,12 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "kmU" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -32456,7 +31592,6 @@
 "krp" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold{
-	dir = 2;
 	level = 2
 	},
 /turf/simulated/floor/specialroom/freezer{
@@ -32466,8 +31601,7 @@
 /area/station/crew_quarters/kitchen/freezer)
 "krs" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -32496,14 +31630,12 @@
 /obj/landmark/observer,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "ksQ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -32562,8 +31694,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -32703,8 +31834,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/red/side{
@@ -32732,8 +31862,7 @@
 /area/station/maintenance/west)
 "kBz" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/shrub/random,
 /turf/simulated/floor/neutral/side{
@@ -32829,8 +31958,7 @@
 /area/station/hangar/arrivals)
 "kGp" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -32872,8 +32000,7 @@
 /area/station/science/lab)
 "kHZ" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -32900,7 +32027,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -32969,8 +32095,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -33043,12 +32168,6 @@
 	dispensable_reagents = list("margarita");
 	name = "Margaritaville Margarita Dispenser"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -33060,7 +32179,6 @@
 	},
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -33261,8 +32379,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -33340,8 +32457,7 @@
 /area/station/crew_quarters/fitness)
 "kUH" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -33366,8 +32482,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
@@ -33496,10 +32611,6 @@
 "lad" = (
 /obj/storage/secure/closet/fridge/kitchen,
 /obj/machinery/light/incandescent,
-/obj/machinery/camera{
-	c_tag = "Kitchen South";
-	dir = 1
-	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "laf" = (
@@ -33529,7 +32640,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -33551,8 +32661,7 @@
 /area/station/maintenance/scidisposal)
 "laY" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
@@ -33599,8 +32708,7 @@
 "ldd" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -33731,8 +32839,7 @@
 /area/station/crew_quarters/bar)
 "ljp" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light_switch/north,
 /obj/stool/chair/comfy/yellow,
@@ -33855,8 +32962,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -33912,8 +33018,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -33976,8 +33081,7 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -34001,8 +33105,7 @@
 /area/station/mining/staff_room)
 "ltk" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/table/auto,
 /obj/item/cloth/handkerchief/colored/white,
@@ -34023,7 +33126,6 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor6"
 	},
@@ -34056,7 +33158,6 @@
 "luQ" = (
 /obj/item/storage/toilet/random{
 	dir = 4;
-	icon_state = "toilet";
 	pixel_x = -8
 	},
 /obj/landmark/start/job/assistant,
@@ -34293,8 +33394,7 @@
 /area/station/quartermaster/refinery)
 "lBp" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -34521,9 +33621,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/red/side{
@@ -34575,12 +33673,9 @@
 /area/station/maintenance/inner/central)
 "lKR" = (
 /obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "lLB" = (
 /obj/landmark/kudzu,
@@ -34631,8 +33726,7 @@
 /area/station/crew_quarters/observatory)
 "lMn" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -34695,8 +33789,7 @@
 "lNZ" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
@@ -34790,8 +33883,7 @@
 /area/station/medical/robotics)
 "lSb" = (
 /obj/stool/chair/comfy{
-	dir = 8;
-	icon_state = "chair_comfy"
+	dir = 8
 	},
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/dirt2,
@@ -34836,8 +33928,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/storage/closet/coffin,
 /turf/simulated/floor/plating,
@@ -34862,8 +33953,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/chapel_office,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/office)
@@ -34928,8 +34018,7 @@
 	icon_state = "1-4"
 	},
 /obj/stool/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet{
@@ -35099,20 +34188,6 @@
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"mgz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	pixel_x = 0;
-	tag = ""
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "mgJ" = (
 /obj/machinery/light/emergency,
 /obj/stool/bench/blue,
@@ -35130,8 +34205,7 @@
 /area/station/science/testchamber)
 "mgN" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side,
@@ -35139,8 +34213,7 @@
 "mgX" = (
 /obj/loudspeaker,
 /obj/shrub{
-	dir = 6;
-	icon_state = "shrub"
+	dir = 6
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass,
@@ -35213,8 +34286,7 @@
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -35250,8 +34322,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/aisat)
 "mjM" = (
@@ -35317,7 +34388,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -35340,6 +34410,12 @@
 	dir = 8;
 	name = "VR simulation pod";
 	network = "arcadevr"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13";
+	tag = ""
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -35542,8 +34618,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -35568,8 +34643,7 @@
 /area/station/storage/tools)
 "mvf" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
@@ -35603,8 +34677,7 @@
 /area/station/hangar/science)
 "mxe" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/tox,
@@ -35618,9 +34691,7 @@
 /area/station/science/lab)
 "mxw" = (
 /obj/decal/boxingropeenter{
-	dir = 4;
-	icon_state = "ringrope";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -35706,8 +34777,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -35749,8 +34819,7 @@
 /area/station/science/artifact)
 "mEA" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -35822,8 +34891,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -36057,8 +35125,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
@@ -36143,8 +35210,7 @@
 /area/station/ranch)
 "mRu" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -36157,7 +35223,6 @@
 "mRB" = (
 /obj/disposalpipe/segment{
 	dir = 4;
-	icon_state = "pipe-s";
 	name = "factory pipe"
 	},
 /turf/simulated/floor/carpet/grime,
@@ -36177,8 +35242,7 @@
 /area/station/hydroponics/bay)
 "mSh" = (
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -36190,9 +35254,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/greenwhite{
@@ -36236,8 +35298,7 @@
 /area/station/crew_quarters/fitness)
 "mTk" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
@@ -36365,8 +35426,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -36408,8 +35468,7 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -36451,8 +35510,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/zeta)
 "mZV" = (
@@ -36509,8 +35567,7 @@
 /area/station/crew_quarters/heads)
 "nbM" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
@@ -36530,8 +35587,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -36558,7 +35614,6 @@
 "neE" = (
 /obj/machinery/computer3/luggable,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
@@ -36624,8 +35679,7 @@
 /area/station/storage/tech)
 "ngG" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -36681,8 +35735,7 @@
 /area/space)
 "njr" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/cable/orange{
 	icon_state = "0-4"
@@ -36711,8 +35764,7 @@
 "nkP" = (
 /obj/machinery/lrteleporter,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 1
@@ -36769,8 +35821,7 @@
 "nmD" = (
 /obj/machinery/disposal,
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -36876,7 +35927,6 @@
 /area/station/science/gen_storage)
 "nqT" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light/delay4,
@@ -36970,7 +36020,6 @@
 /area/station/chapel/office)
 "nwq" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light/delay5,
@@ -37064,9 +36113,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "nAg" = (
 /obj/landmark/start/job/botanist,
@@ -37098,8 +36145,7 @@
 /area/station/hallway/primary/west)
 "nBs" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow/side{
@@ -37196,8 +36242,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/access/engineering_chief,
 /obj/mapping_helper/firedoor_spawn,
@@ -37239,9 +36284,7 @@
 /obj/item/crowbar,
 /obj/item/device/light/flashlight,
 /obj/item/device/light/flashlight,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "nFv" = (
 /obj/item/device/radio/beacon,
@@ -37280,9 +36323,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	pixel_x = 0;
 	tag = ""
 	},
 /obj/landmark/start/job/medical_doctor,
@@ -37438,8 +36479,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -37463,8 +36503,7 @@
 "nMC" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -37553,8 +36592,7 @@
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/restroom)
@@ -37664,12 +36702,6 @@
 /area/space)
 "nTV" = (
 /obj/machinery/computer/tetris,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	name = "autoname  - SS13";
-	pixel_y = 18;
-	tag = ""
-	},
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24
@@ -37681,9 +36713,7 @@
 /area/station/science/testchamber)
 "nUK" = (
 /obj/disposalpipe/segment,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "nVj" = (
 /obj/cable{
@@ -37763,16 +36793,14 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "nXc" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/computer/power_monitor{
 	dir = 8
@@ -37893,7 +36921,6 @@
 "oaN" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "showerhead";
 	pixel_y = 2
 	},
 /obj/machinery/drainage,
@@ -37999,9 +37026,7 @@
 "oez" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
 /obj/mapping_helper/firedoor_spawn,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "ofh" = (
 /obj/machinery/hair_dye_dispenser,
@@ -38063,8 +37088,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/south)
 "ohK" = (
@@ -38104,8 +37128,7 @@
 	},
 /obj/machinery/drone_recharger,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -38214,7 +37237,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -38230,8 +37252,7 @@
 	pixel_x = -6
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/device/radio/intercom/security{
 	dir = 1
@@ -38280,14 +37301,6 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	network = "SS13";
-	tag = ""
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
@@ -38460,14 +37473,12 @@
 /obj/landmark/start/latejoin,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "otq" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -38497,8 +37508,7 @@
 /area/station/crew_quarters/bar)
 "otJ" = (
 /obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /obj/machinery/light/small,
 /obj/machinery/door/window/eastleft{
@@ -38544,8 +37554,7 @@
 /area/station/crew_quarters/captain)
 "ovH" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
@@ -38627,8 +37636,7 @@
 "oyb" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -38641,8 +37649,7 @@
 /area/station/maintenance/inner/central)
 "oyg" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/plating,
@@ -38766,8 +37773,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
@@ -39017,9 +38023,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/redblack{
@@ -39133,7 +38137,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -39188,7 +38191,6 @@
 /obj/stool/bar,
 /obj/machinery/bot/guardbot/old/tourguide,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -39263,7 +38265,6 @@
 /obj/stool/bar,
 /obj/machinery/bot/guardbot,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -39320,8 +38321,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/purple/side{
@@ -39420,8 +38420,7 @@
 /area/station/crew_quarters/kitchen/freezer)
 "oWN" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -39453,8 +38452,7 @@
 "oYW" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
@@ -39499,13 +38497,10 @@
 /area/station/maintenance/south)
 "pbS" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/floor/red/corner{
-	dir = 2
-	},
+/turf/simulated/floor/red/corner,
 /area/station/hallway/primary/south)
 "pbY" = (
 /obj/disposalpipe/segment{
@@ -39546,8 +38541,7 @@
 /area/station/maintenance/west)
 "pdc" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -39575,8 +38569,7 @@
 "pdI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
@@ -39656,8 +38649,7 @@
 	},
 /obj/decal/cleanable/dirt/dirt5,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -39709,9 +38701,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/arrivals{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "pkk" = (
 /turf/simulated/floor/carpet{
@@ -39808,7 +38798,6 @@
 /area/station/crew_quarters/arcade/dungeon)
 "ppT" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light,
@@ -39845,7 +38834,6 @@
 "psJ" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "showerhead";
 	pixel_y = 6
 	},
 /obj/machinery/drainage,
@@ -39946,8 +38934,7 @@
 /area/space)
 "puz" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -40088,8 +39075,7 @@
 /area/station/crew_quarters/quarters)
 "pyb" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
@@ -40116,8 +39102,7 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -40141,8 +39126,7 @@
 "pyF" = (
 /obj/voting_box,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -40187,8 +39171,7 @@
 /obj/item/storage/firstaid/regular,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "pzP" = (
@@ -40288,8 +39271,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -40339,8 +39321,7 @@
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -40358,8 +39339,7 @@
 "pFN" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
@@ -40374,7 +39354,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -40483,9 +39462,7 @@
 /area/station/hallway/secondary/exit)
 "pJc" = (
 /obj/machinery/portable_reclaimer,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "pJD" = (
 /obj/grille/catwalk,
@@ -40509,8 +39486,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -40552,8 +39528,7 @@
 /area/station/crew_quarters/quarters)
 "pPj" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -40561,8 +39536,7 @@
 /area/station/bridge)
 "pPF" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -40593,12 +39567,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "pRA" = (
 /obj/railing/orange/reinforced{
@@ -40610,8 +39581,7 @@
 /area/station/ranch)
 "pRH" = (
 /turf/simulated/shuttle/wall/cockpit{
-	dir = 1;
-	icon_state = "shuttlecock"
+	dir = 1
 	},
 /area/shuttle/arrival/station)
 "pRT" = (
@@ -40643,8 +39613,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/machinery/emitter{
 	dir = 4
@@ -40712,7 +39681,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -40775,8 +39743,7 @@
 /area/station/maintenance/inner/central)
 "pYl" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -40830,8 +39797,7 @@
 /area/station/hallway/primary/north)
 "pZY" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /turf/simulated/floor/escape{
 	dir = 9
@@ -40994,8 +39960,7 @@
 "qfE" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -41042,9 +40007,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/circuit/red,
@@ -41156,8 +40119,7 @@
 /obj/stool/chair/comfy/shuttle/brown,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "qmJ" = (
@@ -41177,9 +40139,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/caution/westeast,
@@ -41259,8 +40219,7 @@
 /obj/mapping_helper/access/hydro,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
@@ -41299,7 +40258,6 @@
 "qpT" = (
 /obj/machinery/camera{
 	c_tag = "Bomb Testing Area";
-	dir = 2;
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
@@ -41327,15 +40285,13 @@
 /area/station/medical/medbay)
 "qrB" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "qrN" = (
 /obj/stool/chair/office{
-	dir = 4;
-	icon_state = "office_chair"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -41534,8 +40490,7 @@
 /area/station/ranch)
 "qyM" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -41667,20 +40622,6 @@
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
-"qCL" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	network = "SS13";
-	tag = ""
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
 "qDS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41721,8 +40662,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -41760,8 +40700,7 @@
 "qFL" = (
 /obj/machinery/door_timer/solitary/new_walls/south,
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -41829,8 +40768,7 @@
 /area/station/chapel/sanctuary)
 "qJm" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/neutral/side{
@@ -42022,20 +40960,10 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
-"qQn" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/pool/no_animate,
-/area/station/crew_quarters/pool)
 "qQA" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -42055,8 +40983,7 @@
 /area/station/quartermaster/refinery)
 "qRj" = (
 /obj/machinery/turret{
-	dir = 1;
-	icon_state = "grey_target_prism"
+	dir = 1
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
@@ -42089,9 +41016,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/west,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "qSd" = (
 /obj/machinery/door/poddoor/blast/single{
@@ -42103,8 +41028,7 @@
 /area/station/turret_protected/Zeta)
 "qSh" = (
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/heads{
@@ -42272,8 +41196,7 @@
 "rar" = (
 /obj/machinery/firealarm/south,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/processing)
@@ -42407,8 +41330,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 2.5;
-	name = "VACUUM AREA";
-	pixel_x = 0
+	name = "VACUUM AREA"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
@@ -42425,8 +41347,7 @@
 	},
 /obj/machinery/firealarm/north,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -42506,8 +41427,7 @@
 /area/station/maintenance/east)
 "rjD" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/processing)
@@ -42522,8 +41442,7 @@
 /area/space)
 "rkg" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/table/auto,
 /obj/item/weldingtool,
@@ -42736,15 +41655,13 @@
 /obj/item/pen,
 /obj/item/stamp/ce,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/ce)
 "rtK" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -42895,8 +41812,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
@@ -42971,9 +41887,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "rBT" = (
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/specialroom/freezer{
 	nitrogen = 105.86;
@@ -42986,8 +41900,7 @@
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -43010,8 +41923,7 @@
 /area/station/solar/aisat)
 "rDh" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/purple/side,
 /area/station/maintenance/west)
@@ -43034,8 +41946,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -43060,7 +41971,6 @@
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -43079,8 +41989,7 @@
 "rGW" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -43105,7 +42014,6 @@
 "rHE" = (
 /obj/stool/chair/couch/green{
 	dir = 4;
-	icon_state = "chair_couch-green";
 	name = "ratty green couch"
 	},
 /turf/simulated/floor/neutral/side{
@@ -43121,8 +42029,7 @@
 /area/station/hallway/secondary/exit)
 "rIc" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
@@ -43172,8 +42079,7 @@
 /area/station/science/testchamber)
 "rKk" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -43185,8 +42091,7 @@
 /area/station/maintenance/east)
 "rKt" = (
 /obj/shrub{
-	dir = 8;
-	icon_state = "shrub"
+	dir = 8
 	},
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/junction/left/south,
@@ -43226,12 +42131,6 @@
 /obj/disposalpipe/trunk/morgue{
 	dir = 4;
 	name = "crematorium pipe"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -43284,8 +42183,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/turret{
-	dir = 1;
-	icon_state = "grey_target_prism"
+	dir = 1
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
@@ -43327,8 +42225,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side,
 /area/station/crew_quarters/hor)
@@ -43349,8 +42246,7 @@
 "rPW" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
@@ -43435,8 +42331,7 @@
 /area/station/science/testchamber)
 "rTT" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -43503,8 +42398,7 @@
 /area/space)
 "rVs" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -43595,8 +42489,7 @@
 /obj/random_item_spawner/dressup/one_or_zero,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "rYA" = (
@@ -43717,8 +42610,7 @@
 /area/station/turret_protected/Zeta)
 "sdN" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
@@ -43758,14 +42650,6 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "seM" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	network = "SS13";
-	tag = ""
-	},
 /obj/disposalpipe/switch_junction/right/north{
 	mail_tag = "genetics";
 	name = "genetics mail junction"
@@ -43774,8 +42658,7 @@
 /area/station/hallway/primary/west)
 "seZ" = (
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -43785,6 +42668,12 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/north,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "sfv" = (
@@ -43821,7 +42710,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -43845,8 +42733,7 @@
 /area/station/security/beepsky)
 "sgK" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -43896,8 +42783,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/corner{
 	dir = 4
@@ -43951,8 +42837,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
@@ -43983,8 +42868,7 @@
 /obj/storage/closet/wardrobe/black,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "slo" = (
@@ -44011,15 +42895,13 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white/side,
 /area/station/crew_quarters/locker)
 "slT" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -44107,8 +42989,7 @@
 "soo" = (
 /obj/loudspeaker,
 /obj/shrub{
-	dir = 6;
-	icon_state = "shrub"
+	dir = 6
 	},
 /obj/decal/cleanable/leaves,
 /obj/machinery/camera{
@@ -44142,16 +43023,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"spf" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/space,
-/area/space)
 "spl" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 8
@@ -44169,8 +43040,7 @@
 /area/station/hydroponics/bay)
 "spH" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/neutral/side{
@@ -44188,8 +43058,7 @@
 /obj/machinery/light/incandescent,
 /obj/decal/cleanable/cobweb,
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /turf/simulated/floor/redblack{
 	dir = 9
@@ -44317,7 +43186,6 @@
 /area/station/maintenance/southwest)
 "stt" = (
 /obj/disposaloutlet{
-	dir = 2;
 	name = "brig delivery chute"
 	},
 /obj/disposalpipe/trunk/brig{
@@ -44364,8 +43232,7 @@
 /obj/decal/cleanable/blood/tracks,
 /obj/machinery/drainage,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -44377,8 +43244,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/grime,
@@ -44440,8 +43306,7 @@
 /area/station/medical/medbay/treatment)
 "syw" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -44452,8 +43317,7 @@
 /area/station/hallway/primary/north)
 "syA" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -44619,8 +43483,7 @@
 "sDo" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
@@ -44634,16 +43497,14 @@
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/item/paper/donut2smesinstructions,
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "sDu" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/phone/wall{
 	pixel_y = 30
@@ -44772,8 +43633,7 @@
 "sHa" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4
@@ -44823,8 +43683,7 @@
 /obj/storage/closet/wardrobe/grey,
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "sJD" = (
@@ -44923,8 +43782,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
@@ -44968,8 +43826,7 @@
 /area/station/mining/staff_room)
 "sNh" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -44987,8 +43844,7 @@
 	},
 /obj/mapping_helper/access/heads,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/stairs/dark{
@@ -45128,9 +43984,7 @@
 /area/station/hallway/primary/south)
 "sRo" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "sRx" = (
 /obj/landmark/gps_waypoint,
@@ -45203,8 +44057,7 @@
 /area/station/science/lobby)
 "sTU" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -45271,13 +44124,11 @@
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
 "sVY" = (
-/obj/machinery/camera,
 /obj/cable/blue{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/decal/cleanable/ripped_poster{
 	pixel_y = 31
@@ -45358,8 +44209,7 @@
 /area/station/medical/medbay)
 "sXM" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/stairs{
 	dir = 4
@@ -45428,19 +44278,13 @@
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "taQ" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby";
-	dir = 4
-	},
 /obj/shrub{
-	dir = 2;
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
@@ -45467,8 +44311,7 @@
 	},
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "tbo" = (
@@ -45555,8 +44398,7 @@
 /area/station/ranch)
 "tfq" = (
 /obj/shrub{
-	dir = 4;
-	icon_state = "shrub"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /obj/machinery/camera{
@@ -45628,8 +44470,7 @@
 	req_access = null
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/mapping_helper/access/maint,
 /obj/mapping_helper/firedoor_spawn,
@@ -45667,8 +44508,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
@@ -45742,8 +44582,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -45756,8 +44595,7 @@
 /area/space)
 "tnl" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
@@ -45786,9 +44624,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "tpm" = (
 /obj/cable{
@@ -45918,8 +44754,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "txI" = (
@@ -46147,8 +44982,7 @@
 /area/station/janitor/supply)
 "tDO" = (
 /obj/stool/chair/comfy{
-	dir = 8;
-	icon_state = "chair_comfy"
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -46160,7 +44994,6 @@
 /area/station/crew_quarters/jazz)
 "tDR" = (
 /obj/submachine/ATM{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/decal/stripe_delivery,
@@ -46168,8 +45001,7 @@
 /area/station/hallway/primary/south)
 "tEp" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -46247,14 +45079,6 @@
 /obj/item/clothing/under/misc/mime,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
-"tGy" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/space)
 "tHq" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/checkpoint/arrivals)
@@ -46297,7 +45121,6 @@
 /area/listeningpost)
 "tIu" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/simulated/floor/plating,
@@ -46348,8 +45171,7 @@
 /area/station/science/lobby)
 "tLe" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -46421,7 +45243,6 @@
 	},
 /obj/cable/yellow,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -46489,8 +45310,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -46557,7 +45377,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -46573,12 +45392,10 @@
 /area/station/chapel/sanctuary)
 "tUY" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 2;
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
@@ -46640,8 +45457,7 @@
 /area/station/medical/medbay/lobby)
 "tWs" = (
 /obj/stool/chair/office{
-	dir = 1;
-	icon_state = "office_chair"
+	dir = 1
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -46655,7 +45471,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -46689,8 +45504,7 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /turf/space,
 /area/space)
@@ -46788,8 +45602,7 @@
 /area/station/maintenance/north)
 "udm" = (
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -46922,8 +45735,7 @@
 "uhm" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
@@ -46992,8 +45804,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/zeta)
 "ukA" = (
@@ -47030,8 +45841,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
+	dir = 8
 	},
 /obj/machinery/emitter{
 	dir = 4
@@ -47114,7 +45924,6 @@
 "unP" = (
 /obj/machinery/camera{
 	c_tag = "South Hallway East";
-	c_tag_order = 999;
 	dir = 4
 	},
 /obj/landmark/kudzu,
@@ -47200,13 +46009,10 @@
 	mail_tag = "buddy_depot";
 	name = "buddydepot mail router"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 2
-	},
+/turf/simulated/floor/neutral/side,
 /area/station/science/lobby)
 "uqL" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /obj/grille/steel{
@@ -47275,8 +46081,7 @@
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -47447,9 +46252,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/plating/airless,
@@ -47457,8 +46260,7 @@
 "uBA" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -47478,8 +46280,7 @@
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -47545,8 +46346,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -47594,8 +46394,7 @@
 	icon_state = "1-8"
 	},
 /obj/stool/chair/office{
-	dir = 1;
-	icon_state = "office_chair"
+	dir = 1
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -47609,8 +46408,7 @@
 /area/station/medical/staff)
 "uHl" = (
 /obj/stool/chair/comfy{
-	dir = 8;
-	icon_state = "chair_comfy"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 6
@@ -47628,8 +46426,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "uHq" = (
@@ -47637,9 +46434,7 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "uHX" = (
-/obj/machinery/door/airlock/pyro/external{
-	icon_state = "airlock_closed"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "uIe" = (
@@ -47648,8 +46443,7 @@
 /area/station/maintenance/southwest)
 "uIt" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/cable/orange{
 	icon_state = "0-2"
@@ -47677,8 +46471,7 @@
 /area/station/crew_quarters/kitchen)
 "uKp" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -47736,8 +46529,7 @@
 	},
 /turf/unsimulated/floor{
 	desc = "";
-	icon = 'icons/turf/shuttle.dmi';
-	icon_state = "floor"
+	icon = 'icons/turf/shuttle.dmi'
 	},
 /area/shuttle/arrival/station)
 "uLL" = (
@@ -47799,8 +46591,7 @@
 "uNC" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -47842,7 +46633,6 @@
 	dir = 10
 	},
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -47990,18 +46780,9 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
 /area/station/science/testchamber/bombchamber)
-"uUd" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/space)
 "uUm" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
@@ -48072,9 +46853,7 @@
 /area/station/medical/medbay/pharmacy)
 "uVW" = (
 /obj/machinery/firealarm/south,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "uVZ" = (
 /obj/cable{
@@ -48092,7 +46871,6 @@
 	icon_state = "in";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -48157,8 +46935,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/chapel/sanctuary)
@@ -48190,12 +46967,9 @@
 /area/space)
 "vaP" = (
 /obj/shrub{
-	dir = 1;
-	icon_state = "shrub"
+	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "vaR" = (
 /obj/cable{
@@ -48329,7 +47103,6 @@
 /obj/machinery/light/incandescent,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -48521,8 +47294,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+	dir = 4
 	},
 /obj/machinery/emitter{
 	dir = 8
@@ -48600,8 +47372,7 @@
 /area/station/maintenance/west)
 "vsc" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4
@@ -48792,8 +47563,7 @@
 /area/space)
 "vzB" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -48853,8 +47623,7 @@
 /area/station/medical/medbay/cloner)
 "vBz" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
@@ -48888,8 +47657,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -48935,10 +47703,7 @@
 	},
 /area/station/quartermaster/magnet)
 "vFi" = (
-/obj/machinery/dispenser{
-	o2tanks = 10;
-	pltanks = 10
-	},
+/obj/machinery/dispenser,
 /obj/machinery/camera{
 	c_tag = "Toxins";
 	dir = 4;
@@ -48969,8 +47734,7 @@
 "vFY" = (
 /obj/machinery/light/incandescent,
 /obj/stool/chair/comfy{
-	dir = 4;
-	icon_state = "chair_comfy"
+	dir = 4
 	},
 /obj/landmark/start/job/assistant,
 /obj/machinery/camera{
@@ -48999,8 +47763,7 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/ce)
@@ -49150,8 +47913,7 @@
 /area/station/engine/substation/north)
 "vLf" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/plating,
@@ -49224,7 +47986,6 @@
 	},
 /obj/forcefield/energyshield/perma{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 2;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
@@ -49248,16 +48009,14 @@
 /obj/item/clothing/mask/monkey_translator,
 /obj/decal/cleanable/dirt/dirt3,
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/bananapeel,
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "vNq" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -49277,8 +48036,7 @@
 	name = "autoname - SS13"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
@@ -49287,9 +48045,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
-	icon_state = "camera";
 	name = "autoname  - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /turf/simulated/floor/escape/corner{
@@ -49409,8 +48165,7 @@
 /obj/mapping_helper/access/maint,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -49552,9 +48307,7 @@
 /area/station/science/chemistry)
 "waO" = (
 /obj/stool/chair,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "waY" = (
 /obj/machinery/door/airlock/pyro/security/alt,
@@ -49566,8 +48319,7 @@
 /area/station/security/interrogation)
 "wbo" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/green/side,
@@ -49575,9 +48327,7 @@
 "wbU" = (
 /obj/stool,
 /obj/decal/boxingropeenter{
-	dir = 4;
-	icon_state = "ringrope";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/specialroom/gym,
@@ -49595,9 +48345,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	pixel_x = 0;
 	tag = ""
 	},
 /turf/space,
@@ -49605,8 +48353,7 @@
 "wdj" = (
 /obj/landmark/bill_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -49669,7 +48416,6 @@
 /area/station/maintenance/west)
 "wfV" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -49758,8 +48504,7 @@
 /area/station/engine/engineering)
 "wjt" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -49821,8 +48566,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/quartermaster/magnet)
 "wkZ" = (
@@ -49858,8 +48602,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -49950,7 +48693,6 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
-	icon_state = "camera";
 	name = "autoname - SS13";
 	tag = ""
 	},
@@ -50001,7 +48743,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
@@ -50231,7 +48972,6 @@
 "wAd" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "showerhead";
 	pixel_y = 6
 	},
 /obj/machinery/drainage,
@@ -50280,14 +49020,12 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/restroom)
 "wDo" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/light/runway_light/delay5,
@@ -50315,9 +49053,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/purplewhite/corner{
-	dir = 2
-	},
+/turf/simulated/floor/purplewhite/corner,
 /area/station/science/chemistry)
 "wEN" = (
 /obj/cable{
@@ -50464,8 +49200,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/storage/closet/coffin,
@@ -50615,9 +49350,7 @@
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
-	icon_state = "camera";
 	name = "autoname - SS13";
-	network = "SS13";
 	tag = ""
 	},
 /obj/disposalpipe/segment/mail,
@@ -50707,10 +49440,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "wWv" = (
-/obj/machinery/camera{
-	c_tag = "Bar West";
-	dir = 4
-	},
 /obj/machinery/light/incandescent,
 /obj/cable{
 	icon_state = "1-2"
@@ -50801,8 +49530,7 @@
 /area/station/hallway/primary/west)
 "wYL" = (
 /obj/shrub{
-	dir = 4;
-	icon_state = "shrub"
+	dir = 4
 	},
 /obj/machinery/camera/ranch{
 	dir = 1
@@ -50849,8 +49577,7 @@
 /area/station/hangar/engine)
 "xae" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/storage/emergency)
@@ -50902,8 +49629,7 @@
 /area/station/ai_monitored/armory)
 "xdj" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -50937,8 +49663,7 @@
 	},
 /obj/critter/parrot/random,
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
+	dir = 1
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/grass/random,
@@ -50999,8 +49724,7 @@
 /area/shuttle/research/outpost)
 "xhF" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/bananapeel,
 /turf/simulated/floor/grass/random,
@@ -51013,7 +49737,6 @@
 "xhV" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet{
-	dir = 2;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
@@ -51031,9 +49754,7 @@
 	pixel_y = -4
 	},
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "xie" = (
 /obj/table/auto,
@@ -51064,8 +49785,7 @@
 /obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -51181,8 +49901,7 @@
 /area/station/science/lab)
 "xlR" = (
 /obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
+	dir = 8
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -51338,8 +50057,7 @@
 "xre" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/light/emergency{
-	dir = 4;
-	icon_state = "ebulb1"
+	dir = 4
 	},
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/white,
@@ -51705,9 +50423,7 @@
 /obj/machinery/phone{
 	pixel_y = -6
 	},
-/turf/simulated/floor/specialroom/medbay{
-	dir = 2
-	},
+/turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "xEz" = (
 /obj/grille/catwalk{
@@ -51724,8 +50440,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
+	dir = 4
 	},
 /area/station/solar/zeta)
 "xEB" = (
@@ -51756,8 +50471,7 @@
 	},
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -51793,14 +50507,7 @@
 "xHQ" = (
 /obj/storage/secure/closet/medical/cloning,
 /obj/machinery/light/emergency{
-	dir = 1;
-	icon_state = "ebulb1"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	tag = ""
+	dir = 1
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/bluewhite{
@@ -51846,7 +50553,6 @@
 "xJV" = (
 /obj/item/storage/toilet/random{
 	dir = 4;
-	icon_state = "toilet";
 	pixel_x = -8
 	},
 /turf/simulated/floor/grime,
@@ -52058,13 +50764,6 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor,
 /area/station/maintenance/west)
-"xQm" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance South North"
-	},
-/obj/machinery/drone_recharger,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "xQA" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor,
@@ -52109,8 +50808,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
@@ -52130,7 +50828,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
@@ -52169,8 +50866,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -52178,8 +50874,7 @@
 /area/station/hallway/primary/north)
 "xVW" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -52343,8 +51038,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
@@ -52487,8 +51181,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -52583,9 +51276,7 @@
 	pixel_x = 13;
 	pixel_y = 10
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
+/turf/unsimulated/floor,
 /area/station/hangar/arrivals)
 "ykF" = (
 /obj/machinery/camera{
@@ -54555,29 +53246,29 @@ aaa
 aaa
 aaa
 aap
-acG
-acG
+ajz
+ajz
 acv
 aaa
 aaa
 aaa
 aaa
 aap
-acG
-acG
+ajz
+ajz
 aag
-acG
-acG
+ajz
+ajz
 aag
-acG
-acG
+ajz
+ajz
 acv
 aaa
 aaa
 aaa
 aap
-acG
-acG
+ajz
+ajz
 acv
 aaa
 aaa
@@ -55157,7 +53848,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 apU
 aqg
 aqf
@@ -55178,7 +53869,7 @@ azr
 ass
 arJ
 arJ
-aae
+smI
 apU
 aqg
 aqg
@@ -55761,7 +54452,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 aas
 aas
 apZ
@@ -56365,7 +55056,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 apU
 aqg
 aqg
@@ -56386,7 +55077,7 @@ prU
 sLe
 aBo
 arJ
-aae
+smI
 apU
 aqg
 aqg
@@ -56971,8 +55662,8 @@ aaa
 aaa
 aaa
 abZ
-acG
-acG
+ajz
+ajz
 acy
 aaa
 arJ
@@ -56992,8 +55683,8 @@ tqG
 arJ
 aaa
 abZ
-acG
-acG
+ajz
+ajz
 acy
 aaa
 aaa
@@ -63665,7 +62356,7 @@ bAw
 bvv
 bvv
 rOg
-aZy
+aQY
 baZ
 krc
 bvv
@@ -63931,7 +62622,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 iyl
 azI
 hfI
@@ -64274,7 +62965,7 @@ bir
 aWQ
 pwG
 oxC
-aYi
+dnP
 arN
 arN
 avq
@@ -64552,7 +63243,7 @@ aaa
 aaa
 aaa
 avq
-cHY
+jFV
 ayH
 hSU
 avq
@@ -64576,7 +63267,7 @@ bhg
 sng
 aJY
 oxC
-aYi
+dnP
 arN
 arN
 avq
@@ -64834,7 +63525,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 mDg
 gSx
 gSx
@@ -65458,7 +64149,7 @@ iRQ
 aKG
 aLF
 aJT
-cHY
+jFV
 ayH
 aNE
 kBE
@@ -66062,7 +64753,7 @@ bHX
 aKI
 aLH
 aJT
-cHY
+jFV
 aKO
 aNE
 aNE
@@ -66968,7 +65659,7 @@ aaa
 avq
 lon
 aJZ
-cHY
+jFV
 ayH
 aID
 aOo
@@ -67300,12 +65991,12 @@ dEj
 oys
 eOn
 jRq
-aYi
+dnP
 hWx
 wWc
 arN
 arN
-bgb
+rPd
 lJA
 oaU
 vhX
@@ -67874,7 +66565,7 @@ avq
 dmM
 oiv
 arN
-cHY
+jFV
 yjM
 aID
 xjy
@@ -68211,7 +66902,7 @@ baj
 bhk
 tbY
 aXp
-bgb
+rPd
 arN
 jLR
 aWR
@@ -68492,7 +67183,7 @@ aUc
 emP
 aUD
 ghP
-mgz
+gna
 faR
 faR
 aYp
@@ -68513,7 +67204,7 @@ xfc
 pQx
 tsC
 aXp
-bgb
+rPd
 jYR
 nFR
 xhH
@@ -68763,9 +67454,9 @@ aqI
 aqI
 aaa
 anB
-acG
+ajz
 azv
-acG
+ajz
 anB
 aaa
 aaa
@@ -68777,7 +67468,7 @@ avq
 mle
 avq
 aJZ
-djY
+qyB
 dIj
 aKL
 gMY
@@ -70327,7 +69018,7 @@ dLJ
 aXp
 lol
 arN
-bjk
+gRF
 xOv
 pCd
 vKz
@@ -71065,7 +69756,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 aag
 aag
 aak
@@ -71218,7 +69909,7 @@ bfX
 mhg
 jHm
 aZE
-qCL
+aTw
 aTw
 pkG
 fbx
@@ -71533,7 +70224,7 @@ beD
 beD
 aJX
 aXp
-rPd
+acG
 aVl
 jhM
 tFy
@@ -71863,7 +70554,7 @@ bGd
 bis
 bis
 blZ
-acG
+ajz
 bFh
 bHN
 bGc
@@ -72097,7 +70788,7 @@ oUY
 uCi
 hCc
 azA
-djY
+qyB
 mGU
 aYy
 xjV
@@ -72273,7 +70964,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 aai
 aai
 aak
@@ -72421,7 +71112,7 @@ azU
 azU
 azU
 azU
-aYz
+aEQ
 elW
 elW
 pYh
@@ -72701,7 +71392,7 @@ azA
 vSE
 uSC
 azA
-djY
+qyB
 arN
 aYy
 aKV
@@ -73003,7 +71694,7 @@ azA
 kzo
 nSH
 azA
-djY
+qyB
 mGU
 aYy
 aZi
@@ -73373,7 +72064,7 @@ btx
 byW
 bis
 blZ
-acG
+ajz
 bFh
 bHN
 bGc
@@ -73634,7 +72325,7 @@ qPK
 aZQ
 bat
 aVx
-xQm
+dAe
 bgm
 azU
 azU
@@ -74270,7 +72961,7 @@ btx
 jQy
 dXv
 wQE
-jAG
+rwt
 btx
 oxv
 lks
@@ -76632,7 +75323,7 @@ aDW
 aDW
 ayR
 ayR
-gHE
+mmb
 azU
 aCy
 aVG
@@ -77211,7 +75902,7 @@ cJF
 txP
 arN
 ayH
-ata
+arN
 arN
 arN
 auR
@@ -77875,7 +76566,7 @@ aCy
 bgk
 aCy
 aaa
-aae
+smI
 acK
 ajz
 jud
@@ -78139,7 +76830,7 @@ aDW
 aDW
 aDW
 aDW
-aFK
+azU
 mqE
 azU
 aGx
@@ -78435,7 +77126,7 @@ aKr
 axc
 ayR
 dAe
-aNs
+mmb
 bgm
 azU
 azU
@@ -79684,7 +78375,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 xsB
 acF
 aaa
@@ -80844,7 +79535,7 @@ gPK
 mQS
 axQ
 ayR
-azS
+azU
 mmb
 aDd
 bgm
@@ -81254,8 +79945,8 @@ bIM
 bIM
 bIM
 tTO
-acG
-acG
+ajz
+ajz
 bHG
 aaa
 aaa
@@ -82143,9 +80834,9 @@ mnW
 bHs
 fKj
 ulZ
-acG
-acG
-acG
+ajz
+ajz
+ajz
 bGU
 bGU
 xLK
@@ -82381,9 +81072,9 @@ nTr
 uAS
 anM
 jif
-acG
+ajz
 aas
-acG
+ajz
 aWx
 aaa
 aaA
@@ -82391,7 +81082,7 @@ aYF
 apU
 aaa
 aWx
-acG
+ajz
 aas
 fQq
 bco
@@ -82763,10 +81454,10 @@ tia
 bIa
 snf
 aas
-acG
-acG
-acG
-acG
+ajz
+ajz
+ajz
+ajz
 cXg
 acF
 aaa
@@ -82921,12 +81612,12 @@ aaa
 aaa
 aaa
 ppT
-acG
-acG
-uUd
-acG
-acG
-acG
+ajz
+ajz
+jWh
+ajz
+ajz
+ajz
 wnS
 rzr
 xuN
@@ -82945,7 +81636,7 @@ wnS
 aaa
 aaa
 aaA
-acG
+ajz
 aoN
 arV
 qmQ
@@ -83653,9 +82344,9 @@ qBB
 uHq
 ulZ
 ulZ
-acG
-acG
-acG
+ajz
+ajz
+ajz
 bGU
 bGU
 uBv
@@ -84555,8 +83246,8 @@ bEl
 bAP
 idF
 bCV
-acG
-acG
+ajz
+ajz
 apU
 aaa
 aaa
@@ -84842,7 +83533,7 @@ bwT
 bhm
 bhm
 bhm
-bAf
+mGp
 bAU
 bAU
 bCr
@@ -85035,25 +83726,25 @@ aaa
 aaa
 aaa
 ppT
-acG
-acG
-uUd
-acG
-acG
-acG
+ajz
+ajz
+jWh
+ajz
+ajz
+ajz
 sfE
 wnS
 wnS
 wnS
 sfE
-acG
-acG
-acG
-acG
-acG
+ajz
+ajz
+ajz
+ajz
+ajz
 aag
-acG
-acG
+ajz
+ajz
 aoO
 anF
 aoH
@@ -85159,14 +83850,14 @@ fHD
 pbK
 mia
 bCV
-acG
-acG
+ajz
+ajz
 aai
-acG
-acG
-acG
-acG
-acG
+ajz
+ajz
+ajz
+ajz
+ajz
 viW
 aas
 xtE
@@ -85688,7 +84379,7 @@ dkY
 aLi
 aLf
 aIb
-qQn
+aIb
 aIb
 aLd
 aEk
@@ -86065,14 +84756,14 @@ bAP
 bAP
 bGs
 aas
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
+ajz
+ajz
+ajz
+ajz
+ajz
+ajz
+ajz
+ajz
 aai
 aai
 kOY
@@ -87503,10 +86194,10 @@ aIR
 aJx
 dfn
 dfn
-dfn
+aae
 aMI
 wTK
-ikc
+nDk
 hJE
 aLj
 hll
@@ -87855,7 +86546,7 @@ bgm
 bgH
 lpF
 bsa
-uUm
+arI
 buZ
 vyp
 bFv
@@ -88127,9 +86818,9 @@ rJf
 vzk
 hPX
 vzk
-acG
-acG
-acG
+ajz
+ajz
+ajz
 kqS
 kqS
 bcq
@@ -88137,7 +86828,7 @@ uVZ
 hIR
 kqS
 kqS
-acG
+ajz
 aCy
 aCy
 aCy
@@ -88155,7 +86846,7 @@ bgH
 bgH
 bgH
 bgH
-bAf
+mGp
 bxH
 uUm
 buZ
@@ -88405,7 +87096,7 @@ awk
 kdj
 aIe
 aIe
-aIS
+aIe
 aIe
 aKs
 tmU
@@ -90589,8 +89280,8 @@ bxT
 bxT
 bxT
 bxT
-acG
-acG
+ajz
+ajz
 byd
 bIc
 bzF
@@ -90796,7 +89487,7 @@ aaa
 aaa
 aaa
 aqB
-arI
+gRl
 aaa
 aaa
 aaa
@@ -92057,7 +90748,7 @@ elW
 baz
 elW
 mYF
-bbX
+azU
 aXV
 bcS
 nFa
@@ -93814,7 +92505,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 nyC
 acF
 aaa
@@ -95112,11 +93803,11 @@ cGj
 cGj
 cGj
 cGj
-acG
-acG
-acG
-acG
-acG
+ajz
+ajz
+ajz
+ajz
+ajz
 byd
 bIc
 bzF
@@ -96874,7 +95565,7 @@ aJf
 aJf
 aRK
 nZJ
-aSw
+aTQ
 aTk
 aTT
 lbJ
@@ -98675,9 +97366,9 @@ aaa
 anB
 acK
 acK
-acG
+ajz
 aWz
-acG
+ajz
 acK
 acK
 anB
@@ -99038,7 +97729,7 @@ hbZ
 byT
 byT
 buj
-spf
+hpu
 aaa
 aaa
 aaa
@@ -99580,11 +98271,11 @@ aaa
 aaa
 anB
 acK
-acG
-acG
+ajz
+ajz
 aLE
-acG
-acG
+ajz
+ajz
 acK
 anB
 aaa
@@ -103920,10 +102611,10 @@ aaa
 aaa
 aaa
 smI
-acG
+ajz
 tIu
-acG
-acG
+ajz
+ajz
 gIe
 uOI
 cZx
@@ -115349,7 +114040,7 @@ anB
 anB
 anB
 anB
-acG
+ajz
 anB
 anB
 anB
@@ -117358,9 +116049,9 @@ jhj
 aUz
 azy
 xZI
-acG
+ajz
 wDo
-acG
+ajz
 wDo
 rZP
 xeP
@@ -119478,9 +118169,9 @@ aaa
 anM
 anM
 euy
-acG
-acG
-acG
+ajz
+ajz
+ajz
 ptL
 aaa
 aaa
@@ -119803,7 +118494,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 dby
 aCX
 dby
@@ -120407,7 +119098,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 dby
 acd
 acd
@@ -120988,9 +119679,9 @@ mJS
 ums
 dGq
 euy
-acG
-acG
-acG
+ajz
+ajz
+ajz
 ptL
 aaa
 aaa
@@ -121011,7 +119702,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 dby
 acd
 acd
@@ -124444,7 +123135,7 @@ bID
 bID
 bID
 bIU
-acG
+ajz
 anB
 aaa
 aaa
@@ -124676,7 +123367,7 @@ aaa
 aaa
 aTA
 aTA
-acG
+ajz
 aTA
 anB
 mjh
@@ -125482,7 +124173,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 qxy
 dCn
 tzz
@@ -125884,7 +124575,7 @@ aaa
 aaa
 aTA
 aTA
-acG
+ajz
 aTA
 anB
 mjh
@@ -126256,7 +124947,7 @@ bID
 bID
 bID
 bIV
-acG
+ajz
 anB
 aaa
 aaa
@@ -126693,8 +125384,8 @@ aaa
 aaa
 aaa
 aaa
-aae
-acG
+smI
+ajz
 acK
 aei
 aeF
@@ -129128,9 +127819,9 @@ uMj
 hIn
 gwy
 gIE
-acG
-acG
-acG
+ajz
+ajz
+ajz
 alG
 xEz
 jfc
@@ -130622,7 +129313,7 @@ efy
 wfV
 eCh
 wfV
-acG
+ajz
 alf
 dCp
 vLY
@@ -130638,9 +129329,9 @@ ajS
 fGu
 ebB
 alf
-acG
-acG
-acG
+ajz
+ajz
+ajz
 alG
 xEz
 jfc
@@ -131528,7 +130219,7 @@ vFT
 atl
 uPM
 atl
-acG
+ajz
 alf
 eYS
 xon
@@ -131825,11 +130516,11 @@ aaa
 aaa
 aaa
 nqT
-acG
-tGy
-acG
-uUd
-acG
+ajz
+kMA
+ajz
+jWh
+ajz
 alf
 alf
 unh
@@ -132429,11 +131120,11 @@ aaa
 aaa
 aaa
 nqT
-acG
-tGy
-acG
+ajz
+kMA
+ajz
 awQ
-acG
+ajz
 alf
 jHZ
 xon
@@ -133363,7 +132054,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+smI
 sWg
 acF
 aaa
@@ -135281,7 +133972,7 @@ anB
 anB
 anB
 anB
-acG
+ajz
 anB
 anB
 anB


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Removes a bunch of cameras from donut2
* Removes almost all maintenance cameras and adjusts the positions of some that peered into maintenance. The ones near the security dock and disposals are mostly untouched

heatmaps... `blue -> red` : `1 -> 5`

Old: https://i.imgur.com/TUa0JEg.jpg
![image](https://github.com/goonstation/goonstation/assets/33204415/64e1003f-df33-4227-ae58-b97171547573)
New: https://i.imgur.com/dgnLhhB.jpg
![image](https://github.com/goonstation/goonstation/assets/33204415/bbb13df5-815c-4b02-b5b4-2f62acb30a3e)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Reduce over coverage, some turfs were viewed by as many as 9 cameras. This makes camera cutting more viable, and reduces the overhead of camera setup
* Reduce/eliminate maintenance coverage for most areas

```changelog
(u)Sovexe
(*)Removed and repositioned many Donut2 security cameras to reduce redundant coverage and maintenance coverage.
```
