### PR TITLE
Maybe fix needs-reproducing staling?

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
         close-issue-message: "This issue has been marked as 'Needs Reproducing' for a month, and is being closed automatically. If you find a way to reproduce this bug, make another issue with more detailed reproduction steps."
         days-before-issue-stale: -1
         days-before-issue-close: 30
-        stale-issue-label: 'S-Needs-Reproducing'
+        only-issue-labels: 'S-Needs-Reproducing'
         exempt-issue-labels: 'E-Verified'
         ignore-issue-updates: true
         close-issue-reason: 'not_planned'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GITHUB]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes `stale-issue-label` to `only-issue-labels` because I think that makes more sense according to my 5 minutes of skimming this readme: https://github.com/actions/stale?tab=readme-ov-file#only-issue-labels


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Any issue with `S-Needs-Reproducing` is supposed to stale and auto-close after a month, but the bot just seems to be removing the label after 3 days instead??