### PR TITLE
make wingrilles layer lower

### DIFF
--- a/code/modules/mapping/helpers/wingrille_spawner.dm
+++ b/code/modules/mapping/helpers/wingrille_spawner.dm
@@ -92,6 +92,7 @@
 	win_path = /obj/window/auto
 	full_win = TRUE
 	no_dirs = TRUE
+	layer = LATTICE_LAYER	// to stop it rendering over things in map editors
 #ifdef PERSPECTIVE_EDITOR_WALL
 	icon_state = "wingrille_new"
 	color = "#A3DCFF"


### PR DESCRIPTION
[MAPPING] [INTERNAL] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers the layer of auto wingrille spawners, so that things like crates and fire alarms layer above them in the map editor. This shouldn't affect the game at all, because they get removed on round start and replaced.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's now easier to see in the map editor if something was accidentally placed on a window's tile, since it won't be under the wingrille spawner. It will also presumably mean that changes appear in mapdiffbot better.