### PR TITLE
Adds a Donut 2 construction area

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -38659,10 +38659,10 @@
 /area/station/crew_quarters/quarters)
 "qbJ" = (
 /obj/machinery/camera{
-	c_tag = "Science Hangar";
-	dir = 8;
-	name = "Outpost Camera";
-	network = "Zeta"
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11396,7 +11396,7 @@
 /area/space)
 "bhY" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/hallway/secondary/construction)
 "bhZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Engineering Hallway";
@@ -13877,13 +13877,11 @@
 	},
 /area/station/engine/engineering)
 "bxe" = (
-/obj/machinery/vending/snack,
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
 /area/station/hallway/primary/south)
 "bxf" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -15422,9 +15420,7 @@
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "bFV" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar,
+/obj/machinery/abcu,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "bFW" = (
@@ -16660,9 +16656,6 @@
 /obj/landmark/start/job/rancher,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"bYD" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/auxillary)
 "bYJ" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -17860,10 +17853,12 @@
 /turf/simulated/floor,
 /area/station/quartermaster/refinery)
 "cNm" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/east,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "cNv" = (
 /obj/item/clothing/under/suit/pinstripe,
 /obj/item/clothing/mask/smile,
@@ -18776,13 +18771,6 @@
 /obj/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
-"dsg" = (
-/obj/machinery/vending/book,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
-"dsh" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/storage/auxillary)
 "dsL" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -21837,9 +21825,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/storage/crate/abcumarker,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "fna" = (
 /obj/machinery/turret{
 	dir = 4
@@ -22540,9 +22527,9 @@
 /turf/simulated/floor/orangeblack,
 /area/station/science/artifact)
 "fRa" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/obj/item/clothing/head/constructioncone,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "fRe" = (
 /obj/grille/catwalk,
 /obj/cable{
@@ -23356,6 +23343,8 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/item/crowbar,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "gvO" = (
@@ -23414,15 +23403,9 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "gxy" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/table/auto,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
+/obj/machinery/vending/book,
 /turf/simulated/floor,
-/area/station/storage/auxillary)
+/area/station/hallway/primary/north)
 "gxD" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -23763,15 +23746,10 @@
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
 "gJU" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/auxillary)
+/obj/machinery/light/incandescent,
+/obj/machinery/vending/floppy,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "gKu" = (
 /obj/grille/steel,
 /obj/cable/orange{
@@ -24364,13 +24342,6 @@
 	},
 /turf/simulated/floor/red/corner,
 /area/station/hallway/primary/east)
-"hel" = (
-/obj/item/extinguisher{
-	pixel_y = 8
-	},
-/obj/storage/closet/fire,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
 "hem" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen,
 /obj/machinery/light/small{
@@ -26604,12 +26575,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/stockex)
-"iEN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/storage/auxillary)
 "iEY" = (
 /obj/table/glass/auto,
 /obj/item/paper_bin,
@@ -30994,13 +30959,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "lwu" = (
-/obj/machinery/bot/firebot,
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/obj/item/clothing/head/constructioncone,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "lwy" = (
 /obj/cable/yellow{
 	icon_state = "2-8"
@@ -31645,13 +31609,9 @@
 	},
 /area/station/medical/research)
 "lNA" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/mapping_helper/wingrille_spawn/auto,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/storage/auxillary)
+/area/station/hallway/secondary/construction)
 "lNK" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -32683,13 +32643,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/tools)
-"mvx" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/storage/auxillary)
 "mvM" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -33763,9 +33716,6 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/arrival/station)
-"ncx" = (
-/turf/simulated/floor,
-/area/station/storage/auxillary)
 "ncO" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -34791,10 +34741,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"nMh" = (
-/obj/machinery/abcu,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
 "nMB" = (
 /obj/table/wood/auto,
 /obj/machinery/firealarm/west,
@@ -38107,12 +38053,9 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "pEG" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/vending/pda,
+/obj/machinery/bot/firebot,
 /turf/simulated/floor,
-/area/station/storage/auxillary)
+/area/station/storage/tools)
 "pEI" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -38715,11 +38658,14 @@
 	},
 /area/station/crew_quarters/quarters)
 "qbJ" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/hand_labeler,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/obj/machinery/camera{
+	c_tag = "Science Hangar";
+	dir = 8;
+	name = "Outpost Camera";
+	network = "Zeta"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "qcy" = (
 /obj/machinery/networked/test_apparatus/impact_pad,
 /obj/machinery/power/data_terminal,
@@ -41508,18 +41454,12 @@
 /area/station/storage/tools)
 "rUr" = (
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "rUv" = (
 /obj/strip_door,
 /obj/disposalpipe/segment/mail,
@@ -41718,14 +41658,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "rZc" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "rZI" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/mapping_helper/firedoor_spawn,
@@ -43621,6 +43555,7 @@
 "tgY" = (
 /obj/machinery/light,
 /obj/disposalpipe/junction/left/east,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/south)
 "thn" = (
@@ -47758,10 +47693,10 @@
 /area/station/science/lobby)
 "vTe" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "vTq" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
@@ -51184,9 +51119,8 @@
 /area/station/wreckage)
 "yhW" = (
 /obj/machinery/camera,
-/obj/machinery/vending/floppy,
-/turf/simulated/floor,
-/area/station/storage/auxillary)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/construction)
 "yif" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -74698,7 +74632,7 @@ aDU
 aIL
 tJE
 awm
-awm
+gxy
 ayR
 kog
 aNn
@@ -82596,14 +82530,14 @@ aaa
 aaa
 adQ
 aaa
-adQ
-aaa
-aaa
-bYD
-nMh
+bhY
+rZc
+rZc
+rZc
+rZc
 fmu
 cNm
-dsh
+lNA
 bxe
 bxO
 eWy
@@ -82898,19 +82832,19 @@ aaa
 aaa
 acK
 ajz
-acK
-aaa
-aaa
-bYD
-dsg
-ncx
+bhY
+yhW
+rZc
+rZc
+rZc
+rZc
 lwu
 lNA
 bxf
-bxJ
-bxJ
-bxJ
-bzW
+bhm
+bhm
+bhm
+mGp
 bxH
 nwC
 bCr
@@ -83200,11 +83134,11 @@ aaa
 aaa
 adQ
 aaa
-adQ
-aaa
-aaa
-bYD
-pEG
+bhY
+rZc
+rZc
+rZc
+rZc
 rZc
 vTe
 rUr
@@ -83502,14 +83436,14 @@ xOf
 fpB
 adQ
 aaa
-adQ
-aaa
-aaa
-bYD
-yhW
-iEN
+bhY
+rZc
+rZc
+rZc
+rZc
+rZc
 fRa
-gJU
+lNA
 mPe
 bhm
 bhm
@@ -83804,14 +83738,14 @@ ohG
 ohG
 ohG
 aaa
-adQ
-aaa
-aaa
-bYD
+bhY
+rZc
+rZc
+rZc
 qbJ
-gxy
-hel
-mvx
+rZc
+rZc
+lNA
 noB
 bhn
 bhn
@@ -84109,11 +84043,11 @@ ohG
 ohG
 ohG
 bhY
-bYD
-bYD
-bYD
-bYD
-bYD
+bhY
+bhY
+bhY
+bhY
+bhY
 sSh
 bhm
 bhm
@@ -84730,7 +84664,7 @@ bCv
 bDS
 eKV
 bEZ
-bCv
+pEG
 bFW
 bAW
 bAP
@@ -91308,7 +91242,7 @@ aHG
 avU
 aJK
 aGO
-bhx
+gJU
 jKv
 lwp
 bST


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Donut 2 Auxiliary storage by a construction area.
The ABCU was moved into main storage.
The CartyParty vendor was removed since there's another one near the crew quarters.
The Books vendor was moved next to the CartyParty in crew quarters.
The Disk vendor was moved in front of the tech storage.
![Donut2Constr](https://github.com/goonstation/goonstation/assets/95481182/89ccc5a8-1c3b-430b-a27f-4a1c5938276d)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Inspired by this thread https://forum.ss13.co/showthread.php?tid=22180


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(+)The Donut 2 Auxilary storage has been repurposed for a construction area.
```
