### PR TITLE
Adds a sabotage method for emergency-injectors

### DIFF
--- a/code/modules/chemistry/tools/emergency_injectors.dm
+++ b/code/modules/chemistry/tools/emergency_injectors.dm
@@ -52,12 +52,8 @@
 
 
 	get_help_message(dist, mob/user)
-		if(!src.empty)
-			. += " Use this to quickly inject medicine into a person."
-		else
-			. += " This injector is empty and thus unuseable."
 		if(!src.manipulated_injection && !src.empty)
-			. += " You can use a cutting tool to sabotage the injector."
+			. += " You can use a <b>knife</b> to sabotage the injector."
 
 	proc/try_injection(mob/user, mob/target)
 		if (src.empty || !src.reagents)

--- a/code/modules/chemistry/tools/emergency_injectors.dm
+++ b/code/modules/chemistry/tools/emergency_injectors.dm
@@ -18,6 +18,7 @@
 	var/empty = 0
 	var/label = "orange" // colors available as of the moment: orange, red, blue, green, yellow, purple, black, white, big red
 	hide_attack = ATTACK_PARTIALLY_HIDDEN
+	var/manipulated_injection = FALSE //! is this injector being tampered with and being unuseable for injecting people?
 
 	New()
 		..()
@@ -25,6 +26,8 @@
 		src.fluid_image = image(src.icon, "emerg_inj-fluid")
 		src.fluid_image.color = src.reagents.get_average_color().to_rgba()
 		src.UpdateIcon()
+		// auto-injector + cutting tool  -> sabotaged auto-injector
+		src.AddComponent(/datum/component/assembly, TOOL_CUTTING, PROC_REF(knife_manipulation), FALSE)
 
 	on_reagent_change()
 		..()
@@ -47,11 +50,22 @@
 			else
 				if (!target.reagents)
 					return ..()
-				logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with [src] [log_reagents(src)]")
-				src.reagents.trans_to(target, amount_per_transfer_from_this)
-				user.visible_message(SPAN_ALERT("[user] injects [target == user ? himself_or_herself(user) : target] with [src]!"),\
-				SPAN_ALERT("You inject [target == user ? "yourself" : target] with [src]!"))
-				playsound(target, 'sound/items/hypo.ogg', 40, FALSE)
+				if (src.manipulated_injection)
+					logTheThing(LOG_COMBAT, user, "tries to inject [constructTarget(target,"combat")] with a sabotaged [src] [log_reagents(src)]")
+					user.visible_message(SPAN_ALERT("[user] tries to use [src] on [target == user ? himself_or_herself(user) : target], but [src] fails and sprays its contents on the ground!"),\
+					SPAN_ALERT("You try to use [src] on [target == user ? "yourself" : target], but [src] jams prematurely and all its contents spray onto the ground!"))
+					var/turf/target_turf = get_turf(user)
+					var/datum/reagents/temp_holder = new
+					src.reagents.trans_to_direct(temp_holder, src.amount_per_transfer_from_this)
+					target_turf.fluid_react(temp_holder, temp_holder.total_volume)
+					temp_holder.reaction(target_turf, TOUCH)
+					playsound(user, 'sound/impact_sounds/Generic_Snap_1.ogg', 30, FALSE)
+				else
+					logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with [src] [log_reagents(src)]")
+					src.reagents.trans_to(target, src.amount_per_transfer_from_this)
+					user.visible_message(SPAN_ALERT("[user] injects [target == user ? himself_or_herself(user) : target] with [src]!"),\
+					SPAN_ALERT("You inject [target == user ? "yourself" : target] with [src]!"))
+					playsound(target, 'sound/items/hypo.ogg', 40, FALSE)
 				if(!src.reagents.total_volume)
 					src.empty = 1
 					src.name += " (expended)"
@@ -68,17 +82,47 @@
 			else
 				if (!user.reagents)
 					return ..()
-				logTheThing(LOG_COMBAT, user, "injects themself with [src] [log_reagents(src)]")
-				src.reagents.trans_to(user, amount_per_transfer_from_this)
-				user.visible_message(SPAN_ALERT("[user] injects [himself_or_herself(user)] with [src]!"),\
-				SPAN_ALERT("You inject yourself with [src]!"))
-				playsound(user, 'sound/items/hypo.ogg', 40, FALSE)
+				if (src.manipulated_injection)
+					logTheThing(LOG_COMBAT, user, "tries to inject themselves with a sabotaged [src] [log_reagents(src)]")
+					user.visible_message(SPAN_ALERT("[user] tries to use [src] on [himself_or_herself(user)], but [src] fails and sprays its contents on the ground!"))
+					var/turf/target_turf = get_turf(user)
+					var/datum/reagents/temp_holder = new
+					src.reagents.trans_to_direct(temp_holder, src.amount_per_transfer_from_this)
+					target_turf.fluid_react(temp_holder, temp_holder.total_volume)
+					temp_holder.reaction(target_turf, TOUCH)
+					playsound(user, 'sound/impact_sounds/Generic_Snap_1.ogg', 30, FALSE)
+				else
+					logTheThing(LOG_COMBAT, user, "injects themself with [src] [log_reagents(src)]")
+					src.reagents.trans_to(user, amount_per_transfer_from_this)
+					user.visible_message(SPAN_ALERT("[user] injects [himself_or_herself(user)] with [src]!"),\
+					SPAN_ALERT("You inject yourself with [src]!"))
+					playsound(user, 'sound/items/hypo.ogg', 40, FALSE)
 				if(!src.reagents.total_volume)
 					src.empty = 1
 					src.name += " (expended)"
 				return
 		else
 			return
+
+	get_help_message(dist, mob/user)
+		if(!src.empty)
+			. += " Use this to quickly inject medicine into a person."
+		else
+			. += " This injector is empty and thus unuseable."
+		if(!src.manipulated_injection && !src.empty)
+			. += " You can use a cutting tool to sabotage the injector."
+
+/// autoinjector manipulation procs
+	proc/knife_manipulation(var/atom/to_combine_atom, var/mob/user)
+		if (src.empty || !src.reagents)
+			boutput(user, SPAN_ALERT("There's no reason to sabotage this, [src] has already been expended!"))
+		else
+			boutput(user, SPAN_NOTICE("you cut into the spring mechanism, making it unuseable for medical use."))
+			src.manipulated_injection = TRUE
+			src.desc += " You can see a deep cut on its side."
+			//Since we sucessfully manipulated the injector, remove all the assembly components
+			src.RemoveComponentsOfType(/datum/component/assembly)
+			return TRUE
 
 /* =================================================== */
 /* -------------------- Sub-Types -------------------- */


### PR DESCRIPTION
[game objects][medical][feature]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Enables autoinjectors to be manipulated with a cutting tool.

Once manipulated with a cutting tool, the internal of the autoinjector will snap and jam upon use, pouring their contents onto the ground

Also, this PR adds help messages to autoinjectors that point at its use and the possibility to manipulate them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Small actions to sabotage station equipment are always nice to have and i would like to see more of them. Beyond this, this enables assisstants easier access to some chemicals for hobo-chemistry (e.g. antihistamine for crank or krokodil).

I don't expect someone to cut an injector that someone else tries to use later at a crucial moment, but you never know. It would be awesome.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)You can cut the spring mechanism of auto-injectors with a knife to make them break and spill their contents upon use.
```
