### PR TITLE
Adds emag effect for robot arms

### DIFF
--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -170,31 +170,19 @@
 			if(!O || O.loc != master.module)
 				return
 			if(!master.module_states[1] && istype(master.part_arm_l,/obj/item/parts/robot_parts/arm/))
-				master.module_states[1] = O
-				O.set_loc(master)
-				O.pickup(master) // Handle light datums and the like.
+				master.equip_slot(1, O)
 			else if(!master.module_states[2])
-				master.module_states[2] = O
-				O.set_loc(master)
-				O.pickup(master)
+				master.equip_slot(2, O)
 			else if(!master.module_states[3] && istype(master.part_arm_r,/obj/item/parts/robot_parts/arm/))
-				master.module_states[3] = O
-				O.set_loc(master)
-				O.pickup(master)
+				master.equip_slot(3, O)
 			else
 				master.uneq_active()
 				if(!master.module_states[1] && istype(master.part_arm_l,/obj/item/parts/robot_parts/arm/))
-					master.module_states[1] = O
-					O.set_loc(master)
-					O.pickup(master)
+					master.equip_slot(1, O)
 				else if(!master.module_states[2])
-					master.module_states[2] = O
-					O.set_loc(master)
-					O.pickup(master)
+					master.equip_slot(2, O)
 				else if(!master.module_states[3] && istype(master.part_arm_r,/obj/item/parts/robot_parts/arm/))
-					master.module_states[3] = O
-					O.set_loc(master)
-					O.pickup(master)
+					master.equip_slot(3, O)
 			update_equipment()
 			update_tools()
 

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -353,6 +353,10 @@
 				D.foreign_limb_effect()
 
 	if (!isdead(src)) // Marq was here, breaking everything.
+		src.limbs.l_arm?.on_life(parent)
+		src.limbs.r_arm?.on_life(parent)
+		src.limbs.l_leg?.on_life(parent)
+		src.limbs.r_leg?.on_life(parent)
 
 		if (src.sims && src.ckey) // ckey will be null if it's an npc, so they're skipped
 			src.sims.Life()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1905,6 +1905,16 @@
 // Robot-specific Procs //
 //////////////////////////
 
+	proc/equip_slot(var/i, var/obj/item/tool)
+		src.module_states[i] = tool
+		tool.set_loc(src)
+		tool.pickup(src) // Handle light datums and the like.
+
+		hud.update_tools()
+		hud.update_equipment()
+
+		update_appearance()
+
 	proc/uneq_slot(var/i)
 		if (module_states[i])
 			if (src.module)

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -369,6 +369,10 @@ ABSTRACT_TYPE(/obj/item/parts)
 	proc/on_holder_examine()
 		return
 
+	///Called every life tick when attached to a mob
+	proc/on_life(datum/controller/process/mobs/parent)
+		return
+
 /obj/item/proc/streak_object(var/list/directions, var/streak_splatter) //stolen from gibs
 	var/destination
 	var/dist = rand(1,6)

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -571,12 +571,19 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 		src.emagged = TRUE
 
 	on_life()
-		//this will be called on robots too buut I don't know how to handle that
-		if (!src.emagged || !ishuman(src.holder) || src.holder.restrained() || prob(60)) //chance to do nothing
+		if (!src.emagged || src.holder.restrained() || prob(60)) //chance to do nothing
 			return
-		var/mob/living/carbon/human/H = src.holder
+
 		if (prob(50))
-			boutput(H, SPAN_ALERT(pick("You hear the servos in your arm make a distressing whining sound!", "Your arm twitches oddly!", "You lose control of your arm for a moment!")))
+			boutput(src.holder, SPAN_ALERT(pick("You hear the servos in your arm make a distressing whining sound!", "Your arm twitches oddly!", "You lose control of your arm for a moment!")))
+
+		if (ishuman(src.holder))
+			src.human_emag_effect()
+		else if (isrobot(src.holder))
+			src.robot_emag_effect()
+
+	proc/human_emag_effect()
+		var/mob/living/carbon/human/H = src.holder
 		var/mob/living/target = H //default to hitting ourselves
 		if (prob(80)) //usually look for something else
 			var/list/mob/living/targets = list()
@@ -607,6 +614,17 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 		else
 			H.hand_attack(target)
 
+	proc/robot_emag_effect()
+		var/mob/living/silicon/robot/robot = src.holder
+		var/robo_slot = src.slot == "l_arm" ? 1 : 3
+		var/last_active = robot.module_states.Find(robot.module_active)
+		robot.uneq_slot(robo_slot)
+		var/obj/item/chosen_tool = pick(robot.module?.tools)
+		if (!chosen_tool)
+			return
+		robot.equip_slot(robo_slot, chosen_tool)
+		if (last_active)
+			robot.swap_hand(last_active)
 
 ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 /obj/item/parts/robot_parts/arm/left

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -165,10 +165,6 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts)
 				if (src.dmg_blunt || src.dmg_burns) return ((src.dmg_blunt + src.dmg_burns) / src.max_health) * 100
 				else return 0
 
-	//Should maybe be on parent, but something something performance concerns
-	proc/on_life()
-		return
-
 ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 /obj/item/parts/robot_parts/head
 	name = "cyborg head"
@@ -508,6 +504,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 	max_health = 60
 	can_hold_items = 1
 	accepts_normal_human_overlays = TRUE
+	var/emagged = FALSE //contains: technical debt
 
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
 		if(!ismob(target))
@@ -568,6 +565,48 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 		if (!isrobot(src.holder)) // probably a human, probably  :p
 			return "has [bicon(src)] \an [initial(src.name)] attached as a"
 		return
+
+	emag_act(mob/user, obj/item/card/emag/E)
+		boutput(user, SPAN_ALERT("You short out the control servos on [src]")) //sneaky emag act
+		src.emagged = TRUE
+
+	on_life()
+		//this will be called on robots too buut I don't know how to handle that
+		if (!src.emagged || !ishuman(src.holder) || src.holder.restrained() || prob(60)) //chance to do nothing
+			return
+		var/mob/living/carbon/human/H = src.holder
+		if (prob(50))
+			boutput(H, SPAN_ALERT(pick("You hear the servos in your arm make a distressing whining sound!", "Your arm twitches oddly!", "You lose control of your arm for a moment!")))
+		var/mob/living/target = H //default to hitting ourselves
+		if (prob(80)) //usually look for something else
+			var/list/mob/living/targets = list()
+			for (var/mob/living/M in view(1, H))
+				if (isintangible(M) || M == H)
+					continue
+				targets |= M
+			if (length(targets))
+				target = pick(targets)
+		//make sure we're using the correct hand
+		if ((H.hand == LEFT_HAND && src.slot != "l_arm") || (H.hand == RIGHT_HAND && src.slot != "r_arm"))
+			H.swap_hand()
+
+		if (target == H)
+			H.set_a_intent(pick(INTENT_HELP, INTENT_DISARM, INTENT_HARM)) //no blocking
+		else
+			H.set_a_intent(pick(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)) //only grabbing
+
+		logTheThing(LOG_COMBAT, key_name(H), "emagged cyberarm attempts to attack [constructTarget(target)]")
+		var/obj/item/equipped = H.equipped()
+		if (isgrab(equipped) || equipped?.chokehold)
+			if (prob(50))
+				equipped.AttackSelf(H)
+			else
+				H.drop_item(equipped, TRUE)
+		else if (equipped)
+			H.weapon_attack(target, H.equipped(), can_reach(H, target), list())
+		else
+			H.hand_attack(target)
+
 
 ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm/left)
 /obj/item/parts/robot_parts/arm/left


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes them randomly attack and switch intents when applied to a human, and randomly switch items when applied to a borg.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny sabotage methods.

## Changelog

```changelog
(u)LeahTheTech
(+)Robotic arms can now be emagged.
```