### PR TITLE
Fix borgs not being able to use surgical tray brake

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1477,12 +1477,18 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 		src.attached_objs.Remove(I)
 		UnregisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING))
 
+	proc/toggle_brake(mob/user)
+		src.anchored = !src.anchored
+		boutput(user, "You [src.anchored ? "apply" : "release"] \the [src.name]'s brake.")
+
 	attack_hand(mob/user)
-		if (!anchored)
-			boutput(user, "You apply \the [name]'s brake.")
-		else
-			boutput(user, "You release \the [name]'s brake.")
-		anchored = !anchored
+		..()
+		toggle_brake(user)
+
+	attack_ai(mob/user)
+		if(BOUNDS_DIST(user, src) > 0 || isAI(user))
+			return
+		toggle_brake(user)
 
 /* ---------- Surgery Tray Parts ---------- */
 /obj/item/furniture_parts/surgery_tray


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves brake logic from `attack_hand` into separate proc, make `attack_hand` and `attack_ai` use it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #15889 
