### PR TITLE
Fix message sign component not displaying text

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3940,7 +3940,7 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 			src.display()
 
 	proc/sanitize_text(text)
-		. = replacetext(html_encode(.), "|n", "<br>")
+		. = replacetext(html_encode(text), "|n", "<br>")
 		var/static/regex/bullshit_byond_parser_url_regex = new(@"(https?|byond)://", "ig")
 		// byond automatically promotes URL-like text in maptext to links, which is an awful idea
 		// it also parses protocols in a nonsensical way - for example ahttp://foo.bar is the letter a followed by a http:// protocol link


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Switches usage of `.` to the proc arg because `.` isn't set to anything at that point

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17323 