### PR TITLE
Fix small bug with wizard bag of holding artifacts

### DIFF
--- a/code/modules/storage/items/bag_of_holding.dm
+++ b/code/modules/storage/items/bag_of_holding.dm
@@ -60,12 +60,12 @@
 
 /datum/storage/artifact_bag_of_holding/wizard/add_contents_extra(obj/item/I, mob/user, visible)
 	..()
-	if (user)
+	if (user.s_active == src.hud)
 		src.show_hud(user)
 
 /datum/storage/artifact_bag_of_holding/wizard/transfer_stored_item_extra(obj/item/I, atom/location, add_to_storage, mob/user)
 	..()
-	if (user)
+	if (user.s_active == src.hud)
 		src.show_hud(user)
 
 // does the randomization of visible contents


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where contents of the wizard bag of holding were always showing when putting an item in


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix

Fixes #16836