### PR TITLE
Electric Chair Fixes

### DIFF
--- a/code/obj/item/assembly/shock_kit.dm
+++ b/code/obj/item/assembly/shock_kit.dm
@@ -46,8 +46,8 @@
 	else return ..()
 
 /obj/item/assembly/shock_kit/attack_self(mob/user as mob)
-	src.part1.attack_self(user, src.status)
-	src.part2.attack_self(user, src.status)
+	src.part1.AttackSelf(user)
+	src.part2.AttackSelf(user)
 	src.add_fingerprint(user)
 	return
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -803,6 +803,7 @@ TYPEINFO(/obj/item/radiojammer)
 		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit( user )
 		W.set_loc(A)
 		A.part1 = W
+		W.master = A
 		W.layer = initial(W.layer)
 		user.u_equip(W)
 		user.put_in_hand_or_drop(A)
@@ -810,6 +811,7 @@ TYPEINFO(/obj/item/radiojammer)
 		user.u_equip(src)
 		src.set_loc(A)
 		A.part2 = src
+		src.master = A
 		src.add_fingerprint(user)
 	return
 

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1493,6 +1493,8 @@ TYPEINFO(/obj/stool/chair/dining/wood)
 				if (!(src.part1 && istype(src.part1)))
 					src.part1 = new /obj/item/assembly/shock_kit(src)
 					src.part1.master = src
+				// Set on/off to electropack's status
+				src.on = src.part1.part2.on
 				src.UpdateIcon()
 		return
 

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1493,8 +1493,6 @@ TYPEINFO(/obj/stool/chair/dining/wood)
 				if (!(src.part1 && istype(src.part1)))
 					src.part1 = new /obj/item/assembly/shock_kit(src)
 					src.part1.master = src
-				// Set on/off to electropack's status
-				src.on = src.part1.part2.on
 				src.UpdateIcon()
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Properly set `master` of helmet and electropack in `shock_kit` construction because the latter won't pass received signals to it otherwise
- Change `attack_self` calls to `AttackSelf` calls in `/obj/item/assembly/shock_kit/attack_self` because it was making the electropack UI not update properly
- ~~Sets initial on/off state of electric chair to on/off state of electropack used to construct it because literally nobody knows the right click menu to turn it on exists (reworking that is outside the scope of the PR)~~

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fixes
