### PR TITLE
Adds materials to LRT so it can be built.

### DIFF
--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -1,6 +1,9 @@
 var/datum/telescope_manager/tele_man
 var/list/special_places = list() //list of location names, which are coincidentally also landmark ids
 
+TYPEINFO(/obj/machinery/lrteleporter)
+	mats = list("telecrystal"=10, "MET-1"=10, "CON-1"=10)
+	
 /obj/machinery/lrteleporter
 	name = "Experimental long-range teleporter"
 	desc = "Well this looks somewhat unsafe."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows the LRT to be built with 1 telecrystal, 1 metal, and 1 copper.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think it's neat and you can make some cooler looking telepad networks with it, or make a secret entrance to a base by having a private LRT receive from a certain place and whatnot
