### PR TITLE
Re-implements invisible catwalk lube fix.

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1461,6 +1461,7 @@ TYPEINFO(/turf/simulated/floor/grass)
 /// wetType: [-2 = glue, -1 = slime, 0 = dry, 1 = water, 2 = lube, 3 = superlube]
 /// silent: makes the overlay invisible and prevents the sound effect
 /turf/simulated/proc/wetify(var/wetType = 2, var/timeout = 80 SECONDS, var/color = null, var/silent = FALSE)
+	var/obj/grille/catwalk/catwalk = null
 	var/image/overlay = null
 	var/alpha = 60
 
@@ -1477,6 +1478,11 @@ TYPEINFO(/turf/simulated/floor/grass)
 	overlay.blend_mode = BLEND_ADD
 	overlay.alpha = alpha
 	overlay.color = color
+
+	if (istype(src, /turf/simulated/floor/airless/plating/catwalks)) // "Guh" - Leah
+		catwalk = locate() in src
+		catwalks.UpdateOverlays(overlay, "wet_overlay")
+
 	src.UpdateOverlays(overlay, "wet_overlay")
 	src.wet = wetType
 

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1479,7 +1479,7 @@ TYPEINFO(/turf/simulated/floor/grass)
 	overlay.alpha = alpha
 	overlay.color = color
 
-	if (istype(src, /turf/simulated/floor/airless/plating/catwalks)) // "Guh" - Leah
+	if (istype(src, /turf/simulated/floor/airless/plating/catwalk)) // "Guh" - Leah
 		catwalk = locate() in src
 		catwalks.UpdateOverlays(overlay, "wet_overlay")
 
@@ -1488,6 +1488,7 @@ TYPEINFO(/turf/simulated/floor/grass)
 
 	SPAWN(timeout)
 		src.UpdateOverlays(null, "wet_overlay")
+		catwalks.UpdateOverlays(null, "wet_overlay")
 		src.wet = 0
 
 /turf/simulated/floor/grassify()

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1488,7 +1488,7 @@ TYPEINFO(/turf/simulated/floor/grass)
 
 	SPAWN(timeout)
 		src.UpdateOverlays(null, "wet_overlay")
-		catwalk.UpdateOverlays(null, "wet_overlay")
+		catwalk?.UpdateOverlays(null, "wet_overlay")
 		src.wet = 0
 
 /turf/simulated/floor/grassify()

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1481,14 +1481,14 @@ TYPEINFO(/turf/simulated/floor/grass)
 
 	if (istype(src, /turf/simulated/floor/airless/plating/catwalk)) // "Guh" - Leah
 		catwalk = locate() in src
-		catwalks.UpdateOverlays(overlay, "wet_overlay")
+		catwalk.UpdateOverlays(overlay, "wet_overlay")
 
 	src.UpdateOverlays(overlay, "wet_overlay")
 	src.wet = wetType
 
 	SPAWN(timeout)
 		src.UpdateOverlays(null, "wet_overlay")
-		catwalks.UpdateOverlays(null, "wet_overlay")
+		catwalk.UpdateOverlays(null, "wet_overlay")
 		src.wet = 0
 
 /turf/simulated/floor/grassify()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot to handle catwalks in #17155 so this PR re-implements Leahthetech's fix. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lube needs to be visible so you can dodge it.




