### PR TITLE
Make space for mailer chute in Clarion QM Office

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14566,8 +14566,7 @@
 	mail_tag = "cargo";
 	mailgroup = "cargo";
 	message = "1";
-	name = "mail chute-'Cargo'";
-	pixel_y = 32
+	name = "mail chute-'Cargo'"
 	},
 /obj/disposalpipe/trunk/mail{
 	dir = 4
@@ -17649,11 +17648,8 @@
 /area/station/garden/aviary)
 "bXc" = (
 /obj/disposalpipe/segment,
-/obj/machinery/navbeacon/mule/QM1_north/east,
 /obj/decal/stripe_caution,
-/obj/machinery/bot/mulebot{
-	home_destination = "QM #1"
-	},
+/obj/machinery/navbeacon/mule/QM2_north,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "bXA" = (
@@ -30401,8 +30397,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "mdJ" = (
-/obj/machinery/navbeacon/mule/QM2_north,
 /obj/decal/stripe_caution,
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #1"
+	},
+/obj/machinery/navbeacon/mule/QM1_north/east,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "meH" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The QM Mail chute on clarion was a wall chute, but was replaced to the new big mailbox  chute. This removes the pixel offset, placing it back "inside" the room instead of in the wall. 

To ensure the north-west corner remains accessible by default, swaps the MULEbot QM nav points.
![68747470733a2f2f616666656374656461726330372e626c6f622e636f72652e77696e646f77732e6e65742f6d6462322f696d616765732f3235323034373438332f32303130373331363135372f6d2f6d6170735f636c6172696f6e2f302d61667465722e706e67](https://github.com/goonstation/goonstation/assets/91498627/58e25be5-ea4c-47a0-8a39-536d697099b5)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17543