### PR TITLE
Fixes incorrect movement modifiers being applied onto admin spawned borgs

### DIFF
--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -98,7 +98,7 @@
 	additive_slowdown = -0.25
 
 // robot modifiers
-/datum/movement_modifier/robot_base
+/datum/movement_modifier/robot_part/robot_base
 	health_deficiency_adjustment = -INFINITY
 	mob_pull_multiplier = 0.2 //make borgs pull mobs slightly slower than full speed (roundstart light borg will pull a corpse at ~1.3 delay, as opposed to ~1 when unencumbered)
 

--- a/code/mob/living/critter/sawfly.dm
+++ b/code/mob/living/critter/sawfly.dm
@@ -51,7 +51,7 @@ This file is the critter itself, and all the custom procs it needs in order to f
 
 		animate_bumble(src) // gotta get the float goin' on
 		src.set_a_intent(INTENT_HARM) // incredibly stupid way of ensuring they aren't passable but it works
-		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/robot_base, "robot_health_slow_immunity") //prevents them from having movespeed slowdown when injured
+		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/robot_part/robot_base, "robot_health_slow_immunity") //prevents them from having movespeed slowdown when injured
 		START_TRACKING
 
 	setup_healths()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -112,7 +112,7 @@
 		src.internal_pda = new /obj/item/device/pda2/cyborg(src)
 		src.internal_pda.name = "[src]'s Internal PDA Unit"
 		src.internal_pda.owner = "[src]"
-		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/robot_base, "robot_health_slow_immunity")
+		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/robot_part/robot_base, "robot_health_slow_immunity")
 		if (frame)
 			src.freemodule = frame.freemodule
 		if (starter && !(src.dependent || src.shell))
@@ -256,6 +256,10 @@
 
 		if (prob(50))
 			src.sound_scream = 'sound/voice/screams/Robot_Scream_2.ogg'
+
+		for (var/datum/movement_modifier/MM in src.movement_modifiers) // Spawning borgs applies human only movemods, this cleans that up
+			if (!istype(MM, /datum/movement_modifier/robot_part))
+				REMOVE_MOVEMENT_MODIFIER(src, MM, src.type)
 
 	set_pulling(atom/movable/A)
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what the title says, admin spawned borgs with treads have the human movemod for treads applied to them, which makes them faster then they should be. This adds a for loop that removes any non robot_part movemods at the end of new() to fix this.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17576


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Not needed
