### PR TITLE
Fix headrev antag removal not removing image groups

### DIFF
--- a/code/modules/antagonists/revolutionary/head_revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/head_revolutionary.dm
@@ -108,11 +108,9 @@
 		. = ..()
 		var/datum/client_image_group/image_group = get_image_group(ROLE_REVOLUTIONARY)
 		image_group.remove_mind_mob_overlay(src.owner)
-		if (image_group.minds_with_associated_mob_image[src.owner])
-			image_group.remove_mind(src.owner)
+		image_group.remove_mind(src.owner)
 		var/datum/client_image_group/heads_group = get_image_group(CLIENT_IMAGE_GROUP_HEADS_OF_STAFF)
-		if (heads_group.minds_with_associated_mob_image[src.owner])
-			heads_group.remove_mind(src.owner)
+		heads_group.remove_mind(src.owner)
 
 	assign_objectives()
 		for(var/datum/mind/head_mind in src.heads_of_staff)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes if checks that never succeed and prevent the client from being removed from the rev/head of staff image groups. These ifs were added by Leah because this proc would runtime under certain circumstances, but I literally cannot get it to runtime with the ifs removed, and I can't see any particular line that would runtime. If a way for it to runtime turns up feel free to blame me and I'll fix it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #16693

