### PR TITLE
Fix silicons not being able to log into computer without ID scanner

### DIFF
--- a/code/modules/networks/computer3/smallprogs.dm
+++ b/code/modules/networks/computer3/smallprogs.dm
@@ -474,24 +474,25 @@ file_save - Save file to local disk."}
 				src.print_text("Service mode [src.service_mode ? "" : "de"]activated.")
 
 			if("term_login")
-				var/obj/item/peripheral/scanner = find_peripheral("ID_SCANNER")
-				if(!scanner)
-					src.print_text("Error: No ID scanner detected.")
-					return
 				if(!src.pnet_card)
 					src.print_text("Alert: No network card detected.")
 					return
 				if(!src.serv_id)
 					src.print_text("Alert: Connection required.")
 					return
-				src.ping_wait = 2
 
 				var/datum/computer/file/record/udat = new // what name, assignment, and access do we have??
+				var/obj/item/peripheral/scanner = find_peripheral("ID_SCANNER")
 				if (issilicon(usr) || isAI(usr)) // silicons dont have IDs and we want them to override any inserted ID
 					udat.fields["registered"] = isAI(usr) ? "AIUSR" : "CYBORG" // should probably make all logins use the actual name of the silicon at some point
 					udat.fields["assignment"] = "AI"
 					udat.fields["access"] = "34"
 				else
+					if(!scanner)
+						src.print_text("Error: No ID scanner detected.")
+						return
+				src.ping_wait = 2
+				if(!udat.fields["registered"]) // if a name hasn't been assigned yet (i.e. not a silicon, need to scan id)
 					var/datum/signal/scansignal = src.peripheral_command("scan_card",null,"\ref[scanner]")
 					if (istype(scansignal))
 						udat.fields["registered"] = scansignal.data["registered"]

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -107,6 +107,16 @@ file_save - Save file to local disk."}
 				src.peripheral_command("ping[src.net_number]", null, "\ref[src.netcard]")
 
 			if("term_login")
+				if (issilicon(usr) || isAI(usr))
+					src.ping_wait = 2
+					var/datum/signal/newsig = new
+					newsig.data["registered"] = isAI(usr) ? "AI" : "CYBORG"
+					newsig.data["assignment"] = "AI"
+					newsig.data["access"] = "34"
+
+					src.receive_command(src.master, "card_authed", newsig)
+					return
+
 				var/obj/item/peripheral/scanner = find_peripheral("ID_SCANNER")
 				if(!scanner)
 					src.print_text("Error: No ID scanner detected.")
@@ -118,26 +128,14 @@ file_save - Save file to local disk."}
 					src.print_text("Alert: Connection required.")
 					return
 				src.ping_wait = 2
-				if (issilicon(usr) || isAI(usr))
-					var/datum/signal/newsig = new
-					newsig.data["registered"] = isAI(usr) ? "AI" : "CYBORG"
-					newsig.data["assignment"] = "AI"
-					newsig.data["access"] = "34"
+				switch(src.peripheral_command("scan_card",null,"\ref[scanner]"))
+					if("nocard")
+						src.print_text("Please insert a card first.")
+					if("noreg")
+						src.print_text("Notice: No name on card.")
+					if("noassign")
+						src.print_text("Notice: No assignment on card.")
 
-					SPAWN(0.4 SECONDS)
-						switch( src.receive_command(src.master, "card_authed", newsig) )
-							if ("nocard")
-								src.print_text("Please insert a card first.")
-
-							if ("noreg")
-								src.print_text("Notice: No name on card.")
-
-							if ("noassign")
-								src.print_text("Notice: No assignment on card.")
-
-					return
-				else
-					src.peripheral_command("scan_card",null,"\ref[scanner]")
 /*
 			if("term_service")
 				if (src.serv_id)

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -107,6 +107,13 @@ file_save - Save file to local disk."}
 				src.peripheral_command("ping[src.net_number]", null, "\ref[src.netcard]")
 
 			if("term_login")
+				if(!src.netcard)
+					src.print_text("Alert: No network card detected.")
+					return
+				if(!src.serv_id)
+					src.print_text("Alert: Connection required.")
+					return
+
 				if (issilicon(usr) || isAI(usr))
 					src.ping_wait = 2
 					var/datum/signal/newsig = new
@@ -120,12 +127,6 @@ file_save - Save file to local disk."}
 				var/obj/item/peripheral/scanner = find_peripheral("ID_SCANNER")
 				if(!scanner)
 					src.print_text("Error: No ID scanner detected.")
-					return
-				if(!src.netcard)
-					src.print_text("Alert: No network card detected.")
-					return
-				if(!src.serv_id)
-					src.print_text("Alert: Connection required.")
 					return
 				src.ping_wait = 2
 				switch(src.peripheral_command("scan_card",null,"\ref[scanner]"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the special handling for silicons in the term_login command to run before ever checking for an ID scanner module because it completely bypasses it and sends the auth signal directly, and thus isn't required. Also fixes a random bug I noticed where the error codes related to ID scanning only ran in the `issilicon` branch (and thus would never run).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17217