### PR TITLE
Wrestlemap Podbay Fixes

### DIFF
--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -36822,7 +36822,7 @@
 	},
 /area/station/medical/medbay/treatment1)
 "qjd" = (
-/obj/machinery/vehicle/pod_smooth/heavy,
+/obj/machinery/vehicle/pod_smooth/heavy/security,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "qje" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -47895,10 +47895,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
-"vdG" = (
-/obj/machinery/computer/door_control,
-/turf/space,
-/area/space)
 "vdO" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -79156,7 +79152,7 @@ vnX
 vnX
 vnX
 say
-vdG
+vnX
 vnX
 vnX
 vnX

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -3236,16 +3236,6 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/space)
-"bvp" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "hangar_main";
-	name = "Mechanic's Bay"
-	},
-/turf/simulated/floor/engine/caution/west,
-/area/station/hangar/main)
 "bvr" = (
 /obj/stool/chair/couch/yellow{
 	dir = 4
@@ -9702,10 +9692,6 @@
 /area/station/maintenance/northwest{
 	name = "Corpse Tunnel"
 	})
-"eji" = (
-/obj/machinery/r_door_control/podbay/qm/new_walls/east,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/qm)
 "ejs" = (
 /obj/decal/cleanable/fungus,
 /turf/simulated/floor/plating,
@@ -13535,13 +13521,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/inner/the_cage)
-"fUg" = (
-/obj/machinery/light/emergency{
-	dir = 8
-	},
-/obj/machinery/r_door_control/podbay/escape/new_walls/west,
-/turf/space,
-/area/space)
 "fUm" = (
 /obj/table/reinforced/auto,
 /obj/item/clipboard,
@@ -15254,16 +15233,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"gKL" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoorleft1";
-	id = "hangar_cargo";
-	name = "Cargo Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/qm)
 "gKP" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
@@ -16411,6 +16380,10 @@
 /area/station/maintenance/west{
 	name = "Boardroom"
 	})
+"hjM" = (
+/obj/machinery/r_door_control/podbay/security,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/elect)
 "hka" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17305,16 +17278,6 @@
 "hEQ" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/the_cage)
-"hFa" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoorleft1";
-	id = "hangar_escape";
-	name = "Escape Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/escape)
 "hFx" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/submachine/laundry_machine,
@@ -18782,16 +18745,6 @@
 "ipI" = (
 /turf/simulated/floor/plating/airless,
 /area/station/mining/staff_room)
-"ipW" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "hangar_escape";
-	name = "Escape Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/escape)
 "iqa" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
@@ -19447,12 +19400,6 @@
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
-"iCY" = (
-/obj/machinery/r_door_control/podbay/mainpod1/new_walls/west{
-	id = "hangar_main"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/main)
 "iCZ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -19566,16 +19513,6 @@
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/carpet/grime,
 /area/station/crewquarters/cryotron)
-"iFf" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoorleft1";
-	id = "hangar_research";
-	name = "Science Hangar"
-	},
-/turf/simulated/floor/engine/caution/west,
-/area/station/hangar/science)
 "iFs" = (
 /obj/rack,
 /obj/item/clothing/shoes/clown_shoes,
@@ -19852,16 +19789,6 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/north)
-"iJY" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "hangar_research";
-	name = "Science Hangar"
-	},
-/turf/simulated/floor/engine/caution/west,
-/area/station/hangar/science)
 "iKR" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20087,12 +20014,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"iOi" = (
-/obj/machinery/r_door_control/podbay/security/new_walls/north{
-	id = "hangar_bridge"
-	},
-/turf/space,
-/area/space)
 "iOr" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/space)
@@ -22215,12 +22136,12 @@
 /turf/simulated/floor/black,
 /area/station/science/teleporter)
 "jHW" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/research_horizontal/vertical,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	icon_state = "bdoorright1";
-	id = "hangar_research";
-	name = "Science Hangar"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/hangar/science)
@@ -22387,10 +22308,6 @@
 	},
 /turf/simulated/floor/black/corner,
 /area/station/engine/storage)
-"jKl" = (
-/obj/machinery/r_door_control/podbay/research/new_walls/east,
-/turf/space,
-/area/space)
 "jKt" = (
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
@@ -22967,6 +22884,10 @@
 /obj/cable,
 /turf/simulated/floor/wood,
 /area/station/medical/staff)
+"jXi" = (
+/obj/machinery/r_door_control/podbay/mainpod1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/main)
 "jXC" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -23786,12 +23707,12 @@
 	name = "Ringside Hallway"
 	})
 "ksg" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mainpod1_horizontal/vertical,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	icon_state = "bdoorright1";
-	id = "hangar_main";
-	name = "Mechanic's Bay"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/hangar/main)
@@ -25080,10 +25001,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"kWI" = (
-/obj/machinery/r_door_control/podbay/qm/new_walls/west,
-/turf/space,
-/area/space)
 "kWK" = (
 /obj/item/clothing/under/towel,
 /obj/machinery/light{
@@ -26862,16 +26779,6 @@
 	},
 /turf/space,
 /area/space)
-"lKH" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoorleft1";
-	id = "hangar_main";
-	name = "Mechanic's Bay"
-	},
-/turf/simulated/floor/engine/caution/west,
-/area/station/hangar/main)
 "lKY" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -28951,15 +28858,6 @@
 "mIb" = (
 /turf/simulated/floor/plating,
 /area/listeningpost/syndicate_teleporter)
-"mIx" = (
-/obj/machinery/light/emergency{
-	dir = 4
-	},
-/obj/machinery/r_door_control/podbay/mainpod1/new_walls/east{
-	id = "hangar_main"
-	},
-/turf/space,
-/area/space)
 "mIN" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -34044,12 +33942,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "oTY" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/escape_horizontal/vertical,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	icon_state = "bdoorright1";
-	id = "hangar_escape";
-	name = "Escape Hangar"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/hangar/escape)
@@ -35192,12 +35090,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "pwA" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal/vertical,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	icon_state = "bdoorright1";
-	id = "hangar_bridge";
-	name = "Command Hangar"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/hangar/sec)
@@ -38963,9 +38861,6 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/machinery/r_door_control/podbay/security/new_walls/north{
-	id = "hangar_bridge"
-	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "rgC" = (
@@ -39000,6 +38895,10 @@
 	dir = 5
 	},
 /area/mining/magnet)
+"rhi" = (
+/obj/machinery/r_door_control/podbay/escape,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/escape)
 "rhm" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -39667,10 +39566,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"rvy" = (
-/obj/machinery/r_door_control/podbay/research/new_walls/west,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/science)
 "rvQ" = (
 /obj/storage/crate/furnacefuel,
 /obj/item/device/radio/intercom{
@@ -41945,6 +41840,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/monitoring)
+"ssJ" = (
+/obj/machinery/r_door_control/podbay/qm,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/qm)
 "ssT" = (
 /obj/cable{
 	icon_state = "5-6"
@@ -46331,16 +46230,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
-"usx" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "hangar_cargo";
-	name = "Cargo Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/qm)
 "usD" = (
 /obj/table/glass/auto,
 /obj/cable{
@@ -48137,6 +48026,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
+"viA" = (
+/obj/machinery/r_door_control/podbay/research,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/science)
 "vje" = (
 /obj/lattice,
 /obj/warp_beacon/mainpod1,
@@ -48867,16 +48760,6 @@
 	dir = 4
 	},
 /area/station/medical/medbay/pharmacy)
-"vvV" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "hangar_bridge";
-	name = "Command Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/sec)
 "vwd" = (
 /obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
@@ -52408,16 +52291,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/pharmacy)
-"wWv" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
-	dir = 4;
-	icon_state = "bdoorleft1";
-	id = "hangar_bridge";
-	name = "Command Hangar"
-	},
-/turf/simulated/floor/engine/caution/east,
-/area/station/hangar/sec)
 "wWw" = (
 /obj/decal/boxingropeenter,
 /turf/simulated/floor/engine{
@@ -52988,7 +52861,6 @@
 	tag = ""
 	},
 /obj/machinery/portable_reclaimer,
-/obj/machinery/r_door_control/podbay/escape/new_walls/east,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "xhY" = (
@@ -53084,12 +52956,12 @@
 	},
 /area/station/hallway/primary/west)
 "xkY" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	autoclose = 1;
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/qm_horizontal/vertical,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	icon_state = "bdoorright1";
-	id = "hangar_cargo";
-	name = "Cargo Hangar"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/hangar/qm)
@@ -79584,7 +79456,7 @@ rGp
 vnX
 vnX
 vnX
-jKl
+vnX
 rGp
 vnX
 vnX
@@ -79883,10 +79755,10 @@ vnX
 vnX
 vnX
 vJc
-iFf
-iJY
 jHW
-vJc
+jHW
+jHW
+viA
 vJc
 vnX
 vnX
@@ -80188,7 +80060,7 @@ aTw
 jzG
 jzG
 jzG
-rvy
+jzG
 vJc
 vJc
 pyz
@@ -81434,7 +81306,7 @@ dtH
 vnX
 qcr
 vnX
-mIx
+wba
 vnX
 vnX
 vnX
@@ -81736,11 +81608,11 @@ aCq
 jxU
 jxU
 jxU
-jxU
-lKH
-bvp
-bvp
-bvp
+jXi
+ksg
+ksg
+ksg
+ksg
 ksg
 jxU
 pyz
@@ -82038,7 +81910,7 @@ xFg
 jxU
 dEi
 wFU
-iCY
+wFU
 wFU
 wFU
 wFU
@@ -109508,12 +109380,12 @@ vTH
 nvR
 dmC
 cKT
-wWv
-vvV
-vvV
-vvV
 pwA
-pZk
+pwA
+pwA
+pwA
+pwA
+hjM
 pZk
 pZk
 flw
@@ -109810,7 +109682,7 @@ nvR
 oQE
 rbw
 yeN
-iOi
+vnX
 vnX
 vnX
 vnX
@@ -111630,7 +111502,7 @@ vnX
 noL
 vnX
 hSw
-eji
+xxa
 xxa
 xxa
 xxa
@@ -111932,11 +111804,11 @@ vnX
 say
 vnX
 hSw
-hSw
-gKL
-usx
-usx
-usx
+ssJ
+xkY
+xkY
+xkY
+xkY
 xkY
 iOr
 guI
@@ -112234,7 +112106,7 @@ vnX
 say
 vnX
 fzG
-kWI
+vnX
 vnX
 vnX
 vnX
@@ -121564,9 +121436,9 @@ eEY
 sUb
 sHe
 huk
-huk
-hFa
-ipW
+rhi
+oTY
+oTY
 oTY
 huk
 bGp
@@ -121866,7 +121738,7 @@ eEY
 sUb
 sUb
 fte
-fUg
+rzd
 vnX
 vnX
 vnX

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -7843,12 +7843,6 @@
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/science/research_director)
-"dyn" = (
-/obj/machinery/vehicle/pod_smooth/industrial,
-/obj/machinery/vehicle/pod_smooth/industrial,
-/obj/machinery/vehicle/pod_smooth/industrial,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/qm)
 "dyr" = (
 /obj/lattice{
 	dir = 9;
@@ -111033,7 +111027,7 @@ say
 vnX
 hSw
 wgA
-dyn
+gWc
 xxa
 xxa
 gWc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Fixes #16669 by replacing all the varedited hangar doors and door controllers with the corresponding subtypes, also adds atmos shields to them all
- Fixes #16668 
- Replaces pods in the command hangar with the /security subtype so they actually have the right comms system to use the door controller
- Also deletes a random invisible door control computer that was floating in space near research (???)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes bugs as well as reduces the number of unneeded varedited things on maps