### PR TITLE
Add a message for graphene hardening compound reinforcing things

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -756,7 +756,7 @@ datum
 					I.ColorTone( rgb(20, 30, 30) )
 					O.icon = I
 					O.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
-					O.visible_message(SPAN_ALERT("The [O] is reinforced by the compound."))
+					O.visible_message(SPAN_ALERT("[O] is reinforced by the compound."))
 				return
 
 			reaction_turf(var/turf/target, var/volume)
@@ -775,7 +775,7 @@ datum
 					I.ColorTone( rgb(20, 30, 30) )
 					T.icon = I
 					T.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
-					T.visible_message(SPAN_ALERT("The [T] is reinforced by the compound."))
+					T.visible_message(SPAN_ALERT("[T] is reinforced by the compound."))
 
 
 //foam precursor

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -756,8 +756,7 @@ datum
 					I.ColorTone( rgb(20, 30, 30) )
 					O.icon = I
 					O.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
-					for(var/mob/M in AIviewers(O, null))
-						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
+					O.visible_message(SPAN_ALERT("The [O] is reinforced by the compound."))
 				return
 
 			reaction_turf(var/turf/target, var/volume)
@@ -772,12 +771,11 @@ datum
 				if(istype(T))
 					var/initial_resistance = initial(T.explosion_resistance)
 					T.explosion_resistance = clamp(T.explosion_resistance + (volume_mult*volume), initial_resistance, initial_resistance + 5)
-					for(var/mob/M in AIviewers(T, null))
-						M.show_message(SPAN_ALERT("The [T] is reinforced by the compound."), 1)
 					var/icon/I = icon(T.icon)
 					I.ColorTone( rgb(20, 30, 30) )
 					T.icon = I
 					T.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
+					T.visible_message(SPAN_ALERT("The [O] is reinforced by the compound."))
 
 
 //foam precursor

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -744,12 +744,17 @@ datum
 
 						P.fatigue_pressure = clamp(P.fatigue_pressure * (2**volume), initial(P.fatigue_pressure), max_reinforcement)
 						colorize = TRUE
+						for(var/mob/M in AIviewers(O, null))
+							M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
+
 
 				else if (istype(O,/obj/window))
 					var/obj/window/W = O
 					var/initial_resistance = initial(W.explosion_resistance)
 					W.explosion_resistance = clamp(W.explosion_resistance + volume, initial_resistance, initial_resistance + 3)
 					colorize = TRUE
+					for(var/mob/M in AIviewers(O, null))
+						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
 
 				if(colorize)
 					var/icon/I = icon(O.icon)
@@ -770,7 +775,8 @@ datum
 				if(istype(T))
 					var/initial_resistance = initial(T.explosion_resistance)
 					T.explosion_resistance = clamp(T.explosion_resistance + (volume_mult*volume), initial_resistance, initial_resistance + 5)
-
+					for(var/mob/M in AIviewers(O, null))
+						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
 					var/icon/I = icon(T.icon)
 					I.ColorTone( rgb(20, 30, 30) )
 					T.icon = I

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -775,7 +775,7 @@ datum
 					I.ColorTone( rgb(20, 30, 30) )
 					T.icon = I
 					T.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
-					T.visible_message(SPAN_ALERT("The [O] is reinforced by the compound."))
+					T.visible_message(SPAN_ALERT("The [T] is reinforced by the compound."))
 
 
 //foam precursor

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -744,23 +744,20 @@ datum
 
 						P.fatigue_pressure = clamp(P.fatigue_pressure * (2**volume), initial(P.fatigue_pressure), max_reinforcement)
 						colorize = TRUE
-						for(var/mob/M in AIviewers(O, null))
-							M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
-
 
 				else if (istype(O,/obj/window))
 					var/obj/window/W = O
 					var/initial_resistance = initial(W.explosion_resistance)
 					W.explosion_resistance = clamp(W.explosion_resistance + volume, initial_resistance, initial_resistance + 3)
 					colorize = TRUE
-					for(var/mob/M in AIviewers(O, null))
-						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
 
 				if(colorize)
 					var/icon/I = icon(O.icon)
 					I.ColorTone( rgb(20, 30, 30) )
 					O.icon = I
 					O.setTexture("hex_lattice", BLEND_ADD, "hex_lattice")
+					for(var/mob/M in AIviewers(O, null))
+						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
 				return
 
 			reaction_turf(var/turf/target, var/volume)
@@ -775,8 +772,8 @@ datum
 				if(istype(T))
 					var/initial_resistance = initial(T.explosion_resistance)
 					T.explosion_resistance = clamp(T.explosion_resistance + (volume_mult*volume), initial_resistance, initial_resistance + 5)
-					for(var/mob/M in AIviewers(O, null))
-						M.show_message(SPAN_ALERT("The [O] is reinforced by the compound."), 1)
+					for(var/mob/M in AIviewers(T, null))
+						M.show_message(SPAN_ALERT("The [T] is reinforced by the compound."), 1)
 					var/icon/I = icon(T.icon)
 					I.ColorTone( rgb(20, 30, 30) )
 					T.icon = I


### PR DESCRIPTION
[CHEMISTRY] [ATMOS] [GAME OBJECTS] [FEATURE]
## About the PR
Adds a message `"The [thing] is reinforced by the compound."` that plays to all mobs in viewing range.

## Why's this needed?
Other than a very slight visual change, there's no indication that it successfully worked. This should make it clearer.

## Changelog
```changelog
(u)Tyrant
(+)Adding Graphene Hardening Compound to things will now show a message in the chat box.
```