### PR TITLE
Correct unit on power generation for crew credits

### DIFF
--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -335,7 +335,7 @@
 	src.score_tab_data[SCORE_TAB_SECTION_ENGINEERING] = list(
 		list(
 			"name" = "Power Generated",
-			"value" = "[engineering_notation(score_tracker.power_generated / (1 * HOUR))]Wh",
+			"value" = "[engineering_notation(score_tracker.power_generated / 3600)]Wh",
 		),
 		list(
 			"name" = "Station Structural Integrity",

--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -335,7 +335,7 @@
 	src.score_tab_data[SCORE_TAB_SECTION_ENGINEERING] = list(
 		list(
 			"name" = "Power Generated",
-			"value" = "[engineering_notation(score_tracker.power_generated)]W",
+			"value" = "[engineering_notation(score_tracker.power_generated / (1 * HOUR))]Wh",
 		),
 		list(
 			"name" = "Station Structural Integrity",


### PR DESCRIPTION
[QoL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the unit of "watts" to "watt-hours" for the unit of total power generated in the credits.

![image](https://github.com/goonstation/goonstation/assets/27376947/ae3b3582-c785-4fcb-b9bf-e2a2a526617a)
ran a quick shift (chui broke and i skipped atmos, weh) and generated a few MJ overall - which comes down to looking like this. More extreme power generation setups of course would go to upwards of mWh or gWh

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The former unit is an expression of power - implicitly in joules/second. This isn't the correct unit to use for the total power! watt-hours are an expression of energy, and the credits are showing the total energy produced -- so this makes sense to use. Could have also just been the overall joules, and still can be if wanted -- just going off a suggestion here.