### PR TITLE
Fix expedition monitors not working

### DIFF
--- a/code/modules/camera/television.dm
+++ b/code/modules/camera/television.dm
@@ -75,3 +75,4 @@
 /obj/machinery/camera/television/mobile/science
 	name = "mobile television - science"
 	c_tag = "science mobile"
+	network = "telesci"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -717,6 +717,11 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 		src.camera = null
 		..()
 
+/obj/item/clothing/head/helmet/camera/telesci
+	name = "telescience camera helmet"
+	desc = "A helmet with a built in camera. It has \"Telescience\" written on it in marker."
+	camera_tag = "Telescience Helmet Cam"
+	camera_network = "telesci"
 
 /obj/item/clothing/head/helmet/camera/security
 	name = "security camera helmet"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -16383,7 +16383,7 @@
 "eJD" = (
 /obj/item/device/gps,
 /obj/item/device/gps,
-/obj/item/clothing/head/helmet/camera,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/item/device/camera_viewer/telesci,
 /obj/table/reinforced/chemistry/auto,
 /obj/item/device/gps,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -38625,7 +38625,7 @@
 	},
 /obj/table/reinforced/auto,
 /obj/item/device/camera_viewer/telesci,
-/obj/item/clothing/head/helmet/camera,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -40528,7 +40528,7 @@
 	pixel_x = 13;
 	pixel_y = -1
 	},
-/obj/item/clothing/head/helmet/camera{
+/obj/item/clothing/head/helmet/camera/telesci{
 	pixel_x = 7;
 	pixel_y = 13
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -40723,10 +40723,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/television/mobile{
-	c_tag = "research 1";
-	dir = 8;
-	name = "mobile camera - research 1"
+/obj/machinery/camera/television/mobile/science{
+	dir = 8
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
@@ -42906,7 +42904,7 @@
 	pixel_y = 11
 	},
 /obj/machinery/recharger,
-/obj/item/clothing/head/helmet/camera,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/specialroom/arcade,
@@ -58477,10 +58475,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/east,
-/obj/machinery/camera/television/mobile{
-	c_tag = "research 2";
-	dir = 8;
-	name = "mobile camera - research 2"
+/obj/machinery/camera/television/mobile/science{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -59269,7 +59265,7 @@
 /area/station/medical/cdc)
 "ffT" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("janitor","escape                checkpoint","mining","escape                hallway","mechanics","cargo                checkpoint","QM","refinery");
+	mail_tag = list("janitor","escape                                checkpoint","mining","escape                                hallway","mechanics","cargo                                checkpoint","QM","refinery");
 	name = "mail junction (escape and cargo sectors)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -60642,7 +60638,7 @@
 /area/station/hallway/secondary/exit)
 "gZy" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("medbay                lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
+	mail_tag = list("medbay                                lobby","telescience","testchamber","research","chemistry","medbay","morgue","pathology","genetics","robotics");
 	name = "mail junction (medsci sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -62180,7 +62176,7 @@
 /area/station/medical/medbay)
 "iOr" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("chapel","chapel                checkpoint","crewA","arrivals                checkpoint");
+	mail_tag = list("chapel","chapel                                checkpoint","crewA","arrivals                                checkpoint");
 	name = "mail junction (arrivals sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -65289,7 +65285,7 @@
 /area/station/engine/inner)
 "lTt" = (
 /obj/disposalpipe/switch_junction/left/north{
-	mail_tag = list("brig","customs                checkpoint","bridge","security");
+	mail_tag = list("brig","customs                                checkpoint","bridge","security");
 	name = "mail junction (command sector)"
 	},
 /turf/simulated/wall/auto/supernorn,
@@ -69034,7 +69030,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical                booth");
+	mail_tag = list("hydroponics","kitchen","detective","crewB","arcade","cafeteria","medical                                booth");
 	name = "mail junction (catering sector)"
 	},
 /turf/simulated/floor/grime,
@@ -73010,7 +73006,7 @@
 /area/station/catwalk/south)
 "uNZ" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = list("engineering","podbay","podbay                checkpoint");
+	mail_tag = list("engineering","podbay","podbay                                checkpoint");
 	name = "mail junction (engineering sector)"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -46597,11 +46597,11 @@
 /obj/item/device/camera_viewer/telesci{
 	pixel_x = -8
 	},
-/obj/item/clothing/head/helmet/camera{
+/obj/item/clothing/head/helmet/camera/telesci{
 	pixel_x = 8;
 	pixel_y = -6
 	},
-/obj/item/clothing/head/helmet/camera{
+/obj/item/clothing/head/helmet/camera/telesci{
 	pixel_x = 8
 	},
 /turf/simulated/floor/orangeblack/side/white,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -18314,7 +18314,7 @@
 	dir = 8;
 	icon_state = "tile1"
 	},
-/obj/item/clothing/head/helmet/camera{
+/obj/item/clothing/head/helmet/camera/telesci{
 	pixel_x = -6;
 	pixel_y = -2
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -58397,7 +58397,7 @@
 "xjm" = (
 /obj/table/reinforced/auto,
 /obj/item/device/camera_viewer/telesci,
-/obj/item/clothing/head/helmet/camera,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/machinery/light_switch/north,
 /obj/machinery/camera{
 	c_tag = "autotag";

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1450,7 +1450,7 @@
 "aHG" = (
 /obj/table/reinforced/auto,
 /obj/item/device/camera_viewer/telesci,
-/obj/item/clothing/head/helmet/camera,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/machinery/light,
 /turf/simulated/floor/purpleblack,
 /area/station/science/teleporter)
@@ -21054,10 +21054,8 @@
 /turf/simulated/floor/engine,
 /area/station/communications/centre)
 "jdJ" = (
-/obj/machinery/camera/television/mobile{
-	c_tag = "research 2";
-	dir = 4;
-	name = "mobile camera - research 2"
+/obj/machinery/camera/television/mobile/science{
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43418,10 +43416,8 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/camera/television/mobile{
-	c_tag = "research 1";
-	dir = 4;
-	name = "mobile camera - research 1"
+/obj/machinery/camera/television/mobile/science{
+	dir = 4
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 8

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -37884,12 +37884,8 @@
 /area/station/security/detectives_office)
 "kAg" = (
 /obj/item/device/gps,
-/obj/item/clothing/head/helmet/camera{
-	camera_tag = "Helmet Cam 2"
-	},
-/obj/item/clothing/head/helmet/camera{
-	camera_tag = "Helmet Cam 1"
-	},
+/obj/item/clothing/head/helmet/camera/telesci,
+/obj/item/clothing/head/helmet/camera/telesci,
 /obj/machinery/firealarm/north,
 /obj/table/round/auto,
 /turf/simulated/floor/purple,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -46374,8 +46374,7 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/item/device/camera_viewer{
-	network = "Zeta";
+/obj/item/device/camera_viewer/telesci{
 	pixel_x = 14;
 	pixel_y = 16
 	},
@@ -46395,7 +46394,7 @@
 	pixel_x = -13;
 	pixel_y = -1
 	},
-/obj/item/clothing/head/helmet/camera{
+/obj/item/clothing/head/helmet/camera/telesci{
 	pixel_x = -7;
 	pixel_y = 13
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Add telesci subtype of helmet cam
- Add telesci network to science subtype of mobile cameras
- Replace helmet cams/mobile cameras on all maps with proper subtypes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17007 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) The expedition monitor should now properly show helmet/mobile cameras.
```
