### PR TITLE
Fix disease bypassing 100% resistance

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -323,6 +323,9 @@
 			return 0
 
 		if (istype(A,/datum/ailment/disease/))
+			// If we have 100% immunity at this point to a disease, don't get sick
+			if (resist_prob == 100)
+				return 0
 			var/datum/ailment/disease/D = A
 			resist_prob -= D.virulence
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check so if a mob has 100% viral resistance to disease, they should not get that disease. Should stop the cold/flu from being transmitted when user is on an air tank or has a full biohazard suit on. 

Just as a sanity check, most antag abilities that relate to diseases enable resistance bypassing on the effect or injects a reagent that imparts the disease. I also confirmed you can still get the cold/flu if given the corresponding associated_reagent since that always bypasses resistance here.

https://github.com/goonstation/goonstation/blob/990997a045c4a222d69ffd2573a29538420d806f/code/modules/chemistry/Reagents-Diseases.dm#L34 

Do note that it looks like this ability below does check if a mob has viral resistance, but it is not given to a werewolf what what I can see. This non-bypass of disease resistance looks to be intended, but if we don't want someone wearing a biohazard suit immune to getting turned to a werewolf via this power, we'd have to make an additional edit to what I've got in this PR. 
https://github.com/goonstation/goonstation/blob/990997a045c4a222d69ffd2573a29538420d806f/code/modules/antagonists/werewolf/abilities/werewolf_spread_affliction.dm#L125

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10638
Additional detail in bug ticket.