### PR TITLE
Fixes a typo in implant message

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1556,7 +1556,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			if (sneaky)
 				boutput(user, SPAN_ALERT("You implanted yourself."))
 			else
-				user.visible_message(SPAN_ALERT(">[user] has implanted [him_or_her(user)]self."),\
+				user.visible_message(SPAN_ALERT("[user] has implanted [him_or_her(user)]self."),\
 					SPAN_ALERT("You implanted yourself."))
 		else
 			if (sneaky)


### PR DESCRIPTION
[BUG][GAME OBJECTS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #17130, a bug that showed a > in front of the "Person has implanted themselves" message.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bugfix, bugfixes are good, and I want to ~~_reach my monthly PR goal_~~ improve the game.
