### PR TITLE
Fixes grabs going into player vending machines

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2299,7 +2299,7 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 				boutput(user, "<span class='alert'>No items were loaded from \the [dropped] into \the [src]!</span>")
 
 	attackby(obj/item/target, mob/user)
-		if (loading && panel_open)
+		if (loading && panel_open && !isgrab(target))
 			addProduct(target, user)
 			update_static_data(user)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #16786 by adding a grab check to the if on `attackby` so it will smash the victim into the machine like normal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Abstract representations of game mechanics are not for sale.