### PR TITLE
Add MouseDrag_T to artlab pitching machine and impact pad

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -3838,6 +3838,12 @@ TYPEINFO(/obj/machinery/networked/test_apparatus)
 			boutput(user, "That is far too big to fit!")
 			return
 
+	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+		if (!istype(O,/obj/) || O.anchored) return
+		if (BOUNDS_DIST(src, O) > 0 || !isturf(O.loc)) return
+		if (!in_interact_range(user, O) || !in_interact_range(user, src) || !isalive(user)) return
+		src.attackby(O, user)
+
 /obj/machinery/networked/test_apparatus/impact_pad
 	name = "Impact Sensor Pad"
 	desc = "A floor pad that detects the physical reactions of objects placed on it."
@@ -3945,6 +3951,12 @@ TYPEINFO(/obj/machinery/networked/test_apparatus)
 			I.set_loc(src.loc)
 
 		return
+
+	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+		if (!istype(O,/obj/) || O.anchored) return
+		if (BOUNDS_DIST(src, O) > 0 || !isturf(O.loc)) return
+		if (!in_interact_range(user, O) || !in_interact_range(user, src) || !isalive(user)) return
+		src.attackby(O, user)
 
 	hitby(atom/movable/M, datum/thrown_thing/thr)
 		if (src.density)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[QOL][SCIENCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds 'MouseDrag_T' to the ArtLab pitching machine and impact pad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Silicons can't refill the pitching machine or put an artifact on the impact pad when its raised.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DrWolfy
(+)Add drag and drop to artlab pitching machine and impact pad
```
