### PR TITLE
Correct dining chair assembly instructions

### DIFF
--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -457,6 +457,7 @@ TYPEINFO(/obj/item/furniture_parts/woodenstool)
 	icon = 'icons/obj/furniture/chairs.dmi'
 	stamina_damage = 15
 	stamina_cost = 15
+	furniture_name = "chair"
 
 	wood
 		name = "wooden chair parts"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME-OBJECTS][TRIVIAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assembly uses `furniture_name`, so add a generic 'chair' name for `dining_chair`.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17379