### PR TITLE
Eaten bioEfffect shows differently for skeletons

### DIFF
--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -1051,11 +1051,15 @@ datum
 						M.setStatusMin("weakened", 9 SECONDS * mult)
 						M.emote("faint")
 					else if (effect <= 4)
-						if(ishuman(M))
-							M.visible_message(SPAN_ALERT("<b>[M.name]'s</b> skin is rotting away!"))
+						if (ishuman(M))
 							random_brute_damage(M, 25 * mult)
 							M.emote("scream")
-							M.bioHolder.AddEffect("eaten") //grody. changed line in human.dm to use decomp1 now
+							if (isskeleton(M))
+								M.visible_message(SPAN_ALERT("<b>[M.name]'s bones crinkle!"))
+								M.bioHolder.AddEffect("brittle")
+							else
+								M.visible_message(SPAN_ALERT("<b>[M.name]'s</b> skin is rotting away!"))
+								M.bioHolder.AddEffect("eaten") //grody. changed line in human.dm to use decomp1 now
 							M.emote("faint")
 					else if (effect <= 7)
 						M.emote("shiver")

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -1052,14 +1052,13 @@ datum
 						M.emote("faint")
 					else if (effect <= 4)
 						if (ishuman(M))
-							random_brute_damage(M, 25 * mult)
-							M.emote("scream")
 							if (isskeleton(M))
-								M.visible_message(SPAN_ALERT("<b>[M.name]'s bones crinkle!"))
-								M.bioHolder.AddEffect("brittle")
+								M.visible_message(SPAN_ALERT("<b>[M.name]'s bones are rotting away from the inside!"))
 							else
 								M.visible_message(SPAN_ALERT("<b>[M.name]'s</b> skin is rotting away!"))
-								M.bioHolder.AddEffect("eaten") //grody. changed line in human.dm to use decomp1 now
+							random_brute_damage(M, 25 * mult)
+							M.emote("scream")
+							M.bioHolder.AddEffect("eaten") //grody. changed line in human.dm to use decomp1 now
 							M.emote("faint")
 					else if (effect <= 7)
 						M.emote("shiver")

--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -86,6 +86,27 @@
 		if (ishuman(owner))
 			owner:set_body_icon_dirty()
 
+/datum/bioEffect/hidden/brittle
+	name = "Brittle"
+	desc = "Once sturdy bones have begun wasting away in place."
+	id = "brittle"
+	effectType = EFFECT_TYPE_DISABILITY
+	isBad = TRUE
+	can_copy = FALSE
+
+	OnMobDraw()
+		if (ishuman(owner) && !owner:decomp_stage)
+			owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp4")
+		return
+
+	OnAdd()
+		if (ishuman(owner))
+			owner:set_body_icon_dirty()
+
+	OnRemove()
+		if (ishuman(owner))
+			owner:set_body_icon_dirty()
+
 /datum/bioEffect/hidden/consumed
 	name = "Consumed"
 	desc = "Most of their flesh has been chewed off."

--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -75,28 +75,10 @@
 
 	OnMobDraw()
 		if (ishuman(owner) && !owner:decomp_stage)
-			owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp1")
-		return
-
-	OnAdd()
-		if (ishuman(owner))
-			owner:set_body_icon_dirty()
-
-	OnRemove()
-		if (ishuman(owner))
-			owner:set_body_icon_dirty()
-
-/datum/bioEffect/hidden/brittle
-	name = "Brittle"
-	desc = "Once sturdy bones have begun wasting away in place."
-	id = "brittle"
-	effectType = EFFECT_TYPE_DISABILITY
-	isBad = TRUE
-	can_copy = FALSE
-
-	OnMobDraw()
-		if (ishuman(owner) && !owner:decomp_stage)
-			owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp4")
+			if (isskeleton(owner))
+				owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp4")
+			else
+				owner:body_standing:overlays += image('icons/mob/human_decomp.dmi', "decomp1")
 		return
 
 	OnAdd()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mutantrace][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When you have the "eaten" status effect as a skeleton, use a more fitting decomposition image..
Similar conditional tweak to krokodil's effect text


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17330