### PR TITLE
Place 2 missing pipes in cogmap1 singularity engine

### DIFF
--- a/assets/maps/engine_rooms/cogmap/singularity_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/singularity_100.dmm
@@ -178,6 +178,7 @@
 /obj/cable/orange{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating/jen,
 /area/station/engine/inner)
 "pl" = (
@@ -330,6 +331,7 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/simulated/floor/plating/jen,
 /area/station/engine/inner)
 "Gn" = (


### PR DESCRIPTION
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The doors to the singularity chamber in cogmap1's singularity engine prefab don't have pipes under them, for some reason. It's likely that they were removed by mistake. This PR places them back

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #17881
