### PR TITLE
Fixes instruments sending chat messages even on cooldown

### DIFF
--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -105,8 +105,8 @@
 
 	proc/play(var/mob/user)
 		if (pick_random_note && length(sounds_instrument))
-			play_note(rand(1, length(sounds_instrument)),user)
-			src.show_play_message(user)
+			if(play_note(rand(1, length(sounds_instrument)),user))
+				src.show_play_message(user)
 		if(length(contextActions))
 			user.showContextActions(contextActions, src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16711 and fixes #16408 by only running `src.show_play_message` if `play_note` succeeded.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Chat spam and messages about playing instruments with no accompanying sounds bad