### PR TITLE
Tweak and fix of the misc tools box

### DIFF
--- a/code/obj/item/storage/misc.dm
+++ b/code/obj/item/storage/misc.dm
@@ -115,11 +115,11 @@
 	/obj/item/reagent_containers/glass/bottle/holywater)
 
 /obj/item/storage/box/misctools //used in CE locker
-	name = "miscellaneous tools"
-	desc = "A box full of tools, but distinctly seperate from a toolbox."
+	name = "spare tools box"
+	desc = "A box full of tools, but distinctly separate from a toolbox."
 	icon_state = "box"
 	spawn_contents = list(
-		/obj/item/electronics/scanner,
+		/obj/item/device/gps,
 		/obj/item/device/analyzer/atmospheric/upgraded,
 		/obj/item/electronics/soldering,
 		/obj/item/cargotele,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the mechscanner from the ce toolbox, adds a space GPS instead. Also correctly spells "separate".

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

They already have a mechscanner in their PDA. Also spelling things right is probably good.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
