### PR TITLE
Sweat rebalance

### DIFF
--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -531,7 +531,7 @@
 	initial_volume = 330
 	initial_reagents = list("cholesterol"=200)
 	unlock_medal_when_eaten = "That's no moon, that's a GOURMAND!"
-	food_effects = list("food_hp_up_big", "food_sweaty_big", "food_bad_breath", "food_warm")
+	food_effects = list("food_hp_up_big", "food_sweaty_bigger", "food_bad_breath", "food_warm")
 	meal_time_flags = MEAL_TIME_FORBIDDEN_TREAT
 
 /obj/item/reagent_containers/food/snacks/burger/aburgination

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -86,7 +86,7 @@
 		 * 	Required: sweatReagent - the chemical you're sweating
 		 *  targetTurf should be left default
 		 */
-	proc/dropSweat(var/sweatReagent, var/sweatAmount = 5, var/sweatChance = 2, var/turf/targetTurf = get_turf(owner))
+	proc/dropSweat(var/sweatReagent, var/sweatAmount = 5, var/sweatChance = 5, var/turf/targetTurf = get_turf(owner))
 		var/datum/reagents/tempHolder = new
 		if (prob(sweatChance))
 			tempHolder.add_reagent(sweatReagent, sweatAmount)

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -453,11 +453,21 @@
 		sweat_adjective = "REALLY "
 		maxDuration = 600
 
+		onUpdate(timePassed)
+			dropSweat("water", 5, 20)
+
+	bigger
+		name ="Food (Sweaty++)"
+		id = "food_sweaty_bigger"
+		desc = "You're drowning in sweat!"
+		sweat_adjective = "RIDICULOUSLY "
+		maxDuration = 300
+
+		onUpdate(timePassed)
+			dropSweat("water", 15, 35)
+
 	getChefHint()
 		. = "Makes the consumer [sweat_adjective]sweaty."
-
-	onUpdate(timePassed)
-		dropSweat("water", 10, 20)
 
 /datum/statusEffect/brainfood
 	id = "brain_food"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sweat previously overwrote itself with sweat+. I also balanced the numbers a little, you shouldn't drown in your own sweat unless you've eaten something bad for you. (THE MONSTER, for now.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The sweat was too silly!



