### PR TITLE
Let tiny items be hidden under floor tiles

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -82,6 +82,8 @@
 	#define COMSIG_MOVABLE_CONTRABAND_CHANGED "mov_contraband_changed"
 	/// get contraband level of movable (check_nonfirearms, check_firearms)
 	#define COMSIG_MOVABLE_GET_CONTRABAND "mov_get_contraband"
+	/// when an AM is revealed from under a floor tile (turf revealed from)
+	#define COMSIG_MOVABLE_FLOOR_REVEALED "mov_floor_revealed"
 
 	// ---- complex ----
 

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -80,6 +80,7 @@
 
 	disposing()
 		clear_armer()
+		UnregisterSignal(src, COMSIG_MOVABLE_FLOOR_REVEALED)
 		. = ..()
 
 	attack_hand(mob/user)

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -38,6 +38,10 @@
 				src.grenade = new /obj/item/chem_grenade/cleaner(src)
 				return
 
+	New()
+		..()
+		RegisterSignal(src, COMSIG_MOVABLE_FLOOR_REVEALED, PROC_REF(triggered))
+
 	examine()
 		. = ..()
 		if (src.armed)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2138,7 +2138,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 /turf/simulated/floor/restore_tile()
 	..()
 	for (var/obj/item/item in src.contents)
-		if (item.w_class <= W_CLASS_TINY) //I wonder if this will cause problems
+		if (item.w_class <= W_CLASS_TINY && !item.anchored) //I wonder if this will cause problems
 			src.hide_inside(item)
 
 ////////////////////////////////////////////ADVENTURE SIMULATED FLOORS////////////////////////

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2135,10 +2135,16 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 				if(BOUNDS_DIST(user,F) == 0 && BOUNDS_DIST(user,src) == 0)
 					C.move_callback(user, F, 0, src)
 
+/turf/simulated/floor/ReplaceWith(what, keep_old_material, handle_air, handle_dir, force)
+	var/list/old_hidden_contents = src.hidden_contents //we have to do this because src will be the new turf after the replace due to byond
+	var/turf/simulated/floor/newfloor = ..()
+	if (istype(newfloor))
+		newfloor.hidden_contents = old_hidden_contents
+
 /turf/simulated/floor/restore_tile()
 	..()
 	for (var/obj/item/item in src.contents)
-		if (item.w_class <= W_CLASS_TINY && !item.anchored) //I wonder if this will cause problems
+		if (item.w_class <= W_CLASS_TINY && !item.anchored && !item.GetComponent(/datum/component/glued)) //I wonder if this will cause problems
 			src.hide_inside(item)
 
 ////////////////////////////////////////////ADVENTURE SIMULATED FLOORS////////////////////////

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2144,7 +2144,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 /turf/simulated/floor/restore_tile()
 	..()
 	for (var/obj/item/item in src.contents)
-		if (item.w_class <= W_CLASS_TINY && !item.anchored && !item.GetComponent(/datum/component/glued)) //I wonder if this will cause problems
+		if (item.w_class <= W_CLASS_TINY && !item.anchored) //I wonder if this will cause problems
 			src.hide_inside(item)
 
 ////////////////////////////////////////////ADVENTURE SIMULATED FLOORS////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so putting a floor tile on a plating turf hides all `W_CLASS_TINY` items in the turf and reveals them when it's pried up again. Also adds a signal for this and makes mousetraps trigger on being revealed in this way.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cool idea, allows for convoluted traps and hidden items. May make hiding items too easy though?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Tiny items can now be hidden under floor tiles, mousetraps hidden like this will trigger when the tile is pried up again.
```
