### PR TITLE
Fix Robustris score covering CHUI titlebar

### DIFF
--- a/browserassets/html/tetris.html
+++ b/browserassets/html/tetris.html
@@ -72,7 +72,8 @@
       this.cvs.height = 500;
 
       this.cvs.style.left = 0 + 'px';
-      this.cvs.style.top =  0 + 'px';
+			// shift down 46 pixels to avoid covering chui titlebar
+      this.cvs.style.top =  46 + 'px';
     },
 
     Initialize: function(){

--- a/code/obj/machinery/computer/tetris/tetris.dm
+++ b/code/obj/machinery/computer/tetris/tetris.dm
@@ -127,6 +127,6 @@ ABSTRACT_TYPE(/datum/game)
 		var/dat = replacetext(code, "{{HIGHSCORE}}", num2text(highscore))
 		dat = replacetext(dat, "{{TOPICURL}}", "'?src=\ref[src];highscore='+this.ScoreCur;")
 
-		user.Browse(dat, "window=tetris;size=375x500")
+		user.Browse(dat, "window=tetris;size=375x546")
 		onclose(user, "tetris")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Shifts the Robustris canvas down 46 pixels because both it and the CHUI titlebar use `position: absolute` and `top: 0px left: 0px`
![image](https://github.com/goonstation/goonstation/assets/75404941/3db03455-fb63-4917-af1d-bd237bea6071)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #16940 