### PR TITLE
Explosive fishing!

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -289,7 +289,7 @@ TYPEINFO(/obj/item/fish_portal)
 				src.visible_message("<b class='alert'>Fishes jump out of [src]! [pick("Holy shit!", "Holy fuck!", "What the hell!", "What the fuck!")]</b>")
 				// lets create a neat water spread effect
 				var/datum/effects/system/steam_spread/splash = new /datum/effects/system/steam_spread
-				splash.set_up(4, 0, get_turf(src), "#382ec9")
+				splash.set_up(6, 0, get_turf(src), color="#382ec9", plane=PLANE_NOSHADOW_ABOVE)
 				splash.attach(src)
 				splash.start()
 		//Now we damage the pond. No infinite dynamite fishing

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -246,14 +246,64 @@ TYPEINFO(/obj/item/fish_portal)
 	icon = 'icons/obj/items/fishing_gear.dmi'
 	icon_state = "fishing_pool"
 
-	basic
-		name = "basic pool"
+	ex_act(severity)
+		// dynamite fishing! make the research pool throw out fish depending on how big the severity of the explosion was
+		var/dynamite_fishing_cooldown = 1 SECOND //! the cooldown of dynamite fishing.
+		// First, we need to get our fishing spot datum
+		var/datum/fishing_spot/fishing_spot = null
+		var/fishing_spot_type = src.type
+		// now we search for the corresponding defined fishing spot up the chain of parents
+		while (fishing_spot_type != null)
+			fishing_spot = global.fishing_spots[fishing_spot_type]
+			if (fishing_spot != null)
+				break
+			fishing_spot_type = type2parent(fishing_spot_type)
+		// now we define our fishing sucess and damage on the fish tank based on the severity
+		// defined values are for severity 3
+		var/explosion_damage = -5 //! how much damage each explosion does
+		var/fish_chance = 20 //! how much fish per roll jumps out of the pond
+		var/fish_rolls = 2 //! how often the fish chance is rolled
+		var/dynamite_fishing_sucessfull = FALSE //! shows if the explosion sucessfully "fished" some fish
+		switch(severity)
+			if(1)
+				//You blew up the whole tank, doofus!
+				explosion_damage = -100
+				fish_chance = 0
+				fish_rolls = 0
+			if(2)
+				explosion_damage = -20
+				fish_chance = 70
+				fish_rolls = 5
+		if (fishing_spot && fish_rolls && !ON_COOLDOWN(src, "dynamite fishing", dynamite_fishing_cooldown))
+			var/turf/target_turf = get_turf(src)
+			// now, if we don't blow it up extremly, we can roll for fish
+			for (var/fish_try in 1 to fish_rolls)
+				if (prob(fish_chance))
+					var/atom/movable/fishing_result = fishing_spot.generate_fish(null, null, src)
+					if(fishing_result)
+						fishing_result.set_loc(target_turf)
+						var/target_point = get_turf(pick(orange(4, src)))
+						fishing_result.throw_at(target_point, rand(0, 10), rand(3, 9))
+						dynamite_fishing_sucessfull = TRUE
+			if (dynamite_fishing_sucessfull)
+				src.visible_message("<b class='alert'>Fishes jump out of [src]! [pick("Holy shit!", "Holy fuck!", "What the hell!", "What the fuck!")]</b>")
+				// lets create a neat water spread effect
+				var/datum/effects/system/steam_spread/splash = new /datum/effects/system/steam_spread
+				splash.set_up(4, 0, get_turf(src), "#382ec9")
+				splash.attach(src)
+				splash.start()
+		//Now we damage the pond. No infinite dynamite fishing
+		src.material_trigger_on_explosion(severity)
+		src.changeHealth(explosion_damage)
 
-	upgraded
-		name = "upgraded pool"
+/obj/fishing_pool/basic
+	name = "basic pool"
 
-	master
-		name = "master pool"
+/obj/fishing_pool/upgraded
+	name = "upgraded pool"
+
+/obj/fishing_pool/master
+	name = "master pool"
 
 /obj/fishing_pool/portable
 	anchored = 0


### PR DESCRIPTION
[Feature][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes how aquatic research pools react to explosions.

When exposed to a severity 2/3 explosion, the pool suffers 20/5 damage and rolls a 70%/20% chance for fish to jump out of the pool 5/2 times. A severity 1 explosion (the kind that gibs people) simply destroys the pool without spawning any fish.

This effect has a 1 second cooldown.

A video for the interaction in action:
https://github.com/goonstation/goonstation/assets/109365375/c391cce5-4152-493f-823e-358a024c69c8

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Dynamite fishing is the kind of silly idea that is just right in the line between funny and usefull that it perfectly fits to goon. With aquatic research pools being locked behind cargo and the basic fishes not having any effect, i don't see it causing any balance issues as well.

Also, having severity 2 explosions showing the best effect and severity 1 explosions destryoing them, i forsee some people trying to optimize their dynamite fishing. That thought just sounds like fun.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Fishes within aquatic research pools have begun to fear explosions and actively jump out of their pool when exposed to them.
```
