### PR TITLE
Gas Meter MechComp-Transmits Pressure and Temperature.

### DIFF
--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -15,6 +15,7 @@
 	SPAWN(1 SECOND)
 		src.target = locate(/obj/machinery/atmospherics/pipe) in loc
 	MAKE_SENDER_RADIO_PACKET_COMPONENT(null, frequency)
+	AddComponent(/datum/component/mechanics_holder)
 
 /obj/machinery/meter/process()
 	if(!target)
@@ -64,6 +65,8 @@
 		signal.data["pressure"] = round(env_pressure)
 
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal)
+
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "pressure=[env_pressure]&temperature=[environment.temperature]")
 
 
 /obj/machinery/meter/get_desc(dist, mob/user)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The pipe meters now transmit a MechComp signal containing the pressure and temperature.
![image](https://github.com/goonstation/goonstation/assets/9563541/ecbaa75b-8a86-49e2-bd5d-871a61312142)
(PR is tested.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More signaling, more good.
Build a pipe-burst warning system.
Or a temperature-bragging system.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MarkNstein
(*)Pipe meters now transmit a MechComp signal containing current pressure and temperature.
```
