### PR TITLE
Fix graviton grenade immunity check

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -287,7 +287,7 @@ TYPEINFO(/obj/item/old_grenade/graviton)
 			for (var/atom/movable/AM in orange(reach, T))
 				if (prob(50)) continue
 				if (AM.anchored == ANCHORED_ALWAYS) continue
-				if (HAS_ANY_FLAGS(AM.event_handler_flags, IMMUNE_SINGULARITY | IMMUNE_SINGULARITY_INACTIVE)) continue
+				if (HAS_FLAG(AM.event_handler_flags, IMMUNE_SINGULARITY) || HAS_FLAG(AM.event_handler_flags, IMMUNE_SINGULARITY_INACTIVE)) continue
 				if (istypes(AM, list(/obj/effect, /obj/overlay))) continue
 				var/area/t = get_area(AM)
 				if (t?.sanctuary) continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Separates the HAS_ANY_FLAGS check into two HAS_FLAG checks,a as the former was always causing it to skip the atom.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17467