### PR TITLE
Afterattack changes

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -364,25 +364,23 @@
 	return FALSE
 
 /mob/living/proc/weapon_attack(atom/target, obj/item/W, reach, params)
-	var/usingInner = 0
 	if (W.useInnerItem && length(W.contents) > 0)
 		var/obj/item/held = W.holding
 		if (!held)
 			held = pick(W.contents)
 		if (held && !istype(held, /obj/ability_button))
 			W = held
-			usingInner = 1
 
 	if (reach)
 		target.Attackby(W, src, params)
-	if (W && (equipped() == W || usingInner))
+	if (!QDELETED(W))
 		var/pixelable = isturf(target)
 		if (!pixelable)
 			if (istype(target, /atom/movable) && isturf(target:loc))
 				pixelable = 1
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
-				if (W)
+				if (!QDELETED(W))
 					W.AfterAttack(target, src, reach, params)
 		else if (!pixelable && W)
 			W.AfterAttack(target, src, reach, params)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -364,23 +364,25 @@
 	return FALSE
 
 /mob/living/proc/weapon_attack(atom/target, obj/item/W, reach, params)
+	var/usingInner = 0
 	if (W.useInnerItem && length(W.contents) > 0)
 		var/obj/item/held = W.holding
 		if (!held)
 			held = pick(W.contents)
 		if (held && !istype(held, /obj/ability_button))
 			W = held
+			usingInner = 1
 
 	if (reach)
 		target.Attackby(W, src, params)
-	if (!QDELETED(W))
+	if (W && (equipped() == W || usingInner))
 		var/pixelable = isturf(target)
 		if (!pixelable)
 			if (istype(target, /atom/movable) && isturf(target:loc))
 				pixelable = 1
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
-				if (!QDELETED(W))
+				if (W)
 					W.AfterAttack(target, src, reach, params)
 		else if (!pixelable && W)
 			W.AfterAttack(target, src, reach, params)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -364,27 +364,27 @@
 	return FALSE
 
 /mob/living/proc/weapon_attack(atom/target, obj/item/W, reach, params)
-	var/usingInner = 0
+	var/usingInner = FALSE
 	if (W.useInnerItem && length(W.contents) > 0)
 		var/obj/item/held = W.holding
 		if (!held)
 			held = pick(W.contents)
 		if (held && !istype(held, /obj/ability_button))
 			W = held
-			usingInner = 1
+			usingInner = TRUE
 
 	if (reach)
 		target.Attackby(W, src, params)
-	if (W && (equipped() == W || usingInner))
+	if (!QDELETED(W) && (equipped() == W || usingInner))
 		var/pixelable = isturf(target)
 		if (!pixelable)
-			if (istype(target, /atom/movable) && isturf(target:loc))
-				pixelable = 1
+			if (istype(target, /atom/movable) && isturf(target.loc))
+				pixelable = TRUE
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
-				if (W)
+				if (!QDELETED(W))
 					W.AfterAttack(target, src, reach, params)
-		else if (!pixelable && W)
+		else if (!pixelable && !QDELETED(W))
 			W.AfterAttack(target, src, reach, params)
 
 /mob/living/onMouseDrag(src_object,over_object,src_location,over_location,src_control,over_control,params)

--- a/code/procs/mobprocs/attacks.dm
+++ b/code/procs/mobprocs/attacks.dm
@@ -1,5 +1,6 @@
 
 /mob/attackby(obj/item/W, mob/user, params, is_special = 0)
+	set waitfor = 0
 	actions.interrupt(src, INTERRUPT_ATTACKED)
 
 	// why is this not in human/attackby?
@@ -28,27 +29,24 @@
 		boutput(user, "<span class='alert'><b>[src]'s Spell Shield prevents your attack!</b></span>")
 
 	if (!shielded || !(W.flags & NOSHIELD))
-		SPAWN( 0 )
 		// drsingh Cannot read null.force
 #ifdef DATALOGGER
-			if (W.force)
-				game_stats.Increment("violence")
+		if (W.force)
+			game_stats.Increment("violence")
 #endif
-			if (!isnull(W))
-				W.attack(src, user, (user.zone_sel && user.zone_sel.selecting ? user.zone_sel.selecting : null), is_special) // def_zone var was apparently useless because the only thing that ever passed def_zone anything was shitty bill when he attacked people
-				if (W && user != src) //ZeWaka: Fix for cannot read null.hide_attack
-					var/anim_mult = clamp(0.5, W.force / 10, 4)
-					if (!W.hide_attack)
-						attack_particle(user,src)
-						attack_twitch(user, anim_mult, anim_mult)
-					else if (W.hide_attack == ATTACK_PARTIALLY_HIDDEN)
-						attack_twitch(user, anim_mult, , anim_mult)
+		if (!isnull(W))
+			W.attack(src, user, (user.zone_sel && user.zone_sel.selecting ? user.zone_sel.selecting : null), is_special) // def_zone var was apparently useless because the only thing that ever passed def_zone anything was shitty bill when he attacked people
+			if (W && user != src) //ZeWaka: Fix for cannot read null.hide_attack
+				var/anim_mult = clamp(0.5, W.force / 10, 4)
+				if (!W.hide_attack)
+					attack_particle(user,src)
+					attack_twitch(user, anim_mult, anim_mult)
+				else if (W.hide_attack == ATTACK_PARTIALLY_HIDDEN)
+					attack_twitch(user, anim_mult, , anim_mult)
 
 
-				if (W.force)
-					message_admin_on_attack(user, "uses \a [W.name] on")
-			return
-	return
+			if (W.force)
+				message_admin_on_attack(user, "uses \a [W.name] on")
 
 
 /mob/proc/message_admin_on_attack(var/mob/attacker, var/attack_type = "attacks")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Currently afterattack() gets run before attack() before the call to attack() is in a SPAWN. This PR removes that spawn (and adds set waitfor = 0 to mob/attackby to prevent bad sleeps).

This was discovered by looking into why https://github.com/goonstation/goonstation/commit/16bd50cd0b4428a772aa849c92f0dd6fd6bd42b7 broke patches. However, the above change alone does not fix the issue. ~~So this PR also loosens the check on AfterAttack() call to allow for it even if the item changed places. As a tradeoff the "is this item deleted" checks have been fixed.~~ No longer the case. Instead I will modify patches later. Calling afterattack on moved stuff causes more problems than it fixes. See issues below.

The intent of this PR is that it causes not observable changes other than fixing bugs (such as patches not working). The *likely* outcome of this PR is more bugs. I recommend testmerging for some time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's called **after**attack, it running **before** attack() is madness.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
