### PR TITLE
anchor mineral magnet targets

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -136,6 +136,7 @@
 	var/scan_range = 7
 	var/turf/magnetic_center
 	alpha = 128
+	anchored = ANCHORED_ALWAYS
 
 	small
 		width = 7


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out the guts of the mineral magnet system could get moved by shit.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It should probably be anchored regardless.
Maybe fix #16642
