### PR TITLE
Fix plasmaglass shard/plant pot interaction (again!)

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -529,14 +529,14 @@ TYPEINFO(/obj/machinery/plantpot)
 			return
 
 
-	else if(istype(W, /obj/item/raw_material/shard/plasmacrystal) && !current)
-		// Planting a crystal shard simply puts a crystal seed inside the plant pot for
-		// a moment, spawns a new plant from it, then deletes both the seed and the shard.
-		user.visible_message(SPAN_NOTICE("[user] plants [W] in the tray."))
+	else if((istype(W, /obj/item/raw_material/shard) && W.material?.getID() == "plasmaglass") && !current)
+		// Planting a plasmaglass shard puts a crystal seed inside the plant pot for
+		// a moment, spawns a new plant from it, then removes the seed and one shard.
+		user.visible_message(SPAN_NOTICE("[user] plants a plasmaglass shard in the tray."))
 		var/obj/item/seed/crystal/WS = new /obj/item/seed/crystal
 		WS.set_loc(src)
 		src.HYPnewplant(WS)
-		qdel(W)
+		W.change_stack_amount(-1)
 		sleep(0.5 SECONDS)
 		qdel(WS)
 		if(!(user in src.contributors))


### PR DESCRIPTION
[Bug][Catering]
## About the PR
This changes the type-check for putting a plasmaglass piece into a plant tray so that it uses all shards made of plasmaclass (instead of just a specific type of shard)
also planting a stack of plasmaglass will only use one shard and not all of them. (Like scrap weapon fixes, right?)

i tried merging this before, but there wsa a big change to one of the files (plantpot.dm), so i closed the requset and copied the changes to the new version of the file. But the code changes are the same as the first pr, after the reveiw. thank you, reviewers! :>  

(sorry if this is the wrong way to fix conflicts! I didn't know how else to fix...)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
you couldn't use plasmaglass shards from broken windows for planting before, but now you can. consistancy is good! (and pali said i was allowed to - thanks pali!)
the other bug bugged me, so i fixed it. 
also fixed the planting message to be in line with putting one glass piece inside! Better text is good.