### PR TITLE
Wizards no longer remember spells learned in VR

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -56,7 +56,7 @@
 		if (!src.vr)
 			H.equip_if_possible(new /obj/item/teleportation_scroll(H), SLOT_L_HAND)
 
-		var/obj/item/SWF_uplink/SB = new /obj/item/SWF_uplink(src.vr)
+		var/obj/item/SWF_uplink/SB = new /obj/item/SWF_uplink(src, src.vr)
 		SB.wizard_key = src.owner.key
 		H.equip_if_possible(SB, SLOT_BELT)
 

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1289,6 +1289,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "spellbook"
 	item_state = "spellbook"
+	var/datum/antagonist/wizard/antag_datum = null
 	var/wizard_key = ""
 	var/temp = null
 	var/uses = 6
@@ -1309,8 +1310,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	uses = 9999
 #endif
 
-	New(var/in_vr = 0)
+	New(datum/antagonist/wizard/antag, in_vr = FALSE)
 		..()
+		src.antag_datum = antag
 		if (in_vr)
 			vr = 1
 			uses *= 2
@@ -1346,8 +1348,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 			return
 		logTheThing(LOG_DEBUG, null, "[constructTarget(user)] purchased the spell [src.name] using the [book] uplink.")
 		if (src.assoc_spell)
-			var/datum/antagonist/wizard/antag_role = user.mind.get_antagonist(ROLE_WIZARD)
-			antag_role.ability_holder.addAbility(src.assoc_spell)
+			book.antag_datum.ability_holder.addAbility(src.assoc_spell)
 		if (src.assoc_item)
 			var/obj/item/I = new src.assoc_item(user.loc)
 			if (istype(I, /obj/item/staff) && user.mind && !isvirtual(user))

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1337,8 +1337,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		if (book.vr && !src.vr_allowed)
 			return 3
 		if (src.assoc_spell)
-			var/datum/antagonist/wizard/antag_role = user.mind.get_antagonist(ROLE_WIZARD)
-			if (antag_role.ability_holder.getAbility(assoc_spell))
+			if (book.antag_datum.ability_holder.getAbility(assoc_spell))
 				return 2
 		if (book.uses < src.cost)
 			return 1 // ran out of points


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][MAJOR][GAME MODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a Wizard's spell book is created, track the antagonist datum that created it so we can assign spells to that datum directly, instead of doing a lookup (and finding the first one i.e. the actual wizard antag datum). 

Leaving VR removes the antag datum, and thus the abilityHolder and abilities are removed as expected.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17923

## Test Plan
- [x] Wizards can still learn book spells
- [x] Non-wizards can enter VR and learn VR spells
- [x] Non-wizards lose spells when exiting VR
- [x] Wizards can enter VR
- [x] Wizards can learn VR spells
- [x] Wizards lose VR spells when exiting VR
- [x] Wizards maintain pre-VR spells (even if there's a duplicate)
- [x] Wizards can still learn spells after entering and leaving VR