### PR TITLE
Add sanctuary checks to a bunch of things

### DIFF
--- a/code/modules/chemistry/tools/sleepy_pen.dm
+++ b/code/modules/chemistry/tools/sleepy_pen.dm
@@ -29,6 +29,8 @@
 	attack(mob/M, mob/user)
 		if (!ismob(M))
 			return
+		if (check_target_immunity(target=M, ignore_everything_but_nodamage=FALSE, source=user))
+			return ..()
 		if (src.reagents.total_volume)
 			if (!M.reagents || (M.reagents && M.reagents.is_full()))
 				user.show_text("[M] cannot absorb any chemicals.", "red")

--- a/code/obj/item/beartrap.dm
+++ b/code/obj/item/beartrap.dm
@@ -58,6 +58,8 @@
 
 	Crossed(mob/living/M)
 		if (src.armed && istype(M) && !(isintangible(M) || isghostcritter(M)) && !M.isFlying)
+			if (check_target_immunity(target=M, ignore_everything_but_nodamage=FALSE, source=src))
+				return ..()
 			src.triggered(M)
 			M.visible_message("<span class='alert'><B>[M] steps on the bear trap!</B></span>",\
 			"<span class='alert'><B>You step on the bear trap!</B></span>")

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -843,19 +843,20 @@ ADMIN_INTERACT_PROCS(/obj/item/roadflare, proc/light, proc/put_out)
 	attack(mob/M, mob/user)
 		if (src.on == FLARE_LIT)
 			if (ishuman(M))
-				if (src.on > 0)
-					var/mob/living/carbon/human/H = M
-					if (H.bleeding || ((H.organHolder && !H.organHolder.get_organ("butt")) && user.zone_sel.selecting == "chest"))
-						src.cautery_surgery(H, user, 5, src.on)
-						return ..()
-					else
-						user.visible_message("<span class='alert'><b>[user]</b> pushes the burning [src] against [H]!</span>",\
-						"<span class='alert'>You press the burning end of [src] against [H]!</span>")
-						playsound(src.loc, 'sound/impact_sounds/burn_sizzle.ogg', 50, 1)
-						H.TakeDamage("All", 0, rand(3,7))
-						if (!H.stat && !ON_COOLDOWN(H, "burn_scream", 4 SECONDS))
-							H.emote("scream")
-						return
+				if (check_target_immunity(target=M, ignore_everything_but_nodamage=FALSE, source=user))
+					return ..()
+				var/mob/living/carbon/human/H = M
+				if (H.bleeding || ((H.organHolder && !H.organHolder.get_organ("butt")) && user.zone_sel.selecting == "chest"))
+					src.cautery_surgery(H, user, 5, src.on)
+					return ..()
+				else
+					user.visible_message("<span class='alert'><b>[user]</b> pushes the burning [src] against [H]!</span>",\
+					"<span class='alert'>You press the burning end of [src] against [H]!</span>")
+					playsound(src.loc, 'sound/impact_sounds/burn_sizzle.ogg', 50, 1)
+					H.TakeDamage("All", 0, rand(3,7))
+					if (!H.stat && !ON_COOLDOWN(H, "burn_scream", 4 SECONDS))
+						H.emote("scream")
+					return
 		else
 			return ..()
 

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -193,14 +193,11 @@ TYPEINFO(/obj/item/saw/syndie)
 					qdel(C)
 				return
 
+		if (check_target_immunity(target=target, ignore_everything_but_nodamage=FALSE, source=user))
+			return ..()
+
 		if (!ishuman(target))
 			target.changeStatus("weakened", 3 SECONDS)
-			return ..()
-
-		if (target.nodamage)
-			return ..()
-
-		if (target.spellshield)
 			return ..()
 
 		target.changeStatus("weakened", 3 SECONDS)
@@ -374,6 +371,8 @@ TYPEINFO(/obj/item/saw/elimbinator)
 
 	attack(mob/target, mob/user)
 		if (ishuman(target))
+			if (check_target_immunity(target=target, ignore_everything_but_nodamage=FALSE, source=user))
+				return ..()
 			var/mob/living/carbon/human/H = target
 			var/list/limbs = list("l_arm","r_arm","l_leg","r_leg")
 			var/the_limb = null

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -811,7 +811,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 /obj/item/knife/butcher/throw_impact(atom/A, datum/thrown_thing/thr)
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
-		if (C.spellshield)
+		if (check_target_immunity(target=C, ignore_everything_but_nodamage=FALSE, source=usr))
 			return ..()
 		if (ismob(usr))
 			A:lastattacker = usr
@@ -834,6 +834,8 @@ TYPEINFO(/obj/item/sword/pink/angel)
 
 	if (iscarbon(target))
 		var/mob/living/carbon/C = target
+		if (check_target_immunity(target=C, ignore_everything_but_nodamage=FALSE, source=user))
+			return ..()
 		if (!isdead(C))
 			random_brute_damage(C, 20,1)//no more AP butcher's knife, jeez
 			take_bleeding_damage(C, user, 10, DAMAGE_STAB)
@@ -1163,9 +1165,7 @@ TYPEINFO(/obj/item/bat)
 /obj/item/swords/attack(mob/target, mob/user, def_zone, is_special = 0)
 	if(!ishuman(target)) //only humans can currently be dismembered
 		return ..()
-	if (target.nodamage)
-		return ..()
-	if (target.spellshield)
+	if (check_target_immunity(target=target, ignore_everything_but_nodamage=FALSE, source=user))
 		return ..()
 	var/zoney = user.zone_sel.selecting
 	var/mob/living/carbon/human/H = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add sanctuary checks to:
- Red saw
- Katana
- Sleepypen
- Butcher knife
- Beartrap
- Roadflare
- Elimbinator


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Weapons aren't supposed to work in sanctuary. This mainly results in griefing in the murderbox.
Fixes #14957
Fixes #13614
Fixes #12340