### PR TITLE
ABCU Blueprint Allowance Revamp - No Syndidoor Plz

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -262,7 +262,9 @@
 					"dir" = O.direction)
 				if (!isnull(O.icon_state)) properties["icon_state"] = O.icon_state // required for old blueprint support
 				new/dmm_suite/preloader(pos, properties) // this doesn't spawn the objects, only presets their properties
-				new O.objecttype(pos) // need this part to also spawn the objects
+				var/obj/spawned_object = new O.objecttype(pos)
+				if(!is_valid_abcu_object(spawned_object))
+					qdel(spawned_object)
 
 	proc/prepare_build(mob/user)
 		if(src.invalid_count)
@@ -607,6 +609,9 @@ proc/save_abcu_blueprint(mob/user, list/turf_list, var/use_whitelist = TRUE)
 			if (use_whitelist && (!istypes(o, WHITELIST_OBJECTS) || istypes(o, BLACKLIST_OBJECTS)))
 				continue
 
+			if(!is_valid_abcu_object(o))
+				continue
+
 			var/id = "\ref[o]"
 			save.cd = "/tiles/[posx],[posy]/objects"
 			while(save.dir.Find(id))
@@ -691,6 +696,13 @@ proc/load_abcu_blueprint(mob/user, var/savepath = "", var/use_whitelist = TRUE)
 
 	boutput(user, SPAN_NOTICE("Loaded blueprint [bp.room_name], with [turf_count] tile\s, and [obj_count] object\s."))
 	return bp
+
+// I regret everything. Proc so we can see if a door is hardened and henceallowed to be ABCUd (if it isnt hardened).
+proc/is_valid_abcu_object(obj/O)
+	if(istype(O, /obj/machinery/door))
+		var/obj/machinery/door/door = O
+		if(door.hardened)
+			return FALSE
 
 #undef WHITELIST_OBJECTS
 #undef BLACKLIST_OBJECTS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[Construction][ABCU]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prep work for changing how the ABCU handles what is and isn't allowed to be scanned/deployed.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I deployed like 100 Listening Post doors and Pali was not amused.
Otherwise, using a list of what is allowed and not allowed is kinda clunky. We want to make this use a variable in the future, this will start us down that path probably.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Metareferencer
(+)The ABCU will no longer deploy Listening Post (or any other Hardened) doors. New blueprints will not include them. Hardened doors from existing blueprints will not be created.
```
