### PR TITLE
add reagnents "paper" and "rubber" as assoc_reagents to their respective tree mutations

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -742,6 +742,7 @@
 	name_prefix = "Paper "
 	iconmod = "TreePaper"
 	crop = /obj/item/paper
+	assoc_reagents = list("paper")
 
 /datum/plantmutation/tree/dog
 	name = "Dogwood Tree"
@@ -780,6 +781,7 @@
 	name_prefix = "Rubber "
 	iconmod = "TreeRubber"
 	crop = /obj/item/material_piece/rubber/latex
+	assoc_reagents = list("rubber")
 
 /datum/plantmutation/tree/sassafras
 	name = "Sassafras Tree"


### PR DESCRIPTION
Apologies for a bit confusing title. All I've done was adding:
assoc_reagents("paper") to paper tree mutation
assoc_reagents("rubber") to rubber tree mutation

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This makes it possible to extract these chemicals from any crops the mutated tree seed is spliced with.

For example: You want to produce a lot of paper chemical so that you can mass produce potash. The Paper Tree does produce paper for sure, but since it's in form of paper sheets and there is no way to stack them, you have to put all them into a beaker one by one. Not very efficient. So instead, you splice the Paper Tree seed with Orange seed. Now you are able to produce oranges that can be extracted into orange juice and **paper chem**! (This would not have been possible before) Making the entire potash production much more efficient.
(I've wanted to add this mainly for the Paper Tree, but I suppose there is little harm in adding it to the Rubber Tree as well)