### PR TITLE
Compostable rice 

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -599,7 +599,9 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 		if (istype(W,/obj/item/reagent_containers/food/snacks/plant/)) src.reagents.add_reagent("poo", 20)
 		else if (istype(W,/obj/item/reagent_containers/food/snacks/mushroom/)) src.reagents.add_reagent("poo", 25)
 		else if (istype(W,/obj/item/seed/)) src.reagents.add_reagent("poo", 2)
-		else if (istype(W,/obj/item/plant/) || istype(W,/obj/item/clothing/head/flower/)) src.reagents.add_reagent("poo", 15)
+		else if (istype(W,/obj/item/plant/) \
+				|| istype(W,/obj/item/clothing/head/flower/) \
+				|| istype(W,/obj/item/reagent_containers/food/snacks/ingredient/rice_sprig)) src.reagents.add_reagent("poo", 15)
 		else if (istype(W,/obj/item/organ/)) src.reagents.add_reagent("poo", 35)
 		else load = 0
 
@@ -622,7 +624,11 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 		if (BOUNDS_DIST(O, src) > 0 || BOUNDS_DIST(O, user) > 0)
 			boutput(user, "<span class='alert'>[O] is too far away to load into [src]!</span>")
 			return
-		if (istype(O, /obj/item/reagent_containers/food/snacks/plant/) || istype(O, /obj/item/reagent_containers/food/snacks/mushroom/) || istype(O, /obj/item/seed/) || istype(O, /obj/item/plant/) || istype(O, /obj/item/clothing/head/flower/))
+		if (istype(O, /obj/item/reagent_containers/food/snacks/plant/) \
+			|| istype(O, /obj/item/reagent_containers/food/snacks/mushroom/) \
+			|| istype(O, /obj/item/seed/) || istype(O, /obj/item/plant/) \
+			|| istype(O, /obj/item/clothing/head/flower/) \
+			|| istype(O, /obj/item/reagent_containers/food/snacks/ingredient/rice_sprig))
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing [O] into [src]!</span>")
 			var/itemtype = O.type
 			var/staystill = user.loc
@@ -637,7 +643,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 					amount = 25
 				else if (istype(P,/obj/item/seed/))
 					amount = 2
-				else if (istype(P,/obj/item/plant/))
+				else if (istype(P,/obj/item/plant/) || istype(P,/obj/item/reagent_containers/food/snacks/ingredient/rice_sprig))
 					amount = 15
 				playsound(src.loc, 'sound/impact_sounds/Slimy_Hit_4.ogg', 30, 1)
 				src.reagents.add_reagent("poo", amount)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Hydroponics][Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds rice sprigs (/obj/item/reagent_containers/food/snacks/ingredient/rice_sprig) as a compostable item same as other plants, producing 15 "compost". Did not add the entire /obj/item/reagent_containers/food/snacks/ingredient/ as that has a lot of non-plant/compostable objects in it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14852
