### PR TITLE
Fix the message on arming a chemgrenade

### DIFF
--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -104,7 +104,7 @@
 			message_admins("[log_reagents ? "Custom grenade" : "Grenade ([src])"] primed at [log_loc(src)] by [key_name(user)].")
 		logTheThing(LOG_COMBAT, user, "primes a [log_reagents ? "custom grenade" : "grenade ([src.type])"] at [log_loc(user)].[log_reagents ? " [log_reagents]" : ""]")
 
-	boutput(user, "<span class='alert'>You prime the grenade! [src.grenade_time / 1 SECOND] seconds!</span>")
+	boutput(user, "<span class='alert'>You prime the grenade! [src.grenade_time / (1 SECOND)] seconds!</span>")
 	src.armed = TRUE
 	src.icon_state = icon_state_armed
 	playsound(src, 'sound/weapons/armbomb.ogg', 75, TRUE, -3)


### PR DESCRIPTION
[bug][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds paranthesis to calculation of the message that describes when a just-armed chem grenade goes off, so instead of multiplying the time (in deciseconds) by 10 it properly divides it by 10

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When arming a chem grenade the time said for it to go off should probably not be multiplied by 100. 

This fixes #16776

