### PR TITLE
Change how sunflower and sunflower seeds share chems

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -618,15 +618,14 @@ ABSTRACT_TYPE(/obj/item/plant/flower)
 		var/obj/item/reagent_containers/food/snacks/plant/seeds = locate() in src
 		if(seeds)
 			boutput(user, SPAN_NOTICE("You notice some [seeds] fall out of [src]!"))
+			seeds.set_loc(get_turf(target))
 			// that's the result if you want to keep 50% of the initial chems in the sunflower at the end.
 			// This accomodates partially for chems injected in the sunflower if some seeds are already missing
 			var/chem_amount = src.reagents.total_volume / (current_seed_count + initial_seed_count)
 			seeds.reagents.maximum_volume = max(chem_amount, seeds.reagents.maximum_volume)
-			seeds.reagents.inert = 1 //let's not explode people by hitting them with a potassium/water sunflower
 			src.reagents.trans_to(seeds, chem_amount)
-			seeds.reagents.inert = 0
 			src.current_seed_count -= 1
-			seeds.set_loc(get_turf(target))
+
 
 	HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status)
 		. = ..()


### PR DESCRIPTION
[hydroponics][bug][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes sunflower and sunflower seeds. Instead of each one receiving their respective chems from `HYPsetup_DNA`, the seeds will receive up to 50% of the chems of the sunflower. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Splices of sunflowers spawned with a full botany amount of chems and the seeds spawned from the sunflower spawned with their own amount as well. This means you would end up with double amount of chems per produce, and with jumbo sunflowers would end up with quintupled amount of chems (without the doubling of chems from having jumbo produce in the first place).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Sunflowers now transfers up to 50% of their chems unto their sunflower seeds
```
