### PR TITLE
Change the emag text for the PTL and adds a sound

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -76,7 +76,7 @@
 	src.emagged = TRUE
 	if (user)
 		src.add_fingerprint(user)
-		playsound(src.loc, 'sound/machines/bweep.ogg', 10, 1)
+		playsound(src.loc, 'sound/machines/bweep.ogg', 10, TRUE)
 		src.visible_message(SPAN_ALERT("The [src.name] quietly chirps 'FINANCE TRANSFER OVERRIDE' from some unseen speaker, then goes quiet."))
 	return 1
 

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -76,7 +76,7 @@
 	src.emagged = TRUE
 	if (user)
 		src.add_fingerprint(user)
-		playsound(src.loc, "sound/machines/bweep.ogg", 10, 1)
+		playsound(src.loc, 'sound/machines/bweep.ogg', 10, 1)
 		src.visible_message(SPAN_ALERT("The [src.name] quietly chirps 'FINANCE TRANSFER OVERRIDE' from some unseen speaker, then goes quiet."))
 	return 1
 

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -86,7 +86,7 @@
 	if (user)
 		user.show_text("You reset the [src.name]'s fund transfer protocols.", "blue")
 	src.emagged = FALSE
-	return 1
+	return TRUE
 
 /obj/machinery/power/pt_laser/update_icon(var/started_firing = 0)
 	overlays = null

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -77,14 +77,20 @@
 	if (user)
 		src.add_fingerprint(user)
 		playsound(src.loc, 'sound/machines/bweep.ogg', 10, TRUE)
-		src.visible_message(SPAN_ALERT("The [src.name] quietly chirps 'FINANCE TRANSFER OVERRIDE' from some unseen speaker, then goes quiet."))
+		src.visible_message(SPAN_ALERT("The [src.name] chirps 'OUTPUT CONTROLS UNLOCKED: INVERSE POLARITY ENABLED' \
+		from some unseen speaker, then goes quiet."))
 	return TRUE
 
 /obj/machinery/power/pt_laser/demag(var/mob/user)
 	if (!src.emagged)
 		return FALSE
+
 	if (user)
-		user.show_text("You reset the [src.name]'s fund transfer protocols.", "blue")
+		user.show_text("You reset the [src.name]'s power output protocols.", "blue")
+
+	if (src.output_number < 0 || src.output < 0) //Checking both is redundant, but just in case
+		src.output_number = 0
+		src.output = 0
 	src.emagged = FALSE
 	return TRUE
 

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -78,7 +78,7 @@
 		src.add_fingerprint(user)
 		playsound(src.loc, 'sound/machines/bweep.ogg', 10, TRUE)
 		src.visible_message(SPAN_ALERT("The [src.name] quietly chirps 'FINANCE TRANSFER OVERRIDE' from some unseen speaker, then goes quiet."))
-	return 1
+	return TRUE
 
 /obj/machinery/power/pt_laser/demag(var/mob/user)
 	if (!src.emagged)

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -76,7 +76,16 @@
 	src.emagged = TRUE
 	if (user)
 		src.add_fingerprint(user)
-		src.visible_message(SPAN_ALERT("[src.name] looks a little wonky, as [user] has messed with the polarity using an electromagnetic card!"))
+		playsound(src.loc, "sound/machines/bweep.ogg", 10, 1)
+		src.visible_message(SPAN_ALERT("The [src.name] quietly chirps 'FINANCE TRANSFER OVERRIDE' from some unseen speaker, then goes quiet."))
+	return 1
+
+/obj/machinery/power/pt_laser/demag(var/mob/user)
+	if (!src.emagged)
+		return 0
+	if (user)
+		user.show_text("You reset the [src.name]'s fund transfer protocols.", "blue")
+	src.emagged = FALSE
 	return 1
 
 /obj/machinery/power/pt_laser/update_icon(var/started_firing = 0)

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -82,7 +82,7 @@
 
 /obj/machinery/power/pt_laser/demag(var/mob/user)
 	if (!src.emagged)
-		return 0
+		return FALSE
 	if (user)
 		user.show_text("You reset the [src.name]'s fund transfer protocols.", "blue")
 	src.emagged = FALSE

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -77,7 +77,7 @@
 	if (user)
 		src.add_fingerprint(user)
 		playsound(src.loc, 'sound/machines/bweep.ogg', 10, TRUE)
-		src.visible_message(SPAN_ALERT("The [src.name] chirps 'OUTPUT CONTROLS UNLOCKED: INVERSE POLARITY ENABLED' \
+		src.audible_message(SPAN_ALERT("The [src.name] chirps 'OUTPUT CONTROLS UNLOCKED: INVERSE POLARITY ENABLED' \
 		from some unseen speaker, then goes quiet."))
 	return TRUE
 


### PR DESCRIPTION
[Rework][Player Actions]

## About the PR 
If you emag the PTL, a small sound will play, and the player who emags it will get a more clear message hitning at what they just did (make it steal money with...negatife power output? power input? its crazy)

Also, for admins, theres a "demag" proc for the ptl now. :>

## Why's this needed? 
the money is being stolen! Now maybe someone can notice, maybe. (probably not!)

## Changelog 
```changelog
(u)NibChocolateeny
(+)Emagging the PTL makes a quiet sound, and has a clearer associated message
``
