### PR TITLE
make cogmap2 genetics/pathology green

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -51834,13 +51834,13 @@
 	},
 /obj/machinery/chem_dispenser/chemical,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 9
 	},
 /area/station/medical/cdc)
 "cTW" = (
 /obj/machinery/vending/pathology,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -51848,7 +51848,7 @@
 /obj/machinery/pathogen_manipulator,
 /obj/item/device/radio/intercom/medical,
 /obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -51863,14 +51863,14 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/cdc)
 "cTZ" = (
 /obj/machinery/synthomatic,
 /obj/machinery/light_switch/north,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/cdc)
@@ -51881,7 +51881,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 5
 	},
 /area/station/medical/cdc)
@@ -51897,7 +51897,7 @@
 	},
 /obj/machinery/cashreg,
 /obj/disposalpipe/segment/transport,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 9
 	},
 /area/station/medical/research{
@@ -51905,7 +51905,7 @@
 	})
 "cUd" = (
 /obj/disposalpipe/segment,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research{
@@ -51915,7 +51915,7 @@
 /obj/storage/secure/closet/medical{
 	name = "locker"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research{
@@ -51930,7 +51930,7 @@
 	mail_tag = "genetics";
 	name = "mail junction (genetics)"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research{
@@ -51939,7 +51939,7 @@
 "cUg" = (
 /obj/disposalpipe/trunk/mail/west,
 /obj/machinery/disposal/mail/autoname/medbay/genetics,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research{
@@ -51954,7 +51954,7 @@
 	pixel_y = 5;
 	print_id = "Genetics"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
 /area/station/medical/research{
@@ -51967,7 +51967,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 5
 	},
 /area/station/medical/research{
@@ -52401,7 +52401,7 @@
 	dir = 4;
 	pixel_x = -8
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -52423,7 +52423,7 @@
 	dir = 8;
 	pixel_x = 8
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -52437,7 +52437,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/research{
@@ -52479,7 +52479,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research{
@@ -52765,13 +52765,13 @@
 /area/station/medical/head)
 "cWw" = (
 /obj/machinery/centrifuge,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/cdc)
 "cWx" = (
 /obj/machinery/centrifuge,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -52793,7 +52793,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /obj/landmark/start/job/geneticist,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/research{
@@ -52836,7 +52836,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /obj/machinery/light_switch/east,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research{
@@ -53410,7 +53410,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -53433,14 +53433,14 @@
 "cYa" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/reagent_containers/glass/petridish,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/cdc)
 "cYb" = (
 /obj/machinery/genetics_scanner,
 /obj/disposalpipe/segment/transport,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/research{
@@ -53487,7 +53487,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research{
@@ -53751,7 +53751,7 @@
 "cYZ" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/microscope,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -53780,7 +53780,7 @@
 "cZd" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/microscope,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -53790,7 +53790,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /obj/item/cloneModule/genepowermodule,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/research{
@@ -53832,7 +53832,7 @@
 /obj/machinery/computer/genetics{
 	dir = 8
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research{
@@ -54125,7 +54125,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/cdc)
@@ -54179,7 +54179,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/research{
@@ -54544,7 +54544,7 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 10
 	},
 /area/station/medical/cdc)
@@ -54552,13 +54552,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
 "daZ" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "dba" = (
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
 "dbb" = (
 /obj/machinery/light{
@@ -54568,7 +54568,7 @@
 	},
 /obj/disposalpipe/trunk/mail/south,
 /obj/machinery/disposal/mail/small/autoname/medbay/pathology/west,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 6
 	},
 /area/station/medical/cdc)
@@ -54583,7 +54583,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 10
 	},
 /area/station/medical/research{
@@ -54593,7 +54593,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
@@ -54603,7 +54603,7 @@
 	},
 /obj/machinery/light,
 /obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
@@ -54611,7 +54611,7 @@
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
@@ -54620,7 +54620,7 @@
 	name = "monkeydome chute"
 	},
 /obj/disposalpipe/trunk/transport,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 6
 	},
 /area/station/medical/research{
@@ -56609,7 +56609,7 @@
 "dhJ" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/drainage,
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/greenwhite,
 /area/station/medical/cdc)
 "dhK" = (
 /obj/lattice{
@@ -67902,7 +67902,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/agar_block,
 /obj/item/reagent_containers/food/snacks/yuck,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 4
 	},
 /area/station/medical/cdc)
@@ -74867,7 +74867,7 @@
 /obj/item/storage/pill_bottle/mutadone,
 /obj/machinery/firealarm/west,
 /obj/disposalpipe/segment/transport,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/greenwhite{
 	dir = 8
 	},
 /area/station/medical/research{


### PR DESCRIPTION
[MAPPING]
## About the PR
Makes the edges of the genetics and pathology rooms green instead of red.

## Why's this needed?
Other maps typically use green in their genetics departments. Map parity is good for navigation and clarity.

## Changelog
```changelog
(u)Tyrant
(+)Cogmap2 genetics is now repainted to be green instead of red.
```