### PR TITLE
Fix scrollwheel now targeting message appearing even when target doesn't change

### DIFF
--- a/_std/plane.dm
+++ b/_std/plane.dm
@@ -156,9 +156,11 @@ client
 		if (A?.MouseWheel(delta_x, delta_y, location, control, params))
 			return
 		if (delta_y > 0)
-			M.zone_sel.select_zone(src.zone_sels_positive_delta[M.zone_sel.selecting])
+			if (src.zone_sels_positive_delta[M.zone_sel.selecting] != M.zone_sel.selecting)
+				M.zone_sel.select_zone(src.zone_sels_positive_delta[M.zone_sel.selecting])
 		else
-			M.zone_sel.select_zone(src.zone_sels_negative_delta[M.zone_sel.selecting])
+			if (src.zone_sels_negative_delta[M.zone_sel.selecting] != M.zone_sel.selecting)
+				M.zone_sel.select_zone(src.zone_sels_negative_delta[M.zone_sel.selecting])
 
 	proc/add_plane(var/atom/movable/screen/plane_parent/plane)
 		RETURN_TYPE(/atom/movable/screen/plane_parent)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds check for if the new target zone is the same as the current i.e. we have scrolled all the way down/up

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Now targeting the right leg. x5000000000