### PR TITLE
Fix invasive growth gene strain not working properly

### DIFF
--- a/code/modules/hydroponics/gene_strains.dm
+++ b/code/modules/hydroponics/gene_strains.dm
@@ -181,7 +181,7 @@
 				else if (checked_plantpot.dead)
 					checked_plantpot.HYPdestroyplant()
 				//Seedless prevents the plant from replanting. And inhibited potential as well.... no infinite maneaters, folks
-				else if (!growing && !HYPCheckCommut(current_plantgenes, /datum/plant_gene_strain/seedless) && !!HYPCheckCommut(current_plantgenes, /datum/plant_gene_strain/reagent_blacklist))
+				else if (!growing && !HYPCheckCommut(current_plantgenes, /datum/plant_gene_strain/seedless) && !HYPCheckCommut(current_plantgenes, /datum/plant_gene_strain/reagent_blacklist))
 					//we create a new seed now
 					var/obj/item/seed/temporary_seed = HYPgenerateseedcopy(current_plantgenes, current_planttype, carrying_plantpot.generation)
 					// now we are able to plant the seed


### PR DESCRIPTION
[Bug][hydroponics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes a double `!` i accidently placed in the code of invasive growth. This made the invasive growth gene strain only able to replant inhibited potential-carriers (Maneater plants) instead of everything else except these plants

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I am very sure we don't want self-replicating man-eating plants.

This fixes #16775