### PR TITLE
Fixes splashing job reward buttons with reagents

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -43,6 +43,7 @@ mob/verb/checkrewards()
 /obj/jobxprewardbutton
 	icon = 'icons/ui/jobxp.dmi'
 	icon_state = "?"
+	flags = NOSPLASH
 	var/datum/jobXpReward/rewardDatum = null
 
 	Click(location,control,params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the NOSPLASH flag to `/obj/jobxprewardbutton`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #16845
