### PR TITLE
Change default photocopier number of copies from 0 to 1

### DIFF
--- a/code/obj/machinery/photocopier.dm
+++ b/code/obj/machinery/photocopier.dm
@@ -13,7 +13,7 @@ TYPEINFO(/obj/machinery/photocopier)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/use_state = 0 //0 is closed, 1 is open, 2 is busy, closed by default
 	var/paper_amount = 0.0 //starts at 0.0, increments by one for every paper added, max of... 30 sheets
-	var/make_amount = 0 //from 0 to 30, amount of copies the photocopier will copy, copy?
+	var/make_amount = 1 //from 0 to 30, amount of copies the photocopier will copy, copy?
 
 	var/list/paper_info = list()//index 1 is name, index 2 is desc, index 3 is info
 	var/list/photo_info = list()//index 1 is name, index 2 is desc, index 3 is fullImage, index 4 is fullIcon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the default number of copies a photocopier creates 1 instead of 0

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I don't think anybody has ever wanted to make 0 copies of something at a photocopier and it's led to at least one instance of confusion because it does the print animation and everything even when it's set to 0
