### PR TITLE
Fix clarion sec recharger positioning

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -25373,12 +25373,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
-"ilF" = (
-/obj/machinery/recharger/wall{
-	pixel_y = -11
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
 "ilH" = (
 /obj/machinery/light_switch/east{
 	dir = 4
@@ -41058,6 +41052,9 @@
 /turf/simulated/floor/redblack,
 /area/station/security/detectives_office)
 "uCg" = (
+/obj/machinery/recharger/wall{
+	pixel_y = 28
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -73393,7 +73390,7 @@ aLW
 oMV
 aPp
 gqn
-ilF
+aQR
 uCg
 bgp
 gOV


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves a recharger in clarion sec down onto the floor with pixel shift so it isn't reachable from the hallway on the other side of the wall

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17403