### PR TITLE
red bucket for borg

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3240,6 +3240,39 @@
 /mob/living/silicon/robot/handle_event(var/event, var/sender)
 	hud.handle_event(event, sender)	// the HUD will handle icon_updated events, so proxy those
 
+/// Modify one tool in existing module, ex redeeming rewards or modififying sponge. Assumes item is in hand
+/mob/living/silicon/robot/proc/swap_individual_tool(var/obj/item/old_tool, var/obj/item/new_tool)
+	var/tool_index
+
+	// Find index of the tool in hand
+	for (var/i = 1 to (src.module_states.len) step 1)
+		var/obj/module_content = src.module_states[i]
+		if (istype(module_content, old_tool.type))
+			tool_index = i
+
+	// Unequip the old tool in hand
+	src.uneq_slot(tool_index)
+
+	// Set new tool to same location as old tool in hand
+	src.module_states[tool_index] = new_tool
+
+	// Set loc and pickup our new tool in hand
+	new_tool.set_loc(src)
+	new_tool.pickup(src)
+
+	// Find module entry for the tool in module
+	for (var/i = 1 to (src.module.tools.len) step 1)
+		var/obj/module_tool = src.module.tools[i]
+		if (istype(module_tool, old_tool.type))
+			tool_index = i
+
+	// Replace the tool module in the correct slot
+	src.module.tools[tool_index] = new_tool
+
+	// Update everything at the end
+	src.hud.update_tools()
+	src.hud.update_equipment()
+
 ///////////////////////////////////////////////////
 // Specific instances of robots can go down here //
 ///////////////////////////////////////////////////

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3250,6 +3250,10 @@
 		if (istype(module_content, old_tool.type))
 			tool_index = i
 
+	// If tool is not found in hand, let's stop
+	if (!tool_index)
+		return
+
 	// Unequip the old tool in hand
 	src.uneq_slot(tool_index)
 

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3276,7 +3276,7 @@
 		return
 
 	// Replace the tool module in the correct slot
-	src.module.tools[tool_index] = new_tool
+	src.module.tools[tool_module_index] = new_tool
 
 	// Update everything at the end
 	src.hud.update_tools()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3243,6 +3243,7 @@
 /// Modify one tool in existing module, ex redeeming rewards or modififying sponge. Assumes item is in hand
 /mob/living/silicon/robot/proc/swap_individual_tool(var/obj/item/old_tool, var/obj/item/new_tool)
 	var/tool_index
+	var/tool_module_index
 
 	// Find index of the tool in hand
 	for (var/i = 1 to (src.module_states.len) step 1)
@@ -3268,7 +3269,11 @@
 	for (var/i = 1 to (src.module.tools.len) step 1)
 		var/obj/module_tool = src.module.tools[i]
 		if (istype(module_tool, old_tool.type))
-			tool_index = i
+			tool_module_index = i
+
+	// If tool is not found in hand, let's stop
+	if (!tool_module_index)
+		return
 
 	// Replace the tool module in the correct slot
 	src.module.tools[tool_index] = new_tool

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -404,8 +404,13 @@
 			skin_target.fingerprints = null
 			skin_target.fingerprints_full = null
 			skin_target.fingerprintslast = null
+			// Update borg's bucket in their module, don't drop it
+			if (issilicon(activator))
+				var/mob/living/silicon/robot/borg_activator = activator
+				borg_activator.swap_individual_tool(skin_target, new_bucket)
+			else
+				activator.put_in_hand(new_bucket)
 			qdel(skin_target)
-			activator.put_in_hand(new_bucket)
 			return 1
 		else
 			boutput(activator, SPAN_ALERT("Unable to redeem... you need to have a bucket in your hands."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Feature][Medal][Silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Borgs can now redeem the https://wiki.ss13.co/Medals#Spotless red bucket reward in the same way human mobs can via a new function to modify individual silicon module tools. This fixes the bucket from "falling out" of the module if the reward is redeemed today. 

In "hand"
![image](https://github.com/goonstation/goonstation/assets/5091297/d7af89fa-2e75-46b8-94e9-64c099521fe5)
In module
![image](https://github.com/goonstation/goonstation/assets/5091297/ee767771-b576-4114-bfc7-652cb7978722)

I'm not sure if my level of error handling is sufficient, and would appreciate feedback please!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8585
Creates building block function to modify cyborg module contents through external means. This helps when the modification isn't a simple icon_state change (round-bottom flask reward) but requires a new object type to swap in the old object. For example, I've got a followup PR for #11496 after this is merged.
