### PR TITLE
skeletons don't drop wigs on death

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2739,7 +2739,7 @@
 			processed += organHolder.tail
 			if (prob(75) && organHolder.tail.loc == src)
 				ret += organHolder.tail
-		if (prob(50))
+		if (prob(50) && !isskeleton(src)) // Skeletons don't have hair, so don't create and drop a wig for them on death
 			var/obj/item/clothing/head/wig/W = create_wig()
 			if (W)
 				processed += W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Mutantraces]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to prevent skeletons from dropping a wig (of the hair they would have had if they weren't a skeleton) on death.

On death, skeletons get a list of all items to drop
https://github.com/goonstation/goonstation/blob/2c56e42ece354469087f179b113744f81b7016dd/code/datums/mutantraces.dm#L1187-L1191

To get a list of items to drop, this runs list_ejectables() which 50% of the time runs create_wig() and creates a wig based on the character's hair choices in character creator. This create_wig step shouldn't just be removed since this is the same function that lists items when mobs get buttgibbed or removed, so a check of if the mob is a skeleton has been added.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15544