### PR TITLE
Fix DNA scrambler message speaking in second person

### DIFF
--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -230,30 +230,23 @@ ADMIN_INTERACT_PROCS(/obj/item/genetics_injector/dna_injector, proc/admin_comman
 			boutput(user, SPAN_ALERT("The [name] is expended and has no more uses."))
 			return
 
-		if(target == user)
+		logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with [src.name] at [log_loc(user)]")
 
-			if(use_mode == SCRAMBLER_MODE_COPY)
-				src.copy_identity(user,user)
-				user.visible_message(SPAN_ALERT("<b>You inject yourself with the [src]! Your appearance has been copied to the [src].</b>"))
-				return
+		if(use_mode == SCRAMBLER_MODE_COPY)
+			user.tri_message(target,\
+			SPAN_ALERT("<b>[user]</b> stabs [target] with the DNA injector!"),\
+			SPAN_ALERT("<b>You stab [target] with the DNA injector. [target]'s appearance has been copied to the [src].</b>"),\
+			SPAN_ALERT("<b>[user]</b> stabs you with the DNA injector!"))
+			src.copy_identity(user,target)
+			return
 
-			if(use_mode == SCRAMBLER_MODE_PASTE)
-				src.paste_identity(user,user)
-				user.visible_message(SPAN_ALERT("<b>You inject yourself with the [src]! The [src] has been totally used up.</b>"))
-				return
-
-		else
-			logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with [src.name] at [log_loc(user)]")
-
-			if(use_mode == SCRAMBLER_MODE_COPY)
-				src.copy_identity(user,target)
-				user.visible_message(SPAN_ALERT("<b>You stab [target] with the DNA injector. [target]'s appearance has been copied to the [src].</b>"))
-				return
-
-			if(use_mode == SCRAMBLER_MODE_PASTE)
-				src.paste_identity(user,target)
-				user.visible_message(SPAN_ALERT("<b>You stab [target] with the DNA injector. The [src] has been totally used up.</b>"))
-				return
+		if(use_mode == SCRAMBLER_MODE_PASTE)
+			user.tri_message(target,\
+			SPAN_ALERT("<b>[user]</b> stabs [target] with the DNA injector!"),\
+			SPAN_ALERT("<b>You stab [target] with the DNA injector. The [src] has been totally used up.</b>"),\
+			SPAN_ALERT("<b>[user]</b> stabs you with the DNA injector!"))
+			src.paste_identity(user,target)
+			return
 
 	proc/copy_identity(var/mob/living/carbon/user,var/mob/living/carbon/target)
 		if (ishuman(target))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Changes DNA scrambler messages to be `tri_message` instead of just being a `visible_message` that used "you" for some reason
- Removed redundant if branch for changing messages if user is target
- Moved message to appear before the appearance changing procs because otherwise it uses the new name in those messages and it's confusing as to who got injected

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17490