### PR TITLE
Light Space Suits can now withstand 5 Minutes in Nadir Acid

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1426,6 +1426,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/hazard)
 	duration_remove = 6 SECONDS
 	duration_put = 6 SECONDS
 	protective_temperature = 1000
+	acid_survival_time = 5 MINUTES
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAME OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chief Engineer on Nadir was given one of these suits despite the fact that they had no acid_survival_time which made them pretty worthless. So I thought 5 minutes sounds good to balance out the more bulky suits which have 8 Minutes. More than welcome to change the numbers about.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having Light Suits have more use in Nadir I think is good. Previously they melted absurdly fast from my knowledge and that doesn't feel totally right. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)444explorer
(+)Using some new materials Light Space Suits can withstand 5 Minutes in Acid
```
