### PR TITLE
Fix leading space in job names of mhelps

### DIFF
--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -130,10 +130,10 @@
 	if (client?.ismuted())
 		return
 
-	var/dead = isdead(client.mob) ? "Dead" : ""
+	var/dead = isdead(client.mob) ? "Dead " : ""
 	var/ircmsg[] = new()
 	ircmsg["key"] = client.key
-	ircmsg["name"] = client.mob.job ? "[stripTextMacros(client.mob.real_name)] \[[dead] [client.mob.job]]" : (dead ? "[stripTextMacros(client.mob.real_name)] \[[dead]\]" : stripTextMacros(client.mob.real_name))
+	ircmsg["name"] = client.mob.job ? "[stripTextMacros(client.mob.real_name)] \[[dead][client.mob.job]]" : (dead ? "[stripTextMacros(client.mob.real_name)] \[[dead]\]" : stripTextMacros(client.mob.real_name))
 	ircmsg["msg"] = html_decode(msg)
 	var/unique_message_id = md5("mhelp" + json_encode(ircmsg))
 	ircmsg["msgid"] = unique_message_id


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Move space separating "Dead" from job name to the dead string instead of being in the combined string and thus appearing every time regardless of "Dead" being added

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Please god it bugs me so much
