### PR TITLE
Fix Clarion mail system infinite loop

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44195,7 +44195,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "xpl" = (
-/obj/disposalpipe/segment/mail,
 /obj/disposalpipe/switch_junction{
 	dir = 1;
 	icon_state = "pipe-sj2";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes an extraneous mail pipe on the same tile as the mail router for medbay that was causing the router to never be reached and all mail tagged for medbay to infinitely zoom around the mail loop forever

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug
