### PR TITLE
Fix passengers being able to steer minisub

### DIFF
--- a/code/datums/movement_controller/tank.dm
+++ b/code/datums/movement_controller/tank.dm
@@ -44,6 +44,8 @@
 	keys_changed(mob/user, keys, changed)
 		if (istype(src.owner, /obj/machinery/vehicle/tank/minisub/escape_sub) || !owner)
 			return
+		if(user != src.owner.pilot)
+			return
 		if(changed & KEY_SHOCK)
 			shooting = keys & KEY_SHOCK
 		if (changed & (KEY_FORWARD|KEY_BACKWARD|KEY_RIGHT|KEY_LEFT))
@@ -70,6 +72,9 @@
 
 	process_move(mob/user, keys)
 		if (istype(src.owner, /obj/machinery/vehicle/tank/minisub/escape_sub))
+			return
+
+		if(user != src.owner.pilot)
 			return
 
 		var/can_user_act = user && user == owner.pilot && !user.getStatusDuration("stunned") && !user.getStatusDuration("weakened") && !user.getStatusDuration("paralysis") && !isdead(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [VEHICLES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds checks for user being pilot in minisub movement controller procs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Shouldn't be able to do that
