### PR TITLE
Fix chat messages duplicating when observing someone

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1071,7 +1071,8 @@
 		listening = all_hearers(message_range, say_location)
 		if (ismob(say_location))
 			for(var/mob/M in say_location)
-				listening |= M
+				if(!istype(M, /mob/dead/target_observer)) // theres already handling for relaying chat to observers!!
+					listening |= M
 			for (var/obj/item/W in say_location) // let the skeleton skulls in the bag / pockets hear the nerd
 				if (istype(W,/obj/item/organ/head))
 					var/obj/item/organ/head/H = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add type check to this for statement because there's already special handling in `/mob/proc/show_message` for relaying chat to observers so this one is just making it happen twice

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #14768