### PR TITLE
Emagged borgs electrify doors with no confirmation prompt

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -2024,16 +2024,24 @@ TYPEINFO(/obj/machinery/door/airlock)
 		//electrify door for 30 seconds
 		if (src.secondsElectrified!=0)
 			src.shock_restore(user)
+			boutput(user, SPAN_NOTICE("De-electrified [src]."))
 		else
 			if(!src.arePowerSystemsOn() || (src.status & NOPOWER))
 				boutput(user, "The door has no power - you can't electrify it.")
 				return
 
-			while (user.client.check_key(KEY_SHOCK))
+			var/mob/living/silicon/user_as_silicon = user
+			if (user_as_silicon.emagged)
+				src.shock_temp(user)
+				boutput(user, SPAN_NOTICE("You remotely electrify [src] for 30 seconds."))
+				return
+
+			while (user.client.check_key(KEY_SHOCK)) // this is here because user holding spacebar auto-accepts the tgui confirmation prompt
 				sleep(0.2 SECONDS) // num seems to work fine
 
 			if (tgui_alert(user, "Are you sure? Electricity might harm a human!", "Electrification Confirmation", list("Yes", "No")) == "Yes")
 				src.shock_temp(user)
+				boutput(user, SPAN_NOTICE("You remotely electrify [src] for 30 seconds."))
 
 /obj/machinery/door/airlock/ui_interact(mob/user, datum/tgui/ui)
 	ui = tgui_process.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Emagged borgs now skip the "Are you sure? Human harm!!" popup when spacebar+click electrifying doors.
Adds boutput messages to (de)electrifying doors because they previously had no feedback.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kill humans faster.
It's a full-on antagonist. Why should it get an intrusive popup warning it about hurting humans? Nobody else gets that.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(+)Emagged silicons now skip the confirmation prompt when electrifying airlocks with spacebar+click.
```
