### PR TITLE
Fix AI eyebots missing tools

### DIFF
--- a/code/modules/robotics/robot/module/empty.dm
+++ b/code/modules/robotics/robot/module/empty.dm
@@ -3,3 +3,4 @@
 /obj/item/robot_module/empty
 	name = "empty cyborg module"
 	desc = "An empty cyborg module."
+	included_tools = null

--- a/code/modules/robotics/robot/module/parent.dm
+++ b/code/modules/robotics/robot/module/parent.dm
@@ -13,7 +13,7 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 	var/list/tools = list()
 	var/mod_hudicon = "unknown"
 	var/cosmetic_mods = null
-	var/included_tools = null
+	var/included_tools = /datum/robot/module_tool_creator/recursive/module/common
 	var/included_cosmetic = null
 	var/radio_type = null
 	var/obj/item/device/radio/headset/radio = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS][BUG][MAJOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives AI eyebots (and blank modules) their tools back.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes regression introduced in #17680. This is why I made sure to get paid per bug fixed.