### PR TITLE
Fix Port-A-Gene allowing anyone inside

### DIFF
--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -80,9 +80,10 @@
 		if (BOUNDS_DIST(src, user) > 0 || BOUNDS_DIST(user, target) > 0)
 			return
 
-		if (target == user)
-			go_in(target)
-		else if (can_operate(user,target))
+		if (can_operate(user, target))
+			if (target == user)
+				go_in(target)
+				return
 			var/previous_user_intent = user.a_intent
 			user.set_a_intent(INTENT_GRAB)
 			user.drop_item()
@@ -92,7 +93,6 @@
 				if (can_operate(user,target))
 					if (istype(user.equipped(), /obj/item/grab))
 						src.Attackby(user.equipped(), user)
-		return
 
 	proc/can_operate(var/mob/M, var/mob/living/target)
 		if (!isalive(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks that the target is valid to be placed in the port-a-gene before allowing entry.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17666