### PR TITLE
Ignore mode argument to `icon_states`

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -226,7 +226,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	proc/load_clothing_icons()
 		SHOULD_CALL_PARENT(TRUE)
 		for (var/category in src.clothing_icons)
-			src.clothing_icon_states[category] = icon_states(src.clothing_icons[category], 1)
+			src.clothing_icon_states[category] = icon_states(src.clothing_icons[category])
 
 	/// Called by /mob/living/carbon/human/update_clothing()'s slot-specific sub-procs.
 	/// Each sub-proc passes its obj to this proc, which you can then operate on.

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -537,7 +537,7 @@
 
 	// does a suit potentially cover our tail?
 	if(our_tail.clothing_image_icon && icon_state)
-		var/tail_overrides = icon_states(our_tail.clothing_image_icon, 1)
+		var/tail_overrides = icon_states(our_tail.clothing_image_icon)
 		if (islist(tail_overrides) && (icon_state in tail_overrides))
 			human_tail_image = image(our_tail.clothing_image_icon, icon_state)
 			src.tail_standing.overlays += human_tail_image


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Per the DM ref "If you are not using the TILED_ICON_MAP value for world.map_format, you can ignore the mode argument. "

Throws in OD because other map formats aren't implemented yet.