### PR TITLE
gives borgs the borg power hammer

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -174,6 +174,7 @@
 		/obj/item/device/gps,
 		/obj/item/extinguisher/large/cyborg,
 		/obj/item/mining_tool/drill,
+		/obj/item/mining_tool/powerhammer/borg,
 		/obj/item/ore_scoop/borg,
 		/obj/item/cargotele,
 		/obj/item/satchel/mining/large,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives mining module borgs the borg mining hammer that's already in the game.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Since borgs only get the mining drill and cannot use explosive mining satchels, its quite common for some of the harder ores to just be impossible to break.

Potential balance concern is that the mining hammer is pretty good as a weapon. I dont feel that this is an issue as it is offset by borgs being generally quite weak in open combat. Any stuns pretty much completely nullifies them as a threat.

Could potentially have its damage or energy costs tweaked for balance reasons.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+)Mining module cyborgs now have the mining power hammer.
```
