### PR TITLE
Adds some words about PR atomization and re-pathing to the contributor guidelines

### DIFF
--- a/.github/CONTRIBUTOR_GUIDELINES.md
+++ b/.github/CONTRIBUTOR_GUIDELINES.md
@@ -23,6 +23,10 @@ As for pull requests, there are some limitations on what we accept, detailed mor
 
 Additionally PRs should be as **atomic** as possible, this means each pull request should ideally do **one** thing. Do not mix bugfixes with features, or refactoring with behaviour changes. This may sound pedantic, but properly atomized PRs are a million times easier to review and so are much more likely to be merged faster.
 
+Examples of PR titles that require atomization:
+- "Fixes a bug with c-sabers disappearing and increases their damage by 12"
+- "Changes singularity.dm to use absolute pathing and fixes some bugs in it"
+
 If you are "re-pathing" (changing the type-paths of existing types) then please include a list of the paths changed, or ideally an [UpdatePaths](https://github.com/goonstation/goonstation/tree/master/tools/UpdatePaths) script for larger scale changes.
 
 As far as a timeline on getting your PR merged, there is none. This is a volunteer-ran project, people have lives outside of the game. It'll get merged when it gets merged. There is also no need to keep your PR up to date with the master branch. Generally, you only should need to touch your PR if there is a merge conflict or a dev asks you to change something.

--- a/.github/CONTRIBUTOR_GUIDELINES.md
+++ b/.github/CONTRIBUTOR_GUIDELINES.md
@@ -21,6 +21,10 @@ Please do not unnecessarily ping us directly unless someone explicitly says it's
 
 As for pull requests, there are some limitations on what we accept, detailed more throughly in [Unwanted Contributions](#Unwanted-Contributions) below. Also, we occasionally hold *Feature Freezes*, where PRs adding new features are not accepted, and will be automatically closed unless you seek approval from a developer before submitting it.
 
+Additionally PRs should be as **atomic** as possible, this means each pull request should ideally do **one** thing. Do not mix bugfixes with features, or refactoring with behaviour changes. This may sound pedantic, but properly atomized PRs are a million times easier to review and so are much more likely to be merged faster.
+
+If you are "re-pathing" (changing the type-paths of existing types) then please include a list of the paths changed, or ideally an [UpdatePaths](https://github.com/goonstation/goonstation/tree/master/tools/UpdatePaths) script for larger scale changes.
+
 As far as a timeline on getting your PR merged, there is none. This is a volunteer-ran project, people have lives outside of the game. It'll get merged when it gets merged. There is also no need to keep your PR up to date with the master branch. Generally, you only should need to touch your PR if there is a merge conflict or a dev asks you to change something.
 
 *Note: Specifically for TGUI PRs, you don't really need to worry about merge conflicts due to their nature*.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
^
Note to self: remember to pull changes into hackmd


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I realised we yell about atomization a lot but don't really define anywhere how PRs should be atomized.