### PR TITLE
Change mutagenic field description to accurately describe effects

### DIFF
--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -425,7 +425,7 @@
 
 /datum/bioEffect/mutagenic_field
 	name = "Mutagenic Field"
-	desc = "The subject emits low-level radiation that may themselves to mutate."
+	desc = "The subject emits low-level radiation that may cause themselves to mutate."
 	id = "mutagenic_field"
 	effectType = EFFECT_TYPE_DISABILITY
 	isBad = 1

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -855,7 +855,7 @@
 
 /datum/bioEffect/mutagenic_field/prenerf
 	name = "High-Power Mutagenic Field"
-	desc = "The subject emits low-level radiation that may cause everyone in range to mutate."
+	desc = "The subject emits powerful radiation that may cause everyone in range to mutate."
 	id = "mutagenic_field_prenerf"
 	affect_others = 1
 	occur_in_genepools = 0

--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -425,7 +425,7 @@
 
 /datum/bioEffect/mutagenic_field
 	name = "Mutagenic Field"
-	desc = "The subject emits low-level radiation that may cause everyone in range to mutate."
+	desc = "The subject emits low-level radiation that may themselves to mutate."
 	id = "mutagenic_field"
 	effectType = EFFECT_TYPE_DISABILITY
 	isBad = 1
@@ -855,6 +855,7 @@
 
 /datum/bioEffect/mutagenic_field/prenerf
 	name = "High-Power Mutagenic Field"
+	desc = "The subject emits low-level radiation that may cause everyone in range to mutate."
 	id = "mutagenic_field_prenerf"
 	affect_others = 1
 	occur_in_genepools = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes mutagenic field description to say that it only causes the subject to mutate, adds the old description to the pre-nerf admin-spawn version. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mutagenic field no longer causes everyone in range to mutate, that was moved to a sub-type that doesn't spawn in genetic pools