### PR TITLE
Override `/mob/proc/get_id` on `/mob/living/silicon`.

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -591,6 +591,12 @@ var/global/list/module_editors = list()
 
 	. = 'sound/impact_sounds/Metal_Clang_3.ogg'
 
+/mob/living/silicon/get_id(not_worn = FALSE)
+	. = ..()
+	if(. || not_worn)
+		return
+	return src.botcard
+
 /mob/living/silicon/proc/singify_text(var/text)
 	var/adverb = pick("robotically", "synthetically", "electronically")
 	var/speech_verb = pick("sings", pick("croons", "intones", "warbles"))


### PR DESCRIPTION
[internal] [silicons] [bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Override `/mob/proc/get_id` on `/mob/living/silicon` to return the internal botcard.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This will make N.A.R.C.S. not longer shoot at silicons. (They were Bad Boys.)

It also seems the right thing to do - as asking if someone has access can then be done by just asking for the mobs ID, and check if the ID has the desired access.

Currently, most other useses of `get_id(` does not apply to silicons (it is only checked for `/mob/living/carbon`).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DasBrain
(+)N.A.R.C.S. should no longer shoot at silicons.
```
