### PR TITLE
standardize presence of jani and botanist clothing boxes

### DIFF
--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -149,13 +149,12 @@ TYPEINFO(/obj/storage/closet)
 							/obj/item/storage/box/trash_bags = 2,
 							/obj/item/clothing/suit/hazard/bio_suit,
 							/obj/item/clothing/head/bio_hood,
-							/obj/item/clothing/under/rank/janitor = 2,
-							/obj/item/clothing/shoes/black = 2,
 							/obj/item/device/light/flashlight,
 							/obj/item/clothing/shoes/galoshes,
 							/obj/item/reagent_containers/glass/bottle/cleaner,
 							/obj/item/storage/box/body_bag,
 							/obj/item/caution = 6,
+							/obj/item/storage/box/clothing/janitor,
 							/obj/item/disk/data/floppy/manudrive/cleaner_grenade)
 
 /obj/storage/closet/law

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -99,6 +99,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/drone_recharger,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "aaH" = (
@@ -4027,7 +4028,6 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "anI" = (
-/obj/machinery/drone_recharger,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "anJ" = (
@@ -5706,11 +5706,21 @@
 /area/station/turret_protected/ai)
 "atK" = (
 /obj/table/auto,
-/obj/item/device/light/lava_lamp,
+/obj/item/device/light/lava_lamp{
+	pixel_x = 6;
+	pixel_y = 17
+	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/item/satchel/hydro{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/bee_egg_carton{
+	pixel_x = -9
 	},
 /obj/item/reagent_containers/glass/water_pipe{
 	pixel_x = 7;
@@ -18350,13 +18360,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "oPh" = (
-/obj/table/auto,
-/obj/item/bee_egg_carton,
-/obj/item/satchel/hydro,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "oUL" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- adds janitor clothing box to the regular locker (previously only the secure locker had it for.. reasons) so that maps without secure lockers will have the box.
- adds a botanist locker to atlas botany

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i meant to do this a while ago, the puffer jackets are unobtainable on some maps because of the lack of box spawns

