### PR TITLE
Fixes phone renaming not updating label

### DIFF
--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -131,7 +131,7 @@ TYPEINFO(/obj/machinery/phone)
 			if(length(t) > 50)
 				return
 			src.phone_id = t
-			boutput(user, "You rename the phone to \"[src.phone_id]\".")
+			boutput(user, "<span class='notice'>You rename the phone to \"[src.phone_id]\".</span>")
 			return
 		..()
 		src._health -= P.force

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -128,8 +128,6 @@ TYPEINFO(/obj/machinery/phone)
 				return
 			if(!in_interact_range(src, user))
 				return
-			if(length(t) > 50)
-				return
 			src.phone_id = t
 			boutput(user, "<span class='notice'>You rename the phone to \"[src.phone_id]\".</span>")
 			return

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -121,13 +121,17 @@ TYPEINFO(/obj/machinery/phone)
 			if(src.labelling)
 				return
 			src.labelling = TRUE
-			var/t = input(user, "What do you want to name this phone?", null, null) as null|text
-			t = sanitize(html_encode(t))
-			if(t && length(t) > 50)
-				return
-			if(t)
-				src.phone_id = t
+			var/t = tgui_input_text(user, "What do you want to name this phone?", null, null, max_length = 50)
 			src.labelling = FALSE
+			t = sanitize(html_encode(t))
+			if(!t)
+				return
+			if(!in_interact_range(src, user))
+				return
+			if(length(t) > 50)
+				return
+			src.phone_id = t
+			boutput(user, "You rename the phone to \"[src.phone_id]\".")
 			return
 		..()
 		src._health -= P.force

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -77,8 +77,6 @@ TYPEINFO(/obj/machinery/phone)
 				temp_name = "[temp_name] [name_counter]"
 			src.phone_id = temp_name
 
-		src.desc += " There is a small label on the phone that reads \"[src.phone_id]\""
-
 		START_TRACKING
 
 	disposing()
@@ -93,6 +91,10 @@ TYPEINFO(/obj/machinery/phone)
 
 		STOP_TRACKING
 		..()
+
+	get_desc()
+		if(!isnull(src.phone_id))
+			return " There is a small label on the phone that reads \"[src.phone_id]\"."
 
 	attack_ai(mob/user as mob)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16712 by moving the label examine text to `get_desc()` so it reflects the current value of `phone_id`. Also switches the input box to tgui so max_length can be used, adds an early return for null input instead of checking `t` in each if, adds a range check, and adds a message indicating successful renaming. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fix for the label description, the other stuff is just general QOL and cleaner code.