### PR TITLE
Borg-Fishing-Addendums

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -20,6 +20,8 @@
 	var/is_fishing = FALSE
 	/// what tier of rod is this? can be 0, 1 or 2
 	var/tier = 0
+	/// variable for borg upgrade-as-you-fish fishing rod
+	var/tranquility = 0
 
 	New()
 		..()
@@ -43,6 +45,15 @@
 					break
 				fishing_spot_type = type2parent(fishing_spot_type)
 			if (fishing_spot)
+				if (src.tranquility >= 25 && src.tier < 2)
+					user.visible_message("<span class='notice'>Your mind starts to quiet. You are one step closer to fishing Nirvana.</span>")
+					src.tier = 2
+				if (src.tranquility >= 75 && src.tier < 3)
+					user.visible_message("<span class='notice'>You have achieved a Zen-like fishing state.</span>")
+					src.tier = 3
+				if ((fishing_spot.rod_tier_required > src.tier) && (issilicon(user)))
+					user.visible_message("<span class='alert'>You are not Tranquil enough to fish here!</span>")
+					return
 				if (fishing_spot.rod_tier_required > src.tier)
 					user.visible_message("<span class='alert'>You need a higher tier rod to fish here!</span>")
 					return
@@ -129,6 +140,9 @@
 
 		if (src.fishing_spot.try_fish(src.user, src.rod, target)) //if it returns one we successfully fished, otherwise lets restart the loop
 			..()
+			//only borgs are allowed to become tranquil
+			if (issilicon(src.user))
+				src.rod.tranquility = (src.rod.tranquility + 1)
 			src.rod.is_fishing = FALSE
 			src.rod.UpdateIcon()
 			src.user.update_inhands()
@@ -177,6 +191,24 @@
 			src.item_state = "fishing_rod-active"
 		else
 			src.icon_state = "fishing_rod_3-inactive"
+			src.item_state = "fishing_rod-inactive"
+
+
+/obj/item/fishing_rod/cybernetic
+	name = "Cybernetic Fishing Rod"
+	desc = "A fishing rod for Cyborgs. Use is said to bring one closer to Fishing Nirvana."
+	icon_state = "fishing_rod-inactive"
+	item_state = "fishing_rod-inactive"
+	tier = 1
+
+	update_icon()
+		//state for fishing
+		if (src.is_fishing)
+			src.icon_state = "fishing_rod-active"
+			src.item_state = "fishing_rod-active"
+		//state for not fishing
+		else
+			src.icon_state = "fishing_rod-inactive"
 			src.item_state = "fishing_rod-inactive"
 
 // portable fishing portal currently found in a prefab in space

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -84,7 +84,7 @@
 		/obj/item/ladle,
 		/obj/item/kitchen/rollingpin/light,
 		/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
-		/obj/item/fishing_rod/basic,
+		/obj/item/fishing_rod/cybernetic,
 	)
 
 /datum/robot/module_tool_creator/recursive/module/common


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[A-Silicons][C-Fishing]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR 
Added a Tranquility variable to base Fishing Rod item, and a Cybernetic Fishing Rod variant for Civilian Cyborgs. Only borgs will utilize the Tranquility variable. Each successful fishing will increase the Tranquility by 1. At 25 tranquility the fishing rod tier will increase to 2. At 75 the fishing rod tier will increase to 3.
No visual change yet, I was not blessed with pixel art abilities.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Borgs can fish, but they can't fish as well as people. Fishing isn't some big powergaming thing, why not let the borgs improve their fishing over time. 

```changelog
(u)metareferencer
(+)Changed Civilian Cyborg fishing rod to be Cybernetic. It increases in tier as you fish!
```
