### PR TITLE
Makes slamming palms on table use player pronouns

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -297,7 +297,7 @@ TYPEINFO_NEW(/obj/table)
 			var/mob/living/carbon/human/H = user
 			if (istype(H.w_uniform, /obj/item/clothing/under/misc/lawyer) && !H.equipped())
 				slaps += 1
-				src.visible_message(SPAN_ALERT("<b>[H] slams their palms against [src]!</b>"))
+				src.visible_message(SPAN_ALERT("<b>[H] slams [his_or_her(H)] palms against [src]!</b>"))
 				if (slaps > 10 && prob(1)) //owned
 					if (H.hand && H.limbs && H.limbs.l_arm)
 						H.limbs.l_arm.sever()
@@ -559,7 +559,7 @@ TYPEINFO_NEW(/obj/table/mauxite)
 			var/mob/living/carbon/human/H = user
 			if (istype(H.w_uniform, /obj/item/clothing/under/misc/lawyer))
 				slaps += 1
-				src.visible_message(SPAN_ALERT("<b>[H] slams their palms against [src]!</b>"))
+				src.visible_message(SPAN_ALERT("<b>[H] slams [his_or_her(H)] palms against [src]!</b>"))
 				if (slaps > 2 && prob(50))
 					src.visible_message(SPAN_ALERT("<b>The [src] collapses!</b>"))
 					deconstruct()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `his_or_her` calls in messages about lawyers slamming palms onto tables

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity