### PR TITLE
Fixes HE pipes showing error sprite when pulled by blackhole.

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -524,13 +524,7 @@
 	fatigue_pressure = INFINITY
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/update_icon()
-	if(node1 && node2)
-		icon_state = "intact"
-
-		var/node1_direction = get_dir(src, node1)
-		var/node2_direction = get_dir(src, node2)
-
-		icon_state = "[node1_direction|node2_direction]"
+	icon_state = (node1 && node2) ? "intact" : "exposed"
 
 
 /obj/machinery/atmospherics/pipe/vertical_pipe


### PR DESCRIPTION
[BUG][MINOR]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
HE pipes now properly show either an intact or exposed sprite, fixing a bug where they would show an error sprite when getting pulled by a blackhole.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
