### PR TITLE
HoS cape layers under hair again if worn on suit

### DIFF
--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -491,7 +491,6 @@ TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
 	icon_state = "hos-cape"
 	item_state = "hos-cape"
 	hides_from_examine = 0
-	wear_layer = MOB_GLASSES_LAYER2
 	c_flags = ONBACK
 
 	setupProperties()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -34,7 +34,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit)
 
 	unequipped(mob/user)
 		. = ..()
-		src.layer = initial(src.wear_layer)
+		src.wear_layer = initial(src.wear_layer)
 
 /obj/item/clothing/suit/hoodie
 	name = "hoodie"


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so the Head of Security cape layers under hair again if worn in the suit slot. It will still layer over hair if worn on your back.

Also fixes a directly related bug in order to get this to work, where on unequip the item's layer was being set to the initial worn layer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it just looks a bit better, compare below images. Second one is how it always appears regardless of slot worn right now

![a](https://github.com/goonstation/goonstation/assets/53062374/a5953ae7-e436-4c49-885b-e7c9ce644099)

![b](https://github.com/goonstation/goonstation/assets/53062374/11459723-4047-46e9-80f6-99bf7254a9a1)