### PR TITLE
Add alloying recipe for glass

### DIFF
--- a/code/modules/materials/Mat_Recipes.dm
+++ b/code/modules/materials/Mat_Recipes.dm
@@ -114,6 +114,21 @@
 		if(one && two) return 1
 		else return 0
 
+/datum/material_recipe/glass // yeah whatever sure char and molitz makes glass who gives a shit
+	name = "glass"
+	result_id = "glass"
+
+	validate(datum/material/M)
+		var/one = FALSE
+		var/two = FALSE
+
+		for(var/datum/material/CM in M.getParentMaterials())
+			if(CM.getID() == "molitz") one = TRUE
+			if(CM.getID() == "char") two = TRUE
+
+		if(one && two) return TRUE
+		else return FALSE
+
 /datum/material_recipe/electrum
 	name = "electrum"
 	result_id = "electrum"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [MATERIALS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds recipe for glass using molitz and char. (No this doesn't make sense but steel is mauxite and char and copper is pharosium and char so lets complete the set)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Being able to produce something that's pretty ubiquitous on station without depending on buying it from cargo is nice 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Glass can now be made by alloying molitz and char.
```
