### PR TITLE
Fix soulguard respawn not preserving factions

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -835,6 +835,7 @@
 	newbody.set_loc(reappear_turf)
 
 	newbody.real_name = src.real_name
+	newbody.faction = src.faction
 
 	// These necessities (organs/limbs/inventory) are bad enough. I don't care about specific damage values etc.
 	// Antag status removal doesn't happen very often (Convair880).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16621 by making sure mob faction is copied over to new body

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug