### PR TITLE
Perm portal brightness increase

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -2792,7 +2792,7 @@ Returns:
 		..()
 		light = new /datum/light/point
 		light.set_color(0.3, 0.6, 0.8)
-		light.set_brightness(0.5)
+		light.set_brightness(1)
 		light.attach(src)
 		light.enable()
 		SPAWN(0.6 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
increases how much light perm portals emit
before
![image](https://github.com/goonstation/goonstation/assets/124026007/b0545786-f5af-4bb8-9763-a550b190f0b8)
after
![image](https://github.com/goonstation/goonstation/assets/124026007/2c0bfe68-d390-47bc-9794-5d1570c474ed)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it looks cooler, I don't mind if you close this PR if you got any issues with it

<!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


