### PR TITLE
Fix claiming pilot then relic uniform medal rewards

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -488,10 +488,23 @@
 			if (H.w_uniform)
 				var/obj/item/clothing/under/rank/M = H.w_uniform
 				if (istype(M, /obj/item/clothing/under/rank/head_of_security))
+					M.icon = initial(M.icon)
+					M.inhand_image_icon = initial(M.inhand_image_icon)
+					M.wear_image_icon = initial(M.wear_image_icon)
+					M.item_state = initial(M.item_state)
+					M.name = initial(M.name)
+					M.real_name = initial(M.real_name)
+					M.desc = initial(M.desc)
 					M.icon_state = "hos-old"
 					H.set_clothing_icon_dirty()
 					return 1
 				else if (istype(M, /obj/item/clothing/under/rank/security))
+					M.icon = initial(M.icon)
+					M.inhand_image_icon = initial(M.inhand_image_icon)
+					M.wear_image_icon = initial(M.wear_image_icon)
+					M.name = initial(M.name)
+					M.real_name = initial(M.real_name)
+					M.desc = initial(M.desc)
 					M.icon_state = "security-old"
 					M.item_state = "security-relic"
 					H.set_clothing_icon_dirty()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The Pilot jumpsuit changes object's icon path, so when the relic uniform reward is claimed on the same item it becomes invisible. By This forces them to switch to the initial icon d

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17106
Fixes #10416