### PR TITLE
Fix false walls made of transparent materials losing transparency on close

### DIFF
--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -189,7 +189,7 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 		src.pathable = 0
 		src.update_air_properties()
 		if (src.visible)
-			src.set_opacity(1)
+			src.set_opacity(src.material.getAlpha() <= MATERIAL_ALPHA_OPACITY ? FALSE : TRUE)
 		src.setIntact(TRUE)
 		update_nearby_tiles()
 		SPAWN(delay)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MATERIALS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the `set_opacity` call on `/turf/simulated/wall/false_wall/proc/close` to respect the alpha of the material its made of

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fix #16882