### PR TITLE
Swap light manufactrurer and bulb/tube manufacturer availability

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2259,7 +2259,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 /obj/machinery/manufacturer/general
 	name = "general manufacturer"
-	supplemental_desc = "This one produces tools and other hardware, as well as general-purpose items like replacement lights."
+	supplemental_desc = "This one produces tools, basic construction supplies, and other hardware."
 	free_resource_amt = 5
 	free_resources = list(/obj/item/material_piece/steel,
 		/obj/item/material_piece/copper,
@@ -2285,22 +2285,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/powercellE,
 		/datum/manufacture/powercellC,
 		/datum/manufacture/powercellH,
-		/datum/manufacture/light_bulb,
-		/datum/manufacture/red_bulb,
-		/datum/manufacture/yellow_bulb,
-		/datum/manufacture/green_bulb,
-		/datum/manufacture/cyan_bulb,
-		/datum/manufacture/blue_bulb,
-		/datum/manufacture/purple_bulb,
-		/datum/manufacture/blacklight_bulb,
-		/datum/manufacture/light_tube,
-		/datum/manufacture/red_tube,
-		/datum/manufacture/yellow_tube,
-		/datum/manufacture/green_tube,
-		/datum/manufacture/cyan_tube,
-		/datum/manufacture/blue_tube,
-		/datum/manufacture/purple_tube,
-		/datum/manufacture/blacklight_tube,
+		/datum/manufacture/lampmanufacturer,
 		/datum/manufacture/table_folding,
 		/datum/manufacture/jumpsuit,
 		/datum/manufacture/shoes,
@@ -2331,7 +2316,9 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/stapler,
 		/datum/manufacture/bagpipe,
 		/datum/manufacture/fiddle,
-		/datum/manufacture/whistle)
+		/datum/manufacture/whistle,
+		/datum/manufacture/blacklight_bulb,
+		/datum/manufacture/blacklight_tube)
 
 #define MALFUNCTION_WIRE_CUT 15 & ~(1<<WIRE_MALF)
 
@@ -2916,7 +2903,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/RCDammolarge,
 		/datum/manufacture/atmos_goggles,
 		/datum/manufacture/engivac,
-		/datum/manufacture/lampmanufacturer,
 		/datum/manufacture/breathmask,
 		/datum/manufacture/engspacesuit,
 		/datum/manufacture/lightengspacesuit,
@@ -2942,7 +2928,23 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/interdictor_rod_lambda,
 		/datum/manufacture/interdictor_rod_sigma,
 		/datum/manufacture/interdictor_rod_epsilon,
-		/datum/manufacture/interdictor_rod_phi
+		/datum/manufacture/interdictor_rod_phi,
+		/datum/manufacture/light_bulb,
+		/datum/manufacture/red_bulb,
+		/datum/manufacture/yellow_bulb,
+		/datum/manufacture/green_bulb,
+		/datum/manufacture/cyan_bulb,
+		/datum/manufacture/blue_bulb,
+		/datum/manufacture/purple_bulb,
+		/datum/manufacture/blacklight_bulb,
+		/datum/manufacture/light_tube,
+		/datum/manufacture/red_tube,
+		/datum/manufacture/yellow_tube,
+		/datum/manufacture/green_tube,
+		/datum/manufacture/cyan_tube,
+		/datum/manufacture/blue_tube,
+		/datum/manufacture/purple_tube,
+		/datum/manufacture/blacklight_tube
 	)
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Move Lamp Manufacturer to General Manufacturer

Move various Light Bulbs/Tubes to Engi Specialist Manufacturer

Adds blacklight bulbs/tubes to the General Manufacturer as a secret option to ensure quartermasters have a path to completing existing light bulb/tube requisitions without requiring cross-departmental dependence.

Further shifts expectations on basic repair duties to be handled by civilian crew e.g. janitors ressponding to station repair requests. Requires less access/interaction to make more drastic changes to the station. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make it easier for janitors/staff assistants/etc. to handle 'basic' repairs on station.  

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)The lamp manufacturer is now available in general manufacturers.
(+)Light bulb and tube boxes can still be printed from the Engineering Specialist Manufacturer. And in the General Manufacturer with a little effort.
```
