### PR TITLE
Allow cyborgs to access any TGUI interface on the same z-level

### DIFF
--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -30,13 +30,9 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 	if(. <= UI_DISABLED)
 		return
 
-	// Robots can interact with anything they can see.
-	if(GET_DIST(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
+	// Robots can interact with anything on the z-level
+	if(get_z(src_object) == get_z(src))
 		return UI_INTERACTIVE
-
-	// AI Borgs can receive updates from anything that the AI can see.
-	if (src.connected_ai)
-		return UI_UPDATE
 
 	return UI_DISABLED // Otherwise they can keep the UI open.
 
@@ -45,8 +41,8 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 	if(. <= UI_DISABLED)
 		return
 
-	// Robots can interact with anything they can see.
-	if(GET_DIST(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
+	// Robots can interact with anything on the z-level
+	if(get_z(src_object) == get_z(src))
 		return UI_INTERACTIVE
 
 	return UI_UPDATE // AI eyebots can receive updates from anything that the AI can see.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I realised you can't do borg telesci nerdery with the new TGUI telesci computer and I think borgs being able to remote-access machinery is a cool thing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm pretty sure the only reason they can't is because we ported the range check from TG anyway and this brings TGUI more in line with how our old-style interfaces work.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Cyborgs can now access any TGUI interface on the same z-level as them regardless of range.
```
