### PR TITLE
Stowaway Spy Thieves now get a registered PDA

### DIFF
--- a/code/modules/antagonists/spy_thief/spy_thief.dm
+++ b/code/modules/antagonists/spy_thief/spy_thief.dm
@@ -30,7 +30,7 @@
 			return FALSE
 
 		var/mob/living/carbon/human/H = src.owner.current
-		var/obj/item/uplink_source = null
+		var/obj/item/device/pda2/uplink_source = null
 		var/loc_string = ""
 
 		// Attempt to locate the owner's PDA.
@@ -73,6 +73,7 @@
 		// If the owner has no PDA, create one.
 		if (!uplink_source)
 			uplink_source = new /obj/item/device/pda2(H)
+			uplink_source.owner = H.real_name // So they don't need to get an ID first
 			loc_string = "in your backpack"
 			if (H.equip_if_possible(uplink_source, SLOT_IN_BACKPACK) == 0)
 				uplink_source.set_loc(get_turf(H))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Currently Stowaway Spy Thieves do get an unregistered PDA, which they first have to register with an ID.
While any ID will do, this puts an unnecessary burden on the player.

There is a small potential for meta-gaming, by scanning available PDAs and comparing it with the Manifest at round-start.
If this is a concern, I can change the created PDA to not have messaging enabled by default.

[A-Gamemodes] [A-Traits] [C-Balance]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Requiring stowaways to obtain an ID is stupid.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(+)Stowaway Spy Thieves now get a registered PDA
```
