### PR TITLE
add external cycling airlocks to kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -365,6 +365,10 @@
 	dir = 4;
 	name = "Owl Zone Access"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "owlrey";
+	name = "Owlrey"
+	},
 /turf/simulated/floor/grey,
 /area/station/garden/owlery)
 "abt" = (
@@ -386,6 +390,10 @@
 "abw" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Owl Zone Access"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "owlrey";
+	name = "Owlrey"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/garden/owlery)
@@ -1002,6 +1010,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "routing2";
+	name = "Routing Cabinet"
+	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
 	name = "Router Cabinet"
@@ -1087,6 +1099,10 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "routing2";
+	name = "Routing Cabinet"
+	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
 	name = "Router Cabinet"
@@ -1130,6 +1146,11 @@
 "aeb" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "inner"
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
@@ -1308,6 +1329,11 @@
 /area/station/maintenance/northwest)
 "aeN" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aeO" = (
@@ -1354,6 +1380,10 @@
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northmaint2";
+	name = "North Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -1809,6 +1839,10 @@
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northmaint2";
+	name = "North Maintenance"
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/north)
@@ -5609,6 +5643,11 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -5808,6 +5847,11 @@
 "avv" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "inner"
 	},
 /turf/simulated/floor/grey/side,
 /area/station/maintenance/northwest)
@@ -8328,6 +8372,10 @@
 /area/station/maintenance/east)
 "aFO" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint";
+	name = "East Maintenance"
+	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/east)
 "aFQ" = (
@@ -13476,6 +13524,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "routing";
+	name = "Routing Depot";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "bcf" = (
@@ -13977,6 +14030,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "routing";
+	name = "Routing Depot";
+	enter_id = "inner"
 	},
 /turf/simulated/floor,
 /area/station/routing/depot)
@@ -15147,6 +15205,10 @@
 "bjz" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastmaint";
+	name = "East Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -17713,6 +17775,10 @@
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westmaint";
+	name = "West Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -21661,6 +21727,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escapebay";
+	name = "Escape Pod Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor,
 /area/station/hangar/escape)
 "bJH" = (
@@ -25232,6 +25303,10 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westinnermaint";
+	name = "West Inner Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "bXG" = (
@@ -26628,6 +26703,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escapebay";
+	name = "Escape Pod Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor,
 /area/station/hangar/escape)
 "cdD" = (
@@ -27206,6 +27286,10 @@
 /area/station/crew_quarters/market)
 "cfS" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "merchanta";
+	name = "Merchant Shuttle Dock"
+	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/market)
 "cfT" = (
@@ -30886,6 +30970,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southwestinnermaint";
+	name = "Southwest Inner Maintenance";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/refinery)
 "cLB" = (
@@ -30932,6 +31021,20 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"cNE" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "northmaint";
+	name = "North Maintenance"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "cNM" = (
 /obj/stool/chair,
 /turf/simulated/floor/neutral/side{
@@ -33162,6 +33265,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "engineering";
+	name = "Engineering Bay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
 "emI" = (
@@ -33727,6 +33835,11 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/engineering_storage,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "engineering";
+	name = "Engineering Bay";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
 "eEn" = (
@@ -33845,6 +33958,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "engineering";
+	name = "Engineering Bay";
+	enter_id = "inner"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/storage)
@@ -34068,6 +34186,10 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westsolars";
+	name = "West Solars"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "ePl" = (
@@ -34972,6 +35094,11 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "routing";
+	name = "Routing Depot";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "fzb" = (
@@ -35723,6 +35850,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -35792,6 +35924,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
+"gfC" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "merchantb";
+	name = "Merchant Shuttle Dock"
+	},
+/turf/simulated/floor/neutral,
+/area/station/crew_quarters/market)
 "gfE" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -37313,6 +37453,10 @@
 "hed" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/cargo,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "cargobay";
+	name = "Cargo Bay"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/cargobay)
 "heQ" = (
@@ -38948,10 +39092,18 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastsolars";
+	name = "East Solars"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "iEB" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southmaint";
+	name = "South Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "iEQ" = (
@@ -39936,6 +40088,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "miningshuttle";
+	name = "Mining Shuttle";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/grey/side,
 /area/station/maintenance/northwest)
@@ -41296,6 +41453,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westinnermaint";
+	name = "West Inner Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "koE" = (
@@ -41783,6 +41944,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westsolars";
+	name = "West Solars"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -42426,6 +42591,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "merchanta";
+	name = "Merchant Shuttle Dock"
 	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/market)
@@ -43523,6 +43692,19 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
+"lPV" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "merchantb";
+	name = "Merchant Shuttle Dock"
+	},
+/turf/simulated/floor/neutral,
+/area/station/crew_quarters/market)
 "lQz" = (
 /obj/machinery/light{
 	dir = 1;
@@ -44260,6 +44442,10 @@
 "mAq" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastinnermaint";
+	name = "East Inner Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
@@ -45187,6 +45373,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining";
+	name = "Mining"
 	},
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
@@ -46300,6 +46490,11 @@
 "oeN" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Auxiliary Docking Point"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape";
+	name = "Escape";
+	enter_id = "inner"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
@@ -47440,6 +47635,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eva";
+	name = "EVA Storage";
+	enter_id = "inner"
+	},
 /turf/simulated/floor,
 /area/station/storage/eva)
 "oYA" = (
@@ -47994,6 +48194,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southwestinnermaint";
+	name = "Southwest Inner Maintenance";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
 "pst" = (
@@ -48076,6 +48281,10 @@
 /obj/grille/catwalk,
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "westmaint";
+	name = "West Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -48908,6 +49117,10 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/mining,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "mining";
+	name = "Mining"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/magnet)
 "qcA" = (
@@ -49563,6 +49776,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escape";
+	name = "Escape";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "qym" = (
@@ -49928,6 +50146,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastsolars";
+	name = "East Solars"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -51504,6 +51726,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eva";
+	name = "EVA Storage";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "sbP" = (
@@ -52215,6 +52442,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eastinnermaint";
+	name = "East Inner Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "sFU" = (
@@ -52225,6 +52456,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "engine";
+	name = "Inner Engineering"
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
@@ -54852,6 +55087,10 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southmaint";
+	name = "South Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "uDK" = (
@@ -54930,6 +55169,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/engineering_engine,
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "engine";
+	name = "Inner Engineering"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "uGb" = (
@@ -56919,6 +57162,11 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "podbay";
+	name = "Pod Bay";
+	enter_id = "outer"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "wmg" = (
@@ -56971,6 +57219,11 @@
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "eva";
+	name = "EVA Storage";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
@@ -57274,6 +57527,11 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "escapebay";
+	name = "Escape Pod Bay";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/escape)
@@ -58512,6 +58770,11 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "southwestinnermaint";
+	name = "Southwest Inner Maintenance";
+	enter_id = "inner"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
@@ -101447,9 +101710,9 @@ ccw
 cdo
 ceh
 cfc
-cfS
+gfC
 cgF
-lgW
+lPV
 cqM
 cqM
 cqM
@@ -107086,7 +107349,7 @@ acX
 fKp
 aca
 ael
-aeU
+cNE
 ael
 agG
 tOx
@@ -107690,7 +107953,7 @@ aaa
 aaO
 adp
 adp
-aeU
+cNE
 adp
 agG
 ahI


### PR DESCRIPTION
[MAPPING] [QOL] [FEATURE]
## About the PR
Similar to https://github.com/goonstation/goonstation/pull/17828. Requires https://github.com/goonstation/goonstation/pull/17828 to be merged first, as there is a bugfix in that which needs to be applied for cycling airlocks to work.

Adds airlock cycling mechanisms to external, space facing airlocks on kondaru. Doesn't apply it to every set of doors for ease of player foot transit.

## Why's this needed?
Same reason as https://github.com/goonstation/goonstation/pull/17828