### PR TITLE
Fixes pug gasping issue

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -182,7 +182,8 @@
 	if (ispug(src))
 		var/mob/living/carbon/human/H = src
 		amount *= 2
-		H.emote(pick("wheeze", "cough", "sputter"))
+		if (!isdead(src))
+			H.emote(pick("wheeze", "cough", "sputter"))
 
 	src.oxyloss = max(0,src.oxyloss + amount)
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the pug's oxy damage emote to not trigger when the mob is dead, which caused bugs. 1) Thralled pugs sometimes can't custom emote and 2) Dead pugs that have their heart removed made noise. See attached bugs for additional information.

I think this is the correct way to check if a mob is dead? 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes https://github.com/goonstation/goonstation/issues/16561
Fixes https://github.com/goonstation/goonstation/issues/16646
I'm confident this fixes #16561 
Probably 80% confident on this fixing #16646 as it went from 50/50 reproducible before this change to non-reproducible in n=5 or so tries on my local instance...