### PR TITLE
Fix wigs for ghost drones

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -429,9 +429,16 @@
 	proc/putonHat(obj/item/clothing/head/W as obj, mob/user as mob)
 		src.hat = W
 		W.set_loc(src)
-		var/image/hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
-		hatImage.pixel_y = 5
-		hatImage.transform *= 0.9
+		var/image/hatImage = null
+		// Treat wigs differently as their icon_state is always bald
+		if (istype(W, /obj/item/clothing/head/wig))
+			hatImage = W.wear_image
+			hatImage.layer = src.layer+0.1
+			hatImage.pixel_y = -7
+		else
+			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
+			hatImage.pixel_y = 5
+			hatImage.transform *= 0.9
 		UpdateOverlays(hatImage, "hat")
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Player hair wigs can now be put on and taken off of ghost drones. Some of them look kinda goofy, like beards or long hair that "disappears" when the ghost drone faces south, but this gets the point across.

![ghostdronehair](https://github.com/goonstation/goonstation/assets/5091297/67f3d749-9376-4c65-8d9c-6f25b9e358f6)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10443 
Wig's icon_state is always "bald" so use the generated wear_image, further detail in linked issue.