### PR TITLE
Add Fuzzy Bathrobe and Slippers to maps without them

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -23472,6 +23472,9 @@
 	desc = "In space?";
 	name = "swimming trunks"
 	},
+/obj/item/clothing/shoes/fuzzy,
+/obj/item/clothing/suit/bathrobe,
+/obj/item/clothing/suit/bathrobe,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "gRv" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -36761,6 +36761,7 @@
 	},
 /obj/item/clothing/shoes/fuzzy,
 /obj/item/clothing/suit/bathrobe,
+/obj/item/clothing/suit/bathrobe,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "nVO" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -34875,6 +34875,9 @@
 /obj/item/clothing/shoes/flippers{
 	pixel_y = -9
 	},
+/obj/item/clothing/shoes/fuzzy,
+/obj/item/clothing/suit/bathrobe,
+/obj/item/clothing/suit/bathrobe,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "fhZ" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -24625,6 +24625,9 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/item/clothing/suit/bathrobe,
+/obj/item/clothing/suit/bathrobe,
+/obj/item/clothing/shoes/fuzzy,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},


### PR DESCRIPTION
[MAPPING]
## About the PR
Adds two fuzzy bathrobes and a set of fuzzy slippers to maps that lacked them. This includes Kondaru, Nadir, Donut2 and Clarion.

## Why's this needed?
Parity across maps is good and should be encouraged. Poolside gaming is of critical import.

## Changelog
```changelog
(u)Tyrant
(+)Kondaru, Nadir, Donut2 and Clarion now have Fuzzy slippers and bathrobes in their pool rooms, just like in other maps.
```