### PR TITLE
Add help message for wrapping paper

### DIFF
--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -14,6 +14,11 @@
 	tooltip_flags = REBUILD_DIST
 	var/style = "r"
 
+	HELP_MESSAGE_OVERRIDE({"Place the wrapping paper on a table.
+							Hold something sharp like <b>scissors</b> or a <b>knife</b> in your non-active hand.
+							Hold the small item to wrap in your active hand.
+							Hit the wrapping paper with the small item."})
+
 	New()
 		..()
 		src.style = rand(1,8)

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -13,21 +13,14 @@
 	stamina_crit_chance = 1
 	tooltip_flags = REBUILD_DIST
 	var/style = "r"
-	HELP_MESSAGE_OVERRIDE("") // so there's the verb and stuff, actual message provided below
+	HELP_MESSAGE_OVERRIDE("Place the wrapping paper on a table. Hold something sharp like <b>scissors</b> or a <b>knife</b> in your non-active hand. \
+							Hold the small item to wrap in your active hand. Hit the wrapping paper with the small item. \
+							Wrapping paper can also be directly used on dead bodies...")
 
 	New()
 		..()
 		src.style = rand(1,8)
 		src.icon_state = "wrap_paper-[src.style]"
-
-	get_help_message(dist, mob/user)
-		var/help_message_string = "Place the wrapping paper on a table. \
-								Hold something sharp like <b>scissors</b> or a <b>knife</b> in your non-active hand. \
-								Hold the small item to wrap in your active hand. \
-								Hit the wrapping paper with the small item."
-		if (user.mind?.special_role)
-			help_message_string += " Wrapping paper can also be directly used on dead bodies..."
-		return help_message_string
 
 /obj/item/wrapping_paper/xmas
 	desc = "This wrapping paper is especially festive."

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -13,16 +13,21 @@
 	stamina_crit_chance = 1
 	tooltip_flags = REBUILD_DIST
 	var/style = "r"
-
-	HELP_MESSAGE_OVERRIDE({"Place the wrapping paper on a table.
-							Hold something sharp like <b>scissors</b> or a <b>knife</b> in your non-active hand.
-							Hold the small item to wrap in your active hand.
-							Hit the wrapping paper with the small item."})
+	HELP_MESSAGE_OVERRIDE("") // so there's the verb and stuff, actual message provided below
 
 	New()
 		..()
 		src.style = rand(1,8)
 		src.icon_state = "wrap_paper-[src.style]"
+
+	get_help_message(dist, mob/user)
+		var/help_message_string = "Place the wrapping paper on a table. \
+								Hold something sharp like <b>scissors</b> or a <b>knife</b> in your non-active hand. \
+								Hold the small item to wrap in your active hand. \
+								Hit the wrapping paper with the small item."
+		if (user.mind?.special_role)
+			help_message_string += " Wrapping paper can also be directly used on dead bodies..."
+		return help_message_string
 
 /obj/item/wrapping_paper/xmas
 	desc = "This wrapping paper is especially festive."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game-Objects][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a help message to wrapping paper explaining how to use it, with a little extra help if user is an antag.

Antag message
![image](https://github.com/goonstation/goonstation/assets/5091297/edac51b6-36ae-4dfd-b51c-f37dfe570a4d)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Without a tooltip, users unfamiliar with the process are more likely just to hit things on the floor with wrapping paper and give up. Also more gift wrapped bodies should be sent to security. More people spreading dubious amounts of cheer is better!