### PR TITLE
Artifact Research Console naming consistency

### DIFF
--- a/code/modules/networks/computer3/mainframe2/artifact_res.dm
+++ b/code/modules/networks/computer3/mainframe2/artifact_res.dm
@@ -923,6 +923,7 @@
 //very WIP ok
 /obj/machinery/networked/artifact_console
 	name = "artifact research console"
+	desc = "It just sorta showed up in a giant box of test equipment."
 	density = 1
 	anchored = ANCHORED
 	device_tag = "PNET_ARTCONSOL"
@@ -938,6 +939,8 @@
 
 	New()
 		..()
+		if (prob(1))
+			src.desc = "Giant mystery science doodad."
 
 		entries = list("","","","","|cLoading...","","","")
 		SPAWN(0.5 SECONDS)

--- a/code/modules/networks/computer3/mainframe2/artifact_res.dm
+++ b/code/modules/networks/computer3/mainframe2/artifact_res.dm
@@ -939,7 +939,7 @@
 
 	New()
 		..()
-		if (prob(1))
+		if (prob(10))
 			src.desc = "Giant mystery science doodad."
 
 		entries = list("","","","","|cLoading...","","","")

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33794,7 +33794,8 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/networked/artifact_console/turf/simulated/floor/white,
+/obj/machinery/networked/artifact_console,
+/turf/simulated/floor/white,
 /area/station/science/artifact)
 "chQ" = (
 /obj/machinery/light_switch{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33794,11 +33794,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
-/turf/simulated/floor/white,
+/obj/machinery/networked/artifact_console/turf/simulated/floor/white,
 /area/station/science/artifact)
 "chQ" = (
 /obj/machinery/light_switch{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -51777,10 +51777,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
+/obj/machinery/networked/artifact_console,
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "cVk" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -5730,10 +5730,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bCY" = (
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
+/obj/machinery/networked/artifact_console,
 /obj/cable{
 	icon_state = "0-8"
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -38485,10 +38485,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
+/obj/machinery/networked/artifact_console,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "bQO" = (

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -19720,10 +19720,7 @@
 /turf/simulated/floor/white,
 /area/station/science/construction)
 "bqh" = (
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
+/obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"

--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -2407,10 +2407,7 @@
 /turf/simulated/floor,
 /area/station/devzone)
 "FP" = (
-/obj/machinery/networked/artifact_console{
-	desc = "It just sorta showed up in a giant box of test equipment.";
-	name = "giant mystery science doodad"
-	},
+/obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On some maps, the artifact research console had a varedited name and description. This moves the description to the artifact console object (previously lacking one), and adds the old varedited name (giant mystery science doodad) as an easter egg replacement for the description.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17129