### PR TITLE
fix runtime of releasing mindless mob as admin

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1184,7 +1184,8 @@
 	else
 		M.ghostize()
 	M.mind = M.oldmind
-	M.oldmind.current = M
+	if (M.oldmind) // If mob was an admin spawned human or npc, no need to set oldmind as there is none
+		M.oldmind.current = M
 	if(M.mind)
 		M.ckey = M.mind.key
 	boutput(M, SPAN_ALERT("Your soul is sucked back into your body!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Admin][Runtime][Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to make sure there's a mind to re-associate to the mob before doing so when an admin releases a possessed mob. An example of a mob with no mind is a mob of type npc or an admin spawned human.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #16661
Error checking good, runtimes bad