### PR TITLE
drastically reduce asteroid field generation time

### DIFF
--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -36,14 +36,12 @@ TYPEINFO_NEW(/turf/simulated/wall/auto)
 
 	New()
 		..()
-		if (map_setting && ticker)
-			src.update_neighbors() // lessen these calls
-
-		if (current_state > GAME_STATE_WORLD_INIT)
+		if (current_state > GAME_STATE_WORLD_NEW)
 			SPAWN(0) //worldgen overrides ideally
 				src.UpdateIcon()
+				src.update_neighbors()
 		else
-			worldgenCandidates[src] = 1
+			worldgenCandidates += src
 
 	generate_worldgen()
 		src.UpdateIcon()
@@ -709,14 +707,13 @@ TYPEINFO_NEW(/turf/unsimulated/wall/auto)
 
 	New()
 		. = ..()
-		if (map_setting && ticker)
-			src.update_neighbors()
-		if (current_state > GAME_STATE_WORLD_INIT)
+		if (current_state > GAME_STATE_WORLD_NEW)
 			SPAWN(0) //worldgen overrides ideally
 				src.UpdateIcon()
+				src.update_neighbors()
 
 		else
-			worldgenCandidates[src] = 1
+			worldgenCandidates += src
 
 	generate_worldgen()
 		src.UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[performance][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Asteroid turfs were constantly doing icon updates on their neighbours as they generated, which is a large waste of effort when you're spawning big balls of them. This fixes the neighbour update behaviour for new autowalls including asteroids.

The `worldgenCandidates[src] = 1` -> `worldgenCandidates += src` change is done because it's faster according to a comment elsewhere in the code. I haven't checked this, but this also makes autowalls consistent with how stuff is getting added to worldgenCandidates elsewhere.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't know how this will translate to the live servers, but some data from my machine (3x compiling with no speed-up flags on cog2, with and without the patch) dropped the time it took to generate the asteroid field from ~67s to ~20s