### PR TITLE
Removes Karmic Punishment from Ahelp & prayer

### DIFF
--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -116,7 +116,8 @@
 	var/in_chapel = 0
 	if(istype(get_area(client.mob), /area/station/chapel))
 		in_chapel = 1
-
+	if (client.mob.mind && client.mob.traitHolder?.hasTrait("atheist"))
+		src.add_karma(-1)
 	var/is_atheist = client.mob.traitHolder?.hasTrait("atheist")
 
 	if (is_atheist)

--- a/code/modules/admin/adminhelp.dm
+++ b/code/modules/admin/adminhelp.dm
@@ -26,9 +26,6 @@
 	if (!msg)
 		return
 
-	if (client.mob.mind)
-		client.mob.add_karma(-1)
-
 	var/logLine = global.logLength + 1
 	var/dead = isdead(client.mob) ? "Dead " : ""
 	var/antag_text = ""
@@ -119,9 +116,6 @@
 	var/in_chapel = 0
 	if(istype(get_area(client.mob), /area/station/chapel))
 		in_chapel = 1
-
-	if (client.mob.mind)
-		src.add_karma(-1)
 
 	var/is_atheist = client.mob.traitHolder?.hasTrait("atheist")
 


### PR DESCRIPTION
<!-- [Admin] [Removal] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes four lines of code that reduces a player's karma by 1 when they Ahelp or pray.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can theoretically be sent to hell if your karma gets to -200, and Ahelps contributing to eternal punishment seems opposed to current administrative philosophy. Praying to god doesn't seem like the sort of thing that'd earn you a seat in the hot place, either.