### PR TITLE
add external cycling airlocks to cogmap 1

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1666,6 +1666,8 @@ About the new airlock wires panel:
 /// adds the airlock in question to the global list.
 /obj/machinery/door/airlock/proc/attempt_cycle_link()
 	if (src.cycle_id)
+		if(!cycling_airlocks[src.cycle_id])	// add a list to the list of lists
+			cycling_airlocks[src.cycle_id] = list()
 		if (!(src in cycling_airlocks[src.cycle_id]))
 			cycling_airlocks[src.cycle_id] += src
 

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -41089,6 +41089,24 @@
 /obj/machinery/meter,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
+"eKd" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/decal/stripe_delivery,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape2";
+	name = "Escape";
+	enter_id = "main"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "eKk" = (
 /obj/machinery/conveyor/EW{
 	name = "cargo belt - west";
@@ -43350,6 +43368,11 @@
 "grs" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape";
+	name = "Escape";
+	enter_id = "main"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "gse" = (
@@ -50279,6 +50302,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape";
+	name = "Escape";
+	enter_id = "main"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "mpC" = (
@@ -55775,6 +55803,20 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
+"qAO" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape";
+	name = "Escape";
+	enter_id = "outer"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "qBh" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable/yellow{
@@ -56778,6 +56820,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
+"rsy" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape2";
+	name = "Escape";
+	enter_id = "main"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "rsK" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -57389,6 +57441,11 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape2";
+	name = "Escape";
+	enter_id = "outer"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -110950,7 +111007,7 @@ cdw
 cpY
 crb
 jje
-grs
+rsy
 kFN
 uzt
 uzt
@@ -111252,7 +111309,7 @@ cqe
 cqe
 hpX
 vIN
-grs
+rsy
 ctI
 yht
 yht
@@ -111555,10 +111612,10 @@ uLB
 uLB
 uLB
 uLB
-mpv
+eKd
 uLB
 uLB
-mpv
+eKd
 uLB
 adC
 adC
@@ -116693,7 +116750,7 @@ cIO
 yht
 yht
 lpQ
-rRo
+qAO
 adC
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -21155,6 +21155,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint2";
+	name = "East Maintenance"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bty" = (
@@ -23880,6 +23884,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solar Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
@@ -38651,6 +38659,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "centmaint1";
+	name = "Central Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ddy" = (
@@ -41191,6 +41203,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining1";
+	name = "Mining";
+	enter_id = "outer"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "ePw" = (
@@ -42726,6 +42743,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint2";
+	name = "East Maintenance"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "fVm" = (
@@ -43112,6 +43133,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
@@ -43907,6 +43933,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "medical";
+	name = "Medical Storage"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Medical Storage"
@@ -44413,6 +44443,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining1";
+	name = "Mining";
+	enter_id = "inner"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -48032,6 +48067,10 @@
 /obj/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solar Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "koS" = (
@@ -50312,6 +50351,11 @@
 "msZ" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "mtb" = (
@@ -50376,6 +50420,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "warehouse";
+	name = "Central Warehouse"
 	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
@@ -50632,6 +50680,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westsolar";
+	name = "West Solar Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "mBW" = (
@@ -50773,6 +50825,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westsolar";
+	name = "West Solar Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "mIC" = (
@@ -50785,6 +50841,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "warehouse";
+	name = "Central Warehouse"
 	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
@@ -50884,6 +50944,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "centmaint1";
+	name = "Central Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -51994,6 +52058,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar";
+	name = "North Solar Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "nGY" = (
@@ -52088,6 +52156,10 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "centmaint2";
+	name = "Central Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -54880,6 +54952,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint1";
+	name = "East Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "pVw" = (
@@ -57007,6 +57083,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "centmaint2";
+	name = "Central Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "rGl" = (
@@ -57813,6 +57893,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining1";
+	name = "Mining";
+	enter_id = "outer"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -59179,6 +59264,10 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/medical,
 /obj/mapping_helper/access/medical,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "medical";
+	name = "Medical Storage"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Medical Storage"
@@ -59266,6 +59355,11 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "tqQ" = (
@@ -60218,6 +60312,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining1";
+	name = "Mining";
+	enter_id = "inner"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "uaJ" = (
@@ -60781,6 +60880,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar";
+	name = "North Solar Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
@@ -63048,6 +63151,10 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint1";
+	name = "East Maintenance"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/east)


### PR DESCRIPTION
[MAPPING] [QOL]
## About the PR
Adds the new cycling airlock mechanism from  #17459 to cogmap1. Spots where they are used are available in mapdiffbot.
To those unfamiliar, all it means is that attempting to open an "outer" door will try to close the "inner door". It only tries it once, however, and is overridden by safety checks. It won't lock you inside, just gently tries to close the other door behind you. These are best applied to setups where two doors separate space and interior.

These were added by using airlock cycle map helpers. I also var edited their names, not just their IDs, so that the strongdmm prefabs tab is more legible.

They have not been added to every single possible place that could use them, notably shuttle docking bays, because they would simply impede foot traffic (and aren't supposed to open out into space anyway). Similarly they're not applied to "departmental airlocks" like in engineering, because it's not... locking air.

This also only adds it to cogmap1 for now. If it's not strongly hated then I'll PR it to other maps.

P.S. This also fixes a pretty critical bug with how cycling airlocks works, ported from coolstation commit d195ae114bca61ec373923b137a323545f929c06

## Why's this needed?
It's nice to use them, and should stop air leaking from careless door opening. Seems like something that should have already existed.

## Changelog
```changelog
(u)Tyrant
(+)Some airlocks are now linked in a way that opening one door tries to close the other doors. "Keep the Air Inside!" ~John Nanotrasen probably.
```