### PR TITLE
Fix snipping security cameras not leaving prints

### DIFF
--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -137,7 +137,7 @@
 		return
 
 	if (issnippingtool(W) && !src.reinforced)
-		SETUP_GENERIC_ACTIONBAR(src, src, 0.5 SECOND, /obj/machinery/camera/proc/snipcamera, null, W.icon, W.icon_state, null, INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
+		SETUP_GENERIC_ACTIONBAR(user, src, 0.5 SECOND, /obj/machinery/camera/proc/snipcamera, list(user), W.icon, W.icon_state, null, INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
 
 	if (!src.camera_status)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Ensure the user is passed to `/obj/machinery/camera/proc/snipcamera` so prints can be added

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17438 
