### PR TITLE
Fixes resonators being fixable with closed panel

### DIFF
--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -628,6 +628,7 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 		else if(istype(W,/obj/item/cable_coil))
 			if(!src.panelopen)
 				boutput(user,"The service panel isn't open.")
+				return
 			if(HAS_FLAG(src.status,BROKEN))
 				if(W.amount >= 3)
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 40, 1)


### PR DESCRIPTION
[BUG][GAME OBJECTS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes the bug that allowed players to replace the wiring of resonators without the panel being open by adding a missing `return` statement


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bugfix, bugfixes are good, everybody loves fixed bugs.
