### PR TITLE
Add missing supply pack crate names

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1227,6 +1227,8 @@ ABSTRACT_TYPE(/datum/supply_packs)
 					/obj/item/clothing/head/headband/nyan/snowleopard = 1,
 					/obj/item/clothing/head/headband/bee = 2,
 					/obj/item/clothing/head/headband/nyan/random = 1)
+	containertype = /obj/storage/crate/packing
+	containername = "Bows and Bands Box"
 
 /datum/supply_packs/mask
 	name = "Masquerade Crate"
@@ -1827,6 +1829,8 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 					/obj/item/reagent_containers/food/drinks/coffee = 2)
 	frames = list(/obj/machinery/space_heater = 2)
 	cost = PAY_TRADESMAN*2
+	containertype = /obj/storage/crate/wooden
+	containername = "Cold Weather Gear"
 
 /datum/supply_packs/complex/hydrostarter
 	name = "Hydroponics: Starter Crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds names to the crates for the cold weather and bows/band supply packs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Crate labelling consistency

