### PR TITLE
Rename tfireflash() to fireflash()

### DIFF
--- a/code/mob/living/critter/mob_bots.dm
+++ b/code/mob/living/critter/mob_bots.dm
@@ -392,5 +392,5 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 				continue
 			if (GET_DIST(holder.owner,F) > max_fire_range)
 				continue
-			tfireflash(F,0.5,temp)
+			fireflash(F,0.5,temp)
 

--- a/code/mob/living/critter/sawfly.dm
+++ b/code/mob/living/critter/sawfly.dm
@@ -176,10 +176,10 @@ This file is the critter itself, and all the custom procs it needs in order to f
 	proc/blowup() //chance to activate when they die and get EMP'd
 		if(prob(66))
 			src.visible_message("<span class='combat'>[src]'s [pick("motor", "core", "fuel tank", "battery", "thruster")] [pick("combusts", "catches on fire", "ignites", "lights up", "bursts into flames")]!<span>")
-			fireflash(src,1,TRUE)
+			fireflash(src,1, ignoreUnreachable = TRUE)
 		else
 			src.visible_message("<span class='combat'>[src]'s [pick("motor", "core", "head", "engine", "thruster")] [pick("overloads", "blows up", "catastrophically fails", "explodes")]!<span>")
-			fireflash(src,0,TRUE)
+			fireflash(src,0, ignoreUnreachable = TRUE)
 			explosion(src, get_turf(src), 0, 0.75, 1.5, 3)
 			qdel(src)
 

--- a/code/modules/antagonists/wizard/abilities/fireball.dm
+++ b/code/modules/antagonists/wizard/abilities/fireball.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	shot_sound = 'sound/effects/mag_fireballlaunch.ogg'
 	damage = 30
-	
+
 	is_magical = 1
 
 	on_hit(atom/hit, direction, var/obj/projectile/projectile)
@@ -15,7 +15,7 @@
 			if(prob(50))
 				explosion_new(null, T, 2, 1.2, turf_safe = TRUE)
 			boutput(projectile.mob_shooter, "<span class='notice'>Your spell is weakened without a staff to channel it.</span>")
-		fireflash(T, 1, 1)
+		fireflash(T, 1, ignoreUnreachable = TRUE)
 
 /datum/projectile/fireball/fire_elemental
 	is_magical = 0
@@ -23,7 +23,7 @@
 	on_hit(atom/hit, direction, obj/projectile/projectile)
 		var/turf/T = get_turf(hit)
 		explosion(projectile, T, -1, -1, 0, 1)
-		fireflash(T, 1, 1)
+		fireflash(T, 1, ignoreUnreachable = TRUE)
 
 /datum/targetable/spell/fireball
 	name = "Fireball"

--- a/code/modules/antagonists/wizard/abilities/phaseshift.dm
+++ b/code/modules/antagonists/wizard/abilities/phaseshift.dm
@@ -363,7 +363,7 @@
 
 		relaymove()
 			..()
-			tfireflash(get_turf(owner), 0, 100)
+			fireflash(get_turf(owner), 0, 100)
 
 
 		dispel()

--- a/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
+++ b/code/modules/antagonists/wraith/objs/machinery/runetrap.dm
@@ -144,7 +144,7 @@
 		if(!try_trigger(AM)) return
 		var/mob/M = AM
 		if(!checkRun(M)) return
-		fireflash(M, 1, TRUE)
+		fireflash(M, 1, ignoreUnreachable = TRUE)
 		playsound(src, 'sound/effects/mag_fireballlaunch.ogg', 50, FALSE)
 		src.visible_message("<span class='alert>[M] steps on [src] and triggers it! A flame engulfs them immediatly!</span>")
 		playsound(src, 'sound/voice/wraith/wraithraise3.ogg', 80)

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -507,13 +507,13 @@
 			var/turf/location = 0
 			if (holder?.my_atom)
 				location = get_turf(holder.my_atom)
-				tfireflash(location, 1, 7000)
+				fireflash(location, 1, 7000)
 			else
 				var/amt = max(1, (holder.covered_cache.len * (created_volume / holder.covered_cache_volume)))
 				for (var/i = 0, i < amt && holder.covered_cache.len, i++)
 					location = pick(holder.covered_cache)
 					holder.covered_cache -= location
-					tfireflash(location, 1/amt, 7000/amt)
+					fireflash(location, 1/amt, 7000/amt)
 
 			return
 

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -1373,4 +1373,4 @@ datum/reagent/drug/hellshroom_extract/proc/breathefire(var/mob/M)
 			continue
 		if (GET_DIST(M,F) > range)
 			continue
-		tfireflash(F,1,temp)
+		fireflash(F,1,temp)

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -402,7 +402,7 @@ datum
 			volatility = 4
 
 			reaction_turf(var/turf/T, var/volume)
-				tfireflash(T, clamp(volume/10, 0, 8), 7000)
+				fireflash(T, clamp(volume/10, 0, 8), 7000)
 				if(!istype(T, /turf/space))
 					SPAWN(max(10, rand(20))) // let's burn right the fuck through the floor
 						switch(volume)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -197,7 +197,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 		var/datum/plantgenes/DNA = src.plantgenes
 		if(!T) return
 		if(!T || src.disposed) return
-		fireflash(T,1,1)
+		fireflash(T,1, ignoreUnreachable = TRUE)
 		if(istype(H))
 			var/p = max(DNA?.get_effective_value("potency"), 0) //no vertical aymptote for you, buster
 			H.TakeDamage("chest", 0, (max(70 * p / (p + 100) + 5, 0)*(1-H.get_heat_protection()/100)), 0)//approaches 75 as potency approaches infinity

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1736,7 +1736,7 @@
 				continue
 			if (GET_DIST(owner,F) > range)
 				continue
-			tfireflash(F,0.5,temp)
+			fireflash(F,0.5,temp)
 
 	cast_misfire(atom/target)
 		if (..())

--- a/code/modules/robotics/bot/chefbot.dm
+++ b/code/modules/robotics/bot/chefbot.dm
@@ -168,7 +168,7 @@
 							sleep(4 SECOND)
 							speak("TURN THE HEAT UP! I WANT TO HEAR IT SIZZLE!", "NO UNDERCOOKED MEAT IN MY KITCHEN!", "I HAVE TO DO THIS SHIT MYSELF! PATHETIC!", "DO I HAVE TO DO EVERYTHING HERE?")
 							src.visible_message("<span class='alert'>[src] flares up in anger!</span>")
-							fireflash(src, 1, 1)
+							fireflash(src, 1, ignoreUnreachable = TRUE)
 						else
 							speak("THIS [pick("HUMAN", "PRIMATE", "STEAK", "BURGER", "PORK", "MEAT")] IS FUCKING [pick("OVERCOOKED", "BURNT")]!")
 				else
@@ -249,7 +249,7 @@
 	var/turf/Tsec = get_turf(src)
 	elecflash(src, radius=1, power=3, exclude_center = 0)
 	if (src.emagged)
-		fireflash(src, 1, 1)
+		fireflash(src, 1, ignoreUnreachable = TRUE)
 	new /obj/item/clothing/head/dramachefhat(Tsec)
 	qdel(src)
 	return

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -328,7 +328,7 @@
 				continue
 			if (GET_DIST(owner,F) > range)
 				continue
-			tfireflash(F,0.5,temp)
+			fireflash(F,0.5,temp)
 
 		//reduce duration
 		src.duration -= min(durationLoss,src.duration)

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -84,7 +84,7 @@
 		switch(curAttack)
 			if("fire")
 				playsound(T, 'sound/effects/bamf.ogg', 50, TRUE, 0)
-				tfireflash(T, powerVars["fireRadius"], powerVars["fireTemp"])
+				fireflash(T, powerVars["fireRadius"], powerVars["fireTemp"])
 
 				ArtifactLogs(user, T, O, "used", "creating fireball on target turf", 0) // Attack wands need special log handling (Convair880).
 

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1544,7 +1544,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			continue
 		if (GET_DIST(user,F) > range)
 			continue
-		tfireflash(F,0.5,2400)
+		fireflash(F,0.5,2400)
 
 // Pulse Rifle //
 // An energy gun that uses the lawbringer's Pulse setting, to beef up the current armory.

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -709,7 +709,7 @@
 				src.ClearSpecificParticles("mine_spark")
 			sleep(0.7 SECONDS) // just enough time to recognize the card
 			if (I)
-				fireflash(I,0,TRUE)
+				fireflash(I,0, ignoreUnreachable = TRUE)
 				I.combust()
 
 	/**

--- a/code/obj/torpedoes.dm
+++ b/code/obj/torpedoes.dm
@@ -46,7 +46,7 @@
 
 	explode()
 		new/obj/effect/supplyexplosion(src.loc)
-		tfireflash(src, 8, 9800, 0)
+		fireflash(src, 8, 9800, FALSE)
 		qdel(src)
 		return
 

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2096,7 +2096,7 @@ TYPEINFO(/obj/vehicle/adminbus)
 	do_special_on_relay(mob/user, dir) //this should probably actually be inside an overriden Move() proc, but I've preserved the original behavior here instead.
 		icon_state = moving_state
 		if(src.power_hotwheels)
-			tfireflash(get_turf(src), 0, 100)
+			fireflash(get_turf(src), 0, 100)
 		if(src.power_staticcharge)
 			elecflash(get_turf(src),radius=0, power=2, exclude_center = 0)
 		if(src.power_bomberbus && prob(power_bomberbus_chance))

--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -1,7 +1,5 @@
-/proc/fireflash(atom/center, radius, ignoreUnreachable)
-	tfireflash(center, radius, rand(2800,3200), ignoreUnreachable)
-
-/proc/tfireflash(atom/center, radius, temp, ignoreUnreachable)
+/// generic proc for creating flashes of hotspot fire
+/proc/fireflash(atom/center, radius, temp = rand(2800, 3200), ignoreUnreachable = FALSE)
 	if (locate(/obj/blob/firewall) in center)
 		return
 	var/list/hotspots = new/list()
@@ -17,10 +15,6 @@
 		hotspots += T.active_hotspot
 
 		T.hotspot_expose(T.active_hotspot.temperature, T.active_hotspot.volume)
-/*// experimental thing to let temporary hotspots affect atmos
-		h.perform_exposure()
-*/
-		//SPAWN(1.5 SECONDS) T.hotspot_expose(2000, 400)
 
 		if(istype(T, /turf/simulated/floor)) T:burn_tile()
 		SPAWN(0)


### PR DESCRIPTION
[INTERNAL][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just renames tfireflash() to fireflash()


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems fireflash() right now is just a wrapper proc for tfireflash() that doesn't add anything extra, so just renaming for making it easier to understand the file
