### PR TITLE
Listening Post and Captain's Office always start with auth disk pinpointers

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12046,6 +12046,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/item/pinpointer/disk,
 /turf/simulated/floor/airless/circuit/red,
 /area/listeningpost)
 "aOi" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -25613,7 +25613,7 @@
 /obj/item/storage/photo_album{
 	pixel_y = -10
 	},
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /obj/item/camera{
 	pixel_y = 6
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -39025,7 +39025,7 @@
 "cBq" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred2"

--- a/maps/density2.dmm
+++ b/maps/density2.dmm
@@ -5348,6 +5348,9 @@
 	},
 /obj/item/disk/data/cartridge/captain,
 /obj/item/peripheral/network/radio/locked,
+/obj/item/pinpointer/disk{
+	pixel_y = 9
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "IV" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -463,7 +463,7 @@
 /area/listeningpost)
 "abV" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /obj/table/wood/auto{
 	dir = 5
 	},
@@ -17689,7 +17689,7 @@
 "cHd" = (
 /obj/table/auto,
 /obj/item/card/id/captains_spare,
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -69414,7 +69414,7 @@
 /area/station/chapel/sanctuary)
 "vgl" = (
 /obj/table/auto,
-/obj/item/pinpointer{
+/obj/item/pinpointer/disk{
 	pixel_x = -4;
 	pixel_y = -9
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29211,7 +29211,7 @@
 "cmC" = (
 /obj/table/wood/auto,
 /obj/machinery/light/small,
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /obj/item/disk/data/cartridge/captain,
 /obj/item/disk/data/cartridge/captain,
 /turf/simulated/floor/black,

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -541,7 +541,11 @@
 /obj/item/item_box/gold_star{
 	item_amount = 20;
 	pixel_x = -6;
-	pixel_y = 3
+	pixel_y = 8
+	},
+/obj/item/pinpointer/disk{
+	pixel_y = -3;
+	pixel_x = -6
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
 /area/station/bridge/captain)
@@ -17700,10 +17704,16 @@
 	},
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = 7
+	pixel_y = 7;
+	pixel_x = 6
 	},
 /obj/item/aiModule/hologram_expansion/syndicate{
-	pixel_y = -4
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/obj/item/pinpointer/disk{
+	pixel_y = 2;
+	pixel_x = -6
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/listeningpost/power)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -12322,7 +12322,7 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = -4
 	},
-/obj/item/pinpointer{
+/obj/item/pinpointer/disk{
 	pixel_x = 3;
 	pixel_y = 7
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -50720,7 +50720,7 @@
 "cnM" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/pinpointer,
+/obj/item/pinpointer/disk,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fred2"

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -13330,7 +13330,7 @@
 /area/station/hallway/secondary/entry)
 "fQB" = (
 /obj/table/wood/auto,
-/obj/item/pinpointer{
+/obj/item/pinpointer/disk{
 	pixel_y = 4
 	},
 /obj/item/paper/telecrystal_update,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the base, no-target versions of the pinpointer in the captain's office and listening post on several maps with the auth disk version.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17648