### PR TITLE
Add set stack amount admin interact proc

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -602,6 +602,17 @@ ABSTRACT_TYPE(/obj/item)
 		qdel(src)
 	return 1
 
+ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
+/obj/item/proc/admin_set_stack_amount()
+	set name = "Set Stack Amount"
+	var/input = tgui_input_number(usr, "Enter a new stack amount", default = src.amount, min_value = 1, max_value = 10000)
+	if(!input)
+		return
+	src.set_stack_amount(input)
+
+/obj/item/proc/set_stack_amount(var/new_amount)
+	return src.change_stack_amount(new_amount - src.amount)
+
 /obj/item/proc/stack_item(obj/item/other)
 	var/added = 0
 	var/imrobot


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN] [INTERNAL] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `/obj/item/proc/set_stack_amount` because it only ever had a proc to change stacks by relative amounts for some reason, adds `/obj/item/proc/admin_set_stack_amount` which uses the former to provide an option in the admin menu to change the stack size of things without varediting

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Spawning materials and then having to manually set stack size is a pain in the ass if theres a lot