### PR TITLE
Some Sulfuric Acid Mixing Tweaks

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2641,13 +2641,13 @@
 		temperature_change = 4 //changes to 8 in closed containers
 		stateful = TRUE
 
-		on_reaction(var/datum/reagents/holder)
+		on_reaction(var/datum/reagents/holder, created_volume)
 			if(holder.has_reagent("water"))
-				holder.remove_reagent("water", reaction_speed/2)
+				holder.remove_reagent("water", created_volume/2)
 			else
-				holder.remove_reagent("steam", reaction_speed) //if it gets above 100C, you can still use steam (in a closed container) at half efficiency
-				holder.remove_reagent("sulfur", reaction_speed/2) //also uses these less efficiently; this should mean an even amount of water, sulfur and oxygen will always deplete evenly-ish
-				holder.remove_reagent("oxygen", reaction_speed/2)
+				holder.remove_reagent("steam", created_volume) //if it gets above 100C, you can still use steam (in a closed container) at half efficiency
+				holder.remove_reagent("sulfur", created_volume/2) //also uses these less efficiently; this should mean an even amount of water, sulfur and oxygen will always deplete evenly-ish
+				holder.remove_reagent("oxygen", created_volume/2)
 
 			var/location = get_turf(holder.my_atom)
 			if (holder.my_atom && holder.my_atom.is_open_container() || istype(holder,/datum/reagents/fluid_group))

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2633,26 +2633,36 @@
 		name = "Sulfuric Acid" // COGWERKS CHEM REVISION PROJECT: This could be Fluorosulfuric Acid instead
 		id = "acid"
 		result = "acid"
-		required_reagents = list("sulfur" = 1, "water" = 1, "oxygen" = 1)
+		required_reagents = list("sulfur" = 1, "oxygen" = 1) //water or steam required, see does_react()
 		result_amount = 2
 		mix_phrase = "The mixture gives off a sharp acidic tang."
 		instant = FALSE
 		reaction_speed = 3
-		temperature_change = 10
+		temperature_change = 4 //changes to 8 in closed containers
+		stateful = TRUE
 
 		on_reaction(var/datum/reagents/holder)
+			if(holder.has_reagent("water"))
+				holder.remove_reagent("water", reaction_speed/2)
+			else
+				holder.remove_reagent("steam", reaction_speed) //if it gets above 100C, you can still use steam (in a closed container) at half efficiency
+				holder.remove_reagent("sulfur", reaction_speed/2) //also uses these less efficiently; this should mean an even amount of water, sulfur and oxygen will always deplete evenly-ish
+				holder.remove_reagent("oxygen", reaction_speed/2)
+
 			var/location = get_turf(holder.my_atom)
 			if (holder.my_atom && holder.my_atom.is_open_container() || istype(holder,/datum/reagents/fluid_group))
-				var/smoke_to_create = clamp((holder.total_temperature - T20C)/20 , 0, 5)//for every degree over 20C, make .05u of smoke (up to 5u)...
-				if(smoke_to_create > 0)                                     //...but if under 20C, don't make any
+				temperature_change = 4
+				var/smoke_to_create = clamp((holder.total_temperature - (T20C + 40))/20 , 0, 5)//for every degree over 60C, make .05u of smoke (up to 5u)...
+				if(smoke_to_create > 0)                                                        //...but if under 60C, don't make any
 					var/datum/reagents/smokeContents = new/datum/reagents/
 					smokeContents.add_reagent("acid", smoke_to_create)
 					smoke_reaction(smokeContents, 2, location, do_sfx = FALSE)
 			else
-				if(holder.total_temperature > T20C)
-					var/extra_product = ceil(clamp((holder.total_temperature - T20C) / 10, 1, 15))
-					var/extra_heat = clamp(extra_product + 10, 10, 30)
-					if(istype(holder.my_atom, /obj) && (holder.maximum_volume <= holder.total_volume)) //not enough space for the extra sulfuric acid = beaker shattered + acid vapors leak out
+				temperature_change = 8 //closed container = more contained heat
+				if(holder.total_temperature > T20C + 40)
+					var/extra_product = ceil(clamp((holder.total_temperature - (T20C + 30)) / 10, 1, 15))
+					var/extra_heat = clamp(extra_product + 10, 5, 10)
+					if(holder.total_temperature > T100C + 50) //mixture gets too hot = beaker shattered + acid vapors leak out
 						var/obj/container = holder.my_atom
 						if(container.shatter_chemically())
 							var/datum/reagents/smokeContents = new/datum/reagents/
@@ -2661,6 +2671,10 @@
 						return
 					holder.add_reagent("acid", extra_product, temp_new = holder.total_temperature, chemical_reaction = TRUE)
 					holder.temperature_reagents(holder.total_temperature + extra_heat)
+
+		does_react(var/datum/reagents/holder)
+			if(holder.has_reagent("water") || holder.has_reagent("steam"))
+				return TRUE
 
 	clacid
 		name = "Hydrochloric Acid"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes some stuff about the chem rework sulfuric acid based on feedback I've gotten from it and some ideaposting in discord. In general they're orientated around making it less annoying to make while keeping it still a unique and weirdfun recipe.

- Lowers the heat generated by it from 10 (kelvin) per cycle to 4 in an open container and 8 in a closed container. 10 was definitely too much, and even using something like cryostylane couldn't outpace the heat it was generating. It's meant to be something you can offset, so lower works better here.
- Allows you to use steam in place of water, at the cost of using twice the units to make the same amount. This idea was suggested by rubberrats on discord and I liked it, since it's annoying to end up with like, 13u of sulfur and oxygen, 70u of acid at the end of everything. Using steam also decreases the efficiency of sulfur and oxygen in the recipe to match so you always end up with just acid at the end if the steam doesn't boil off. It also is still 'bad' but not *as* 'bad' as it was, so you're still incentivized to cool the reaction for max output per seconds spent mixing.
- Changed the off-gassing threshold to be 50C instead of 20C, or 323.15K. This means an open container of sulfuric acid won't off-gas until it hits 323.15K. It was originally the intent for players to cool the reaction down first to get this, and be able to safely mix in an open beaker, but I think the interesting part of that is maintaining the temp and not initially cooling it, so raising the threshold beyond what it starts with is easier to work with.
- Changed shatter behavior to instead break at 150C, or 423.15K, but still only in a closed beaker (though you won't mix it in an open beaker at this temp anyways because the steam will boil off and delete itself). The "breaking if it overfills" thing just doesn't really materialize much and is difficult to explain, the only way I've consistently seen it happen is by players just overfilling a beaker with reactants in a dispenser, and I think basing it off heat plays better with the theme of the chem and is easier to understand (and also to trigger by accident). It also means a closed barrel isn't a nearly 100% safe place to mix tons of very hot acid, too, which would be very strong with the steam changes I feel.
- Also the heat generated in a closed beaker when its above 50C (from the 'vapor' that would be made in an open beaker that's retained) has its minimum floor lowered, again just making it overheat way less aggressively and quickly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

All the changes have their reasoning explained pretty clearly in the list, but generally speaking I wanted to tweak acid since it's a bit annoying with the update and something you have to make very frequently. This should also make it much easier to make precise amounts of acid, if you wanted to make a big complicated condenser setup, and make it less horribly punishing to mix it in an open beaker (since I want both open and closed beaker setups to be useful in some way) by making it generate substantially less heat and smoke, and letting you maintain that reaction with consistent cooling.

I also just wanted to address a bit of feedback I've gotten on chem changes I made, and try and make the process less tedious while keeping the interesting parts of the recipe that I like. I think for something so commonly made it could stand to be a bit more lenient at least.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flaborized
(+)Some sulfuric acid tweaks: Steam can now be used in place of water, using twice as many reactants. Open sulfuric acid reactions now start offgassing at 323.15K. Closed container reactions now shatter if they hit 423.15K instead of when the container is full. Closed reactions now heat by 8K per cycle, and open ones heat by 4K, from 10K for both.
```
