### PR TITLE
Player Piano Lowered MIN_TIMING

### DIFF
--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -5,7 +5,7 @@
 	icon_state = "piano_key"
 	w_class = W_CLASS_TINY
 
-#define MIN_TIMING 0.25
+#define MIN_TIMING 0.1
 #define MAX_TIMING 0.5
 #define MAX_NOTE_INPUT 15360
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Lowers the Player Piano's `MIN_TIMING` from `0.25` to `0.1`.

I've choosen `0.1` since it's around 200 BPM.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allows faster songs to be played at their intended speed.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimil
(+)Lowered Player Piano min timing to 0.1
```
