### PR TITLE
MechComp List Connections Fully Reports Incoming.

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -155,7 +155,10 @@ TYPEINFO(/datum/component/mechanics_holder)
 	if (length(src.connected_incoming))
 		out += "<br>Incoming:"
 		for(var/atom/A in src.connected_incoming)
-			out += "<br>&nbsp;&nbsp;&nbsp;&nbsp;[bicon(A)] [SPAN_NOTICE(A.name)]"
+			var/pointer_container[1] //A list of size 1, to store the address of the list we want
+			SEND_SIGNAL(A, _COMSIG_MECHCOMP_GET_OUTGOING, pointer_container)
+			var/list/trg_outgoing = pointer_container[1]
+			out += "<br>&nbsp;&nbsp;&nbsp;&nbsp;[bicon(A)] [SPAN_NOTICE(A.name)] &rarr; [SPAN_SUCCESS(trg_outgoing[parent])]"
 	else
 		out += "<br>No incoming connections."
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using a multi-tool on a component and selecting the "List Connections" option: it now reports which input a trigger is connected to. 
i.g. `-> Set A` was not reported before.
![image](https://github.com/goonstation/goonstation/assets/9563541/909dbf60-5d5c-412e-bf6a-bb5d39e4493e)
(PR is tested.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes troubleshooting assemblies easier. QoL.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MarkNstein
(+)MechComp's "List Connections" feature now reports which input an incoming trigger is connected to.
```
