### PR TITLE
Check for juicer overfill before juicing.

### DIFF
--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -701,7 +701,7 @@ ported and crapped up by: haine
 			var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 			user.show_text("You transfer [trans] unit\s of the solution to [target].")
 
-		if (reagents.total_volume == reagents.maximum_volume) // See if the juicer is full.
+		if (src.reagents.total_volume >= src.reagents.maximum_volume) // See if the juicer is full.
 			user.show_text("[src] is full!", "red")
 			return
 


### PR DESCRIPTION
[game objects][bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check if the volume is greater-than or equal to the max volume instead of just equal; prevents the juicer from unneedingly juicing a fruit and using a negative reagent transfer amount.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* numbers are floats
* Fixes #17851