### PR TITLE
Makes Piña Colada comply with the Law of Conservation of Mass

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1687,7 +1687,7 @@
 		id = "pinacolada"
 		result = "pinacolada"
 		required_reagents = list("juice_pineapple" = 1, "rum" = 1, "coconut_milk" = 1)
-		result_amount = 4
+		result_amount = 3
 		mix_phrase = "The drink gives off the smell of a rainy beach."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 


### PR DESCRIPTION
[CATERING][CHEMISTRY]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
<!-- I spent way too much time writing this-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusts the Piña Colada recipe to result in three parts of Piña Colada instead of four parts of Piña Colada, to match the Piña Colada's recipe, which only uses three ingredients in equal parts. Fixes #17291, sort of.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It'd make sense for Piña Colada to adhere to the Law of Conservation of Mass, as the majority of other, non-Piña-Colada drinks already does. Since there are three reactants in the reaction, and the mass of the product is equal to the mass of the reactant(s), the amount of Piña Colada should be equal to three.
