### PR TITLE
Purgatives and dialysis machine rebalance

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -87,7 +87,7 @@ datum
 					M = holder.my_atom
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-1 * mult)
-				flush(holder,4 * mult, flushed_reagents)
+				flush(holder,5 * mult, flushed_reagents)
 				..()
 				return
 
@@ -2552,7 +2552,7 @@ datum
 					description = initial(description)
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(holder, 0.8 * mult, flushed_reagents)//Tea is good for you!
+				flush(holder, 1 * mult, flushed_reagents)//Tea is good for you!
 				..()
 				return
 
@@ -4696,7 +4696,7 @@ datum
 			var/list/flushed_reagents = list("cholesterol")
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(holder, 2.4 * mult, flushed_reagents)
+				flush(holder, 3 * mult, flushed_reagents)
 				..()
 
 		fooddrink/iced/coconutmilkespresso

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -87,7 +87,7 @@ datum
 					M = holder.my_atom
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-1 * mult)
-				flush(holder,5 * mult, flushed_reagents)
+				flush(holder,4 * mult, flushed_reagents)
 				..()
 				return
 
@@ -1311,7 +1311,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(holder, 8 * mult)
+				flush(holder, 4.8 * mult)
 				if(M.health > 10)
 					M.take_toxin_damage(2 * mult)
 				if(probmult(20))
@@ -2552,7 +2552,7 @@ datum
 					description = initial(description)
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(holder, 1 * mult, flushed_reagents)//Tea is good for you!
+				flush(holder, 0.8 * mult, flushed_reagents)//Tea is good for you!
 				..()
 				return
 
@@ -4696,7 +4696,7 @@ datum
 			var/list/flushed_reagents = list("cholesterol")
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(holder, 3 * mult, flushed_reagents)
+				flush(holder, 2.4 * mult, flushed_reagents)
 				..()
 
 		fooddrink/iced/coconutmilkespresso

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -365,7 +365,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 
-				flush(holder, 5 * mult)
+				flush(holder, 3 * mult)
 				if(M.health > 20)
 					M.take_toxin_damage(5 * mult, 1)	//calomel doesn't damage organs.
 				if(probmult(6))
@@ -714,7 +714,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
-				flush(holder, 3 * mult, flushed_reagents)
+				flush(holder, 2.4 * mult, flushed_reagents)
 
 				if (M.health < -5 && M.health > -30)
 					M.HealDamage("All", 1 * mult, 1 * mult, 1 * mult)
@@ -803,7 +803,7 @@ datum
 				if (M.druggy > 0)
 					M.druggy -= 3
 					M.druggy = max(0, M.druggy)
-				flush(holder, 5 * mult, flushed_reagents)
+				flush(holder, 4 * mult, flushed_reagents)
 				if(M.hasStatus("stimulants"))
 					M.changeStatus("stimulants", -15 SECONDS * mult)
 				if(probmult(5))
@@ -854,7 +854,7 @@ datum
 				M.changeStatus("drowsy", -10 SECONDS)
 				if(M.sleeping && probmult(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1 * mult)
-				flush(holder, 2 * mult, flushed_reagents) //combats symptoms not source //ok combats source a bit more
+				flush(holder, 1.6 * mult, flushed_reagents) //combats symptoms not source //ok combats source a bit more
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)
@@ -1241,7 +1241,7 @@ datum
 			target_organs = list("left_kidney", "right_kidney", "liver", "stomach", "intestines")
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(holder, 5 * mult) //flushes all chemicals but itself
+				flush(holder, 3 * mult) //flushes all chemicals but itself
 				M.take_radiation_dose(-0.05 SIEVERTS * mult)
 				if (prob(75))
 					M.HealDamage("All", 0, 0, 4 * mult)
@@ -1284,7 +1284,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				M.jitteriness = max(M.jitteriness-20,0)
-				flush(holder, 3 * mult, flushed_reagents)
+				flush(holder, 2.4 * mult, flushed_reagents)
 				if(probmult(7)) M.emote("yawn")
 				if(prob(3))
 					M.setStatusMin("stunned", 3 SECONDS * mult)
@@ -1550,7 +1550,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				if(prob(50))
-					flush(holder, 1 * mult)
+					flush(holder, 0.6 * mult)
 				M.HealDamage("All", 0, 0, 1.5 * mult)
 
 				if (ishuman(M))
@@ -1593,7 +1593,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(holder, 8 * mult, flushed_reagents)
+				flush(holder, 6.4 * mult, flushed_reagents)
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-2 * mult)
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -803,7 +803,7 @@ datum
 				if (M.druggy > 0)
 					M.druggy -= 3
 					M.druggy = max(0, M.druggy)
-				flush(holder, 4 * mult, flushed_reagents)
+				flush(holder, 5 * mult, flushed_reagents)
 				if(M.hasStatus("stimulants"))
 					M.changeStatus("stimulants", -15 SECONDS * mult)
 				if(probmult(5))
@@ -854,7 +854,7 @@ datum
 				M.changeStatus("drowsy", -10 SECONDS)
 				if(M.sleeping && probmult(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1 * mult)
-				flush(holder, 1.6 * mult, flushed_reagents) //combats symptoms not source //ok combats source a bit more
+				flush(holder, 2 * mult, flushed_reagents) //combats symptoms not source //ok combats source a bit more
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)
@@ -1284,7 +1284,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				M.jitteriness = max(M.jitteriness-20,0)
-				flush(holder, 2.4 * mult, flushed_reagents)
+				flush(holder, 3 * mult, flushed_reagents)
 				if(probmult(7)) M.emote("yawn")
 				if(prob(3))
 					M.setStatusMin("stunned", 3 SECONDS * mult)
@@ -1550,7 +1550,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				if(prob(50))
-					flush(holder, 0.6 * mult)
+					flush(holder, 1 * mult)
 				M.HealDamage("All", 0, 0, 1.5 * mult)
 
 				if (ishuman(M))
@@ -1593,7 +1593,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(holder, 6.4 * mult, flushed_reagents)
+				flush(holder, 8 * mult, flushed_reagents)
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-2 * mult)
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -714,7 +714,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
-				flush(holder, 2.4 * mult, flushed_reagents)
+				flush(holder, 3 * mult, flushed_reagents)
 
 				if (M.health < -5 && M.health > -30)
 					M.HealDamage("All", 1 * mult, 1 * mult, 1 * mult)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3109,7 +3109,7 @@ datum
 					M.take_toxin_damage(3 * mult)
 				else
 					M.take_toxin_damage(2 * mult)
-				flush(holder, 1.6 * mult, flushed_reagents)
+				flush(holder, 2 * mult, flushed_reagents)
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3109,7 +3109,7 @@ datum
 					M.take_toxin_damage(3 * mult)
 				else
 					M.take_toxin_damage(2 * mult)
-				flush(holder, 2 * mult, flushed_reagents)
+				flush(holder, 1.6 * mult, flushed_reagents)
 				..()
 				return
 

--- a/code/obj/machinery/dialysis.dm
+++ b/code/obj/machinery/dialysis.dm
@@ -14,7 +14,7 @@ TYPEINFO(/obj/machinery/dialysis)
 	var/mob/living/carbon/patient
 	var/list/whitelist
 	// In units per process tick.
-	var/draw_amount = 10
+	var/draw_amount = 16
 	var/hacked = FALSE
 	var/last_in = 0
 	var/last_out = 0


### PR DESCRIPTION
[Balance][Chemistry][Game objects][Input wanted]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR reduced the strenght on several purgative chems and increased the numbers on the dialysis machine.

Chemicals that purge all chemicals have their effectiveness reduced by 40%. This applies to the following chemicals:
- calomel
- pentetic acid
- hunchback

To compensate for these changes, the dialysis machine was improved significantly. It drains and cleans blood with an 60% increased rate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When it comes to purging chemicals, the dialysis machine is vastly outclassed in effectiveness against purgative chemicals.

Purgative chemicals, while dealing damage and having negative implications like stuns/slowdowns, are easily transportable due to pills and work with a very high efficiency. The dialysis machine, in contrast to this, is bulky and purges chems fairly slowly. the positive is being able to selectively purge non-whitelist chems only.

What this creates is that the dialysis machine is very much unused except for very serious poison cases and on RP. This makes purging chemicals, a task medbay should be the most competent for, to be relegated to people running to the bar or having a few pills prepared in chemistry.

This PR aims to make the dialysis machine, a medbay-exclusive item, able to outcompete general purgatives. From my tests, with the numbers from the PR, purges chems from a victim injected with 100u plasma with almost the same speed calomel does.

Under this point, calomel is faster for the task than the dialysis machine, above that number the dialysis machine is faster, due to chems in blood scaling with the amount of chemicals in someone.

This should be a step to further move doctors away from being glorified chem dispensers. And Purgatives are still effective due to having the ability to be very easily transportable from A to B.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(*)Calomel, hunchback and pentetic acid were found to be far less effective. To compensate, NT has greatly improved the effectiveness of its dialysis machines.
```
