### PR TITLE
stop mosquitoes drawing blood from borgs

### DIFF
--- a/code/datums/abilities/critter/bloodbite.dm
+++ b/code/datums/abilities/critter/bloodbite.dm
@@ -24,9 +24,14 @@
 		if (BOUNDS_DIST(holder.owner, target) > 0)
 			boutput(holder.owner, SPAN_ALERT("That is too far away to bite."))
 			return 1
-		playsound(target,'sound/items/drink.ogg', rand(10,50), 1, pitch = 1.4)
+
 		var/mob/M = target
 
+		if (issilicon(M))
+			boutput(holder.owner, SPAN_ALERT("You detect no blood to suck!"))
+			return 1
+
+		playsound(target,'sound/items/drink.ogg', rand(10,50), 1, pitch = 1.4)
 		holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] sucks some blood from [M]!</b>"), SPAN_ALERT("You suck some blood from [M]!"))
 		holder.owner.reagents.add_reagent("blood", 1)
 		if (isliving(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks if the target of blood_bite (used by antag ghost mosquito critter) is a silicon, and if so, cancels the ability use and gives the player a message.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15278