### PR TITLE
Change bathsalts recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4203,9 +4203,9 @@
 		name = "Bath Salts"
 		id= "bathsalts"
 		result = "bathsalts"
-		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "mugwort" = 1)
+		required_reagents = list("catdrugs" = 1, "saltpetre" = 1)
 		min_temperature = T0C + 100
-		result_amount = 6
+		result_amount = 3
 		mix_phrase = "Tiny cubic crystals precipitate out of the mixture. Huh."
 		mix_sound = 'sound/misc/fuse.ogg'
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simplifies the bathsalts recipe to use catdrugs and saltpetre.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Existing recipe took a lot of effort to make requiring yuck, denatured_enzyme and mugwort.
After discussion Cogs suggested plant nutrients and catdrugs.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat & Dr Cogwerks
(*)Bathsalts recipe has changed to cat drugs and saltpetre.
```
