### PR TITLE
How to relay clicks?

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -454,7 +454,7 @@
 		else
 			. = ..()
 
-/mob/living/click(atom/target, params, location, control)
+/mob/living/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	. = ..()
 	if (. == 100)
 		return 100
@@ -511,7 +511,7 @@
 
 				return
 		else
-			var/reach = can_reach(src, target)
+			var/reach = force_reachable || can_reach(src, target)
 			if (src.pre_attack_modify())
 				equipped = src.equipped() //might have changed from successful modify
 			if (reach || (equipped && equipped.special) || (equipped && (equipped.flags & EXTRADELAY))) //Fuck you, magic number prickjerk //MBC : added bit to get weapon_attack->pixelaction to work for itemspecial

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1095,7 +1095,7 @@
 
 		src.next_click = world.time + src.combat_click_delay
 
-/mob/living/carbon/human/click(atom/target, list/params)
+/mob/living/carbon/human/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	if (src.client)
 		if (src.client.experimental_intents)
 			if (src.client.check_key(KEY_THROW))

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -533,7 +533,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 				return (src.pull_w_class >= W_CLASS_BULKY)
 		return 0
 
-	click(atom/target, list/params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (((src.client && src.client.check_key(KEY_THROW)) || src.in_throw_mode) && src.can_throw)
 			src.throw_item(target,params)
 			return

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -455,7 +455,7 @@
 	else
 		return ..()
 
-/mob/living/critter/flock/click(atom/target, list/params)
+/mob/living/critter/flock/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	. = ..()
 	if (istype(target, /obj/machinery/door/feather) && !in_interact_range(target, src))
 		var/obj/machinery/door/feather/door = target

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -152,7 +152,7 @@
 		. = ..()
 
 
-	click(atom/target, params, location, control)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (!src.mainframe) return
 
 		var/in_ai_range = (get_z(mainframe) == get_z(target)) || (inunrestrictedz(target) && inonstationz(mainframe))

--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -287,7 +287,7 @@
 		else
 			return 0.75 + movement_delay_modifier
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (istype(target,/atom/movable/screen/blob/))
 			if (params["middle"])
 				var/atom/movable/screen/blob/B = target

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -161,7 +161,7 @@
 	src.targeting_ability = holder.drone_controller
 	src.update_cursor()
 
-/mob/living/intangible/flock/click(atom/target, params)
+/mob/living/intangible/flock/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	if (targeting_ability)
 		..()
 		return

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -409,7 +409,7 @@
 	equipped()
 		return 0
 
-	click(atom/target)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (src.targeting_ability)
 			..()
 		if (!density)

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -231,7 +231,7 @@
 		else
 			return 1
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (target == src)
 			src.self_interact()
 		else

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -36,7 +36,7 @@
 				z.free()
 		..()*/
 
-	click(atom/target)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		src.examine_verb(target)
 
 	Cross(atom/movable/mover)

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -179,7 +179,7 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 			return 1
 	return 0 // we have no hands doofus
 
-/mob/living/silicon/click(atom/target, params, location, control)
+/mob/living/silicon/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	if (src.targeting_ability)
 		..()
 	if (!src.stat && !src.restrained() && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis") && !src.getStatusDuration("stunned") && !src.getStatusDuration("low_signal"))
@@ -187,7 +187,7 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 			var/obj/O = target
 			if(O.receive_silicon_hotkey(src)) return
 
-	var/inrange = in_interact_range(target, src)
+	var/inrange = force_reachable || in_interact_range(target, src)
 	var/obj/item/equipped = src.equipped()
 	if (params["ctrl"] || src.client.check_any_key(KEY_EXAMINE | KEY_POINT) || (equipped && (inrange || (equipped.flags & EXTRADELAY))) || istype(target, /turf) || ishelpermouse(target)) // slightly hacky, oh well, tries to check whether we want to click normally or use attack_ai
 		..()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -625,7 +625,7 @@ or don't if it uses a custom topopen overlay
 	else ..()
 	src.update_appearance()
 
-/mob/living/silicon/ai/click(atom/target, params)
+/mob/living/silicon/ai/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	if (!src.stat)
 		if (!src.client.check_any_key(KEY_EXAMINE | KEY_OPEN | KEY_BOLT | KEY_SHOCK | KEY_POINT) ) // ugh
 			//only allow Click-to-track on mobs. Some of the 'trackable' atoms are also machines that can open a dialog and we don't wanna mess with that!

--- a/code/mob/living/silicon/drone.dm
+++ b/code/mob/living/silicon/drone.dm
@@ -178,7 +178,7 @@
 
 		hud.set_active_tool(switchto)
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		var/obj/item/equipped = src.active_tool
 		var/use_delay = !(target in src.contents) && !istype(target,/atom/movable/screen) && (!disable_next_click || ismob(target) || (target && target.flags & USEDELAY) || (equipped && equipped.flags & USEDELAY))
 		if (use_delay && world.time < src.next_click)
@@ -187,7 +187,7 @@
 		if (GET_DIST(src, target) > 0)
 			set_dir(get_dir(src, target))
 
-		var/reach = can_reach(target, src)
+		var/reach = force_reachable || can_reach(target, src)
 		if (equipped && (reach || (equipped.flags & EXTRADELAY)))
 			if (use_delay)
 				src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -360,7 +360,7 @@
 
 		..()
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (src.client && src.client.check_key(KEY_EXAMINE))
 			src.examine_verb(target) // in theory, usr should be us, this is shit though
 			return
@@ -388,7 +388,7 @@
 				movable.pull(src)
 			return
 
-		var/reach = can_reach(src, target)
+		var/reach = force_reachable || can_reach(src, target)
 		if (reach || (equipped && (equipped.flags & EXTRADELAY))) //Fuck you, magic number prickjerk
 			if (use_delay)
 				src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -642,7 +642,7 @@
 			else src.module_active = null
 	hud.update_active_tool()
 
-/mob/living/silicon/hivebot/click(atom/target, list/params)
+/mob/living/silicon/hivebot/click(atom/target, list/params, location, control, force_reachable=FALSE)
 	if ((target in src.module.tools) && !(target in src.module_states))
 		for (var/i = 1; i <= 3; i++)
 			if (!src.module_states[i])

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1763,7 +1763,7 @@
 	equipped_list(var/check_for_magtractor=1)
 		. = src.module_states
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (istype(target, /obj/item/roboupgrade) && (target in src.upgrades)) // ugh
 			src.activate_upgrade(target)
 			return

--- a/code/mob/wraith/poltergeist.dm
+++ b/code/mob/wraith/poltergeist.dm
@@ -124,7 +124,7 @@
 		..()
 		update_well_dist(master, marker)
 
-	click(atom/target)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		. = ..()
 		if (target == master)
 			src.enter_master()

--- a/code/modules/antagonists/wraith/critters/spiker.dm
+++ b/code/modules/antagonists/wraith/critters/spiker.dm
@@ -49,7 +49,7 @@
 		HH.can_hold_items = 1
 		HH.can_attack = 1
 
-	click(atom/target, params, location, control)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (src.shuffling)
 			boutput(src, "<span class='notice'>You cannot interact with this while in this form!</span>")
 			return

--- a/code/modules/power/hamster_wheel.dm
+++ b/code/modules/power/hamster_wheel.dm
@@ -45,8 +45,12 @@ TYPEINFO(/obj/machinery/power/power_wheel)
 		. = ..()
 
 	attack_hand(mob/user)
+		if(!isliving(user))
+			return ..()
+		var/mob/living/Luser = user
 		if(occupant && user != occupant)
-			occupant.Attackhand(user)
+			Luser.next_click = 0
+			Luser.click(occupant, params=list(), force_reachable=TRUE)
 			if(user.a_intent == INTENT_DISARM || user.a_intent == INTENT_GRAB)
 				eject_occupant()
 		else

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -68,7 +68,7 @@
 		..()
 		qdel(src.hud) // no escape!!!
 
-	click(atom/target, params)
+	click(atom/target, list/params, location, control, force_reachable=FALSE)
 		if (target == src) // no recursive living objects ty
 			return
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR is meant to be more of a potential discussion starter. Currently relaying clicks from one thing to another is sometimes useful (often for stuff in vis contents of an objects, or for glue or for god knows what). The current way tends to be to pass Attackby / Attackhand calls along. This bypasses the cooldowns in living/click. This PR is a (pretty bad) attempt to fix that.

One could imagine that a good way to relay the click would be to just call user.click(actual_target) except that doesn't work becaue can_reach. So this adds a new argument to click() which forces reachability checks to always succeed. However, this still doesn't work because the Attackhand of the hamsterwheel (right, this is fixing #16810) is in a click call which already set the cooldown so the next click call we invoke will hit this cooldown like a brick wall. So to avoid this we reset the cooldown manually.

As you can see this is awful. A better solution would likely be to split click() into several more atomic procs but like who's gonna do that. Idk, let me know how you'd do this.

fixes #16810
