### PR TITLE
changes `blood_absorption_rate` into `proc/get_blood_absorption_rate()` and make it depend on the blood level on `living/human`

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -100,7 +100,6 @@
 	var/blood_color = DEFAULT_BLOOD_COLOR
 	var/bleeding = 0
 	var/bleeding_internal = 0
-	var/blood_absorption_rate = 1 // amount of blood to absorb from the reagent holder per Life()
 	var/list/bandaged = list()
 	var/being_staunched = 0 // is someone currently putting pressure on their wounds?
 
@@ -2265,3 +2264,7 @@
 		else
 			src.say(message)
 		src.stat = old_stat // back to being dead 😌
+
+/// Returns the rate of blood to absorb from the reagent holder per Life()
+/mob/living/proc/get_blood_absorption_rate()
+	return 1 // that's the standard absorption rate

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3475,3 +3475,23 @@
 		. += 1
 	if(istype(src.wear_mask, /obj/item/clothing/mask/clown_hat))
 		. += 1
+
+/mob/living/carbon/human/get_blood_absorption_rate()
+	. = ..()
+	var/blood_metabolism_multiplier = 1
+	//We adjust the amount of blood we absorb depending on how much the body needs it. Hypotensive causes a higher rate, Hypertensive causes a decreased rate
+	switch(src.blood_volume)
+		if(551 to INFINITY)
+			blood_metabolism_multiplier = 0.8
+		if(476 to 550)
+			blood_metabolism_multiplier = 1
+		if(426 to 475)
+			blood_metabolism_multiplier = 1.25
+		if(301 to 425)
+			blood_metabolism_multiplier = 1.5
+		if(201 to 300)
+			blood_metabolism_multiplier = 2
+		else
+			blood_metabolism_multiplier = 3
+	//Now we multiply the absorption rate with the metabolism multiplier
+	. *= blood_metabolism_multiplier

--- a/code/mob/living/life/chems.dm
+++ b/code/mob/living/life/chems.dm
@@ -13,7 +13,7 @@
 			owner.reagents.temperature_reagents(owner.bodytemperature, 100*reagent_time_multiplier, 100, 15*reagent_time_multiplier)
 
 			if (blood_system && owner.reagents.get_reagent("[owner.blood_id]"))
-				var/blood2absorb = min(owner.blood_absorption_rate, owner.reagents.get_reagent_amount("[owner.blood_id]")) * reagent_time_multiplier
+				var/blood2absorb = min(owner.get_blood_absorption_rate(), owner.reagents.get_reagent_amount("[owner.blood_id]")) * reagent_time_multiplier
 				owner.reagents.remove_reagent("[owner.blood_id]", blood2absorb)
 				owner.blood_volume += blood2absorb
 			if (owner.metabolizes && owner.reagents)//idk it runtimes)


### PR DESCRIPTION
[medical][rework][internal]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes `blood_absorption_rate` from `/mob/living` and instead introduces `/mob/living/proc/get_blood_absorption_rate()`. This proc returns a value that is instead of `blood_absorption_rate` used to determine how much blood a target gains from blood in their reagent holder.

Secondly, for `living/human`, the blood absorption rate now depends on how high their blood level is. On hypotension it is higher, on hypertension lower.

At following blood levels, blood will be metabolized at the following rates (formerly 1u/lifetick)

- 551+       : 0,8u/lifetick
- 476 - 550: 1u/lifetick
- 426 - 475: 1.25u/lifetick
- 301 - 425: 1.5u/lifetick
- 201 - 300: 2u/lifetick
- 0     - 299: 3u/lifetick 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Firstly, this enables to set the blood absorption rate dynamically depending on the circumstances on the mob. This means e.g. we could make mutantraces that have a much harder time absorbing blood. Or add mutations that inhibit the absorption of blood or make it easier to bloodgib.

Secondly, Making the blood absorption rate depend on the blood level on humans makes it easier to treat severe cases of hypotension (e.g. vampire attacks). Likewise, it makes blood injection to bloodgib slightly harder.

Lastly, it wa brought to my attention that the dialysis machine buff in #16698 made it able to overpower the blood metabolism rate and, given unreasonable long use, bleed people dry. With this change, the blood level will reach an equilibrium at around 430 blood level.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Being hypotensive makes it easier to receive blood via injetions (e.g. bloodbags) and likewise being hypertensive causes injected blood to be slightly harder to metabolize
```
