### PR TITLE
Add sinks to cogmap 1 janitorial rooms

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -19012,6 +19012,10 @@
 /area/station/janitor/office)
 "bfy" = (
 /obj/reagent_dispensers/watertank,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 6
+	},
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -38701,6 +38705,10 @@
 /obj/item/spraybottle/cleaner{
 	pixel_x = 5;
 	pixel_y = -3
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -6
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8


### PR DESCRIPTION
[MAPPING]
## About the PR
Adds two sinks, one to the janitor's office and one to the closet. They're blocked by a crate/a water tank, but they can be moved out of the way.

## Why's this needed?
They lacked them. Other maps have them, map parity is good.

## Changelog
```changelog
(u)Tyrant
(+)Cogmap1's janitor rooms now have sinks in them.
```