### PR TITLE
Abstract runtime fix for player zoldorfing

### DIFF
--- a/code/obj/zoldorf.dm
+++ b/code/obj/zoldorf.dm
@@ -62,8 +62,8 @@ var/global/list/datum/zoldorfitem/zoldorf_items = list()
 	var/list/omencolors = list("none","custom","red","green")
 	var/list/notes = list()
 	var/omencolor
-	var/obj/o1 = new
-	var/obj/o2 = new
+	var/obj/effect/o1 = new
+	var/obj/effect/o2 = new
 	var/inuse = 0
 	var/colorinputbuffer
 	var/smokecolor
@@ -84,8 +84,6 @@ var/global/list/datum/zoldorfitem/zoldorf_items = list()
 
 	New()
 		. = ..()
-		o1.mouse_opacity = 0
-		o2.mouse_opacity = 0
 		START_TRACKING
 
 	proc/updatejar() //updates soul jar display based on partial souls and adds any spillover to the current zoldorf's soul pool


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use obj/effect for the crystal ball effects on player-zoldorf machine

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix an abstract runtime error on raw `/obj/` usage