### PR TITLE
Fix disguiser organ names being permament

### DIFF
--- a/code/obj/item/device/disguiser.dm
+++ b/code/obj/item/device/disguiser.dm
@@ -134,6 +134,7 @@ TYPEINFO(/obj/item/device/disguiser)
 		// Restore original appearance.
 		else
 			user.real_name = src.real_name
+			user.on_realname_change()
 			AH.CopyOther(oldAH)
 			if (user.limbs)
 				user.limbs.reset_stone()

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -623,6 +623,7 @@
 			var/list/organ_name_parts = splittext(O.name, "'s")
 			if(length(organ_name_parts) == 2)
 				O.name = "[user_name]'s [organ_name_parts[2]]"
+				O.donor_name = user_name
 
 	//input organ = string value of organ_list assoc list
 	proc/get_organ(var/organ)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes organ name reset after the holographic disguise expires.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Organ name changes were permanent.
Head was not renamed to match disguise (it sets name in update_icon using donor._name).