### PR TITLE
Remove "too dazed to use" from obj/machinery/attack_hand()

### DIFF
--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -180,11 +180,6 @@
 		return 1
 
 	if (user)
-		if (ishuman(user))
-			if(user.get_brain_damage() >= 60 || prob(user.get_brain_damage()))
-				boutput(user, SPAN_ALERT("You are too dazed to use [src] properly."))
-				return 1
-
 		src.add_fingerprint(user)
 		interact_particle(user,src)
 	return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Balance][Bug][Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This removes the "too dazed to use" message when interacting with machines.

Previously, this message would appear if you had 60 or more brain damage, or at a braindamage% rate below that.
This message appears to be intended to also block interaction with the machine, but I personally cannot remember a time in which that actually worked on the majority of machines.

After checking (I think) everything on devtest with 70 brain damage, I found that while a couple dozen things prompted this message, only the cryo healing tube, data bank, and the old artifact lab gizmo actually blocked my interaction.

Here was me running around clicking things until I found something that blocked interaction.
![image](https://github.com/goonstation/goonstation/assets/25803648/de219065-4c2a-4cca-bdbc-6ebe74075409)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I do not feel this currently contributes anything to the game, that it's bugged state should be fixed somehow, and that honestly there would be no benefit or fun derived from fixing it to block interaction fully.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mylie Daniels
(+)Brain damage no longer causes a message when interacting with machinery.
```
