### PR TITLE
Meteor parallax fix

### DIFF
--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -131,6 +131,11 @@ var/global/meteor_shower_active = 0
 					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/south, 0 SECONDS)
 				if (WEST)
 					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/west, 0 SECONDS)
+				if (-1)	// from ALL DIRECTIONS (may cause lag? probably not though, it's only 4 layers)
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/north, 0 SECONDS)
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/east, 0 SECONDS)
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/south, 0 SECONDS)
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/west, 0 SECONDS)
 	#endif
 
 			var/start_x

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -122,7 +122,6 @@ var/global/meteor_shower_active = 0
 				playsound_global(world, 'sound/machines/disaster_alert.ogg', 60)
 
 	#ifndef UNDERWATER_MAP
-			var/scroll_angle
 			switch(src.wave_direction)
 				if (NORTH)
 					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/north, 0 SECONDS)

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -125,17 +125,13 @@ var/global/meteor_shower_active = 0
 			var/scroll_angle
 			switch(src.wave_direction)
 				if (NORTH)
-					scroll_angle = 180
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/north, 0 SECONDS)
 				if (EAST)
-					scroll_angle = 270
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/east, 0 SECONDS)
 				if (SOUTH)
-					scroll_angle = 0
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/south, 0 SECONDS)
 				if (WEST)
-					scroll_angle = 90
-
-			if (scroll_angle)
-				ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower, 0 SECONDS)
-				GET_PARALLAX_RENDER_SOURCE_FROM_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower)?.scroll_angle = scroll_angle
+					ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, /atom/movable/screen/parallax_render_source/meteor_shower/west, 0 SECONDS)
 	#endif
 
 			var/start_x

--- a/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
@@ -127,7 +127,20 @@
 	static_colour = TRUE
 	parallax_value = 0.5
 	scroll_speed = 500
+	scroll_angle = 0
 
+// scrolling doesnt work if scroll_angle is changed after initialisation i think. So I made these.
+/atom/movable/screen/parallax_render_source/meteor_shower/north
+	scroll_angle = 180
+
+/atom/movable/screen/parallax_render_source/meteor_shower/north
+	scroll_angle = 0
+
+/atom/movable/screen/parallax_render_source/meteor_shower/east
+	scroll_angle = 270
+
+/atom/movable/screen/parallax_render_source/meteor_shower/west
+	scroll_angle = 90
 
 // Effects
 

--- a/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
@@ -133,7 +133,7 @@
 /atom/movable/screen/parallax_render_source/meteor_shower/north
 	scroll_angle = 180
 
-/atom/movable/screen/parallax_render_source/meteor_shower/north
+/atom/movable/screen/parallax_render_source/meteor_shower/south
 	scroll_angle = 0
 
 /atom/movable/screen/parallax_render_source/meteor_shower/east


### PR DESCRIPTION
[QOL]
## About the PR
So the meteor parallax had a bug previously. What would happen is that every time a meteor event happened, the background parallax would scroll upward only. If it was approaching from the south, it wouldn't appear at all.

This PR fixes that so that meteor approach direction on the parallax and in the game matches. This also adds support for meteors approaching from all directions by adding 4 layers at once (although it could probably be made into one animated layer if necessary).

## Why's this needed?
Fixes #17684