### PR TITLE
Syndicate Cyborgs always show up as following the same laws to other silicons when examined

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -739,7 +739,7 @@
 			else
 				var/mob/living/silicon/S = user
 				lr =  S.law_rack_connection
-			if(src.law_rack_connection != lr)
+			if(src.law_rack_connection != lr && !src.syndicate)
 				. += "[SPAN_ALERT("[src.name] is not connected to your law rack!")]<br>"
 			else
 				. += "[src.name] follows the same laws you do.<br>"


### PR DESCRIPTION
[silicons] [balance]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This changes the examine text of syndicate cyborgs to always indicate that they follow the same laws as the examiner.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

In my most recent roboticist traitor round, the AI told me after the round that they knew about the existence of the syndicate cyborgs from the start - because they randomly examined the cyborgs after they were re-constructed.  
Fortunately, the AI decided to not act on it.

In my opinion syndicate borgs should try to blend in with the other borgs - but when a single examine makes other silicons question their trustworthiness...

There are still other ways to tell if a cyborg is a syndicate cyborg - such as looking at the robotics console.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(*)Syndicate Cyborgs always show up as following the same laws to other silicons when examined.
```
