### PR TITLE
Fix gravity well chat spam

### DIFF
--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -195,14 +195,14 @@ TYPEINFO(/obj/gravity_well_generator)
 
 	attack_hand(mob/user)
 		if (active)
-			src.visible_message("<font color='blue'>[bicon(src)] [user] deactivated the gravity well.</font>")
+			src.visible_message("<font color='blue'>[bicon(src)] [user] deactivated the gravity well.</font>", group = "gravity_well")
 
 			icon_state = "gravgen-off"
 			src.anchored = UNANCHORED
 			src.active = 0
 
 		else
-			src.visible_message("<font color='blue'>[bicon(src)] [user] activated the gravity well.</font>")
+			src.visible_message("<font color='blue'>[bicon(src)] [user] activated the gravity well.</font>", group = "gravity_well")
 
 			icon_state = "gravgen-on"
 			src.active = 1

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -195,14 +195,14 @@ TYPEINFO(/obj/gravity_well_generator)
 
 	attack_hand(mob/user)
 		if (active)
-			src.visible_message("<font color='blue'>[bicon(src)] [user] deactivated the gravity well.</font>", group = "gravity_well")
+			src.visible_message(SPAN_NOTICE("[bicon(src)] [user] deactivated the gravity well."), group = "gravity_well")
 
 			icon_state = "gravgen-off"
 			src.anchored = UNANCHORED
 			src.active = 0
 
 		else
-			src.visible_message("<font color='blue'>[bicon(src)] [user] activated the gravity well.</font>", group = "gravity_well")
+			src.visible_message(SPAN_NOTICE("[bicon(src)] [user] activated the gravity well."), group = "gravity_well")
 
 			icon_state = "gravgen-on"
 			src.active = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a chat group for activating/deactivating the gravity well because it has no cooldown and is easy to chatspam by doing this. Also changes it to use `SPAN_NOTICE` instead of the nigh-unreadable `<font color='blue'>`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![image](https://github.com/goonstation/goonstation/assets/75404941/f4d5ac4e-54c4-4021-94f1-9d7ed1c95396)
