### PR TITLE
Lets midround wraiths evolve without souls

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -299,7 +299,7 @@ var/global
 	announce_banlogin = 1
 	announce_jobbans = 0
 	radio_audio_enabled = 1
-
+	latejoin_wraith = 0
 
 	outpost_destroyed = 0
 	signal_loss = 0

--- a/code/modules/admin/custom_spawn_event.dm
+++ b/code/modules/admin/custom_spawn_event.dm
@@ -190,6 +190,8 @@
 					boutput(ui.user, "That's not a mob, dingus.")
 			if ("select_mob_type")
 				src.spawn_event.thing_to_spawn = tgui_input_list(ui.user, "Select mob type", "Select type", concrete_typesof(/mob/living)) || src.spawn_event.thing_to_spawn
+				if (src.spawn_event.thing_to_spawn == /mob/living/intangible/wraith)
+					latejoin_wraith = 1
 			if ("select_job")
 				var/list/job_names = list()
 				for (var/datum/job/job in (job_controls.staple_jobs + job_controls.special_jobs + job_controls.hidden_jobs))

--- a/code/modules/antagonists/wraith/abilties/specialize.dm
+++ b/code/modules/antagonists/wraith/abilties/specialize.dm
@@ -9,10 +9,9 @@
 	var/static/list/paths = list("Rot" = 1, "Summoner" = 2, "Trickster" = 3)
 	var/list/paths_buttons = list()
 
-
 	New()
-		if (istype(ticker.mode, /datum/game_mode/disaster)) //For Disaster wraith
-			desc = "Choose a form to evolve into using the power of the void"
+		if (istype(ticker.mode, /datum/game_mode/disaster) || latejoin_wraith == 1) //For Disaster wraith
+			desc = "Choose a form to evolve into using the power of the void!"
 
 		..()
 
@@ -29,15 +28,15 @@
 			return 1
 
 	proc/evolve(var/effect as text)
+		var/mob/living/intangible/wraith/W
 		var/datum/abilityHolder/wraith/AH = holder
-		if (AH.corpsecount < AH.absorbs_to_evolve && !istype(ticker.mode, /datum/game_mode/disaster))
+		if (AH.corpsecount < AH.absorbs_to_evolve && !istype(ticker.mode, /datum/game_mode/disaster) && !latejoin_wraith)
 			boutput(holder.owner, SPAN_NOTICE("You didn't absorb enough souls. You need to absorb at least [AH.absorbs_to_evolve - AH.corpsecount] more!"))
 			return 1
 		if (holder.points < pointCost)
 			boutput(holder.owner, SPAN_NOTICE("You do not have enough points to cast this. You need at least [pointCost] points."))
 			return 1
 		else
-			var/mob/living/intangible/wraith/W
 			switch (effect)
 				if (1)
 					W = new/mob/living/intangible/wraith/wraith_decay(holder.owner)

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -121,6 +121,9 @@
 
 		src.respawn_lock = 1
 
+		if(src.antagonist_type == "Wraith")
+			latejoin_wraith = 1
+
 		// 1: alert | 2: alert (chatbox) | 3: alert acknowledged (chatbox) | 4: no longer eligible (chatbox) | 5: waited too long (chatbox)
 		var/list/text_messages = list()
 		text_messages.Add("Would you like to respawn as a [src.antagonist_type] antagonist? Your name will be added to the list of eligible candidates and may be selected at random by the game.") // Do disclose which type it is. You know, ghosts can already metagame in a myriad of ways.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Gamemodes] [C-Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wraiths can currently bypass the 3 souls needed to evolve on disaster rounds. This PR gives the same functionality to midround wraiths.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Midrounds start from roughly 25 minutes into the shift. From my observations, it takes a fast wraith about 10 minutes to get the souls needed to evolve. A slower, unlucky or newer wraith might take around 20 minutes. 

Midround wraiths, at best, lose out on 25 minutes to build up to evolution. Often they're spawned later, which is a particular detriment to trickster wraith on classic I feel. This is because when you evolve, you lose your points and (correct me if I'm wrong) passive point gen total, on top of the time needed to collect the souls. Wraiths tend to have some long cooldowns, so I think this would allow for more interaction past animated objects and such for midround wraiths.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
```changelog
(u)CalliopeSoups
(+) Midround wraiths can now evolve as soon as they have the points.
```
