### PR TITLE
Status displays clear maptext on losing power

### DIFF
--- a/code/obj/machinery/status_display.dm
+++ b/code/obj/machinery/status_display.dm
@@ -110,6 +110,7 @@ TYPEINFO(/obj/machinery/status_display)
 	// timed process
 	process()
 		if(status & NOPOWER)
+			maptext = ""
 			ClearAllOverlays()
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When losing power, status displays clear existing maptext to fully turn off.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8635