### PR TITLE
borg tongs plate fix

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -197,11 +197,15 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				return
 
 			src.Eat(user,user)
-		else if (istype(W, /obj/item/tongs))
-			if (src.stored)
+		else if (istype(W, /obj/item/tongs)) // Borg only tool to move food out of containers
+			if (src.stored) // If snack is in a foodbox
 				boutput(user, "You take [src] out of [src.stored.linked_item].")
 				src.stored.transfer_stored_item(src, get_turf(src), user = user)
 				user.put_in_hand_or_drop(src)
+			else if (istype(src.loc, /obj/item/plate)) // If snack is on a plate/tray/pizza box (implied you're a borg)
+				boutput(user, "You remove [src] from the [src.loc.name].")
+				var/obj/item/plate/plate_action = src.loc
+				plate_action.remove_contents(src)
 			else
 				src.AttackSelf(user)
 		else

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -117,6 +117,12 @@
 				boutput(user, "<i>You feel as though something of value has been lost...</i>")
 			src.make_slices()
 
+		// I don't know why pizza attackby doesn't call the rest of the attackby proc chain, and I'm too afraid to ask, so dupe code here
+		if ((istype(W, /obj/item/tongs)) && (istype(src.loc, /obj/item/plate))) // If pizza is is on a plate/tray/pizza box (implied you're a borg)
+			boutput(user, "You remove [src] from the [src.loc.name].")
+			var/obj/item/plate/plate_action = src.loc
+			plate_action.remove_contents(src)
+
 	//todo: make this use the actual generic slicing behaviour
 	proc/make_slices()
 		var/makeslices = src.bites_left

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -912,6 +912,9 @@ TRAYS
 			boutput(user, SPAN_ALERT("There's no more space in \the [src]!"))
 			return
 
+		if (src.open && istype(food, /obj/item/tongs)) // Stops borgs from seeing duplicate messages
+			return
+
 		. = ..()
 
 	proc/toggle_box(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects][Catering][Feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds a check to allow borgs using tongs to remove food from plate/tray/pizza boxes. 
- Adds a separate check for pizza to do the same thing as above since pizza doesn't call parent procs on attackby. 
- Also removes an unnecessary dialog line saying borgs can't put their tongs in a pizza box when they attack an open pizza box. (found while testing bugfix)  
>You can't do that, the tongs is attached to you!
>NAME hits the pizza box with the tongs!

NOTE: If a item that isn't a /obj/item/reagent_containers/food/snacks gets put on a plate/tray/pizza box, a borg will not be able to remove it with tongs. I believe this is intentional to the design of tongs though. [(Original PR](https://github.com/goonstation/goonstation/pull/8727))

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17304
Borgs don't need to be reminded they can't put their tongs in a foodbox, just attack it like normal.