### PR TITLE
Fix vending machine usage not leaving fingerprints

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -64,7 +64,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 	layer = OBJ_LAYER - 0.1 // so items get spawned at 3, don't @ me
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
-	flags = TGUI_INTERACTIVE
+	flags = TGUI_INTERACTIVE | FPRINT
 	var/freestuff = 0
 	var/obj/item/card/id/scan = null
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3063,7 +3063,6 @@ TYPEINFO(/obj/machinery/vending/janitor)
 			return
 		if (user.stat || user.restrained())
 			return
-		src.add_fingerprint(user)
 
 		ui_interact(user)
 
@@ -3072,7 +3071,6 @@ TYPEINFO(/obj/machinery/vending/janitor)
 		if (.) return
 
 		var/obj/item/I = usr.equipped()
-		src.add_fingerprint(usr)
 
 		switch(action)
 			if("o2_eject")

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -696,10 +696,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 		if (src.shock(user, 100))
 			return
 
-	ui_interact(user)
-
-	interact_particle(user,src)
-	return
+	return ..()
 
 /obj/machinery/vending/Topic(href, href_list)
 	if (status & (BROKEN|NOPOWER))

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3055,14 +3055,6 @@ TYPEINFO(/obj/machinery/vending/janitor)
 
 		.["target_pressure"] = src.target_pressure
 
-	attack_hand(mob/user)
-		if (status & (BROKEN|NOPOWER))
-			return
-		if (user.stat || user.restrained())
-			return
-
-		ui_interact(user)
-
 	ui_act(action, params)
 		. = ..()
 		if (.) return

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -517,6 +517,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 	if (.)
 		return .
 	var/obj/item/I = usr.equipped()
+	src.add_fingerprint(usr)
 
 	//Let's assume the switch handles the action, we'll set to FALSE later if it isn't the case
 	. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Reverts https://github.com/goonstation/goonstation/commit/c3f084d393a50dd9d0b228b2fd5fbe7478801953 because that was seemingly mistakenly only applied to the oxygen vendor
- make `attack_hand` properly call parent so it leaves a fingerprint
- puts `add_fingerprint` in the base `/obj/machinery/vending/ui_act`
- adds `FPRINT` flag to vending machines.
- remove `/obj/machinery/vending/air_vendor/attack_hand` because it's not doing anything the parent isn't doing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #16904