### PR TITLE
Makes busting a singularity uncompress into a white hole

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1578,7 +1578,7 @@ datum/projectile/bullet/autocannon
 	on_hit(atom/hit)
 		var/obj/machinery/the_singularity/S = hit
 		if(istype(S))
-			new /obj/bhole(S.loc,rand(100,300))
+			new /obj/whitehole(S.loc, 0 SECONDS, 30 SECONDS)
 			qdel(S)
 		else
 			new /obj/effects/rendersparks(hit.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Instead of collapsing into a black hole, busted singularities now uncollapse into a white hole.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes busting a rogue singularity a bit less devastating and more interesting. Plus, if its destroying the singularity, surely all that matter has to go somewhere?

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+) Using the singularity buster to destroy a singularity now causes a white hole to spawn.
```
