### PR TITLE
Removes one "through" from satchel text

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -101,7 +101,7 @@
 			return
 
 		// attack_hand does all the checks for if you can do this
-		user.visible_message(SPAN_NOTICE("<b>[user]</b> looks through through \the [src]..."),\
+		user.visible_message(SPAN_NOTICE("<b>[user]</b> looks through \the [src]..."),\
 		SPAN_NOTICE("You look through \the [src]."))
 		var/list/satchel_contents = list()
 		var/list/has_dupes = list()


### PR DESCRIPTION
[Bug][Trivial][Game-Objects]

## About the PR
Fix a tyopo with satchels. that is it! 

## Why's this needed? 
no spelling mistakes is better.

also, fixes #17270