### PR TITLE
Fix disposal/mail chutes never flushing if you pull the handle while recharging

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -428,7 +428,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			mode = DISPOSAL_CHUTE_CHARGED
 			power_usage = 100
 			update()
-			if (is_processing)
+			if (is_processing && !flush)
 				UnsubscribeProcess()
 				is_processing = 0
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check for if the handle is currently down before unsubscribing from processing once charging is complete

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17428 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Flushing a disposal/mail chute during recharging should now make it flush as soon as it's done.
```
