### PR TITLE
Fix description for refilled cigarette boxes

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -601,6 +601,7 @@
 	else
 		src.icon_state = "[src.package_style]o"
 		src.overlays += "cig[length(src.contents)]"
+		src.desc = initial(src.desc)
 	return
 
 /obj/item/cigpacket/attack_hand(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix description for refilled cigarette boxes by setting it every time the cigarette pack icon's updated i.e. when  a cigarette is added/removed/

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17708
