### PR TITLE
Fix foam weapons leaving gunshot residue on user

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1067,6 +1067,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	muzzle_flash = null
 	default_magazine = /obj/item/ammo/bullets/foamdarts
 	var/pulled = FALSE
+	add_residue = FALSE
 
 	New()
 		ammo = new default_magazine
@@ -1165,6 +1166,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	max_ammo_capacity = 6
 	muzzle_flash = null
 	default_magazine = /obj/item/ammo/bullets/foamdarts
+	add_residue = FALSE
 
 	New()
 		ammo = new default_magazine
@@ -1188,6 +1190,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	max_ammo_capacity = 12
 	muzzle_flash = null
 	default_magazine = /obj/item/ammo/bullets/foamdarts
+	add_residue = FALSE
 
 	New()
 		ammo = new default_magazine


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

changes `add_residue` to `FALSE` for the foam dart gun, foam revolver, and foam shotgun.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Having harmless toys that any crewmember can acquire apply gunshot residue to the user kind of makes the mechanic useless for actual detective work