### PR TITLE
adds spaces to the ends of 3 mutant plant prefixes

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -223,7 +223,7 @@
 
 /datum/plantmutation/beans/jelly // hehehe
 	name = "Jelly Bean"
-	name_prefix = "Jelly"
+	name_prefix = "Jelly "
 	iconmod = "BeanJelly"
 	assoc_reagents = list("VHFCS")
 	crop = /obj/item/reagent_containers/food/snacks/candy/jellybean/someflavor
@@ -232,7 +232,7 @@
 
 /datum/plantmutation/coffee/mocha
 	name = "Mocha Coffee"
-	name_prefix = "Mocha"
+	name_prefix = "Mocha "
 	iconmod = "CoffeeMocha"
 	crop = /obj/item/reagent_containers/food/snacks/plant/coffeeberry/mocha
 	PTrange = list(20,null)
@@ -240,7 +240,7 @@
 
 /datum/plantmutation/coffee/latte
 	name = "Latte Coffee"
-	name_prefix = "Latte"
+	name_prefix = "Latte "
 	iconmod = "CoffeeLatte"
 	crop = /obj/item/reagent_containers/food/snacks/plant/coffeeberry/latte
 	ENrange = list(10,null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Catering]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds spaces to the end of 3 mutant plant name prefixes, so that the name+prefix are separate (like all the other prefxises)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes "Mocha Coffee" and "Latte Coffee" plants coming out as "MochaCoffee" and "LatteCoffee" when looked at/scanned
Also jelley bean, but you could debate about if "jellybean" vs "jelly bean" is better? code calls it "Jelly Bean" so i changed it too


i don't think this needs a changelog? (This is my first pr, pls be nice! :>
