### PR TITLE
Eye color changing verb for cyborgs

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2229,6 +2229,22 @@
 		targethead.mode = newMode
 		update_bodypart(part = "head")
 		return 1
+	
+	verb/cmd_alter_eye_color()
+		set category = "Robot Commands"
+		set name = "Change eye color"
+		var/datum/robot_cosmetic/C = null
+		if (src.cosmetic_mods)
+			C = src.cosmetic_mods
+		else
+			boutput(usr, "<span class='alert'>ERROR: Cannot find cyborg's decorations.</span>")
+			return
+		var/selected_color = input(usr) as color
+		if(selected_color)
+			C.fx = hex_to_rgb_list(selected_color)
+			src.update_appearance()
+			src.update_bodypart("head")
+		. = TRUE
 
 	verb/access_internal_pda()
 		set category = "Robot Commands"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a verb to cyborgs that lets them change their eye color on the fly

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it's cool to be able to make your eyes glow red when going rogue without going to a docking station


