### PR TITLE
Implement preassembled pod frames

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
+++ b/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
@@ -12,14 +12,6 @@
 	)
 	available = list(
 		/datum/manufacture/pod_wars/lock,
-		/datum/manufacture/putt/engine,
-		/datum/manufacture/putt/boards,
-		/datum/manufacture/putt/control,
-		/datum/manufacture/putt/parts,
-		/datum/manufacture/pod/boards,
-		/datum/manufacture/pod/control,
-		/datum/manufacture/pod/parts,
-		/datum/manufacture/pod/engine,
 		/datum/manufacture/engine2,
 		/datum/manufacture/engine3,
 		/datum/manufacture/pod/lock,
@@ -66,14 +58,6 @@
 	team_num = TEAM_NANOTRASEN
 	available = list(
 		/datum/manufacture/pod_wars/lock,
-		/datum/manufacture/putt/engine,
-		/datum/manufacture/putt/boards,
-		/datum/manufacture/putt/control,
-		/datum/manufacture/putt/parts,
-		/datum/manufacture/pod/boards,
-		/datum/manufacture/pod/control,
-		/datum/manufacture/pod/parts,
-		/datum/manufacture/pod/engine,
 		/datum/manufacture/engine2,
 		/datum/manufacture/engine3,
 		/datum/manufacture/pod/lock,
@@ -101,14 +85,6 @@
 	team_num = TEAM_SYNDICATE
 	available = list(
 		/datum/manufacture/pod_wars/lock,
-		/datum/manufacture/putt/engine,
-		/datum/manufacture/putt/boards,
-		/datum/manufacture/putt/control,
-		/datum/manufacture/putt/parts,
-		/datum/manufacture/pod/boards,
-		/datum/manufacture/pod/control,
-		/datum/manufacture/pod/parts,
-		/datum/manufacture/pod/engine,
 		/datum/manufacture/engine2,
 		/datum/manufacture/engine3,
 		/datum/manufacture/pod/lock,

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2916,33 +2916,6 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /////// pod construction components
 
-/datum/manufacture/pod/parts
-	name = "Pod Frame Kit"
-	item_paths = list("MET-2")
-	item_amounts = list(30)
-	item_outputs = list(/obj/item/pod/frame_box)
-	time = 20 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/pod/engine
-	name = "Engine Manifold"
-	item_paths = list("MET-2","CON-1")
-	item_amounts = list(10,5)
-	item_outputs = list(/obj/item/pod/engine)
-	time = 10 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/pod/boards
-	name = "Pod Circuitry"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(5,5)
-	item_outputs = list(/obj/item/pod/boards)
-	time = 10 SECONDS
-	create = 1
-	category = "Component"
-
 /datum/manufacture/pod/armor_light
 	name = "Light Pod Armor"
 	item_paths = list("MET-2","CON-1")
@@ -2970,15 +2943,6 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Component"
 
-/datum/manufacture/pod/control
-	name = "Pod Control Interface"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(10,10)
-	item_outputs = list(/obj/item/pod/control)
-	time = 10 SECONDS
-	create = 1
-	category = "Component"
-
 /datum/manufacture/pod/preassembeled_parts
 	name = "Preassembled Pod Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")
@@ -2989,43 +2953,6 @@ ABSTRACT_TYPE(/datum/manufacture)
 	category = "Component"
 
 ABSTRACT_TYPE(/datum/manufacture/sub)
-
-/datum/manufacture/sub/parts
-	name = "Minisub Frame Kit"
-	item_paths = list("MET-2")
-	item_amounts = list(15)
-	item_outputs = list(/obj/item/sub/frame_box)
-	time = 10 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/sub/engine
-	name = "Minisub Engine Manifold"
-	item_paths = list("MET-2","CON-1")
-	item_amounts = list(5,2)
-	item_outputs = list(/obj/item/sub/engine)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/sub/boards
-	name = "Minisub Circuitry"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(2,2)
-	item_outputs = list(/obj/item/sub/boards)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/sub/control
-	name = "Minisub Control Interface"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(5,5)
-	item_outputs = list(/obj/item/sub/control)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
 /datum/manufacture/sub/preassembeled_parts
 	name = "Preassembled Minisub Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")
@@ -3036,43 +2963,6 @@ ABSTRACT_TYPE(/datum/manufacture/sub)
 	category = "Component"
 
 ABSTRACT_TYPE(/datum/manufacture/putt)
-
-/datum/manufacture/putt/parts
-	name = "MiniPutt Frame Kit"
-	item_paths = list("MET-2")
-	item_amounts = list(15)
-	item_outputs = list(/obj/item/putt/frame_box)
-	time = 10 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/putt/engine
-	name = "MiniPutt Engine Manifold"
-	item_paths = list("MET-2","CON-1")
-	item_amounts = list(5,2)
-	item_outputs = list(/obj/item/putt/engine)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/putt/boards
-	name = "MiniPutt Circuitry"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(2,2)
-	item_outputs = list(/obj/item/putt/boards)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
-/datum/manufacture/putt/control
-	name = "MiniPutt Control Interface"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(5,5)
-	item_outputs = list(/obj/item/putt/control)
-	time = 5 SECONDS
-	create = 1
-	category = "Component"
-
 /datum/manufacture/putt/preassembeled_parts
 	name = "Preassembled MiniPutt Frame Kit"
 	item_paths = list("MET-2","CON-1","CRY-1")

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -75,10 +75,6 @@ var/datum/station_zlevel_repair/station_repair = new
 		if(add_sub)
 			for_by_tcl(man, /obj/machinery/manufacturer)
 				if(istype(man, /obj/machinery/manufacturer/hangar) && (man.z == Z_LEVEL_STATION))
-					man.add_schematic(/datum/manufacture/sub/engine)
-					man.add_schematic(/datum/manufacture/sub/boards)
-					man.add_schematic(/datum/manufacture/sub/control)
-					man.add_schematic(/datum/manufacture/sub/parts)
 					man.add_schematic(/datum/manufacture/sub/wheels)
 
 	proc/mass_driver_fixup()

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2639,23 +2639,14 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/obj/item/material_piece/glass)
 	available = list(
 #ifdef UNDERWATER_MAP
-		/datum/manufacture/sub/engine,
-		/datum/manufacture/sub/boards,
-		/datum/manufacture/sub/control,
-		/datum/manufacture/sub/parts,
+		/datum/manufacture/sub/preassembeled_parts,
 #else
-		/datum/manufacture/putt/engine,
-		/datum/manufacture/putt/boards,
-		/datum/manufacture/putt/control,
-		/datum/manufacture/putt/parts,
+		/datum/manufacture/putt/preassembeled_parts,
+		/datum/manufacture/pod/preassembeled_parts,
 #endif
-		/datum/manufacture/pod/engine,
-		/datum/manufacture/pod/boards,
 		/datum/manufacture/pod/armor_light,
 		/datum/manufacture/pod/armor_heavy,
 		/datum/manufacture/pod/armor_industrial,
-		/datum/manufacture/pod/control,
-		/datum/manufacture/pod/parts,
 		/datum/manufacture/cargohold,
 		/datum/manufacture/orescoop,
 		/datum/manufacture/conclave,
@@ -2664,6 +2655,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/pod/weapon/mining,
 		/datum/manufacture/pod/weapon/mining/drill,
 		/datum/manufacture/pod/weapon/ltlaser,
+		/datum/manufacture/engine,
 		/datum/manufacture/engine2,
 		/datum/manufacture/engine3,
 		/datum/manufacture/pod/lock,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements https://github.com/goonstation/goonstation/pull/15196
Removes the now unnecessary pod/submarine frame and Engine manifolds, Circuit boards, Control interface.

Needs Magpie manufacturer to be edited in secrets.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Actually makes Preassembled Pod Kits do something.
Simplifies pod/sub construction.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Garash2k & Flappybat
(*)Pod/sub construction has been replaced with Preassembled Pod Kits. No longer do you need half a dozen components, just assemble and add pod armor!
```
