### PR TITLE
Stops rattlesnakes from appearing alive when dead

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2032,7 +2032,8 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 					icon_state = "rattlesnake_rattle"
 					playsound(src, 'sound/musical_instruments/tambourine/tambourine_4.ogg', 80, TRUE, channel=VOLUME_CHANNEL_EMOTE)
 					SPAWN(1 SECONDS)
-						icon_state = "rattlesnake"
+						if(isalive(src))
+							icon_state = "rattlesnake"
 					return SPAN_EMOTE("<b>[src]</b> rattles [his_or_her(src)] tail!")
 		return null
 


### PR DESCRIPTION
[LABEL][bug][trivial][critters]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a isalive check on the rattlesnake rattle emote, stopping it from returning to the regular sprite even if dead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Dead snake need look dead.

