### PR TITLE
Add empty gas tank to list of valid tanks for portable combustion generator

### DIFF
--- a/code/modules/power/chem_combustion.dm
+++ b/code/modules/power/chem_combustion.dm
@@ -61,7 +61,8 @@ TYPEINFO(/obj/machinery/power/combustion_generator)
 	var/static/valid_tanks = list(
 		/obj/item/tank/air,
 		/obj/item/tank/oxygen,
-		/obj/item/tank/anesthetic
+		/obj/item/tank/anesthetic,
+		/obj/item/tank/empty
 	)
 
 	// tanks


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `/obj/item/tank/empty` to the portable combustion generator's list of valid oxygen tanks

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Looks and functions the same as all the other cylindrical tanks