### PR TITLE
add sec showers to every map

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18098,6 +18098,10 @@
 	},
 /obj/machinery/drainage,
 /mob/living/carbon/human/npc/monkey/stirstir,
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/simulated/floor/sanitary,
 /area/station/security/brig/genpop)
 "ocq" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -20643,6 +20643,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -21533,14 +21534,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/crew_quarters/ce)
-"fko" = (
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/black,
-/area/station/security/main)
 "fkU" = (
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass/botany{
@@ -24811,9 +24804,16 @@
 /obj/machinery/status_display{
 	pixel_y = -30
 	},
-/turf/simulated/floor/red/side{
-	dir = 10
+/obj/machinery/drainage,
+/obj/decal/stripe_caution,
+/obj/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/security/main)
 "hTx" = (
 /obj/cable{
@@ -36488,11 +36488,8 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/left{
+/obj/window_blinds/cog2{
 	dir = 8
 	},
 /turf/simulated/floor/black,
@@ -75464,7 +75461,7 @@ iar
 aQR
 egp
 qYU
-fko
+aQR
 aQR
 ybG
 rcS

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -214,7 +214,16 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/observatory)
 "abj" = (
-/turf/simulated/floor,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/machinery/drainage,
+/obj/decal/stripe_caution,
+/obj/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/routing/security)
 "abn" = (
 /turf/simulated/floor/black,
@@ -3143,6 +3152,7 @@
 "alC" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
+/obj/machinery/door/window/eastright,
 /turf/simulated/floor,
 /area/station/routing/security)
 "alD" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -35277,8 +35277,10 @@
 /area/station/security/main)
 "bXl" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "1-2"
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/obj/machinery/sleeper/compact{
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -35736,28 +35738,27 @@
 /area/station/security/main)
 "bYA" = (
 /obj/machinery/light,
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/obj/machinery/sleeper/compact{
-	dir = 8
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fred2"
 	},
 /area/station/security/main)
 "bYC" = (
+/obj/machinery/door/window/eastright,
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "fred5"
+	icon_state = "fred2"
 	},
 /area/station/security/main)
 "bYD" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/carpet{
+/obj/machinery/shower{
 	dir = 4;
-	icon_state = "fred4"
+	pixel_x = 8
 	},
+/obj/machinery/drainage,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/sanitary/white,
 /area/station/security/main)
 "bYE" = (
 /obj/disposalpipe/segment/mail/vertical,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -24360,6 +24360,9 @@
 /obj/storage/cart/forensic{
 	req_access_txt = "1"
 	},
+/obj/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
 "hbZ" = (
@@ -50412,6 +50415,16 @@
 /obj/machinery/phone/wall,
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
+"xEr" = (
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 8
+	},
+/obj/decal/stripe_caution,
+/obj/machinery/door/window/northright,
+/turf/simulated/floor/grime,
+/area/station/security/equipment)
 "xEB" = (
 /obj/item/feather,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
@@ -92316,7 +92329,7 @@ bol
 boX
 bpB
 bqr
-piD
+hsx
 piD
 qPO
 moJ
@@ -92922,7 +92935,7 @@ moJ
 bqs
 brm
 piD
-hsx
+xEr
 moJ
 brn
 ffV

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -10597,6 +10597,9 @@
 	dir = 4
 	},
 /obj/landmark/start/job/security_assistant,
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "dbf" = (
@@ -13831,10 +13834,16 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "ebx" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = 6
 	},
-/turf/simulated/floor/carpet/grime,
+/obj/machinery/drainage,
+/obj/window/reinforced{
+	dir = 4
+	},
+/obj/decal/stripe_caution,
+/turf/simulated/floor/sanitary/white,
 /area/station/security/quarters)
 "eby" = (
 /obj/cable{
@@ -39148,6 +39157,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "lRz" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39450,10 +39450,16 @@
 	},
 /area/station/hallway/secondary/exit)
 "iQW" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/red/side{
-	dir = 8
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -8
 	},
+/obj/window/reinforced{
+	dir = 4
+	},
+/obj/decal/stripe_caution,
+/turf/simulated/floor/sanitary/white,
 /area/station/hangar/sec)
 "iRq" = (
 /obj/machinery/light_switch/east,
@@ -39545,7 +39551,7 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
 "iUj" = (
-/obj/storage/closet/welding_supply,
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -43599,6 +43605,7 @@
 	dir = 1;
 	name = "autoname - SS13"
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
 "lRp" = (
@@ -54016,6 +54023,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "tTC" = (
@@ -54279,7 +54287,7 @@
 /area/station/crew_quarters/quarters_east)
 "ufA" = (
 /obj/machinery/light,
-/obj/machinery/vending/air_vendor/plasma,
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
 "ufL" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2654,6 +2654,12 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
+"blN" = (
+/obj/machinery/door/window/northright,
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/hangar/sec)
 "blV" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
@@ -8394,6 +8400,9 @@
 	},
 /area/station/security/brig)
 "dPx" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
 /turf/simulated/floor/redblack/corner,
 /area/station/hangar/sec)
 "dQn" = (
@@ -48816,8 +48825,14 @@
 	name = "Transception Array Control"
 	})
 "vlv" = (
-/obj/stool/chair/red{
-	dir = 8
+/obj/table/reinforced/auto,
+/obj/item/device/gps{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/gps{
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -50942,18 +50957,16 @@
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/arcade/dungeon)
 "wgR" = (
-/obj/table/reinforced/auto,
-/obj/item/device/gps{
-	pixel_x = -5;
-	pixel_y = 4
+/obj/machinery/drainage,
+/obj/window/reinforced{
+	dir = 8
 	},
-/obj/item/device/gps{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/decal/stripe_caution,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = 6
 	},
-/turf/simulated/floor/redblack{
-	dir = 5
-	},
+/turf/simulated/floor/sanitary/white,
 /area/station/hangar/sec)
 "whb" = (
 /obj/cable{
@@ -90319,7 +90332,7 @@ qov
 ufa
 uBF
 wgR
-vlv
+blN
 vlv
 ujg
 uBF

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1047,6 +1047,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/window/southleft,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "adi" = (
@@ -4627,7 +4628,16 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor/red,
+/obj/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = 6
+	},
+/obj/machinery/drainage,
+/obj/decal/stripe_caution,
+/turf/simulated/floor/sanitary/white,
 /area/station/security/main)
 "apD" = (
 /turf/simulated/wall/auto/supernorn,


### PR DESCRIPTION
[MAPPING] [RP]
## About the PR
Add small dedicated security shower cubicles to every map. Except atlas, where a shower is added to the brig toilet. I tried to place them in spots that aren't visible in the public, and in a way that doesn't impede the shape and structure of the security department. In some places the positioning is a little awkward, but I did as best I could.

Most of them use thindoors and thindows in order to stay more compact.

## Why's this needed?
Typical RP security main behaviour is to shower in the brig to raise hygiene, which can be strange if there are... actual inmates. And showering in the public washrooms is basically begging to get robbed.

## Changelog
```changelog
(u)Tyrant
(*)All Security departments now have dedicated showers for their staff that aren't just the brig showers. Except for Atlas, which has had a brig shower added.
```