### PR TITLE
Rename terminal under APC to power terminal

### DIFF
--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -4,7 +4,7 @@
 // using this solves the problem of having the APC in a wall yet also inside an area
 
 /obj/machinery/power/terminal
-	name = "terminal"
+	name = "power terminal"
 	icon_state = "term"
 	desc = "An underfloor wiring terminal for power equipment"
 	level = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Rename the terminal that spawns connected to an APC to link it to the wirenet from "terminal" to "power terminal"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Many aspiring network engineers have been tripped up by trying to connect their DWAINE computers to the terminals under an APC (because they're much easier to find than proper data terminals), this will hopefully help disambiguate them from data terminals due to specifically having "power" instead of "data" in the name
