### PR TITLE
Adds separate gang member antag preference

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -115,7 +115,7 @@
 	for(var/datum/gang/gang in src.gangs)
 		num_people_needed += min(gang.current_max_gang_members, max_member_count) - length(gang.members)
 	if(isnull(candidates))
-		candidates = get_possible_enemies(ROLE_GANG_LEADER, num_people_needed, allow_carbon=TRUE, filter_proc=PROC_REF(can_join_gangs))
+		candidates = get_possible_enemies(ROLE_GANG_MEMBER, num_people_needed, allow_carbon=TRUE, filter_proc=PROC_REF(can_join_gangs))
 	var/num_people_available = min(num_people_needed, length(candidates))
 	var/people_added_per_gang = round(num_people_available / num_teams)
 	num_people_available = people_added_per_gang * num_teams

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -31,6 +31,7 @@ datum/preferences
 	var/be_syndicate_commander = 0
 	var/be_spy = 0
 	var/be_gangleader = 0
+	var/be_gangmember = 0
 	var/be_revhead = 0
 	var/be_changeling = 0
 	var/be_wizard = 0
@@ -986,6 +987,7 @@ datum/preferences
 				be_syndicate_commander = 0
 				be_spy = 0
 				be_gangleader = 0
+				be_gangmember = 0
 				be_revhead = 0
 				be_changeling = 0
 				be_wizard = 0
@@ -1411,6 +1413,7 @@ datum/preferences
 			src.be_syndicate = FALSE
 			src.be_syndicate_commander = FALSE
 			src.be_gangleader = FALSE
+			src.be_gangmember = FALSE
 			src.be_revhead = FALSE
 			src.be_conspirator = FALSE
 #endif
@@ -1421,6 +1424,7 @@ datum/preferences
 			src.be_syndicate_commander = FALSE
 			src.be_spy = FALSE
 			src.be_gangleader = FALSE
+			src.be_gangmember = FALSE
 			src.be_revhead = FALSE
 			src.be_changeling = FALSE
 			src.be_wizard = FALSE
@@ -1440,6 +1444,7 @@ datum/preferences
 			<a href="byond://?src=\ref[src];preferences=1;b_syndicate_commander=1" class="[src.be_syndicate_commander ? "yup" : "nope"]">[crap_checkbox(src.be_syndicate_commander)] Nuclear Operative Commander</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_spy=1" class="[src.be_spy ? "yup" : "nope"]">[crap_checkbox(src.be_spy)] Spy/Thief</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_gangleader=1" class="[src.be_gangleader ? "yup" : "nope"]">[crap_checkbox(src.be_gangleader)] Gang Leader</a>
+			<a href="byond://?src=\ref[src];preferences=1;b_gangmember=1" class="[src.be_gangmember ? "yup" : "nope"]">[crap_checkbox(src.be_gangmember)] Gang Member</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_revhead=1" class="[src.be_revhead ? "yup" : "nope"]">[crap_checkbox(src.be_revhead)] Revolution Leader</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_changeling=1" class="[src.be_changeling ? "yup" : "nope"]">[crap_checkbox(src.be_changeling)] Changeling</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_wizard=1" class="[src.be_wizard ? "yup" : "nope"]">[crap_checkbox(src.be_wizard)] Wizard</a>
@@ -1666,6 +1671,11 @@ datum/preferences
 
 		if (link_tags["b_gangleader"])
 			src.be_gangleader = !( src.be_gangleader)
+			src.SetChoices(user)
+			return
+
+		if (link_tags["b_gangmember"])
+			src.be_gangmember = !( src.be_gangmember )
 			src.SetChoices(user)
 			return
 

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -93,6 +93,7 @@
 		F["[profileNum]_be_syndicate_commander"] << src.be_syndicate_commander
 		F["[profileNum]_be_spy"] << src.be_spy
 		F["[profileNum]_be_gangleader"] << src.be_gangleader
+		F["[profileNum]_be_gangmember"] << src.be_gangmember
 		F["[profileNum]_be_revhead"] << src.be_revhead
 		F["[profileNum]_be_changeling"] << src.be_changeling
 		F["[profileNum]_be_wizard"] << src.be_wizard
@@ -286,6 +287,7 @@
 		F["[profileNum]_be_syndicate_commander"] >> src.be_syndicate_commander
 		F["[profileNum]_be_spy"] >> src.be_spy
 		F["[profileNum]_be_gangleader"] >> src.be_gangleader
+		F["[profileNum]_be_gangmember"] >> src.be_gangmember
 		F["[profileNum]_be_revhead"] >> src.be_revhead
 		F["[profileNum]_be_changeling"] >> src.be_changeling
 		F["[profileNum]_be_wizard"] >> src.be_wizard

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -55,6 +55,7 @@ var/list/roles_to_prefs = list(
 	ROLE_NUKEOP = "be_syndicate",
 	ROLE_VAMPIRE = "be_vampire",
 	ROLE_GANG_LEADER = "be_gangleader",
+	ROLE_GANG_MEMBER = "be_gangmember",
 	ROLE_WIZARD = "be_wizard",
 	ROLE_CHANGELING = "be_changeling",
 	ROLE_WEREWOLF = "be_werewolf",


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME MODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds preference/UI code for gang member, changes `fill_gangs` proc to use this pref instead of gang leader. No other changes to selection or scaling have been made in this PR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Now that random gang members are a permanent fixture of the game mode, it would be nice to allow people to choose which one they want to be, given that a leader has different expectations than a member.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(*)There are now separate antagonist preferences for gang leader and gang member.
```
