### PR TITLE
Enable logging runtimes during global init

### DIFF
--- a/code/datum.dm
+++ b/code/datum.dm
@@ -2,8 +2,8 @@ TYPEINFO(/datum)
 	var/admin_spawnable = TRUE
 
 #ifdef IMAGE_DEL_DEBUG
-var/global/list/deletedImageData = new
-var/global/list/deletedImageIconStates = new
+var/global/list/deletedImageData = list()
+var/global/list/deletedImageIconStates = list()
 
 /image/Del()
 	deletedImageData.len++;
@@ -14,7 +14,7 @@ var/global/list/deletedImageIconStates = new
 #endif
 
 #ifdef DELETE_QUEUE_DEBUG
-var/global/list/deletedObjects = new
+var/global/list/deletedObjects = list()
 
 /datum/Del()
 	if(!("[src.type]" in deletedObjects))

--- a/code/datums/tooltip.dm
+++ b/code/datums/tooltip.dm
@@ -69,7 +69,7 @@ Notes:
 	boutput(who, "<span style='font-size: 0.85em'>\[[time2text(world.realtime, "hh:mm:ss")]\] <strong>(TOOLTIP DEBUG | DM)</strong> [msg]</span>")
 #endif
 
-var/global/list/atomTooltips = new()
+var/global/list/atomTooltips = list()
 
 /datum/tooltipHolder
 	//Configurable vars

--- a/code/error_handling.dm
+++ b/code/error_handling.dm
@@ -6,7 +6,7 @@
 * It does NOT catch reference bugs
 */
 
-var/global/list/runtimeDetails = new()
+var/global/list/runtimeDetails = list()
 var/global/runtime_count = 0
 var/global/blame_for_runtimes = FALSE
 

--- a/code/procs/station_name.dm
+++ b/code/procs/station_name.dm
@@ -20,8 +20,8 @@ var/global/station_name_changing = 1 //Are people allowed to change the station 
 var/global/station_or_ship = null
 var/global/station_name = null
 var/global/the_station_name = null
-var/global/list/station_name_whitelist = new()
-var/global/list/station_name_whitelist_sectioned = new()
+var/global/list/station_name_whitelist = list()
+var/global/list/station_name_whitelist_sectioned = list()
 
 var/global/stationNameChangeDelay = 1 MINUTE //deciseconds. 600 = 60 seconds
 var/global/lastStationNameChange = 0 //timestamp


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It turns out `/var/global/list/A = list()` is **not equivalent** to `/var/global/list/A = new()`
AS a result, errors occurring during global init were being sent to `/world/Error()` and then failing to log because `runtimeDetails` was in a not-quite-initialised and not-actually-null state (thanks BYOND!)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1) Makes it so we can log runtimes during init
2) Makes it so OD can get through init without throwing runtimes because things weren't initialised properly before they were used.