### PR TITLE
Remove achievement requirement for Flock structures

### DIFF
--- a/_std/macros/flock.dm
+++ b/_std/macros/flock.dm
@@ -36,8 +36,6 @@
 // achievements
 #define FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES "all_structures"
 #define FLOCK_ACHIEVEMENT_CHEAT_COMPUTE "infinite_compute"
-#define FLOCK_ACHIEVEMENT_CAGE_HUMAN "human_dissection"
-#define FLOCK_ACHIEVEMENT_BULLETS_HIT "bullets_hit"
 
 #define FLOCK_BULLETS_HIT_THRESHOLD 15
 

--- a/code/datums/components/flock/flockprotection.dm
+++ b/code/datums/components/flock/flockprotection.dm
@@ -53,9 +53,6 @@
 		flock_speak(snitch, "Damage sighted on [report_name], [pick_string("flockmind.txt", "flockdrone_enemy")] [attacker]", snitch.flock)
 	snitch.flock.updateEnemy(attacker)
 
-	if (projectile_attack)
-		snitch.flock.check_for_bullets_hit_achievement(projectile_attack)
-
 /// Raise COMSIG_FLOCK_ATTACK on common sources of damage (projectiles, items, fists, etc.)
 /datum/component/flock_protection
 	/// Do we get mad if someone punches it?

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -828,22 +828,6 @@ proc/get_default_flock()
 /datum/flock/proc/hasAchieved(var/str)
 	return (str in src.achievements)
 
-/datum/flock/proc/check_for_bullets_hit_achievement(obj/projectile/P)
-	if (!istype(P.proj_data, /datum/projectile/bullet))
-		return
-	if (src.bullets_hit > FLOCK_BULLETS_HIT_THRESHOLD)
-		return
-
-	var/attacker = P.shooter
-	if(!(ismob(attacker) || iscritter(attacker) || isvehicle(attacker)))
-		attacker = P.mob_shooter // shooter is updated on reflection, so we fall back to mob_shooter if it turns out to be a wall or something
-	if (istype(attacker, /mob/living/critter/flock))
-		var/mob/living/critter/flock/flockcritter = attacker
-		if (flockcritter.flock == src)
-			return
-	src.bullets_hit++
-	if (src.bullets_hit == FLOCK_BULLETS_HIT_THRESHOLD)
-		src.achieve(FLOCK_ACHIEVEMENT_BULLETS_HIT)
 ////////////////////
 // GLOBAL PROCS!!
 ////////////////////

--- a/code/datums/flock/flockunlockable.dm
+++ b/code/datums/flock/flockunlockable.dm
@@ -35,44 +35,33 @@ ABSTRACT_TYPE(/datum/unlockable_flock_structure)
 
 	///Returns true when unlock condition is met, false when it isn't.
 	proc/check_unlocked()
-		return src.my_flock.hasAchieved(FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES)
+		return TRUE
 
 /datum/unlockable_flock_structure/relay
 	structType = /obj/flock_structure/relay
 
 	check_unlocked()
 		var/relay_built = src.my_flock.relay_in_progress || src.my_flock.relay_finished
-		return ..() || (src.my_flock.total_compute() >= FLOCK_RELAY_COMPUTE_COST && !relay_built && !src.my_flock.flockmind?.tutorial)
+		return src.my_flock.hasAchieved(FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES) || \
+			(src.my_flock.total_compute() >= FLOCK_RELAY_COMPUTE_COST && !relay_built && !src.my_flock.flockmind?.tutorial)
 
 /datum/unlockable_flock_structure/collector
 	structType = /obj/flock_structure/collector
 
-	check_unlocked()
-		return TRUE
-
 /datum/unlockable_flock_structure/sentinel
 	structType = /obj/flock_structure/sentinel
-
-	check_unlocked()
-		return TRUE
 
 /datum/unlockable_flock_structure/compute
 	structType = /obj/flock_structure/compute
 
+	check_unlocked()
+		return src.my_flock.hasAchieved(FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES)
+
 /datum/unlockable_flock_structure/gnesisturret
 	structType = /obj/flock_structure/gnesisturret
-
-	check_unlocked()
-		return ..() || src.my_flock.hasAchieved(FLOCK_ACHIEVEMENT_CAGE_HUMAN)
 
 /datum/unlockable_flock_structure/sapper
 	structType = /obj/flock_structure/sapper
 
-	check_unlocked()
-		return ..() || src.my_flock.total_compute() >= 150
-
 /datum/unlockable_flock_structure/interceptor
 	structType = /obj/flock_structure/interceptor
-
-	check_unlocked()
-		return ..() || src.my_flock.hasAchieved(FLOCK_ACHIEVEMENT_BULLETS_HIT)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -767,7 +767,6 @@
 		return FALSE
 	if (!..())
 		return
-	src.flock?.check_for_bullets_hit_achievement(P)
 
 /mob/living/critter/flock/drone/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	..()

--- a/code/modules/tutorials/flock_tutorial.dm
+++ b/code/modules/tutorials/flock_tutorial.dm
@@ -361,7 +361,6 @@
 
 	SetUp()
 		..()
-		src.ftutorial.fowner.flock.achieve(FLOCK_ACHIEVEMENT_BULLETS_HIT)
 		src.ftutorial.portal_in(get_turf(src.ftutorial.center), /mob/living/carbon/human/normal/chef/shoot_gun_person/)
 		src.location = locate(src.ftutorial.center.x - 1, src.ftutorial.center.y - 3, src.ftutorial.center.z)
 		location.UpdateOverlays(marker, "marker")

--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -83,7 +83,6 @@
 			playsound(src, 'sound/impact_sounds/Flesh_Tear_1.ogg', 80, TRUE)
 			boutput(H, "<span class='alert bold'>[src] wrenches your [initial(target.name)] clean off and begins peeling it apart! Fuck!</span>")
 			src.visible_message("<span class='alert bold'>[src] wrenches [target.name] clean off and begins peeling it apart!</span>")
-			flock?.achieve(FLOCK_ACHIEVEMENT_CAGE_HUMAN)
 		else if(length(organs))
 			eating_occupant = TRUE
 			target = pick(organs)
@@ -93,7 +92,6 @@
 			playsound(src, 'sound/impact_sounds/Flesh_Tear_2.ogg', 80, TRUE)
 			boutput(H, "<span class='alert bold'>[src] tears out your [initial(target.name)]! OH GOD!</span>")
 			src.visible_message("<span class='alert bold'>[src] tears out [target.name]!</span>")
-			flock?.achieve(FLOCK_ACHIEVEMENT_CAGE_HUMAN)
 		else
 			H.gib()
 			occupant = null
@@ -152,7 +150,6 @@
 			occupant = null
 			playsound(src, 'sound/impact_sounds/Flesh_Tear_2.ogg', 80, TRUE)
 			src.visible_message("<span class='alert bold'>[src] rips what's left of its occupant to shreds!</span>")
-			flock?.achieve(FLOCK_ACHIEVEMENT_CAGE_HUMAN)
 
 	proc/spawnEgg()
 		src.visible_message("<span class='notice'>[src] spits out a device!</span>")


### PR DESCRIPTION
[GAME MODES][GAME OBJECTS][REMOVAL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes the achievement requirement from Flock structures, meaning you can unlock all buildable ones other than the Relay immediately.

Not sure regarding the theme of Flock, but I think it would still make sense thematically, that they would be aware of what harms them and what they can utilize. Thinking of Interceptor and Sapper.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Couple of reasons-
-May have been an interesting way to unlock structures, but in practice with the fast-paced gameplay of Flock and the time to build structures, they just never get used. For any reason, maybe players forget with how much stuff is going on, or just don't see the chat messages for unlocks, they aren't really used
-Assuming Flock is winning, I feel like waiting on specific tasks doesn't really help them much as they are going to be winning without these structures anyways. This would help reduce Flock needing to survive longer than necessary to unlock structures
-Hopefully allows Flock's structures to be utilized more
-Allows Flock to play some more into the building side of RTS, allowing which structures they want immediately, location, and combinations


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(*)Flock structures no longer require specific tasks to be performed and start off available immediately.
```
