### PR TITLE
Intangibles should not have cross effect for strip door plastic flaps

### DIFF
--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -146,6 +146,8 @@ TYPEINFO(/obj/strip_door)
 			var/mob/living/M = A
 			if (isghostdrone(M)) // except for drones
 				return TRUE
+			else if (isintangible(A))
+				return TRUE
 			else if (istype(A,/mob/living/critter/changeling/handspider) || istype(A,/mob/living/critter/changeling/eyespider))
 				return TRUE
 			else if (isdead(M))
@@ -159,6 +161,8 @@ TYPEINFO(/obj/strip_door)
 	Crossed(atom/A)
 		..()
 		if (!src.flap_material)
+			return
+		if (isintangible(A))
 			return
 		if (isliving(A))
 			var/mob/living/M = A


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Return intangibles early on Cross/Crossed to prevent blocking/slowing from the installed plastic flaps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Intangible mobs should not be slowed down or stsopped by physical objects