### PR TITLE
Fix detective PDA missing when not a smoker

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -578,7 +578,7 @@ ABSTRACT_TYPE(/datum/job/security)
 		M.traitHolder.addTrait("training_drinker")
 
 		if (M.traitHolder && !M.traitHolder.hasTrait("smoker"))
-			slot_poc1 = list(/obj/item/device/light/zippo) //Smokers start with a trinket version
+			items_in_backpack += list(/obj/item/device/light/zippo) //Smokers start with a trinket version
 
 // Research Jobs
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Respawning]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the detective's zippo lighter to spawn in the backpack when they are not a smoker. Also hah, I guess most detectives are smokers?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16435
Detectives should spawn with PDAs regardless of traits taken, otherwise the non-smoking zippo overwrites the PDA slot.
`	slot_poc1 = list(/obj/item/device/pda2/forensic)`
