### PR TITLE
Makes tank explosions scale with volume

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -155,7 +155,8 @@ Contains:
 			air_contents.react()
 			pressure = MIXTURE_PRESSURE(air_contents)
 
-			var/volume_scale = air_contents.volume / 70 //wooo magic number (70 is the default volume of an air tank)
+			//wooo magic numbers! 70 is the default volume of an air tank and quad rooting it seems to produce pretty reasonable scaling
+			var/volume_scale = (air_contents.volume / 70) ** (1/4)
 			var/range = (pressure - TANK_FRAGMENT_PRESSURE) * volume_scale / TANK_FRAGMENT_SCALE
 			// (pressure - 5066.25 kpa) divided by 1013.25 kpa
 			range = min(range, 12)
@@ -167,13 +168,13 @@ Contains:
 					var/turf/T = get_turf(B.loc)
 					if(T)
 						logTheThing(LOG_BOMBING, src, "exploded at [log_loc(T)], range: [range], last touched by: [src.fingerprintslast]")
-						explosion(src, T, round(range * 0.25), round(range * 0.5), round(range), round(range * 1.5))
+						explosion(src, T, range * 0.25, range * 0.5, range, range * 1.5)
 				qdel(src)
 				return
 			var/turf/epicenter = get_turf(loc)
 			logTheThing(LOG_BOMBING, src, "exploded at [log_loc(epicenter)], , range: [range], last touched by: [src.fingerprintslast]")
 			src.visible_message(SPAN_ALERT("<b>[src] explosively ruptures!</b>"))
-			explosion(src, epicenter, round(range * 0.25), round(range * 0.5), round(range), round(range * 1.5))
+			explosion(src, epicenter, range * 0.25, range * 0.5, range, range * 1.5)
 			qdel(src)
 
 		else if(pressure > TANK_RUPTURE_PRESSURE)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -155,7 +155,8 @@ Contains:
 			air_contents.react()
 			pressure = MIXTURE_PRESSURE(air_contents)
 
-			var/range = (pressure - TANK_FRAGMENT_PRESSURE) / TANK_FRAGMENT_SCALE
+			var/volume_scale = air_contents.volume / 70 //wooo magic number (70 is the default volume of an air tank)
+			var/range = (pressure - TANK_FRAGMENT_PRESSURE) * volume_scale / TANK_FRAGMENT_SCALE
 			// (pressure - 5066.25 kpa) divided by 1013.25 kpa
 			range = min(range, 12)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Scales down the power of tank explosions by a factor of their volume relative to the default tank volume, so we get:
- Standard 70l tank = 192 power (maxcap)
- Mini oxygen tank = 108
- Pocket oxygen tank = 50

Assuming a theoretical near-perfect mix of cold oxygen and hot plasma.
This also means that tanks of >70l volume will produce larger explosions (still bounded by maxcap) but afaik there aren't any currently.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You do not need 5 boxes of pocket sized maxcap hand grenades! Bad clown!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Tank explosions now scale with the volume of the tank, smaller tank = less boom :(
```
