### PR TITLE
fix grammar/typo for random room coat

### DIFF
--- a/assets/maps/random_rooms/3x3/hosroom.dmm
+++ b/assets/maps/random_rooms/3x3/hosroom.dmm
@@ -15,7 +15,7 @@
 /obj/item/clothing/shoes/swat,
 /obj/item/clothing/head/danberet,
 /obj/item/clothing/suit/gimmick/guncoat/dirty{
-	name = "Old And Diry Coats"
+	name = "Dirty Old Coat"
 	},
 /obj/item/reagent_containers/food/drinks/bottle/vintage,
 /turf/simulated/floor/plating/damaged1,


### PR DESCRIPTION
[Bug][Trivial][Mapping]

## About the PR 
cahnges over-ride name of coat in randomn room (HoS type) to be more correct
single coat goes from "Old And Diry Coats" -> "Dirty Old Coat"

## Why's this needed?
fix for #17934 - less typoes are better
maybe old name was meant for crate??? still not right spellign