### PR TITLE
Makes airlock garland unclickable

### DIFF
--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -680,6 +680,7 @@ proc/compare_ornament_score(list/a, list/b)
 	icon_state = "garland"
 	layer = 5
 	anchored = ANCHORED
+	mouse_opacity = FALSE
 
 /obj/decal/tinsel
 	plane = PLANE_DEFAULT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets `mouse_opacity` to `FALSE` for the garland on airlocks so that it is treated as invisible to clicks. This does not impact the grinch's ability to destroy it with the vandalize ability.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Trying to close an airlock by clicking on it already requires a bit of precision and sticking something else on top that covers the sprite and has no mechanical purpose in being clicked makes it worse
