### PR TITLE
sponges wring out when used in-hand

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -514,7 +514,7 @@ TRASH BAG
 	. = ..()
 	var/turf/location = get_turf(user)
 	if (location)
-		src.reagents.reaction(location, TOUCH, src.reagents.total_volume)
+		src.reagents.trans_to(location, src.reagents.total_volume)
 
 /obj/item/sponge/attackby(obj/item/W, mob/user)
 	if (istool(W, TOOL_CUTTING | TOOL_SNIPPING))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Transfers the sponge's contents to the floor instead of doing a touch reaction when using in-hand.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17689 - sponges should be empty after wringing out

## Test Plan
Holding a wet sponge,
- [x] Clicking on self applies touch 
- [x] Pressing the use in-hand key dumps the reagents onto the floor