### PR TITLE
Colorful Roachperson Carapaces!

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -19,6 +19,7 @@
 #define ishuman(x) istype(x, /mob/living/carbon/human)
 #define iscow(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/cow))
 #define ispug(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/pug))
+#define isroach(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/roach))
 #define isfrog(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/amphibian))
 #define isskeleton(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/skeleton))
 #define iscritter(x) istype(x, /obj/critter)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -640,8 +640,15 @@ var/list/removed_jobs = list(
 			if ("update-skinTone")
 				var/new_tone = "#FEFEFE"
 				var/mob/living/carbon/human/H = src.preview.preview_thing
-				if (isroach(H))
-					new_tone = tgui_color_picker(usr, "Please select skin color.", "Character Generation", AH.s_tone)
+				if (usr.has_medal("Contributor") || isroach(H))
+					switch(tgui_alert(usr, "Roaches (and Contributors) can pick any skin color!", "Swag Alert!", list("Paint me like a posh fence!", "Use Standard tone.", "Cancel")))
+						if("Paint me like a posh fence!")
+							new_tone = tgui_color_picker(usr, "Please select skin color.", "Character Generation", AH.s_tone)
+						if("Use Standard tone.")
+							new_tone = get_standard_skintone(usr)
+						else
+							return
+
 					if(new_tone)
 						AH.s_tone = new_tone
 						AH.s_tone_original = new_tone

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -639,15 +639,9 @@ var/list/removed_jobs = list(
 
 			if ("update-skinTone")
 				var/new_tone = "#FEFEFE"
-				if (usr.has_medal("Contributor"))
-					switch(tgui_alert(usr, "Goonstation contributors get to pick any colour for their skin tone!", "Thanks, pal!", list("Paint me like a posh fence!", "Use Standard tone.", "Cancel")))
-						if("Paint me like a posh fence!")
-							new_tone = tgui_color_picker(usr, "Please select skin color.", "Character Generation", AH.s_tone)
-						if("Use Standard tone.")
-							new_tone = get_standard_skintone(usr)
-						else
-							return
-
+				var/mob/living/carbon/human/H = src.preview.preview_thing
+				if (isroach(H) || traitPreferences.traits_selected.Find("poshfence"))
+					new_tone = tgui_color_picker(usr, "Please select skin color.", "Character Generation", AH.s_tone)
 					if(new_tone)
 						AH.s_tone = new_tone
 						AH.s_tone_original = new_tone

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -640,7 +640,7 @@ var/list/removed_jobs = list(
 			if ("update-skinTone")
 				var/new_tone = "#FEFEFE"
 				var/mob/living/carbon/human/H = src.preview.preview_thing
-				if (isroach(H) || traitPreferences.traits_selected.Find("poshfence"))
+				if (isroach(H))
 					new_tone = tgui_color_picker(usr, "Please select skin color.", "Character Generation", AH.s_tone)
 					if(new_tone)
 						AH.s_tone = new_tone
@@ -961,7 +961,7 @@ var/list/removed_jobs = list(
 				return TRUE
 
 			if ("unselect-trait")
-				if (params["id"] == ("roach") || params["id"] == ("poshfence")) //This prevents an exploit where people can get odd-colored skin for free
+				if (params["id"] == ("roach")) //This prevents an exploit where people can get odd-colored skin for free
 					var/stone = rand(34,-184)
 					if (stone < -30)
 						stone = rand(34,-184)
@@ -975,7 +975,7 @@ var/list/removed_jobs = list(
 				return TRUE
 
 			if ("reset-traits")
-				if (traitPreferences.traits_selected.Find("roach") || traitPreferences.traits_selected.Find("poshfence")) //Same exploit here
+				if (traitPreferences.traits_selected.Find("roach")) //Same exploit here
 					var/stone = rand(34,-184)
 					if (stone < -30)
 						stone = rand(34,-184)

--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -961,10 +961,29 @@ var/list/removed_jobs = list(
 				return TRUE
 
 			if ("unselect-trait")
+				if (params["id"] == ("roach") || params["id"] == ("poshfence")) //This prevents an exploit where people can get odd-colored skin for free
+					var/stone = rand(34,-184)
+					if (stone < -30)
+						stone = rand(34,-184)
+					if (stone < -50)
+						stone = rand(34,-184)
+
+					AH.s_tone = blend_skintone(stone, stone, stone)
+					AH.s_tone_original = AH.s_tone
+
 				src.profile_modified = src.traitPreferences.unselectTrait(params["id"], src.custom_parts)
 				return TRUE
 
 			if ("reset-traits")
+				if (traitPreferences.traits_selected.Find("roach") || traitPreferences.traits_selected.Find("poshfence")) //Same exploit here
+					var/stone = rand(34,-184)
+					if (stone < -30)
+						stone = rand(34,-184)
+					if (stone < -50)
+						stone = rand(34,-184)
+
+					AH.s_tone = blend_skintone(stone, stone, stone)
+					AH.s_tone_original = AH.s_tone
 				src.traitPreferences.resetTraits()
 				src.profile_modified = TRUE
 				return TRUE

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -26,6 +26,7 @@
 		"nopug",
 		"cloner_stuff",
 		"hemophilia",
+		"poshfence"
 	)
 
 	proc/selectTrait(var/id, var/list/parts_selected = null)
@@ -964,6 +965,12 @@ ABSTRACT_TYPE(/datum/trait/job)
 		var/datum/trait/job/chaplain/chap_trait = owner.traitHolder?.getTrait("training_chaplain")
 		chap_trait?.faith_mult = 1
 
+/datum/trait/poshfence
+	name= "Dermachromatic"
+	desc = "Your skin is an odd color."
+	id = "poshfence"
+	points = -1
+	category = list("poshfence")
 
 /datum/trait/lizard
 	name = "Reptilian"
@@ -998,7 +1005,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "One space-morning, on the shuttle-ride to the station, you found yourself transformed in your seat into a horrible vermin. A cockroach, specifically."
 	id = "roach"
 	points = -1
-	category = list("species")
+	category = list("species", "poshfence")
 	mutantRace = /datum/mutantrace/roach
 
 /datum/trait/pug

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -26,7 +26,6 @@
 		"nopug",
 		"cloner_stuff",
 		"hemophilia",
-		"poshfence"
 	)
 
 	proc/selectTrait(var/id, var/list/parts_selected = null)
@@ -965,13 +964,6 @@ ABSTRACT_TYPE(/datum/trait/job)
 		var/datum/trait/job/chaplain/chap_trait = owner.traitHolder?.getTrait("training_chaplain")
 		chap_trait?.faith_mult = 1
 
-/datum/trait/poshfence
-	name= "Dermachromatic"
-	desc = "Your skin is an odd color."
-	id = "poshfence"
-	points = -1
-	category = list("poshfence")
-
 /datum/trait/lizard
 	name = "Reptilian"
 	icon_state = "lizardT"
@@ -1005,7 +997,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "One space-morning, on the shuttle-ride to the station, you found yourself transformed in your seat into a horrible vermin. A cockroach, specifically."
 	id = "roach"
 	points = -1
-	category = list("species", "poshfence")
+	category = list("species")
 	mutantRace = /datum/mutantrace/roach
 
 /datum/trait/pug

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -964,6 +964,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 		var/datum/trait/job/chaplain/chap_trait = owner.traitHolder?.getTrait("training_chaplain")
 		chap_trait?.faith_mult = 1
 
+
 /datum/trait/lizard
 	name = "Reptilian"
 	icon_state = "lizardT"


### PR DESCRIPTION
[mutantraces][feature]
## About the PR
Allows for roachpeople to choose from the full range of skin colors, the same way contributors can.

## Why's this needed?
(copied from the forum thread [here](https://forum.ss13.co/showthread.php?tid=22161))

As of right now, the only ways to get custom-colored skin for a character is either to have the much-coveted Contributor medal, or to go to Genetics in-round (if it's staffed) and ask them to change the color (it has to be simple to do on the annoying RGB knobs since you can't input a hex code, unlike the hair dye machine).

It's frustrating to me that a powerful character customization was put behind a medal so rarely given out to players, and under such arbitrary methods as "bother an admin after you've done some indeterminate (but significant) amount of work for the codebase." With every other character customization option that I know of either being unlocked at the start or unlocked by playing the game (the contest medals do not customize your character), it really just... doesn't seem fair.

I was recently gifted the medal arbitrarily after doing pretty much nothing for the codebase (just made some minor changes to chemlab organization and changed alcoholic drinks), and I've really been enjoying having it, especially for a Blattodean that I roleplay as a mantid. I think being able to change exoskeleton color fits the mutrace well-- and it allows for a variety of insect species to be played using the mutrace, e.g. wasps.

## Changelog 
```changelog
(u)Minty
(*)Roachpeople just got a whole lot more colorful!
```
