### PR TITLE
Standardizes toxins chamber airlocks

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13933,7 +13933,9 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "bpC" = (
 /obj/cable{
@@ -14043,7 +14045,13 @@
 	can_rupture = 0;
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "bqE" = (
 /obj/table/auto,
@@ -14329,7 +14337,9 @@
 	},
 /area/station/science/lab)
 "brR" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "brX" = (
 /turf/simulated/wall/auto/supernorn,
@@ -27003,12 +27013,15 @@
 /area/station/medical/medbay)
 "jvN" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/door/airlock/pyro/glass/toxins{
-	name = "Chamber Access"
-	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/tox,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "jwm" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -27540,12 +27553,13 @@
 	},
 /area/listeningpost/solars)
 "jSd" = (
-/obj/machinery/door/airlock/pyro/glass/toxins{
-	dir = 4;
-	name = "Chamber Access"
-	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/tox,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4;
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "jSA" = (
@@ -41861,6 +41875,16 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
+"viB" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/door_control{
+	id = "tox_accessvent";
+	name = "Access Buffer Vent";
+	dir = 5;
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "vjL" = (
 /obj/machinery/power/smes,
 /obj/cable{
@@ -41910,6 +41934,21 @@
 /obj/mapping_helper/access/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"vmb" = (
+/obj/grille/steel{
+	auto = 0;
+	connects_to_obj = null;
+	icon_state = "grille12-0"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	id = "tox_accessvent";
+	layer = 8;
+	name = "Buffer Vent"
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "vmJ" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -89308,12 +89347,12 @@ pBV
 bju
 bkH
 bkH
-bkH
+viB
 jvN
 bpA
 bqC
 brR
-bnd
+vmb
 oMK
 aaa
 aaa

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -26891,13 +26891,18 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
 "bLe" = (
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "bLf" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "bLg" = (
 /obj/lattice,
@@ -27772,7 +27777,8 @@
 /obj/machinery/door_control{
 	id = "tox_vent2";
 	name = "Chamber Two Exhaust";
-	pixel_y = 24
+	pixel_y = 24;
+	pixel_x = -8
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -27789,6 +27795,12 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/machinery/door_control{
+	id = "tox_accessvent";
+	name = "Access Buffer Vent";
+	pixel_y = 24;
+	pixel_x = 8
 	},
 /turf/simulated/floor/grime,
 /area/station/science/lab)
@@ -46532,17 +46544,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "hQg" = (
-/obj/machinery/door/airlock/pyro/glass{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "glass_locked";
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Toxins Research Access";
+/obj/mapping_helper/access/tox,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Combustion Chamber Access";
 	req_access_txt = null
 	},
-/obj/mapping_helper/access/tox,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "hQt" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -53144,6 +53151,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
+"obl" = (
+/obj/grille/steel{
+	auto = 0;
+	connects_to_obj = null;
+	icon_state = "grille3-0"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "tox_accessvent";
+	layer = 8;
+	name = "Buffer Vent"
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "obH" = (
 /obj/item/device/radio/intercom/medical{
 	dir = 8;
@@ -53732,18 +53755,15 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "oBx" = (
-/obj/machinery/door/airlock/pyro/glass{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "glass_locked";
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Toxins Research Access";
-	req_access_txt = null
-	},
 /obj/mapping_helper/access/tox,
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "oCb" = (
 /obj/machinery/bot/medbot/no_camera,
@@ -89822,9 +89842,9 @@ adC
 adC
 adC
 adC
-adC
-adC
-aag
+aaf
+aaw
+aap
 aar
 aar
 aar
@@ -90124,8 +90144,8 @@ adC
 adC
 adC
 adC
-adC
-adC
+aag
+aap
 bHW
 oZV
 oZV
@@ -90427,7 +90447,7 @@ adC
 adC
 adC
 bHW
-bHW
+obl
 bHW
 bIO
 bPv

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -15689,7 +15689,9 @@
 	},
 /area/station/solar/west)
 "bHe" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "bHf" = (
 /obj/item/cable_coil/cut{
@@ -16718,10 +16720,12 @@
 /area/station/science/lobby)
 "bZW" = (
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/toxins,
-/obj/mapping_helper/airlock/bolter,
 /obj/mapping_helper/access/tox,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "caf" = (
 /obj/stool/chair/blue{
@@ -18790,6 +18794,18 @@
 "dsh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/auxillary)
+"dsB" = (
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "tox_accessvent";
+	layer = 8;
+	name = "Buffer Vent"
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "dsL" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -20707,6 +20723,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
+"eBi" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "eBm" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -20958,13 +20983,15 @@
 /area/station/maintenance/east)
 "eKR" = (
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/toxins{
-	dir = 4;
-	id = "test_chamber"
-	},
-/obj/mapping_helper/airlock/bolter,
 /obj/mapping_helper/access/tox,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4;
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "eKV" = (
 /obj/machinery/portable_reclaimer,
@@ -33319,8 +33346,11 @@
 	entrance_scanner = 1;
 	pixel_x = 32
 	},
-/turf/simulated/floor/plating/airless,
-/area/listeningpost)
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "ast1"
+	},
+/area/space)
 "mQe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50604,6 +50634,12 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent,
+/obj/machinery/door_control{
+	id = "tox_accessvent";
+	name = "Access Buffer Vent";
+	pixel_y = -9;
+	pixel_x = 23
+	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "xNm" = (
@@ -131440,7 +131476,7 @@ eYy
 igT
 qgJ
 alf
-bHe
+eBi
 alf
 aaa
 aaa
@@ -132044,7 +132080,7 @@ pxc
 pxc
 pxc
 alf
-alf
+dsB
 alf
 aaa
 aaa
@@ -132346,8 +132382,8 @@ aaa
 aaa
 aaa
 alf
-aaa
-aaa
+aai
+acy
 aaa
 aaa
 aaa

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8538,6 +8538,21 @@
 	},
 /turf/simulated/floor/dojo/sand/circle,
 /area/station/crew_quarters/captain)
+"csL" = (
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/decal/stripe_delivery,
+/obj/machinery/door_control{
+	id = "tox_accessvent";
+	name = "Access Buffer Vent";
+	pixel_y = 28
+	},
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/science/lab)
 "csM" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 8
@@ -10016,6 +10031,18 @@
 "cQi" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/south_side)
+"cQm" = (
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "tox_accessvent";
+	layer = 8;
+	name = "Buffer Vent"
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "cQo" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -17567,14 +17594,16 @@
 /turf/simulated/floor/plating,
 /area/station/medical/asylum/kitchen)
 "fkZ" = (
-/obj/machinery/door/airlock/pyro/glass{
-	icon_state = "glass_locked";
-	locked = 1
-	},
 /obj/mapping_helper/access/tox,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
-/turf/simulated/floor/plating/jen,
+/obj/machinery/door/airlock/pyro/external{
+	name = "Combustion Chamber Access";
+	req_access_txt = null
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "flq" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -50464,6 +50493,15 @@
 /obj/marker/supplymarker,
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
+"ppW" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/science/lab)
 "pqe" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -53587,7 +53625,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "qlG" = (
-/turf/simulated/floor/plating/jen,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
 /area/station/science/lab)
 "qlP" = (
 /turf/simulated/floor/caution/misc{
@@ -112903,8 +112943,8 @@ sNh
 pbi
 qtC
 pEb
-rdj
-rdj
+nkb
+nkb
 hyr
 wKc
 hyq
@@ -113206,7 +113246,7 @@ eJu
 xMH
 pEb
 hyr
-hyr
+cQm
 hyr
 cBs
 kLZ
@@ -114112,7 +114152,7 @@ ugO
 ugO
 rnV
 hyr
-qlG
+ppW
 hyr
 dTb
 bET
@@ -114718,7 +114758,7 @@ kuM
 hyr
 qlG
 hyr
-jYs
+csL
 oJg
 gBa
 tif

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -40591,9 +40591,7 @@
 	autoclose = 0;
 	dir = 4;
 	frequency = 1449;
-	icon_state = "glass_locked";
 	id_tag = "tox_airlock_exterior";
-	locked = 1;
 	name = "Toxins Research Access";
 	req_access_txt = null
 	},
@@ -43215,7 +43213,6 @@
 "lFD" = (
 /obj/machinery/door/airlock/pyro/medical{
 	autoclose = 0;
-	icon_state = "research_locked";
 	name = "Toxin Chamber";
 	req_access = null
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[A-Mapping] [C-QoL]
Makes the Toxins chamber access airlocks more consistent with other maps.

Changes
* Added a shutter to vent the airlocks (Same used on Kondaru already)
* Changed airlocks to use the same style that engineering combustion chamber has.
* Unbolted doors and changed frequencies.
* Added flooring, and lighting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These access routes are really incosistent, some maps had airless tiles and doors with different frequencies to the rest of the station, This makes them more usable by bringing them to the standard of Kondaru.


