### PR TITLE
Pronoun usage in fire extinguishing message

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1644,7 +1644,7 @@
 			if (istype(H))
 				H.hud.update_resting()
 			for (var/mob/O in AIviewers(M))
-				O.show_message(SPAN_ALERT("<B>[M] throws themselves onto the floor!</B>"), 1, group = "resist")
+				O.show_message(SPAN_ALERT("<B>[M] throws [himself_or_herself(M)] onto the floor!</B>"), 1, group = "resist")
 		else
 			for (var/mob/O in AIviewers(M))
 				O.show_message(SPAN_ALERT("<B>[M] rolls around on the floor, trying to extinguish the flames.</B>"), 1, group = "resist")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Use player pronouns in message about throwing themselves onto the floor to extinguish flames

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity