### PR TITLE
borgs with 0% health parts should break that part

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -136,7 +136,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts)
 	proc/ropart_take_damage(var/bluntdmg = 0,var/burnsdmg = 0)
 		src.dmg_blunt += bluntdmg
 		src.dmg_burns += burnsdmg
-		if (src.dmg_blunt + src.dmg_burns > src.max_health)
+		if (src.dmg_blunt + src.dmg_burns >= src.max_health)
 			if(src.holder) return 1 // need to do special stuff in this case, so we let the borg's melee hit take care of it
 			else
 				src.visible_message("<b>[src]</b> breaks!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the check for comparing robot part damage against part health to be a 'greater than or equals to' and not a 'greater than'. This means borgs taking part damage exactly equal to part health will have that part broken instead of sticking around at 0% health. 

NOTE: It was expressed in Discord that borgs getting one more hit after a part reaches 0% is intended behavior, so if it is, please close this PR 👍  

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parts that have taken 100% of their health as damage should break. 0% part health on the UI seems like that part should be broken and no longer work (and if that's the head, the borg should be destroyed).
Tangentially related to #4837 - Robots being stuck in a half alive half dead state was fixed, but the situation of a 0% part health borg remains. 
![image](https://github.com/goonstation/goonstation/assets/5091297/f49caad9-e3e0-42b1-81dd-f4e6e34c63a0)
![image](https://github.com/goonstation/goonstation/assets/5091297/afbe936f-e390-4e8d-8363-a77764a702e6)