### PR TITLE
Disable "give random game tip" task on Lunar Museum tour bot

### DIFF
--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -645,6 +645,8 @@ Contents:
 /datum/computer/file/guardbot_task/tourguide/lunar
 
 	wait_for_guests = 1
+	// focus, Molly.
+	tip_prob = 0
 
 	var/neat_things_underground = 0
 	var/has_been_underground = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[REMOVAL] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets `tip_prob` to 0 for the Lunar Museum tour subtype.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

While funny, it is a bit weird and out of character for Molly to interrupt a speech about moon rocks to tell you that you can use your own money to buy shipments from cargo
