### PR TITLE
cog1 area fix

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3310,7 +3310,7 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/exit)
+/area/station/security/checkpoint/arrivals)
 "ame" = (
 /obj/machinery/deep_fryer{
 	dir = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes this wrong area on cog1

![image](https://github.com/goonstation/goonstation/assets/31984217/f3550a82-b8c8-455c-ae0f-29aefc21ea06)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Apparently it threw off the nukie planning map 

