### PR TITLE
Fix Museum of Lunar History Tour Guide Breaking

### DIFF
--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -839,6 +839,7 @@ Contents:
 	desc = "A security door used to separate museum compartments."
 	autoclose = FALSE
 	req_access_txt = ""
+	object_flags = BOTS_DIRBLOCK
 
 /obj/machinery/door/poddoor/blast/lunar/tour
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the `BOTS_DIRBLOCK` object flag to the blast doors in the Museum of Lunar History.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The tour guide's pathfinding got broken at some point because it no longer considered the blast doors valid paths it could go through even though the map is designed to have it open a bunch of them
