### PR TITLE
Make pdas have a force of 3 and emergency oxygen tanks a force of 5

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -11,6 +11,7 @@
 	flags = FPRINT | TABLEPASS
 	c_flags = ONBELT
 	wear_layer = MOB_BELT_LAYER
+	force = 3
 	var/obj/item/card/id/ID_card = null // slap an ID card into that thang
 	var/obj/item/pen = null // slap a pen into that thang
 	var/registered = null // so we don't need to replace all the dang checks for ID cards

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -460,7 +460,7 @@ TYPEINFO(/obj/item/tank/jetpack/micro)
 	c_flags = null
 	health = 5
 	w_class = W_CLASS_TINY
-	force = 4
+	force = 5
 	stamina_damage = 20
 	stamina_cost = 8
 	desc = "A tiny personal oxygen tank meant to keep you alive in an emergency. To use, put on a secure mask and open the tank's release valve."

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -460,7 +460,6 @@ TYPEINFO(/obj/item/tank/jetpack/micro)
 	c_flags = null
 	health = 5
 	w_class = W_CLASS_TINY
-	force = 5
 	stamina_damage = 20
 	stamina_cost = 8
 	desc = "A tiny personal oxygen tank meant to keep you alive in an emergency. To use, put on a secure mask and open the tank's release valve."

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -460,7 +460,7 @@ TYPEINFO(/obj/item/tank/jetpack/micro)
 	c_flags = null
 	health = 5
 	w_class = W_CLASS_TINY
-	force = 1
+	force = 4
 	stamina_damage = 20
 	stamina_cost = 8
 	desc = "A tiny personal oxygen tank meant to keep you alive in an emergency. To use, put on a secure mask and open the tank's release valve."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what the title says


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doors and windows can't exactly be punched out, and I think itd be good if players who were really desperate could slowly break them just with what they spawn with. This gives any person a tool to avoid getting permatrapped in a room. I'm not worried about the combat implications considering that punches do more damage then either of these. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)PDAs now deal 3 damage and emergency oxygen tanks 5.
```
