### PR TITLE
Fix claiming a lawbringer not respecting the current egun charge usage

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -300,7 +300,7 @@ mob/verb/checkrewards()
 		if (istype(O, sacrifice_path))
 			var/obj/item/gun/energy/E = O
 			var/list/ret = list()
-			if(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE, ret) & CELL_RETURNED_LIST)
+			if(SEND_SIGNAL(E, COMSIG_CELL_CHECK_CHARGE, ret) & CELL_RETURNED_LIST)
 				charge = ret["charge"]
 				max_charge = ret["max_charge"]
 			C.mob.remove_item(E)


### PR DESCRIPTION
[Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The signal sent to get the egun charge before claiming/adjusting the new lawbringer charge is sent to src instead of the egun, so it just pretends the egun is full. This change sends the signal to the right place.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17519

