### PR TITLE
Move Clarion's central maintenance apc

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13481,6 +13481,10 @@
 	pixel_y = 21
 	},
 /obj/storage/cart/trash,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "boU" = (
@@ -20736,21 +20740,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "eJJ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Armory APC";
-	noalerts = 1;
-	pixel_x = -24
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
 	name = "autoname  - SS13";
 	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/central)
@@ -35410,6 +35407,9 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR
Sequel to  #17827.

Moves and renames the central maint APC. Previously it was behind a heads only door and confusingly called armoury APC (it didn't control the armoury).

## Why's this needed?
Bugs bad. There shouldn't be two armoury APCs, that's misleading. And central maintenance's APC shouldn't be behind a head access door, it just hassles engineers trying to fix/sabotage it.

## Changelog
```changelog
(u)Tyrant
(+)Clarion's central maintenance APC has been moved to actually be in central maintenance (and is no longer confusingly called armoury APC)
```