### PR TITLE
Salvage trader buys electronics debris instead of machine cleanables

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -759,11 +759,13 @@
 	comname = "Scrap Metal"
 	comtype = /obj/item/scrap
 	price = PAY_UNTRAINED/10
+	desc_buy = "We are interested in recycling ground metal scrap."
 
 /datum/commodity/salvage/electronic_debris
 	comname = "Electronic Debris"
 	comtype = /obj/item/electronics
 	price = PAY_UNTRAINED/10
+	desc_buy = "We will recover metals from resistors, fuses, and other electronic debris."
 
 /datum/commodity/salvage/robot_upgrades
 	comname = "Cyborg Upgrade"

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -760,15 +760,10 @@
 	comtype = /obj/item/scrap
 	price = PAY_UNTRAINED/10
 
-/datum/commodity/salvage/machinedebris
-	comname = "Twisted Shrapnel"
-	comtype = /obj/decal/cleanable/machine_debris
-	price = PAY_UNTRAINED
-
-/datum/commodity/salvage/robotdebris
-	comname = "Robot Debris"
-	comtype = /obj/decal/cleanable/robot_debris
-	price = PAY_UNTRAINED
+/datum/commodity/salvage/electronic_debris
+	comname = "Electronic Debris"
+	comtype = /obj/item/electronics
+	price = PAY_UNTRAINED/10
 
 /datum/commodity/salvage/robot_upgrades
 	comname = "Cyborg Upgrade"

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -989,8 +989,7 @@ ABSTRACT_TYPE(/obj/npc/trader/robot/robuddy)
 		src.goods_sell += new /datum/commodity/podparts/goldarmor(src)
 
 		src.goods_buy += new /datum/commodity/salvage/scrap(src)
-		src.goods_buy += new /datum/commodity/salvage/machinedebris(src)
-		src.goods_buy += new /datum/commodity/salvage/robotdebris(src)
+		src.goods_buy += new /datum/commodity/salvage/electronic_debris(src)
 		src.goods_buy += new /datum/commodity/relics/gnome(src)
 		src.goods_buy += new /datum/commodity/goldbar(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces two commodities for cleanables that are no longer movable with "Electronic Debris", currently dropped from syndicate drones (and subtypes i.e. nanites). Adds a description to better indicate which debris (and which scrap) the trader is looking for.

The lack of subtype exclusion makes this take in frames, soldering irons, and device analyzers. I'm not sure there's a good way around that, nor do I know it is a major concern in light of the low sale price.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #16760