### PR TITLE
fix using colored beret reward on construction cone hat

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -343,7 +343,10 @@
 			var/mob/living/carbon/human/H = activator
 			if (!istype(H.head, /obj/item/clothing/head/helmet) && istype(H.head, /obj/item/clothing/head)) // ha...
 				var/obj/item/clothing/head/M = H.head
+				M.icon = 'icons/obj/clothing/item_hats.dmi'
 				M.icon_state = "beret_base"
+				M.item_state = "beret_base"
+				M.wear_state = "beret_base"
 				M.wear_image_icon = 'icons/mob/clothing/head.dmi'
 				M.color = random_saturated_hex_color(1)
 				M.name = "beret"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The construction cone hat changes the base icon for its icon, which causes the reward to fail as it's referencing an icon state in the default head clothing icon file.

This change ensures the beret is using the correct file, which ensures it will work both with the construction cone hat as well as any other hats that change the default icon file and other base settings.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17558