### PR TITLE
Fix abdomen spelling in organ failure

### DIFF
--- a/code/modules/medical/diseases/organ_diseases/appendicitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/appendicitis.dm
@@ -60,7 +60,7 @@
 			if (probmult(5))
 				boutput(H, SPAN_ALERT("Your back aches terribly!"))
 			if (probmult(3))
-				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right adbomen!"))
+				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right abdomen!"))
 				// H.organHolder.takepancreas
 
 			if (probmult(5)) H.emote(pick("faint", "collapse", "groan"))

--- a/code/modules/medical/diseases/organ_diseases/kidney_failure.dm
+++ b/code/modules/medical/diseases/organ_diseases/kidney_failure.dm
@@ -64,7 +64,7 @@
 			if (probmult(5))
 				boutput(H, SPAN_ALERT("Your back aches terribly!"))
 			if (probmult(3))
-				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right adbomen!"))
+				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right abdomen!"))
 				// H.organHolder.takekidney
 
 			if (probmult(5)) H.emote(pick("faint", "collapse", "groan"))

--- a/code/modules/medical/diseases/organ_diseases/liver_failure.dm
+++ b/code/modules/medical/diseases/organ_diseases/liver_failure.dm
@@ -48,7 +48,7 @@
 			if (probmult(5))
 				boutput(H, SPAN_ALERT("Your back aches terribly!"))
 			if (probmult(3))
-				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right adbomen!"))
+				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right abdomen!"))
 				// H.organHolder.takeliver
 
 			if (probmult(5)) H.emote(pick("faint", "collapse", "groan"))

--- a/code/modules/medical/diseases/organ_diseases/pancreatitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/pancreatitis.dm
@@ -43,7 +43,7 @@
 			if (probmult(5))
 				boutput(H, SPAN_ALERT("Your back aches terribly!"))
 			if (probmult(3))
-				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right adbomen!"))
+				boutput(H, SPAN_ALERT("You feel excruciating pain in your upper-right abdomen!"))
 				// H.organHolder.takepancreas
 
 			if (probmult(5)) H.emote(pick("faint", "collapse", "groan"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
typo fix `adbomen` -> `abdomen`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17521