### PR TITLE
Extra things for ABCU whitelist

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -494,9 +494,9 @@
 	/obj/rack, \
 	/obj/structure, \
 	/obj/kitchenspike, \
-	/obj/barricade, \
 	/obj/railing, \
 	/obj/disposalpipe, \
+	/obj/structure/woodwall, \
 	/obj/machinery/light, \
 	/obj/machinery/door_control, \
 	/obj/machinery/light_switch, \
@@ -518,9 +518,6 @@
 	/obj/machinery/glass_recycler, \
 	/obj/machinery/microwave, \
 	/obj/machinery/disposal, \
-	/obj/machinery/hydro_growlamp, \
-	/obj/machinery/plantpot, \
-	/obj/machinery/chem_master, \
 	/obj/machinery/coffeemaker, \
 	/obj/machinery/vending/pizza, \
 	/obj/machinery/vending/cola, \
@@ -529,7 +526,6 @@
 	/obj/machinery/bathtub, \
 	/obj/item/instrument/large/jukebox, \
 	/obj/submachine/claw_machine, \
-	/obj/submachine/seed_vendor, \
 	/obj/submachine/chem_extractor, \
 	/obj/submachine/chef_oven, \
 	/obj/submachine/chef_sink, \

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -526,6 +526,7 @@
 	/obj/machinery/vending/cola, \
 	/obj/machinery/vending/coffee, \
 	/obj/machinery/vending/snack, \
+	/obj/machinery/bathtub, \
 	/obj/item/instrument/large/jukebox, \
 	/obj/submachine/claw_machine, \
 	/obj/submachine/seed_vendor, \
@@ -546,7 +547,7 @@
 	/obj/securearea, \
 	/obj/submachine/mixer, \
 	/obj/submachine/foodprocessor, \
-
+	\
 )
 // blacklist overrules whitelist
 #define BLACKLIST_OBJECTS list( \

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -498,6 +498,7 @@
 	/obj/machinery/light_switch, \
 	/obj/machinery/camera, \
 	/obj/item/device/radio/intercom, \
+	/obj/item/storage/toilet, \
 	/obj/machinery/firealarm, \
 	/obj/machinery/power/apc, \
 	/obj/machinery/alarm, \
@@ -506,6 +507,9 @@
 	/obj/machinery/floorflusher, \
 	/obj/machinery/activation_button/driver_button, \
 	/obj/machinery/door_control, \
+	/obj/machinery/conveyor/, \
+	/obj/machinery/conveyor_switch, \
+	/obj/machinery/drainage, \
 	/obj/machinery/disposal, \
 	/obj/submachine/chef_oven, \
 	/obj/submachine/chef_sink, \

--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -486,12 +486,16 @@
 #define WHITELIST_OBJECTS list( \
 	/obj/stool, \
 	/obj/grille, \
+	/obj/lattice, \
 	/obj/window, \
 	/obj/machinery/door, \
 	/obj/cable, \
 	/obj/table, \
 	/obj/rack, \
 	/obj/structure, \
+	/obj/kitchenspike, \
+	/obj/barricade, \
+	/obj/railing, \
 	/obj/disposalpipe, \
 	/obj/machinery/light, \
 	/obj/machinery/door_control, \
@@ -510,7 +514,22 @@
 	/obj/machinery/conveyor/, \
 	/obj/machinery/conveyor_switch, \
 	/obj/machinery/drainage, \
+	/obj/machinery/phone, \
+	/obj/machinery/glass_recycler, \
+	/obj/machinery/microwave, \
 	/obj/machinery/disposal, \
+	/obj/machinery/hydro_growlamp, \
+	/obj/machinery/plantpot, \
+	/obj/machinery/chem_master, \
+	/obj/machinery/coffeemaker, \
+	/obj/machinery/vending/pizza, \
+	/obj/machinery/vending/cola, \
+	/obj/machinery/vending/coffee, \
+	/obj/machinery/vending/snack, \
+	/obj/item/instrument/large/jukebox, \
+	/obj/submachine/claw_machine, \
+	/obj/submachine/seed_vendor, \
+	/obj/submachine/chem_extractor, \
 	/obj/submachine/chef_oven, \
 	/obj/submachine/chef_sink, \
 	/obj/machinery/launcher_loader, \
@@ -527,6 +546,7 @@
 	/obj/securearea, \
 	/obj/submachine/mixer, \
 	/obj/submachine/foodprocessor, \
+
 )
 // blacklist overrules whitelist
 #define BLACKLIST_OBJECTS list( \


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Beefs up the whitelist a bit, excluding stuff that should be balanced on their material requirements. 

Possibly controversial picks:
- Conveyor belts
- Botany stuff
- Drains

My argument for conveyor belts is they should still need a decent amount of time to connect to a switch properly and turn them all on etc. Plus I think the builds it could allow would be fun to see, sushi resteraunts and modular conveyor dark rides.

Botany stuff should be fine as I didn't add anything that you can't get by rushing the russian ship.

I can see an argument for drains skipping a step for building in ocean maps?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The blacklist should be used more once there's a system that can allow for adding an object's material cost to the blueprint total, but for now this is a quick fix for a lot of common things people would build. It's possible something I've added doesn't work correctly when built with an abcu, I haven't tested them all yet.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+) Adds conveyor belts to the ABC-U whitelist among other things.
