### PR TITLE
Consistently give oxytank for Missile Arrival purchase

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -484,12 +484,12 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	missile_arrival
 		name = "Missile Arrival"
 		cost = 20000
+		path = /obj/item/tank/emergency_oxygen  // oh boy they'll need this if they are unlucky
 		icon = 'icons/obj/large/32x64.dmi'
 		icon_state = "arrival_missile"
 		icon_dir = SOUTH
 
 		Create(var/mob/living/M)
-			M.back?.storage?.add_contents(new /obj/item/tank/emergency_oxygen(M.back)) // oh boy they'll need this if they are unlucky
 			var/mob/living/carbon/human/H = M
 			if(istype(H))
 				H.equip_new_if_possible(/obj/item/clothing/mask/breath, SLOT_WEAR_MASK)
@@ -498,7 +498,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					launch_with_missile(M.loc)
 				else
 					launch_with_missile(M)
-			return 1
+			return ..()
 
 	critter_respawn
 		name = "Alt Ghost Critter"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use the more robust item-giving behavior for persistent purchases to provide the pocket o2 tank for missile arrival.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17695

## Test Plan
With Missile Arrival selected as your bank purchase:
- [x] As a clown, pocket oxygen tank should be in your funny pack
- [x] As a cyborg, you shouldn't receive a pocket oxygen tank
- [x] As a staff assistant, pocket oxygen tank is in your backpack
