### PR TITLE
Fixes empty gas tanks not being usable in flamethrowers

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -590,7 +590,7 @@ A Flamethrower in various states of assembly
 	if (!W || user.stat || user.restrained() || user.lying)
 		return
 
-	if (src.swappable_tanks && (istype(W,/obj/item/tank/oxygen) || istype(W,/obj/item/tank/air) || istype(W,/obj/item/tank/anesthetic) || istype(W,/obj/item/reagent_containers/food/drinks/fueltank)))
+	if (src.swappable_tanks && (istype(W,/obj/item/tank/oxygen) || istype(W,/obj/item/tank/air) || istype(W,/obj/item/tank/anesthetic) || istype(W,/obj/item/tank/empty) || istype(W,/obj/item/reagent_containers/food/drinks/fueltank)))
 		if(src.lit)
 			boutput(user, "<span class='notice'>You turn off \the [src]'s igniter. Safety first!</span>")
 			lit = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16682 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should fit like any other cylindrical tank can