### PR TITLE
Add some special procs for bulk artifact spawning and (de)/activation

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -383,6 +383,8 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_caviewer,
 		/client/proc/cmd_custom_spawn_event,
 		/client/proc/cmd_special_shuttle,
+		/client/proc/toggle_all_artifacts,
+		/client/proc/spawn_tons_of_artifacts,
 		/client/proc/toggle_radio_maptext,
 
 		/datum/admins/proc/toggleaprilfools,

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -3014,6 +3014,10 @@ var/global/force_radio_maptext = FALSE
 				return
 			if("Yes")
 				var/amt_artifacts = min(input(usr,"How many artifacts do we want to spawn?\n(Default: 50)",,50) as num, ARTIFACT_HARD_LIMIT)
+				var/response = input(src, "High number of types: [length(spawn_matches)] - Type YES to continue", "Caution!") as null|text
+				if (response != "YES")
+					message_admins("[key_name(usr)] aborted spawning [amt_artifacts] due to failing to type 'YES'") // im telling on u!!!
+					return
 				var/floors_only = (alert(src, "Only spawn artifacts on floors?",, "Yes", "No") == "Yes")
 				logTheThing(LOG_ADMIN, src, "started spawning [amt_artifacts] artifacts.")
 				message_admins("[key_name(usr)] started spawning [amt_artifacts] artifacts.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2968,3 +2968,60 @@ var/global/force_radio_maptext = FALSE
 				return
 	else
 		boutput(src, "You must be at least an Administrator to use this command.")
+/client/proc/toggle_all_artifacts()
+	// Housekeeping
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	set name = "Toggle All Artifacts"
+	if (holder && src.holder.level >= LEVEL_ADMIN)
+		switch(alert("What would you like to do?",,"Activate All","Deactivate All","Cancel"))
+			if("Cancel")
+				return
+			if("Activate All")
+				// You definitely can activate an artnuke like this maybe be sure we're sure
+				switch(alert("ARE YOU SURE????","HEY WOAH THERE","Yes","No"))
+					if(!"Yes")
+						return
+				logTheThing(LOG_ADMIN, src, "started activating all available artifacts.")
+				message_admins("[key_name(usr)] started activating all available artifacts.")
+				for(var/artifact as anything in by_cat[TR_CAT_ARTIFACTS])
+					var/obj/holder = artifact
+					holder.ArtifactActivated()
+			if("Deactivate All")
+				// No confirmation for this since you cant really activate an artnuke like this
+				logTheThing(LOG_ADMIN, src, "started deactivating all available artifacts.")
+				message_admins("[key_name(usr)] started deactivating all available artifacts.")
+				for(var/artifact as anything in by_cat[TR_CAT_ARTIFACTS])
+					var/obj/holder = artifact
+					holder.ArtifactDeactivated()
+	else
+		boutput(src, "You must be at least an Administrator to use this command.")
+
+/client/proc/spawn_tons_of_artifacts()
+	var/artifact_bulk_limit = 100 // only this many artifacts per second
+	var/artifact_hard_limit = 2000 // Stops you from putting in 99999999999 and killing the server
+	// Housekeeping
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	set name = "Bulk Spawn Artifacts"
+	if (holder && src.holder.level >= LEVEL_ADMIN)
+		switch(alert("THIS COULD SERIOUSLY FUCK THINGS UP. That being said, do it anyway?","WOAH THERE BUCKAROO","Yes","No"))
+			if("No")
+				return
+			if("Yes")
+				// The actual stuff
+				var/artifacts_spawned = 0
+				var/amt_artifacts = input(usr,"How many artifacts do we want to spawn?\n(Default: 50)",,50) as num
+				amt_artifacts = min(amt_artifacts, artifact_hard_limit)
+				var/floors_only = (alert(src, "Only spawn artifacts on floors?",, "Yes", "No") == "Yes")
+				logTheThing(LOG_ADMIN, src, "started spawning [amt_artifacts] artifacts.")
+				message_admins("[key_name(usr)] started spawning [amt_artifacts] artifacts.")
+				while (artifacts_spawned < amt_artifacts)
+					var/turf/T = locate(rand(1, world.maxx), rand(1, world.maxy), Z_LEVEL_STATION)
+					if (floors_only && !istype(T, /turf/simulated/floor))
+						continue
+					Artifact_Spawn(T)
+					artifacts_spawned += 1
+					// mitigate lag
+					if (artifacts_spawned % artifact_bulk_limit == 0)
+						sleep(1 SECOND)
+				logTheThing(LOG_ADMIN, src, "finished spawning [amt_artifacts] artifacts.")
+				message_admins("[key_name(usr)] finished spawning [amt_artifacts] artifacts.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2980,7 +2980,7 @@ var/global/force_radio_maptext = FALSE
 				// You definitely can activate an artnuke like this maybe be sure we're sure
 				var/response = input(src, "Extremely stupid button pressing shenanagains detected - Type YES to continue", "Caution!") as null|text
 				if (response != "YES")
-					message_admins("[key_name(usr)] aborted spawning [amt_artifacts] due to failing to type 'YES'") // im telling on u!!!
+					message_admins("[key_name(usr)] aborted toggling every dang artifact due to failing to type 'YES'") // im telling on u!!!
 					return
 				logTheThing(LOG_ADMIN, src, "started activating all available artifacts.")
 				message_admins("[key_name(usr)] started activating all available artifacts.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2997,7 +2997,7 @@ var/global/force_radio_maptext = FALSE
 		boutput(src, "You must be at least an Administrator to use this command.")
 
 #define ARTIFACT_BULK_LIMIT 100
-#define ARTIFACT_HARD_LIMIT 20000
+#define ARTIFACT_HARD_LIMIT 2000
 #define ARTIFACT_MAX_SPAWN_ATTEMPTS 100
 
 /client/proc/spawn_tons_of_artifacts()
@@ -3014,10 +3014,11 @@ var/global/force_radio_maptext = FALSE
 				return
 			if("Yes")
 				var/amt_artifacts = min(input(usr,"How many artifacts do we want to spawn?\n(Default: 50)",,50) as num, ARTIFACT_HARD_LIMIT)
-				var/response = input(src, "High number of types: [length(spawn_matches)] - Type YES to continue", "Caution!") as null|text
-				if (response != "YES")
-					message_admins("[key_name(usr)] aborted spawning [amt_artifacts] due to failing to type 'YES'") // im telling on u!!!
-					return
+				if (amt_artifacts > ARTIFACT_BULK_LIMIT)
+					var/response = input(src, "High number of types: [length(amt_artifacts)] - Type YES to continue", "Caution!") as null|text
+					if (response != "YES")
+						message_admins("[key_name(usr)] aborted spawning [amt_artifacts] due to failing to type 'YES'") // im telling on u!!!
+						return
 				var/floors_only = (alert(src, "Only spawn artifacts on floors?",, "Yes", "No") == "Yes")
 				logTheThing(LOG_ADMIN, src, "started spawning [amt_artifacts] artifacts.")
 				message_admins("[key_name(usr)] started spawning [amt_artifacts] artifacts.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2978,9 +2978,10 @@ var/global/force_radio_maptext = FALSE
 				return
 			if("Activate All")
 				// You definitely can activate an artnuke like this maybe be sure we're sure
-				switch(alert("ARE YOU SURE????","HEY WOAH THERE","Yes","No"))
-					if(!"Yes")
-						return
+				var/response = input(src, "Extremely stupid button pressing shenanagains detected - Type YES to continue", "Caution!") as null|text
+				if (response != "YES")
+					message_admins("[key_name(usr)] aborted spawning [amt_artifacts] due to failing to type 'YES'") // im telling on u!!!
+					return
 				logTheThing(LOG_ADMIN, src, "started activating all available artifacts.")
 				message_admins("[key_name(usr)] started activating all available artifacts.")
 				for(var/artifact as anything in by_cat[TR_CAT_ARTIFACTS])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two admin-only procs, Toggle-All-Artifacts and Bulk-Spawn-Artifacts.
Toggle-All-Artifacts allows you to either turn on all existing artifacts, or turn them all off. (Some may instantly re-activate anyway, though.)
Bulk-Spawn-Artifacts lets you spawn artifacts similarly to a radiation blowout, but with control over the amount of artifacts spawned. Also lets you choose to allow artifacts to spawn in space.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
May be helpful for testing, and hopefully can be fun to use on live if someone wants to. Mostly, I was surprised that these procs didn't exist already when I went to look for them in a local.

Feel free to close if this is simply not wanted, the primary reason I'm creating a PR is because I made this for fun and want to see if it's worth keeping around.

https://github.com/goonstation/goonstation/assets/27376947/b82556c1-26af-4cb6-adc6-46c400c48815

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
Doesn't really need one, since it doesn't impact regular players directly