### PR TITLE
Action bars for antique laser gun repair

### DIFF
--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -402,8 +402,8 @@
 				gun.repair_stage = 3
 				if(stage_item.material)
 					gun.quality_counter += stage_item.material.getQuality()
-				user.u_equip(stage_item)
-				qdel(stage_item)
+				user.u_equip(src.stage_item)
+				qdel(src.stage_item)
 				return
 			if(3)
 				boutput(owner, "<span class='notice'>You solder the coil into place.</span>")
@@ -414,8 +414,8 @@
 				gun.repair_stage = 5
 				if(stage_item.material)
 					gun.quality_counter += stage_item.material.getQuality()
-				user.u_equip(stage_item)
-				qdel(stage_item)
+				user.u_equip(src.stage_item)
+				qdel(src.stage_item)
 				return
 			if(6)
 				var/obj/item/ammo/power_cell/cell = src.stage_item

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -397,6 +397,7 @@
 				if(coil.material)
 					gun.quality_counter += coil.material.getQuality()
 				coil.use(10)
+				return
 			if(2)
 				user.show_text("You install the coil.", "blue")
 				gun.repair_stage = 3
@@ -404,9 +405,11 @@
 					gun.quality_counter += stage_item.material.getQuality()
 				user.u_equip(stage_item)
 				qdel(stage_item)
+				return
 			if(3)
 				user.show_text("You solder the coil into place.", "blue")
 				gun.repair_stage = 4
+				return
 			if(6)
 				var/obj/item/ammo/power_cell/cell = src.stage_item
 				user.show_text("You install the power cell.", "blue")
@@ -416,4 +419,5 @@
 				gun.our_cell = cell
 				if(cell.material)
 					gun.quality_counter += cell.material.getQuality()
+				return
 

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -387,6 +387,7 @@
 
 	onEnd()
 		..()
+		var/mob/user = owner
 		switch(gun.repair_stage)
 			if(1)
 				var/obj/item/cable_coil/coil = src.stage_item
@@ -397,7 +398,6 @@
 				coil.use(10)
 				return
 			if(2)
-				var/mob/user = owner
 				boutput(owner, "<span class='notice'>You install the coil.</span>")
 				gun.repair_stage = 3
 				if(stage_item.material)
@@ -409,8 +409,15 @@
 				boutput(owner, "<span class='notice'>You solder the coil into place.</span>")
 				gun.repair_stage = 4
 				return
+			if(4)
+				boutput(owner, "<span class='notice'>You install the lens.</span>")
+				gun.repair_stage = 5
+				if(stage_item.material)
+					gun.quality_counter += stage_item.material.getQuality()
+				user.u_equip(stage_item)
+				qdel(stage_item)
+				return
 			if(6)
-				var/mob/user = owner
 				var/obj/item/ammo/power_cell/cell = src.stage_item
 				boutput(owner, "<span class='notice'>You install the power cell.</span>")
 				gun.repair_stage = 7

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -352,7 +352,6 @@
 
 	var/obj/item/captaingun/gun
 	var/obj/item/stage_item
-	var/mob/user
 
 	New(var/obj/O, var/obj/item/I)
 		..()
@@ -362,44 +361,44 @@
 			src.stage_item = I
 			src.icon = I.icon
 			src.icon_state = I.icon_state
-		if(owner)
-			src.user = owner
 
 	onUpdate()
 		..()
 		if(!src.gun || !src.stage_item || BOUNDS_DIST(owner, gun) > 0)
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		if(istype(user) && stage_item != user.equipped())
+		var/mob/source = owner
+		if(istype(source) && stage_item != source.equipped())
 			interrupt(INTERRUPT_ALWAYS)
 
 	onStart()
 		..()
 		switch(gun.repair_stage)
 			if(1)
-				user.show_text("You begin to rewire the gun's circuit board...", "blue")
+				boutput(owner, "<span class='notice'>You begin to rewire the gun's circuit board...</span>")
 			if(2)
-				user.show_text("You begin to install the coil...", "blue")
+				boutput(owner, "<span class='notice'>You begin to install the coil...</span>")
 			if(3)
-				user.show_text("You begin to solder the coil into place...", "blue")
+				boutput(owner, "<span class='notice'>You begin to solder the coil into place...</span>")
 			if(4)
-				user.show_text("You begin to install the lens...", "blue")
+				boutput(owner, "<span class='notice'>You begin to install the lens...</span>")
 			if(6)
-				user.show_text("You begin to install the power cell...", "blue")
+				boutput(owner, "<span class='notice'>You begin to install the power cell...</span>")
 
 	onEnd()
 		..()
 		switch(gun.repair_stage)
 			if(1)
 				var/obj/item/cable_coil/coil = src.stage_item
-				user.show_text("You rewire the circuit board.", "blue")
+				boutput(owner, "<span class='notice'>You rewire the circuit board.</span>")
 				gun.repair_stage = 2
 				if(coil.material)
 					gun.quality_counter += coil.material.getQuality()
 				coil.use(10)
 				return
 			if(2)
-				user.show_text("You install the coil.", "blue")
+				var/mob/user = owner
+				boutput(owner, "<span class='notice'>You install the coil.</span>")
 				gun.repair_stage = 3
 				if(stage_item.material)
 					gun.quality_counter += stage_item.material.getQuality()
@@ -407,12 +406,13 @@
 				qdel(stage_item)
 				return
 			if(3)
-				user.show_text("You solder the coil into place.", "blue")
+				boutput(owner, "<span class='notice'>You solder the coil into place.</span>")
 				gun.repair_stage = 4
 				return
 			if(6)
+				var/mob/user = owner
 				var/obj/item/ammo/power_cell/cell = src.stage_item
-				user.show_text("You install the power cell.", "blue")
+				boutput(owner, "<span class='notice'>You install the power cell.</span>")
 				gun.repair_stage = 7
 				user.u_equip(cell)
 				cell.set_loc(gun)

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -382,3 +382,77 @@
 
 		//DEBUG_MESSAGE("[src.name]'s quality_counter: [quality_counter]")
 		return
+
+/datum/action/bar/icon/captaingun_assembly
+	id = "captaingun_assembly"
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ATTACKED | INTERRUPT_STUNNED
+	icon = 'icons/ui/actions.dmi'
+	icon_state = "working"
+	duration = 3.5 SECONDS
+
+	var/obj/item/captaingun/gun
+	var/obj/item/stage_item
+	var/mob/user
+
+	New(var/obj/O, var/obj/item/I)
+		..()
+		if(O)
+			src.gun = O
+		if(I)
+			src.stage_item = I
+			src.icon = I.icon
+			src.icon_state = I.icon_state
+		if(owner)
+			src.user = owner
+
+	onUpdate()
+		..()
+		if(!src.gun || !src.stage_item || BOUNDS_DIST(owner, gun) > 0)
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		if(istype(user) && stage_item != user.equipped())
+			interrupt(INTERRUPT_ALWAYS)
+
+	onStart()
+		..()
+		switch(gun.repair_stage)
+			if(1)
+				user.show_text("You begin to rewire the gun's circuit board...", "blue")
+			if(2)
+				user.show_text("You begin to install the coil...", "blue")
+			if(3)
+				user.show_text("You begin to solder the coil into place...", "blue")
+			if(4)
+				user.show_text("You begin to install the lens...", "blue")
+			if(6)
+				user.show_text("You begin to install the power cell...", "blue")
+
+	onEnd()
+		..()
+		switch(gun.repair_stage)
+			if(1)
+				user.show_text("You rewire the circuit board.", "blue")
+				gun.repair_stage = 2
+				if(stage_item.material)
+					gun.quality_counter += stage_item.material.getQuality()
+				// remove wire
+			if(2)
+				user.show_text("You install the coil.", "blue")
+				gun.repair_stage = 3
+				if(stage_item.material)
+					gun.quality_counter += stage_item.material.getQuality()
+				user.u_equip(stage_item)
+				qdel(stage_item)
+			if(3)
+				user.show_text("You solder the coil into place.", "blue")
+				gun.repair_stage = 4
+			if(6)
+				var/obj/item/ammo/power_cell/cell = src.stage_item
+				user.show_text("You install the power cell.", "blue")
+				gun.repair_stage = 7
+				user.u_equip(cell)
+				cell.set_loc(gun)
+				gun.our_cell = cell
+				if(cell.material)
+					gun.quality_counter += cell.material.getQuality()
+

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -275,77 +275,37 @@
 			if (src.repair_stage == 1)
 				var/obj/item/cable_coil/C = O
 				if (C.amount >= 10)
-					user.show_text("You begin to rewire the gun's circuit board...", "blue")
-					if (do_after(user, 3.5 SECONDS))
-						user.show_text("You rewire the circuit board.", "blue")
-						src.repair_stage = 2
-						if (C.material)
-							src.quality_counter += C.material.getQuality()
-					else
-						user.show_text("You were interrupted!", "red")
-						return
+					actions.start(new /datum/action/bar/icon/captaingun_assembly(src, C), user)
+					return
 				else
 					user.show_text("You need more wire than that.", "red")
 					return
 
 		else if (istype(O, /obj/item/coil/small))
 			if (src.repair_stage == 2)
-				user.show_text("You begin to install the coil...", "blue")
-				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the coil.", "blue")
-					src.repair_stage = 3
-					if (O.material)
-						src.quality_counter += O.material.getQuality()
-					user.u_equip(O)
-					qdel(O)
-				else
-					user.show_text("You were interrupted!", "red")
-					return
+				actions.start(new /datum/action/bar/icon/captaingun_assembly(src, O), user)
+				return
 
 		else if (istype(O, /obj/item/electronics/soldering))
 			if (src.repair_stage == 3)
-				user.show_text("You begin to solder the coil into place...", "blue")
-				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You solder the coil into place.", "blue")
-					src.repair_stage = 4
-				else
-					user.show_text("You were interrupted!", "red")
-					return
+				actions.start(new /datum/action/bar/icon/captaingun_assembly(src, O), user)
+				return
 
 		else if (istype(O, /obj/item/lens))
 			if (src.repair_stage == 4)
-				user.show_text("You begin to install the lens...", "blue")
-				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the lens.", "blue")
-					src.repair_stage = 5
-					if (O.material)
-						src.quality_counter += O.material.getQuality()
-					user.u_equip(O)
-					qdel(O)
-				else
-					user.show_text("You were interrupted!", "red")
-					return
+				actions.start(new /datum/action/bar/icon/captaingun_assembly(src, O), user)
+				return
 
 		else if (ispulsingtool(O))
 			if (src.repair_stage == 5)
 				user.show_text("You initialize the control board.", "blue")
 				src.repair_stage = 6
+				return
 
 		else if (istype(O, /obj/item/ammo/power_cell))
 			if (src.repair_stage == 6)
-				var/obj/item/ammo/power_cell/P = O
-				user.show_text("You begin to install the power cell...", "blue")
-				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the power cell.", "blue")
-					src.repair_stage = 7
-					user.u_equip(P)
-					P.set_loc(src)
-					src.our_cell = P
-					if (P.material)
-						src.quality_counter += P.material.getQuality()
-				else
-					user.show_text("You were interrupted!", "red")
-					return
+				actions.start(new /datum/action/bar/icon/captaingun_assembly(src, O), user)
+				return
 
 		else
 			..()
@@ -431,11 +391,12 @@
 		..()
 		switch(gun.repair_stage)
 			if(1)
+				var/obj/item/cable_coil/coil = src.stage_item
 				user.show_text("You rewire the circuit board.", "blue")
 				gun.repair_stage = 2
-				if(stage_item.material)
-					gun.quality_counter += stage_item.material.getQuality()
-				// remove wire
+				if(coil.material)
+					gun.quality_counter += coil.material.getQuality()
+				coil.use(10)
 			if(2)
 				user.show_text("You install the coil.", "blue")
 				gun.repair_stage = 3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Creates a new action bar datum to handle each stage of the antique laser gun repair and changes `attackby` to use it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Removal of `do_after` is a good thing and the antique laser gun is pretty bad with it