### PR TITLE
Prevent souldorf from triggering crusher

### DIFF
--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -26,6 +26,7 @@
 		src.sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 		src.see_invisible = INVIS_GHOST
 		src.see_in_dark = SEE_DARK_FULL
+		src.flags |= UNCRUSHABLE
 
 	proc/addAllAbilities()
 		src.addAbility(/datum/targetable/zoldorfAbility/fortune)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make the player-controlled zoldorf/souldorf-ball uncrushable, as it is ethereal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17516