### PR TITLE
Allow reclaiming genes even if at material cap

### DIFF
--- a/code/modules/medical/genetics/chromosomes.dm
+++ b/code/modules/medical/genetics/chromosomes.dm
@@ -45,7 +45,7 @@
 
 /datum/dna_chromosome/reclaimer
 	name = "Weakener"
-	desc = "Makes a gene reclaimable and doubles the amount of materials you get from reclaiming it."
+	desc = "Makes a gene easier to reclaim and doubles the amount of materials you get from reclaiming it."
 
 	check_apply(datum/bioEffect/BE)
 		if(!istype(BE))

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -691,7 +691,7 @@
 			if (prob(E.reclaim_fail))
 				scanner_alert(ui.user, "Reclamation failed.", error = TRUE)
 			else
-				var/waste = (E.reclaim_mats + genResearch.researchMaterial) - reclamation_cap
+				var/waste = min(E.reclaim_mats, (E.reclaim_mats + genResearch.researchMaterial) - reclamation_cap)
 				genResearch.researchMaterial = max(genResearch.researchMaterial, min(genResearch.researchMaterial + E.reclaim_mats, reclamation_cap))
 				if (waste > 0)
 					scanner_alert(ui.user, "Reclamation successful. [E.reclaim_mats] materials gained. Material count now at [genResearch.researchMaterial]. [waste] units of material wasted due to material capacity limit.")

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -692,11 +692,7 @@
 				scanner_alert(ui.user, "Reclamation failed.", error = TRUE)
 			else
 				var/waste = (E.reclaim_mats + genResearch.researchMaterial) - reclamation_cap
-				if (waste >= E.reclaim_mats)
-					scanner_alert(ui.user, "Nothing would be gained from reclamation due to material capacity limit. Reclamation aborted.", error = TRUE)
-					playsound(src, 'sound/machines/buzz-two.ogg', 50, TRUE, -10)
-					return
-				genResearch.researchMaterial = min(genResearch.researchMaterial + E.reclaim_mats, reclamation_cap)
+				genResearch.researchMaterial = max(genResearch.researchMaterial, min(genResearch.researchMaterial + E.reclaim_mats, reclamation_cap))
 				if (waste > 0)
 					scanner_alert(ui.user, "Reclamation successful. [E.reclaim_mats] materials gained. Material count now at [genResearch.researchMaterial]. [waste] units of material wasted due to material capacity limit.")
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDICAL][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows use of the "Reclaim" button in genetics even if the material count is at or above its (150%) maximum.

Alters the description of the Weakener chromosome slightly to better convey what it does.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is a useful way to remove mutations from crew in the scanner before Mutation Storage is available. While it means the material from it will be wasted, it still lets you clean up a target's bad mutations, and gets some more use out of the oft-forgotten DNA Reclaimer feature.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mordent
(*)Reclaim feature of genetics consoles now works even if at genetic material cap.
```