### PR TITLE
Autobanner round logging

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -220,10 +220,10 @@ var/global/list/playersSeen = list()
 		var/ircmsg[] = new()
 		ircmsg["key"] = row["akey"]
 		ircmsg["key2"] = "[row["ckey"]] (IP: [row["ip"]], CompID: [row["compID"]])"
+		ircmsg["msg"] = row["reason"]
 		if (chain > 0 && targetC) //if we're auto-banning them
 			//paranoia ? because I'd much rather display null than crash the ban proc
-			ircmsg["key2"] += " rounds participated: [targetC.player?.rounds_participated]"
-		ircmsg["msg"] = row["reason"]
+			ircmsg["msg"] += "\n Rounds participated: [targetC.player?.rounds_participated]"
 		ircmsg["time"] = expiry
 		ircmsg["timestamp"] = row["timestamp"]
 		ircbot.export_async("ban", ircmsg)

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -222,7 +222,7 @@ var/global/list/playersSeen = list()
 		ircmsg["key2"] = "[row["ckey"]] (IP: [row["ip"]], CompID: [row["compID"]])"
 		if (chain > 0 && targetC) //if we're auto-banning them
 			//paranoia ? because I'd much rather display null than crash the ban proc
-			ircmsg["key2"] += "rounds participated: [targetC.player?.rounds_participated]"
+			ircmsg["key2"] += " rounds participated: [targetC.player?.rounds_participated]"
 		ircmsg["msg"] = row["reason"]
 		ircmsg["time"] = expiry
 		ircmsg["timestamp"] = row["timestamp"]

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -168,8 +168,8 @@ var/global/list/playersSeen = list()
 				targetC = C
 
 		row["reason"] = html_decode(row["reason"])
-
-		if (text2num(row["chain"]) > 0) //Prepend our evasion attempt info for: the user, admins, notes (everything except the actual ban reason in the db)
+		var/chain = text2num(row["chain"])
+		if (chain > 0) //Prepend our evasion attempt info for: the user, admins, notes (everything except the actual ban reason in the db)
 			row["reason"] = "\[Evasion Attempt x[row["chain"]]\] Previous Reason: [row["reason"]]"
 
 		var/replacement_text
@@ -214,16 +214,20 @@ var/global/list/playersSeen = list()
 		if (row["ckey"] && row["ckey"] != "N/A")
 			addPlayerNote(row["ckey"], row["akey"], "Banned [serverLogSnippet] by [row["akey"]], reason: [row["reason"]], duration: [duration]")
 
+		if(!targetC)
+			targetC = find_player(row["ckey"])?.client
+
 		var/ircmsg[] = new()
 		ircmsg["key"] = row["akey"]
 		ircmsg["key2"] = "[row["ckey"]] (IP: [row["ip"]], CompID: [row["compID"]])"
+		if (chain > 0 && targetC) //if we're auto-banning them
+			//paranoia ? because I'd much rather display null than crash the ban proc
+			ircmsg["key2"] += "rounds participated: [targetC.player?.rounds_participated]"
 		ircmsg["msg"] = row["reason"]
 		ircmsg["time"] = expiry
 		ircmsg["timestamp"] = row["timestamp"]
 		ircbot.export_async("ban", ircmsg)
 
-		if(!targetC)
-			targetC = find_player(row["ckey"])?.client
 		if (targetC)
 			del(targetC)
 		else

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -223,7 +223,7 @@ var/global/list/playersSeen = list()
 		ircmsg["msg"] = row["reason"]
 		if (chain > 0 && targetC) //if we're auto-banning them
 			//paranoia ? because I'd much rather display null than crash the ban proc
-			ircmsg["msg"] += "\n Rounds participated: [targetC.player?.rounds_participated]"
+			ircmsg["msg"] += "\nRounds participated: [targetC.player?.rounds_participated]"
 		ircmsg["time"] = expiry
 		ircmsg["timestamp"] = row["timestamp"]
 		ircbot.export_async("ban", ircmsg)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ADMIN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "rounds participated" line to the auto-banner discord message.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good to be able to tell at a glance when an actual player bounces off the auto-banner vs when it's a 0 rounds played alt account.