### PR TITLE
Add Syndicate Radio Channel to Syndicate Cyborgs and make them drop Syndie Frames on death

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -643,3 +643,9 @@ var/global/list/module_editors = list()
 	var/chosen = tgui_input_list(usr, "Select a rack to link", "Law racks", racks)
 	if (chosen)
 		src.set_law_rack(racks[chosen])
+
+/mob/living/silicon/proc/add_radio_upgrade(var/obj/item/device/radio_upgrade/upgrade)
+	return FALSE
+
+/mob/living/silicon/proc/remove_radio_upgrade()
+	return FALSE

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -44,9 +44,10 @@
 	var/module_active = null
 	var/list/module_states = list(null,null,null)
 
-	var/obj/item/device/radio/default_radio = null // radio used when there's no module radio
-	var/obj/item/device/radio/radio = null
-	var/obj/item/device/radio/ai_radio = null // Radio used for when this is an AI-controlled shell.
+	var/obj/item/device/radio/headset/default_radio = null // radio used when there's no module radio
+	var/obj/item/device/radio/headset/radio = null
+	var/obj/item/device/radio/headset/ai_radio = null // Radio used for when this is an AI-controlled shell.
+	var/obj/item/device/radio_upgrade/radio_upgrade = null // Used for syndicate robots
 	var/mob/living/silicon/ai/connected_ai = null
 	var/obj/machinery/camera/camera = null
 	var/obj/item/robot_module/module = null
@@ -209,12 +210,14 @@
 			src.botcard.access = get_all_accesses()
 			src.botcard.registered = "Cyborg"
 			src.botcard.assignment = "Cyborg"
-			src.default_radio = new /obj/item/device/radio(src)
+			src.default_radio = new /obj/item/device/radio/headset(src)
 			if (src.shell)
 				src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
 				src.radio = src.ai_radio
 			else
 				src.radio = src.default_radio
+				// Do not apply the radio upgrade to AI shells
+				src.apply_radio_upgrade()
 			src.ears = src.radio
 			src.camera = new /obj/machinery/camera(src)
 			src.camera.c_tag = src.real_name
@@ -263,7 +266,9 @@
 		src.borg_death_alert()
 		logTheThing(LOG_COMBAT, src, "was destroyed at [log_loc(src)].")
 		src.mind?.register_death()
-		if (src.syndicate)
+		var/was_syndicate = src.syndicate
+		if (was_syndicate)
+			// This will set src.syndicate to FALSE as side effect
 			src.remove_syndicate("death")
 
 		src.eject_brain(fling = TRUE) //EJECT
@@ -282,7 +287,7 @@
 
 			var/obj/item/parts/robot_parts/robot_frame/frame =  new(T)
 			frame.emagged = src.emagged
-			frame.syndicate = src.syndicate
+			frame.syndicate = was_syndicate
 			frame.freemodule = src.freemodule
 
 			src.ghostize()
@@ -1536,6 +1541,7 @@
 					if (src.module && istype(src.module.radio))
 						src.radio = src.module.radio
 					src.ears = src.radio
+					src.apply_radio_upgrade()
 					src.radio.set_loc(src)
 					src.part_head.ai_interface = null
 					if(src.ai_radio)
@@ -1871,6 +1877,28 @@
 		else
 			return null
 
+	proc/apply_radio_upgrade()
+		if(!istype(src.radio_upgrade))
+			return
+		// Remove it from the previous radio if applicable
+		var/obj/item/device/radio/headset/previous_radio = src.radio_upgrade.loc
+		if (istype(previous_radio))
+			previous_radio.remove_radio_upgrade()
+		if (istype(src.radio)) // Might be null when the robot is activated
+			src.radio.install_radio_upgrade(src.radio_upgrade)
+
+	add_radio_upgrade(var/obj/item/device/radio_upgrade/upgrade)
+		src.radio_upgrade = upgrade
+		src.apply_radio_upgrade()
+		return TRUE
+
+	remove_radio_upgrade()
+		if (!istype(src.radio_upgrade))
+			return FALSE
+		src.radio.remove_radio_upgrade()
+		src.radio_upgrade = null
+		return TRUE
+
 //////////////////////////
 // Robot-specific Procs //
 //////////////////////////
@@ -1949,6 +1977,7 @@
 				src.radio = RM.radio
 				src.internal_pda.mailgroups = RM.mailgroups
 				src.internal_pda.alertgroups = RM.alertgroups
+				src.apply_radio_upgrade()
 			src.ears = src.radio
 			src.radio.set_loc(src)
 
@@ -1971,6 +2000,7 @@
 				src.radio = src.default_radio
 				src.internal_pda.mailgroups = initial(src.internal_pda.mailgroups)
 				src.internal_pda.alertgroups = initial(src.internal_pda.alertgroups)
+				src.apply_radio_upgrade()
 			src.ears = src.radio
 		return RM
 

--- a/code/modules/antagonists/syndicate_cyborg/syndicate_cyborg.dm
+++ b/code/modules/antagonists/syndicate_cyborg/syndicate_cyborg.dm
@@ -2,7 +2,7 @@
 	id = ROLE_SYNDICATE_ROBOT
 	display_name = "\improper Syndicate cyborg"
 	antagonist_icon = "syndieborg"
-	remove_on_death = TRUE
+	remove_on_death = FALSE // This is done in /mob/living/silicon/robot/death -> /mob/living/silicon/proc/remove_syndicate
 	remove_on_clone = TRUE
 	faction = FACTION_SYNDICATE
 
@@ -17,6 +17,7 @@
 		cyborg.law_rack_connection = ticker?.ai_law_rack_manager?.default_ai_rack_syndie
 		cyborg.syndicate = TRUE
 		cyborg.show_laws()
+		cyborg.add_radio_upgrade(new/obj/item/device/radio_upgrade/syndicatechannel)
 
 	remove_equipment()
 		if (!isrobot(src.owner.current))
@@ -26,6 +27,7 @@
 		cyborg.law_rack_connection = ticker?.ai_law_rack_manager?.default_ai_rack
 		cyborg.syndicate = FALSE
 		cyborg.show_laws()
+		cyborg.remove_radio_upgrade()
 
 	add_to_image_groups()
 		. = ..()

--- a/code/modules/robotics/robot/module/parent.dm
+++ b/code/modules/robotics/robot/module/parent.dm
@@ -17,7 +17,7 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 	var/included_tools = null
 	var/included_cosmetic = null
 	var/radio_type = null
-	var/obj/item/device/radio/radio = null
+	var/obj/item/device/radio/headset/radio = null
 	var/list/mailgroups = list(MGO_SILICON, MGD_PARTY)
 	var/list/alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH)
 

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -644,3 +644,10 @@ TYPEINFO(/obj/item/device/radio_upgrade)
 
 			src.secure_frequencies = list("z" = frequency)
 			src.secure_classes = list("z" = RADIOCL_SYNDICATE)
+
+	// Used by syndieborgs
+	syndicatechannel
+		name = "syndicate radio channel upgrade"
+		desc = "A device capable of communicating over a private secure radio channel. Can be installed in a radio headset."
+		secure_frequencies = list("z" = R_FREQ_SYNDICATE)
+		secure_classes = list("z" = RADIOCL_SYNDICATE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Syndicate Cyborgs now have access to the syndicate radio channel
Fixes #13396
Fixes #16663

[A-Silicons] [C-Feature] [C-Bug]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Syndicate Robots can facilitate traitors teaming up. It is much more fun to be evil together.
As such, a reliable way to keep in contact with syndicate borgs can help with that.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(*)Syndicate Cyborgs now have access to the Syndicate Radio Channel. Buy a wiretap upgrade or a headset from CARL so you can speak with them.
(+)Syndicate Cyborgs now drop a Syndicate Frame when destroyed (#13396).
```
