### PR TITLE
Makes the progression of blood-loss more granular

### DIFF
--- a/code/mob/living/life/blood.dm
+++ b/code/mob/living/life/blood.dm
@@ -166,6 +166,8 @@
 					var/feeling = pick("[extreme]ill", "[extreme]sick", "[extreme]numb", "[extreme]cold", "[extreme]dizzy", "[extreme]out of it", "[extreme]confused", "[extreme]off-balance", "[extreme]terrible", "[extreme]awful", "like death", "like you're dying", "[extreme]tingly", "like you're going to pass out", "[extreme]faint")
 					boutput(owner, SPAN_ALERT("<b>You feel [feeling]!</b>"))
 					owner.changeStatus("weakened", 4 SECONDS * mult)
+				if (prob(30))
+					owner.changeStatus("shivering", 6 SECONDS)
 				owner.contract_disease(/datum/ailment/malady/shock, null, null, 1) // if you have no blood you're gunna be in shock
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -3)
 				owner.add_stam_mod_max("hypotension", -15)
@@ -179,12 +181,14 @@
 				if (prob(6))
 					owner.change_misstep_chance(rand(1,2) * mult)
 				if (prob(8))
-					owner.emote(pick("faint", "collapse", "pale", "shudder", "shiver", "gasp", "moan"))
+					owner.emote(pick("faint", "collapse", "pale", "shudder", "gasp", "moan"))
 				if (prob(14))
 					var/extreme = pick("", "really ", "very ", "extremely ", "terribly ", "insanely ")
 					var/feeling = pick("[extreme]ill", "[extreme]sick", "[extreme]numb", "[extreme]cold", "[extreme]dizzy", "[extreme]out of it", "[extreme]confused", "[extreme]off-balance", "[extreme]terrible", "[extreme]awful", "like death", "like you're dying", "[extreme]tingly", "like you're going to pass out", "[extreme]faint")
 					boutput(owner, SPAN_ALERT("<b>You feel [feeling]!</b>"))
 					owner.changeStatus("weakened", 3 SECONDS * mult)
+				if (prob(25))
+					owner.changeStatus("shivering", 6 SECONDS) // Getting very cold (same duration as shivers from cold)
 				if (prob(25))
 					owner.contract_disease(/datum/ailment/malady/shock, null, null, 1)
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -2)
@@ -192,7 +196,7 @@
 
 			if (300 to 415) // low (100/65)
 				if (prob(2))
-					owner.emote(pick("pale", "shudder", "shiver"))
+					owner.emote(pick("pale", "shudder")) // Additional shivers handled by the status effect
 				if (prob(5))
 					var/extreme = pick("", "kinda ", "a little ", "sorta ", "a bit ")
 					var/feeling = pick("ill", "sick", "numb", "cold", "dizzy", "out of it", "confused", "off-balance", "tingly", "faint")
@@ -200,10 +204,10 @@
 				if (prob(5))
 					owner.contract_disease(/datum/ailment/malady/shock, null, null, 1)
 				if (prob(15))
-					owner.setStatus("drowsy", 6 SECONDS * mult) //drowsiness and stuttering
+					owner.setStatus("drowsy", 6 SECONDS * mult) // Drowsiness and stuttering
 					owner.stuttering += rand(6,10)
 				else if (probmult(20))
-					owner.setStatus("slowed", 6 SECONDS, 7) //less slow than an average slowdown
+					owner.changeStatus("shivering", 6 SECONDS) // Feeling cold from low blood pressure
 					owner.change_eye_blurry(5, 5)
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -1)
 				owner.add_stam_mod_max("hypotension", -5)

--- a/code/mob/living/life/blood.dm
+++ b/code/mob/living/life/blood.dm
@@ -151,7 +151,7 @@
 			return ..()
 
 		switch (current_blood_amt)
-			if (-INFINITY to 10) // welp
+			if (-INFINITY to 1) // welp
 				owner.take_oxygen_deprivation(1 * mult)
 				owner.change_eye_blurry(7, 7)
 				owner.take_brain_damage(2 * mult)
@@ -170,7 +170,7 @@
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -3)
 				owner.add_stam_mod_max("hypotension", -15)
 
-			if (10 to 300) // very low (70/50)
+			if (1 to 300) // very low (70/50)
 				owner.take_oxygen_deprivation(0.8 * mult)
 				owner.take_brain_damage(0.8 * mult)
 				owner.losebreath += (0.8 * mult)

--- a/code/mob/living/life/blood.dm
+++ b/code/mob/living/life/blood.dm
@@ -151,8 +151,9 @@
 			return ..()
 
 		switch (current_blood_amt)
-			if (-INFINITY to 0) // welp
+			if (-INFINITY to 10) // welp
 				owner.take_oxygen_deprivation(1 * mult)
+				owner.change_eye_blurry(7, 7)
 				owner.take_brain_damage(2 * mult)
 				owner.losebreath += (1 * mult)
 				owner.setStatus("drowsy", rand(15, 20) SECONDS)
@@ -169,10 +170,11 @@
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -3)
 				owner.add_stam_mod_max("hypotension", -15)
 
-			if (1 to 299) // very low (70/50)
+			if (10 to 300) // very low (70/50)
 				owner.take_oxygen_deprivation(0.8 * mult)
 				owner.take_brain_damage(0.8 * mult)
 				owner.losebreath += (0.8 * mult)
+				owner.change_eye_blurry(5, 5)
 				owner.setStatus("drowsy", rand(5, 10) SECONDS)
 				if (prob(6))
 					owner.change_misstep_chance(rand(1,2) * mult)
@@ -188,7 +190,7 @@
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -2)
 				owner.add_stam_mod_max("hypotension", -10)
 
-			if (300 to 414) // low (100/65)
+			if (300 to 415) // low (100/65)
 				if (prob(2))
 					owner.emote(pick("pale", "shudder", "shiver"))
 				if (prob(5))
@@ -197,17 +199,23 @@
 					boutput(owner, SPAN_ALERT("<b>You feel [extreme][feeling]!</b>"))
 				if (prob(5))
 					owner.contract_disease(/datum/ailment/malady/shock, null, null, 1)
+				if (prob(15))
+					owner.setStatus("drowsy", 6 SECONDS * mult) //drowsiness and stuttering
+					owner.stuttering += rand(6,10)
+				else if (probmult(20))
+					owner.setStatus("slowed", 6 SECONDS, 7) //less slow than an average slowdown
+					owner.change_eye_blurry(5, 5)
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension", -1)
 				owner.add_stam_mod_max("hypotension", -5)
 
-			if (415 to 584) // normal (120/80)
+			if (415 to 585) // normal (120/80)
 				REMOVE_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypertension")
 				REMOVE_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypotension")
 				owner.remove_stam_mod_max("hypertension")
 				owner.remove_stam_mod_max("hypotension")
 				return ..()
 
-			if (585 to 665) // high (140/90)
+			if (585 to 666) // high (140/90)
 				if (prob(2))
 					var/msg = pick("You feel kinda sweaty",\
 					"You can feel your heart beat loudly in your chest",\
@@ -222,7 +230,7 @@
 				APPLY_ATOM_PROPERTY(owner, PROP_MOB_STAMINA_REGEN_BONUS, "hypertension", -1)
 				owner.add_stam_mod_max("hypertension", -5)
 
-			if (666 to 749) // very high (160/100)
+			if (666 to 750) // very high (160/100)
 				if (prob(2))
 					var/msg = pick("You feel sweaty",\
 					"Your heart beats rapidly",\


### PR DESCRIPTION
[LABEL][Medical][Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a chance of drowsiness, stuttering, blurry vision and shiver slowdowns when the player is between 300 and 415 blood.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As it stands, the divide between more than 300 blood and less than 300 blood is very binary, and you go pretty fast from very negligible effects to extremely severe ones. Hopefully this PR would make the stage just before the dangerous part of low blood pressure more significant, and make the progression of blood loss more linear and less binary.

## Changelog

```changelog
(u)Colossusqw
(+)Non-lethal bleeding now has a bit more imposing effects.
```
