### PR TITLE
Fix dead point chat spacing

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -77,7 +77,7 @@
 		return
 
 
-	src.visible_message("<span class='game deadsay'><span class='prefix'>DEAD:</span><b>[src]</b> points to [target].</span>")
+	src.visible_message("<span class='game deadsay'><span class='prefix'>DEAD:</span> <b>[src]</b> points to [target].</span>")
 	var/point_invisibility = src.invisibility
 #ifdef HALLOWEEN
 	if(prob(20))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add space to match emote code in `code\mob\dead.dm`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #16811
