### PR TITLE
use patch name in generating patch name

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1018,7 +1018,7 @@ TYPEINFO(/obj/machinery/chem_master)
 				// unused by log_phrase?
 				//global.phrase_log.log_phrase("patch", src.item_name, no_duplicates=TRUE)
 
-				patch.name = "[item_name] patch"
+				patch.name = "[item_name] [patch.name]"
 				patch.medical = src.check_patch_whitelist()
 				src.beaker.reagents.trans_to(patch, reagent_amount)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Names individually generated patches from the chemaster according to patch.name instead of a static string "patch".
 patch.name is either "patch" or "mini-patch" as set by the user in the UI.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17260
Chemaster totally does work! In investigating this bug report, I found when making a individual mini-patch it was being called "<item_name> patch" instead of "<item_name> mini-patch"