### PR TITLE
Fix Grinch medal not being awarded

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1075,7 +1075,6 @@ proc/create_fluff(datum/mind/target)
 
 /datum/objective/specialist/ruin_xmas
 	explanation_text = "Ruin Spacemas for everyone! Make sure Spacemas cheer is at or below 20% when the round ends."
-	medal_name = "You're a mean one..."
 
 	check_completion()
 		if (christmas_cheer <= 20)

--- a/code/modules/antagonists/grinch/grinch.dm
+++ b/code/modules/antagonists/grinch/grinch.dm
@@ -2,6 +2,7 @@
 	id = ROLE_GRINCH
 	display_name = "grinch"
 	antagonist_icon = "grinch"
+	success_medal = "You're a mean one..."
 
 	/// The ability holder of this grinch, containing their respective abilities.
 	var/datum/abilityHolder/grinch/ability_holder


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MEDAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Switches the grinch medal from being awarded for the ruin xmas objective to being the `success_medal` for grinch because there's some fuckery with gamemode code making it not be awarded and it makes more sense as an antag victory medal anyways

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17284 