### PR TITLE
Fix some items not being addable to artifact bags of holding

### DIFF
--- a/code/modules/storage/items/bag_of_holding.dm
+++ b/code/modules/storage/items/bag_of_holding.dm
@@ -9,10 +9,15 @@
 /datum/storage/no_hud/eldritch_bag_of_holding/add_contents_extra(obj/item/I, mob/user, visible)
 	..()
 	if (istype(I, /obj/item/artifact/bag_of_holding))
-		var/obj/item/artifact/bag_of_holding/boh = I
-		var/datum/artifact/artifact = boh.artifact
+		var/datum/artifact/artifact = I.artifact
 		if (artifact.activated)
-			combine_bags_of_holding(src.linked_item, boh, user)
+			destroy_bag_of_holding(src.linked_item, I, user)
+			return
+	if (istype(I, /obj/item/artifact/activator_key))
+		var/obj/item/artifact/bag_of_holding/boh = src.linked_item
+		var/datum/artifact/activator_key/key = I.artifact
+		if (key.activated && (key.universal || key.artitype == boh.artifact.artitype))
+			destroy_bag_of_holding(src.linked_item, I, user)
 			return
 	var/obj/item/artifact/bag_of_holding/boh = src.linked_item
 	boh.ArtifactFaultUsed(user, boh)
@@ -26,10 +31,15 @@
 /datum/storage/artifact_bag_of_holding/add_contents_extra(obj/item/I, mob/user, visible)
 	..()
 	if (istype(I, /obj/item/artifact/bag_of_holding))
-		var/obj/item/artifact/bag_of_holding/boh = I
-		var/datum/artifact/artifact = boh.artifact
+		var/datum/artifact/artifact = I.artifact
 		if (artifact.activated)
-			combine_bags_of_holding(src.linked_item, boh, user)
+			destroy_bag_of_holding(src.linked_item, I, user)
+			return
+	if (istype(I, /obj/item/artifact/activator_key))
+		var/obj/item/artifact/bag_of_holding/boh = src.linked_item
+		var/datum/artifact/activator_key/key = I.artifact
+		if (key.activated && (key.universal || key.artitype == boh.artifact.artitype))
+			destroy_bag_of_holding(src.linked_item, I, user)
 			return
 	var/obj/item/artifact/bag_of_holding/boh = src.linked_item
 	boh.ArtifactFaultUsed(user, boh)
@@ -90,9 +100,9 @@
 
 // --- other ---
 
-// when a bag of holding artifact is put into into another, after its been done
-// boh "added" is put into boh "boh"
-proc/combine_bags_of_holding(obj/item/artifact/boh, obj/item/artifact/added, mob/user = null)
+// when a "forbidden" artifact is put into an existing boh, after its been done
+// artifact "added" is put into boh "boh"
+proc/destroy_bag_of_holding(obj/item/artifact/boh, obj/added, mob/user = null)
 	var/effect
 	var/turf/T = get_turf(boh)
 	switch(rand(1, 4))
@@ -117,7 +127,7 @@ proc/combine_bags_of_holding(obj/item/artifact/boh, obj/item/artifact/added, mob
 			effect = "black hole"
 		// teleport items everywhere
 		if (3)
-			var/list/items = boh.storage.get_contents() + added.storage.get_contents() - added
+			var/list/items = boh.storage.get_contents() + added.storage?.get_contents() - added
 			// teleport to random storages
 			if (prob(50))
 				if (length(items))
@@ -142,7 +152,7 @@ proc/combine_bags_of_holding(obj/item/artifact/boh, obj/item/artifact/added, mob
 			// teleport to random turfs
 			else
 				var/list/turfs = block(locate(1, 1, T.z || Z_LEVEL_STATION), locate(world.maxx, world.maxy, T.z || Z_LEVEL_STATION))
-				for (var/obj/item/I as anything in added.storage.get_contents())
+				for (var/obj/item/I as anything in added.storage?.get_contents())
 					added.storage.transfer_stored_item(I, pick(turfs))
 				for (var/obj/item/I as anything in (boh.storage.get_contents() - added))
 					boh.storage.transfer_stored_item(I, pick(turfs))
@@ -172,7 +182,7 @@ proc/combine_bags_of_holding(obj/item/artifact/boh, obj/item/artifact/added, mob
 
 	logTheThing(LOG_STATION, boh, "artifact bags of holding combined at [log_loc(T)][user ? " by [user] " : null]with effect [effect].")
 
-	for (var/obj/item/I as anything in (added.storage.get_contents() + boh.storage.get_contents() - added))
+	for (var/obj/item/I as anything in (added.storage?.get_contents() + boh.storage.get_contents() - added))
 		qdel(I)
 	qdel(added)
 	qdel(boh)

--- a/code/obj/artifacts/artifact_items/handheld_storage.dm
+++ b/code/obj/artifacts/artifact_items/handheld_storage.dm
@@ -66,6 +66,15 @@
 		src.reset_visible_state()
 		..()
 
+	Artifact_attackby(obj/item/W, mob/user)
+		if (istype(W, /obj/item/artifact/activator_key))
+			return ..()
+		// skip stimulus checks
+		if (src.artifact.activated)
+			src.ArtifactHitWith(W, user)
+			return TRUE
+		return ..()
+
 	// reset state to pre-worn state
 	proc/reset_visible_state()
 		if (src.icon == initial(src.icon))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -262,12 +262,14 @@
 					if(K.corrupting && length(A.faults) < 10) // there's only so much corrupting you can do ok
 						for(var/i=1,i<rand(1,3),i++)
 							src.ArtifactDevelopFault(100)
-				else if (A.activated)
+					// prevent instantly adding to contents, since a bad effect happens
 					if (istype(src, /obj/item/artifact/bag_of_holding))
-						if (!user || user.a_intent == INTENT_HARM)
-							src.ArtifactDeactivated()
-					else
-						src.ArtifactDeactivated()
+						return
+				else if (A.activated)
+					if (istype(src, /obj/item/artifact/bag_of_holding) && src.storage.check_can_hold(W) == STORAGE_CAN_HOLD)
+						src.storage.add_contents(W, user)
+						return
+					src.ArtifactDeactivated()
 
 	if (isweldingtool(W))
 		if (W:try_weld(user,0,-1,0,1))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -263,7 +263,11 @@
 						for(var/i=1,i<rand(1,3),i++)
 							src.ArtifactDevelopFault(100)
 				else if (A.activated)
-					src.ArtifactDeactivated()
+					if (istype(src, /obj/item/artifact/bag_of_holding))
+						if (!user || user.a_intent == INTENT_HARM)
+							src.ArtifactDeactivated()
+					else
+						src.ArtifactDeactivated()
 
 	if (isweldingtool(W))
 		if (W:try_weld(user,0,-1,0,1))


### PR DESCRIPTION
[GAME OBJECTS][PLAYER ACTIONS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes some items, like multitools, not being able to be added to artifact bags of holding.

Also, activator keys will now have the same effect when added to a bag of holding with an origin they can activate as adding another bag of holding.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #16834


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)FlameArrow57
(+)It's no longer advised to put an activator key into a bag of holding it can activate!
```
