### PR TITLE
Adds a postmaster's uniform box to QM closets.

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -543,7 +543,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	item_state = "chefhat" //TODO: unique inhand sprite?
 
 /obj/item/clothing/head/mailcap
-	name = "Postmaster's hat"
+	name = "postmaster's hat"
 	desc = "The hat of a postmaster."
 	icon_state = "mailcap"
 	item_state = "mailcap"

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -543,8 +543,8 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	item_state = "chefhat" //TODO: unique inhand sprite?
 
 /obj/item/clothing/head/mailcap
-	name = "Mailman's hat"
-	desc = "The hat of a mailman."
+	name = "Postmaster's hat"
+	desc = "The hat of a postmaster."
 	icon_state = "mailcap"
 	item_state = "mailcap"
 

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -669,7 +669,7 @@ ABSTRACT_TYPE(/obj/item/clothing/under/misc)
 	item_state = "hydro-senior"
 
 /obj/item/clothing/under/misc/mail
-	name = "mailman's jumpsuit"
+	name = "postmaster's jumpsuit"
 	desc = "The crisp threads of a postmaster."
 	icon_state = "mail"
 	item_state = "mail"

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -254,7 +254,7 @@
 	/obj/item/clothing/shoes/witchfinder)
 
 /obj/item/storage/box/clothing/mail
-	name = "\improper Postal carrier's equipment"
+	name = "\improper Postmaster's equipment"
 	spawn_contents = list(/obj/item/clothing/under/misc/mail,\
 	/obj/item/clothing/head/mailcap,\
 	/obj/item/clothing/shoes/black,\

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -253,6 +253,14 @@
 	/obj/item/clothing/head/witchfinder,\
 	/obj/item/clothing/shoes/witchfinder)
 
+/obj/item/storage/box/clothing/mail
+	name = "\improper Postal carrier's equipment"
+	spawn_contents = list(/obj/item/clothing/under/misc/mail,\
+	/obj/item/clothing/head/mailcap,\
+	/obj/item/clothing/shoes/black,\
+	/obj/item/clothing/gloves/black,\
+	/obj/item/device/radio/headset/mail)
+
 /* ============================== */
 /* ---------- Costumes ---------- */
 /* ============================== */

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -812,6 +812,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	name = "\improper Quartermaster's locker"
 	req_access = list(access_cargo)
 	spawn_contents = list(/obj/item/storage/box/clothing/qm,
+	/obj/item/storage/box/clothing/mail,
 	/obj/item/pen/fancy,
 	/obj/item/paper_bin,
 	/obj/item/clipboard,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a postmaster's uniform box to QM closets.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QM does mail now, maybe one of 'em wants to dress the part without hunting out a uniform.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Gannets
(+)Added a postmaster's uniform box to QM closets.
```
