### PR TITLE
Oshan QM barcode machine uses no-belthell variant 

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -25824,7 +25824,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "bOa" = (
-/obj/machinery/computer/barcode/qm{
+/obj/machinery/computer/barcode/qm/no_belthell{
 	dir = 4
 	},
 /turf/simulated/floor/orangeblack,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

There is no belthell on Oshan, so change the QM console to only include the Shipping Market destination. 

Considered using the oshan-specific variant, but there's no way to send crates from cargo to the central belt. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Remove superfluous/unused bacodes from console