### PR TITLE
Remove roundstart jars from cog1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -47201,9 +47201,6 @@
 	pixel_x = -7;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/jar,
-/obj/item/reagent_containers/glass/jar,
-/obj/item/reagent_containers/glass/jar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "jKQ" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33667,34 +33667,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cnN" = (
-/obj/rack,
-/obj/item/circuitboard/qmorder{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/robot_module_rewriter{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/barcode_qm{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/barcode{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/card{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/cloning{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/circuitboard/teleporter{
-	pixel_x = 5;
-	pixel_y = -5
+/obj/rack/organized/techstorage_eng{
+	order_override = "zigzag"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -37817,34 +37791,8 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "cCc" = (
-/obj/rack,
-/obj/item/circuitboard/qmsupply{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/telescope{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/circuitboard/powermonitor{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/genetics{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/circuitboard/powermonitor_smes{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/arcade{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/circuitboard/operating{
-	pixel_x = 5;
-	pixel_y = -1
+/obj/rack/organized/techstorage_med{
+	order_override = "zigzag"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -47253,6 +47201,9 @@
 	pixel_x = -7;
 	pixel_y = 2
 	},
+/obj/item/reagent_containers/glass/jar,
+/obj/item/reagent_containers/glass/jar,
+/obj/item/reagent_containers/glass/jar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "jKQ" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33667,8 +33667,34 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cnN" = (
-/obj/rack/organized/techstorage_eng{
-	order_override = "zigzag"
+/obj/rack,
+/obj/item/circuitboard/qmorder{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/robot_module_rewriter{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/barcode_qm{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/barcode{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/circuitboard/card{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/cloning{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/circuitboard/teleporter{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -37791,8 +37817,34 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "cCc" = (
-/obj/rack/organized/techstorage_med{
-	order_override = "zigzag"
+/obj/rack,
+/obj/item/circuitboard/qmsupply{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/telescope{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/circuitboard/powermonitor{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/genetics{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/circuitboard/powermonitor_smes{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/arcade{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/circuitboard/operating{
+	pixel_x = 5;
+	pixel_y = -1
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -47201,9 +47253,6 @@
 	pixel_x = -7;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/glass/jar,
-/obj/item/reagent_containers/glass/jar,
-/obj/item/reagent_containers/glass/jar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "jKQ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the pickle jars from cog1 due to causing a silly bug, but nonetheless a bug.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17819 where lots of jars end up in the cog1 catering storage crate
Addings jars into the .dmm file means that they will continuously get saved and loaded each round, eventually going up to the pickle jar limit. This should not happen.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MeggalBozale
(+)An absurd amount of pickle jars no longer spawn on Cog1,
```
