### PR TITLE
help message for /obj/machinery/vending

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -136,6 +136,11 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 	power_usage = 50
 
+	HELP_MESSAGE_OVERRIDE({"You can insert credits or swipe your ID and enter your pin to pay for items. Certain vendors have access requirements. \
+							You can hack most vendors with a <b>screwdriver</b>, <b>multitool</b>, and optionally a <b>snipping tool</b>. You can \
+							use a <b>prying tool</b> to lift the machine up when tipped over or rotate the machine when upright."})
+
+
 	New()
 		START_TRACKING
 		src.create_products()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -136,11 +136,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 	power_usage = 50
 
-	HELP_MESSAGE_OVERRIDE({"You can insert credits or swipe your ID and enter your pin to pay for items. Certain vendors have access requirements. \
-							You can hack most vendors with a <b>screwdriver</b>, <b>multitool</b>, and optionally a <b>snipping tool</b>. You can \
-							use a <b>prying tool</b> to lift the machine up when tipped over or rotate the machine when upright."})
-
-
 	New()
 		START_TRACKING
 		src.create_products()
@@ -252,6 +247,20 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 		else
 			return src.loc
+
+	HELP_MESSAGE_OVERRIDE({""})
+	get_help_message(dist, mob/user)
+		if (src.status & BROKEN) // Vendor is tipped
+			. += {"You can use a <b>crowbar</b> to lift the machine back up.\n"}
+			return // No need to show other tooltips
+		if ((src.can_hack) && (src.panel_open)) // Wire panel open for hacking
+			. += {"You can use a <b>multitool</b> to pulse and <b>wirecutters</b> to cut wires in the wire panel.\n"}
+			return // No need to clutter help text with other tips
+		if (src.acceptcard)
+			. += {"You can swipe your ID and enter your pin to pay for items.\n"}
+		if ((src.can_hack) && (!src.panel_open))
+			. += {"You can use a <b>screwdriver</b> to open the maintenance panel.\n"}
+		. += {"You can use a <b>crowbar</b> to rotate the machine.\n"}
 
 #define WIRE_EXTEND 1
 #define WIRE_SCANID 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL][Game Object]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a generic help message to /obj/machinery/vending.

![image](https://github.com/goonstation/goonstation/assets/5091297/63a96a69-3956-4d51-873d-36786507c793)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11720
"Fix" in the sense that we've added a help message of some common things that can be done with vendors for players unfamiliar with them vs actually fixing facing. If we want to preserve facing when righting the vending machine, let me know here and I'll take a stab at it!