### PR TITLE
adds the ability to trap pizza boxes with mousetraps/landmines

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -917,6 +917,22 @@ TRAYS
 
 		. = ..()
 
+	proc/mousetrap_check(mob/user)
+		if (!ishuman(user) || is_incapacitated(user))
+			return FALSE
+		for(var/obj/item/mousetrap/MT in src.food_inside)
+			if (MT.armed)
+				user.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a mousetrap!</B>"),\
+					SPAN_ALERT("<B>You open the pizza box, but there was a live mousetrap in there!</B>"))
+				MT.triggered(user, user.hand ? "l_hand" : "r_hand")
+				return TRUE
+		for(var/obj/item/mine/M in src.food_inside)
+			if (M.armed && M.used_up != TRUE)
+				user.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a [M.name]!</B>"),\
+					SPAN_ALERT("<B>You open the pizza box, but there was a live [M.name] in there!</B>"))
+				M.triggered(user)
+				return TRUE
+
 	proc/toggle_box(mob/user)
 		if (length(src.contents - src.food_inside) > 0)
 			boutput(user, SPAN_ALERT("You have to remove the boxes on \the [src] before you can open it!"))
@@ -942,6 +958,9 @@ TRAYS
 			src.UpdateIcon()
 
 		else
+			if (src.mousetrap_check(user))
+				return FALSE
+
 			if (isnull(user)) // We only need a null-check here because of the shit_goes_everywhere proc
 				icon_state = "pizzabox_open"
 				src.open = TRUE

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -918,17 +918,15 @@ TRAYS
 		. = ..()
 
 	proc/mousetrap_check(mob/user)
-		if (!ishuman(user) || is_incapacitated(user))
-			return FALSE
 		for(var/obj/item/mousetrap/MT in src.food_inside)
 			if (MT.armed)
-				user.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a mousetrap!</B>"),\
+				user?.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a mousetrap!</B>"),\
 					SPAN_ALERT("<B>You open the pizza box, but there was a live mousetrap in there!</B>"))
 				MT.triggered(user, user.hand ? "l_hand" : "r_hand")
 				return TRUE
 		for(var/obj/item/mine/M in src.food_inside)
 			if (M.armed && M.used_up != TRUE)
-				user.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a [M.name]!</B>"),\
+				user?.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a [M.name]!</B>"),\
 					SPAN_ALERT("<B>You open the pizza box, but there was a live [M.name] in there!</B>"))
 				M.triggered(user)
 				return TRUE

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -922,7 +922,7 @@ TRAYS
 			if (MT.armed)
 				user?.visible_message(SPAN_ALERT("<B>[user] opens the pizza box and sets off a mousetrap!</B>"),\
 					SPAN_ALERT("<B>You open the pizza box, but there was a live mousetrap in there!</B>"))
-				MT.triggered(user, user.hand ? "l_hand" : "r_hand")
+				MT.triggered(user, user?.hand ? "l_hand" : "r_hand")
 				return TRUE
 		for(var/obj/item/mine/M in src.food_inside)
 			if (M.armed && M.used_up != TRUE)


### PR DESCRIPTION
[game objects][feature]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

simply adds the ability to rig pizza boxes with mousetraps or landmines, identically to the way you currently can with other storage containers!
_(you just place an armed mousetrap/rigged mousetrap/landmine inside of a pizza box and close it, and open it for a surprise!)_

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

would be pretty funny to hand out pizzas to crewmembers only to be met with a buttbomb to the face (or, if you're eviler, bombs!)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lyy
(+)Pizza boxes can now be rigged with mousetraps or landmines.
```
