### PR TITLE
Fix photos showing up in inventory

### DIFF
--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -215,32 +215,31 @@ TYPEINFO(/obj/item/camera_film/large)
 		..(location)
 		if (istype(IM))
 			fullImage = IM
-			IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
-			IM.pixel_y = 1
-			src.UpdateOverlays(IM, "photo")
+			render_photo_image(src.layer)
 		if (istype(IC))
 			fullIcon = IC
 		if (nname)
 			src.name = nname
 		if (ndesc)
 			src.desc = ndesc
+
+	/// Resize and update photo overlay (layer)
+	proc/render_photo_image(var/layer)
+		var/image/IM = src.fullImage
+		IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
+		IM.pixel_y = 1
+		IM.layer = layer
+		src.UpdateOverlays(IM, "photo")
+
 	// Update overlay layer for photo to show in hand/backpack
 	pickup()
 		..()
-		var/image/IM = fullImage
-		IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
-		IM.pixel_y = 1
-		IM.layer = HUD_LAYER_2
-		src.UpdateOverlays(IM, "photo")
+		render_photo_image(HUD_LAYER_2)
 
 	// Update overlay layer for photo when dropping on floor or in belt/bag/container
 	dropped()
 		..()
-		var/image/IM = fullImage
-		IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
-		IM.pixel_y = 1
-		IM.layer = src.layer
-		src.UpdateOverlays(IM, "photo")
+		render_photo_image(src.layer)
 
 /obj/item/photo/get_desc(var/dist)
 	if(dist>1)
@@ -254,7 +253,6 @@ TYPEINFO(/obj/item/camera_film/large)
 				. += "<br>"
 		if (written)
 			. += "At the bottom is written: [written]"
-
 
 /obj/item/photo/attackby(obj/item/W, mob/user)
 	var/obj/item/pen/P = W

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -224,6 +224,23 @@ TYPEINFO(/obj/item/camera_film/large)
 			src.name = nname
 		if (ndesc)
 			src.desc = ndesc
+	// Update overlay layer for photo to show in hand/backpack
+	pickup()
+		..()
+		var/image/IM = fullImage
+		IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
+		IM.pixel_y = 1
+		IM.layer = HUD_LAYER_2
+		src.UpdateOverlays(IM, "photo")
+
+	// Update overlay layer for photo when dropping on floor or in belt/bag/container
+	dropped()
+		..()
+		var/image/IM = fullImage
+		IM.transform = matrix(24/32, 22/32, MATRIX_SCALE)
+		IM.pixel_y = 1
+		IM.layer = src.layer
+		src.UpdateOverlays(IM, "photo")
 
 /obj/item/photo/get_desc(var/dist)
 	if(dist>1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
First attempt at solving the issue of polaroid photos showing contents when on the ground, but not when in hand/belt/bag/photobook. Do note, this doesn't get other overlays (stickers, blood, signatures, writing) to show up on the photos in hand, but I couldn't find a straightforward way to update that without running a ton of .UpdateOverlays which I understand are kind of resource intensive...  They still show up correctly when the photo is on the floor. 

![image](https://github.com/goonstation/goonstation/assets/5091297/e4e38b3e-f6c1-4a77-a56f-910a7e920aaa)

Best I can tell, the `src.UpdateOverlays(IM, "photo")` overlay doesn't get updated when the photo changes layers between floor and hands. Is there a better way to force this overlay to update?

I know upfront this probably isn't the most efficient code or clean enough to push to prod, so I'd appreciate some guidance in getting it cleaned up as I've hit my level of understanding😸😅 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9120 
First attempt at least... Tourists should be able to show off their photobook with ease! Stare at your picture of Jones in your hand forever! 