### PR TITLE
Make a crate visible in nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -45252,11 +45252,6 @@
 	},
 /area/station/medical/morgue)
 "trK" = (
-/obj/storage/crate{
-	desc = "A small, cuboid object with a hinged top and empty interior. It smells kinda bad and seems to have an odd stain on it.";
-	icon = 'icons/misc/halloween.dmi';
-	name = "dented crate"
-	},
 /obj/item/reagent_containers/glass/bottle/ammonia/large,
 /obj/item/reagent_containers/glass/bottle/ammonia/large,
 /obj/decal/cleanable/dirt,
@@ -45264,6 +45259,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/storage/crate/bloody,
 /turf/simulated/floor/plating,
 /area/station/hydroponics{
 	do_not_irradiate = 1;


### PR DESCRIPTION
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some reason, an attempt was made to have a dented crate via var editing a regular crate. This didn't work, due to the icon being incorrect and not matching the crate, rendering it invisible. This PR replaces that crate with the 'bloody' subtype, which makes it look rusted and renames it to 'dented crate' as was originally intended.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes  #17346