### PR TITLE
Allow synthflesh removal from pustule with syringe

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1449,13 +1449,15 @@
 	duration = 3 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED
 	var/mob/mob_owner
-	var/mob/target
+	var/target
 	var/syringe_mode
 	var/obj/item/reagent_containers/syringe/S
 
-	New(var/mob/target, var/item, var/icon, var/icon_state)
+	New(var/target, var/item, var/icon, var/icon_state)
 		..()
 		src.target = target
+		if(istype(src.target,/obj/item/reagent_containers/synthflesh_pustule))
+			src.duration = 1 SECONDS
 		if (istype(item, /obj/item/reagent_containers/syringe))
 			S = item
 		else
@@ -1492,7 +1494,13 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		if (!isnull(S) && syringe_mode == S.mode)
-			S.syringe_action(owner, target)
+			if(istype(src.target,/obj/item/reagent_containers/synthflesh_pustule))
+				var/obj/item/reagent_containers/synthflesh_pustule/P = src.target
+				P.reagents.trans_to(src.S, src.S.amount_per_transfer_from_this)
+				P.poke_timer = initial(P.poke_timer)
+				P.poked = TRUE
+			else
+				S.syringe_action(owner, target)
 
 /datum/action/bar/icon/pill
 	duration = 3 SECONDS

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -116,12 +116,16 @@
 					boutput(user, SPAN_ALERT("The [src.name] is full."))
 					return
 
+				if (istype(target,/obj/item/reagent_containers/synthflesh_pustule))
+					actions.start(new/datum/action/bar/icon/syringe(target, src, src.icon, src.icon_state), user)
+					return
+
 				if (!target.is_open_container() && (!istype(target,/obj/reagent_dispensers) && !istype(target,/obj/item/clothing/mask/cigarette/custom)))
 					boutput(user, SPAN_ALERT("You cannot directly remove reagents from this object."))
 					return
 
 				target.reagents.trans_to(src, src.amount_per_transfer_from_this)
-				logTheThing(LOG_CHEMISTRY, user, "draws 5 units of reagents from [constructTarget(target,"combat")] [log_reagents(target)] with a syringe [log_reagents(src)] at [log_loc(user)].")
+				logTheThing(LOG_CHEMISTRY, user, "draws [src.amount_per_transfer_from_this] units of reagents from [constructTarget(target,"combat")] [log_reagents(target)] with a syringe [log_reagents(src)] at [log_loc(user)].")
 				user.update_inhands()
 
 				boutput(user, SPAN_NOTICE("You fill [src] with [src.amount_per_transfer_from_this] units of the solution."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[ENHANCEMENT][CHEMISTRY]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows removal of synthflesh from pustules using syringes using a 1 second interruptible action. Process is only one way.

A few seconds after poking, the pustule will attempt to heal it using 15 units of synthflesh and reducing efficiency by 20% to prevent it from being abused. If it doesn't have enough to fix the hole it gets destroyed instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cyborgs can't make synthflesh. It requires picking it up and plopping them on a beaker or barrel, which they can't do.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DrWolfy
(+)Synthflesh in pustules can now be recovered with a syringe, reducing the pustule efficiency.
```
