### PR TITLE
Fixes printing press making blank books

### DIFF
--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -27,7 +27,7 @@
 	var/ink_level = 100
 	/// the default modes, can be expanded to have "Ink Colors" and "Custom Cover"
 	var/list/press_modes = list("Choose book cover", "Set book info", "Set book contents",
-	"Set newspaper info", "Amount to make", "Print", "View Information")
+	"Set newspaper info", "Set newspaper contents", "Amount to make", "Print", "View Information")
 
 	/// how many books to make?
 	var/book_amount = 0
@@ -270,7 +270,7 @@
 					src.visible_message("\The [src] already has that upgrade installed.")
 					return
 				src.press_modes += "Set newspaper info"
-				src.press_modes += "Toggle newspaper mode"
+				src.press_modes += "Set newspaper contents"
 				src.newspaper_upgrade = TRUE
 				src.visible_message("\The [src] accepts the upgrade.")
 

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -361,7 +361,7 @@
 			boutput(user, "Information set.")
 			return
 		if ("set newspaper contents")
-			var/info_sel = input(user, "What do you want the article to say?", "Information Control", src.newspaper_info_raw)
+			var/info_sel = input(user, "What do you want the article to say?", "Information Control", src.newspaper_info_raw) as null|message
 			if (!info_sel)
 				return
 			info_sel = src.trim_input(info_sel)

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -346,7 +346,7 @@
 			if (!src.newspaper_upgrade)
 				boutput(user, "Your free trial of newspaper printing has expired. Please enter Newspaper Printing Upgrade.")
 				return
-			var/name_sel = input("What do you want the headline to be?", "Information Control", src.book_name)
+			var/name_sel = input("What do you want the headline to be?", "Information Control", src.newspaper_headline)
 			if (length(name_sel) > src.headline_len_lim)
 				boutput(user, "Aborting, headline too long.")
 				return

--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -364,7 +364,9 @@
 			var/info_sel = input(user, "What do you want the article to say?", "Information Control", src.newspaper_info_raw)
 			if (!info_sel)
 				return
-			src.declare_contents(info_sel, src.newspaper_info_raw, src.newspaper_info)
+			info_sel = src.trim_input(info_sel)
+			src.newspaper_info_raw = info_sel
+			src.newspaper_info = src.convert_input(info_sel)
 			phrase_log.log_phrase("newspaperarticle", src.newspaper_info, TRUE, user, FALSE)
 			boutput(user, "Newspaper contents set.")
 			return
@@ -388,7 +390,9 @@
 			var/info_sel = input("What do you want your book to say?", "Content Control", src.book_info_raw) as null|message
 			if (!info_sel)
 				return
-			src.declare_contents(info_sel, src.book_info_raw, src.book_info)
+			info_sel = src.trim_input(info_sel)
+			src.book_info_raw = info_sel
+			src.book_info = src.convert_input(info_sel)
 			phrase_log.log_phrase("bookcontent", src.book_info, TRUE, user, FALSE)
 			boutput(user, "Book contents set.")
 			return
@@ -548,10 +552,9 @@
 		else //just in case, yell at me if this is bad
 			return
 
-/// sets book_info and book_info_raw, for newspapers as well.
-/obj/machinery/printing_press/proc/declare_contents(var/info_sel, var/raw_info, var/non_raw_info)
-	info_sel = copytext(html_encode(info_sel), 1, 4*MAX_MESSAGE_LEN) //for now this is ~700 words, 4096 characters, please increase if people say that its too restrictive/low
-	raw_info = info_sel
+/// HTML encodes input and converts bbcode to HTML
+/obj/machinery/printing_press/proc/convert_input(var/info_sel)
+	info_sel = html_encode(info_sel)
 	info_sel = replacetext(info_sel, "\n", "<BR>")
 	info_sel = replacetext(info_sel, "\[b\]", "<B>")
 	info_sel = replacetext(info_sel, "\[/b\]", "</B>")
@@ -575,7 +578,11 @@
 	info_sel = replacetext(info_sel, "\[/li\]", "</LI>")
 	info_sel = replacetext(info_sel, "\[bq\]", "<BLOCKQUOTE>")
 	info_sel = replacetext(info_sel, "\[/bq\]", "</BLOCKQUOTE>")
-	non_raw_info = info_sel
+	return info_sel
+
+/// trim text down to max length for contents
+/obj/machinery/printing_press/proc/trim_input(var/info_sel)
+	return copytext(info_sel, 1, 4*MAX_MESSAGE_LEN) //for now this is ~700 words, 4096 characters, please increase if people say that its too restrictive/low
 
 /////////////////////
 //Book making stuff//


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #15775 by making the `declare_contents` proc not try to do clever pass by reference stuff because that doesn't work. Also fixes two other bugs I found while doing this wherein: The code to set custom newspaper contents was all there but the option was not in the list, and the input box for newspaper headline auto-filled with the currently set book name instead of the headline.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The people want to write

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) The printing press actually prints books with words in them now!
```
