### PR TITLE
Adds Nanotrasen and Syndicate to the color options of the Agent Card

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -304,7 +304,7 @@ TYPEINFO(/obj/item/card/emag)
 	if(!src.registered)
 		var/reg = copytext(src.sanitize_name(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)), 1, 100)
 		var/ass = copytext(src.sanitize_name(input(user, "What occupation would you like to put on this card?\n Note: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Staff Assistant"), 1), 1, 100)
-		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","blue","red","green","purple","yellow","No band")
+		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","blue","red","green","purple","yellow","nanotrasen","syndicate","No band")
 		var/datum/pronouns/pronouns = choose_pronouns(user, "What pronouns would you like to put on this card?", "Pronouns")
 		src.pronouns = pronouns
 		switch (color)
@@ -324,6 +324,10 @@ TYPEINFO(/obj/item/card/emag)
 				src.icon_state = "id_res"
 			if ("yellow")
 				src.icon_state = "id_eng"
+			if ("nanotrasen")
+				src.icon_state = "polaris"
+			if ("syndicate")
+				src.icon_state = "id_syndie"
 			else
 				return // Abort process.
 		src.registered = reg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS] [ENHANCEMENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Nanotrasen and Syndicate ID sprites to the list of ID colors that can be chosen with the agent card.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Deceptive traitors can use the NT colors to impersonate a Nanotrasen official. And the not-so-sneaky, can now proudly display their true allegiance.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Keiiro
(+)Nanotrasen and Syndicate card colors are now available for selection with an Agent Card.
```
