### PR TITLE
Fix Gnome Chompski Crew Objective Never Succeeding

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -978,7 +978,7 @@ ABSTRACT_TYPE(/datum/objective/crew/staffassistant)
 	explanation_text = "Ensure that Gnome Chompski escapes on the shuttle."
 	medal_name = "Guardin' gnome"
 	check_completion()
-		for_by_tcl(G, /obj/item/gnomechompski)
+		for(var/obj/item/gnomechompski/G in by_cat[TR_CAT_GHOST_OBSERVABLES])
 			if (in_centcom(G)) return 1
 		return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the search for Gnome Chompski in `/datum/objective/crew/staffassistant/chompski/check_completion` to `by_cat[TR_CAT_GHOST_OBSERVABLES]` because Chompski was moved into there at some point

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17089 
