### PR TITLE
portable reclaimer no longer clears leftovers

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -726,7 +726,7 @@
 	var/sound/sound_process = sound('sound/effects/pop.ogg')
 	var/sound/sound_grump = sound('sound/machines/buzz-two.ogg')
 	var/atom/output_location = null
-	var/list/atom/leftovers = null
+	var/list/atom/leftovers = list()
 
 	attack_hand(var/mob/user)
 		if (active)
@@ -735,7 +735,6 @@
 		if (length(src.contents) < 1)
 			boutput(user, SPAN_ALERT("There's nothing inside to reclaim."))
 			return
-		leftovers = list()
 		user.visible_message("<b>[user.name]</b> switches on [src].")
 		active = 1
 		anchored = ANCHORED
@@ -765,14 +764,6 @@
 		if (reject)
 			src.reject = 0
 			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")
-			playsound(src.loc, sound_grump, 40, 1)
-
-		var/waste = 0
-		for(var/matID in leftovers)
-			if(leftovers[matID] > 0)
-				waste = 1
-		if (waste)
-			src.visible_message("<b>[src]</b> emits a grumpy buzz and disintegrates some leftovers.")
 			playsound(src.loc, sound_grump, 40, 1)
 
 		active = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][Materials][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Portable reclaimer no longer clears leftovers. As in: if you put 5 sheets, reclaim, put 5 sheets and then finally reclaim again, it will yield the 1 bar as if you reclaimed the 10 sheets at once. Currently all the materials would be wasted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Is nice. Also it makes it so that adding the ability to reclaim trash items (cyborg legs, empty implant cases) makes sense.

There really isn't a reason to clear it


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(+)Portable reclaimers have been upgraded to no longer disintegrate leftovers
```
