### PR TITLE
add external cycling airlocks to atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -479,6 +479,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar2";
+	name = "North Solars"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/substation/west)
 "abY" = (
@@ -897,6 +901,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar";
+	name = "North Solars"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "adb" = (
@@ -914,6 +922,10 @@
 	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar";
+	name = "North Solars"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
@@ -1843,6 +1855,10 @@
 /area/station/medical/morgue)
 "afX" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northmerch";
+	name = "North Merchant Dock"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/primary/south)
 "afZ" = (
@@ -8201,6 +8217,11 @@
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solars";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/substation/east)
 "aBu" = (
@@ -8685,6 +8706,10 @@
 "aCX" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/mining,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining";
+	name = "Mining"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/staff_room)
 "aCY" = (
@@ -9123,6 +9148,11 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solars";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/substation/east)
 "aEc" = (
@@ -10318,6 +10348,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/mining,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining";
+	name = "Mining"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/mining/staff_room)
 "aHJ" = (
@@ -10344,6 +10378,10 @@
 /area/station/janitor/office)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southmerch";
+	name = "South Merchant Dock"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/main)
 "aHO" = (
@@ -10478,6 +10516,11 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solars";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "aIx" = (
@@ -10498,6 +10541,11 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southsolar";
+	name = "South Solars";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -10853,6 +10901,11 @@
 "aKb" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "inner"
+	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "aKc" = (
@@ -11070,6 +11123,11 @@
 /area/station/hangar/arrivals)
 "aKJ" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "outer"
+	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "aKK" = (
@@ -18069,6 +18127,10 @@
 /obj/mapping_helper/access/engineering_power,
 /obj/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northsolar2";
+	name = "North Solars"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/substation/west)


### PR DESCRIPTION
[MAPPING] [QOL] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Similar to https://github.com/goonstation/goonstation/pull/17828. Requires https://github.com/goonstation/goonstation/pull/17828 to be merged first, as there is a bugfix in that which needs to be applied for cycling airlocks to work.

Adds airlock cycling mechanisms to external, space facing airlocks on atlas. Doesn't apply it to every set of doors for ease of player foot transit.

## Why's this needed?
Same reason as https://github.com/goonstation/goonstation/pull/17828