### PR TITLE
Fix being unable to shove bodies into furnace

### DIFF
--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -151,6 +151,9 @@ TYPEINFO(/obj/machinery/power/furnace)
 		if (!in_interact_range(src, user)  || BOUNDS_DIST(O, user) > 0 || !can_act(user))
 			return
 		else
+			if (ismob(O))
+				boutput(user, SPAN_ALERT("You have to grab [O] to stuff [him_or_her(O)] in!"))
+				return
 			if (src.fuel >= src.maxfuel)
 				boutput(user, SPAN_ALERT("The furnace is already full!"))
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an `ismob` check to `/obj/machinery/power/furnace/MouseDrop_T` because it was not written to be able to handle mobs, you have to grab someone and click to do that. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fix #17100 