### PR TITLE
Reintroduce Format Complete medal 

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -108,6 +108,7 @@ TYPEINFO(/obj/item/aiModule)
 				src.lawText = src.lawTextSafe
 				tooltip_rebuild = 1
 				boutput(user, "The law module seems to be functioning better now!")
+				user.unlock_medal("Format Complete", TRUE)
 			else
 				boutput(user, "The law module seems unaffected.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [MEDAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make the Format Complete medal obtainable again, acquired by using a multi-tool to reset a law module that's been corrupted by an ion storm.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Unobtainable medals are no fun for anyone and this is thematically similar to the old unlock requirement
