### PR TITLE
Football abilities no longer require the jumpsuit

### DIFF
--- a/code/obj/item/football.dm
+++ b/code/obj/item/football.dm
@@ -62,8 +62,7 @@
 
 /mob/living/carbon/human/proc/wearing_football_gear()
 	return ( (src.wear_suit && istype(src.wear_suit,/obj/item/clothing/suit/armor/football)) \
-			&& (src.shoes && istype(src.shoes,/obj/item/clothing/shoes/cleats) || istype(mutantrace, /datum/mutantrace/cow)) \
-			&& (src.w_uniform && istype(src.w_uniform,/obj/item/clothing/under/football)) )
+			&& (src.shoes && istype(src.shoes,/obj/item/clothing/shoes/cleats) || istype(mutantrace, /datum/mutantrace/cow)) )
 
 
 /mob/living/carbon/human/proc/rush()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, you can now rush without wearing the jumpsuit, none of the other requirements have changed. This allows you to stack both football armor and bowling ball kit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a spief/traitor gets both football and bowling, they deserve to be able to take advantage of both and become king of sportsball.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)You can now use football abilities without wearing the jumpsuit, none of the other requirements have changed. This allows you to stack both football armor and bowling ball kit.

```
