### PR TITLE
Fixes DevTest Turbine's Pipe Network

### DIFF
--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -16,9 +16,7 @@
 /turf/simulated/floor,
 /area/devzone)
 "ah" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 1
-	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/engine,
 /area/devzone)
 "ai" = (
@@ -509,7 +507,7 @@
 /turf/simulated/floor/orangeblack,
 /area/devzone)
 "hT" = (
-/obj/machinery/atmospherics/binary/nuclear_reactor,
+/obj/machinery/atmospherics/binary/nuclear_reactor/prefilled/normal,
 /turf/simulated/floor/engine,
 /area/devzone)
 "hV" = (
@@ -1343,7 +1341,10 @@
 /turf/simulated/floor,
 /area/devzone)
 "sG" = (
-/obj/machinery/atmospherics/pipe/manifold/overfloor,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 5
+	},
 /obj/storage/closet/radiation,
 /turf/simulated/floor/engine,
 /area/devzone)
@@ -2136,6 +2137,12 @@
 /obj/lattice,
 /obj/machinery/atmospherics/unary/vent,
 /turf/space,
+/area/devzone)
+"EF" = (
+/obj/machinery/atmospherics/pipe/manifold/overfloor{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
 /area/devzone)
 "EL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -4106,8 +4113,8 @@ rS
 kI
 ax
 kk
-ah
 ye
+ah
 sr
 cZ
 VY
@@ -4148,8 +4155,8 @@ rz
 rS
 kI
 SP
-ah
 Ul
+EF
 sG
 WI
 yd
@@ -4538,7 +4545,7 @@ HJ
 ng
 ng
 ng
-Zx
+Yx
 Yx
 Ck
 Yx


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the turbine in DevTest usable. It was not connecting the the manifold-pipe on the hot side. Swapping to a bend fixes it.
Alludes to a "bigger picture bug" about pipe-network-interfacing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug half-fix.