### PR TITLE
Better food processor checks

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -1223,6 +1223,10 @@ TYPEINFO(/obj/submachine/foodprocessor)
 			if (!proceed)
 				boutput(user, SPAN_ALERT("You can't put that in the processor!"))
 				return
+			// If item is attached to you, don't drop it in, ex Silicons can't load in their icing tubes
+			if (W.cant_drop)
+				boutput(user, SPAN_ALERT("You can't put that in the [src] when it's attached to you!"))
+				return
 			user.visible_message(SPAN_NOTICE("[user] loads [W] into the [src]."))
 			user.u_equip(W)
 			W.set_loc(src)
@@ -1266,9 +1270,11 @@ TYPEINFO(/obj/submachine/foodprocessor)
 			user.visible_message(SPAN_NOTICE("[user] begins quickly stuffing food into [src]!"))
 			var/staystill = user.loc
 			for(var/obj/item/reagent_containers/food/M in view(1,user))
-				M.set_loc(src)
-				sleep(0.3 SECONDS)
-				if (user.loc != staystill) break
+				// Stop putting attached items in processor, looking at you borgs with icing tubes...
+				if (!M.cant_drop)
+					M.set_loc(src)
+					sleep(0.3 SECONDS)
+					if (user.loc != staystill) break
 			for(var/obj/item/plant/P in view(1,user))
 				P.set_loc(src)
 				sleep(0.3 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check if the eligible item being added to the food processor is tagged with "cant_drop". If so, don't add it in. Adds a check for both click-dragging and directly clicking the food processor with the item. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13110 
Prevents the civilian borg icing tube from being duplicated by making it not eligible to be grabbed in the list of qualifying items around the user when click dragging.

Fixes #14824 
Prevents the civilian borg icing tube from being inserted into the food processor, which effectively was removing it from the cyborg module and cursing the handed person who grabbed it after.