### PR TITLE
Generate camera network correctly for cogmap1 random engine

### DIFF
--- a/code/world/initialization/2_init.dm
+++ b/code/world/initialization/2_init.dm
@@ -154,7 +154,6 @@
 	Z_LOG_DEBUG("World/Init", "Setting up random rooms...")
 	buildRandomRooms()
 	makepowernets()
-	build_camera_network()
 	#endif
 
 	#ifdef SECRETS_ENABLED
@@ -177,6 +176,7 @@
 
 	UPDATE_TITLE_STATUS("Calculating cameras")
 	Z_LOG_DEBUG("World/Init", "Updating camera visibility...")
+	build_camera_network()
 	camera_coverage_controller.setup()
 
 	UPDATE_TITLE_STATUS("Preloading client data...")

--- a/code/world/initialization/2_init.dm
+++ b/code/world/initialization/2_init.dm
@@ -118,7 +118,6 @@
 	build_reagent_cache()
 	build_supply_pack_cache()
 	build_syndi_buylist_cache()
-	build_camera_network()
 	build_manufacturer_icons()
 	clothingbooth_setup()
 	initialize_biomes()
@@ -155,6 +154,7 @@
 	Z_LOG_DEBUG("World/Init", "Setting up random rooms...")
 	buildRandomRooms()
 	makepowernets()
+	build_camera_network()
 	#endif
 
 	#ifdef SECRETS_ENABLED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move camera network generation to after random room generation, so that cameras inside the engine prefabs are labelled correctly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17534