### PR TITLE
Adds nerfed hunger and thirst to classic

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -164,9 +164,14 @@
 		name = "Hunger"
 		icon_state = "hunger"
 		desc = "Hunger can be raised by eating various edible items, more complex dishes raise your hunger more."
-		depletion_rate = 0.078
 		var/debuff = "hungry"
+#ifdef RP_MODE
 		var/debuff_threshold = 25
+		depletion_rate = 0.078
+#else
+		var/debuff_threshold = 10
+		depletion_rate = 0.072
+#endif
 		var/debuffed = FALSE
 
 		onIncrease()
@@ -182,7 +187,7 @@
 				debuffed = TRUE
 
 		getWarningMessage()
-			if (value < 25)
+			if (value < debuff_threshold)
 				return pick(SPAN_ALERT("You are [pick("utterly", "absolutely", "positively", "completely", "extremely", "perfectly")] [pick("starving", "unfed", "ravenous", "famished")]!"), SPAN_ALERT("You feel like you could [pick("die of [pick("hunger", "starvation")] any moment now", "eat a [pick("donkey", "horse", "whale", "moon", "planet", "star", "galaxy", "universe", "multiverse")]")]!"))
 			else if (value < 50)
 				return SPAN_ALERT("You feel [pick("hungry", "peckish", "ravenous", "undernourished", "famished", "esurient")]!")
@@ -193,11 +198,15 @@
 			name = "Thirst"
 			icon_state = "thirst"
 			desc = "Thirst can be raised by drinking various liquids. Certain liquids can also lower your thirst."
+#ifdef RP_MODE
 			depletion_rate = 0.0909
+#else
+			depletion_rate = 0.079
+#endif
 			debuff = "thirsty"
 
 			getWarningMessage()
-				if (value < 25)
+				if (value < debuff_theshold)
 					return pick(SPAN_ALERT("You are [pick("utterly", "absolutely", "positively", "completely", "extremely", "perfectly")] dry!"), SPAN_ALERT("You feel [pick("like you could die of thirst any moment now", "as dry as [pick("sand", "the moon", "solid carbon dioxide", "bones")]")]!"))
 				else if (value < 50)
 					return SPAN_ALERT("You feel [pick("thirsty", "dry")]!")
@@ -473,7 +482,7 @@
 #ifdef RP_MODE
 	var/provide_plumbobs = 0
 #else
-	var/provide_plumbobs = 1
+	var/provide_plumbobs = 0
 #endif
 
 	New()
@@ -616,6 +625,12 @@ var/global/datum/simsControl/simsController = new()
 			//addMotive(/datum/simsMotive/bladder)
 			//addMotive(/datum/simsMotive/energy)
 			//addMotive(/datum/simsMotive/sanity)
+
+	classic
+		start_y = 3
+		make_motives()
+			addMotive(/datum/simsMotive/hunger)
+			addMotive(/datum/simsMotive/hunger/thirst)
 
 		wolf
 			make_motives()

--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -206,7 +206,7 @@
 			debuff = "thirsty"
 
 			getWarningMessage()
-				if (value < debuff_theshold)
+				if (value < debuff_threshold)
 					return pick(SPAN_ALERT("You are [pick("utterly", "absolutely", "positively", "completely", "extremely", "perfectly")] dry!"), SPAN_ALERT("You feel [pick("like you could die of thirst any moment now", "as dry as [pick("sand", "the moon", "solid carbon dioxide", "bones")]")]!"))
 				else if (value < 50)
 					return SPAN_ALERT("You feel [pick("thirsty", "dry")]!")
@@ -632,11 +632,11 @@ var/global/datum/simsControl/simsController = new()
 			addMotive(/datum/simsMotive/hunger)
 			addMotive(/datum/simsMotive/hunger/thirst)
 
-		wolf
-			make_motives()
-				addMotive(/datum/simsMotive/hunger/wolfy)
-				addMotive(/datum/simsMotive/hunger/thirst)
-				addMotive(/datum/simsMotive/hygiene)
+	wolf
+		make_motives()
+			addMotive(/datum/simsMotive/hunger/wolfy)
+			addMotive(/datum/simsMotive/hunger/thirst)
+			addMotive(/datum/simsMotive/hygiene)
 
 	New(var/mob/living/L)
 		..()

--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -636,7 +636,9 @@ var/global/datum/simsControl/simsController = new()
 		make_motives()
 			addMotive(/datum/simsMotive/hunger/wolfy)
 			addMotive(/datum/simsMotive/hunger/thirst)
+#ifdef RP_MODE
 			addMotive(/datum/simsMotive/hygiene)
+#endif
 
 	New(var/mob/living/L)
 		..()

--- a/code/global.dm
+++ b/code/global.dm
@@ -394,7 +394,7 @@ var/global
 #ifdef RP_MODE
 	global_sims_mode = 1 // SET THIS TO 0 TO DISABLE SIMS MODE
 #else
-	global_sims_mode = 0 // SET THIS TO 0 TO DISABLE SIMS MODE
+	global_sims_mode = 1 // SET THIS TO 0 TO DISABLE SIMS MODE
 #endif
 
 	narrator_mode = 0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -197,6 +197,7 @@
 		sims = new /datum/simsHolder/rp(src)
 #else
 		sims = new /datum/simsHolder/human(src)
+		sims = new /datum/simsHolder/classic(src)
 #endif
 
 	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",EFFECTS_LAYER_UNDER_4)

--- a/code/modules/antagonists/werewolf/abilities/_werewolf_ability_holder.dm
+++ b/code/modules/antagonists/werewolf/abilities/_werewolf_ability_holder.dm
@@ -310,12 +310,12 @@
 			if (H.sims)
 				// Did you know that the motive system has no way to remove a motive? Now you do! This has been fun facts with aloe
 				qdel(H.sims)
-				H.sims = new /datum/simsHolder/rp/wolf(H)
+				H.sims = new /datum/simsHolder/wolf(H)
 
 	onRemove(mob/from_who)
 		. = ..()
 		var/mob/living/carbon/human/H = from_who
-		if (istype(H.sims, /datum/simsHolder/rp/wolf))
+		if (istype(H.sims, /datum/simsHolder/wolf))
 			qdel(H.sims)
 			H.sims = new /datum/simsHolder/rp(H)
 

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -229,7 +229,11 @@
 		icon_state = "stam-"
 		duration = INFINITE_STATUS
 		maxDuration = null
+#ifdef RP_mode
 		change = -5
+#else
+		change = -2
+#endif
 
 	staminaregen/cursed
 		id = "weakcurse"
@@ -336,7 +340,11 @@
 			icon_state = "heart-"
 			duration = INFINITE_STATUS
 			maxDuration = null
+#ifdef RP_MODE
 			change = -20
+#else
+			change = -10
+#endif
 
 			onAdd(optional=null)
 				. = ..(change)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR introduces hunger and thirst to classic, with lower depletion rates and smaller hits to your stamina for being starved or parched. The threshold for being so has also been reduced on classic.

Discussion thread: https://forum.ss13.co/showthread.php?tid=22179

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's a lack of motivation for crew to engage with food made by the chef, and I think there's been less chefs for it. There's other factors, but I think an actual hunger meter makes people engage with food more which should be obvious. 

Thirst is less needed but I feel hunger alone is odd, and the bartender deserves the boost too. Thirst can be harder to fill and more impactful to your stamina, so I nerfed numbers a little on classic.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(*)Classic players now need to eat and drink, with lesser consequences for not doing so.
```
