### PR TITLE
Fix disposal pipe expel() proc resetting tile info

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -314,12 +314,17 @@
 			T = get_turf(src)
 		if(T.intact && istype(T,/turf/simulated/floor)) //intact floor, pop the tile
 			var/turf/simulated/floor/F = T
-			//F.health	= 100
-			F.burnt	= 1
-			F.setIntact(FALSE)
-			F.levelupdate()
-			new /obj/item/tile/steel(H)	// add to holder so it will be thrown with other stuff
-			F.icon_state = "plating"
+			var/obj/item/floor_covering_thing = null
+			if(F.reinforced)
+				floor_covering_thing = new /obj/item/rods(H) // add to holder so it will be thrown with other stuff
+				floor_covering_thing.set_stack_amount(2)
+			else
+				floor_covering_thing = new /obj/item/tile(H)
+			if(F.material)
+				floor_covering_thing.setMaterial(F.material)
+			else // /turf/simulated/floor should always have a material but whatever lets be paranoid
+				floor_covering_thing.setMaterial(getMaterial("steel"))
+			F.to_plating(TRUE)
 
 		if(direction)		// direction is specified
 			if(istype(T, /turf/space)) // if ended in space, then range is unlimited


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Changes disposal pipe `expel` proc to use the `to_plating` proc (which properly sets vars for tracking old floor name/pattern) instead of reverting it to plating manually. 
- Adds check for reinforcement to spawn the appropriate covering (rods or tile).
- Properly sets material of resulting floor covering.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17295 
