### PR TITLE
Ghost & Cyborg can climb (sea) ladders

### DIFF
--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -441,6 +441,16 @@ TYPEINFO(/obj/machinery/fluid_canister)
 			user.set_loc(target)
 			user.show_text("You climb [src].")
 
+	Click(location, control, params)
+		if (isobserver(usr))
+			return src.attack_hand(usr)
+		..()
+
+	attack_ai(mob/user)
+		if (!user.stat && !user.getStatusDuration("weakened") && BOUNDS_DIST(user, src) <= 0)
+			return src.attack_hand(user)
+		. = ..()
+
 
 TYPEINFO(/obj/item/sea_ladder)
 	mats = 7

--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -447,7 +447,7 @@ TYPEINFO(/obj/machinery/fluid_canister)
 		..()
 
 	attack_ai(mob/user)
-		if (!user.stat && !user.getStatusDuration("weakened") && BOUNDS_DIST(user, src) <= 0)
+		if (can_act(user) && in_interact_range(src, usr))
 			return src.attack_hand(user)
 		. = ..()
 

--- a/code/obj/ladder.dm
+++ b/code/obj/ladder.dm
@@ -147,6 +147,14 @@ ADMIN_INTERACT_PROCS(/obj/ladder/embed, proc/toggle_hidden)
 /obj/ladder/attack_ai(mob/user)
 	return src.attack_hand(user)
 
+/obj/ladder/Click(location, control, params)
+	if (isobserver(usr))
+		var/obj/ladder/otherLadder = src.get_other_ladder()
+		if (get_turf(otherLadder))
+			usr.set_loc(get_turf(otherLadder))
+			return
+	..()
+
 /obj/ladder/attackby(obj/item/W, mob/user)
 	if (src.unclimbable) return
 	if (istype(W, /obj/item/grab))


### PR DESCRIPTION
[Silicons] [Bug] [Feature] [Observer]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Makes ladders climbable by Ghosts
* Makes sea ladders climbable by Ghosts
* Makes sea ladders climbable by Cyborgs


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

* Sea Ladders should be useable by Cyborgs. They can use normal ladders after all.
* Making ladders climbable by ghosts is a nice QoL for ghosts. They can already use portals by clicking on them.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(+)Sea Ladders can now be climbed by Cyborgs.
(+)Ladders and Sea Ladders can be climbed by ghosts.
```
