### PR TITLE
Pizza Snipping

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -108,7 +108,7 @@
 					return
 				else
 					boutput(user, SPAN_NOTICE("You sharpen the pizza, and start slicing it."))
-		if (istool(W, TOOL_CUTTING | TOOL_SAWING))
+		if (istool(W, TOOL_CUTTING | TOOL_SAWING | TOOL_SNIPPING))
 			if (src.sliced)
 				boutput(user, SPAN_ALERT("This has already been sliced."))
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CATERING][GAME-OBJECTS][FEATURE][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the TOOL_SNIPPING flag to the pizza slicing code, allowing it to be sliced by scissors and other snipping tools.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I believe this could help with the issue of people not having any tools nearby to cut pizza with. Since scissors can already be found in lockers all around the station (usually closer than knives), allowing them to cut pizza could improve the pizza-eating experience.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Pizzas can now be cut with snipping tools. Knifeless rejoice!
```
