### PR TITLE
Push objects out from under cryotron sprite on player spawn

### DIFF
--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -128,6 +128,9 @@
 				return
 			if (thePerson.loc == firstLoc)
 				step(thePerson, SOUTH)
+			for (var/obj/O in src.loc) // dropped stuff & whatever spawned under them
+				if (O.anchored == UNANCHORED)
+					O.set_loc(locate(src.x, src.y-1, src.z)) // dump it in front of the cyrotron
 			src.icon_state = "cryotron_up"
 			flick("cryotron_go_up", src)
 

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -129,7 +129,7 @@
 			if (thePerson.loc == firstLoc)
 				step(thePerson, SOUTH)
 			for (var/obj/O in src.loc) // dropped stuff & whatever spawned under them
-				if (O.anchored == UNANCHORED)
+				if (O.anchored == UNANCHORED && O != src)
 					O.set_loc(locate(src.x, src.y-1, src.z)) // dump it in front of the cyrotron
 			src.icon_state = "cryotron_up"
 			flick("cryotron_go_up", src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR pushes all loose objects out from under the cryogenics storage unit when a person spawns in, making it easier to equip/pick-up dropped items and buckle into wheelchairs. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17370