### PR TITLE
Use Clear Acid for PTL path on Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -118228,7 +118228,7 @@ dAB
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 iUo
 bzS
@@ -118530,7 +118530,7 @@ dAB
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -118832,7 +118832,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -119134,7 +119134,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -119436,7 +119436,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -119738,7 +119738,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -120040,7 +120040,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -120342,7 +120342,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -120644,7 +120644,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -120946,7 +120946,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -121248,7 +121248,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -121550,7 +121550,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -121852,7 +121852,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -122154,7 +122154,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -122456,7 +122456,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -122758,7 +122758,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -123060,7 +123060,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -123362,7 +123362,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -123664,7 +123664,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -123966,7 +123966,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -124268,7 +124268,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -124570,7 +124570,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -124872,7 +124872,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -125174,7 +125174,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -125476,7 +125476,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -125778,7 +125778,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -126080,7 +126080,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -126382,7 +126382,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -126684,7 +126684,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -126986,7 +126986,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -127288,7 +127288,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -127590,7 +127590,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -127892,7 +127892,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -128194,7 +128194,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -128496,7 +128496,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -128798,7 +128798,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -129100,7 +129100,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -129402,7 +129402,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -129704,7 +129704,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -130006,7 +130006,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -130308,7 +130308,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -130610,7 +130610,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -130912,7 +130912,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -131214,7 +131214,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -131516,7 +131516,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -131818,7 +131818,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -132120,7 +132120,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -132422,7 +132422,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS
@@ -132724,7 +132724,7 @@ bzS
 bzS
 bzS
 bzS
-bzS
+rJg
 bzS
 bzS
 bzS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the acid turf with the clear variant for the entire horizontal line east of the PTL to the wall barrier.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #17967

## Test Plan
- [x] PTL still functions (gains credits)