### PR TITLE
Bake common tools into robot module definitions

### DIFF
--- a/code/modules/robotics/robot/module/empty.dm
+++ b/code/modules/robotics/robot/module/empty.dm
@@ -3,4 +3,3 @@
 /obj/item/robot_module/empty
 	name = "empty cyborg module"
 	desc = "An empty cyborg module."
-	include_common_tools = FALSE

--- a/code/modules/robotics/robot/module/engineering.dm
+++ b/code/modules/robotics/robot/module/engineering.dm
@@ -8,7 +8,6 @@
 	radio_type = /obj/item/device/radio/headset/engineer
 	mailgroups = list(MGO_ENGINEER, MGD_STATIONREPAIR, MGO_SILICON, MGD_PARTY)
 	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_CRISIS, MGA_RKIT)
-	include_common_tools = FALSE
 
 /datum/robot_cosmetic/engineering
 	fx = list(255, 255, 0)

--- a/code/modules/robotics/robot/module/medical.dm
+++ b/code/modules/robotics/robot/module/medical.dm
@@ -8,7 +8,6 @@
 	radio_type = /obj/item/device/radio/headset/medical
 	mailgroups = list(MGD_MEDBAY, MGD_MEDRESEACH, MGO_SILICON, MGD_PARTY)
 	alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_CRISIS, MGA_SALES)
-	include_common_tools = FALSE
 
 /datum/robot_cosmetic/medical
 	head_mod = "Medical Mirror"

--- a/code/modules/robotics/robot/module/parent.dm
+++ b/code/modules/robotics/robot/module/parent.dm
@@ -13,7 +13,6 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 	var/list/tools = list()
 	var/mod_hudicon = "unknown"
 	var/cosmetic_mods = null
-	var/include_common_tools = TRUE
 	var/included_tools = null
 	var/included_cosmetic = null
 	var/radio_type = null
@@ -23,14 +22,10 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 
 /obj/item/robot_module/New()
 	..()
-	// add contents
-	if (src.include_common_tools)
-		src.add_contents(/datum/robot/module_tool_creator/recursive/module/common)
 	src.add_contents(src.included_tools)
 	// no need to keep the definition past initializing
 	src.included_tools = null
 
-	// add cosmetics
 	if (ispath(src.included_cosmetic, /datum/robot_cosmetic))
 		src.cosmetic_mods = new included_cosmetic(src)
 
@@ -44,7 +39,7 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 	if (istype(adding_contents, /obj/item))
 		// handle adding single instance of tool
 		var/obj/item/I = adding_contents
-		I.cant_drop = 1
+		I.cant_drop = TRUE
 		I.set_loc(src)
 		src.tools += I
 		return I

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -8,10 +8,22 @@
  * - mining
  */
 
+// convenient bundling of common tools, some modules do not include this as they want the items in a different order
+/datum/robot/module_tool_creator/recursive/module/common
+	definitions = list(
+		/obj/item/portable_typewriter/borg,
+		/obj/item/robojumper,
+		/obj/item/device/analyzer/atmospheric/upgraded,
+		/obj/item/device/reagentscanner,
+		/obj/item/device/light/flashlight,
+		/obj/item/device/analyzer/healthanalyzer/upgraded,
+		/obj/item/tool/omnitool/silicon,
+	)
+
 // security officer. bartender. clown.
-// DOES inherit common tools
 /datum/robot/module_tool_creator/recursive/module/brobocop
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/device/detective_scanner,
 		/obj/item/noisemaker,
 		/obj/item/robot_foodsynthesizer,
@@ -39,9 +51,9 @@
 	)
 
 // scientist.
-// DOES inherit common tools
 /datum/robot/module_tool_creator/recursive/module/science
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/device/gps, // Let's them assist with telesci
 		/obj/item/extinguisher/large/cyborg,
 		/obj/item/hand_labeler,
@@ -61,9 +73,9 @@
 	)
 
 // botanist. chef. janitor.
-// DOES inherit common tools
 /datum/robot/module_tool_creator/recursive/module/civilian
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/extinguisher/large/cyborg,
 		/obj/item/reagent_containers/glass/bucket, // TODO: make large version
 		/obj/item/spraybottle/cleaner/robot,
@@ -91,19 +103,7 @@
 		/obj/item/paper_bin/robot,
 	)
 
-/datum/robot/module_tool_creator/recursive/module/common
-	definitions = list(
-		/obj/item/portable_typewriter/borg,
-		/obj/item/robojumper,
-		/obj/item/device/analyzer/atmospheric/upgraded,
-		/obj/item/device/reagentscanner,
-		/obj/item/device/light/flashlight,
-		/obj/item/device/analyzer/healthanalyzer/upgraded,
-		/obj/item/tool/omnitool/silicon,
-	)
-
 // engineer. mechanic.
-// DOES NOT inherit common tools
 /datum/robot/module_tool_creator/recursive/module/engineering
 	definitions = list(
 		/obj/item/portable_typewriter/borg,
@@ -138,7 +138,6 @@
 	)
 
 // medical doctor.
-// DOES NOT inherit common tools
 /datum/robot/module_tool_creator/recursive/module/medical
 	definitions = list(
 		/obj/item/portable_typewriter/borg,
@@ -169,9 +168,9 @@
 	)
 
 // miner. quartermaster.
-// DOES inherit common tools
 /datum/robot/module_tool_creator/recursive/module/mining
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/device/gps,
 		/obj/item/extinguisher/large/cyborg,
 		/obj/item/mining_tool/drill,
@@ -190,6 +189,7 @@
 //These are not publically used anymore
 /datum/robot/module_tool_creator/recursive/module/construction_ai
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/rcd,
 		/obj/item/electronics/scanner,
 		/obj/item/electronics/soldering,
@@ -200,6 +200,7 @@
 
 /datum/robot/module_tool_creator/recursive/module/construction_worker
 	definitions = list(
+		/datum/robot/module_tool_creator/recursive/module/common,
 		/obj/item/weldingtool,
 		/obj/item/electronics/scanner,
 		/obj/item/electronics/soldering,

--- a/code/modules/robotics/robot/robot_module_rewriter.dm
+++ b/code/modules/robotics/robot/robot_module_rewriter.dm
@@ -4,7 +4,7 @@
 	icon_state = "robot_module_rewriter"
 	anchored = ANCHORED
 	density = 1
-	light_r =1
+	light_r = 1
 	light_g = 0.4
 	light_b = 0
 	circuit_type = /obj/item/circuitboard/robot_module_rewriter
@@ -32,22 +32,25 @@
 
 	var/list/availableModulesData = list()
 	for (var/obj/item/robot_module/module in src.modules)
-		var/list/availableModuleData = list()
-		availableModuleData["name"] = module.name
-		availableModuleData["ref"] = "\ref[module]"
+		var/list/availableModuleData = list(
+			"name" = module.name,
+			"ref" = "\ref[module]"
+		)
 		// wrapping in a list to append actual list rather than contents
 		availableModulesData += list(availableModuleData)
 	modulesData["available"] = availableModulesData
 
 	var/list/selectedModuleData = null
 	if (src.selectedModule)
-		selectedModuleData = list()
-		selectedModuleData["ref"] = "\ref[src.selectedModule]"
+		selectedModuleData = list(
+			"ref" = "\ref[src.selectedModule]"
+		)
 		var/list/selectedModuleToolsData = list()
 		for (var/obj/item/tool in src.selectedModule.tools)
-			var/list/toolData = list()
-			toolData["name"] = tool.name
-			toolData["ref"] = "\ref[tool]"
+			var/list/toolData = list(
+				"name" = tool.name,
+				"ref" = "\ref[tool]"
+			)
 			// wrapping in a list to append actual list rather than contents
 			selectedModuleToolsData += list(toolData)
 		selectedModuleData["tools"] = selectedModuleToolsData


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Silicons][C-Code-Quality]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the `include_common_tools` var for cyborg modules, instead bakes that behavior into the module definitions.
Very minor code tidy in robot module rewriter.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Module definitions support doing it this way, this reduces the complexity of module initialization.