### PR TITLE
OpenDream: lots of things need a delay before hard del

### DIFF
--- a/code/del.dm
+++ b/code/del.dm
@@ -25,7 +25,8 @@ proc/qdel(var/datum/D)
 				qdel(C)
 
 		#ifdef OPENDREAM
-		del(D)
+		SPAWN(1)
+			del(D)
 		return
 		#endif
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is unbelievably cursed, but in lieu of GC....

It turns out a lot of things in goon rely on `qdel()` not being instant.
