### PR TITLE
Consistently update breathing HUD during breath lifeprocess

### DIFF
--- a/code/datums/hud/critter.dm
+++ b/code/datums/hud/critter.dm
@@ -165,6 +165,13 @@
 /datum/hud/critter/proc/get_left()
 	return "-[src.left_offset]"
 
+/// update the oxygen and tox indicators based on status
+/datum/hud/critter/proc/update_breathing_indicators(datum/organ/lung/status/status_updates)
+		src.set_suffocating(status_updates.show_oxy_indicator)
+		src.update_tox_indicator(status_updates.show_tox_indicator)
+		// fire indicator is handled in critter on_life
+		// src.set_breathing_fire(status_updates.show_fire_indicator)
+
 /// sets the suffocation icon on the hud to show suffocation status
 /datum/hud/critter/proc/set_suffocating(var/status)
 	if (!src.oxygen)

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -1134,6 +1134,11 @@
 			return
 		fire.icon_state = "fire[status]"
 
+	proc/update_breathing_indicators(datum/organ/lung/status/update)
+		src.update_oxy_indicator(update.show_oxy_indicator)
+		src.update_tox_indicator(update.show_tox_indicator)
+		src.update_fire_indicator(update.show_fire_indicator)
+
 	proc/update_rad_indicator()
 		if (!rad) // not rad :'(
 			return

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -1134,11 +1134,6 @@
 			return
 		fire.icon_state = "fire[status]"
 
-	proc/update_breathing_indicators(datum/organ/lung/status/update)
-		src.update_oxy_indicator(update.show_oxy_indicator)
-		src.update_tox_indicator(update.show_tox_indicator)
-		src.update_fire_indicator(update.show_fire_indicator)
-
 	proc/update_rad_indicator()
 		if (!rad) // not rad :'(
 			return

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -1119,6 +1119,11 @@
 		bodytemp.icon_state = "temp[state]"
 		bodytemp.tooltipTheme = "tempInd tempInd[state]"
 
+	proc/update_breathing_indicators(datum/organ/lung/status/status_updates)
+		src.update_oxy_indicator(status_updates.show_oxy_indicator)
+		src.update_tox_indicator(status_updates.show_tox_indicator)
+		src.update_fire_indicator(status_updates.show_fire_indicator)
+
 	proc/update_tox_indicator(var/status)
 		if (!toxin)
 			return

--- a/code/mob/living/life/breath.dm
+++ b/code/mob/living/life/breath.dm
@@ -5,18 +5,9 @@
 	var/breathtimernotifredundant = 0
 	var/breathstate = 0
 
-	//consider these temporary...hopefully
-	proc/update_oxy(var/on)
-		if (human_owner)
-			human_owner.hud.update_oxy_indicator(on)
-		if (critter_owner)
-			critter_owner.hud.set_suffocating(on)
-
-	proc/update_toxy(var/on)
-		if (human_owner)
-			human_owner.hud.update_tox_indicator(on)
-		if (critter_owner)
-			critter_owner.hud.update_tox_indicator(on)
+	proc/update_breath_hud(datum/organ/lung/status/status_updates)
+		src.human_owner?.hud.update_breathing_indicators(status_updates)
+		src.critter_owner?.hud.update_breathing_indicators(status_updates)
 
 	process(var/datum/gas_mixture/environment)
 		if(isdead(owner))
@@ -25,6 +16,7 @@
 		//special (read: stupid) manual breathing stuff. weird numbers are so that messages don't pop up at the same time as manual blinking ones every time
 		if (manualbreathing && human_owner)
 			breathtimer += get_multiplier()
+			var/datum/organ/lung/status/status_updates = new
 
 			switch(breathtimer)
 				if (0 to 15)
@@ -38,12 +30,12 @@
 					if (!breathtimernotifredundant)
 						breathtimerstage = 1
 				if (52 to 61)
-					update_oxy(1)
+					status_updates.show_oxy_indicator = TRUE
 					owner.take_oxygen_deprivation(breathtimer/12)
 					if (breathtimernotifredundant < 2)
 						breathtimerstage = 2
 				if (62 to INFINITY)
-					update_oxy(1)
+					status_updates.show_oxy_indicator = TRUE
 					owner.take_oxygen_deprivation(breathtimer/6)
 					if (breathtimernotifredundant < 3)
 						breathtimerstage = 3
@@ -60,6 +52,7 @@
 					boutput(owner, SPAN_ALERT("Your lungs are burning and the need to take a breath is almost unbearable!"))
 					breathtimernotifredundant = 3
 			breathtimerstage = 0
+			src.human_owner.hud.update_breathing_indicators(status_updates)
 		else // plain old automatic breathing
 			breathe(environment)
 
@@ -70,6 +63,7 @@
 
 	proc/breathe(datum/gas_mixture/environment)
 		var/mult = get_multiplier()
+		var/datum/organ/lung/status/status_updates = new
 
 		var/atom/underwater = 0
 		if (isturf(owner.loc))
@@ -99,8 +93,10 @@
 						F.just_do_the_apply_thing(owner, mult, hasmask = 1)
 
 		else if (islivingobject(owner.loc))
+			src.update_breath_hud(status_updates)
 			return // no breathing inside possessed objects
 		else if (istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell))
+			src.update_breath_hud(status_updates)
 			return
 		else if (istype(owner.loc, /obj/machinery/bathtub) && owner.lying)
 			var/obj/machinery/bathtub/B = owner.loc
@@ -112,6 +108,7 @@
 		//if (istype(loc, /obj/machinery/clonepod)) return
 
 		if (HAS_ATOM_PROPERTY(owner, PROP_MOB_REBREATHING))
+			src.update_breath_hud(status_updates)
 			return
 
 		// Changelings generally can't take OXY/LOSEBREATH damage...except when they do.
@@ -122,6 +119,7 @@
 		// If your mutant race doesn't need oxygen from breathing, ya no losebreath
 		// so, now you do
 		if (ischangeling(owner) || HAS_ATOM_PROPERTY(owner, PROP_MOB_BREATHLESS))
+			src.update_breath_hud(status_updates)
 			if (owner.losebreath)
 				owner.losebreath = 0
 			if (owner.get_oxygen_deprivation())
@@ -130,8 +128,10 @@
 
 		if (underwater)
 			if (human_owner?.mutantrace && human_owner?.mutantrace.aquatic)
+				src.update_breath_hud(status_updates)
 				return
 			if(human_owner?.hasStatus("aquabreath"))
+				src.update_breath_hud(status_updates)
 				return
 			if (prob(25) && owner.losebreath > 0)
 				boutput(owner, SPAN_ALERT("You are drowning!"))
@@ -213,9 +213,13 @@
 
 	///Return value is the number of lungs that successfully breathed
 	proc/handle_breath(datum/gas_mixture/breath, var/atom/underwater = 0, var/mult = 1) //'underwater' really applies for any reagent that gets deep enough. but what ever
-		if (owner.nodamage) return
+		var/datum/organ/lung/status/status_updates = new
+		if (owner.nodamage)
+			src.update_breath_hud(status_updates)
+			return
 		var/area/A = get_area(owner)
 		if( A?.sanctuary )
+			src.update_breath_hud(status_updates)
 			return
 		// Looks like we're in space
 		// or with recent atmos changes, in a room that's had a hole in it for any amount of time, so now we check src.loc
@@ -224,7 +228,7 @@
 				owner.take_oxygen_deprivation(6 * mult)
 			else
 				owner.take_oxygen_deprivation(3 * mult)
-			update_oxy(1)
+			status_updates.show_oxy_indicator = TRUE
 
 			//consume some reagents if we drowning
 			if (underwater && (owner.get_oxygen_deprivation() > 40 || underwater.type == /obj/fluid/airborne))
@@ -235,13 +239,12 @@
 					var/turf/space/fluid/F = underwater
 					F.force_mob_to_ingest(owner, mult)// * mult
 
-
+			src.update_breath_hud(status_updates)
 			return 0
 
 		if (owner.health < 0 || (human_owner?.organHolder && human_owner?.organHolder.get_working_lung_amt() == 0)) //We aren't breathing.
+			src.update_breath_hud(status_updates)
 			return 0
-
-		var/datum/organ/lung/status/status_updates = new
 
 		var/datum/gas_mixture/left_breath = breath.remove_ratio(0.5)
 		var/datum/gas_mixture/right_breath = breath.remove_ratio(1) // the rest
@@ -257,9 +260,8 @@
 		breath.merge(left_breath)
 		breath.merge(right_breath)
 
-		update_oxy(status_updates.show_oxy_indicator)
-		update_toxy(status_updates.show_tox_indicator)
-		human_owner.hud.update_fire_indicator(status_updates.show_fire_indicator)
+		src.update_breath_hud(status_updates)
+
 		for(var/emote in status_updates.emotes)
 			human_owner?.emote(emote)
 

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -227,6 +227,8 @@
 		H.oxyloss = 0
 		H.losebreath = 0
 		if(ismob(owner))
+			var/datum/organ/lung/status/status_updates = new
+			H.hud.update_breathing_indicators(status_updates)
 			if(src.power == 1)
 				APPLY_ATOM_PROPERTY(H, PROP_MOB_REBREATHING, src.type)
 			else

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -226,9 +226,10 @@
 		var/mob/living/carbon/human/H = owner
 		H.oxyloss = 0
 		H.losebreath = 0
+		H.hud?.update_oxy_indicator(0)
+		H.hud?.update_tox_indicator(0)
+		H.hud?.update_fire_indicator(0)
 		if(ismob(owner))
-			var/datum/organ/lung/status/status_updates = new
-			H.hud.update_breathing_indicators(status_updates)
 			if(src.power == 1)
 				APPLY_ATOM_PROPERTY(H, PROP_MOB_REBREATHING, src.type)
 			else

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -226,9 +226,6 @@
 		var/mob/living/carbon/human/H = owner
 		H.oxyloss = 0
 		H.losebreath = 0
-		H.hud?.update_oxy_indicator(0)
-		H.hud?.update_tox_indicator(0)
-		H.hud?.update_fire_indicator(0)
 		if(ismob(owner))
 			if(src.power == 1)
 				APPLY_ATOM_PROPERTY(H, PROP_MOB_REBREATHING, src.type)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Adds `update_breathing_indicators` proc to human/critter HUD code
* In the `breathe` lifeloop and related procs, ensure the HUD is updated before returning by using `update_breathing_indicators` and a lung status datum.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16752
Fixes #14230