### PR TITLE
Properly reset rack-based AI abilities on rack destruction/deconstruction

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -104,6 +104,9 @@
 		//remove from list
 		src.registered_racks -= dead_rack
 
+		//clear abilities
+		dead_rack.ai_abilities = list()
+
 		//find all connected borgs and remove their connection too
 		for (var/mob/living/silicon/R in mobs)
 			if (isghostdrone(R))
@@ -113,7 +116,8 @@
 				R.playsound_local(R, 'sound/misc/lawnotify.ogg', 100, flags = SOUND_IGNORE_SPACE)
 				R.show_text("<h3>ERROR: Lost connection to law rack. No laws detected!</h3>", "red")
 				logTheThing(LOG_STATION,  R, "[R.name] loses connection to the rack [constructName(dead_rack)] and now has no laws")
-
+				if(isAI(R))
+					dead_rack.reset_ai_abilities(R)
 		for (var/mob/living/intangible/aieye/E in mobs)
 			if(E.mainframe?.law_rack_connection == dead_rack)
 				E.mainframe.law_rack_connection = null

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -583,19 +583,7 @@
 				if(isAI(R))
 					var/mob/living/silicon/ai/holoAI = R
 					holoAI.holoHolder.text_expansion = src.holo_expansions.Copy()
-
-					var/ability_type
-					var/datum/abilityHolder/silicon/ai/aiAH = R.abilityHolder
-					var/list/current_abilities = list()
-					for(var/datum/ability in aiAH.abilities)
-						current_abilities |= ability.type
-					var/list/abilities_to_remove = current_abilities - ai_abilities
-					for(ability_type in abilities_to_remove)
-						if (ispath(ability_type, /datum/targetable/ai/module))
-							aiAH.removeAbility(ability_type)
-					var/list/abilities_to_add = ai_abilities - current_abilities
-					for(ability_type in abilities_to_add)
-						aiAH.addAbility(ability_type)
+					src.reset_ai_abilities(R)
 		src.calculate_power_usage()
 		for (var/mob/living/intangible/aieye/E in mobs)
 			if(E.mainframe?.law_rack_connection == src)
@@ -798,6 +786,20 @@
 		for (var/i in 1 to MAX_CIRCUITS)
 			if (src.law_circuits[i])
 				src.power_usage += 100
+
+	proc/reset_ai_abilities(mob/living/silicon/ai/target)
+		var/ability_type
+		var/datum/abilityHolder/silicon/ai/aiAH = target.abilityHolder
+		var/list/current_abilities = list()
+		for(var/datum/ability in aiAH.abilities)
+			current_abilities |= ability.type
+		var/list/abilities_to_remove = current_abilities - src.ai_abilities
+		for(ability_type in abilities_to_remove)
+			if (ispath(ability_type, /datum/targetable/ai/module))
+				aiAH.removeAbility(ability_type)
+		var/list/abilities_to_add = src.ai_abilities - current_abilities
+		for(ability_type in abilities_to_add)
+			aiAH.addAbility(ability_type)
 
 /particles/rack_smoke
 	icon = 'icons/effects/effects.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clear linked AI Ability Holders when an AI Rack is unregistered (i.e. destroyed/dismantled)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17625

## Test Plan
Test **without** `SKIP_CAMERA_COVERAGE` (and `IM_REALLY_IN_A_FUCKING_HURRY_HERE`) defined!
1. Go to the law rack
1. Spawn `/obj/item/aiModule/ability_expansion/laser`
1. Add the `CLF:Laser Expansion Module` to the rack
1. Possess the AI character, and go to AIeye view
    - [x] The `Camera Laser` ability button should show (top-left)
1. Delete the law rack
    - [x] The `Camera Laser` ability button should be removed
