### PR TITLE
Add baseline 15 potency to plants

### DIFF
--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -252,7 +252,7 @@ ABSTRACT_TYPE(/datum/plant)
 	var/harvtime = 0 // same vars found in /datum/plant honestly. They go largely towards
 	var/harvests = 0 // the same purpose for the most part.
 	var/cropsize = 0
-	var/potency = 0  // Apart from this one - this one deals with reagents.
+	var/potency = 15  // Apart from this one - this one deals with reagents.
 	var/endurance = 0
 	var/list/commuts = null // General transferrable mutations
 	var/datum/plantmutation/mutation = null // is it mutated? if so which variation?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL][HYDROPONICS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes all seeds start at potency 15


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Partially addresses the difficulties in getting Fruit Juice as bartender
- Lets well meaning, less-knowledgeable  botanists provide useful ingredients to Bar
- Bartenders can simply ask for 'apples'/'oranges', instead of 'infused apples & oranges' 
- Makes a bit more sense (space seeds create bone dry watermelon?
- Makes 'dry food' a unique thing for botanists to make
- Makes more sense than adding a flat '15' to all reagents created by plants

dunno if there are more balance ramifications, idk any seed you cant just hit "infuse" 4 times with saltpetre on.

i got more bartending ideas coming up to better address bartending/botany co-operation directly. but this is a 2 character bandaid that helps a lot

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Plants have a baseline 15 potency
```
