### PR TITLE
Update pod part requsition contract to use available manufacturer outputs

### DIFF
--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -689,10 +689,9 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		src.payout += rand(0,40) * 10
 
 		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/engine_component,1)
-		if(prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_engine,1)
-		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_circuitry,1)
+		if(prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_mining,1)
+		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_tank,1)
 		if(prob(70) || length(src.rc_entries) < 2) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_armor,1)
-		if(prob(80)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_control,1)
 		if(prob(60) || length(src.rc_entries) < 4) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_tool,1)
 		if(prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/pod_secondary,1)
 
@@ -713,22 +712,42 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 				feemod = PAY_DOCTORATE*5
 		..()
 
-/datum/rc_entry/item/pod_engine
-	name = "pod engine manifold"
-	typepath = /obj/item/pod/engine
-	feemod = PAY_TRADESMAN*3
+/datum/rc_entry/item/pod_mining
+	name = "pod mining accessory"
 
 	New()
-		src.feemod += rand(0,20) * 10
+		switch(rand(1, 10))
+			if(1 to 6)
+				name = "magnet link array"
+				typepath = /obj/item/shipcomponent/communications/mining
+				feemod = PAY_TRADESMAN*4
+			if(7 to 9)
+				name = "pod-mounted ore scoop with hold"
+				typepath = /obj/item/shipcomponent/secondary_system/orescoop
+				feemod = PAY_TRADESMAN*5
+			if(10)
+				name = "pod-mounted geological scanner"
+				typepath = /obj/item/shipcomponent/sensor/mining
+				feemod = PAY_TRADESMAN*12
 		..()
 
-/datum/rc_entry/item/pod_circuitry
-	name = "pod circuitry kit"
-	typepath = /obj/item/pod/boards
-	feemod = PAY_TRADESMAN*2
+/datum/rc_entry/item/pod_tank
+	name = "pod atmospheric tank"
 
 	New()
-		src.feemod += rand(0,20) * 10
+		switch(rand(1, 10))
+			if(1 to 6)
+				name = "pod-compatible gas tank"
+				typepath = /obj/item/tank
+				feemod = PAY_TRADESMAN*2
+			if(7 to 9)
+				name = "pod air tank"
+				typepath = /obj/item/tank/air
+				feemod = PAY_TRADESMAN*5
+			if(10)
+				name = "pod fuel tank"
+				typepath = /obj/item/tank/plasma
+				feemod = PAY_TRADESMAN*8
 		..()
 
 /datum/rc_entry/item/pod_armor
@@ -750,14 +769,6 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 				feemod = PAY_TRADESMAN*12
 		..()
 
-/datum/rc_entry/item/pod_control
-	name = "pod control interface"
-	typepath = /obj/item/pod/control
-	feemod = PAY_TRADESMAN*3
-
-	New()
-		src.feemod += rand(0,20) * 10
-		..()
 
 /datum/rc_entry/item/pod_tool
 	name = "youshouldn'tseemium cannon"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes references to the older the engine, cirtcuitry, and control components used in pod construction from the pod requisition contract.

Adds two new categorizes of pod parts for use in the pod requisition contract:

mining-specific parts

magnet link comm array, ore scoop/hold, and mining sensor

gas tanks (any/air/plasma)

General manufacturers can print general tanks for the any-tank requirement. air-tanks are pretty flush on station, while plasma tanks are rarer and likely require crew interaction (engineering, mining, and/or science).

Doesn't change the reward for this requisition. Previously found these rewards to be undertuned, so the reduction of one item category didn't strike me as reason to adjust the payout.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When pod construction was changed to use kits intead of separate components, the requisition contratcts were not altered away from the now-inaccessible parts. This makes sure the pod requsition completable. 

Fixes #17364
Fixes #17418