### PR TITLE
Use technical storage circuit board map spawners

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13757,14 +13757,7 @@
 /area/station/storage/tech)
 "bqF" = (
 /obj/machinery/light/small,
-/obj/rack,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/qmorder,
-/obj/item/circuitboard/telescope,
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bqG" = (
@@ -29593,16 +29586,9 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/disposal)
 "lyC" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/operating,
-/obj/item/circuitboard/qmsupply,
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "lzl" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -35100,34 +35100,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cnN" = (
-/obj/rack,
-/obj/item/circuitboard/qmorder{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/robot_module_rewriter{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/barcode_qm{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/barcode{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/card{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/circuitboard/teleporter{
-	pixel_x = 5;
-	pixel_y = -5
+/obj/rack/organized/techstorage_eng{
+	order_override = "zigzag"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -39231,35 +39205,7 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "cCc" = (
-/obj/rack,
-/obj/item/circuitboard/qmsupply{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/telescope{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/powermonitor{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/genetics{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/powermonitor_smes{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/arcade{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/circuitboard/operating{
-	pixel_x = 5;
-	pixel_y = -1
-	},
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cCe" = (
@@ -58606,6 +58552,10 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
+"sFp" = (
+/obj/rack/organized/techstorage_med,
+/turf/space,
+/area/space)
 "sFD" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
@@ -70314,7 +70264,7 @@ adC
 adC
 adC
 adC
-adC
+sFp
 adC
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -58552,10 +58552,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
-"sFp" = (
-/obj/rack/organized/techstorage_med,
-/turf/space,
-/area/space)
 "sFD" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
@@ -70264,7 +70260,7 @@ adC
 adC
 adC
 adC
-sFp
+adC
 adC
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -39205,7 +39205,9 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "cCc" = (
-/obj/rack/organized/techstorage_med,
+/obj/rack/organized/techstorage_med{
+	order_override = "zigzag"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cCe" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -40858,14 +40858,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "coR" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/qmorder,
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "coS" = (
@@ -45141,14 +45134,7 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "cBk" = (
-/obj/rack,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/item/circuitboard/operating,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/qmsupply,
-/obj/item/circuitboard/telescope,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "cBl" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -29015,12 +29015,6 @@
 	},
 /turf/space,
 /area/space)
-"kko" = (
-/obj/rack/organized/techstorage_med{
-	order_override = "diagonal"
-	},
-/turf/space,
-/area/space)
 "kkp" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -59682,7 +59676,7 @@ aaa
 aaa
 aaa
 aaa
-kko
+aaa
 aaa
 aaa
 aaa

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -6789,13 +6789,7 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aJc" = (
-/obj/rack,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/operating,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/genetics,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aJd" = (
@@ -29021,6 +29015,12 @@
 	},
 /turf/space,
 /area/space)
+"kko" = (
+/obj/rack/organized/techstorage_med{
+	order_override = "diagonal"
+	},
+/turf/space,
+/area/space)
 "kkp" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -43729,15 +43729,10 @@
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "tlf" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/powermonitor_smes,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "tlV" = (
@@ -59687,7 +59682,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+kko
 aaa
 aaa
 aaa

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -26104,33 +26104,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
 "hPQ" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/circuitboard/card{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/robot_module_rewriter{
-	pixel_x = -1
-	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/barcode_qm{
-	pixel_x = 3;
-	pixel_y = -6
-	},
-/obj/item/circuitboard/barcode{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/circuitboard/qmsupply{
-	pixel_x = 5;
-	pixel_y = -9
+/obj/rack/organized/techstorage_eng{
+	order_override = "diagonal"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tech)
@@ -40841,37 +40816,11 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "msQ" = (
-/obj/rack,
-/obj/item/circuitboard/arcade{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/circuitboard/powermonitor{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/powermonitor_smes{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/circuitboard/operating{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/circuitboard/genetics{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/circuitboard/qmorder{
-	pixel_x = 6;
-	pixel_y = -8
-	},
-/obj/item/circuitboard/telescope{
-	pixel_x = 6;
-	pixel_y = -6
-	},
 /obj/machinery/light/incandescent/netural{
 	dir = 1
+	},
+/obj/rack/organized/techstorage_med{
+	order_override = "diagonal"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tech)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44228,18 +44228,11 @@
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
 "myd" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/qmsupply,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "mzu" = (
@@ -46691,9 +46684,6 @@
 	},
 /area/station/solar/west)
 "osJ" = (
-/obj/rack,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -46702,11 +46692,7 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/east,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/bank_data,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/qmorder,
-/obj/item/circuitboard/telescope,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "osY" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -11271,14 +11271,6 @@
 	},
 /area/listeningpost)
 "fhp" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/qmsupply,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -11287,7 +11279,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_north,
-/obj/item/circuitboard/transception,
+/obj/rack/organized/techstorage_eng/transception,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "fip" = (
@@ -21242,14 +21234,7 @@
 	},
 /area/station/security/main)
 "jfZ" = (
-/obj/rack,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/bank_data,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/qmorder,
-/obj/item/circuitboard/telescope,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "jge" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -11007,14 +11007,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aJX" = (
-/obj/rack,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/card,
-/obj/item/circuitboard/robot_module_rewriter,
-/obj/item/circuitboard/cloning,
-/obj/item/circuitboard/barcode_qm,
-/obj/item/circuitboard/barcode,
-/obj/item/circuitboard/qmsupply,
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aJY" = (
@@ -11073,14 +11066,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aKp" = (
-/obj/rack,
-/obj/item/circuitboard/arcade,
-/obj/item/circuitboard/powermonitor,
-/obj/item/circuitboard/powermonitor_smes,
-/obj/item/circuitboard/operating,
-/obj/item/circuitboard/genetics,
-/obj/item/circuitboard/qmorder,
-/obj/item/circuitboard/telescope,
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aKr" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -40260,67 +40260,11 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bVf" = (
-/obj/rack,
-/obj/item/circuitboard/qmsupply{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/telescope{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/powermonitor{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/genetics{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/powermonitor_smes{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/arcade{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/circuitboard/operating{
-	pixel_x = -5;
-	pixel_y = -1
-	},
+/obj/rack/organized/techstorage_med,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bVg" = (
-/obj/rack,
-/obj/item/circuitboard/qmorder{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/robot_module_rewriter{
-	pixel_x = 5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/barcode_qm{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/barcode{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/card{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/cloning{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/circuitboard/teleporter{
-	pixel_x = -5;
-	pixel_y = -5
-	},
+/obj/rack/organized/techstorage_eng,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bVh" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -40260,11 +40260,15 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bVf" = (
-/obj/rack/organized/techstorage_med,
+/obj/rack/organized/techstorage_med{
+	order_override = "zigzag"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bVg" = (
-/obj/rack/organized/techstorage_eng,
+/obj/rack/organized/techstorage_eng{
+	order_override = "zigzag"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bVh" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements the organized racks for circuit board cards from #17774 across current maps.

Forces donut3 to use 'diagonal' and cogmap1 to use 'zigzag' sorting ala their current pixel-shifted cards; the rest are set to use the default (random; weighted to zigzag).

Atlas has them all in a box, did not change.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map consistency/looks.

## What's it look like?
![Screenshot 2024-01-28 231805](https://github.com/goonstation/goonstation/assets/91498627/5f251859-40ed-4001-a086-218ff7a3e5d7)


<img width="349" alt="Screenshot 2024-01-28 232133" src="https://github.com/goonstation/goonstation/assets/91498627/531bb839-0344-4c2c-845f-e54a59b2e566">






<img width="249" alt="Screenshot 2024-01-28 232509" src="https://github.com/goonstation/goonstation/assets/91498627/78df89f8-56c1-47f7-aede-39b51517cd2e">
