### PR TITLE
Add MechComp integration to the TEG blowers

### DIFF
--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -4,6 +4,8 @@
 #define LEFT_CIRCULATOR 1
 #define RIGHT_CIRCULATOR 2
 #define BASE_LUBE_CHECK_RATE 5
+/// Max circulator pressure
+#define CIRCULATOR_MAX_PRESSURE 1e5
 
 // Circulator variants
 /// no backflow
@@ -111,7 +113,7 @@
 		if(!length(input.signal)) return
 		var/newpressure = text2num(input.signal)
 		if(!isnum_safe(newpressure) || newpressure == src.target_pressure) return
-		src.target_pressure = clamp(newpressure, 0, 1e5)
+		src.target_pressure = clamp(newpressure, 0, CIRCULATOR_MAX_PRESSURE)
 		logTheThing(LOG_STATION, src, "set target pressure to [src.target_pressure] kPa using mechcomp.")
 
 	disposing()
@@ -541,7 +543,7 @@ datum/pump_ui/circulator_ui
 	value_name = "Target Transfer Pressure"
 	value_units = "kPa"
 	min_value = 0
-	max_value = 1e5
+	max_value = CIRCULATOR_MAX_PRESSURE
 	incr_sm = 10
 	incr_lg = 100
 	var/obj/machinery/atmospherics/binary/circulatorTemp/our_circ
@@ -1792,6 +1794,7 @@ TYPEINFO(/obj/machinery/power/furnace/thermo)
 #undef PUMP_POWERLEVEL_5
 #undef LEFT_CIRCULATOR
 #undef RIGHT_CIRCULATOR
+#undef CIRCULATOR_MAX_PRESSURE
 #undef BASE_LUBE_CHECK_RATE
 #undef BACKFLOW_PROTECTION
 #undef LEAKS_GAS

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -105,7 +105,7 @@
 
 	proc/toggle_active()
 		src.target_pressure_enabled = !src.target_pressure_enabled
-		logTheThing(LOG_STATION, src, "toggled blower power using mechcomp.")
+		logTheThing(LOG_STATION, src, "toggled blower power [src.target_pressure_enabled ? "on" : "off"] using mechcomp.")
 
 	proc/set_target_pressure(datum/mechanicsMessage/input)
 		if(!length(input.signal)) return

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -94,8 +94,8 @@
 		target_pressure = min_circ_pressure
 		target_pressure_enabled = FALSE
 		AddComponent(/datum/component/mechanics_holder)
-		SEND_SIGNAL(src, COMSIG_MECHCOMP_ADD_INPUT, "Toggle Active", PROC_REF(toggle_active))
-		SEND_SIGNAL(src, COMSIG_MECHCOMP_ADD_INPUT, "Set Target Pressure", PROC_REF(set_target_pressure))
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_ADD_INPUT, "Toggle Active", PROC_REF(mechcomp_toggle_active))
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_ADD_INPUT, "Set Target Pressure", PROC_REF(mechcomp_set_target_pressure))
 
 
 	proc/assign_variant(partial_serial_num, variant_a, variant_b=null)
@@ -105,11 +105,11 @@
 			src.serial_num += "-[variant_b]"
 			variant_b_active = TRUE
 
-	proc/toggle_active()
+	proc/mechcomp_toggle_active()
 		src.target_pressure_enabled = !src.target_pressure_enabled
 		logTheThing(LOG_STATION, src, "toggled blower power [src.target_pressure_enabled ? "on" : "off"] using mechcomp.")
 
-	proc/set_target_pressure(datum/mechanicsMessage/input)
+	proc/mechcomp_set_target_pressure(datum/mechanicsMessage/input)
 		if(!length(input.signal)) return
 		var/newpressure = text2num(input.signal)
 		if(!isnum_safe(newpressure) || newpressure == src.target_pressure) return

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -141,9 +141,6 @@
 		..()
 		ui.show_ui(user)
 
-	attack_ai(mob/user)
-		ui.show_ui(user)
-
 	attackby(obj/item/W, mob/user)
 		var/open = is_open_container()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a "toggle active" and "set target pressure" input to the TEG blowers. Switches opening the blower UI from click with multitool to click with empty hand because of the overlap with the mechcomp connection popup.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Opens the door for more automation setups with the TEG in the same vein as the nuclear reactor, which I think is a cool direction for engineering and gives more reason to integrate MechComp into stuff.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(*) The blowers on the TEG can now be controlled by MechComp. Accessing the blower UI has been changed to clicking with an empty hand.
```
