### PR TITLE
Adds player interaction logs to pump_ui

### DIFF
--- a/code/modules/atmospherics/machinery/binary/pump_ui.dm
+++ b/code/modules/atmospherics/machinery/binary/pump_ui.dm
@@ -36,12 +36,15 @@
 				var/value_to_set = input(usr, "[value_name] ([min_value] - [max_value] [value_units]):", "Enter new value", get_value()) as num
 				if(isnum_safe(value_to_set))
 					src.set_value(clamp(value_to_set, min_value, max_value))
+					logTheThing(LOG_STATION, usr, "has set [src.get_atom()] value to [src.get_value()] at [log_loc(src.get_atom())]")
 
 			if("toggle_power")
 				src.toggle_power()
+				logTheThing(LOG_STATION, usr, "has set [src.get_atom()] power to [src.is_on() ?  "On" : "Off"] at [log_loc(src.get_atom())]")
 
 			if("bump_value")
 				src.set_value(clamp(get_value() + text2num_safe(href_list["bump_value"]), min_value, max_value))
+				logTheThing(LOG_STATION, usr, "has set [src.get_atom()] value to [src.get_value()] at [log_loc(src.get_atom())]")
 
 	src.show_ui(usr)
 /// Displays the UI


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Admin] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds station logs to pump_ui interactions

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A lot of pump_ui objects have high grief potential and can be difficult for inexperienced engineers to notice they are turned off/have had lowered settings.
