### PR TITLE
Minimum player count for nuclear emergency

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -47,7 +47,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define BONUS_POINTS // gives a bunch of starting points to various abilities/uplinks/weapon vendors
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.
 //#define SHOW_ME_STATUSES // incredibly hacky visible status effects
-#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
+//#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
 
 //#define STOP_DISTRACTING_ME //All of the below
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -47,6 +47,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define BONUS_POINTS // gives a bunch of starting points to various abilities/uplinks/weapon vendors
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.
 //#define SHOW_ME_STATUSES // incredibly hacky visible status effects
+#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
 
 //#define STOP_DISTRACTING_ME //All of the below
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -48,13 +48,21 @@
 
 		if (player.ready)
 			num_players++
+#ifndef ME_AND_MY_40_ALT_ACCOUNTS
+	if (num_players < 15)
+		boutput(world, SPAN_ALERT("<b>ERROR: Minimum player count of 15 required for Nuclear game mode, aborting nuke round pre-setup.</b>"))
+		return 0
+#endif
+
 	var/num_synds = clamp( round(num_players / 6 ), 2, agents_possible)
 
 	possible_syndicates = get_possible_enemies(ROLE_NUKEOP, num_synds)
 
+#ifndef ME_AND_MY_40_ALT_ACCOUNTS
 	if (!islist(possible_syndicates) || length(possible_syndicates) < 2)
 		boutput(world, SPAN_ALERT("<b>ERROR: couldn't assign at least two players as Syndicate operatives, aborting nuke round pre-setup.</b>"))
 		return 0
+#endif
 
 	// I wandered in and made things hopefully a bit easier to work with since we have multiple maps now - Haine
 	var/list/list/target_locations = null

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -51,7 +51,8 @@
 			num_players++
 #ifndef ME_AND_MY_40_ALT_ACCOUNTS
 	if (num_players < minimum_players)
-		boutput(world, SPAN_ALERT("<b>ERROR: Minimum player count of 15 required for Nuclear game mode, aborting nuke round pre-setup.</b>"))
+		boutput(world, SPAN_ALERT("<b>ERROR: Minimum player count of [minimum_players] required for Nuclear game mode, aborting nuke round pre-setup.</b>"))
+		logTheThing(LOG_GAMEMODE, src, "Failed to start nuclear mode. [num_players] players were ready but a minimum of [minimum_players] players is required. ")
 		return 0
 #endif
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -18,6 +18,7 @@
 	var/agent_radiofreq = 0 //:h for syndies, randomized per round
 	var/obj/machinery/nuclearbomb/the_bomb = null
 	var/bomb_check_timestamp = 0 // See check_finished().
+	var/minimum_players = 15 // Minimum ready players for the mode
 	var/const/agents_possible = 10 //If we ever need more syndicate agents. cogwerks - raised from 5
 	var/podbay_authed = FALSE // Whether or not we authed our podbay yet
 	var/obj/machinery/computer/battlecruiser_podbay/auth_computer = null // The auth computer in the cairngorm so we can auth it
@@ -49,7 +50,7 @@
 		if (player.ready)
 			num_players++
 #ifndef ME_AND_MY_40_ALT_ACCOUNTS
-	if (num_players < 15)
+	if (num_players < minimum_players)
 		boutput(world, SPAN_ALERT("<b>ERROR: Minimum player count of 15 required for Nuclear game mode, aborting nuke round pre-setup.</b>"))
 		return 0
 #endif

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -1,11 +1,5 @@
 // If the game somtimes isn't registering a win properly, then ticker.mode.check_win() isn't being called somewhere.
 
-//uncomment to disable safety checks and win conditions to allow for local testing
-//#define THE_REVOLUTION_WILL_NOT_BE_TELEVISED 1
-
-#ifdef THE_REVOLUTION_WILL_NOT_BE_TELEVISED
-#warn Revolution debug mode enabled. IF YOU COMMIT THIS TO LIVE EVERYTHING WILL BREAK AND YOUR KNEECAPS WILL BE FORFEIT!!1
-#endif
 /datum/game_mode/revolution
 	name = "Revolution"
 	config_tag = "revolution"
@@ -91,7 +85,7 @@
 /datum/game_mode/revolution/post_setup()
 	waittime = rand(waittime_l, waittime_h)
 	trackertime = rand(trackertime_min, trackertime_max)
-#ifndef THE_REVOLUTION_WILL_NOT_BE_TELEVISED
+#ifndef ME_AND_MY_40_ALT_ACCOUNTS
 	var/list/heads = get_living_heads()
 	if(!head_revolutionaries || !heads)
 		boutput(world, SPAN_ALERT("<B>Not enough players for revolution game mode. Restarting world in 5 seconds.</B>"))
@@ -120,7 +114,7 @@
 	radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(signal2)
 	trackertimed = TRUE
 
-#ifndef THE_REVOLUTION_WILL_NOT_BE_TELEVISED
+#ifndef ME_AND_MY_40_ALT_ACCOUNTS
 /datum/game_mode/revolution/process()
 	..()
 	if (!istype(ticker.mode, /datum/game_mode/revolution/extended) && ticker.round_elapsed_ticks >= round_limit && !gibwave_started)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a 15 minimum ready player count to the nuclear mode.
Adds a build define to skip game mode checks, replaces THE_REVOLUTION_WILL_NOT_BE_TELEVISED.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Low player counts isn't ideal for team modes.
Nuclear can start with just two players right now.
15 players suggested by Gannets.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(*)The Nuclear Emergency game mode now requires 15 players.
```
