### PR TITLE
Don't allow unpowered bolted airlocks to be unbolted

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -981,7 +981,7 @@ About the new airlock wires panel:
 				src.set_locked()
 				tgui_process.update_uis(src)
 			else
-				if(src.arePowerSystemsOn()) //only can raise bolts if power's on
+				if(src.arePowerSystemsOn() && !(src.status & NOPOWER)) //only can raise bolts if power's on
 					boutput(usr, "You hear a clunk from inside the door.")
 					src.set_unlocked()
 			SPAWN(1 DECI SECOND)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[Game-Objects] [Bug] [Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Currently you can raise the bolts of an unpowered door if the door is unpowered because the area does not have power.
This PR fixes that by also checking if the door is actually powered.

Because this change makes it impossible to raise the bolts until the area is powered too, this may have an impact on how the AI may bolt their upload.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugs bad, mkay?

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(+)Airlocks now also require the area to have power to raise the bolts.
```
