### PR TITLE
Add air alarms to Atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -210,6 +210,10 @@
 /obj/table/auto,
 /obj/item/kitchen/utensil/knife,
 /obj/item/plate,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/white/side{
 	dir = 4
 	},
@@ -742,6 +746,10 @@
 	icon_state = "1-2"
 	},
 /obj/stool/bench/blue,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/white/checker,
 /area/station/hallway/secondary/exit)
 "acI" = (
@@ -1384,6 +1392,10 @@
 /area/station/mining/refinery)
 "aeF" = (
 /obj/machinery/portable_reclaimer,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -1514,6 +1526,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "aeZ" = (
@@ -1634,6 +1650,10 @@
 	},
 /area/station/medical/morgue)
 "afr" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -3169,6 +3189,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/cafeteria)
 "akt" = (
@@ -4137,6 +4161,9 @@
 	can_rupture = 0;
 	dir = 10
 	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aok" = (
@@ -4481,6 +4508,10 @@
 /obj/item/hand_tele{
 	pixel_x = 2;
 	pixel_y = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 10
@@ -5014,6 +5045,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 6
 	},
@@ -5380,6 +5415,10 @@
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
 	},
 /turf/simulated/floor/blue/checker{
 	dir = 8
@@ -6747,6 +6786,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/purple,
 /area/station/janitor/office)
 "awO" = (
@@ -6946,6 +6988,10 @@
 /obj/table/reinforced/auto,
 /obj/item/paper/Port_A_Brig,
 /obj/item/remote/porter/port_a_brig,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -7969,6 +8015,10 @@
 /area/station/medical/research)
 "aAN" = (
 /obj/table/auto,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
 	},
@@ -9461,6 +9511,10 @@
 /area/station/science/chemistry)
 "aFm" = (
 /obj/machinery/light_switch/auto,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -12746,6 +12800,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -13465,6 +13523,9 @@
 "aSW" = (
 /obj/stool/chair/office/blue,
 /obj/machinery/light_switch/auto,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "aSY" = (
@@ -14530,6 +14591,10 @@
 /area/station/medical/morgue)
 "aWo" = (
 /obj/shrub,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "aWp" = (
@@ -14962,6 +15027,9 @@
 "aXy" = (
 /obj/table/auto,
 /obj/random_item_spawner/ai_experimental,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aXB" = (
@@ -15781,6 +15849,15 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/refinery)
+"buU" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/quartermaster/office)
 "bvy" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -15877,6 +15954,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"bSI" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "bTQ" = (
 /obj/storage/crate/furnacefuel,
 /obj/cable{
@@ -16013,6 +16096,15 @@
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/core)
+"cwL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "cwS" = (
 /obj/machinery/door/airlock/pyro/external{
 	req_access_txt = "40"
@@ -16102,6 +16194,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"dat" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/simulated/floor/black,
+/area/station/storage/tools)
 "dcx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -16163,6 +16262,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 14
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/hotloop)
 "drJ" = (
@@ -16174,6 +16277,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"dti" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "dtX" = (
 /obj/lattice{
 	dir = 6;
@@ -16616,6 +16726,16 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hallway/primary/north)
+"fIQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "fOt" = (
 /obj/submachine/foodprocessor,
 /obj/machinery/firealarm/north,
@@ -16924,6 +17044,10 @@
 /area/station/hallway/primary/north)
 "hXE" = (
 /obj/decal/mule/dropoff,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -17049,6 +17173,10 @@
 	icon_state = "0-4"
 	},
 /obj/effects/background_objects/x5,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "iAi" = (
@@ -17480,6 +17608,13 @@
 /obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/engine,
 /area/station/mining/staff_room)
+"leF" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -15
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "lgg" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -17513,6 +17648,10 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig/genpop)
@@ -17801,6 +17940,10 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/west,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -15
+	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -18035,6 +18178,16 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
+"nOy" = (
+/obj/rack,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/mask/breath,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/storage/eva)
 "nSa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18168,6 +18321,10 @@
 /obj/machinery/navbeacon/tour/atlas/tour2,
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -18499,6 +18656,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"qcC" = (
+/obj/machinery/plantpot,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "qdr" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -19388,6 +19553,17 @@
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/core)
+"uBQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
+/area/station/science/teleporter)
 "uBZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19724,6 +19900,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"woh" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "wra" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56407,7 +56590,7 @@ aRa
 aCs
 aCY
 aXl
-aSr
+bSI
 aSr
 aSr
 aSr
@@ -60638,7 +60821,7 @@ aGq
 aEA
 aEA
 aDa
-aSw
+uBQ
 aPe
 aGG
 pOs
@@ -61816,7 +61999,7 @@ adX
 aeI
 adX
 aKu
-adX
+buU
 aeI
 ait
 ajl
@@ -64836,7 +65019,7 @@ akF
 aqE
 aqE
 aqS
-agt
+dat
 axh
 axj
 axl
@@ -65458,7 +65641,7 @@ atL
 umO
 yaQ
 aro
-aqp
+qcC
 aqK
 azN
 aZT
@@ -66351,7 +66534,7 @@ aha
 ajt
 aha
 aha
-aca
+cwL
 alU
 anA
 aou
@@ -67579,7 +67762,7 @@ ayg
 ayg
 ayg
 aRn
-oVw
+dti
 aMQ
 aBx
 aFv
@@ -68182,7 +68365,7 @@ azV
 aUC
 ayF
 ayF
-ayF
+woh
 guq
 aDZ
 aBx
@@ -73005,7 +73188,7 @@ apA
 aud
 afl
 aps
-ahV
+leF
 ayh
 awV
 xRX
@@ -74822,7 +75005,7 @@ mSy
 pgZ
 pbm
 pTF
-awG
+fIQ
 awG
 awf
 aSB
@@ -75414,7 +75597,7 @@ hXE
 act
 atQ
 act
-anU
+nOy
 anU
 anU
 ieQ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds air alarms to most rooms on Atlas


