### PR TITLE
Adds unique QM mailchutes to maps

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -24,7 +24,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 	var/mode = DISPOSAL_CHUTE_CHARGING	// item mode 0=off 1=charging 2=charged
 	var/flush = 0	// true if flush handle is pulled
 	var/obj/disposalpipe/trunk/trunk = null // the attached pipe trunk
-	var/flushing = 0	// true if flushing in progress
+	var/flushing = FALSE	// true if flushing in progress
 	var/icon_style = "disposal"
 	var/handle_normal_state = null // this is the overlay added when the handle is in the non-flushing position (for the small chutes, mainly this can be ignored otherwise)
 	var/light_style = "disposal" // for the lights and stuff
@@ -327,7 +327,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 	// update the icon & overlays to reflect mode & status
 	proc/update()
 		if (status & BROKEN)
-			icon_state = "disposal-broken"
+			icon_state = "disposal-broken"	// this icon state doesn't apparently exist
 			ClearAllOverlays()
 			mode = DISPOSAL_CHUTE_OFF
 			flush = 0

--- a/code/modules/disposals/mail_chute.dm
+++ b/code/modules/disposals/mail_chute.dm
@@ -89,8 +89,8 @@
 		if(!src.destination_tag)
 			return
 
-		flushing = 1
-		if (istype(src, /obj/machinery/disposal/mail)) flick("mailchute-flush", src)
+		flushing = TRUE
+		if (istype(src, /obj/machinery/disposal/mail)) flick("[src.icon_state]-flush", src)
 		else flick("disposal-flush", src)
 
 		var/obj/disposalholder/H = new /obj/disposalholder	// virtual holder object which actually
@@ -107,7 +107,7 @@
 
 
 		H.start(src) // start the holder processing movement
-		flushing = 0
+		flushing = FALSE
 		// now reset disposal state
 		flush = 0
 		if(mode == 2)	// if was ready,
@@ -973,6 +973,8 @@
 	mail_tag = "QM"
 	mailgroup = MGD_CARGO
 	message = 1
+	icon_style = "qm_mail"
+	light_style = "qm_mailchute"
 
 	autoname
 		autoname = TRUE

--- a/code/modules/disposals/mail_chute.dm
+++ b/code/modules/disposals/mail_chute.dm
@@ -10,7 +10,7 @@
 	var/list/destinations = list()
 	var/frequency = FREQ_MAIL_CHUTE
 	var/last_inquire = 0 //No signal spamming etc
-	var/autoname = 0
+	var/autoname = FALSE
 
 	var/message = null
 	var/mailgroup = null
@@ -20,7 +20,7 @@
 
 	New()
 		..()
-		if (src.autoname == 1 && !isnull(src.mail_tag))
+		if (src.autoname && !isnull(src.mail_tag))
 			src.name = "mail chute ([src.mail_tag])"
 
 		if (!src.net_id)
@@ -145,7 +145,7 @@
 		return
 
 /obj/machinery/disposal/mail/autoname
-	autoname = 1
+	autoname = TRUE
 
 	// Please keep the destinations identical to /obj/machinery/disposal/mail/small/autoname.
 	janitor
@@ -331,7 +331,7 @@
 	density = 0
 
 /obj/machinery/disposal/mail/small/autoname
-	autoname = 1
+	autoname = TRUE
 /*
 	New() // Would be more elegant, but I want them to be aligned properly in the map editor.
 		..()
@@ -965,3 +965,14 @@
 				dir = SOUTH
 			west
 				dir = WEST
+/// special mail chutes for the cargo bay
+/obj/machinery/disposal/mail/qm
+	icon_state = "qm_mailchute"
+	repressure_speed = 0.5
+	name = "QM"
+	mail_tag = "QM"
+	mailgroup = MGD_CARGO
+	message = 1
+
+	autoname
+		autoname = TRUE

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14572,18 +14572,13 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/storage)
 "btE" = (
-/obj/machinery/disposal/mail/small{
-	dir = 1;
-	mail_tag = "cargo";
-	mailgroup = "cargo";
-	message = "1";
-	name = "mail chute-'Cargo'";
-	pixel_y = 32
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 4
 	},
-/obj/table/reinforced/auto,
+/obj/machinery/disposal/mail/qm{
+	mail_tag = "cargo";
+	name = "mail chute-'Cargo'"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "btH" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -28178,14 +28178,12 @@
 /turf/simulated/floor/neutral/side,
 /area/station/quartermaster/office)
 "bPo" = (
-/obj/machinery/disposal/mail{
-	mail_tag = "cargo";
-	mailgroup = "cargo";
-	message = "1";
-	name = "mail chute-'Cargo'"
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 1
+	},
+/obj/machinery/disposal/mail/qm/autoname{
+	mail_tag = "cargo";
+	name = "mail chute-'Cargo'"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/quartermaster/office)

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -47999,7 +47999,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/trunk/mail/east,
-/obj/machinery/disposal/mail/autoname/qm,
+/obj/machinery/disposal/mail/qm,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/quartermaster/office)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -3273,12 +3273,12 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/disposal/mail{
-	mail_tag = "cargo";
-	name = "mail chute-'Cargo'"
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 8
+	},
+/obj/machinery/disposal/mail/qm{
+	name = "mail chute-'Cargo'";
+	mail_tag = "cargo"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 6

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -57086,10 +57086,10 @@
 	dir = 5;
 	icon_state = "line2"
 	},
-/obj/machinery/disposal/mail/small/autoname/qm/west,
 /obj/disposalpipe/trunk/mail{
 	dir = 4
 	},
+/obj/machinery/disposal/mail/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "rpt" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -22819,7 +22819,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/research_outpost/indigo_rye)
 "bMZ" = (
-/obj/machinery/disposal/mail/autoname/qm,
+/obj/machinery/disposal/mail/qm,
 /obj/disposalpipe/trunk/mail/east,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5952,7 +5952,7 @@
 	})
 "cLn" = (
 /obj/machinery/light,
-/obj/machinery/disposal/mail/autoname/qm,
+/obj/machinery/disposal/mail/qm,
 /obj/disposalpipe/trunk/mail/north,
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/cargobay{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13254,10 +13254,11 @@
 /area/station/hallway/secondary/exit)
 "aSy" = (
 /obj/disposalpipe/trunk/mail/north,
-/obj/machinery/disposal/mail/autoname{
-	mail_tag = "quartermasters' office"
-	},
 /obj/decal/stripe_delivery,
+/obj/machinery/disposal/mail/qm{
+	mail_tag = "quartermasters' office";
+	name = "mail chute"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aSz" = (


### PR DESCRIPTION
[MAPPING] [FEATURE]
## About the PR
Adds the sprites from #17280 as a subtype of mail chutes. Places them in all maps with mail systems (everywhere except atlas). Also makes them repressurise at speed `0.5` instead of `0.1`, buffing them slightly in favour of regular ones, since with the new mail update from zamu, they be using them a lot. Repressurisation speed may possibly need to be tweaked to be higher or lower for balance.

## Why's this needed?
They are COOL okay they need to be USED

## Changelog
```changelog
(u)Gannets, & Tyrant
(*)Cargo now has a new mail chute, which repressurises faster!
```