### PR TITLE
Fix yobihodazine not depleting below 1u

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -421,8 +421,8 @@ datum
 					var/oxyloss = M.get_oxygen_deprivation()
 					M.take_oxygen_deprivation(-INFINITY)
 					M.take_brain_damage(oxyloss / 15)
-					..()
-					return
+				..()
+				return
 
 		medical/synthflesh
 			name = "synthetic flesh"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tweaks the indentation in on_mob_life of yobihodazine to call parent every time.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16903 
