### PR TITLE
Fix red bucket reward being droppable as a cyborg

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3279,6 +3279,7 @@
 	src.module_states[tool_index] = new_tool
 
 	// Set loc and pickup our new tool in hand
+	new_tool.cant_drop = TRUE
 	new_tool.set_loc(src)
 	new_tool.pickup(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assigns all items to be undroppable when replaced, mirroring how items are assigned `cant_drop` in the robot module's `add_contents` proc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17705