### PR TITLE
Add a minimum synthesis temperature of 70 °C to LSD

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4168,6 +4168,7 @@
 		id = "LSD"
 		result = "LSD"
 		required_reagents = list("diethylamine" = 1, "space_fungus" = 1)
+		min_temperature = T0C + 70
 		result_amount = 3
 		mix_phrase = "The mixture turns a rather unassuming color and settles."
 


### PR DESCRIPTION
[Chemistry][Hydroponics][Balance][QoL]

## About the PR
Add a minimum temperatuer to LSD making of 70°C. The reaction is still immediate and not changed more tahn that.

## Why's this needed? 
very small betterment for botany - diethylamine and space fungus are both good for plants in tray water (nutrients), but if you try to add both at same time, they make lsd, which is not helpful. with the change, plant tray water at normal temperature (~30°C) will not make lsd, so both nutrients can be used at one time

I tested and it is easy to make with welder and other chemiacles from normal temperature (2 taps with welder that is on), so people with ingredients can still make without it being so hard. I can make temperature not so high, but i do not want lsd making to happen accidentally if room gests too hot

not sure why it changes in lore reasons??? hotter things mix better, faster, maybe?  ¯\_(ツ)_/¯

## Changelog 

```changelog
(u)NibChocolateeny
(+)LSD is now synthesized at 70 °C (343.15 K). Botanists rejoice!
```
