### PR TITLE
Brings us rust iconstates

### DIFF
--- a/_std/rust_g.dm
+++ b/_std/rust_g.dm
@@ -127,6 +127,12 @@
 #define rustg_dmi_strip_metadata(fname) RUSTG_CALL(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) RUSTG_CALL(RUST_G, "dmi_create_png")(path, width, height, data)
 #define rustg_dmi_resize_png(path, width, height, resizetype) RUSTG_CALL(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
+/**
+ * input: must be a path, not an /icon; you have to do your own handling if it is one, as icon objects can't be directly passed to rustg.
+ *
+ * output: json_encode'd list. json_decode to get a flat list with icon states in the order they're in inside the .dmi
+ */
+#define rustg_dmi_icon_states(fname) RUSTG_CALL(RUST_G, "dmi_icon_states")(fname)
 
 #define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
 #define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)


### PR DESCRIPTION
[INTERNAL][PERFORMANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates rust_g.dm to have rustg_dmi_icon_states, which is mega faster than standard icon states. does not actually put them anywhere yet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being up to date with fast stuff is good :)
