### PR TITLE
Fixes random room runtime checker

### DIFF
--- a/code/modules/worldgen/RandomRoomRuntimeChecker.dm
+++ b/code/modules/worldgen/RandomRoomRuntimeChecker.dm
@@ -23,15 +23,15 @@
 #if defined(CI_RUNTIME_CHECKING)
 	var/startTime = world.timeofday
 	boutput(world, SPAN_ALERT("Generating random rooms..."))
-	var/list/room_types = concrete_typesof(/datum/mapPrefab/random_room)
+	var/list/room_types = get_map_prefabs(/datum/mapPrefab/random_room)
 	boutput(world, SPAN_ALERT("Found [length(room_types)] random rooms..."))
 	for (var/room_type in room_types)
-		var/datum/mapPrefab/random_room/R = new room_type()
+		var/datum/mapPrefab/random_room/R = room_types[room_type]
 		var/turf/T = locate(1+AST_MAPBORDER, 1+AST_MAPBORDER, Z_LEVEL_STATION)
 		var/loaded = file2text(R.prefabPath)
 		var/dmm_suite/D = new/dmm_suite()
 		D.read_map(loaded, T.x, T.y, T.z, R.prefabPath, DMM_OVERWRITE_MOBS | DMM_OVERWRITE_OBJS)
-		boutput(world, SPAN_ALERT("Prefab placement [R.type][R.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]"))
+		boutput(world, SPAN_ALERT("Prefab placement [R.prefabPath][R.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]"))
 		check_map_correctness()
 		sleep(1 SECOND)
 		// cleanup

--- a/code/z_dmm_suite/reader.dm
+++ b/code/z_dmm_suite/reader.dm
@@ -180,6 +180,8 @@ dmm_suite
 				for(var/atomModel in splittext(models, comma_delim))
 					var bracketPos = findtext(atomModel, "{")
 					var atomPath = text2path(copytext(atomModel, 1, bracketPos))
+					if(!atomPath)
+						stack_trace("Attempted to load invalid type [copytext(atomModel, 1, bracketPos)]!")
 					var/list/attributes
 					if(bracketPos)
 						attributes = new()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TOOLING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes random room checker code to actually load the prefabs properly, I didn't get any runtimes on my local server which is suspicious but it definitely loads all the prefabs. Also adds stack trace for catching invalid types that exist in prefabs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The random room checker does nothing right now due to a bug