### PR TITLE
Replace ailment cure strings with bitflags

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -21,6 +21,7 @@
 #include "defines\actions.dm"
 #include "defines\admin.dm"
 #include "defines\ai.dm"
+#include "defines\ailments.dm"
 #include "defines\antagonists.dm"
 #include "defines\announcement_origins.dm"
 #include "defines\artifacts.dm"

--- a/_std/defines/ailments.dm
+++ b/_std/defines/ailments.dm
@@ -1,0 +1,20 @@
+// ailment cure bitflags
+
+/// ailment is incurable
+#define CURE_INCURABLE   (1<<0)
+/// ailment cure is unknown. same as incurable. just no known cures
+#define CURE_UNKNOWN (1<<1)
+/// ailment may cure itself as time passes
+#define CURE_TIME (1<<2)
+/// ailment cure is electric shock
+#define CURE_ELEC_SHOCK (1<<3)
+/// ailment cure is antibiotics
+#define CURE_ANTIBIOTICS (1<<4)
+/// ailment cure is some form of surgery
+#define CURE_SURGERY (1<<5)
+/// ailment cure is by sleeping
+#define CURE_SLEEP (1<<6)
+/// ailment cure is by removal of heart
+#define CURE_HEART_TRANSPLANT (1<<7)
+/// ailment cure is determined by the ailment
+#define CURE_CUSTOM (1<<8)

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -424,7 +424,8 @@
 /datum/ailment/disease/hootonium
 	name = "Hyperhootemia"
 	scantype = "Virus"
-	cure = "Space Owl Diffusion"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Space Owl Diffusion"
 	max_stages = 3
 	associated_reagent = "hootonium" // associated reagent, duh
 

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -2,7 +2,10 @@
 	// all the vars that don't change/are defaults go in here - these will be in a central list for referencing
 	var/name = "ailment"
 	var/scantype = "Ailment"			// what type this shows up as on scanners
-	var/cure = "Unknown"				// how do we get rid of it
+	/// flags for determining how this ailment is cured
+	var/cure_flags = CURE_UNKNOWN
+	/// description for the cure that appears in medical scanners, etc. if null, presets based on the cure flags
+	var/cure_desc = null
 	var/spread = "Unknown"				// how does it spread
 	var/info = null						// info related to the thing to show on health scanners
 	var/print_name = null				// printed name for health scanners
@@ -48,17 +51,17 @@
 /datum/ailment/parasite
 	name = "Parasite"
 	scantype = "Parasite"
-	cure = "Surgery"
+	cure_flags = CURE_SURGERY
 
 /datum/ailment/disability
 	name = "Disability"
 	scantype = "Disability"
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 
 /datum/ailment/disease
 	name = "Disease"
 	scantype = "Virus"
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	var/virulence = 100
 	var/develop_resist = 0
 	var/associated_reagent = null // associated reagent, duh
@@ -75,7 +78,10 @@
 	var/name = null							// an override - uses the base disease name if null - if not, it uses this
 	var/scantype = null						// same as above but for scantype
 	var/detectability = 0					// scans must >= this to detect the disease
-	var/cure = "Unknown"					// how do we get rid of it
+	/// flags for determining how this ailment is cured
+	var/cure_flags = CURE_UNKNOWN
+	/// description for the cure that appears in medical scanners, etc. if null, presets based on the cure flags
+	var/cure_desc = null
 	var/spread = "Unknown" 					// how does this disease transmit itself around?
 	var/info = null							// info related to the thing to show on health scanners
 	var/stage = 1							// what stage the disease is currently at
@@ -129,12 +135,37 @@
 			text += "Info: [src.info]<br>"
 		if (istype(src.master,/datum/ailment/disease) && src.spread)
 			text += "Spread: [src.spread]<br>"
-		if (src.cure == "Incurable")
-			text += "Infection is incurable. Suggest quarantine measures."
-		else if (src.cure == "Unknown")
-			text += "No suggested remedies."
+		var/cure_method = "Suggested Remedy: "
+		if (src.cure_flags & CURE_INCURABLE)
+			cure_method = "Infection is incurable. Suggest quarantine measures."
+		else if (src.cure_flags & CURE_UNKNOWN)
+			cure_method = "No suggested remedies."
+		else if (src.cure_flags & CURE_CUSTOM)
+			cure_method += src.cure_desc
 		else
-			text += "Suggested Remedy: [src.cure]"
+			var/list/cures = list()
+			if (src.cure_flags & CURE_TIME)
+				cures += "Self-curing"
+			if (src.cure_flags & CURE_ELEC_SHOCK)
+				cures += "Electric shock"
+			if (src.cure_flags & CURE_ANTIBIOTICS)
+				cures += "Antibiotics"
+			if (src.cure_flags & CURE_SURGERY)
+				cures += "Surgery"
+			if (src.cure_flags & CURE_SLEEP)
+				cures += "Sleep"
+			if (src.cure_flags & CURE_HEART_TRANSPLANT)
+				cures += "Heart transplant"
+
+			if (length(cures) == 1)
+				cure_method += cures[1]
+			else if (length(cures) == 2)
+				cure_method += "[cures[1]] or [cures[2]]"
+			else
+				for (var/i in 1 to (length(cures) - 1))
+					cure_method += cures[i] + ", "
+				cure_method += " or [cures[length(cures)]]"
+		text += cure_method
 		text += "</small></span>"
 		return text
 
@@ -183,20 +214,12 @@
 				stage++
 
 		// Common cures
-		if (cure != "Incurable")
-			if (cure == "Sleep" && affected_mob.sleeping && probmult(33))
+		if (!(src.cure_flags & CURE_INCURABLE))
+			if ((src.cure_flags & CURE_SLEEP) && affected_mob.sleeping && probmult(33))
 				state = "Remissive"
 				return 1
 
-			else if (cure == "Self-Curing" && probmult(5))
-				state = "Remissive"
-				return 1
-
-			else if (cure == "Beatings" && affected_mob.get_brute_damage() >= 40)
-				state = "Remissive"
-				return 1
-
-			else if (cure == "Burnings" && (affected_mob.get_burn_damage() >= 40 || affected_mob.getStatusDuration("burning")))
+			else if ((src.cure_flags & CURE_TIME) && probmult(5))
 				state = "Remissive"
 				return 1
 
@@ -250,7 +273,7 @@
 
 	proc/setup()
 		src.stage_prob = master.stage_prob
-		src.cure = master.cure
+		src.cure_flags = master.cure_flags
 		src.was_setup = 1
 
 	stage_act(var/mult)
@@ -387,7 +410,8 @@
 			AD.virulence = strain.virulence
 			AD.detectability = strain.detectability
 			AD.develop_resist = strain.develop_resist
-			AD.cure = strain.cure
+			AD.cure_flags = strain.cure_flags
+			AD.cure_desc = strain.cure_desc
 			AD.spread = strain.spread
 			AD.info = strain.info
 			AD.resistance_prob = strain.resistance_prob
@@ -401,7 +425,8 @@
 			AD.virulence = D.virulence
 			AD.detectability = D.detectability
 			AD.develop_resist = D.develop_resist
-			AD.cure = D.cure
+			AD.cure_flags = D.cure_flags
+			AD.cure_desc = D.cure_desc
 			AD.spread = D.spread
 			AD.info = D.info
 			AD.resistance_prob = D.resistance_prob
@@ -429,7 +454,8 @@
 			AD.reagentcure = strain.reagentcure
 			AD.recureprob = strain.recureprob
 			AD.detectability = strain.detectability
-			AD.cure = strain.cure
+			AD.cure_flags = strain.cure_flags
+			AD.cure_desc = strain.cure_desc
 			AD.spread = strain.spread
 			AD.info = strain.info
 			AD.resistance_prob = strain.resistance_prob
@@ -440,7 +466,8 @@
 			AD.reagentcure = M.reagentcure
 			AD.recureprob = M.recureprob
 			AD.detectability = M.detectability
-			AD.cure = M.cure
+			AD.cure_flags = M.cure_flags
+			AD.cure_desc = M.cure_desc
 			AD.spread = M.spread
 			AD.info = M.info
 			AD.resistance_prob = M.resistance_prob
@@ -455,7 +482,8 @@
 		var/datum/ailment_data/parasite/AD = new /datum/ailment_data/parasite
 		AD.name = A.name
 		AD.stage_prob = A.stage_prob
-		AD.cure = A.cure
+		AD.cure_flags = A.cure_flags
+		AD.cure_desc = A.cure_desc
 		AD.reagentcure = A.reagentcure
 		AD.recureprob = A.recureprob
 		AD.master = A
@@ -470,7 +498,8 @@
 		var/datum/ailment_data/AD = new /datum/ailment_data
 		AD.name = A.name
 		AD.stage_prob = A.stage_prob
-		AD.cure = A.cure
+		AD.cure_flags = A.cure_flags
+		AD.cure_desc = A.cure_desc
 		AD.reagentcure = A.reagentcure
 		AD.recureprob = A.recureprob
 		AD.master = A
@@ -549,7 +578,7 @@
 /mob/living/proc/Virus_ShockCure(var/probcure = 50)
 	src.changeStatus("defibbed", (12 * (probcure * 0.1)) SECONDS) // also makes it *slightly* harder to shitsec someone to death
 	for (var/datum/ailment_data/V in src.ailments)
-		if (V.cure == "Electric Shock" && prob(probcure))
+		if ((V.cure_flags & CURE_ELEC_SHOCK) && prob(probcure))
 			src.cure_disease(V)
 
 /mob/living/proc/shock_cyberheart(var/shockInput)

--- a/code/modules/antagonists/wraith/diseases/rat_plague.dm
+++ b/code/modules/antagonists/wraith/diseases/rat_plague.dm
@@ -2,7 +2,8 @@
 	name = "Rat Plague"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Mercury"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Mercury"
 	reagentcure = list("mercury")
 	associated_reagent = "rat_spit"
 	stage_prob = 6

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -55,7 +55,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				for(var/datum/ailment_data/disease/virus in M.ailments)
-					if (virus.cure == "Antibiotics")
+					if (virus.cure_flags & CURE_ANTIBIOTICS)
 						virus.state = "Remissive"
 				if(M.hasStatus("poisoned"))
 					M.changeStatus("poisoned", -10 SECONDS * mult)

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -1399,7 +1399,7 @@
 				return
 			var/attempted_parasite_removal = 0
 			for (var/datum/ailment_data/an_ailment in H.ailments)
-				if (an_ailment.cure == "Surgery")
+				if (an_ailment.cure_flags & CURE_SURGERY)
 					attempted_parasite_removal = 1
 					var/success = an_ailment.surgery(user, H)
 					if (success)

--- a/code/modules/medical/disabilities/badvision.dm
+++ b/code/modules/medical/disabilities/badvision.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disability/badvision
 	name = "Impaired Vision"
 	max_stages = 1
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	affected_species = list("Human","Monkey")
 
 /datum/ailment/disability/badvision/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/disabilities/blind.dm
+++ b/code/modules/medical/disabilities/blind.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disability/blind
 	name = "Blindness"
 	max_stages = 1
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	affected_species = list("Human","Monkey")
 
 /datum/ailment/disability/blind/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/disabilities/clumsy.dm
+++ b/code/modules/medical/disabilities/clumsy.dm
@@ -1,10 +1,11 @@
 /datum/ailment/disability/clumsy
 	name = "Dyspraxia"
 	max_stages = 1
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	affected_species = list("Human")
 	cluwne
-		cure = "Decursing"
+		cure_flags = CURE_CUSTOM
+		cure_desc = "Decursing"
 		reagentcure = list("water_holy")
 
 /datum/ailment/disability/clumsy/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/disabilities/cough.dm
+++ b/code/modules/medical/disabilities/cough.dm
@@ -1,7 +1,8 @@
 /datum/ailment/disability/cough
 	name = "Chronic Cough"
 	max_stages = 1
-	cure = "styptic_powder"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Styptic powder "
 	reagentcure = list("styptic_powder")
 	recureprob = 10
 	affected_species = list("Human")

--- a/code/modules/medical/disabilities/deaf.dm
+++ b/code/modules/medical/disabilities/deaf.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disability/deaf
 	name = "Deafness"
 	max_stages = 1
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	affected_species = list("Human","Monkey")
 
 /datum/ailment/disability/deaf/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/diseases/addiction.dm
+++ b/code/modules/medical/diseases/addiction.dm
@@ -5,7 +5,8 @@
 	scantype = "Chemical Dependency"
 	max_stages = 5
 	stage_prob = 3
-	cure = "Time"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Time"
 	affected_species = list("Human")
 
 /datum/ailment/addiction/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/addiction/D, mult)

--- a/code/modules/medical/diseases/avian_flu.dm
+++ b/code/modules/medical/diseases/avian_flu.dm
@@ -2,7 +2,8 @@
 	name = "Avian Flu"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Chicken Soup"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Chicken soup"
 	associated_reagent = "feather_fluid"
 	reagentcure = list("chickensoup")
 	affected_species = list("Human")

--- a/code/modules/medical/diseases/berserker.dm
+++ b/code/modules/medical/diseases/berserker.dm
@@ -2,7 +2,8 @@
 	name = "Berserker"
 	max_stages = 2
 	spread = "Non-Contagious"
-	cure = "Haloperidol"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Haloperidol"
 	reagentcure = list("haloperidol")
 	recureprob = 10
 	associated_reagent = "pubbie tears"

--- a/code/modules/medical/diseases/clowning_around.dm
+++ b/code/modules/medical/diseases/clowning_around.dm
@@ -11,7 +11,7 @@
 	name = "Clowning Around"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Antibiotics"
+	cure_flags = CURE_ANTIBIOTICS
 	associated_reagent = "rainbow fluid"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/cluwneing_around.dm
+++ b/code/modules/medical/diseases/cluwneing_around.dm
@@ -6,7 +6,7 @@
 	name = "Cluwneing Arewund"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Antibiotics"
+	cure_flags = CURE_ANTIBIOTICS
 	associated_reagent = "painbow fluid"
 	affected_species = list("Human")
 	var/oldjob
@@ -19,7 +19,7 @@
 		name += "[pick("AreoU","UroO","ArU","AoOro","AhRu")][pick("ndE","Ned","nhd")]"
 	cluwne
 		laugh_rate = 18
-		cure = "Incurable"
+		cure_flags = CURE_INCURABLE
 
 /datum/ailment/disease/cluwneing_around/on_infection(var/mob/living/affected_mob,var/datum/ailment_data/D)
 	..()
@@ -27,7 +27,7 @@
 		src.oldname = affected_mob.real_name
 		src.oldjob = affected_mob.job
 	if (istype(affected_mob.wear_mask, /obj/item/clothing/mask/cursedclown_hat))
-		D.cure = "Incurable"
+		D.cure_flags = CURE_INCURABLE
 
 /datum/ailment/disease/cluwneing_around/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
@@ -60,8 +60,7 @@
 					affected_mob.say("THE RINGMASTER DOESN'T RUN THE CIRCUS... HUNKE!")
 
 		if(3)
-			if(D.cure != "Incurable")
-				D.cure = "Incurable"
+			D.cure_flags = CURE_INCURABLE
 
 			if (affected_mob.job != "Cluwne")
 				affected_mob.real_name = "cluwne"

--- a/code/modules/medical/diseases/cold.dm
+++ b/code/modules/medical/diseases/cold.dm
@@ -4,7 +4,7 @@
 	spread = "Airborne"
 	virulence = 30 // Reduced from 100 %. Station-wide, basically incurable and unavoidable epidemics weren't fun (Convair880).
 	resistance_prob = 25 // Increased from 0 %.
-	cure = "Sleep"
+	cure_flags = CURE_SLEEP
 	associated_reagent = "mucus"
 	affected_species = list("Human")
 //

--- a/code/modules/medical/diseases/corrupt_robotic_transformation.dm
+++ b/code/modules/medical/diseases/corrupt_robotic_transformation.dm
@@ -5,7 +5,7 @@
 	scantype = "Nano-Infection"
 	max_stages = 6
 	spread = "Non-Contagious"
-	cure = "Electric Shock"
+	cure_flags = CURE_ELEC_SHOCK
 	associated_reagent = "corruptnanites"
 	affected_species = list("Human","Monkey")
 

--- a/code/modules/medical/diseases/dna_spread.dm
+++ b/code/modules/medical/diseases/dna_spread.dm
@@ -2,7 +2,7 @@
 	name = "Space Rhinovirus"
 	max_stages = 4
 	spread = "Airborne"
-	cure = "Antibiotics"
+	cure_flags = CURE_ANTIBIOTICS
 	// associated_reagent = "liquid dna"
 	affected_species = list("Human")
 	//Also important for rhinovirus is strain_data on ailment_data/disease, which is where the bioholders transformed from/to are stored

--- a/code/modules/medical/diseases/fake_gbs.dm
+++ b/code/modules/medical/diseases/fake_gbs.dm
@@ -2,7 +2,8 @@
 	name = "GBS"
 	max_stages = 5
 	spread = "Airborne"
-	cure = "Cryoxadone"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Cryoxadone"
 	reagentcure = list("cryoxadone")
 	recureprob = 10
 	associated_reagent = "stringy gibbis"

--- a/code/modules/medical/diseases/flu.dm
+++ b/code/modules/medical/diseases/flu.dm
@@ -4,7 +4,7 @@
 	spread = "Airborne"
 	virulence = 30 // Reduced from 100 %. Station-wide, basically incurable and unavoidable epidemics weren't fun (Convair880).
 	resistance_prob = 25 // Increased from 0 %.
-	cure = "Sleep"
+	cure_flags = CURE_SLEEP
 	associated_reagent = "green mucus"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/food_poisoning.dm
+++ b/code/modules/medical/diseases/food_poisoning.dm
@@ -2,9 +2,8 @@
 	name = "Food Poisoning"
 	max_stages = 3
 	spread = "Non-Contagious"
-	cure = "Sleep"
+	cure_flags = (CURE_SLEEP | CURE_ANTIBIOTICS)
 	associated_reagent = "salmonella"
-	reagentcure = list("spaceacillin")
 	affected_species = list("Human")
 //
 /datum/ailment/disease/food_poisoning/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -2,7 +2,8 @@
 	name = "Frog Flu"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Robustissin, Robust Coffee, getting robusted"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Robustissin, Robust Coffee, getting robusted"
 	associated_reagent = "sheltestgrog"
 	reagentcure = list("cold_medicine", "coffee")
 	affected_species = list("Human")

--- a/code/modules/medical/diseases/gbs.dm
+++ b/code/modules/medical/diseases/gbs.dm
@@ -2,7 +2,8 @@
 	name = "GBS"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Cryoxadone"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Cryoxadone"
 	reagentcure = list("cryoxadone")
 	recureprob = 10
 	associated_reagent = "gibbis"

--- a/code/modules/medical/diseases/going_catty.dm
+++ b/code/modules/medical/diseases/going_catty.dm
@@ -2,9 +2,8 @@
 	name = "Toxoplasmosis"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Antibiotics"
+	cure_flags = CURE_ANTIBIOTICS
 	associated_reagent = "mewtini"
-	reagentcure = list("spaceacillin")
 	affected_species = list("Human")
 
 /datum/ailment/disease/going_catty/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/diseases/headspider.dm
+++ b/code/modules/medical/diseases/headspider.dm
@@ -2,7 +2,7 @@
 	name = "Unidentified Foreign Body"
 	max_stages = 4 // takes too goddamn long
 	affected_species = list("Human", "Monkey")
-	cure = "Surgery"
+	cure_flags = CURE_SURGERY
 	stage_prob = 13
 //
 

--- a/code/modules/medical/diseases/heart_removal.dm
+++ b/code/modules/medical/diseases/heart_removal.dm
@@ -3,7 +3,7 @@
 	scantype = "Medical Emergency"
 	max_stages = 1
 	spread = "The patient's heart is missing."
-	cure = "Heart Transplant"
+	cure_flags = CURE_HEART_TRANSPLANT
 	affected_species = list("Human","Monkey")
 
 /datum/ailment/disease/noheart/stage_act(var/mob/living/carbon/human/H, var/datum/ailment/D, mult)

--- a/code/modules/medical/diseases/high_fever.dm
+++ b/code/modules/medical/diseases/high_fever.dm
@@ -3,7 +3,8 @@
 	name = "High Fever"
 	max_stages = 5
 	stage_prob = 10
-	cure = "ice"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Ice"
 	reagentcure = list("ice")
 
 	associated_reagent = "too much"

--- a/code/modules/medical/diseases/infection.dm
+++ b/code/modules/medical/diseases/infection.dm
@@ -2,8 +2,7 @@
 	name = "MRSA"
 	max_stages = 3
 	spread = "The patient has an aggressive Staph infection."
-	cure = "Antibiotics"
-	reagentcure = list("spaceacillin")
+	cure_flags = CURE_ANTIBIOTICS
 	recureprob = 5
 	affected_species = list("Human")
 	stage_prob = 3

--- a/code/modules/medical/diseases/infection.dm
+++ b/code/modules/medical/diseases/infection.dm
@@ -3,7 +3,6 @@
 	max_stages = 3
 	spread = "The patient has an aggressive Staph infection."
 	cure_flags = CURE_ANTIBIOTICS
-	recureprob = 5
 	affected_species = list("Human")
 	stage_prob = 3
 

--- a/code/modules/medical/diseases/kuru.dm
+++ b/code/modules/medical/diseases/kuru.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disease/kuru
 	name = "Space Kuru"
 	max_stages = 4
-	cure = "Incurable"
+	cure_flags = CURE_INCURABLE
 	associated_reagent = "prions"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/leprosy.dm
+++ b/code/modules/medical/diseases/leprosy.dm
@@ -4,7 +4,6 @@
 	spread = "Non-Contagious"
 	resistance_prob = 100
 	cure_flags = CURE_ANTIBIOTICS
-	recureprob = 100
 	associated_reagent = "mycobacterium leprae"
 	affected_species = list("Human")
 	stage_prob = 3

--- a/code/modules/medical/diseases/leprosy.dm
+++ b/code/modules/medical/diseases/leprosy.dm
@@ -3,8 +3,7 @@
 	max_stages = 5
 	spread = "Non-Contagious"
 	resistance_prob = 100
-	cure = "Antibiotics"
-	reagentcure = list("spaceacillin")
+	cure_flags = CURE_ANTIBIOTICS
 	recureprob = 100
 	associated_reagent = "mycobacterium leprae"
 	affected_species = list("Human")

--- a/code/modules/medical/diseases/lungrot.dm
+++ b/code/modules/medical/diseases/lungrot.dm
@@ -3,7 +3,8 @@
 	max_stages = 5
 	stage_prob = 4
 	spread = "Non-Contagious"
-	cure = "Robustissin application after removal of salbutamol."
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Robustissin application after removal of salbutamol."
 	associated_reagent = "lungrot_bloom"
 	reagentcure = list("cold_medicine")
 	//for as long as salbutamol is in the patient, robustissin is extremly ineffective

--- a/code/modules/medical/diseases/lycanthropy.dm
+++ b/code/modules/medical/diseases/lycanthropy.dm
@@ -3,7 +3,8 @@
 	print_name = "Unidentified virus"
 	max_stages = 5
 	spread = "Saliva"
-	cure = "Incurable"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Silver nitrate"
 	reagentcure = list("silver_nitrate")
 	recureprob = 10
 	affected_species = list("Human")

--- a/code/modules/medical/diseases/malady.dm
+++ b/code/modules/medical/diseases/malady.dm
@@ -2,7 +2,7 @@
 /datum/ailment/malady
 	name = "Malady"
 	scantype = "Medical Malady"
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 
 /datum/ailment_data/malady
 	var/robo_restart = 0 // used for cyberheart stuff
@@ -45,20 +45,12 @@
 					stage++
 
 		// Common cures
-		if (cure != "Incurable")
-			if (cure == "Sleep" && affected_mob.sleeping && probmult(33))
+		if (!(cure_flags & CURE_INCURABLE))
+			if ((cure_flags & CURE_SLEEP) && affected_mob.sleeping && probmult(33))
 				state = "Remissive"
 				return 1
 
-			else if (cure == "Self-Curing" && probmult(5))
-				state = "Remissive"
-				return 1
-
-			else if (cure == "Beatings" && affected_mob.get_brute_damage() >= 40)
-				state = "Remissive"
-				return 1
-
-			else if (cure == "Burnings" && (affected_mob.get_burn_damage() >= 40 || affected_mob.getStatusDuration("burning")))
+			else if ((cure_flags & CURE_TIME) && probmult(5))
 				state = "Remissive"
 				return 1
 
@@ -98,7 +90,8 @@
 	scantype = "Medical Emergency"
 	info = "The patient is in shock."
 	max_stages = 3
-	cure = "Saline Solution"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Saline solution"
 	reagentcure = list("saline")
 	recureprob = 10
 	affected_species = list("Human","Monkey")
@@ -160,7 +153,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	info = "The patient has low blood sugar."
-	cure = "Deactivation of implants/augments combined with eating or glucose treatment"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Deactivation of implants/augments combined with eating or glucose treatment"
 	affected_species = list("Human")
 	stage_prob = 1
 
@@ -210,7 +204,8 @@
 	scantype = "Potential Medical Emergency"
 	max_stages = 1
 	info = "The patient has a blood clot."
-	cure = "Anticoagulants"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Anticoagulants"
 	reagentcure = list("heparin")
 	recureprob = 10
 	affected_species = list("Human","Monkey")
@@ -328,7 +323,8 @@
 	scantype = "Medical Concern"
 	info = "The patient's arteries have narrowed."
 	max_stages = 2
-	cure = "Lifestyle Changes, Anticoagulants or Aspirin"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Lifestyle Changes, Anticoagulants or Aspirin"
 	reagentcure = list("heparin"=1, "salicylic_acid"=2)
 	affected_species = list("Human","Monkey")
 	stage_prob = 1
@@ -410,7 +406,8 @@
 	scantype = "Medical Emergency"
 	info = "The patient is having a cardiac emergency."
 	max_stages = 3
-	cure = "Cardiac Stimulants"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Cardiac Stimulants"
 	reagentcure = list("atropine"=8,"epinephrine"=10,"heparin"=5)
 	recureprob = 10
 	affected_species = list("Human","Monkey")
@@ -498,7 +495,7 @@
 	scantype = "Medical Emergency"
 	info = "The patient's heart has stopped."
 	max_stages = 1
-	cure = "Electric Shock"
+	cure_flags = CURE_ELEC_SHOCK
 	affected_species = list("Human","Monkey")
 	reagentcure = list("atropine" = 0.01, // atropine is not recommended for use in treating cardiac arrest anymore but SHRUG
 	"epinephrine" = 0.1) // epi is recommended though

--- a/code/modules/medical/diseases/medusa.dm
+++ b/code/modules/medical/diseases/medusa.dm
@@ -6,7 +6,8 @@
 	reagentcure = list("omnizine")
 	associated_reagent = "medusa"
 	affected_species = list("Human","Monkey")
-	cure = "Omnizine."
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Omnizine"
 
 /datum/ailment/disease/medusa/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())

--- a/code/modules/medical/diseases/monkey_madness.dm
+++ b/code/modules/medical/diseases/monkey_madness.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disease/monkey_madness
 	name = "Monkey Madness"
 	max_stages = 1
-	cure = "Incurable"
+	cure_flags = CURE_INCURABLE
 	associated_reagent = "banana peel"
 	affected_species = list("Monkey")
 

--- a/code/modules/medical/diseases/necrotic_degeneration.dm
+++ b/code/modules/medical/diseases/necrotic_degeneration.dm
@@ -2,7 +2,8 @@
 	name = "Necrotic Degeneration"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Healing Reagents"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Healing reagents"
 	reagentcure = list("omnizine","cryoxadone","mannitol","penteticacid","styptic_powder")
 	recureprob = 8
 	associated_reagent = "necrovirus"
@@ -61,7 +62,7 @@
 				affected_mob.take_brain_damage(10)
 			if (probmult(10))
 				affected_mob.emote(pick("moan"))
-			cure = "Incurable"
+			cure_flags = CURE_INCURABLE
 		if(5)
 			boutput(affected_mob, SPAN_ALERT("Your heart seems to have stopped..."))
 			if (zombie_mutantrace)

--- a/code/modules/medical/diseases/organ_diseases/appendicitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/appendicitis.dm
@@ -3,7 +3,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	spread = "The patient's appendicitis is dangerously enlarged"
-	cure = "Removal of organ"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Removal of organ"
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1

--- a/code/modules/medical/diseases/organ_diseases/kidney_failure.dm
+++ b/code/modules/medical/diseases/organ_diseases/kidney_failure.dm
@@ -4,7 +4,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	spread = "The patient's kidneys are starting to fail"
-	cure = "anti-toxin drugs"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Anti-toxin drugs"
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1

--- a/code/modules/medical/diseases/organ_diseases/liver_failure.dm
+++ b/code/modules/medical/diseases/organ_diseases/liver_failure.dm
@@ -3,7 +3,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	spread = "The patient's liver is starting to fail"
-	cure = "anti-toxin drugs"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Anti-toxin drugs"
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1

--- a/code/modules/medical/diseases/organ_diseases/pancreatitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/pancreatitis.dm
@@ -3,7 +3,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	spread = "The patient's pancreas is dangerously enlarged"
-	cure = "Removal of organ"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Removal of organ"
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1

--- a/code/modules/medical/diseases/organ_diseases/respiratory_failure.dm
+++ b/code/modules/medical/diseases/organ_diseases/respiratory_failure.dm
@@ -4,7 +4,8 @@
 	scantype = "Medical Emergency"
 	max_stages = 3
 	spread = "The patient's respiratory is starting to fail"
-	cure = "Oxygen-healing drugs or surgery"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Oxygen-healing drugs or surgery"
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1

--- a/code/modules/medical/diseases/panacaea.dm
+++ b/code/modules/medical/diseases/panacaea.dm
@@ -2,7 +2,8 @@
 	name = "Panacaea"
 	max_stages = 2
 	spread = "Airborne"
-	cure = "Self-Curing"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Self-curing"
 	associated_reagent = "viral curative"
 	affected_species = list("Human", "Monkey", "Alien")
 

--- a/code/modules/medical/diseases/plasmatoid.dm
+++ b/code/modules/medical/diseases/plasmatoid.dm
@@ -2,7 +2,8 @@
 	name = "Plasmatoid"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Mutadone"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Mutadone"
 	reagentcure = list("mutadone")
 	recureprob = 15
 	associated_reagent = "liquid plasma"

--- a/code/modules/medical/diseases/robotic_transformation.dm
+++ b/code/modules/medical/diseases/robotic_transformation.dm
@@ -5,7 +5,7 @@
 	scantype = "Nano-Infection"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Electric Shock"
+	cure_flags = CURE_ELEC_SHOCK
 	associated_reagent = "nanites"
 	affected_species = list("Human","Monkey")
 
@@ -79,7 +79,7 @@
 	scantype = "Nano-Infection"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Electric Shock"
+	cure_flags = CURE_ELEC_SHOCK
 	associated_reagent = "goodnanites"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/space_madness.dm
+++ b/code/modules/medical/diseases/space_madness.dm
@@ -3,7 +3,8 @@
 	scantype = "Psychological Condition"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Haloperidol"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Haloperidol"
 	reagentcure = list("haloperidol")
 	associated_reagent = "loose_screws"
 	affected_species = list("Human")

--- a/code/modules/medical/diseases/space_plague.dm
+++ b/code/modules/medical/diseases/space_plague.dm
@@ -2,7 +2,8 @@
 	name = "Space Plague"
 	max_stages = 3
 	spread = "Non-Contagious"
-	cure = "Mercury"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Mercury"
 	associated_reagent = "rat_venom"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/teleportitis.dm
+++ b/code/modules/medical/diseases/teleportitis.dm
@@ -2,7 +2,7 @@
 	name = "Teleportitis"
 	max_stages = 1
 	spread = "Non-Contagious"
-	cure = "Electric Shock"
+	cure_flags = CURE_ELEC_SHOCK
 	associated_reagent = "liquid spacetime"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/tissue_necrosis.dm
+++ b/code/modules/medical/diseases/tissue_necrosis.dm
@@ -2,7 +2,8 @@
 	name = "Tissue Necrosis"
 	max_stages = 5
 	spread = "Non-Contagious"
-	cure = "Formaldehyde"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Formaldehyde"
 	associated_reagent = "rotting"
 	affected_species = list("Human")
 	reagentcure = list("formaldehyde")

--- a/code/modules/medical/diseases/vamplague.dm
+++ b/code/modules/medical/diseases/vamplague.dm
@@ -3,7 +3,6 @@
 	max_stages = 4
 	spread = "Non-Contagious"
 	cure_flags = CURE_ANTIBIOTICS
-	recureprob = 20
 	associated_reagent = "grave dust"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/vamplague.dm
+++ b/code/modules/medical/diseases/vamplague.dm
@@ -2,7 +2,7 @@
 	name = "Grave Fever"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Antibiotics"
+	cure_flags = CURE_ANTIBIOTICS
 	recureprob = 20
 	associated_reagent = "grave dust"
 	affected_species = list("Human")
@@ -37,7 +37,7 @@
 	max_stages = 3
 	stage_prob = 9
 	spread = "Non-Contagious"
-	cure = "None"
+	cure_flags = CURE_UNKNOWN
 	associated_reagent = "vampire_serum"
 	affected_species = list("Human")
 

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -446,7 +446,7 @@ TYPEINFO(/obj/item/robodefibrillator)
 
 	var/shockcure = 0
 	for (var/datum/ailment_data/V in patient.ailments)
-		if (V.cure == "Electric Shock")
+		if (V.cure_flags & CURE_ELEC_SHOCK)
 			shockcure = 1
 			break
 

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -103,7 +103,7 @@
 		//possible parasite removal surgery
 		if (length(donor.ailments) > 0)
 			for (var/datum/ailment_data/an_ailment in donor.ailments)
-				if (an_ailment.cure == "Surgery")
+				if (an_ailment.cure_flags & CURE_SURGERY)
 					var/datum/contextAction/surgery_region/parasite/parasite_action = new /datum/contextAction/surgery_region/parasite()
 					src.contexts += parasite_action
 					break

--- a/code/obj/item/organs/heart.dm
+++ b/code/obj/item/organs/heart.dm
@@ -68,7 +68,7 @@
 
 		if (src.donor)
 			for (var/datum/ailment_data/disease in src.donor.ailments)
-				if (disease.cure == "Heart Transplant")
+				if (disease.cure_flags & CURE_HEART_TRANSPLANT)
 					src.donor.cure_disease(disease)
 			src.donor.blood_id = (ischangeling(src.donor) && src.blood_id == "blood") ? "bloodc" : src.blood_id
 		if (ishuman(M) && islist(src.diseases))

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -369,7 +369,7 @@ ABSTRACT_TYPE(/obj/item/storage/toolbox)
 
 /datum/ailment/disability/memetic_madness
 	name = "Memetic Kill Agent"
-	cure = "Unknown"
+	cure_flags = CURE_UNKNOWN
 	affected_species = list("Human")
 	max_stages = 4
 	stage_prob = 8


### PR DESCRIPTION
[INTERNAL][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just does some minor rework of internal code to make ailment cures strings use bitflag checks instead

var/cure, which currently is used as a string check for exact cures, as well as cure descriptions, is split into two variables. One is the bitflag var, the other is a custom description that can be set to appear on how to cure the ailment in medical scans. If the description is not used, the bitflags will be used to determine the description.

Also removes some unused cure types and makes it clear for food poisoning you can cure it with spaceacillin

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it a lot easier to give multiple, common cures for ailments