### PR TITLE
Fix Donut2 Auxiliary Storage camera name

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -51189,9 +51189,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/wreckage)
 "yhW" = (
-/obj/machinery/camera{
-	c_tag = "Autolathe"
-	},
+/obj/machinery/camera,
 /obj/machinery/vending/floppy,
 /turf/simulated/floor,
 /area/station/storage/auxillary)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the manual name for this camera, allowing it to automatically pick up the area name (Auxiliary Storage)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17432