### PR TITLE
Adds two new recipes for Death Spice

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4335,10 +4335,11 @@
 		mix_phrase = "The mixture dries into a pale blue powder."
 		mix_sound = 'sound/misc/fuse.ogg'
 
-	deathspice	// Clean chemlab version
+	deathspice	// Clean chemlab version. Requiring cooling after hot rxns should make bulk production interesting
 		name = "Death Spice 1"
 		id = "death_spice 1"
 		result = "death_spice"
+		max_temperature = T0C - 80
 		result_amount = 3
 		required_reagents = list("charcoal" = 2, "neurotoxin" = 1)
 		mix_phrase = "The mixture shimmers, drying into a fine, iridescent powder."
@@ -4347,6 +4348,7 @@
 	deathspice/deathspice2	// hobochem/botany version, spliced versions should give nicotine too!!! YAY!!!
 		name = "Death Spice 2"
 		id = "death_spice 2"
+		min_temperature = -INFINITY
 		result_amount = 3
 		required_reagents = list("paper" = 1, "pepper" = 1, "nicotine" = 0.4, "space_fungus" = 1)
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4335,6 +4335,21 @@
 		mix_phrase = "The mixture dries into a pale blue powder."
 		mix_sound = 'sound/misc/fuse.ogg'
 
+	deathspice	// Clean chemlab version
+		name = "Death Spice 1"
+		id = "death_spice 1"
+		result = "death_spice"
+		result_amount = 3
+		required_reagents = list("charcoal" = 2, "neurotoxin" = 1)
+		mix_phrase = "The mixture shimmers, drying into a fine, iridescent powder."
+		mix_sound = 'sound/misc/fuse.ogg'
+
+	deathspice/deathspice2	// hobochem/botany version, spliced versions should give nicotine too!!! YAY!!!
+		name = "Death Spice 2"
+		id = "death_spice 2"
+		result_amount = 3
+		required_reagents = list("paper" = 1, "pepper" = 1, "nicotine" = 0.4, "space_fungus" = 1)
+
 /*	helldrug // the worst thing. if splashed on floor, create void turf. if ingested, replace mob with crunch critter and teleport user to hell
 		name = "Cthonium"
 		id = "cthonium"


### PR DESCRIPTION
[Chemistry][feature]{add to wiki]
## About the PR 
Adds two new recipes for death spice, one for chemlabs and one for hobochem/clever botanical splices:
(at < -80C) 
(2) Charcoal + (1) Neurotoxin -> (3) Death Spice

(any temperature)
(1) Paper + (1) Pepper + (0.4) Nicotine + (1) Space Fungus -> (3) Death Spice

## Why's this needed? 
Death spice is a silly and "harmless" chem that's terribly rare on station! We could use a little more in our lives.

## Changelog 

```changelog
(u)Mintyphresh
(+)Deathspice is now craftable:
(-80C) (2) Charcoal + (1) Neurotoxin -> (3) Death Spice
(1) Paper + (1) Pepper + (0.4) Nicotine + (1) Space Fungus -> (3) Death Spice
```
