### PR TITLE
un emag the nadir prefab's metalman borg

### DIFF
--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_robotfactory.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_robotfactory.dmm
@@ -1039,9 +1039,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
 	},
-/mob/living/silicon/robot/spawnable/standard/metalman{
-	emagged = 1
-	},
+/mob/living/silicon/robot/spawnable/standard/metalman,
 /turf/simulated/floor/shuttlebay{
 	icon_state = "engine-blue"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

changes the metalman skin'd borg in one of nadir's prefabs to no longer be emagged by default

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

a prespawned emagged borg isnt great and apparently people are being weird with it
