### PR TITLE
Fix bartenders skillfully spilling their drinks everywhere.

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -594,15 +594,15 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	on_spin_emote(var/mob/living/carbon/human/user as mob)
 		. = ..()
 		if (src.reagents && src.reagents.total_volume > 0)
-			if(user.mind.assigned_role == "Bartender")
-				. = ("You deftly [pick("spin", "twirl")] [src] managing to keep all the contents inside.")
-				if(!ON_COOLDOWN(user, "bartender spinning xp", 180 SECONDS)) //only for real cups
-					JOB_XP(user, "Bartender", 1)
 			if (istype(src, /obj/item/reagent_containers/food/drinks/cola))
 				var/obj/item/reagent_containers/food/drinks/cola/soda_can = src
 				if (soda_can.is_sealed && (soda_can.reagents.has_reagent("cola", 5) || soda_can.reagents.has_reagent("tonic", 5) || soda_can.reagents.has_reagent("sodawater", 5)))
 					soda_can.shaken = TRUE
 					return
+			if(user.mind.assigned_role == "Bartender")
+				. = ("You deftly [pick("spin", "twirl")] [src] managing to keep all the contents inside.")
+				if(!ON_COOLDOWN(user, "bartender spinning xp", 180 SECONDS)) //only for real cups
+					JOB_XP(user, "Bartender", 1)
 			else
 				user.visible_message(SPAN_ALERT("<b>[user] spills the contents of [src] all over [him_or_her(user)]self!</b>"))
 				logTheThing(LOG_CHEMISTRY, user, "spills the contents of [src] [log_reagents(src)] all over [him_or_her(user)]self at [log_loc(user)].")


### PR DESCRIPTION
[Bug] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When bartenders *twirl or *spin their drinks, they are supposed to "deftly twirl the wine drinking glass managing to keep all the contents inside." And this happens until it spills everywhere, because the code continues on afterwards to hit another if/else chain that independently decides whether or not to spill the drink (shake soda cans, spill drinks.)

This change rightfully prevents bartenders from spilling drinks, as intended.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bartenders are good at their jobs and probably shouldn't be spilling drinks after hitting a special case that brags about not spilling drinks.

Fixes #17157 

## Changelog
```changelog
(u)MeggalBozale
(+)Bartenders will no longer skillfully spill your wine everywhere, rather opting to keep it in the glass.
```
