### PR TITLE
Fix lamp manufactuerer context menu

### DIFF
--- a/code/modules/fluids/fluid_objects.dm
+++ b/code/modules/fluids/fluid_objects.dm
@@ -375,10 +375,8 @@ TYPEINFO(/obj/machinery/fluid_canister)
 			return
 		fluid_canister.change_mode(src.mode)
 
-	checkRequirements(var/obj/machinery/fluid_canister/fluid_canister, var/mob/user)
-		if(!can_act(user) || !in_interact_range(fluid_canister, user))
-			return FALSE
-		return TRUE
+	checkRequirements(obj/machinery/fluid_canister/fluid_canister, mob/user)
+		. = can_act(user) && in_interact_range(fluid_canister, user)
 
 	off
 		name = "OFF"

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -1039,9 +1039,7 @@
 	icon_state = "wrench"
 
 	checkRequirements(var/atom/target, var/mob/user)
-		if(!can_act(user) || !in_interact_range(target, user))
-			return FALSE
-		return TRUE
+		. = can_act(user) && in_interact_range(target, user)
 
 	solitaire
 		name = "Solitaire Stack"

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -898,8 +898,7 @@
 	icon_state = "dismiss"
 
 	checkRequirements(var/atom/target, var/mob/user)
-		if(!can_act(user) || !in_interact_range(target, user))
-			return FALSE
+		. = can_act(user) && in_interact_range(target, user)
 
 	execute(var/atom/target, var/mob/user)
 		var/obj/item/lamp_manufacturer/M = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

checkRequirements has to return TRUE if it's valid, so change the check to return the result of checks.

For the vast majority of other checks, no change is needed as there are other criteria that can evaluate to true, but in this instance it is just the can_use and range check.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fix #16808
