### PR TITLE
Allow mouse wheel scrolling to set target body attack zone

### DIFF
--- a/_std/plane.dm
+++ b/_std/plane.dm
@@ -87,6 +87,10 @@ client
 	var/list/plane_parents = list()
 	var/list/plane_displays = list()
 	var/atom/movable/screen/plane_display/master/game_display
+	// list of current zone sel to the next zone sel if you scroll up
+	var/static/list/zone_sels_positive_delta = list("chest" = "l_arm", "l_arm" = "r_arm", "r_arm" = "l_leg", "l_leg" = "r_leg", "r_leg" = "head", "head" = "chest")
+	// list of current zone sel to the next zone sel if you scroll down
+	var/static/list/zone_sels_negative_delta = list("l_arm" = "chest", "r_arm" = "l_arm", "l_leg" = "r_arm", "r_leg" = "l_leg", "head" = "r_leg", "chest" = "head")
 
 	New()
 		Z_LOG_DEBUG("Client/New", "[src.ckey] - Adding plane_parents")
@@ -143,6 +147,18 @@ client
 		SPAWN(5 SECONDS)
 			apply_depth_filter()
 		..()
+
+	MouseWheel(atom/A, delta_x, delta_y, location, control, params)
+		var/mob/M = src.mob
+		if (!M?.zone_sel)
+			return
+		// overrides atom/mousewheel, so atom/mousewheel always needs to be called and should return true if defined anywhere
+		if (A?.MouseWheel(delta_x, delta_y, location, control, params))
+			return
+		if (delta_y > 0)
+			M.zone_sel.select_zone(src.zone_sels_positive_delta[M.zone_sel.selecting])
+		else
+			M.zone_sel.select_zone(src.zone_sels_negative_delta[M.zone_sel.selecting])
 
 	proc/add_plane(var/atom/movable/screen/plane_parent/plane)
 		RETURN_TYPE(/atom/movable/screen/plane_parent)

--- a/_std/plane.dm
+++ b/_std/plane.dm
@@ -88,9 +88,9 @@ client
 	var/list/plane_displays = list()
 	var/atom/movable/screen/plane_display/master/game_display
 	// list of current zone sel to the next zone sel if you scroll up
-	var/static/list/zone_sels_positive_delta = list("chest" = "l_arm", "l_arm" = "r_arm", "r_arm" = "l_leg", "l_leg" = "r_leg", "r_leg" = "head", "head" = "chest")
+	var/static/list/zone_sels_positive_delta = list("l_arm" = "chest", "r_arm" = "l_arm", "l_leg" = "r_arm", "r_leg" = "l_leg", "head" = "r_leg", "chest" = "head")
 	// list of current zone sel to the next zone sel if you scroll down
-	var/static/list/zone_sels_negative_delta = list("l_arm" = "chest", "r_arm" = "l_arm", "l_leg" = "r_arm", "r_leg" = "l_leg", "head" = "r_leg", "chest" = "head")
+	var/static/list/zone_sels_negative_delta = list("chest" = "l_arm", "l_arm" = "r_arm", "r_arm" = "l_leg", "l_leg" = "r_leg", "r_leg" = "head", "head" = "chest")
 
 	New()
 		Z_LOG_DEBUG("Client/New", "[src.ckey] - Adding plane_parents")

--- a/_std/plane.dm
+++ b/_std/plane.dm
@@ -88,9 +88,9 @@ client
 	var/list/plane_displays = list()
 	var/atom/movable/screen/plane_display/master/game_display
 	// list of current zone sel to the next zone sel if you scroll up
-	var/static/list/zone_sels_positive_delta = list("l_arm" = "chest", "r_arm" = "l_arm", "l_leg" = "r_arm", "r_leg" = "l_leg", "head" = "r_leg", "chest" = "head")
+	var/static/list/zone_sels_positive_delta = list("head" = "head", "chest" = "head", "l_arm" = "chest", "r_arm" = "l_arm", "l_leg" = "r_arm", "r_leg" = "l_leg")
 	// list of current zone sel to the next zone sel if you scroll down
-	var/static/list/zone_sels_negative_delta = list("chest" = "l_arm", "l_arm" = "r_arm", "r_arm" = "l_leg", "l_leg" = "r_leg", "r_leg" = "head", "head" = "chest")
+	var/static/list/zone_sels_negative_delta = list("head" = "chest", "chest" = "l_arm", "l_arm" = "r_arm", "r_arm" = "l_leg", "l_leg" = "r_leg", "r_leg" = "r_leg")
 
 	New()
 		Z_LOG_DEBUG("Client/New", "[src.ckey] - Adding plane_parents")

--- a/code/datums/buildmode.dm
+++ b/code/datums/buildmode.dm
@@ -399,7 +399,7 @@ ABSTRACT_TYPE(/datum/buildmode)
 			mode.click_mode_right(pa.Find("ctrl"), pa.Find("alt"), pa.Find("shift"))
 
 	MouseWheel(delta_x, delta_y, location, control, params)
-		. = ..()
+		. = TRUE
 		var/current = 0
 		for(var/datum/buildmode/mode in holder.hotkey_bar)
 			if(mode == holder.mode)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -75,6 +75,7 @@
 	MouseWheel(dx, dy, loc, ctrl, parms)
 		if (master && (!master.click_check || (usr in master.mobs)))
 			master.scrolled(src.id, dx, dy, usr, parms, src)
+			return TRUE
 
 	mouse_drop(atom/over_object, src_location, over_location, over_control, params)
 		if (master && (!master.click_check || (usr in master.mobs)))

--- a/code/modules/minimap/minimap_object.dm
+++ b/code/modules/minimap/minimap_object.dm
@@ -232,6 +232,7 @@
 			src.mouse_opacity = 2
 
 	MouseWheel(dx, dy, loc, ctrl, params)
+		. = TRUE
 		var/list/param_list = params2list(params)
 		var/datum/minimap/z_level/minimap = src.displayed_minimap
 		var/datum/minimap/z_level/controlled_minimap = src.controlled_minimap.map


### PR DESCRIPTION
[PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that scrolling the mouse wheel will set the target body zone that you attack

I saw that mouse wheel implementation in the code is hardly used, which would make this simpler to implement, and I think mouse wheel scrolling is pretty fast, compared to an action like hitting multiple hotkeys or a single hotkey to cycle between zones.

Performance when scrolling the mouse wheel to set the zone:
![image](https://github.com/goonstation/goonstation/assets/53062374/a47616dc-42e6-47d2-8eed-e1983d2fa619)
Performance when scrolling over at atom that implements MouseWheel is roughly the same.

Things to note that I found-
-client/MouseWheel() is not called at all when in a scrollable interface, like the chat log, or a TGUI interface
-It is called most everywhere else (I think)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently there's 6 zones you can select, including chest, arms, legs, and head. This makes it so that in order to set your target attack zone faster than clicking the HUD zones, you either have to override more important hotkeys, or angle your hand in a painful way to reach the hotkeys for the zones you want to attack which is even more difficult when moving around

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
```changelog
(u)FlameArrow57
(*)Scrolling the mouse wheel will now set the target body zone you are attacking. Scrolling downwards is in the order head -> chest -> left arm -> right arm -> left leg -> right leg, without wrap around. 
```
