### PR TITLE
Prevent ants from crawling on kitchen islands

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -45,6 +45,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 			return FALSE
 		if (locate(/obj/table) in src.loc) // locate is faster than typechecking each movable
 			return TRUE
+		if (locate(/obj/surgery_tray) in src.loc) // includes kitchen islands
+			return TRUE
 		return FALSE
 
 	proc/get_food_color()

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -1230,13 +1230,6 @@ TRAYS
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "kitchen_island"
 
-//kitchen island
-/obj/surgery_tray/kitchen_island
-	name = "kitchen island"
-	desc = "a table! with wheels!"
-	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "kitchen_island"
-
 /obj/item/tongs
 	name = "tongs"
 	desc = "A device that allows you to use food items as if they were used in-hand, or get food items out of food boxes."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add an additional check for surgery trays (which kitchen islands are a subtype of) for table checks, used for ants. Also de-duplicates the kitchen island object.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17510