### PR TITLE
Allow stickers to be attached to storages that aren't full

### DIFF
--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -23,6 +23,8 @@
 		pixel_y = rand(-8, 8)
 		pixel_x = rand(-8, 8)
 
+		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(storage_check))
+
 	afterattack(var/atom/A as mob|obj|turf, var/mob/user as mob, reach, params)
 		if (!A)
 			return
@@ -106,6 +108,15 @@
 				attached.ClearSpecificOverlays(overlay_key)
 			attached.visible_message("<span class='alert'><b>[src]</b> is destroyed!</span>")
 		..()
+
+	// allow sticking to targets that have storage rather than adding to contents
+	proc/storage_check(obj/item/source, atom/target, mob/user)
+		. = FALSE
+		if (target.storage?.check_can_hold(source) == STORAGE_CAN_HOLD)
+			if (user?.a_intent != INTENT_HARM)
+				return
+			src.afterattack(target, user)
+			return TRUE
 
 /obj/item/sticker/postit
 	// this used to be some paper shit, then it was a cleanable/writing, now it's a sticker

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -15,6 +15,7 @@
 	var/overlay_key
 	var/atom/attached
 	var/list/random_icons = list()
+	HELP_MESSAGE_OVERRIDE("Can be attached to a storage item directly, rather than adding to its contents, by using harm-intent.")
 
 	New()
 		..()

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -113,8 +113,10 @@
 	// allow sticking to targets that have storage rather than adding to contents
 	proc/storage_check(obj/item/source, atom/target, mob/user)
 		. = FALSE
+		if (!user)
+			return
 		if (target.storage?.check_can_hold(source) == STORAGE_CAN_HOLD)
-			if (user?.a_intent != INTENT_HARM)
+			if (user.a_intent != INTENT_HARM)
 				return
 			src.afterattack(target, user)
 			return TRUE

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -108,9 +108,9 @@
 			attached.visible_message("<span class='alert'><b>[src]</b> is destroyed!</span>")
 		..()
 
-	mouse_drop(atom/over_location)
-		if (over_location.storage && can_act(usr) && (src in usr.equipped_list()) && BOUNDS_DIST(usr, over_location) <= 0)
-			src.afterattack(over_location, usr)
+	mouse_drop(atom/over_object)
+		if (over_object.storage && can_act(usr) && (src in usr.equipped_list()) && BOUNDS_DIST(usr, over_object) <= 0)
+			src.afterattack(over_object, usr)
 		else
 			..()
 

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -15,7 +15,7 @@
 	var/overlay_key
 	var/atom/attached
 	var/list/random_icons = list()
-	HELP_MESSAGE_OVERRIDE("Can be attached to a storage item directly, rather than adding to its contents, by using harm-intent.")
+	HELP_MESSAGE_OVERRIDE("Can be attached to a storage item directly, rather than adding to its contents, by mouse dropping it onto the storage.")
 
 	New()
 		..()
@@ -23,8 +23,6 @@
 			src.icon_state = pick(src.random_icons)
 		pixel_y = rand(-8, 8)
 		pixel_x = rand(-8, 8)
-
-		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(storage_check))
 
 	afterattack(var/atom/A as mob|obj|turf, var/mob/user as mob, reach, params)
 		if (!A)
@@ -110,16 +108,11 @@
 			attached.visible_message("<span class='alert'><b>[src]</b> is destroyed!</span>")
 		..()
 
-	// allow sticking to targets that have storage rather than adding to contents
-	proc/storage_check(obj/item/source, atom/target, mob/user)
-		. = FALSE
-		if (!user)
-			return
-		if (target.storage?.check_can_hold(source) == STORAGE_CAN_HOLD)
-			if (user.a_intent != INTENT_HARM)
-				return
-			src.afterattack(target, user)
-			return TRUE
+	mouse_drop(atom/over_location)
+		if (over_location.storage && can_act(usr) && (src in usr.equipped_list()) && BOUNDS_DIST(usr, over_location) <= 0)
+			src.afterattack(over_location, usr)
+		else
+			..()
 
 /obj/item/sticker/postit
 	// this used to be some paper shit, then it was a cleanable/writing, now it's a sticker


### PR DESCRIPTION
[GAME OBJECTS][PLAYER ACTIONS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows stickers to be attached to storages that aren't full by click dragging them onto the storage item


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently you can only attach a sticker to a storage if its contents are full.

Fixes #16835


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Stickers, including artifact forms, will now attach to storage items, rather than being added to their contents, when click dragging them onto the storage.
```
