### PR TITLE
Bugifx - Lizard tails should drop again

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -4433,11 +4433,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		src.secondary_color = rgb(rand(50,190), rand(50,190), rand(50,190))
 	src.setup_overlays()
 
-/mob/living/critter/small_animal/livingtail/Move()
-	. = ..()
-	if (src.currentsteps++ >= src.maxsteps)
-		src.death()
-
 /mob/living/critter/small_animal/livingtail/setup_overlays()
 	var/image/overlayprimary = image('icons/misc/critter.dmi', "twitchytail_colorkey1")
 	overlayprimary.color = primary_color
@@ -4454,6 +4449,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		playsound(src, 'sound/impact_sounds/Slimy_Splat_1.ogg', 30, TRUE)
 		make_cleanable(/obj/decal/cleanable/blood/splatter, src.loc)
 	..()
+	if (src.currentsteps++ >= src.maxsteps)
+		src.death()
 
 /mob/living/critter/small_animal/livingtail/death(var/gibbed)
 	if (gibbed)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -4420,14 +4420,14 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	ai_retaliates = FALSE
 
 	var/obj/item/organ/tail/lizard/tail_memory = null
-	var/maxsteps = 5
-	var/currentsteps = 0
+	var/max_life_timer = 5
+	var/current_life_timer = 0
 	var/primary_color = "#21a833"
 	var/secondary_color = "#000000"
 
 /mob/living/critter/small_animal/livingtail/New()
 	..()
-	src.maxsteps = rand(5, 15)
+	src.max_life_timer = rand(5, 15)
 	if (!tail_memory)
 		src.primary_color = rgb(rand(50,190), rand(50,190), rand(50,190))
 		src.secondary_color = rgb(rand(50,190), rand(50,190), rand(50,190))
@@ -4449,7 +4449,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		playsound(src, 'sound/impact_sounds/Slimy_Splat_1.ogg', 30, TRUE)
 		make_cleanable(/obj/decal/cleanable/blood/splatter, src.loc)
 	..()
-	if (src.currentsteps++ >= src.maxsteps)
+	if (src.current_life_timer++ >= src.max_life_timer)
 		src.death()
 
 /mob/living/critter/small_animal/livingtail/death(var/gibbed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Providing a "fix" for lizard tails not dropping that’ll either be accepted or gets attention from someone who can figure out what’s going on with mob ai :D 

What I think is happening: When counting steps to determine when the tail should die, /mob/living/critter/small_animal/livingtail/death more often than not gets called twice by the AI mob controller. This causes the tail to get deleted the first time, then https://github.com/goonstation/goonstation/blob/b47b5ab317ec8dcfa5299720defab0668135abac/code/del.dm#L144 gets run since we’re trying to delete a null atom and the dropped tail gets yeeted to the abyss. Stackraces available in linked bug ticket.

**Solution:** Move the step count to the life process. This way the tail can still use the wander mob AI, but if it ends up not moving, it’ll still die at some point and not call die twice. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes https://github.com/goonstation/goonstation/issues/16374 
- During testing I found that tails dropped in space aren't able to move. They get stuck in a loop, never stop living, and splatter blood spots on the tile forever! Proposed PR fixes this as well.
