### PR TITLE
Add max_seen argument to JPS

### DIFF
--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -279,7 +279,6 @@
 		if(path)
 			for(var/i = 1 to round(0.5 * length(path)))
 				path.Swap(i, length(path) - i + 1)
-	// boutput(world, "search ended with total_seen [src.total_seen]")
 	sources = null
 	qdel(open)
 

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -7,6 +7,8 @@
 
 /// Pathfind option key; The maximum number of steps we can take in a given path to search (default: 30, 0 = infinite)
 #define POP_MAX_DIST "max_distance"
+/// Pathfind option key; The maximum number of actual tiles seen. Sometimes a better limiter maybe?
+#define POP_MAX_SEEN "max_seen"
 /// Pathfind option key; Minimum distance to the target before path returns, could be used to get near a target, but not right to it - for an AI mob with a gun, for example.
 #define POP_MIN_DIST "min_distance"
 /// Pathfind option key; An ID card representing what access we have and what doors we can open. Its location relative to the pathing atom is irrelevant
@@ -44,7 +46,7 @@
  * Returns: List of turfs from the caller to the end or a list of lists of the former if multiple ends are specified.
  * If no paths were found, returns an empty list, which is important for bots like medibots who expect an empty list rather than nothing.
  */
-/proc/get_path_to(caller, ends, max_distance = 30, mintargetdist, id=null, simulated_only=TRUE, turf/exclude=null, skip_first=FALSE, cardinal_only=TRUE, required_goals=null, do_doorcheck=FALSE)
+/proc/get_path_to(caller, ends, max_distance = 30, max_seen = null, mintargetdist, id=null, simulated_only=TRUE, turf/exclude=null, skip_first=FALSE, cardinal_only=TRUE, required_goals=null, do_doorcheck=FALSE)
 	if(isnull(ends))
 		return
 	var/single_end = !islist(ends)
@@ -55,6 +57,7 @@
 
 	var/list/options = list(
 		POP_MAX_DIST=max_distance,
+		POP_MAX_SEEN=max_seen,
 		POP_MIN_DIST=mintargetdist,
 		POP_ID=id,
 		POP_SIMULATED_ONLY=simulated_only,
@@ -174,6 +177,8 @@
 	var/list/sources
 	/// The list we compile at the end if successful to pass back
 	var/list/list/turf/paths
+	/// The total number of tiles seen so far
+	var/total_seen = 0
 
 	// general pathfinding vars/args
 
@@ -181,6 +186,8 @@
 	var/mintargetdist = 0
 	/// I don't know what this does vs , but they limit how far we can search before giving up on a path
 	var/max_distance = 30
+	/// Max number of tiles seen, null skips the check
+	var/max_seen = null
 	/// Space is big and empty, if this is TRUE then we ignore pathing through unsimulated tiles
 	var/simulated_only
 	/// A specific turf we're avoiding, like if a mulebot is being blocked by someone t-posing in a doorway we're trying to get through
@@ -208,6 +215,7 @@
 	sources = new()
 	src.options = options
 	src.max_distance = options[POP_MAX_DIST]
+	src.max_seen = options[POP_MAX_SEEN]
 	src.mintargetdist = options[POP_MIN_DIST]
 	src.simulated_only = options[POP_SIMULATED_ONLY]
 	src.avoid = options[POP_EXCLUDE]
@@ -247,6 +255,9 @@
 
 	//then run the main loop
 	while(!open.is_empty() && !FINISHED_SEARCH)
+		if (src.max_seen && (src.total_seen > src.max_seen))
+			// boutput(world, "ending search early due to total_seen limit")
+			return
 		if(!caller)
 			return
 		current_processed_node = open.pop() //get the lower f_value turf in the open list
@@ -268,7 +279,7 @@
 		if(path)
 			for(var/i = 1 to round(0.5 * length(path)))
 				path.Swap(i, length(path) - i + 1)
-
+	// boutput(world, "search ended with total_seen [src.total_seen]")
 	sources = null
 	qdel(open)
 
@@ -318,6 +329,7 @@
 			return
 		lag_turf = current_turf
 		current_turf = get_step(current_turf, heading)
+		src.total_seen++
 		steps_taken++
 		if(!CAN_STEP(lag_turf, current_turf))
 			return
@@ -391,6 +403,7 @@
 			return
 		lag_turf = current_turf
 		current_turf = get_step(current_turf, heading)
+		src.total_seen++
 		steps_taken++
 		if(!CAN_STEP(lag_turf, current_turf))
 			return

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -282,7 +282,7 @@ var/list/ai_move_scheduled = list()
 			var/required_goals = null // find all targets
 			if(score_by_distance_only)
 				required_goals = 1 // we only need to find the first one
-			var/list/atom/paths_found = get_path_to(holder.owner, targets, max_dist*2, distance_from_target, null, simulated_only, required_goals)
+			var/list/atom/paths_found = get_path_to(holder.owner, targets, max_distance=max_dist*2, mintargetdist=distance_from_target, simulated_only=simulated_only, required_goals=required_goals)
 			if(score_by_distance_only)
 				if(length(paths_found))
 					. = paths_found[1]

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -1403,7 +1403,7 @@ stare
 		startpos = get_turf(holder.owner)
 	if(targetpos && GET_DIST(holder.owner,targetpos) > 0) //if we have a target and we're not already there
 		if(!path || !length(path))
-			path = get_path_to(holder.owner, targetpos, 5, 1) //short search, we don't want this to be expensive
+			path = get_path_to(holder.owner, targetpos, max_distance=5, mintargetdist=1) //short search, we don't want this to be expensive
 		if(length(path))
 			holder.move_to_with_path(targetpos, path, 0)
 			return

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -110,7 +110,7 @@
 	if(length(holder.target_path) && GET_DIST(holder.target_path[length(holder.target_path)], move_target) <= distance_from_target)
 		src.found_path = holder.target_path
 	else
-		src.found_path = get_path_to(holder.owner, move_target, src.max_path_dist, distance_from_target, null, !move_through_space)
+		src.found_path = get_path_to(holder.owner, move_target, max_distance=src.max_path_dist, mintargetdist=distance_from_target, simulated_only=!move_through_space)
 		if(GET_DIST(get_turf(holder.target), move_target) <= distance_from_target)
 			holder.target_path = src.found_path
 	if(!src.found_path || !jpsTurfPassable(src.found_path[1], get_turf(src.holder.owner), src.holder.owner)) // no path :C

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -289,6 +289,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/bot, proc/admin_command_speak)
 	var/adjacent = 0
 	var/scanrate = 10
 	var/max_dist = 600
+	var/max_seen = 1000
 
 	New(obj/machinery/bot/newmaster, _move_delay = 3, _target_turf, _current_movepath, _adjacent = 0, _scanrate = 10, _max_dist = 80)
 		..()
@@ -337,7 +338,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/bot, proc/admin_command_speak)
 			return
 		var/compare_movepath = src.current_movepath
 		master.path = get_path_to(src.master, src.the_target, mintargetdist = adjacent ? 1 : 0, \
-			max_distance=src.max_dist, id=master.botcard, skip_first=FALSE, simulated_only=FALSE, cardinal_only=TRUE, do_doorcheck=TRUE)
+			max_distance=src.max_dist, max_seen=src.max_seen, id=master.botcard, skip_first=FALSE, simulated_only=FALSE, cardinal_only=TRUE, do_doorcheck=TRUE)
 		if(!length(master.path))
 			qdel(src)
 			return

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -19,6 +19,7 @@
 	var/obj/machinery/bot/guardbot/master = null
 	var/delay = 3
 	var/max_dist = 100
+	var/max_seen = 1000
 
 	New(var/newmaster, max_dist=100)
 		..()
@@ -60,7 +61,7 @@
 
 			// Same distance cap as the MULE because I'm really tired of various pathfinding issues. Buddy time and docking stations are often way more than 150 steps away.
 			// It's 200 something steps alone to get from research to the bar on COG2 for instance, and that's pretty much in a straight line.
-			var/list/thePath = get_path_to(src.master, target_turf, max_distance=src.max_dist, \
+			var/list/thePath = get_path_to(src.master, target_turf, max_distance=src.max_dist, max_seen=src.max_seen, \
 				simulated_only=issimulatedturf(master.loc) && issimulatedturf(target_turf), \
 				id=src.master.botcard, skip_first=FALSE, cardinal_only=TRUE, do_doorcheck=TRUE)
 			if (!master)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a `max_seen` argument to JPS pathfinding as an alternative way to limit pathfinding range and implements it on guardbuddies and bots with a value of 1000 (no idea if this number is reasonable)

@pali6 let me know if I did this wrong
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Might be faster/better than simple range, worth trying out.