### PR TITLE
add solars to the ABCU whitelist

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -521,6 +521,8 @@
 	/obj/securearea, \
 	/obj/submachine/mixer, \
 	/obj/submachine/foodprocessor, \
+	/obj/machinery/power/solar,\
+	/obj/machinery/power/tracker,\
 )
 // blacklist overrules whitelist
 #define BLACKLIST_OBJECTS list( \


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://github.com/goonstation/goonstation/assets/64938519/ab993835-973a-42fb-bef5-dbb70c476517)

completely untested, just added the panels and trackers to the whitelist

**this does not add the console to the whitelist, people still have to go scan one of those**

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
solar panels are a pain to mass produce in the amounts needed for solar arrays, people suggested this now that the ABCU actually works
