### PR TITLE
Declare /obj/random_item_spawner abstract

### DIFF
--- a/assets/maps/random_rooms/3x5/snailsoda.dmm
+++ b/assets/maps/random_rooms/3x5/snailsoda.dmm
@@ -134,14 +134,6 @@
 	color = "#69ffe3";
 	layer = 2
 	},
-/obj/random_item_spawner{
-	max_amt2spawn = 10;
-	amt2spawn = 5;
-	items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/orange,/obj/item/reagent_containers/food/drinks/bottle/soda/lime,/obj/item/reagent_containers/food/drinks/bottle/soda/gingerale,/obj/item/reagent_containers/food/drinks/bottle/soda/pink,/obj/item/reagent_containers/food/drinks/milk,/obj/item/reagent_containers/food/drinks/fruitmilk,/obj/item/reagent_containers/food/snacks/ice_cream/goodrandom,/obj/item/reagent_containers/food/drinks/energyshake);
-	rare_items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/softsoft_pizza,/obj/item/reagent_containers/food/snacks/greengoo,/obj/item/reagent_containers/food/snacks/plant/purplegoop/orangegoop,/obj/item/reagent_containers/food/drinks/milk/clownspider,/obj/item/reagent_containers/food/snacks/ice_cream/random,/obj/item/reagent_containers/food/drinks/weightloss_shake,/obj/critter/snail);
-	rare_chance = 15;
-	min_amt2spawn = 5
-	},
 /obj/item/storage/box/costume/roller_disco,
 /obj/item/reagent_containers/food/snacks/plant/lettuce{
 	pixel_y = 11;

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1,4 +1,4 @@
-
+ABSTRACT_TYPE(/obj/random_item_spawner)
 /obj/random_item_spawner
 	name = "random item spawner"
 	icon = 'icons/obj/objects.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mark `/obj/random_item_spawner` abstract as it is the base type and contains no list of items to spawn

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I suspect this will catch out the random rooms that have occasionally been runtiming 
