### PR TITLE
Add end of round gang portraits

### DIFF
--- a/code/datums/hud/gang_victory.dm
+++ b/code/datums/hud/gang_victory.dm
@@ -3,6 +3,7 @@
 	var/atom/movable/screen/text
 
 	New(datum/gang/winning_gang)
+		//big gang name victory text
 		src.text = create_screen("gangvictory", "Gang Victory Display", null, "", "NORTH,CENTER", HUD_LAYER_3)
 		text.maptext = "<span class='c ol vga vt' style='background: #00000080;font-size: 5;'>[winning_gang.gang_name] won the round!</span>"
 		text.maptext_width = 600
@@ -11,4 +12,41 @@
 		text.maptext_height = 100
 		text.plane = PLANE_HUD
 		text.layer = 420
+
+		//individual gang member portraits
+		var/member_count = 0
+		var/list/members = winning_gang.members
+		members.Insert(round(length(members)/2), winning_gang.leader) //put the leader roughly in the middle
+		for (var/datum/mind/gang_mind in members)
+			var/mob/ganger = gang_mind.current
+			if (!ganger) //paranoia because we REALLY don't want to blow up the round-end stack
+				continue
+
+			if (isliving(ganger) && isdead(ganger))
+				if (!ganger.ghost)
+					ganger = ganger.ghostize()
+				else
+					ganger = ganger.ghost
+
+			var/position = -round(length(members)/2) + member_count
+			var/position_string = "CENTER[position > 0 ? "+" : ""][position ? position : ""], CENTER+1.8"
+
+			//getFlatIcon's dir argument doesn't work here for some reason
+			var/old_dir = ganger.dir
+			ganger.set_dir(SOUTH)
+			var/icon/flat_icon = getFlatIcon(ganger)
+			ganger.set_dir(old_dir)
+
+			var/atom/movable/screen/screen_obj = create_screen("gang_member[member_count]", ganger.real_name, null, "", position_string, mouse_opacity=FALSE)
+			screen_obj.Scale(2,2)
+			screen_obj.icon = flat_icon
+
+			var/atom/movable/screen/nametag = create_screen("gang_member[member_count]_name", ganger.real_name, null, "", position_string, mouse_opacity=FALSE)
+			nametag.maptext_y = 40
+			nametag.maptext_x = -32
+			//centered, pixel, drop shadow (I love readable class names!)
+			nametag.maptext = "<span class='c pixel sh' [gang_mind == winning_gang.leader ? "style='color: #FFD149;'" : ""]>[ganger.real_name]</span>"
+			nametag.maptext_width = 100
+
+			member_count++
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds cool portraits of all the members of the winning gang at the end of the round.
Looks something like this:
![image](https://github.com/goonstation/goonstation/assets/20713227/147b04fb-9da5-4724-9643-3244a46014a0)
Only the gang leader's name is gold, dead gang members will show as ghosts.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More uhhh Pride and Clout for the winning gang members, hopefully making people more likely to care about winning the round.
This might be a little too in your face, I'm open to suggestions to change it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Members of the winning gang will now be displayed at round end.
```
