### PR TITLE
Removes Pure Love's forced hugging

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1884,15 +1884,6 @@ datum
 
 					boutput(M, SPAN_NOTICE("You feel [.]."))
 
-				else if (prob(50) && !M.restrained() && ishuman(M)) // only humans hug, I think?
-					var/mob/living/carbon/human/H = M
-					for (var/mob/living/carbon/human/hugTarget in orange(1,H))
-						if (hugTarget == H)
-							continue
-						if (!hugTarget.stat)
-							H.emote(prob(5)?"sidehug":"hug", emoteTarget="[hugTarget]")
-							break
-
 				..()
 
 		colors


### PR DESCRIPTION
## About the PR
[Chemistry] [Removal]
Removes the code that forces people to hug emote when they have Pure Love in them.

## Why's this needed?

Being forced to hug strangers is weird in a gross way. Getting hugged by strangers unprompted is weird in a gross way. Being able to force other people to hug each other is weird in a gross way.
