### PR TITLE
Fix bug with TTVs using bombs

### DIFF
--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -194,11 +194,12 @@ TYPEINFO(/obj/item/device/transfer_valve)
 			boutput(user, SPAN_ALERT("You think working with explosives would bring a lot of much heat onto your gang to mess with this. But you do it anyway."))
 		src.ui_interact(user)
 
+#define TANK_PRESSURE(item_tank) (hasvar(item_tank, "air_contents")) ? MIXTURE_PRESSURE(item_tank.air_contents) : 0
 	ui_data(mob/user)
-		var/tank_one_data = (src.tank_one) ? list("name"=src.tank_one.name, "num"=1, "pressure"=MIXTURE_PRESSURE(src.tank_one.air_contents), \
+		var/tank_one_data = (src.tank_one) ? list("name"=src.tank_one.name, "num"=1, "pressure"=TANK_PRESSURE(src.tank_one), \
 											      "maxPressure"=TANK_FRAGMENT_PRESSURE) \
 										   : list("name"=null, "num"=1, "pressure"=null, "maxPressure"=null)
-		var/tank_two_data = (src.tank_two) ? list("name"=src.tank_two.name, "num"=2, "pressure"=MIXTURE_PRESSURE(src.tank_two.air_contents), \
+		var/tank_two_data = (src.tank_two) ? list("name"=src.tank_two.name, "num"=2, "pressure"=TANK_PRESSURE(src.tank_two), \
 											      "maxPressure"=TANK_FRAGMENT_PRESSURE) \
 										   : list("name"=null, "num"=2, "pressure"=null, "maxPressure"=null)
 		return list(
@@ -207,6 +208,7 @@ TYPEINFO(/obj/item/device/transfer_valve)
 			"device" = "[src.attached_device]",
 			"opened" = src.valve_open,
 		)
+#undef TANK_PRESSURE
 
 	ui_interact(mob/user, datum/tgui/ui)
 		ui = tgui_process.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot about buttbombs fuckkkk it crashes the interface because it has no air_contents

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Im stupid and forgot buttbombs exist and they should be usable
