### PR TITLE
Buff-R-Matic 3000 cleans /obj/decal/cleanable

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -753,6 +753,10 @@ TYPEINFO(/obj/vehicle/floorbuffer)
 			if (D_turf.active_liquid)
 				D_turf.active_liquid.try_connect_to_adjacent()
 
+			// clean floor drawings akin to the mop
+			var/turf/T = get_turf(src)
+			T.clean_forensic()
+
 			qdel(D)
 
 /obj/vehicle/floorbuffer/attackby(obj/item/W, mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][Feature][Game-Objects][Vehicles]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the Buff-R-Matic so when the chemical sprayer is on it cleans /obj/decal/cleanable (crayon drawings on the floor, gibs, egg splats, paper/leaves, etc), same as the mop. Unsure if this should be marked as a bugfix since documentation indicates it was intended for the Buff-R-Matic to have the same feature set as a mop but faster or a feature since this adds something new to the Buff-R-Matic. Please feel free to delete the tag that's not needed.

![floor-buffer-crayon](https://github.com/goonstation/goonstation/assets/5091297/f9c6de00-6d32-459b-8fb9-654f0d648289)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15281