### PR TITLE
Adds camera to mechlab on cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -45471,6 +45471,12 @@
 "cBy" = (
 /obj/rack,
 /obj/random_item_spawner/tools,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "cBz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds security camera to the mechanic's lab in cogmap 2

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI previously could not access the main door of this area nor see anything inside the mechlab, this prevents awkward situations where the AI has to let people in through the back door instead of opening the door regularly and allows the AI to help with projects should it be required.
