### PR TITLE
Disables antag captains on classic

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -152,9 +152,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	wages = PAY_EXECUTIVE
 	high_priority_job = 1
 	receives_miranda = 1
-#ifdef RP_MODE
 	allow_traitors = 0
-#endif
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	allow_spy_theft = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disables captains rolling antag on classic, bringing it back in line with RP.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After joining yet another round with a rampaging antag captain spawn-killing any secoffs who join, I'm finally convinced a role that spawns with AA, armour and a taser should not be able to roll antag. Also it will hopefully lead to captains being more trusted and therefore responsible (maybe?)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Captains can no longer spawn as antagonist roles.
```
