### PR TITLE
foam and stinger grenade fix targetx

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -623,7 +623,7 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 			burst_circle.spread_projectile_type = src.custom_projectile_type
 			burst_circle.pellet_shot_volume = 75 / burst_circle.pellets_to_fire
 		burst_circle.pellets_to_fire = src.pellets_to_fire
-		var/targetx = T.y - rand(-5,5)
+		var/targetx = T.x - rand(-5,5)
 		var/targety = T.y - rand(-5,5)
 		var/turf/newtarget = locate(targetx, targety, T.z)
 		shoot_projectile_ST_pixel_spread(T, burst_circle, newtarget)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -613,7 +613,7 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 	var/pellets_to_fire = 18
 	launcher_damage = 5
 
-	detonate()
+	detonate(mob/user)
 		var/turf/T = ..()
 		if (!T)
 			qdel(src)
@@ -623,10 +623,16 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 			burst_circle.spread_projectile_type = src.custom_projectile_type
 			burst_circle.pellet_shot_volume = 75 / burst_circle.pellets_to_fire
 		burst_circle.pellets_to_fire = src.pellets_to_fire
-		var/targetx = T.x - rand(-5,5)
-		var/targety = T.y - rand(-5,5)
-		var/turf/newtarget = locate(targetx, targety, T.z)
-		shoot_projectile_ST_pixel_spread(T, burst_circle, newtarget)
+		// Pelt that clown/clumsy person with all the foam darts for the funny half the time
+		if (user?.bioHolder.HasEffect("clumsy") && prob(50))
+			shoot_projectile_ST_pixel_spread(T, burst_circle, T)
+			JOB_XP(user, "Clown", 1)
+		// If not clumsy, do the usual explode on a slight offset to grenade position
+		else
+			var/targetx = T.x - rand(-5,5)
+			var/targety = T.y - rand(-5,5)
+			var/turf/newtarget = locate(targetx, targety, T.z)
+			shoot_projectile_ST_pixel_spread(T, burst_circle, newtarget)
 		SPAWN(0.5 SECONDS)
 			qdel(src)
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -483,7 +483,7 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 				PJ.spread_projectile_type = src.custom_projectile_type
 				PJ.pellet_shot_volume = 75 / PJ.pellets_to_fire //anti-ear destruction
 			PJ.pellets_to_fire = src.pellets_to_fire
-			var/targetx = T.y - rand(-5,5)
+			var/targetx = T.x - rand(-5,5)
 			var/targety = T.y - rand(-5,5)
 			var/turf/newtarget = locate(targetx, targety, T.z)
 			shoot_projectile_ST_pixel_spread(T, PJ, newtarget)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -613,7 +613,7 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 	var/pellets_to_fire = 18
 	launcher_damage = 5
 
-	detonate(mob/user)
+	detonate()
 		var/turf/T = ..()
 		if (!T)
 			qdel(src)
@@ -623,16 +623,10 @@ TYPEINFO(/obj/item/old_grenade/singularity)
 			burst_circle.spread_projectile_type = src.custom_projectile_type
 			burst_circle.pellet_shot_volume = 75 / burst_circle.pellets_to_fire
 		burst_circle.pellets_to_fire = src.pellets_to_fire
-		// Pelt that clown/clumsy person with all the foam darts for the funny half the time
-		if (user?.bioHolder.HasEffect("clumsy") && prob(50))
-			shoot_projectile_ST_pixel_spread(T, burst_circle, T)
-			JOB_XP(user, "Clown", 1)
-		// If not clumsy, do the usual explode on a slight offset to grenade position
-		else
-			var/targetx = T.x - rand(-5,5)
-			var/targety = T.y - rand(-5,5)
-			var/turf/newtarget = locate(targetx, targety, T.z)
-			shoot_projectile_ST_pixel_spread(T, burst_circle, newtarget)
+		var/targetx = T.x - rand(-5,5)
+		var/targety = T.y - rand(-5,5)
+		var/turf/newtarget = locate(targetx, targety, T.z)
+		shoot_projectile_ST_pixel_spread(T, burst_circle, newtarget)
 		SPAWN(0.5 SECONDS)
 			qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug with foam dart grenades and stinger grenades that was setting the targetx to the y coordinate, causing a higher than normal chance of trying to lookup a turf location that did not exist, making the grenade poof out of existence and not actually explode. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Starting to fix #13906 - There's still a chance the targeting could choose an invalid turf within the -5 to 5 x and y radius of the original turf, but should be lower now that we're using actual x and y coordinates. Wasn't sure how to implement good turf checks without overcomplicating the grenades by a lot. (Would appreciate suggestions!)

You can replicate the grenades disappearing more easily by exploding them in your hand when in the bottom right corner of the devtest map. There's more options around you for locations that don't have a valid turf on lookup.