### PR TITLE
Give blue clowns clown training

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1779,6 +1779,8 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 		..()
 		if (!M)
 			return
+
+		M.traitHolder.addTrait("training_clown")
 		M.bioHolder.AddEffect("regenerator", magical=1)
 
 /datum/job/special/halloween/candy_salesman


### PR DESCRIPTION
[FEATURE] [EVENT]
## About the PR
Adds clown training to blue clowns, so that they speak in comic sans, explode into confetti, and are clumsy, just like normal clowns.

## Why's this needed?
Seeing a clown and blue clown walking together, it becomes really obvious that one doesn't speak in comic sans.

## Changelog
```changelog
(u)tyrant
(+)Blue clowns now also have clown training, and speak in comic sans.
```