### PR TITLE
Fix reconcile_air null runtimes

### DIFF
--- a/code/modules/atmospherics/pipe_network.dm
+++ b/code/modules/atmospherics/pipe_network.dm
@@ -118,6 +118,8 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 	ZERO_GASES(src.air_transient)
 
 	for(var/datum/gas_mixture/gas as anything in src.gases)
+		if (isnull(gas))
+			continue
 		src.air_transient.volume += gas.volume
 		total_thermal_energy += THERMAL_ENERGY(gas)
 		total_heat_capacity += HEAT_CAPACITY(gas)
@@ -141,6 +143,8 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 
 	//Update individual gas_mixtures by volume ratio
 	for(var/datum/gas_mixture/gas as anything in src.gases)
+		if (isnull(gas))
+			continue
 		#define _RECONCILE_AIR_TRANSFER(GAS, ...) gas.GAS = src.air_transient.GAS * gas.volume / src.air_transient.volume ;
 		APPLY_TO_GASES(_RECONCILE_AIR_TRANSFER)
 		#undef _RECONCILE_AIR_TRANSFER


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[09:34:25] pipe_network.dm,121: Cannot read null.volume
proc name: reconcile air (/datum/pipe_network/proc/reconcile_air)
  source file: pipe_network.dm,121
  usr: null
  src: /datum/pipe_network (/datum/pipe_network)
  call stack:
/datum/pipe_network (/datum/pipe_network): reconcile air()
/datum/pipe_network (/datum/pipe_network): process()
Machine (/datum/controller/process/machines): doWork()
Machine (/datum/controller/process/machines): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(Machine (/datum/controller/process/machines), 0)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
3000+ runtimes