### PR TITLE
Unifiy max pressure values on atmos devices

### DIFF
--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -11,6 +11,8 @@ Thus, the two variables affect pump operation are set in New():
 		Higher quantities of this cause more air to be perfected later
 			but overall network volume is also increased as this increases...
 */
+/// Max pump pressure.
+#define MAX_PRESSURE 149 * ONE_ATMOSPHERE
 
 /obj/machinery/atmospherics/binary/pump
 	icon = 'icons/obj/atmospherics/pump.dmi'
@@ -114,7 +116,7 @@ Thus, the two variables affect pump operation are set in New():
 
 		if("set_output_pressure")
 			var/number = text2num_safe(signal.data["parameter"])
-			number = clamp(number, 0, ONE_ATMOSPHERE*50)
+			number = clamp(number, 0, MAX_PRESSURE)
 
 			target_pressure = number
 
@@ -132,7 +134,7 @@ Thus, the two variables affect pump operation are set in New():
 	value_name = "Target Pressure"
 	value_units = "kPa"
 	min_value = 0
-	max_value = 15000
+	max_value = MAX_PRESSURE
 	incr_sm = 50
 	incr_lg = 100
 	var/obj/machinery/atmospherics/binary/pump/our_pump
@@ -158,3 +160,5 @@ Thus, the two variables affect pump operation are set in New():
 
 /datum/pump_ui/basic_pump_ui/get_atom()
 	return our_pump
+
+#undef MAX_PRESSURE

--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -1,4 +1,7 @@
 /// Shoves transfer_rate volume of gas from air1 to air2
+/// Max volume flow rate.
+#define MAX_VOLUME 1000
+
 /obj/machinery/atmospherics/binary/volume_pump
 	name = "Gas pump"
 	desc = "A pump"
@@ -81,7 +84,7 @@
 
 		if("set_transfer_rate")
 			var/number = text2num_safe(signal.data["parameter"])
-			number = clamp(number, 0, src.air1.volume)
+			number = clamp(number, 0, MAX_VOLUME)
 
 			src.transfer_rate = number
 
@@ -98,7 +101,7 @@
 	value_name = "Flow Rate"
 	value_units = "L/s"
 	min_value = 0
-	max_value = 1000
+	max_value = MAX_VOLUME
 	incr_sm = 10
 	incr_lg = 100
 	var/obj/machinery/atmospherics/binary/volume_pump/our_pump
@@ -124,3 +127,5 @@
 
 /datum/pump_ui/volume_pump_ui/get_atom()
 	return our_pump
+
+#undef MAX_VOLUME

--- a/code/modules/atmospherics/machinery/trinary/mixer.dm
+++ b/code/modules/atmospherics/machinery/trinary/mixer.dm
@@ -3,6 +3,8 @@
 #define _RESET_SIGNAL_GAS(GAS, _, _, ID, ...) signal.data[ID + #GAS] = 0;
 #define SET_SIGNAL_MIXTURE(MIXTURE, ID) APPLY_TO_GASES(_SET_SIGNAL_GAS, MIXTURE, ID)
 #define RESET_SIGNAL_MIXTURE(ID) APPLY_TO_GASES(_RESET_SIGNAL_GAS, ID)
+/// Max mixer pressure.
+#define MAX_PRESSURE 20 * ONE_ATMOSPHERE
 
 /obj/machinery/atmospherics/trinary/mixer
 	name = "Gas mixer"
@@ -118,9 +120,9 @@
 				src.node2_ratio = (100-number)/100
 
 		if ("set_pressure")
-			var/number2 = text2num(signal.data["parameter"])
-			if (isnum_safe(number2))
-				src.target_pressure = max(0, number2)
+			var/number = text2num(signal.data["parameter"])
+			if (isnum_safe(number))
+				src.target_pressure = clamp(number, 0, MAX_PRESSURE)
 			else
 				src.target_pressure = 0
 
@@ -188,3 +190,4 @@
 #undef _RESET_SIGNAL_GAS
 #undef SET_SIGNAL_MIXTURE
 #undef RESET_SIGNAL_MIXTURE
+#undef MAX_PRESSURE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Atmospherics] [Code Quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR aims to remove the differing max pressure values between pump_ui and signal inputs.
For example, pumps can be manually given target pressures of 15000kPa, but signal packets can only set them up to 5066.25kPa. Additionally adds a clamp to the mixer value.

I've tested the changes to have minimal impact on the mixer computer and pump computer
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These changes make dealing with signal packets a little cleaner and stops target pressure like this 
![image](https://github.com/goonstation/goonstation/assets/22815407/cce664d6-68ad-41bb-87bf-7a8e2cee902f)