### PR TITLE
Re-arrange get_desc check so that you can see if people have butts without surgery

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -247,12 +247,10 @@
 		else
 			. += "<br>[SPAN_ALERT("<B>[src.name]'s entire chest is missing!</B>")]"
 
-
-		if (src.organHolder.back_op_stage > BACK_SURGERY_CLOSED)
-			if (!src.organHolder.butt)
-				. += "<br>[SPAN_ALERT("<B>[src.name]'s butt seems to be missing!</B>")]"
-			else
-				. += "<br>[SPAN_ALERT("<B>[src.name] has an open incision on [t_his] butt!</B>")]"
+		if (!src.organHolder.butt)
+			. += "<br>[SPAN_ALERT("<B>[src.name]'s butt seems to be missing!</B>")]"
+		else if (src.organHolder.back_op_stage > BACK_SURGERY_CLOSED)
+			. += "<br>[SPAN_ALERT("<B>[src.name] has an open incision on [t_his] butt!</B>")]"
 
 	if (src.limbs)
 		if (!src.limbs.l_arm)


### PR DESCRIPTION
[QoL][Medical]

## About the PR
changes around the ordre of checks around the butt organ so you can see if person does not have a butt without needing BACK_OP_STAGE beign > 0 - meaning, you can see with out doing sugery on the person

## Why's this needed? 
the butt is an external thing. it is not like a heart where you need surgery to see if it is there, a person with no butt will be flat! This fixes that. Makes sense , I think.

also good for doctor and antag that watn to know if 1) patient needs butt, or on other side 2) if they can use ability based on not having butt (wizard). katana and wisard butt spell do not set BACK_OP_STAGE to not-closed when they remove butts, and probably fart storm too, so there is a time when a person can have no butt and have BACK_OP_STAGE not be closed without somebody else closing with suture (and knowing there is no butt, probably)

please tell me if code is not good - it is small, but i am not very sure about it

## Changelog

```changelog
(u)NibChocolateeny
(+)You no longer have to do surgery to determine - by visual observation - if someone lacks a butt.
```
