### PR TITLE
remove a couple light tubes in hos office + botany

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -127542,7 +127542,7 @@ adC
 adC
 adC
 mPp
-apZ
+srq
 arn
 arn
 auc
@@ -127555,7 +127555,7 @@ avj
 xiw
 arn
 arn
-aHw
+srq
 mPp
 adC
 adC
@@ -127844,7 +127844,7 @@ adC
 adC
 adC
 mPp
-apZ
+srq
 arn
 arn
 fnq
@@ -127857,7 +127857,7 @@ nhn
 iTs
 arn
 arn
-aHw
+srq
 mPp
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -50539,10 +50539,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 21
-	},
 /obj/machinery/power/apc/autoname_north,
 /obj/item/implantcase/counterrev{
 	pixel_x = 8;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

removes one light tube in the hos office, and four in botany

![Screenshot (532)](https://github.com/goonstation/goonstation/assets/73998720/e72f2c3a-356f-400e-b4e4-c944b9cd1576)
![Screenshot (531)](https://github.com/goonstation/goonstation/assets/73998720/651e26e1-54c7-4302-89a7-ec4de8a345cc)
(photos show updated rooms)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

the amount of light tubes in these confined spaces is an attack on the eyes. decreased eye strain is good for game

