### PR TITLE
Fixes "Barrettes" Being called "Hairclips" in the Clothing Booth

### DIFF
--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -155,27 +155,27 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/accessory/hairclips)
 		path = /obj/item/clothing/head/barrette/butterflyorg
 
 	barrette_blue
-		name = "Blue Hairclips"
+		name = "Blue Barrettes"
 		path = /obj/item/clothing/head/barrette/blue
 
 	barrette_green
-		name = "Green Hairclips"
+		name = "Green Barrettes"
 		path = /obj/item/clothing/head/barrette/green
 
 	barrette_pink
-		name = "Pink Hairclips"
+		name = "Pink Barrettes"
 		path = /obj/item/clothing/head/barrette/pink
 
 	barrette_gold
-		name = "Gold Hairclips"
+		name = "Gold Barrettes"
 		path = /obj/item/clothing/head/barrette/gold
 
 	barrette_black
-		name = "Black Hairclips"
+		name = "Black Barrettes"
 		path = /obj/item/clothing/head/barrette/black
 
 	barrette_silver
-		name = "Silver Hairclips"
+		name = "Silver Barrettes"
 		path = /obj/item/clothing/head/barrette/silver
 
 //Casual


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Barrettes were called Hairclips in the clothing booth, which is already used by another piece of clothing.

