### PR TITLE
Player Piano Shortened Rest

### DIFF
--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -245,6 +245,12 @@ TYPEINFO(/obj/player_piano)
 		note_accidentals = list()
 
 		for (var/string in piano_notes)
+			if (lowertext(string) == "r")
+				note_names += "r"
+				note_octaves += "r"
+				note_accidentals += "r"
+				note_volumes += 0
+				continue
 			var/list/curr_notes = splittext("[string]", ",")
 			if (length(curr_notes) < 4) // Music syntax not followed
 				break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

<!-- Adds a check to the start of the for loop in `build_notes()` which sets the necessary variables when the note equals 'R'. -->
Made 'R' an alternative to 'R,R,R,R'.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reduces the character count of large songs, so less space is needed to store them.

For example:
- [Last Train Home ~ Still Far - Anohana](https://wiki.ss13.co/Piano_Song_Dump/Last_Train_Home_~_Still_Far_-_Anohana) goes from 43,148 to 15,272
- [Alpha - Minecraft](https://wiki.ss13.co/Piano_Song_Dump/Alpha_-_Minecraft) goes from 249,474 to 77,562

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimil
(+)For player pianos, 'R' is now an alternative to 'R,R,R,R'
```