### PR TITLE
Add minimap colour for morgue/crematorium

### DIFF
--- a/_std/defines/minimap.dm
+++ b/_std/defines/minimap.dm
@@ -31,6 +31,7 @@
 #define MAPC_MEDICAL "#1ba7e9"
 #define MAPC_MEDLOBBY "#78c5e9"
 #define MAPC_ROBOTICS "#5b6eb1"
+#define MAPC_MORGUE "#2b6a92"
 #define MAPC_MEDRESEARCH "#3fb583"
 #define MAPC_PATHOLOGY "#167970"
 

--- a/code/area.dm
+++ b/code/area.dm
@@ -2939,13 +2939,13 @@ ABSTRACT_TYPE(/area/station/medical)
 	name = "Morgue"
 	icon_state = "morgue"
 	sound_environment = 3
-	station_map_colour = MAPC_MEDICAL
+	station_map_colour = MAPC_MORGUE
 
 /area/station/medical/crematorium
 	name = "Crematorium"
 	icon_state = "morgue"
 	sound_environment = 3
-	station_map_colour = MAPC_MEDICAL
+	station_map_colour = MAPC_MORGUE
 
 /area/station/medical/medbooth
 	name = "Medical Booth"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a darkish blue-grey for the morgue/crematorium on the minimap.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10727
Morgue/crematorium are rooms of note, should stand out from the surrounding rooms.

## How's it look?
![image](https://github.com/goonstation/goonstation/assets/91498627/bf393135-b130-440a-b67b-22d7e6b87c61)

![image](https://github.com/goonstation/goonstation/assets/91498627/b9db4265-5e3f-4c44-a8de-92dcb44156b6)

