### PR TITLE
Cleanup of burn_possible

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -223,9 +223,3 @@
 #define MATCH_UNLIT 0
 #define MATCH_LIT 1
 #define MATCH_INERT 2 /// broken or burn out
-
-
-// for the burn_possible var in /obj/item
-#define BURN_IMPOSSIBLE 0
-#define BURN_POSSIBLE 1
-#define BURN

--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -223,3 +223,9 @@
 #define MATCH_UNLIT 0
 #define MATCH_LIT 1
 #define MATCH_INERT 2 /// broken or burn out
+
+
+// for the burn_possible var in /obj/item
+#define BURN_IMPOSSIBLE 0
+#define BURN_POSSIBLE 1
+#define BURN

--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -209,7 +209,7 @@
 	p_class = 1
 	burn_point = 220
 	burn_output = 300
-	burn_possible = 1
+	burn_possible = TRUE
 	rand_pos = 1
 
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)

--- a/code/WorkInProgress/infernal_contracts.dm
+++ b/code/WorkInProgress/infernal_contracts.dm
@@ -182,7 +182,7 @@ proc/is_weak_rollable_contract(type)
 	force = 15
 	throwforce = 15
 	throw_range = 20
-	burn_possible = 0
+	burn_possible = FALSE
 	hit_type = DAMAGE_STAB
 	color = "#FF0000"
 	font_color = "#FF0000"
@@ -217,12 +217,12 @@ proc/is_weak_rollable_contract(type)
 	name = "box of demonic pens"
 	desc = "Contains a set of seven pens, great for collectors."
 	spawn_contents = list(/obj/item/pen/fancy/satan = 4)
-	burn_possible = 0 //Only makes sense since it's from hell.
+	burn_possible = FALSE //Only makes sense since it's from hell.
 
 /obj/item/paper/soul_selling_kit
 	color = "#FF0000"
 	name = "Paper-'Soul Stealing 101'"
-	burn_possible = 0 //Only makes sense since it's from hell.
+	burn_possible = FALSE //Only makes sense since it's from hell.
 	info = {"<b>You shouldn't be seeing this yet!</b>"}
 
 	New()
@@ -251,7 +251,7 @@ proc/is_weak_rollable_contract(type)
 	throwforce = 15
 	throw_speed = 1
 	throw_range = 8
-	burn_possible = 0 //Only makes sense since it's from hell.
+	burn_possible = FALSE //Only makes sense since it's from hell.
 	item_function_flags = IMMUNE_TO_ACID // we don't get a spare, better make sure it lasts.
 	w_class = W_CLASS_BULKY
 	max_wclass = W_CLASS_NORMAL
@@ -372,7 +372,7 @@ END GUIDE
 	throw_speed = 4
 	throw_range = 10
 	desc = "A blank contract that's gone missing from hell."
-	burn_possible = 0 //Only makes sense since it's from hell.
+	burn_possible = FALSE //Only makes sense since it's from hell.
 	var/limiteduse = 0 //whether it has a limited number of uses. 1 is limited, 0 is unlimited.
 	var/inuse = 0 //is someone currently signing this thing?
 	var/used = 0 // how many times a limited use contract has been signed so far

--- a/code/datums/components/foldable.dm
+++ b/code/datums/components/foldable.dm
@@ -93,7 +93,7 @@ TYPEINFO(/datum/component/foldable)
 
 	burn_point = 2500
 	burn_output = 2500
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 10
 
 	var/atom/movable/thingInside

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -1037,7 +1037,7 @@ TYPEINFO(/obj/item/clothing/shoes/stomp_boots)
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW
 	laces = LACES_NONE
-	burn_possible = 0
+	burn_possible = FALSE
 	abilities = list(/obj/ability_button/stomper_boot_stomp)
 
 	setupProperties()
@@ -1275,7 +1275,7 @@ TYPEINFO(/obj/item/clothing/shoes/stomp_boots)
 
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 4
 	var/can_put_up = 1
 

--- a/code/modules/admin/gimmick/wizard_rings.dm
+++ b/code/modules/admin/gimmick/wizard_rings.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/item_wizard_rings.dmi'
 	icon_state = "ring"
 	item_state = "ring"
-	burn_possible = 0
+	burn_possible = FALSE
 	magical = 1
 	var/ability_path = null			//The ability that this ring is linked to.	//When it's null it's either soulguard or the parent. I'm lazy.
 	var/last_cast = 0

--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -355,7 +355,7 @@
 					var/turf/oldloc = get_turf(src)
 					src.visible_message(SPAN_ALERT("[src] blasts its ass all over the bible.<br><b>A mysterious force <u>is not pleased</u>!</b>"))
 					src.set_loc(pick(get_area_turfs(/area/afterlife/hell/hellspawn)))
-					B.burn_possible = 0 // protect the book
+					B.burn_possible = FALSE // protect the book
 					SPAWN(1 SECOND)
 						if(B)
 							B.burn_possible = initial(B.burn_possible) // But only till the explosion's gone

--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -43,7 +43,7 @@
 	//cogwerks - burning vars
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 	var/list/form_startpoints
 	var/list/form_endpoints
 	var/font_css_crap = null
@@ -582,7 +582,7 @@
 	//cogwerks - burn vars
 	burn_point = 600
 	burn_output = 800
-	burn_possible = 1
+	burn_possible = TRUE
 
 	/// the item type this bin contains, should always be a subtype for /obj/item for reasons...
 	var/bin_type = /obj/item/paper
@@ -845,7 +845,7 @@
 /obj/item/paper/folded
 	name = "folded paper"
 	icon_state = "paper"
-	burn_possible = 1
+	burn_possible = TRUE
 	sealed = 1
 	var/old_desc = null
 	var/old_icon_state = null

--- a/code/modules/writing/pens_writing_etc.dm
+++ b/code/modules/writing/pens_writing_etc.dm
@@ -1239,7 +1239,7 @@
 	//cogwerks - burning vars
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 10
 	w_class = W_CLASS_TINY
 
@@ -1367,7 +1367,7 @@
 	amount = 10
 	burn_point = 220
 	burn_output = 200
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 2
 
 	// @TODO

--- a/code/obj/critter/automaton.dm
+++ b/code/obj/critter/automaton.dm
@@ -174,7 +174,7 @@ var/global/the_automaton = null
 				user.canmove = 0
 				user.anchored = ANCHORED
 				user.set_loc(src.loc)
-				K.burn_possible = 1
+				K.burn_possible = TRUE
 				SPAWN(2 SECONDS)
 					src.visible_message(SPAN_ALERT("<B>[src] forces [user] inside one of the keyholes!</B>."))
 					user.implode()

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -27,8 +27,7 @@ ABSTRACT_TYPE(/obj/item)
 	/*_______*/
 	/*Burning*/
 	/*‾‾‾‾‾‾‾*/
-	var/burn_possible = 1 //cogwerks fire project - can object catch on fire - let's have all sorts of shit burn at hellish temps
-	//MBC : im shit. change burn_possible to '2' if you want it to pool itself instead of qdeling when burned
+	var/burn_possible = TRUE //cogwerks fire project - can object catch on fire - let's have all sorts of shit burn at hellish temps
 	var/burning = null
 	/// How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
 	var/health = null
@@ -955,11 +954,8 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 
 			src.combust_ended()
 
-			if (src.burn_possible == 2)
-				qdel(src)
-			else
-				src.overlays.len = 0
-				qdel(src)
+			src.overlays.len = 0
+			qdel(src)
 			return
 	else
 		if (burning_last_process != src.burning)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -18,7 +18,7 @@ Custom Books
 	//cogwerks - burn vars
 	burn_point = 400
 	burn_output = 1100
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 4
 	//
 

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -209,7 +209,7 @@ TYPEINFO(/obj/item/camera_film/large)
 	tooltip_flags = REBUILD_DIST
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 
 	New(location, var/image/IM, var/icon/IC, var/nname, var/ndesc)
 		..(location)

--- a/code/obj/item/canvas.dm
+++ b/code/obj/item/canvas.dm
@@ -41,7 +41,7 @@
 
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 	health = 10
 
 	stamina_damage = 0

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -829,7 +829,7 @@
 	stamina_crit_chance = 1
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 4
 	var/match_amt = 6 // -1 for infinite
 	rand_pos = 1
@@ -908,7 +908,7 @@
 	stamina_crit_chance = 1
 	burn_point = 220
 	burn_output = 600
-	burn_possible = 1
+	burn_possible = TRUE
 
 	var/on = MATCH_UNLIT
 

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -780,7 +780,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "brassgauntlet"
 	item_state = "brassgauntlet"
 	punch_damage_modifier = 3
-	burn_possible = 0
+	burn_possible = FALSE
 	cant_self_remove = 1
 	cant_other_remove = 1
 	abilities = list()

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -398,7 +398,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	icon_state = "clown"
 	item_state = "clown_hat"
 	item_function_flags = IMMUNE_TO_ACID
-	burn_possible = 0
+	burn_possible = FALSE
 	color_r = 1
 	color_g = 1
 	color_b = 1
@@ -553,7 +553,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	desc = "A little mask, made of paper. It isn't gunna stay on anyone's face like this, though."
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 3
 
 	attackby(obj/item/W, mob/user)
@@ -582,7 +582,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	see_face = FALSE
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/pen))

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -16,7 +16,7 @@
 	//cogwerks - burn vars
 	burn_point = 400
 	burn_output = 800
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 5
 	tooltip_flags = REBUILD_DIST
 	var/step_sound = "step_default"
@@ -70,7 +70,7 @@
 	protective_temperature = 0
 	var/uses = 6
 	var/emagged = 0
-	burn_possible = 0
+	burn_possible = FALSE
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW
 
@@ -178,7 +178,7 @@ TYPEINFO(/obj/item/clothing/shoes/magnetic)
 	desc = "Keeps the wearer firmly anchored to the ground. Provided the ground is metal, of course."
 	icon_state = "magboots"
 	// c_flags = NOSLIP
-	burn_possible = 0
+	burn_possible = FALSE
 	laces = LACES_NONE
 	kick_bonus = 2
 	step_sound = "step_plating"
@@ -207,7 +207,7 @@ TYPEINFO(/obj/item/clothing/shoes/hermes)
 	icon_state = "wizard" //TODO: replace with custom sprite, thinking winged sandals
 	c_flags = NOSLIP
 	magical = 1
-	burn_possible = 0
+	burn_possible = FALSE
 	laces = LACES_NONE
 	step_sound = "step_flipflop"
 	step_priority = STEP_PRIORITY_LOW
@@ -230,7 +230,7 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 	name = "mechanised boots"
 	desc = "Industrial-grade boots fitted with mechanised balancers and stabilisers to increase running speed under a heavy workload."
 #endif
-	burn_possible = 0
+	burn_possible = FALSE
 	laces = LACES_NONE
 	kick_bonus = 2
 
@@ -522,7 +522,7 @@ TYPEINFO(/obj/item/clothing/shoes/moon)
 	desc = "Some kind of fancy boots with little propulsion rockets attached to them, that let you move through space with ease and grace! Okay, maybe not grace. That part depends on you. Also, they are a fashion disaster. On the plus side, you can more easily escape the fashion police while wearing them!"
 	icon_state = "rocketboots"
 	laces = LACES_NONE
-	burn_possible = 0
+	burn_possible = FALSE
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW
 	var/on = 1

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -14,7 +14,7 @@
 	//cogwerks - burn vars
 	burn_point = 400
 	burn_output = 800
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 10
 	var/team_num
 
@@ -157,7 +157,7 @@
 	inhand_image_icon = 'icons/mob/inhand/jumpsuit/hand_js_pride.dmi'
 	icon_state = "gay"
 	item_state = "gay"
-	burn_possible = 0
+	burn_possible = FALSE
 
 	ace
 		name = "ace pride jumpsuit"
@@ -1246,7 +1246,7 @@ TYPEINFO(/obj/item/clothing/under/towel)
 	body_parts_covered = TORSO
 	burn_point = 450
 	burn_output = 800
-	burn_possible = 1
+	burn_possible = TRUE
 	rand_pos = 0
 	mat_changename = FALSE
 	default_material = "cotton"

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -199,7 +199,7 @@ TYPEINFO(/obj/item/device/chameleon)
 	name = "chameleon bomb"
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "cham_bomb"
-	burn_possible = 0
+	burn_possible = FALSE
 	HELP_MESSAGE_OVERRIDE(null)
 	var/strength = 12
 

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -758,7 +758,7 @@ ADMIN_INTERACT_PROCS(/obj/item/roadflare, proc/light, proc/put_out)
 	stamina_crit_chance = 1
 	burn_point = 220
 	burn_output = 1200
-	burn_possible = 1
+	burn_possible = TRUE
 
 	var/on = FLARE_UNLIT
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -722,7 +722,7 @@ TYPEINFO(/obj/item/radiojammer)
 	icon_state = "beacon"
 	item_state = "signaler"
 	desc = "A small beacon that is tracked by the Teleporter Computer, allowing things to be sent to its general location."
-	burn_possible = 0
+	burn_possible = FALSE
 	anchored = ANCHORED
 
 	var/list/obj/portals_pointed_at_us

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1592,7 +1592,7 @@ TYPEINFO(/obj/item/old_grenade/oxygen)
 	name = "pipe frame"
 	desc = "Two small pipes joined together with grooves cut into the side."
 	icon_state = "Pipe_Frame"
-	burn_possible = 0
+	burn_possible = FALSE
 	material_amt = 0.3
 	HELP_MESSAGE_OVERRIDE("") // so there's the verb and stuff, actual message provided below
 	var/state = 1

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -364,7 +364,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	icon_state = "medium"
 	w_class = W_CLASS_TINY
 	var/forensic_ID = null
-	burn_possible = 0
+	burn_possible = FALSE
 
 	small
 		icon_state = "small"

--- a/code/obj/item/keys.dm
+++ b/code/obj/item/keys.dm
@@ -8,7 +8,7 @@ ABSTRACT_TYPE(/obj/item/device/key)
 	item_state = "pen"
 	force = null
 	w_class = W_CLASS_TINY
-	burn_possible = 0 // too important to burn!
+	burn_possible = FALSE // too important to burn!
 	var/id = null
 	var/dodgy = 0 //Woe be upon the poor fool who tries to give a dodgy key to the automaton
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -272,7 +272,7 @@
 	//cogwerks - burn vars
 	burn_point = 450
 	burn_output = 1600
-	burn_possible = 2
+	burn_possible = TRUE
 	health = 20
 
 /obj/item/raw_material/claretine // relate this to wizardry somehow
@@ -368,7 +368,7 @@
 	//cogwerks - burn vars
 	burn_point = 1000
 	burn_output = 10000
-	burn_possible = 2
+	burn_possible = TRUE
 	health = 40
 	powersource = 1
 	crystal = 1
@@ -517,7 +517,7 @@
 	desc = "Some twisted and ruined metal. It could probably be smelted down into something more useful."
 	icon_state = "scrap"
 	stack_type = /obj/item/raw_material/scrap_metal
-	burn_possible = 0
+	burn_possible = FALSE
 	mat_changename = TRUE
 	material_name = "Steel"
 	default_material = "steel"
@@ -547,7 +547,7 @@
 	stamina_damage = 5
 	stamina_cost = 5
 	stamina_crit_chance = 35
-	burn_possible = 0
+	burn_possible = FALSE
 	event_handler_flags = USE_FLUID_ENTER
 	material_amt = 0.1
 	material_name = "Glass"

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -138,7 +138,7 @@ TYPEINFO(/obj/item/disk)
 	invisibility = INVIS_ALWAYS
 	anchored = ANCHORED_ALWAYS
 	flags = TABLEPASS | UNCRUSHABLE
-	burn_possible = 0
+	burn_possible = FALSE
 	item_function_flags = IMMUNE_TO_ACID
 
 	disposing()

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -30,7 +30,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 	health = 4
 	burn_point = 330
 	burn_output = 800
-	burn_possible = 2
+	burn_possible = TRUE
 	item_function_flags = COLD_BURN
 	crop_suffix	= " leaf"
 

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -15,7 +15,7 @@
 	w_class = W_CLASS_TINY
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 	///what style of card sprite are we using?
 	var/card_style
 	///number of cards in a full deck (used for reference when updating stack size)
@@ -365,7 +365,7 @@ ABSTRACT_TYPE(/obj/item/card_group)
 	w_class = W_CLASS_TINY
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 	health = 10
 	inventory_counter_enabled = 1
 	/// same function as playing_card card name
@@ -1033,7 +1033,7 @@ ABSTRACT_TYPE(/obj/item/card_group)
 	w_class = W_CLASS_TINY
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 2
+	burn_possible = TRUE
 	health = 10
 	var/obj/item/card_group/stored_deck
 	var/box_style = "white"

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -14,7 +14,7 @@
 	throw_range = 8
 	w_class = W_CLASS_TINY
 	burn_point = 400
-	burn_possible = 2
+	burn_possible = TRUE
 	burn_output = 750
 	amount = 1
 	max_stack = 1000000

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -28,7 +28,7 @@
 		//cogwerks - burn vars
 	burn_point = 2500
 	burn_output = 2500
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 10
 
 	New()

--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -368,7 +368,7 @@
 	item_state = "scroll"
 	burn_point = 220
 	burn_output = 9
-	burn_possible = 1
+	burn_possible = TRUE
 	var/scrolltype
 	var/hat
 	var/obj/item/hatstorage

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -52,7 +52,7 @@
 
 	burn_point = 2500
 	burn_output = 2500
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 10
 
 	New(var/loc, var/obj/object)

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -236,7 +236,7 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals/posters.dmi', "wa
 	//cogwerks - burning vars (stolen from paper - haine)
 	burn_point = 220
 	burn_output = 900
-	burn_possible = 1
+	burn_possible = TRUE
 	health = 15
 
 	var/imgw = 400


### PR DESCRIPTION
[INTERNAL] [CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the code for `/obj/item` there exists a var called `burn_possible`. It behaved almost like a boolean but could also equal 2 instead, for memory pooling reasons.

This PR replaces all instances of `burn_possible` with `TRUE` and `FALSE` defines, turning instances of `0` into `FALSE` and values of `1` or `2` into `TRUE`. In addition, the check for `if (burn_possible == 2)` has been removed and the `else` block made the standard.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`pool(src)` has been replaced with `qdel(src)` in the single spot where `burn_possible == 2` was checked, meaning that the var having a value of `2` is now useless. There is no longer any need for it as of about 2 years ago, so it's best to remove the usage entirely to avoid confusion.