### PR TITLE
Fix stamina bar not updating to max if you regenerate a tiny amount of stamina

### DIFF
--- a/code/obj/screen.dm
+++ b/code/obj/screen.dm
@@ -78,7 +78,13 @@
 
 	proc/update_value(var/mob/living/C)
 		last_update = TIME
-		if(C.stamina_max <= 0 || abs(C.stamina - last_val) * 32 / C.stamina_max <= 1) return //No need to change anything
+
+		if (C.stamina_max <= 0)
+			return
+		// Don't change if we have barely changed stamina to begin with, but change if we just hit the max value
+		if ((abs(C.stamina - last_val) / C.stamina_max) < 0.05 \
+		    && !(C.stamina == C.stamina_max && last_val != C.stamina_max))
+			return
 		else last_val = C.stamina
 
 		if(C.stamina < 0)


### PR DESCRIPTION
[Bug] [Code-Quality] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title explains this, if you regenerate only ~3% of your stamina the stamina bar icon won't update. This is fine for performance until you are regenerating to max from 195/200 stam, in which case it appears you don't have max stamina when you do.

This change improves the check to self-document a bit better, and to update when the stamina bar just reaches its max value. Also changes the bar update to when you regenerate <5% of your stamina

https://github.com/goonstation/goonstation/assets/27376947/ab9327c8-69a1-45f0-a5d6-f742a171de3d

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems pretty annoying that it won't update all the way.
Fixes #17422