### PR TITLE
Allow monkeys to pickpocket again

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -477,18 +477,15 @@
 				if(!length(choices))
 					return
 				thingy = pick(choices)
-				slot = thingy.equipped_in_slot
 			else if (theft_target.l_store && theft_target.r_store)
 				thingy = pick(theft_target.l_store, theft_target.r_store)
-				if (thingy == theft_target.r_store)
-					slot = 16
 			else if (theft_target.l_store)
 				thingy = theft_target.l_store
 			else if (theft_target.r_store)
 				thingy = theft_target.r_store
-				slot = 16
 			else // ???
 				return
+		slot = theft_target.get_slot_from_item(thingy)
 		walk_towards(src, null)
 		if(ismonkey(theft_target))
 			src.say("I help!")
@@ -565,9 +562,12 @@
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "grabbed"
 
-	var/mob/living/carbon/human/npc/source  //The npc doing the action
-	var/mob/living/carbon/human/target  	//The target of the action
-	var/slot						    	//The slot number
+	/// NPC who is pickpocketing
+	var/mob/living/carbon/human/npc/source
+	/// The pick-pocketing victim
+	var/mob/living/carbon/human/target
+	/// The SLOT_* define (i.e. SLOT_BACK)
+	var/slot
 
 	New(var/Source, var/Target, var/Slot)
 		source = Source


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][AI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the slot defines were changed from numbers to strings in #17162, the monkey pickpocketing proc was not updated in step causing the pickpocket action for monkeys to always fail.

This change uses the existing helper function to match an item with its equipped slot, reducing some code duplication and ensuring the `SLOT_*` defines are used as expected.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix monkey pickpocketing

## Test Plan
* Spawn a bunch of monkeys (in e.g. monkeydome)
* Stand around with stuff in your pockets
* Get successfully stolen from by NPC monkeys