### PR TITLE
Terminal program authentication code refactor

### DIFF
--- a/code/modules/networks/computer3/base_os.dm
+++ b/code/modules/networks/computer3/base_os.dm
@@ -593,6 +593,8 @@
 		return
 
 	initialize()
+		if (..())
+			return TRUE
 		src.print_text("Loading [src.setup_version_name]<br>Scanning for peripheral cards...")
 
 		src.peripherals = new //Figure out what cards are there now so we can address them later all easy-like

--- a/code/modules/networks/computer3/base_os.dm
+++ b/code/modules/networks/computer3/base_os.dm
@@ -12,7 +12,6 @@
 	var/echo_input = 1
 	var/log_errors = 1
 	var/list/peripherals = list()
-	var/authenticated = null //Is anyone logged in?
 
 	var/setup_version_name = "ThinkDOS 0.7.2"
 	var/setup_needs_authentication = 1 //Do we need to present an ID to use this?

--- a/code/modules/networks/computer3/base_program.dm
+++ b/code/modules/networks/computer3/base_program.dm
@@ -12,6 +12,10 @@
 	//var/id_tag = null
 	var/executable = 1
 
+	var/tmp/authenticated = null //! Are we currently logged in?
+	var/datum/computer/file/user_data/account = null
+	var/setup_acc_filepath = "/logs/sysusr"//! Where do we look for login data?
+
 	os
 		name = "blank system program"
 		extension = "TSYS"
@@ -110,8 +114,36 @@
 
 			return 0
 
+		///Extracted with great pain from the like 6 other fucking programs that copy pasted this, whyyyy
+		///Returns true to halt the call stack
 		initialize() //Called when a program starts running.
-			return
+			SHOULD_CALL_PARENT(TRUE)
+			src.authenticated = null
+			if (!length(src.req_access)) //no access required, don't authenticate user
+				return FALSE
+
+			if(!src.find_access_file()) //Find the account information, as it's essentially a ~digital ID card~
+				src.print_text("<b>Error:</b> Cannot locate user file.  Quitting...")
+				src.master.unload_program(src) //Oh no, couldn't find the file.
+				return TRUE
+			if(!src.check_access(src.account.access))
+				src.print_text("User [src.account.registered] does not have needed access credentials.<br>Quitting...")
+				src.master.unload_program(src)
+				return TRUE
+			src.authenticated = src.account.registered
+
+		///Look for the whimsical account_data file
+		find_access_file()
+			var/datum/computer/folder/accdir = src.holder.root
+			if(src.master.host_program) //Check where the OS is, preferably.
+				accdir = src.master.host_program.holder.root
+
+			var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
+			if(target && istype(target))
+				src.account = target
+				return 1
+
+			return 0
 
 		restart()
 			return

--- a/code/modules/networks/computer3/emailclient.dm
+++ b/code/modules/networks/computer3/emailclient.dm
@@ -49,10 +49,11 @@
 	var/max_lines = 16
 	var/signature = null
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
 	var/defaultDomain = "NT13"
 
 	initialize()
+		if (..())
+			return TRUE
 		src.netCard = null
 		src.menu = 0
 		var/introdat = "ViewPoint Email Client V1.5<br>Copyright 2051 Thinktronic Systems, LTD.<br>"
@@ -64,15 +65,13 @@
 
 			src.server_netid = null
 			src.master.unload_program(src)
-			return
+			return TRUE
 
 		else
 			introdat += mainmenu_text()
 
 		src.master.temp = null
 		src.print_text(introdat)
-
-		return
 
 	input_text(text)
 		if(..())
@@ -671,17 +670,16 @@ SUBJECT: [ckeyEx(headerList["subj"]) ? copytext(uppertext(headerList["subj"]), 1
 			signal.data["address_1"] = attempted_netid
 			signal.data["command"] = "term_connect"
 			signal.data["device"] = "SRV_TERMINAL"
-			var/datum/computer/file/user_data/user_data = get_user_data()
 			var/datum/computer/file/record/udat = null
-			if (istype(user_data))
+			if (istype(src.account))
 				udat = new
 
-				var/userid = format_username(user_data.registered)
+				var/userid = format_username(src.account.registered)
 
 				udat.fields["userid"] = userid
 				src.user_address = "[userid]@[defaultDomain]"
-				//udat.fields["assignment"] = user_data.assignment
-				udat.fields["access"] = list2params(user_data.access)
+				//udat.fields["assignment"] = src.account.assignment
+				udat.fields["access"] = list2params(src.account.access)
 				if (!udat.fields["access"] || !udat.fields["userid"])
 					//qdel(udat)
 					udat.dispose()
@@ -739,17 +737,6 @@ SUBJECT: [ckeyEx(headerList["subj"]) ? copytext(uppertext(headerList["subj"]), 1
 				return (potential_server_netid == null)
 
 			return 0
-
-		get_user_data()
-			var/datum/computer/folder/accdir = src.holder.root
-			if(src.master.host_program) //Check where the OS is, preferably.
-				accdir = src.master.host_program.holder.root
-
-			var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-			if(target && istype(target))
-				return target
-
-			return null
 
 		mainmenu_text(display_server=1)
 			. = null

--- a/code/modules/networks/computer3/med_rec.dm
+++ b/code/modules/networks/computer3/med_rec.dm
@@ -40,18 +40,17 @@
 	req_access = list(access_medical)
 	var/tmp/menu = MENU_MAIN
 	var/tmp/field_input = 0
-	var/tmp/authenticated = null //Are we currently logged in?
 	var/datum/record_database/record_database = null
-	var/datum/computer/file/user_data/account = null
 	var/datum/db_record/active_general = null //General record
 	var/datum/db_record/active_medical = null //Medical record
 	var/log_string = null //Log usage of record system, can be dumped to a text file.
 	var/list/datum/db_record/possible_active = null
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
 	var/setup_logdump_name = "medlog" //What name do we give our logdump textfile?
 
 	initialize()
+		if (..())
+			return TRUE
 /*
 		var/title_art = {"<pre>
   __  __        _     _____          _
@@ -59,27 +58,14 @@
  | |\\/| / -_) _` |___| | | | '_/ _` | / /
  |_|  |_\\___\\__,_|     |_| |_| \\__,_|_\\_\\</pre>"}
 */
-		src.authenticated = null
 		src.record_database = data_core.general
 		src.master.temp = null
 		src.menu = MENU_MAIN
 		src.field_input = 0
-		//src.print_text(" [title_art]")
-		if(!src.find_access_file()) //Find the account information, as it's essentially a ~digital ID card~
-			src.print_text("<b>Error:</b> Cannot locate user file.  Quitting...")
-			src.master.unload_program(src) //Oh no, couldn't find the file.
-			return
 
-		if(!src.check_access(src.account.access))
-			src.print_text("User [src.account.registered] does not have needed access credentials.<br>Quitting...")
-			src.master.unload_program(src)
-			return
-
-		src.authenticated = src.account.registered
 		src.log_string += "<br><b>LOGIN:</b> [src.authenticated]"
 
 		src.print_text(mainmenu_text())
-		return
 
 
 	input_text(text)
@@ -789,18 +775,6 @@
 
 			src.print_text(dat)
 			return 1
-
-		find_access_file() //Look for the whimsical account_data file
-			var/datum/computer/folder/accdir = src.holder.root
-			if(src.master.host_program) //Check where the OS is, preferably.
-				accdir = src.master.host_program.holder.root
-
-			var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-			if(target && istype(target))
-				src.account = target
-				return 1
-
-			return 0
 
 #undef MENU_MAIN
 #undef MENU_INDEX

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -35,8 +35,6 @@
 	req_access = list(access_security)
 	var/tmp/menu = MENU_MAIN
 	var/tmp/field_input = 0
-	var/tmp/authenticated = null //Are we currently logged in?
-	var/tmp/datum/computer/file/user_data/account = null
 	var/datum/record_database/record_database = list()  //List of records, for jumping direclty to a specific ID
 	var/datum/db_record/active_general = null //General record
 	var/datum/db_record/active_secure = null //Security record
@@ -52,12 +50,13 @@
 	var/tmp/list/known_printers = list()
 	var/tmp/printer_status = "???"
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
 	var/setup_logdump_name = "seclog" //What name do we give our logdump textfile?
 	var/setup_mailgroup = MGD_SECURITY //The PDA mailgroup used when alerting security pdas to an arrest set.
 	var/setup_mail_freq = FREQ_PDA //Which frequency do we transmit PDA alerts on?
 
 	initialize() //Forms "SECMATE" ascii art. Oh boy.
+		if (..())
+			return TRUE
 	/*
 		var/title_art = {"<pre> ____________________    _ __________________
 \\  ___\\  ___\\  ___\\ -./  \\  __ \\ _  _\\  ___\\
@@ -65,28 +64,17 @@
  \\/\\_____\\_____\\_____\\ \\_\\ \\ \\ \\_\\ \\ \\ \\ \\_____\\
   \\/_____/_____/_____/_/  \\/_/_/\\/_/\\/_/\\/_____/ </pre>"}
 */
-		src.authenticated = null
 		src.record_database = data_core.general
 		src.master.temp = null
 		src.menu = MENU_MAIN
 		src.field_input = 0
 		//src.print_text(" [title_art]")
-		if(!src.find_access_file()) //Find the account information, as it's essentially a ~digital ID card~
-			src.print_text("<b>Error:</b> Cannot locate user file.  Quitting...")
-			src.master.unload_program(src) //Oh no, couldn't find the file.
-			return
 
 		src.radiocard = locate() in src.master.peripherals
 		if(!radiocard || !istype(src.radiocard))
 			src.radiocard = null
 			src.print_text("<b>Warning:</b> No radio module detected.")
 
-		if(!src.check_access(src.account.access))
-			src.print_text("User [src.account.registered] does not have needed access credentials.<br>Quitting...")
-			src.master.unload_program(src)
-			return
-
-		src.authenticated = src.account.registered
 		src.log_string += "<br><b>LOGIN:</b> [src.authenticated]"
 
 		src.print_text(mainmenu_text())
@@ -827,18 +815,6 @@
 			last_arrest_report = world.time
 			peripheral_command("transmit", signal, "\ref[src.radiocard]")
 			return
-
-		find_access_file() //Look for the whimsical account_data file
-			var/datum/computer/folder/accdir = src.holder.root
-			if(src.master.host_program) //Check where the OS is, preferably.
-				accdir = src.master.host_program.holder.root
-
-			var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-			if(target && istype(target))
-				src.account = target
-				return 1
-
-			return 0
 
 		local_print()
 			var/obj/item/peripheral/printcard = find_peripheral("LAR_PRINTER")

--- a/code/modules/networks/computer3/smallprogs.dm
+++ b/code/modules/networks/computer3/smallprogs.dm
@@ -55,6 +55,8 @@
 	var/const/logfile_path = "signal_log"
 
 	initialize()
+		if (..())
+			return TRUE
 		src.print_text("Signal Catcher 1.2<br>Commands: \"active \[ON/OFF/AUTO],\" \"Save \[filename]\" as signal, \"View\" current signal.<br>\"Quit\" to exit but remain in memory, \"FQuit\" to quit normally.")
 
 	disposing()
@@ -216,6 +218,8 @@
 	var/obj/item/peripheral/network/ping_card = null //The card we are actually going to use to send pings.
 
 	initialize()
+		if (..())
+			return TRUE
 		src.ping_card = null
 		src.print_text("Ping! V4.92<br>Commands: \"Ping\" to ping network. \"View\" to view prevous ping data.<br>\"Quit\" to exit but remain in memory, \"FQuit\" to quit normally.")
 
@@ -327,9 +331,9 @@
 
 	var/tmp/datum/computer/file/temp_file
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
-
 	initialize()
+		if (..())
+			return TRUE
 		attempt_id = null
 		src.pnet_card = null
 		var/introdat = "FROG Terminal Client V1.3<br>Copyright 2053 Thinktronic Systems, LTD."
@@ -534,16 +538,15 @@ file_save - Save file to local disk."}
 
 				src.attempt_id = argument1
 
-				var/datum/computer/file/user_data/user_data = get_user_data()
 				var/datum/computer/file/record/udat = null
-				if (istype(user_data))
+				if (istype(src.account))
 					udat = new
-					udat.fields["registered"] = user_data.registered
+					udat.fields["registered"] = src.account.registered
 					if (src.service_mode)
-						udat.fields["userid"] = format_username(user_data.registered)
+						udat.fields["userid"] = format_username(src.account.registered)
 
-					udat.fields["assignment"] = user_data.assignment
-					udat.fields["access"] = list2params(user_data.access)
+					udat.fields["assignment"] = src.account.assignment
+					udat.fields["access"] = list2params(src.account.access)
 					if (!udat.fields["registered"] || !udat.fields["assignment"] || !udat.fields["access"])
 						//qdel(udat)
 						udat.dispose()
@@ -847,17 +850,6 @@ file_save - Save file to local disk."}
 		src.peripheral_command("transmit", termsignal, "\ref[pnet_card]")
 		return
 
-	proc/get_user_data()
-		var/datum/computer/folder/accdir = src.holder.root
-		if(src.master.host_program) //Check where the OS is, preferably.
-			accdir = src.master.host_program.holder.root
-
-		var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-		if(target && istype(target))
-			return target
-
-		return null
-
 #define WORKING_PACKET_MAX 32
 
 /datum/computer/file/terminal_program/sigpal
@@ -874,6 +866,8 @@ file_save - Save file to local disk."}
 		..()
 
 	initialize()
+		if (..())
+			return TRUE
 		working_signal = list()
 		src.pnet_card = null
 		attached_file = null
@@ -1273,6 +1267,8 @@ file_save - Save file to local disk."}
 		return
 
 	initialize()
+		if (..())
+			return TRUE
 		//Set working lists back to normal...
 		src.text_buffer = new
 		src.working_signal = get_free_signal()
@@ -1364,6 +1360,8 @@ file_save - Save file to local disk."}
 
 
 	initialize()
+		if (..())
+			return TRUE
 
 		var/dat = "Crew Manifest<br>Entries cannot be modified from this terminal.<br>"
 

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -354,6 +354,8 @@ file_save - Save file to local disk."}
 		return
 
 	initialize()
+		if (..())
+			return TRUE
 		//src.service_mode = 0
 		src.print_text("Loading TermOS, Revision C<br>Copyright 2046-2053 Thinktronic Systems, LTD.")
 

--- a/code/modules/networks/computer3/writer.dm
+++ b/code/modules/networks/computer3/writer.dm
@@ -21,9 +21,9 @@
 	var/tmp/list/known_printers = list()
 	var/tmp/printer_status = "???"
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
-
 	initialize()
+		if (..())
+			return TRUE
 		src.print_text("WizWrite V3.0")
 		src.connected = 0
 		src.mode = 0
@@ -379,15 +379,14 @@
 			signal.data["address_1"] = address
 			signal.data["command"] = "term_connect"
 			signal.data["device"] = "SRV_TERMINAL"
-			var/datum/computer/file/user_data/user_data = get_user_data()
 			var/datum/computer/file/record/udat = null
-			if (istype(user_data))
+			if (istype(src.account))
 				udat = new
 
-				var/userid = format_username(user_data.registered)
+				var/userid = format_username(src.account.registered)
 
 				udat.fields["userid"] = userid
-				udat.fields["access"] = list2params(user_data.access)
+				udat.fields["access"] = list2params(src.account.access)
 				if (!udat.fields["access"] || !udat.fields["userid"])
 //					qdel(udat)
 					udat.dispose()
@@ -477,17 +476,6 @@
 			signal.data["title"] = print_title
 			src.peripheral_command("print",signal, "\ref[printcard]")
 			return 0
-
-		get_user_data()
-			var/datum/computer/folder/accdir = src.holder.root
-			if(src.master.host_program) //Check where the OS is, preferably.
-				accdir = src.master.host_program.holder.root
-
-			var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-			if(target && istype(target))
-				return target
-
-			return null
 
 		get_config_menu()
 			if (src.connected && src.server_netid)

--- a/code/modules/transport/cruisers/cruiser_console.dm
+++ b/code/modules/transport/cruisers/cruiser_console.dm
@@ -9,6 +9,8 @@
 		..()
 
 	initialize()
+		if (..())
+			return TRUE
 		src.print_text("Cruiser Control Assistant<br>Type \"help\" for commands.")
 
 	input_text(text)

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -253,34 +253,21 @@ TYPEINFO(/area/station/shield_zone)
 	name = "ShieldControl"
 	size = 10
 	req_access = list(access_engineering_engine)
-	var/tmp/authenticated = null //Are we currently logged in?
-	var/datum/computer/file/user_data/account = null
 	var/obj/item/peripheral/network/powernet_card/pnet_card = null
 	var/tmp/gen_net_id = null //The net id of our linked generator
 	var/tmp/reply_wait = -1 //How long do we wait for replies? -1 is not waiting.
 
-	var/setup_acc_filepath = "/logs/sysusr"//Where do we look for login data?
-
 	initialize()
-		src.authenticated = null
+		if (..())
+			return TRUE
 		src.master.temp = null
-		if (!src.find_access_file()) //Find the account information, as it's essentially a ~digital ID card~
-			src.print_text("<b>Error:</b> Cannot locate user file.  Quitting...")
-			src.master.unload_program(src) //Oh no, couldn't find the file.
-			return
 
 		src.pnet_card = locate() in src.master.peripherals
 		if (!pnet_card || !istype(src.pnet_card))
 			src.pnet_card = null
 			src.print_text("<b>Warning:</b> No network adapter detected.")
 
-		if (!src.check_access(src.account.access))
-			src.print_text("User [src.account.registered] does not have needed access credentials.<br>Quitting...")
-			src.master.unload_program(src)
-			return
-
 		src.reply_wait = -1
-		src.authenticated = src.account.registered
 
 		var/intro_text = {"<b>ShieldControl</b>
 		<br>Emergency Defense Shield System
@@ -422,18 +409,6 @@ TYPEINFO(/area/station/shield_zone)
 							logTheThing(LOG_STATION, null, "[key_name(usr)] deactivated shields")
 				return
 		return
-
-	proc/find_access_file() //Look for the whimsical account_data file
-		var/datum/computer/folder/accdir = src.holder.root
-		if (src.master.host_program) //Check where the OS is, preferably.
-			accdir = src.master.host_program.holder.root
-
-		var/datum/computer/file/user_data/target = parse_file_directory(setup_acc_filepath, accdir)
-		if (target && istype(target))
-			src.account = target
-			return 1
-
-		return 0
 
 	proc/detect_generator() //Send out a ping signal to find a comm dish.
 		if (!src.pnet_card)

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -1039,7 +1039,8 @@ meaty thoughts from cogwerks to his spacepal aibm:
 	var/tmp/inPasswordRequestMode = 0
 
 	initialize()
-		..()
+		if (..())
+			return TRUE
 		src.master.temp = ""
 		src.master.temp_add = ""
 		src.print_text("&#x041F;&#x043E;&#x0436;a&#x043B;y&#x0439;c&#x0442;a, &#x0432;c&#x0442;a&#x0432;&#x044C;&#x0442;e &#x043A;&#x043B;&#x044E;&#x0447;&#x0438; a&#x0432;&#x0442;o&#x0440;&#x0438;&#x044D;a&#x0446;&#x0438;&#x0438;.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the redefinitions of `find_access_file` and `get_user_data` and associated variables with one proc on the parent type that's called by `initialize`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I started trying to write a new terminal program and now here we are an hour later.
Terminal authentication didn't need to be implemented 12 separate times.