### PR TITLE
Sets cloning with records to FALSE

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -4,7 +4,7 @@
 // time to show the message for before removing it
 #define MESSAGE_SHOW_TIME 	5 SECONDS
 
-var/global/cloning_with_records = TRUE
+var/global/cloning_with_records = FALSE
 ADMIN_INTERACT_PROCS(/obj/machinery/computer/cloning, proc/scan_someone, proc/clone_someone)
 /obj/machinery/computer/cloning
 	name = "Cloning Console"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr is a step sister pr to #17235, this sets the global/cloning_with_records established in #9626 to FALSE . This means that you cannot scan someone to have a cloning record in the computer, you can still clone directly from disks. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#17235 had a lot of feedback about how that change would be nice with prescanning but not on its own. The intent of this pr is primarily to be testmerged at the devs expression that way they can easily test out this change for up to several days in a row with/without the linked pr, and observe if what is deserved is wanted, merged.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea and Luxizzle
(*)Scanning people to get clone records has been disabled. You can still clone directly from security disks with cloning records on them. 
```
