### PR TITLE
Donut sticker fix

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -498,6 +498,9 @@ TRAYS
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/tongs))
 			return src.Attackhand(user)
+		// Stops trying to fit sticker in the box when we want it ON the box
+		if (istype(W, /obj/item/sticker))
+			return
 		if(src.count >= src.max_count)
 			boutput(user, "You can't fit anything else in [src]!")
 			return

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -520,14 +520,22 @@ TRAYS
 			if(!user.put_in_hand(src))
 				return ..()
 
+	proc/find_food(var/list/box_contents)
+		// First in, last out food search
+		// Mostly needed since stickers add themselves to contents and need to stay there to be able to be removed...
+		for (var/i = length(box_contents) to 1 step -1)
+			var/obj/content = box_contents[i]
+			if (istype(content, /obj/item/reagent_containers/food/snacks))
+				return content
+
 	attack_hand(mob/user)
 		if((!istype(src.loc, /turf) && !user.is_in_hands(src)) || src.count == 0)
 			..()
 			return
 		src.add_fingerprint(user)
 		var/list/obj/item/reagent_containers/food/snacks/myFoodList = src.contents
-		if(length(myFoodList) >= 1)
-			var/obj/item/reagent_containers/food/snacks/myFood = myFoodList[myFoodList.len]
+		var/obj/item/reagent_containers/food/snacks/myFood = find_food(myFoodList)
+		if(myFood)
 			if(src.count >= 1)
 				src.count--
 				tooltip_rebuild = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
No more deleting donuts/lollypops/eggs/sugar cubes with stickers! Food boxes (/obj/item/kitchen/food_box) were checking food_box.contents, which should just contain the relevant allowed_food, but stickers add themselves to that list so they can later be removed by fire/acetone. Added a proc to return the next valid food in the list vs whatever was next in the list so objects within the box get correctly decremented. 

Also stops the duplicate message saying "You put the [sticker] **into** the [food_box]" since that doubles up with "You place the [sticker] **on** the [food box]" and we're not putting it in the box.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12749