### PR TITLE
Storehouse: MAPGEN Flags and Meat Storehosue Biomes

### DIFF
--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -774,7 +774,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 		turfs_to_clear += station_repair.get_mass_driver_turfs()
 		generator.clear_walls(turfs_to_clear)
 
-		generator.generate_terrain(space, reuse_seed=TRUE)
+		generator.generate_terrain(space, reuse_seed=TRUE, flags=MAPGEN_ALLOW_VEHICLES * station_repair.allows_vehicles)
 
 		logTheThing(LOG_ADMIN, ui.user, "added some storehouses to space.")
 		logTheThing(LOG_DIARY, ui.user, "added some storehouses to space.", "admin")


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updated Storehouse generator to respect Mapgen flags
Correct BSP Storehouse usage to terminate properly instead of blowing up.

Convert Meat Storehouse to utilize Biomes to handle Light and Critter generation to leverage more standardizes rng and utilize more standardized spatial hashing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bad Bugs, Unify Code, Rainbows and Kittens


