### PR TITLE
Fixes claiming your own spief uplink not spawning reward

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -958,7 +958,6 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		if (istype(antag_role))
 			antag_role.stolen_items[delivery.name] = new /mutable_appearance(delivery)
 
-		qdel(delivery)
 
 		if (req_bounties() > 1)
 			bounty_tally += 1
@@ -966,6 +965,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		else
 			src.spawn_reward(bounty, user)
 		src.ui_update()
+		qdel(delivery)
 		return TRUE
 
 	proc/loop()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the call to `qdel` for the bounty item to after the `spawn_reward` call so it won't runtime and not spawn the reward.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #16675 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Claiming your own uplink as a spy thief should now properly spawn the reward.
```
