### PR TITLE
Hub shuttle status content is bold

### DIFF
--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -61,7 +61,7 @@
 				locstr = "RCL"
 			else
 				locstr = "ETA"
-			statsus += " | Shuttle: [locstr] [(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]<br>"
+			statsus += " | Shuttle: <b>[locstr] [(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</b><br>"
 	else
 		statsus += "<br>"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bolded the shuttle status content (i.e., ETA 0:30, but not the word Shuttle:)

Forgot to do it in previous PRs

Really sorry for spamming PRs like this I just noticed it wasnt bold when opening up the byond launcher right now

If these bold tags make the char count go over the limit, (do they count? not sure how byond counts chars)
Then feel free to close this

Again sorry for the PR spam this should be the final hub PR

Skipped changelog due to how minor it is
