### PR TITLE
Prevent reagent temperatures from going below 0 Kelvin

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -99,7 +99,7 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 
 	proc/set_reagent_temp(var/new_temp = T0C, var/react = 0)
 		src.last_temp = total_temperature
-		src.total_temperature = new_temp
+		src.total_temperature = max(new_temp, 0)
 		if (react)
 			temperature_react()
 			handle_reactions()


### PR DESCRIPTION
[bug][chemistry]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When setting the reagent temperature, put a bound on the new temperature to ensure it's at least 0 degrees.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The `cryostylane_area_cooling` chemistry recipe causes a negative temperature change in the reagents. Similar other negative temperature changes like charcoal/steam require a hot temperature to occur, and so did not run into this issue.

Fixes #17665