### PR TITLE
Increases range limit on floor and wall designer

### DIFF
--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -610,7 +610,7 @@ TYPEINFO(/obj/item/room_planner)
 			T = get_turf(T)
 		if (!T || !mode)
 			return 0
-		if (GET_DIST(T, user) > 1)
+		if (GET_DIST(T, user) > 3)
 			return 0
 
 		if (mode == "restore original") //For those who want to undo the carnage


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the Floor and Wall Designer's range from 1 tile away maximum to 3 tiles away maximum.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

1. Some rooms have tiles you cannot stand next to without breaking some stuff. Usually tables, more often walls that have multiple things in the way.

2. Some designs require the user to stand in an unusual way; for example, for a 4-tile "plus" design, you stand on the rim of where you want to place the design and click such that you're making corner floorings in the "opposite" way that's intended.

3. A range greater than one makes it easier to quickly click on tiles that are partially obscured; trying to click on, for example, a floortile a vending machine is on without paying enough attention (such as from trying to tile quickly) can cause you to hit the vending machine. >1 range allows you to stand away from such obstructions, guaranteeing a floortile change instead of hitting something/putting the device on a table/etc.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Saccha
(+)The floor and wall designer has a range of three tiles.
```
