### PR TITLE
removed one (1) cart from cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -69313,11 +69313,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/engine/inner)
-"qNC" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/obj/storage/cart,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "qNE" = (
 /obj/table/reinforced/auto,
 /obj/decal/stripe_delivery,
@@ -101229,7 +101224,7 @@ azn
 aCd
 aDl
 qlm
-qNC
+awf
 awf
 awf
 qlm


### PR DESCRIPTION
[MAPPING]
## About the PR
Removes a single supply cart from inside a glass window on cogmap2.

## Why's this needed?
fixes #17719