### PR TITLE
Add STOP_DISTRACTING_ME define to disable random crew mail

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -65,6 +65,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define CHECK_MORE_RUNTIMES // Enables checking for some additional errors which might be too costly on live server
 //#define QUICK_MOB_DELETION // Enables deleting mobs with build mode right click on obj place mode
 //#define SHUT_UP_ABOUT_MY_PAY // disables PDA messages from the wagesystem
+//#define FUCK_OFF_WITH_THE_MAIL // Disables random crew mail system
 
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
@@ -187,6 +188,7 @@ o+`        `-` ``..-:yooos-..----------..`
 #define CHECK_MORE_RUNTIMES
 #define QUICK_MOB_DELETION
 #define SHUT_UP_ABOUT_MY_PAY
+#define FUCK_OFF_WITH_THE_MAIL
 #endif
 
 #ifdef IM_REALLY_IN_A_FUCKING_HURRY_HERE

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -167,7 +167,9 @@
 			return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
 
 	proc/market_shift()
+		#ifndef FUCK_OFF_WITH_THE_MAIL
 		var/time_since_previous = (TIME - last_market_update)
+		#endif
 		last_market_update = TIME
 
 		// Chance of a commodity being hot. Sometimes the market is on fire.
@@ -291,6 +293,7 @@
 		while(length(src.req_contracts) < src.max_req_contracts)
 			src.add_req_contract()
 
+		#ifndef FUCK_OFF_WITH_THE_MAIL
 		SPAWN(0)
 			// ~ Random Crew Mail Generation ~
 			// doing it here because i'm stupid
@@ -330,6 +333,7 @@
 
 					logTheThing(LOG_STATION, null, "Mail: Created [created_mail.len] packages, shipping now.")
 					shippingmarket.receive_crate(mail_crate)
+		#endif
 
 		SPAWN(5 SECONDS)
 			// 20% chance to shuffle out generic traders for a new one


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new define to `STOP_DISTRACTING_ME` to disable the crates full of crew mail being delivered every market shift.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Annoying having crates spawning in cargo every market shift when you're testing something
