### PR TITLE
Martian gibstare now causes head explosion

### DIFF
--- a/code/datums/abilities/critter/gibstare.dm
+++ b/code/datums/abilities/critter/gibstare.dm
@@ -31,10 +31,13 @@
 	onEnd()
 		..()
 		logTheThing(LOG_COMBAT, owner, "gibs [constructTarget(target,"combat")] using Martian gib stare.")
-		owner.visible_message(SPAN_ALERT("<b>[target.name]'s</b> head explodes!"))
 		if (target == owner)
 			boutput(owner, SPAN_SUCCESS("Good. Job."))
-		target.gib()
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			H.head_explosion()
+		else
+			target.gib()
 		ability.disabled = FALSE
 		ability?.actionFinishCooldown()
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3554,3 +3554,20 @@
 /mob/living/carbon/human/choose_name(retries, what_you_are, default_name, force_instead)
 	. = ..()
 	src.on_realname_change()
+
+/mob/living/carbon/human/proc/head_explosion()
+	var/list/nearby_turfs = list()
+	for(var/turf/T in view(5, src))
+		nearby_turfs += T
+		var/obj/brain = src.organHolder.drop_organ("brain")
+		var/obj/l_eye = src.organHolder.drop_organ("left_eye")
+		var/obj/r_eye = src.organHolder.drop_organ("right_eye")
+		var/obj/head = src.organHolder.drop_organ("head")
+		brain?.throw_at(pick(nearby_turfs), pick(1,2), 10)
+		l_eye?.throw_at(pick(nearby_turfs), pick(1,2), 10)
+		r_eye?.throw_at(pick(nearby_turfs), pick(1,2), 10)
+		qdel(head)
+	take_bleeding_damage(src, null, 500, DAMAGE_STAB)
+	src.visible_message(SPAN_ALERT("<B>BOOM!</B> [src]'s head explodes."),\
+	SPAN_ALERT("<B>BOOM!</B>"),\
+	SPAN_ALERT("You hear someone's head explode."))

--- a/code/obj/item/gun/russian.dm
+++ b/code/obj/item/gun/russian.dm
@@ -45,26 +45,13 @@
 			return 0
 		else if(src.shotsLeft == 1)
 			if(ishuman(user))
-				var/list/nearby_turfs = list()
-				for(var/turf/T in view(5, user))
-					nearby_turfs += T
 				var/mob/living/carbon/human/H = user
-				var/obj/brain = H.organHolder.drop_organ("brain")
-				var/obj/l_eye = H.organHolder.drop_organ("left_eye")
-				var/obj/r_eye = H.organHolder.drop_organ("right_eye")
-				var/obj/head = H.organHolder.drop_organ("head")
-				brain?.throw_at(pick(nearby_turfs), pick(1,2), 10)
-				l_eye?.throw_at(pick(nearby_turfs), pick(1,2), 10)
-				r_eye?.throw_at(pick(nearby_turfs), pick(1,2), 10)
-				qdel(head)
+				H.head_explosion()
 			else
 				user.TakeDamage("head", 300, 0)
-			take_bleeding_damage(user, null, 500, DAMAGE_STAB)
+				take_bleeding_damage(user, null, 500, DAMAGE_STAB)
 			src.shotsLeft = 0
 			playsound(user, 'sound/weapons/Gunshot.ogg', 100, TRUE)
-			user.visible_message(SPAN_ALERT("<B>BOOM!</B> [user]'s head explodes."),\
-				SPAN_ALERT("<B>BOOM!</B>"),\
-				SPAN_ALERT("You hear someone's head explode."))
 			logTheThing(LOG_COMBAT, user, "shoots themselves with [src] at [log_loc(user)].")
 			inventory_counter.update_number(0)
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Martian gibstare with the Russian revolver's head explosion.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The description already implied the head exploded, not a full gibbing.
Keeps the deadliness of the mutant but allows for revival, particularly if it happens on station rather than solo player going to the martian base.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(+)Martian mutants now cause Russian revolver style head explosions rather than gibs, leaving a brain and body for cloning or borging.
```
