### PR TITLE
Add silicon support for ABCU

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -95,7 +95,7 @@
 					src.current_bp = W
 					return
 			else if (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece))
-				boutput(user, "<span class='notice'>You insert the material into the machine.</span>")
+				boutput(user, "<span class='notice'>You insert [W] into the machine.</span>")
 				W.set_loc(src)
 				return
 			return

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -39,6 +39,7 @@
 	opacity = 0
 	anchored = UNANCHORED
 	processing_tier = PROCESSING_FULL
+	event_handler_flags = NO_MOUSEDROP_QOL
 
 	var/invalid_count = 0
 	var/building = FALSE
@@ -62,10 +63,6 @@
 		..()
 		UnsubscribeProcess()
 
-	attack_ai(mob/user)
-		boutput(user, "<span class='alert'>This machine is not linked to your network.</span>")
-		return
-
 	attackby(obj/item/W, mob/user)
 		if(istype(W, /obj/item/blueprint))
 			if(src.current_bp)
@@ -83,6 +80,26 @@
 			W.set_loc(src)
 			return
 		return
+	
+	MouseDrop_T(obj/item/W, mob/user)
+		if (!in_interact_range(src, user)  || BOUNDS_DIST(W, user) > 0 || !can_act(user))
+			return
+		else
+			if(istype(W, /obj/item/blueprint))
+				if(src.current_bp)
+					boutput(user, "<span class='alert'>Theres already a blueprint in the machine.</span>")
+					return
+				else
+					boutput(user, "<span class='notice'>You insert the blueprint into the machine.</span>")
+					W.set_loc(src)
+					src.current_bp = W
+					return
+			else if (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece))
+				boutput(user, "<span class='notice'>You insert the material into the machine.</span>")
+				W.set_loc(src)
+				return
+			return
+		
 
 	attack_hand(mob/user)
 		if(src.building && !src.paused)

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -138,6 +138,7 @@
 		/obj/item/lamp_manufacturer,
 		/obj/item/deconstructor/borg,
 		/obj/item/pinpointer/category/apcs/station,
+		/obj/item/blueprint_marker,
 		#ifdef MAP_OVERRIDE_OSHAN
 			/obj/item/mining_tool/power_shovel/borg,
 		#endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows mousedropping materials and blueprints into the ABCU.
Adds the blueprint marker to the engineering cyborg's item list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People don't use ABCU's that much, so I thought it would be cool to expand the list of people that can use it
