### PR TITLE
Minimum distance option for sound hallucinations and option to have image override hallucinations appear only out of view

### DIFF
--- a/code/datums/components/hallucinations.dm
+++ b/code/datums/components/hallucinations.dm
@@ -138,7 +138,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 				parent_mob.playsound_local(origin, chosen, 100, 1)
 		. = ..()
 
-	CheckDupeComponent(timeout, sound_list, sound_prob)
+	CheckDupeComponent(timeout, sound_list, sound_prob, min_distance)
 		if(sound_list ~= src.sound_list) //this is the same hallucination, just update timeout and prob
 			if(timeout == -1)
 				src.ttl = timeout
@@ -327,7 +327,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 				qdel(halluc)
 		. = ..()
 
-	CheckDupeComponent(timeout, image_list, target_list, range, image_prob, image_time, override)
+	CheckDupeComponent(timeout, image_list, target_list, range, image_prob, image_time, override, visible_creation)
 		if(image_list ~= src.image_list && src.target_list ~= target_list) //this is the same hallucination, just update timeout and prob, time
 			if(timeout == -1)
 				src.ttl = timeout

--- a/code/datums/components/hallucinations.dm
+++ b/code/datums/components/hallucinations.dm
@@ -8,7 +8,7 @@ TYPEINFO(/datum/component/hallucination/random_sound)
 		ARG_INFO("timeout", DATA_INPUT_NUM, "how long this hallucination lasts in seconds. -1 for permanent", 30),
 		ARG_INFO("sound_list", DATA_INPUT_LIST_BUILD, "List of sounds that the mob can hallucinate appearing."),
 		ARG_INFO("sound_prob", DATA_INPUT_NUM, "probability of a sound being played per mob life tick", 10),
-		ARG_INFO("min_distance", DATA_INPUT_NUM, "minimum distance to the mob the sound will play from", -1)
+		ARG_INFO("min_distance", DATA_INPUT_NUM, "minimum distance to the mob the sound will play from", 0)
 	)
 
 TYPEINFO(/datum/component/hallucination/random_image)
@@ -115,7 +115,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 	var/sound_prob = 10
 	var/min_distance = 0
 
-	Initialize(timeout=30, sound_list=null, sound_prob=10, min_distance = -1)
+	Initialize(timeout=30, sound_list=null, sound_prob=10, min_distance = 0)
 		.=..()
 		if(. == COMPONENT_INCOMPATIBLE || length(sound_list) == 0)
 			return .

--- a/code/datums/components/hallucinations.dm
+++ b/code/datums/components/hallucinations.dm
@@ -113,7 +113,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 /datum/component/hallucination/random_sound
 	var/list/sound_list
 	var/sound_prob = 10
-	var/min_distance = -1
+	var/min_distance = 0
 
 	Initialize(timeout=30, sound_list=null, sound_prob=10, min_distance = -1)
 		.=..()
@@ -129,10 +129,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 			var/atom/origin = parent_mob.loc
 			var/turf/mob_turf = get_turf(parent_mob)
 			if (mob_turf)
-				if(src.min_distance > 0)
-					origin = locate(mob_turf.x + pick(rand(-10,-src.min_distance),rand(src.min_distance,10)), mob_turf.y + pick(rand(-10,-src.min_distance),rand(src.min_distance,10)), mob_turf.z)
-				else
-					origin = locate(mob_turf.x + rand(-10,10), mob_turf.y + rand(-10,10), mob_turf.z)
+				origin = locate(mob_turf.x + pick(rand(-10,-src.min_distance),rand(src.min_distance,10)), mob_turf.y + pick(rand(-10,-src.min_distance),rand(src.min_distance,10)), mob_turf.z)
 			//wacky loosely typed code ahead
 			var/datum/hallucinated_sound/chosen = pick(src.sound_list)
 			if (istype(chosen)) //it's a datum

--- a/code/datums/components/hallucinations.dm
+++ b/code/datums/components/hallucinations.dm
@@ -302,7 +302,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 		src.range = range
 		src.target_list = target_list
 		src.override = override
-		src.visible_creation = TRUE
+		src.visible_creation = visible_creation
 
 	do_mob_tick(mob,mult)
 		if(probmult(image_prob))

--- a/code/obj/artifacts/artifact_machines/madness.dm
+++ b/code/obj/artifacts/artifact_machines/madness.dm
@@ -48,7 +48,8 @@
 						'sound/voice/screams/mascream6.ogg',
 						'sound/voice/screams/mascream7.ogg'
 					),
-					sound_prob = 40
+					sound_prob = 40,
+					min_distance = 5
 				)
 			)
 		),
@@ -114,7 +115,8 @@
 					range=8,
 					image_prob=100,
 					image_time=60,
-					override=TRUE
+					override=TRUE,
+					visible_creation = FALSE
 				)
 			),
 			list(/datum/component/hallucination/fake_attack,
@@ -303,7 +305,8 @@
 					range=6,
 					image_prob=40,
 					image_time=30,
-					override=TRUE
+					override=TRUE,
+					visible_creation = FALSE
 				)
 			),
 			//flock sounds
@@ -354,14 +357,14 @@
 				continue
 
 			var/mob/living/carbon/human/H  = L
-			if(istype(H) && istype(H.head, /obj/item/clothing/head/tinfoil_hat)) 
+			if(istype(H) && istype(H.head, /obj/item/clothing/head/tinfoil_hat))
 				continue
 
 			if(!ON_COOLDOWN(L, "halluc_cooldown_\ref[src]", 60 SECONDS)) //dont spam logs - we only want to log when a new effect applies - not a refresh
 				logTheThing(LOG_COMBAT, L, "was affected by a [src.effect_type] hallucination from [src.associated_object] at [log_loc(src.associated_object)]")
 			else
 				EXTEND_COOLDOWN(L, "halluc_cooldown_\ref[src]", 60 SECONDS)
-        
+
 			for(var/list/comp_args_tuple in src.madness_effects[src.effect_type])
 				//yes, we really do mean _AddComponent here, because it's already a list we're passing
 				//also we do it with the summed list because _AddComponent modifies the list that is passed to it


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Internal]{C-Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`random_sound` hallucinations now have an argument called min_distance, default -1 (no minimum distance, old behavior), that provides a limit on how close the sound can originate from.

`random_image_override` hallucinations now have an argument called visible_creation, default TRUE, which if FALSE causes images to only appear in spots within range that can NOT currently be viewed by the affected mob.
I did not add this to `random_image` hallucinations, as those appear to be used as a lighter version of random_image_override when only the barebones features are needed.

As a minor demonstration, the screaming madness artifact now has a minimum distance of 5, and the flock and ghost madness artifacts now only override human images outside view.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Honestly, I'm working on hallucination things for my own adventure/prefab stuff and am atomizing this out of that.  I suppose it just helps make more convincing hallucinations?
