### PR TITLE
Fix AI spacebux purchase not working on latejoin AI

### DIFF
--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -248,6 +248,7 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 						else if (S.syndicate)
 							logTheThing(LOG_STATION, src, "[key_name(S)] late-joins as an syndicate cyborg.")
 							S.mind?.add_antagonist(ROLE_SYNDICATE_ROBOT, respect_mutual_exclusives = FALSE, source = ANTAGONIST_SOURCE_LATE_JOIN)
+						S.Equip_Bank_Purchase(S.mind?.purchased_bank_item)
 						SPAWN(1 DECI SECOND)
 							S.bioHolder?.mobAppearance?.pronouns = S.client.preferences.AH.pronouns
 							S.choose_name()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a call to Equip_Bank_Purchase to the code for handling moving new_player into SICC borg/AI

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17204
