### PR TITLE
Update item name after freshly laundred status ends

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2372,6 +2372,7 @@
 			C.setProperty("coldprot", C.getProperty("coldprot") - LAUNDERED_COLDPROT_AMOUNT)
 			if (C.stains)
 				C.stains -= LAUNDERED_STAIN_TEXT
+				C.UpdateName()
 
 #undef LAUNDERED_COLDPROT_AMOUNT
 #undef LAUNDERED_STAIN_TEXT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After remvoing the freshly-laundred stain from its list, update the name of the object appropriately.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The freshly-laundered effect did not update the name of the item, causing the name to desync from when the effect actually ended.