### PR TITLE
Double cluwne spell duration

### DIFF
--- a/code/modules/antagonists/wizard/abilities/cluwne.dm
+++ b/code/modules/antagonists/wizard/abilities/cluwne.dm
@@ -35,7 +35,7 @@
 		actions.start(new/datum/action/bar/icon/cluwne_spell(usr, target, src), holder.owner)
 
 /datum/action/bar/icon/cluwne_spell
-	duration = 1.5 SECONDS
+	duration = 3 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	icon = 'icons/ui/actions.dmi'
 	icon_state = "cluwne"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the wizard cluwne spell from 1.5 seconds to 3 seconds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Magic missile has a knockdown duration of 4 seconds making it a trivial combo, 3 seconds will require better timing from the wizard.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappypat
(+)Wizard's cluwne spell duration increased from 1.5 seconds to 3 seconds.
```
