### PR TITLE
Fix wiretap radio upgrade still letting you hear frequencies after removal

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -64,6 +64,9 @@
 		var/obj/item/device/radio/headset/headset = new src.type
 		src.secure_frequencies = headset.secure_frequencies
 		src.secure_classes = headset.secure_classes
+		for(var/sayToken in src.secure_connections)
+			src.secure_connections[sayToken].RemoveComponent()
+			src.secure_connections.Remove(sayToken)
 		src.set_secure_frequencies()
 
 /obj/item/device/radio/headset/wizard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add code in `remove_radio_upgrade` to properly clean up the list of radio components in the headset

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #14689 