### PR TITLE
turn off PDA light when deleting

### DIFF
--- a/code/obj/item/device/pda2/modules.dm
+++ b/code/obj/item/device/pda2/modules.dm
@@ -201,6 +201,11 @@ TYPEINFO(/obj/item/device/pda_module)
 		if (src.host)
 			src.host.updateSelfDialog()
 
+	disposing() // Remove lightsources first upon deletion for no lingering light effects
+		if (src.on)
+			src.toggle_light()
+		..()
+
 /obj/item/device/pda_module/flashlight/dan
 	name = "Deluxe Dan's Fancy Flashlight Module"
 	desc = "What a name, what an experience."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Game-Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to the deletion of PDA flashlight modules to turn them off if they're on. Note since this change happens in the parent pda flashlight module object, all children PDA flashlight modules have the same behavior applied. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17335 
Prevents a phantom light overlay from sticking with the mob after the PDA with flashlight on is deleted. 