### PR TITLE
Atlas drinkslide fix

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1440,7 +1440,7 @@ ADMIN_INTERACT_PROCS(/obj/item/reagent_containers/food/drinks/drinkingglass, pro
 		if(isnull(source_table))
 			for(var/dir in cardinal)
 				source_table = locate() in get_step(user, dir)
-				if(!isnull(source_table))
+				if(!isnull(source_table) && source_table.drinkslideable)
 					user.set_dir(dir)
 					break
 		if(isnull(source_table))

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -37,6 +37,8 @@ TYPEINFO_NEW(/obj/table)
 	var/drawer_locked = FALSE
 	/// id for key checks, keys with the same id can lock it
 	var/lock_id = null
+	/// when false, prevent the table from being auto-selected as an origin for sliding drinks across tables
+	var/drinkslideable = TRUE
 	HELP_MESSAGE_OVERRIDE({"You can use a <b>wrench</b> on <span class='harm'>harm</span> intent to disassemble it."})
 
 	New(loc)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2861,7 +2861,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "ajs" = (
-/obj/table/wood/round/auto,
+/obj/table/wood/round/auto{
+	drinkslideable = 0
+	},
 /obj/machinery/glass_recycler/bar,
 /obj/item/clothing/glasses/spectro{
 	pixel_y = 11
@@ -2887,7 +2889,9 @@
 /obj/drink_rack/cup{
 	pixel_y = 32
 	},
-/obj/table/wood/round/auto,
+/obj/table/wood/round/auto{
+	drinkslideable = 0
+	},
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12050,6 +12050,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/item/pinpointer/disk,
 /turf/simulated/floor/airless/circuit/red,
 /area/listeningpost)
 "aOi" = (


### PR DESCRIPTION
[catering][player-actions][bug][
## About the PR
Adds a new variable to tables called "drinkslideable" (default true) that, if false, will not allow drinkslides to start from that table. Implements this on Atlas, switching the back two tables to be non-drinkslideable.


## Why's this needed?
Drinksliding from the east side of atlas bar to the west would cause the player to begin drinksliding from the back table, meaning that the glass would attempt to cross the gap between the back and front of the bar (and consequently shatter on the ground). This mapping tool should let mappers make more compact bars without worrying about this silly bug.