### PR TITLE
Fix ping tool reporting PDAs twice

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -776,7 +776,7 @@
 
 			if(signal.data["address_1"] && signal.data["address_1"] != src.master.net_id)
 				if((signal.data["address_1"] == "ping") && signal.data["sender"])
-					var/datum/signal/pingreply = new
+					var/datum/signal/pingreply = get_free_signal()
 					pingreply.source = src.master
 					pingreply.data["device"] = "NET_PDA_51XX"
 					pingreply.data["netid"] = src.master.net_id

--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -122,7 +122,7 @@
 
 
 	proc/receive_signal(obj/item/device/pda2/pda, datum/signal/signal, transmission_method, range, connection_id)
-		if(signal.data["address_1"] == master.net_id && signal.data["command"] == "ping_reply")
+		if(signal.data["address_1"] == master.net_id && signal.data["command"] == "ping_reply" && connection_id == "ping")
 			if(!result)
 				result = new/list()
 			result += "[signal.data["device"]] \[[signal.data["netid"]]\] [signal.data["data"]]<BR>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check for `connection_id` being `ping` in the ping tool because on the PDA freq you get all the packets twice, once from the `ping` component and again from the `pda` component. Also switches the ping response on PDAs to use `get_free_signal` like everything else.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17494 
