### PR TITLE
Increase minimum number of nukies to two

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -48,12 +48,12 @@
 
 		if (player.ready)
 			num_players++
-	var/num_synds = clamp( round(num_players / 6 ), 1, agents_possible)
+	var/num_synds = clamp( round(num_players / 6 ), 2, agents_possible)
 
 	possible_syndicates = get_possible_enemies(ROLE_NUKEOP, num_synds)
 
-	if (!islist(possible_syndicates) || length(possible_syndicates) < 1)
-		boutput(world, SPAN_ALERT("<b>ERROR: couldn't assign any players as Syndicate operatives, aborting nuke round pre-setup.</b>"))
+	if (!islist(possible_syndicates) || length(possible_syndicates) < 2)
+		boutput(world, SPAN_ALERT("<b>ERROR: couldn't assign at least two players as Syndicate operatives, aborting nuke round pre-setup.</b>"))
 		return 0
 
 	// I wandered in and made things hopefully a bit easier to work with since we have multiple maps now - Haine


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases minimum antag count for nuclear to two.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Single operatives increase the chance for the only antag to be AFK/have to leave, can result in extremely quick nukie losses, may leave players unhappy that they have no teammates.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(*)Minimum number of nuclear operatives has increased to two.
```
