### PR TITLE
Metal foam triggers projectile collision before self-disposal

### DIFF
--- a/code/obj/foamedmetal.dm
+++ b/code/obj/foamedmetal.dm
@@ -43,7 +43,8 @@
 	blob_act(var/power)
 		dispose()
 
-	bullet_act()
+	bullet_act(obj/projectile/P)
+		P.collide(src.loc)
 		if(metal==1 || prob(50))
 			dispose()
 

--- a/code/obj/foamedmetal.dm
+++ b/code/obj/foamedmetal.dm
@@ -44,9 +44,9 @@
 		dispose()
 
 	bullet_act(obj/projectile/P)
-		P.collide(src.loc)
 		if(metal==1 || prob(50))
-			dispose()
+			SPAWN(0)
+				dispose()
 
 	attack_hand(var/mob/user)
 		if (user.is_hulk() || (prob(75 - metal*25)))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Manually trigger the collision of projectiles with metal foam, ensuring `on_hit` is called for the projectile before the foam is disposed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17319