### PR TITLE
New QM Crew Objective: Deliver Mail

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -265,6 +265,13 @@ ABSTRACT_TYPE(/datum/objective/crew/quartermaster)
 	check_completion()
 		return length(shippingmarket.complete_orders)
 
+#define MAIL_DELIVERY_OBJ_COUNT 30
+/datum/objective/crew/quartermaster/maildelivery
+	explanation_text = "Ensure [MAIL_DELIVERY_OBJ_COUNT] pieces of mail are opened by their addressees."
+	check_completion()
+		return game_stats.GetStat("mail_opened") >= MAIL_DELIVERY_OBJ_COUNT
+#undef MAIL_DELIVERY_OBJ_COUNT
+
 ABSTRACT_TYPE(/datum/objective/crew/detective)
 /datum/objective/crew/detective/drunk
 	explanation_text = "Have alcohol in your bloodstream at the end of the round."

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -265,12 +265,10 @@ ABSTRACT_TYPE(/datum/objective/crew/quartermaster)
 	check_completion()
 		return length(shippingmarket.complete_orders)
 
-#define MAIL_DELIVERY_OBJ_COUNT 30
 /datum/objective/crew/quartermaster/maildelivery
-	explanation_text = "Ensure [MAIL_DELIVERY_OBJ_COUNT] pieces of mail are opened by their addressees."
+	explanation_text = "Ensure 30 pieces of mail are opened by their addressees."
 	check_completion()
-		return game_stats.GetStat("mail_opened") >= MAIL_DELIVERY_OBJ_COUNT
-#undef MAIL_DELIVERY_OBJ_COUNT
+		return game_stats.GetStat("mail_opened") >= 30
 
 ABSTRACT_TYPE(/datum/objective/crew/detective)
 /datum/objective/crew/detective/drunk


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new crew objective for quartermasters: ensure 30 pieces of mail are correctly delivered/opened over the course of an entire shift. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Encourage active mail delivery. More variance in crew objectives.
