### PR TITLE
Don't ghostize virtual mobs

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -288,7 +288,9 @@
 	RETURN_TYPE(/mob/dead)
 	// do nothing for NPCs
 	if(src.key || src.client)
-
+		if(isvirtual(src))
+			src.death()
+			return null
 		if(src.mind && src.mind.damned) // Wow so much sin. Off to hell with you.
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, hell_respawn), src.mind)
 			return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #16929

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghostize will send a virtual mob straight to ghost rather than their original body.
Tested with human wearing VR goggles and a ghost entering VR.