### PR TITLE
Prevent prefilled drinking glasses from overfilling

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1660,18 +1660,22 @@ ADMIN_INTERACT_PROCS(/obj/item/reagent_containers/food/drinks/drinkingglass, pro
 				src.amount_per_transfer_from_this = 15
 				src.gulp_size = 15
 				src.initial_volume = 15
+				src.reagents.maximum_volume = 15
 			if ("wine")
 				src.name = "wine glass"
 				src.icon_state = "glass-wine"
 				src.initial_volume = 30
+				src.reagents.maximum_volume = 30
 			if ("cocktail")
 				src.name = "cocktail glass"
 				src.icon_state = "glass-cocktail"
 				src.initial_volume = 20
+				src.reagents.maximum_volume = 20
 			if ("flute")
 				src.name = "champagne flute"
 				src.icon_state = "glass-flute"
 				src.initial_volume = 20
+				src.reagents.maximum_volume = 20
 
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled


### PR DESCRIPTION
[BUG] [CHEMISTRY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The prefilled variant of drinking glass, aka `/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled`, would manually set `initial_volume` to the correct amount once the random drink type was picked. However, since the parent code of `New()` had already run, the true `reagents.maximum_volume` was set at `50` due to that being the `initial_volume` of the parent drinking glass when it was made.

This PR manually sets `src.reagents.maximum_volume` at the same time as `initial_volume` is set.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17585
Previously, you could end up with shot glasses with 50u of chemicals inside.