### PR TITLE
add external cycling airlocks to Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1740,6 +1740,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "North Maintenance";
+	cycle_id = "northmaint"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "axg" = (
@@ -8238,6 +8242,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Toxin Storage";
+	cycle_id = "toxins"
+	},
 /turf/simulated/floor/black,
 /area/station/science/storage)
 "coS" = (
@@ -8245,7 +8253,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/access,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -9722,7 +9729,6 @@
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cMR" = (
@@ -10168,6 +10174,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "North Maintenance";
+	cycle_id = "northmaint"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
@@ -14301,6 +14311,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "East Solar Maintenance";
+	cycle_id = "eastsolar"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "ejc" = (
@@ -14888,6 +14902,11 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/access/maint,
+/obj/mapping_helper/airlock/cycler{
+	name = "Med Bay";
+	cycle_id = "medbay";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "esP" = (
@@ -24923,6 +24942,10 @@
 /area/station/ai_monitored/armory)
 "hvZ" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	name = "North Inner Maintenance";
+	cycle_id = "n_innermaint"
+	},
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/north)
 "hwl" = (
@@ -25918,6 +25941,11 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Med Bay";
+	cycle_id = "medbay";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -29456,6 +29484,11 @@
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/mining,
+/obj/mapping_helper/airlock/cycler{
+	name = "Mining";
+	cycle_id = "mining";
+	enter_id = "inner"
+	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
 "iWm" = (
@@ -30408,6 +30441,10 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Bomb Testing Chamber";
+	cycle_id = "bombtest"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber/bombchamber)
@@ -33483,6 +33520,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Bomb Testing Chamber";
+	cycle_id = "bombtest"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber/bombchamber)
 "khw" = (
@@ -34932,7 +34973,6 @@
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access,
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -35700,6 +35740,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Toxin Storage";
+	cycle_id = "toxins"
 	},
 /turf/simulated/floor/black,
 /area/station/science/storage)
@@ -41251,6 +41295,11 @@
 	dir = 8;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Mining";
+	cycle_id = "mining";
+	enter_id = "outer"
 	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
@@ -47835,6 +47884,10 @@
 /obj/mapping_helper/access/research,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Science Lobby";
+	cycle_id = "scilobby"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/lobby)
 "oAy" = (
@@ -47874,6 +47927,10 @@
 "oBp" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/airlock/cycler{
+	name = "North Inner Maintenance";
+	cycle_id = "n_innermaint"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "oBq" = (
@@ -48791,6 +48848,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/research,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Science Lobby";
+	cycle_id = "scilobby"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "oQI" = (
@@ -50755,6 +50816,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "West Solar Maintenance";
+	cycle_id = "westsolar"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/west)
@@ -54276,6 +54341,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Northeast Maintenance";
+	cycle_id = "northeastmaint"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "qwZ" = (
@@ -55374,6 +55443,10 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
+	},
+/obj/mapping_helper/airlock/cycler{
+	name = "Southwest Inner Maintenance";
+	cycle_id = "sw_innermaint"
 	},
 /turf/simulated/floor/grime{
 	dir = 8
@@ -61538,6 +61611,10 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/maint,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Southwest Inner Maintenance";
+	cycle_id = "sw_innermaint"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "sMH" = (
@@ -62432,7 +62509,6 @@
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "tbs" = (
@@ -69749,6 +69825,10 @@
 	},
 /obj/mapping_helper/access/maint,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Northeast Maintenance";
+	cycle_id = "northeastmaint"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "vmB" = (
@@ -72094,6 +72174,10 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering,
+/obj/mapping_helper/airlock/cycler{
+	name = "West Solar Maintenance";
+	cycle_id = "westsolar"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "vVY" = (
@@ -74995,6 +75079,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/airlock/cycler{
+	name = "East Solar Maintenance";
+	cycle_id = "eastsolar"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
 "wNd" = (
@@ -76835,6 +76923,10 @@
 	powerlevel = 1
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Pool and Owlrey";
+	cycle_id = "pool"
+	},
 /turf/simulated/floor,
 /area/spacehabitat/pool)
 "xms" = (
@@ -77375,6 +77467,10 @@
 	name = "Pool Access"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/airlock/cycler{
+	name = "Pool and Owlrey";
+	cycle_id = "pool"
+	},
 /turf/simulated/floor/grey,
 /area/spacehabitat/pool)
 "xuj" = (
@@ -79039,6 +79135,18 @@
 	tag = ""
 	},
 /obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/plating/jen,
+/area/station/hallway/secondary/exit)
+"xTv" = (
+/obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/decal/tile_edge/line/white{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
 "xTw" = (
@@ -143531,7 +143639,7 @@ etV
 etV
 sdZ
 sdZ
-fdX
+xTv
 sdZ
 sdZ
 etV
@@ -143541,7 +143649,7 @@ sdZ
 etV
 sdZ
 sdZ
-fdX
+xTv
 sdZ
 sdZ
 etV


### PR DESCRIPTION
[MAPPING] [QOL] [FEATURE]
## About the PR
See title.

Also removes some of the blank access spawners that were on some public doors.

## Why's this needed?
Same reasoning as #17828