### PR TITLE
Allows CO2 and fluids to act as neutron shielding

### DIFF
--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -840,14 +840,18 @@
 
 	tick(var/obj/projectile/P)
 		var/turf/simulated/T = get_turf(P)
-		if (issimulatedturf(T))
+		if (istype(T, /turf/space/fluid)) //can't really calculate this, just make it do something at least
+			P.power -= 10
+		else if (issimulatedturf(T))
 			var/obj/fluid/fluid = T.active_liquid
 			if (fluid)
-				var/viscosity = max(fluid.group.avg_viscosity, 10) //fluid group viscocity is either 1 or on a scale between 10-20, why
+				var/viscosity = max(fluid.group.avg_viscosity, 10) //fluid group viscocity seems to be either 1 or on a scale between 10-20, why
 				P.power -= viscosity * fluid.my_depth_level / 2
 				fluid.group.reagents.add_reagent("radium", P.power / 10)
 
-			P.power -= min(T.air.carbon_dioxide / 7, 40)
+			if (T.air?.carbon_dioxide)
+				P.power -= min(T.air.carbon_dioxide / 7, 40)
+				T.air.radgas += 1
 
 		if(P.power <= 0)
 			P.die()

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -839,6 +839,16 @@
 		return TRUE
 
 	tick(var/obj/projectile/P)
+		var/turf/simulated/T = get_turf(P)
+		if (issimulatedturf(T))
+			var/obj/fluid/fluid = T.active_liquid
+			if (fluid)
+				var/viscosity = max(fluid.group.avg_viscosity, 10) //fluid group viscocity is either 1 or on a scale between 10-20, why
+				P.power -= viscosity * fluid.my_depth_level / 2
+				fluid.group.reagents.add_reagent("radium", P.power / 10)
+
+			P.power -= min(T.air.carbon_dioxide / 7, 40)
+
 		if(P.power <= 0)
 			P.die()
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Neutrons lose power on passing through fluids based on the level and viscosity of the fluid, adding a small amount of radium as they do so to simulate tritium contamination (we don't have tritium)
Neutrons lose power on passing through CO2 gas, adding a small amount of fallout gas as they do to simulate umm idk I like fallout gas.

Numbers are sourced from me recompiling and tweaking them until it feels right, may be subject to change after contact with live server engineering,

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shielding nuclear reactors is hard, flooding your reactor room with CO2 and liquid dark matter to contain the angry neutrons is cool.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)CO2 and fluid puddles now work as partial neutron shielding, leaving behind fallout gas and radium contaminants respectively.
```
