### PR TITLE
Adjusts area on donut2 to correct wallphone name

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -26419,7 +26419,7 @@
 "gAx" = (
 /obj/machinery/phone/wall,
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/lobby)
+/area/station/medical/research)
 "gAQ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45367,7 +45367,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/medbay/lobby)
+/area/station/medical/research)
 "tSw" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -67796,7 +67796,7 @@ xib
 bao
 bsG
 bbo
-bbM
+bch
 bch
 bch
 bch
@@ -68098,7 +68098,7 @@ kDX
 aWZ
 bbB
 aUC
-ofj
+beC
 eVQ
 aUE
 kfd
@@ -68702,7 +68702,7 @@ sfy
 baq
 baV
 bbq
-ofj
+beC
 hFZ
 gbs
 bfy
@@ -69004,7 +69004,7 @@ uhm
 bbB
 aYv
 bbr
-ofj
+beC
 bji
 bfD
 bfy
@@ -69608,7 +69608,7 @@ aWl
 dXO
 ipJ
 aWl
-bbM
+bch
 beC
 beC
 beC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The wall of genetics in Donut2 is considered medbay lobby which makes the genetics wallphone list as "medbay lobby" despite being in genetics and not in medbay lobby


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I called medbay lobby and it was genetics 


[Bug][Mapping]