### PR TITLE
adds a minimum temperature for cyanide offgas

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2483,6 +2483,7 @@
 		id = "cyanide_offgas"
 		required_reagents = list("cyanide" = 0) //removed in on_reaction
 		result_amount = 1
+		min_temperature = T0C + 30 // Generates vapor above room temperature
 		mix_phrase = "The mixture slowly gives off fumes."
 		mix_sound = null
 		instant = FALSE


### PR DESCRIPTION
[LABEL][chemistry][balance]

## About the PR

This PR adds a minimum temperature requirement of 30C for cyanide to begin offgassing. Cyanide production will still require a period where it is succeptible to offgassing, considering it requires 100C to produce.


## Why's this needed?

At the moment, having no way to properly stop cyanide from offgassing besides just putting a lid both severely limits how it can be used(cannot be bottled, cannot be put in glasses, etc) and makes any process involving it much more awkward than need be. 

This PR adds a way to stabilize cyanide via cooling it down to room temperature, thus keeping the offgassing effect and making the chemist need to always be paying attention to the temperature of mixes, since any heating up will cause the effect to start, without it being a bit of a unavoidable gotcha that makes cyanide be more of a pain to use than it's really worth.


## Changelog

```changelog
(u)Colossusqw
(+)Cyanide now only offgasses at 30 C or more.
```
