### PR TITLE
Standardise `return_air()`, ditch `hasvar("air_contents")`

### DIFF
--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -272,14 +272,10 @@ var/global/list/turf/hotly_processed_turfs = list()
 
 /// Returns air mixture of turf or air group, if we have one. If we don't, return [/turf/return_air].
 /turf/simulated/return_air()
-	if(src.air)
-		if(src.parent?.group_processing)
-			return src.parent.air
-		else
-			return src.air
-
+	if(src.parent?.group_processing)
+		return src.parent.air
 	else
-		return ..()
+		return src.air
 
 /// Removes some moles from turf or air group.
 /turf/simulated/remove_air(amount)

--- a/code/modules/atmospherics/machinery/unary/unary_base.dm
+++ b/code/modules/atmospherics/machinery/unary/unary_base.dm
@@ -73,6 +73,9 @@
 
 	return results
 
+/obj/machinery/atmospherics/unary/return_air()
+	return air_contents
+
 /obj/machinery/atmospherics/unary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference==node)
 		network?.dispose()

--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -143,3 +143,6 @@
 				return
 
 	return
+
+/obj/machinery/portable_atmospherics/return_air()
+	return air_contents

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -504,6 +504,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 				user.suiciding = 0
 		return 1
 
+	return_air()
+		return air_contents
+
 /obj/machinery/disposal/small
 	icon = 'icons/obj/disposal_small.dmi'
 	handle_normal_state = "disposal-handle"

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -396,11 +396,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/iterations = owner.material.getProperty("molitz_bubbles")
 		if(iterations <= 0) return
 
-		var/datum/gas_mixture/air
-		if(hasvar(owner, "air_contents"))
-			air = owner:air_contents
-		if(!istype(air) && hasvar(owner.loc, "air_contents"))
-			air = owner.loc:air_contents
+		var/datum/gas_mixture/air = owner.return_air() || owner.loc.return_air()
 		if(!istype(air))
 			var/turf/target = get_turf(owner)
 			air = target?.return_air()

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -759,6 +759,9 @@
 		H.vent_gas(loc)
 		qdel(H)
 
+	return_air()
+		return air_contents
+
 /obj/item/mechanics/thprint
 	name = "Thermal printer"
 	desc = ""

--- a/code/obj/item/assembly/single_tank_bomb.dm
+++ b/code/obj/item/assembly/single_tank_bomb.dm
@@ -170,6 +170,10 @@
 	SPAWN(1 SECOND)
 		prox_check()
 
+/obj/item/assembly/proximity_bomb/return_air()
+	return src.part3?.return_air()
+
+
 /////////////////////////////////////////////////// Single tank bomb (timer) ////////////////////////////////////
 
 /obj/item/assembly/time_bomb
@@ -258,6 +262,9 @@
 			src.part3.release()
 	return
 
+/obj/item/assembly/time_bomb/return_air()
+	return src.part3?.return_air()
+
 /////////////////////////////////////////////////// Single tank bomb (remote signaller) ////////////////////////////////////
 
 /obj/item/assembly/radio_bomb
@@ -342,3 +349,6 @@
 		if (!src.status && src.force_dud == 0)
 			src.part3.release()
 	return
+
+/obj/item/assembly/radio_bomb/return_air()
+	return src.part3?.return_air()

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -174,6 +174,9 @@ A Flamethrower in various states of assembly
 				P_special_data["chem_pct_app_tile"] = 0.15
 		inventory_counter?.update_percent(src.fueltank?.reagents?.total_volume, src.fueltank?.reagents?.maximum_volume)
 
+/obj/item/gun/flamethrower/return_air()
+	return src.gastank?.return_air()
+
 /obj/item/gun/flamethrower/assembled
 	name = "flamethrower"
 	icon = 'icons/obj/items/weapons.dmi'

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -350,6 +350,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/floorflusher, proc/flush)
 		AM.pipe_eject(0)
 		AM?.throw_at(target, 5, 1)
 
+	return_air()
+		return air_contents
+
 /obj/machinery/floorflusher/industrial
 	name = "industrial loading chute"
 	desc = "Totally just a giant disposal chute"

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -682,7 +682,8 @@
 			return
 		. = ..()
 
-
+	return_air()
+		return air_contents
 
 /datum/neutron //this is literally just a tuple
 	var/dir = NORTH

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -307,6 +307,9 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 	var/const/plasma_react_mols = 25
 	var/const/co2_react_mols = 10
 
+	return_air()
+		return air_contents
+
 	melt()
 		..()
 		gas_thermal_cross_section = 0.1 //oh no, all the fins and stuff are melted

--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -261,6 +261,9 @@
 					user.TakeDamage("head", 200, 0, 0, DAMAGE_CRUSH)
 				return TRUE
 
+	return_air()
+		return air_contents
+
 	ui_interact(mob/user, datum/tgui/ui)
 		ui = tgui_process.try_update_ui(user, src, ui)
 		if (!ui)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -735,33 +735,9 @@
 	if(visible)
 		animate_scanning(A, "#00a0ff", alpha_hex = "32")
 
-	var/datum/gas_mixture/check_me = null
+	var/datum/gas_mixture/check_me = A.return_air()
 	var/pressure = null
 	var/total_moles = null
-
-	if (hasvar(A, "air_contents"))
-		check_me = A:air_contents // Not pretty, but should be okay here.
-	if (isturf(A))
-		check_me = A.return_air()
-	if (istype(A, /obj/machinery/atmospherics/pipe))
-		var/obj/machinery/atmospherics/pipe/P = A
-		check_me = P.parent.air
-	if (istype(A, /obj/item/assembly/time_bomb))
-		var/obj/item/assembly/time_bomb/TB = A
-		if (TB.part3)
-			check_me = TB.part3.air_contents
-	if (istype(A, /obj/item/assembly/radio_bomb))
-		var/obj/item/assembly/radio_bomb/RB = A
-		if (RB.part3)
-			check_me = RB.part3.air_contents
-	if (istype(A, /obj/item/assembly/proximity_bomb))
-		var/obj/item/assembly/proximity_bomb/PB = A
-		if (PB.part3)
-			check_me = PB.part3.air_contents
-	if (istype(A, /obj/item/gun/flamethrower/assembled/))
-		var/obj/item/gun/flamethrower/assembled/FT = A
-		if (FT.gastank)
-			check_me = FT.gastank.air_contents
 
 	if (!check_me || !istype(check_me, /datum/gas_mixture/))
 		if (pda_readout == 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements `return_air()` on a bunch of things that didn't have it, and eliminates all the instances of using `hasvar("air_contents")`   and `thing:air_contents`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Standardisation good. 


