### PR TITLE
Fix intermittent runtime about invalid random item spawner

### DIFF
--- a/assets/maps/random_rooms/3x5/snailsoda.dmm
+++ b/assets/maps/random_rooms/3x5/snailsoda.dmm
@@ -138,7 +138,7 @@
 	max_amt2spawn = 10;
 	amt2spawn = 5;
 	items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/orange,/obj/item/reagent_containers/food/drinks/bottle/soda/lime,/obj/item/reagent_containers/food/drinks/bottle/soda/gingerale,/obj/item/reagent_containers/food/drinks/bottle/soda/pink,/obj/item/reagent_containers/food/drinks/milk,/obj/item/reagent_containers/food/drinks/fruitmilk,/obj/item/reagent_containers/food/snacks/ice_cream/goodrandom,/obj/item/reagent_containers/food/drinks/energyshake);
-	rare_items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/softsoft_pizza,/obj/item/reagent_containers/food/snacks/greengoo,/obj/item/reagent_containers/food/snacks/plant/purplegoop/orangegoop,/obj/item/reagent_containers/food/drinks/milk/clownspider,/obj/item/reagent_containers/food/snacks/ice_cream/random,/obj/item/reagent_containers/food/drinks/weightloss_shake,/obj/critter/snail);
+	rare_items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/softsoft_pizza,/obj/item/reagent_containers/food/snacks/greengoo,/obj/item/reagent_containers/food/snacks/plant/purplegoop/orangegoop,/obj/item/reagent_containers/food/drinks/milk/clownspider,/obj/item/reagent_containers/food/snacks/ice_cream/random,/obj/item/reagent_containers/food/drinks/weightloss_shake,/mob/living/critter/small_animal/slug/snail);
 	rare_chance = 15;
 	min_amt2spawn = 5
 	},

--- a/assets/maps/random_rooms/3x5/snailsoda.dmm
+++ b/assets/maps/random_rooms/3x5/snailsoda.dmm
@@ -138,7 +138,7 @@
 	max_amt2spawn = 10;
 	amt2spawn = 5;
 	items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/orange,/obj/item/reagent_containers/food/drinks/bottle/soda/lime,/obj/item/reagent_containers/food/drinks/bottle/soda/gingerale,/obj/item/reagent_containers/food/drinks/bottle/soda/pink,/obj/item/reagent_containers/food/drinks/milk,/obj/item/reagent_containers/food/drinks/fruitmilk,/obj/item/reagent_containers/food/snacks/ice_cream/goodrandom,/obj/item/reagent_containers/food/drinks/energyshake);
-	rare_items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/softsoft_pizza,/obj/item/reagent_containers/food/snacks/greengoo,/obj/item/reagent_containers/food/snacks/plant/purplegoop/orangegoop,/obj/item/reagent_containers/food/drinks/milk/clownspider,/obj/item/reagent_containers/food/snacks/ice_cream/random,/obj/item/reagent_containers/food/drinks/weightloss_shake,/mob/living/critter/small_animal/slug/snail);
+	rare_items2spawn = list(/obj/item/reagent_containers/food/drinks/bottle/soda/softsoft_pizza,/obj/item/reagent_containers/food/snacks/greengoo,/obj/item/reagent_containers/food/snacks/plant/purplegoop/orangegoop,/obj/item/reagent_containers/food/drinks/milk/clownspider,/obj/item/reagent_containers/food/snacks/ice_cream/random,/obj/item/reagent_containers/food/drinks/weightloss_shake);
 	rare_chance = 15;
 	min_amt2spawn = 5
 	},
@@ -199,6 +199,7 @@
 	heal_amt = 2;
 	rand_pos = 0
 	},
+/mob/living/critter/small_animal/slug/snail,
 /turf/simulated/floor/white/checker2,
 /area/dmm_suite/clear_area)
 "Q" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change the obj critter snail to a mob critter and just stick it in the locker instead of being in the random item spawner pool cause its not an /obj anymore

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes this fucking thing
![image](https://github.com/goonstation/goonstation/assets/75404941/4c00148d-0188-4ae5-854e-94179f9d9261)
