### PR TITLE
Make cannabis affixes potency scaling respect plantgenes

### DIFF
--- a/code/modules/hydroponics/plants_herb.dm
+++ b/code/modules/hydroponics/plants_herb.dm
@@ -160,12 +160,12 @@ ABSTRACT_TYPE(/datum/plant/herb)
 
 	HYPharvested_proc(obj/machinery/plantpot/POT, mob/user)
 		// check if we need to add a suffix
-		if (!src.weed_suffix && POT.plantgenes.potency > INITIAL_REQUIRED_POTENCY)
+		if (!src.weed_suffix && POT.plantgenes?.get_effective_value("potency") > INITIAL_REQUIRED_POTENCY)
 			src.weed_suffix = pick_string("chemistry_tools.txt", "WEED_suffixes")
 
 		if (src.weed_suffix)
 			// if we have a suffix, check if we need to generate more prefixes
-			var/target_prefix_num = min(MAX_PREFIXES, round(POT.plantgenes.potency / POTENCY_PER_PREFIX))
+			var/target_prefix_num = min(MAX_PREFIXES, round(POT.plantgenes?.get_effective_value("potency") / POTENCY_PER_PREFIX))
 			if (length(src.weed_prefixes) < target_prefix_num)
 				var/prefixes_to_add = target_prefix_num - length(src.weed_prefixes)
 				for (var/i in 1 to prefixes_to_add)


### PR DESCRIPTION
[hydroponics][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the affix generation of weed respect use `get_effective_value("potency")` instead of referencing potency directly.

This makes the affix generation take plant gene strains like "superior quality"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Most botany effects scaling with stats should respect plant gene strains that modify these, like superior quality.
