### PR TITLE
Clear overlays on stealth storage boxes

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -307,6 +307,7 @@
 			src.icon_state = initial(src.icon_state)
 			src.item_state = initial(src.item_state)
 			src.inhand_image = initial(src.inhand_image)
+			src.overlays = initial(src.overlays)
 			src.tooltip_rebuild = TRUE
 			boutput(usr, SPAN_ALERT("You reset the [src.name]."))
 			src.cloaked = 0


### PR DESCRIPTION
[Game-Objects] [Bug]

##
About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![dreamseeker_cNdnr34Hj4](https://github.com/goonstation/goonstation/assets/27376947/12e80ba7-bf7b-4a96-b197-7b08e3d29065)
overlays are not cleared on stealth storages, so copying an item with overlays will retain the image on the box. not very stealthy when that happens.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17457 
