### PR TITLE
Fixes Nicotini capitalisation

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4371,7 +4371,7 @@ datum
 				..()
 
 		fooddrink/alcoholic/nicotini
-			name = "nicotini"
+			name = "Nicotini"
 			id = "nicotini"
 			description = "Why would you even mix this? How does nicotine even taste?"
 			reagent_state = LIQUID


### PR DESCRIPTION
[BUG][CHEMISTRY][CATERING]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
<!--You can't see me -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR capitalises the N in Nicotini's name, fixes #17156. Yep, that's it. Nothin' else to see here, move along.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bugfix! Everyone loves bugfixes. Also, spelling should be consistent.