### PR TITLE
Fix Clarion Disposal flaps and doors

### DIFF
--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -106,7 +106,10 @@ TYPEINFO(/obj/strip_door)
 		..()
 		var/connectdir = get_connected_directions_bitflag(connects_to)
 		if (connectdir & NORTH || connectdir & SOUTH)
-			src.dir = EAST
+			if (!((connectdir & NORTH) && (connectdir & SOUTH)) && (connectdir && (EAST || WEST))) // if NEW or SEW, connect EW not to N or S. Fixes a plastic flap on clarion.
+				src.dir = NORTH
+			else
+				src.dir = EAST
 			return
 		if (connectdir & EAST || connectdir & WEST)
 			src.dir = NORTH

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -105,14 +105,18 @@ TYPEINFO(/obj/strip_door)
 	update_icon()
 		..()
 		var/connectdir = get_connected_directions_bitflag(connects_to)
-		if (connectdir & NORTH || connectdir & SOUTH)
-			if (!((connectdir & NORTH) && (connectdir & SOUTH)) && (connectdir && (EAST || WEST))) // if NEW or SEW, connect EW not to N or S. Fixes a plastic flap on clarion.
-				src.dir = NORTH
-			else
-				src.dir = EAST
-			return
-		if (connectdir & EAST || connectdir & WEST)
+		if ((connectdir & NORTH) && (connectdir & SOUTH))
 			src.dir = NORTH
+			return
+		if ((connectdir & EAST) && (connectdir & WEST))
+			src.dir = EAST
+			return
+		if ((connectdir & NORTH) || (connectdir & SOUTH))
+			src.dir = NORTH
+			return
+		if ((connectdir & EAST) || (connectdir & WEST))
+			src.dir = EAST
+			return
 
 	proc/change_direction()
 		if(src.dir == EAST)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -6539,7 +6539,8 @@
 	icon_state = "bdoornoblasts1";
 	id = "disposals_vent";
 	layer = 4;
-	name = "Disposals Vent"
+	name = "Disposals Vent";
+	dir = 4
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -20005,7 +20006,9 @@
 	id = "disposals";
 	operating = 1
 	},
-/obj/strip_door,
+/obj/strip_door{
+	dir = 1
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/disposal)
 "dRV" = (
@@ -37499,7 +37502,9 @@
 	id = "disposals";
 	operating = 1
 	},
-/obj/strip_door,
+/obj/strip_door{
+	dir = 4
+	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
@@ -43274,7 +43279,8 @@
 	id = "disposals_door";
 	layer = 4;
 	name = "Disposals Safety Door";
-	opacity = 0
+	opacity = 0;
+	dir = 4
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR
Rotates two doors. Plastic flags apparently do detection in their construction, so the code there was tweaked to cover the singular use case present in clarion's disposals, where south, east and west were all "valid connections". Instead of trying to connect to the south in such a scenario, it will try to connect eastwest.

The faulty logic occurred because it checks for a north or south connection first, and if it succeeds, connects that way.

## Why's this needed?
Fixes #16851