### PR TITLE
Allow non-goonhub CDN domains in gulpfile.

### DIFF
--- a/browserassets/gulpfile.mjs
+++ b/browserassets/gulpfile.mjs
@@ -33,7 +33,7 @@ const sources = {
 const serverType = argv.servertype || 'main'
 let cdnSubdomain = 'cdn'
 if (serverType !== 'main') cdnSubdomain += serverType
-const cdn = `https://${cdnSubdomain}.goonhub.com`
+const cdn = argv.cdn || `https://${cdnSubdomain}.goonhub.com`
 
 // Read git revision from stamped file (stamped during build process)
 let rev = fs.readFileSync('./revision', 'utf-8') || '1'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TOOLS] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change gulpfile to accept a "cdn" argument which becomes the the base url used by gulp.
Defers to the old behavior if it's not specified to keep backwards compatibility for current CI.

`npx gulp build --cdn="https://cdn.goonhub.com"` does the same thing as `npx gulp build --servertype=main`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Needed for forks that don't use cdn*.goonhub.com. Including it upstream avoids the occasional conflict downstream.
