### PR TITLE
Move medal procs to /datum/player

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -360,12 +360,7 @@
 	clients += src
 
 	SPAWN(0) // to not lock up spawning process
-		if (IsGuestKey(src.key))
-			src.has_contestwinner_medal = 0
-		else if (!config || !config.medal_hub || !config.medal_password)
-			src.has_contestwinner_medal = 0
-		else
-			src.has_contestwinner_medal = world.GetMedal("Too Cool", src.key, config.medal_hub, config.medal_password)
+		src.has_contestwinner_medal = src.player.has_medal("Too Cool")
 
 	src.initSizeHelpers()
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -864,62 +864,22 @@
 		src.equipped().intent_switch_trigger(src)
 
 // medals
-/mob/proc/revoke_medal(title, debug)
-	if (!debug && (!src.client || !src.key))
+
+/mob/proc/revoke_medal(title)
+	src.mind.get_player().clear_medal(title)
+
+/mob/proc/unlock_medal(title, announce=FALSE)
+	set waitfor = 0
+	if (!src.client)
 		return
-	else if (IsGuestKey(src.key))
-		return
-	else if (!config || !config.medal_hub || !config.medal_password)
-		return
+	src.mind.get_player().unlock_medal(title, announce)
 
-	return world.ClearMedal(title, key, config.medal_hub, config.medal_password)//revoking medals is probably a good idea to have be synchronous for the guarantee.
-
-/mob/proc/unlock_medal(title, announce, debug)
-	if (!debug && (!src.client || !src.key))
-		return
-	else if (IsGuestKey(src.key))
-		return
-	else if (!config || !config.medal_hub || !config.medal_password)
-		return
-
-	var/key = src.key
-	var/displayed_key = src.mind.displayed_key
-	SPAWN(0)
-		var/result = world.SetMedal(title, key, config.medal_hub, config.medal_password)
-
-		if (result == 1)
-			var/list/unlocks = list()
-			for(var/A in rewardDB)
-				var/datum/achievementReward/D = rewardDB[A]
-				if (D.required_medal == title)
-					unlocks.Add(D)
-			if (announce)
-				boutput(world, "<span class=\"medal\">[displayed_key] earned the [title] medal.</span>")//src.client.stealth ? src.client.fakekey : << seems to be causing trouble
-			else if (ismob(src) && src.client)
-				boutput(src, "<span class=\"medal\">You earned the [title] medal.</span>")
-
-			if (length(unlocks))
-				for(var/datum/achievementReward/B in unlocks)
-					boutput(src, "<span class=\"medal\"><FONT FACE=Arial SIZE=+1>You've unlocked a Reward : [B.title]!</FONT></span>")
-
-		else if (isnull(result) && ismob(src) && src.client)
-			return
-//			boutput(src, "<span class='alert'>You would have earned the [title] medal, but there was an error communicating with the BYOND hub.</span>")
-
-/mob/proc/has_medal(var/medal) //This is not spawned because of return values. Make sure the proc that uses it uses spawn or you lock up everything.
+/mob/proc/has_medal(medal) //This is not spawned because of return values. Make sure the proc that uses it uses spawn or you lock up everything.
 	LAGCHECK(LAG_HIGH)
 #ifdef SHUT_UP_AND_GIVE_ME_MEDAL_STUFF
 	return TRUE
 #else
-	if (IsGuestKey(src.key))
-		return null
-	else if (!config)
-		return null
-	else if (!config.medal_hub || !config.medal_password)
-		return null
-
-	var/result = world.GetMedal(medal, src.key, config.medal_hub, config.medal_password)
-	return result
+	src.mind.get_player().has_medal(medal)
 #endif
 
 /mob/verb/list_medals()
@@ -939,17 +899,16 @@
 
 	SPAWN(0)
 		var/list/output = list()
-		var/medals = world.GetMedal("", src.key, config.medal_hub, config.medal_password)
+		var/list/medals = src.mind.get_player().get_all_medals()
 
 		if (isnull(medals))
 			output += "<span class='alert'>Sorry, could not contact the BYOND hub for your medal information.</span>"
 			return
 
-		if (!medals)
+		if (length(medals) == 0)
 			boutput(src, "<b>You don't have any medals.</b>")
 			return
 
-		medals = params2list(medals)
 		sortList(medals, /proc/cmp_text_asc)
 
 		output += "<b>Medals:</b>"

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2472,18 +2472,10 @@ var/global/night_mode_enabled = 0
 
 	if (!target_key)
 		target_key = input("Enter target key", "Target account key", null) as null|text
-	var/medals = world.GetMedal("", null, config.medal_hub, config.medal_password)
-	medals = params2list(medals)
-	var/mob/M
-	for (var/client/C in clients)
-		LAGCHECK(LAG_LOW)
-		if (C.key == target_key	)
-			M = C.mob
-	if (isnull(M))
-		M = new /mob
-		M.key = target_key
+	var/datum/player/player = make_player(target_key)
+	var/list/medals = player.get_all_medals()
 	for (var/medal in medals)
-		var/result = world.ClearMedal(medal, M, config.medal_hub, config.medal_password)
+		var/result = player.clear_medal(medal)
 		if (isnull(result))
 			boutput(src, "Failed to clear medal; error!")
 			break
@@ -2507,12 +2499,12 @@ var/global/night_mode_enabled = 0
 	var/revoke = (alert(src, "Mass grant or revoke medals?", "Mass grant/revoke", "Grant", "Revoke") == "Revoke")
 	var/key = input("Enter player key", "Player key", null) as null|text
 	while(key)
-		var/player = ckey(key)
+		var/datum/player/player = make_player(key)
 		var/result
 		if (revoke)
-			result = world.ClearMedal(medal, player, config.medal_hub, config.medal_password)
+			result = player.clear_medal(medal)
 		else
-			result = world.SetMedal(medal, player, config.medal_hub, config.medal_password)
+			result = player.unlock_medal_sync(medal)
 		if (isnull(result))
 			boutput(src, "Failed to set medal; error communicating with BYOND hub!")
 			break
@@ -2528,25 +2520,18 @@ var/global/night_mode_enabled = 0
 
 	if (!config || !config.medal_hub || !config.medal_password)
 		return
-	var/mob/M = new /mob
 	if (!old_key)
 		old_key = input("Enter old account key", "Old account key", null) as null|text
-	M.key = old_key // Old key shouldn't be online, so
 	if (!new_key)
 		new_key = input("Enter new account key", "New account key", null) as null|text
-	var/medals = world.GetMedal("", M, config.medal_hub, config.medal_password)
-	if (!medals)
+	var/datum/player/old_player = make_player(old_key)
+	var/datum/player/new_player = make_player(new_key)
+	var/list/medals = old_player.get_all_medals()
+	if (isnull(medals))
 		boutput(src, "No medals; error communicating with BYOND hub!")
 		return
-	medals = params2list(medals)
-	for (var/client/C in clients)
-		LAGCHECK(LAG_LOW)
-		if (C.ckey == ckey(new_key))
-			M = C.mob
-	if (M.ckey == ckey(old_key))
-		M.ckey = ckey(new_key)
 	for (var/medal in medals)
-		var/result = world.SetMedal(medal, M, config.medal_hub, config.medal_password)
+		var/result = new_player.unlock_medal_sync(medal)
 		if (isnull(result))
 			boutput(src, "Failed to set medal; error communicating with BYOND hub!")
 			break

--- a/code/modules/admin/spacebee_extension/commands.dm
+++ b/code/modules/admin/spacebee_extension/commands.dm
@@ -724,11 +724,13 @@
 				Provided: gr:[json_encode(giverevoke)] p:[json_encode(player)] m:[json_encode(medalname)]", user)
 			return
 
+		var/datum/player/player_datum = make_player(player)
+
 		var/result
 		if (giverevoke == "give")
-			result = world.SetMedal(medalname, player, config.medal_hub, config.medal_password)
+			result = player_datum.unlock_medal_sync(medalname)
 		else if (giverevoke == "revoke")
-			result = world.ClearMedal(medalname, player, config.medal_hub, config.medal_password)
+			result = player_datum.clear_medal(medalname)
 		else
 			system.reply("Failed to set medal; neither `give` nor `revoke` was specified as the first argument.")
 			return

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1364,7 +1364,7 @@
 		if (L?.traitHolder?.hasTrait("hemophilia"))
 			blood_mult = blood_mult + 3
 		T.fluid_react_single(blood_id,blood_mult * blood_amount)
-		var/result = world.ClearMedal("Original Sin", activator, config.medal_hub, config.medal_password)
+		var/result = activator.mind.get_player().clear_medal("Original Sin")
 		logTheThing(LOG_COMBAT, activator, "Activated the blood flood gib reward thing (Original Sin)")
 		if (result)
 			boutput(activator, "<span class='alert'>You feel your soul cleansed of sin.</span>")

--- a/code/player.dm
+++ b/code/player.dm
@@ -220,6 +220,60 @@
 #endif
 			return TRUE
 
+	/// Gives this player a medal. Will not sleep, but does not have a return value. Use unlock_medal_sync if you need to know if it worked
+	proc/unlock_medal(medal_name, announce=FALSE)
+		set waitfor = 0
+		src.unlock_medal_sync(medal_name, announce)
+
+	/// Gives this player a medal. Will sleep, make sure the proc calling this is in a spawn etc
+	proc/unlock_medal_sync(medal_name, announce=FALSE)
+		if (IsGuestKey(src.ckey) || !config || !config.medal_hub || !config.medal_password)
+			return FALSE
+
+		var/key = src.key
+		var/displayed_key = src.client?.mob?.mind?.displayed_key || src.key
+		var/result = world.SetMedal(medal_name, key, config.medal_hub, config.medal_password)
+		if(!result)
+			return FALSE
+		. = TRUE
+
+		var/list/unlocks = list()
+		for(var/A in rewardDB)
+			var/datum/achievementReward/D = rewardDB[A]
+			if (D.required_medal == medal_name)
+				unlocks.Add(D)
+
+		if (announce)
+			boutput(world, "<span class=\"medal\">[displayed_key] earned the [medal_name] medal.</span>")
+		else if (src.client)
+			boutput(src.client, "<span class=\"medal\">You earned the [medal_name] medal.</span>")
+
+		if (length(unlocks))
+			for(var/datum/achievementReward/B in unlocks)
+				boutput(src.client, "<span class=\"medal\"><FONT FACE=Arial SIZE=+1>You've unlocked a Reward : [B.title]!</FONT></span>")
+
+	/// Removes a medal from this player. Will sleep, make sure the proc calling this is in a spawn etc
+	proc/clear_medal(medal_name)
+		if (IsGuestKey(src.ckey) || !config || !config.medal_hub || !config.medal_password)
+			return null
+		return world.ClearMedal(medal_name, src.key, config.medal_hub, config.medal_password)
+
+	/// Checks if this player has a medal. Will sleep, make sure the proc calling this is in a spawn etc
+	proc/has_medal(medal_name)
+		if (IsGuestKey(src.ckey) || !config || !config.medal_hub || !config.medal_password)
+			return
+		return world.GetMedal(medal_name, src.key, config.medal_hub, config.medal_password)
+
+	/// Returns a list of all medals of this player. Will sleep, make sure the proc calling this is in a spawn etc
+	proc/get_all_medals()
+		RETURN_TYPE(/list)
+		if (!config || !config.medal_hub || !config.medal_password)
+			return
+		. = world.GetMedal("", src.key, config.medal_hub, config.medal_password)
+		if(isnull(.))
+			return
+		. = params2list(.)
+
 	/// Refreshes clouddata
 	proc/cloud_fetch_data_only()
 		var/list/data = cloud_fetch_target_data_only(src.ckey)

--- a/code/player.dm
+++ b/code/player.dm
@@ -244,9 +244,9 @@
 				unlocks.Add(D)
 
 		if (announce)
-			boutput(world, "<span class='medal'>[displayed_key] earned the [medal_name] medal.</span>")
+			boutput(world, "<span class='medal'>[displayed_key] earned the [medal_name] medal!</span>")
 		else if (src.client)
-			boutput(src.client, "<span class='medal'>You earned the [medal_name] medal.</span>")
+			boutput(src.client, "<span class='medal'>You earned the [medal_name] medal!</span>")
 
 		if (length(unlocks))
 			for(var/datum/achievementReward/B in unlocks)

--- a/code/player.dm
+++ b/code/player.dm
@@ -244,13 +244,13 @@
 				unlocks.Add(D)
 
 		if (announce)
-			boutput(world, "<span class=\"medal\">[displayed_key] earned the [medal_name] medal.</span>")
+			boutput(world, "<span class='medal'>[displayed_key] earned the [medal_name] medal.</span>")
 		else if (src.client)
-			boutput(src.client, "<span class=\"medal\">You earned the [medal_name] medal.</span>")
+			boutput(src.client, "<span class='medal'>You earned the [medal_name] medal.</span>")
 
 		if (length(unlocks))
 			for(var/datum/achievementReward/B in unlocks)
-				boutput(src.client, "<span class=\"medal\"><FONT FACE=Arial SIZE=+1>You've unlocked a Reward : [B.title]!</FONT></span>")
+				boutput(src.client, "<span class='medal'><FONT FACE=Arial SIZE=+1>You've unlocked a Reward : [B.title]!</FONT></span>")
 
 	/// Removes a medal from this player. Will sleep, make sure the proc calling this is in a spawn etc
 	proc/clear_medal(medal_name)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For organization purposes it is a good idea to have these unified and on the datum which represents potentially logged out clients. This will also help with potential API 2 stuff.