### PR TITLE
Cleans up areas which create seeds from parent plants to use HYPgenerateseedcopy

### DIFF
--- a/code/datums/components/seedy.dm
+++ b/code/datums/components/seedy.dm
@@ -31,26 +31,7 @@
 	. = ..()
 
 /datum/component/seedy/proc/generate_seed()
-	var/obj/item/seed/SEED
-	if (planttype.unique_seed)
-		SEED = new planttype.unique_seed
-	else
-		SEED = new /obj/item/seed
-		SEED.removecolor()
-
-	if (!src.planttype.hybrid && !src.planttype.unique_seed)
-		SEED.generic_seed_setup(src.planttype, TRUE)
-	HYPpassplantgenes(src.DNA,SEED.plantgenes)
-	SEED.generation = src.generation
-	if (src.planttype.hybrid)
-		var/plantType = src.planttype.type
-		var/datum/plant/hybrid = new plantType(SEED)
-		for (var/V in src.planttype.vars)
-			if (issaved(src.planttype.vars[V]) && V != "holder")
-				hybrid.vars[V] = src.planttype.vars[V]
-		SEED.planttype = hybrid
-		SEED.plant_seed_color(src.planttype.seedcolor)
-
+	var/obj/item/seed/SEED = HYPgenerateseedcopy(src.DNA, src.planttype, src.generation)
 	return SEED
 
 /datum/component/seedy/proc/on_pre_attack(var/atom/affected_parent, var/atom/target, var/mob/user, var/damage)

--- a/code/mob/living/critter/plant.dm
+++ b/code/mob/living/critter/plant.dm
@@ -48,22 +48,10 @@
 	// We need to pass the plantgenes from the plant to our new lovely botany pet
 	var/datum/plantgenes/new_genes = src.plantgenes
 
+	// Copy the genes from the plant we're harvesting to the new piece of produce.
 	HYPpassplantgenes(passed_genes,new_genes)
 	src.generation = harvested_plantpot.generation
-	// Copy the genes from the plant we're harvesting to the new piece of produce.
-
-	if(origin_plant.hybrid)
-		// We need to do special shit with the genes if the plant is a spliced
-		// hybrid since they run off instanced datums rather than referencing
-		// a specific already-existing one.
-		var/plantType = origin_plant.type
-		var/datum/plant/hybrid = new plantType(src)
-		for(var/V in origin_plant.vars)
-			if(issaved(origin_plant.vars[V]) && V != "holder")
-				hybrid.vars[V] = origin_plant.vars[V]
-		src.planttype = hybrid
-	else
-		src.planttype = origin_plant
+	src.planttype = HYPgenerateplanttypecopy(src, origin_plant)
 
 	// If the plant this critter was harvested from was damaged, we damage the critter as well
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -382,28 +382,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				if (doseed)
 					var/datum/plant/stored = P.planttype
 					if (istype(stored) && !stored.isgrass)
-						var/obj/item/seed/S
-						if (stored.unique_seed)
-							S = new stored.unique_seed
-							S.set_loc(consumer.loc)
-						else
-							S = new /obj/item/seed
-							S.set_loc(consumer.loc)
-							S.removecolor()
-
-						var/datum/plantgenes/DNA = P.plantgenes
-						var/datum/plantgenes/PDNA = S.plantgenes
-						if (!stored.hybrid && !stored.unique_seed)
-							S.generic_seed_setup(stored, TRUE)
-						HYPpassplantgenes(DNA,PDNA)
-						if (stored.hybrid)
-							var/plantType = stored.type
-							var/datum/plant/hybrid = new plantType(S)
-							for (var/V in stored.vars)
-								if (issaved(stored.vars[V]) && V != "holder")
-									hybrid.vars[V] = stored.vars[V]
-							S.planttype = hybrid
-							S.plant_seed_color(stored.seedcolor)
+						HYPgenerateseedcopy(SRCDNA, stored, P.generation, consumer.loc)
 						consumer.visible_message(SPAN_NOTICE("<b>[consumer]</b> spits out a seed."),\
 						SPAN_NOTICE("You spit out a seed."))
 			if(src.dropped_item)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -33,20 +33,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 		// not this is fruit but some veg do this too.
 		var/datum/plantgenes/new_genes = src.plantgenes
 
+		// Copy the genes from the plant we're harvesting to the new piece of produce.
 		HYPpassplantgenes(passed_genes,new_genes)
 		src.generation = harvested_plantpot.generation
-		// Copy the genes from the plant we're harvesting to the new piece of produce.
-
-		if(origin_plant.hybrid)
-			// We need to do special shit with the genes if the plant is a spliced
-			// hybrid since they run off instanced datums rather than referencing
-			// a specific already-existing one.
-			var/plantType = origin_plant.type
-			var/datum/plant/hybrid = new plantType(src)
-			for(var/V in origin_plant.vars)
-				if(issaved(origin_plant.vars[V]) && V != "holder")
-					hybrid.vars[V] = origin_plant.vars[V]
-			src.planttype = hybrid
+		src.planttype = HYPgenerateplanttypecopy(src, origin_plant)
 
 		// Now we calculate the effect of quality on the item
 		switch(quality_status)

--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -124,6 +124,8 @@ proc/HYPgenerate_produce_name(var/atom/manipulated_atom, var/obj/machinery/plant
 
 
 proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD)
+	if(!PARENT || !CHILD)
+		return
 	// This is a proc used to copy genes from PARENT to CHILD. It's used in a whole bunch
 	// of places, usually when seeds or fruit are created and need to get their genes from
 	// the thing that spawned them.
@@ -144,12 +146,18 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD)
 proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/parent_planttype, var/parent_generation, var/location_to_create)
 	//This proc generates a seed at location_to_create with a copy of the planttype and genes of a given parent plant.
 	//This can be used, when you want to quickly generate seeds out of objects or other plants e.g. creeper or fruits.
-	var/obj/item/seed/child = new /obj/item/seed(location_to_create)
+	var/obj/item/seed/child
+	if (parent_planttype.unique_seed)
+		child = new parent_planttype.unique_seed
+	else
+		child = new /obj/item/seed(location_to_create)
 	var/datum/plant/child_planttype = HYPgenerateplanttypecopy(child, parent_planttype)
 	var/datum/plantgenes/child_genes = child.plantgenes
-	var/datum/plantmutation/child_mutation = parent_genes.mutation
+	var/datum/plantmutation/child_mutation
+	if(parent_genes)
+		child_mutation = parent_genes.mutation
 	// If the plant is a standard plant, our work here is mostly done
-	if (!child_planttype.hybrid)
+	if (!child_planttype.hybrid && !parent_planttype.unique_seed)
 		child.generic_seed_setup(child_planttype)
 	else
 		child.planttype = child_planttype
@@ -161,8 +169,9 @@ proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/pare
 			seedname = "[child_mutation.name]"
 		else if(child_mutation.name_prefix || child_mutation.name_suffix)
 			seedname = "[child_mutation.name_prefix][child_planttype.name][child_mutation.name_suffix]"
-	HYPpassplantgenes(parent_genes, child_genes)
 	child.name = "[seedname] seed"
+	//What's missing is transfering genes and the generation
+	HYPpassplantgenes(parent_genes, child_genes)
 	child.generation = parent_generation
 	//Now the seed it created and we can release it upon the world
 	return child

--- a/code/obj/item/seeds.dm
+++ b/code/obj/item/seeds.dm
@@ -37,29 +37,28 @@
 	HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status)
 		// If the crop is just straight up seeds. Don't need reagents, but we do
 		// need to pass genes and whatnot along like we did for fruit.
-		var/obj/item/seed/new_seed = src
-		if(origin_plant.unique_seed)
-			new_seed = new origin_plant.unique_seed
-			new_seed.set_loc(harvested_plantpot)
+		var/datum/plant/child_planttype = HYPgenerateplanttypecopy(src, origin_plant)
+		var/datum/plantgenes/child_genes = src.plantgenes
+		var/datum/plantmutation/child_mutation = passed_genes.mutation
+		// If the plant is a standard plant, our work here is mostly done
+		if (!child_planttype.hybrid && !origin_plant.unique_seed)
+			src.generic_seed_setup(child_planttype)
 		else
-			new_seed = new /obj/item/seed
-			new_seed.set_loc(harvested_plantpot)
-			new_seed.removecolor()
-
-		var/datum/plantgenes/HDNA = harvested_plantpot.plantgenes
-		var/datum/plantgenes/SDNA = new_seed.plantgenes
-		if(!origin_plant.unique_seed && !origin_plant.hybrid)
-			new_seed.generic_seed_setup(origin_plant, TRUE)
-		HYPpassplantgenes(HDNA,SDNA)
-		new_seed.generation = harvested_plantpot.generation
-		if(origin_plant.hybrid)
-			var/datum/plant/hybrid = new /datum/plant(new_seed)
-			for(var/V in origin_plant.vars)
-				if(issaved(origin_plant.vars[V]) && V != "holder")
-					hybrid.vars[V] = origin_plant.vars[V]
-			new_seed.planttype = hybrid
-		qdel(src)
-		return new_seed
+			src.planttype = child_planttype
+			src.plant_seed_color(child_planttype.seedcolor)
+		//Now we generate the seeds name
+		var/seedname = "[child_planttype.name]"
+		if(istype(child_mutation,/datum/plantmutation/))
+			if(!child_mutation.name_prefix && !child_mutation.name_suffix && child_mutation.name)
+				seedname = "[child_mutation.name]"
+			else if(child_mutation.name_prefix || child_mutation.name_suffix)
+				seedname = "[child_mutation.name_prefix][child_planttype.name][child_mutation.name_suffix]"
+		src.name = "[seedname] seed"
+		//What's missing is transfering genes and the generation
+		HYPpassplantgenes(passed_genes, child_genes)
+		src.generation = harvested_plantpot.generation
+		//Now the seed it created and we can release it upon the world
+		return src
 
 
 	//kudzumen can analyze seeds via ezamine when close.

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1057,38 +1057,7 @@ TYPEINFO(/obj/machinery/plantpot)
 			if(((growing.isgrass || (growing.force_seed_on_harvest > 0 )) && prob(80)) && !istype(getitem,/obj/item/seed/) && !HYPCheckCommut(DNA,/datum/plant_gene_strain/seedless) && (growing.force_seed_on_harvest >= 0 ))
 				// Same shit again. This isn't so much the crop as it is giving you seeds
 				// incase you couldn't get them otherwise, though.
-				var/obj/item/seed/S
-				if(growing.unique_seed)
-					S = new growing.unique_seed
-					S.set_loc(src)
-				else
-					S = new /obj/item/seed
-					S.set_loc(src)
-					S.removecolor()
-				var/datum/plantgenes/HDNA = src.plantgenes
-				var/datum/plantgenes/SDNA = S.plantgenes
-				if(!growing.unique_seed && !growing.hybrid)
-					S.generic_seed_setup(growing, TRUE)
-
-				var/seedname = "[growing.name]"
-				if(istype(MUT,/datum/plantmutation/))
-					if(!MUT.name_prefix && !MUT.name_suffix && MUT.name)
-						seedname = "[MUT.name]"
-					else if(MUT.name_prefix || MUT.name_suffix)
-						seedname = "[MUT.name_prefix][growing.name][MUT.name_suffix]"
-
-				S.name = "[seedname] seed"
-				S.plant_seed_color(growing.seedcolor)
-				HYPpassplantgenes(HDNA,SDNA)
-				S.generation = src.generation
-				if(growing.hybrid)
-					var/plantType = growing.type
-					var/datum/plant/hybrid = new plantType(S)
-					for(var/V in growing.vars)
-						if(issaved(growing.vars[V]) && V != "holder")
-							hybrid.vars[V] = growing.vars[V]
-					S.planttype = hybrid
-
+				HYPgenerateseedcopy(src.plantgenes, growing, src.generation, src)
 				seedcount++
 
 		// Give XP based on base quality of crop harvest. Will make better later, like so more plants harvasted and stuff, this is just for testing.

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -257,38 +257,11 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 					else
 						boutput(ui.user, SPAN_NOTICE("Extracted [give] seeds from [I]."))
 						while (give > 0)
-							var/obj/item/seed/S
-							if (stored.unique_seed) S = new stored.unique_seed(src)
-							else S = new /obj/item/seed(src,0)
-							var/datum/plantgenes/SDNA = S.plantgenes
-							if (!stored.unique_seed && !stored.hybrid)
-								S.generic_seed_setup(stored, TRUE)
-							HYPpassplantgenes(DNA,SDNA)
-
-							S.name = stored.name
-							S.plant_seed_color(stored.seedcolor)
-							if (stored.hybrid)
-								var/hybrid_type = stored.type
-								var/datum/plant/hybrid = new hybrid_type(S)
-								for(var/V in stored.vars)
-									if (issaved(stored.vars[V]) && V != "holder")
-										hybrid.vars[V] = stored.vars[V]
-								S.planttype = hybrid
-								S.name = hybrid.name
-
-							var/seedname = S.name
-							if (DNA.mutation && istype(DNA.mutation,/datum/plantmutation/))
-								var/datum/plantmutation/MUT = DNA.mutation
-								if (!MUT.name_prefix && !MUT.name_prefix && MUT.name)
-									seedname = "[MUT.name]"
-								else if (MUT.name_prefix || MUT.name_suffix)
-									seedname = "[MUT.name_prefix][seedname][MUT.name_suffix]"
-
-							S.name = "[seedname] seed"
-
-							S.generation = P.generation
-							if (!src.seedoutput) src.seeds.Add(S)
-							else S.set_loc(src.loc)
+							var/obj/item/seed/S = HYPgenerateseedcopy(DNA, stored, P.generation, src)
+							if (!src.seedoutput)
+								src.seeds.Add(S)
+							else
+								S.set_loc(src.loc)
 							give -= 1
 					src.extractables.Remove(I)
 					qdel(I)


### PR DESCRIPTION
[internal][code quality][hydroponics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR goes over multiple areas which create seeds out of sources with existing `plantgene` and `plant` to use `HYPgenerateseedcopy` instead of copy-pasted code for copying over plant stats. Also, in cases planttypes are carried over, this PR makes these use `HYPgenerateplanttypecopy` now

To make this feasable, this goes over `HYPgenerateseedcopy` to make sure to respect `plant.unique_seed` and accept input without `plantgenes` 

Last but not least, instead of replacing a seed-crop with a blank seed with copied information, now the information gets directly copied on the harvested seed instead (there is no plant rn which has seeds as its crop, but oh well)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There are multiple areas where seeds or planttypes are created out of existing information, all with their respective copied code. Since #12845 introduced `HYPgenerateseedcopy` and `HYPgenerateplanttypecopy` for cases such as this, we might as well put them to good use.

Bundling all these means that some inconsistencies are removed as well. E.g. seeds spit out while eating fruit now have their correct seed name and colouring.