### PR TITLE
reduces amount of phenol needed for glue production

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2617,8 +2617,8 @@
 		name = "Space Glue"
 		id = "spaceglue"
 		result = "spaceglue"
-		required_reagents = list("plasma" = 1, "phenol" = 1, "oxygen" = 1, "hydrogen" = 1, "formaldehyde" = 1)
-		result_amount = 5
+		required_reagents = list("plasma" = 1, "phenol" = 0.25, "oxygen" = 1, "hydrogen" = 1, "formaldehyde" = 0.75)
+		result_amount = 4
 		mix_phrase = "The substance turns a dull yellow and becomes thick and sticky."
 
 	superlube

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2617,7 +2617,7 @@
 		name = "Space Glue"
 		id = "spaceglue"
 		result = "spaceglue"
-		required_reagents = list("plasma" = 1, "phenol" = 0.25, "oxygen" = 1, "hydrogen" = 1, "formaldehyde" = 0.75)
+		required_reagents = list("plasma" = 1, "phenol" = 0.25, "oxygen" = 1, "hydrogen" = 1, "formaldehyde" = 1)
 		result_amount = 4
 		mix_phrase = "The substance turns a dull yellow and becomes thick and sticky."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes glue's recipe to 1 plasma, 1 oxygen, 1 hydrogen, 1 formaldehyde, 0.25 phenol, reduces total yield from 5 to 4.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

After the chem update, many chems have currently become very resource intensive to produce, this PR focuses on reducing the work and time investment in the production of space glue via reducing the needed amount of formaldehyde and phenol.

```changelog
(u)Colossusqw
(+)Glue's recipe now only requires 0.25 units of phenol.
```
