### PR TITLE
Maintain HUD x/y position for multiple ability holders

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -1200,8 +1200,8 @@
 			for(var/atom/movable/screen/ability/A in src.hud.objects)
 				src.hud.remove_object(A)
 
-		x_occupied = 1
-		y_occupied = 0
+		x_occupied = start_x
+		y_occupied = start_y
 		any_abilities_displayed = 0
 		if (!src.hidden)
 			for (var/datum/abilityHolder/H in holders)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[muutantraces]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
start_x and start_y were not used in the updateButtons code, causing new ability holders to stomp over existing icons.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17316