### PR TITLE
Priority role terminal program for HoP and captain

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -990,7 +990,8 @@ var/datum/job_controller/job_controls
 				alert(usr, "Could not find a savefile with that ckey!.")
 			src.job_creator()
 
-/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0)
+///Soft supresses crash on failing to find a job
+/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0, var/soft = FALSE, var/case_sensitive = TRUE)
 	RETURN_TYPE(/datum/job)
 	if (!string || !istext(string))
 		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string in controller detected")
@@ -1007,21 +1008,22 @@ var/datum/job_controller/job_controls
 		return null
 	var/list/results = list()
 	for (var/datum/job/J in job_controls.staple_jobs)
-		if (J.name == string || (string in J.alias_names))
+		if (J.match_to_string(string, case_sensitive))
 			results += J
 	if (!staple_only)
 		for (var/datum/job/J in job_controls.special_jobs)
-			if (J.name == string || (string in J.alias_names))
+			if (J.match_to_string(string, case_sensitive))
 				results += J
 		for (var/datum/job/J in job_controls.hidden_jobs)
-			if (J.name == string || (string in J.alias_names))
+			if (J.match_to_string(string, case_sensitive))
 				results += J
 	if(length(results) == 1)
 		return results[1]
 	else if(length(results) > 1)
 		stack_trace("Multiple jobs share the name '[string]'!")
 		return results[1]
-	CRASH("No job found with name '[string]'!")
+	if (!soft)
+		CRASH("No job found with name '[string]'!")
 
 /proc/find_job_in_controller_by_path(var/path)
 	if (!path || !ispath(path) || !istype(path,/datum/job/))

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -131,6 +131,22 @@
 				if(M.real_name != default && M.real_name != orig_real)
 					phrase_log.log_phrase("name-[ckey(src.name)]", M.real_name, no_duplicates=TRUE)
 
+	/// Is this job highlighted for priority latejoining
+	proc/is_highlighted()
+		return global.priority_job == src
+
+	///Check if a string matches this job's name or alias with varying case sensitivity
+	proc/match_to_string(string, case_sensitive)
+		if (case_sensitive)
+			return src.name == string || (string in src.alias_names)
+		else
+			if(cmptext(src.name, string))
+				return TRUE
+			for (var/alias in src.alias_names)
+				if (cmptext(src.name, string))
+					return TRUE
+
+
 // Command Jobs
 
 ABSTRACT_TYPE(/datum/job/command)
@@ -1423,7 +1439,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_lhan = list(/obj/item/storage/secure/sbriefcase)
 	items_in_backpack = list(/obj/item/baton/cane)
-	alt_names = list("Senator", "President", "CEO", "Board Member", "Mayor", "Vice-President", "Governor")
+	alt_names = list("Senator", "President", "Board Member", "Mayor", "Vice-President", "Governor")
 	wiki_link = "https://wiki.ss13.co/VIP"
 
 	New()

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -442,75 +442,75 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 	proc/LateJoinLink(var/datum/job/J)
 		// This is pretty ugly but: whatever! I don't care.
 		// It likely needs some tweaking but everything does.
-		if (!J.no_late_join)
-			var/limit = J.limit
-			if (!IsJobAvailable(J))
-				// Show unavailable jobs, but no joining them
-				limit = 0
+		if (J.no_late_join)
+			return
+		var/limit = J.limit
+		if (!IsJobAvailable(J))
+			// Show unavailable jobs, but no joining them
+			limit = 0
 
-			var/c = countJob(J.name) 	// gross
-			if (limit == 0 && c == 0)
-				// 0 slots, nobody in it, don't show it
-				return
+		var/c = countJob(J.name) 	// gross
+		if (limit == 0 && c == 0)
+			// 0 slots, nobody in it, don't show it
+			return
 
-			//If it's Revolution time, lets show all command jobs as filled to (try to) prevent metagaming.
-			if(istype(J, /datum/job/command/) && istype(ticker.mode, /datum/game_mode/revolution))
-				c = max(c, limit)
+		//If it's Revolution time, lets show all command jobs as filled to (try to) prevent metagaming.
+		if(istype(J, /datum/job/command/) && istype(ticker.mode, /datum/game_mode/revolution))
+			c = max(c, limit)
 
-			var/hover_text = J.short_description || "Join the round as [J.name]."
+		var/hover_text = J.short_description || "Join the round as [J.name]."
 
-			// probalby could be a define but dont give a shite
-			var/maxslots = 5
-			var/list/slots = list()
-			var/shown = clamp(c, (limit == -1 ? maxslots : limit), maxslots)
-			// if there's still an open space, show a final join link
-			if (limit == -1 || (limit > maxslots && c < limit))
-				slots += {"<a href='byond://?src=\ref[src];
-				SelectedJob=\ref[J];latejoin=join' class='latejoin-card' style='border-color: [J.linkcolor];
-				' title='[hover_text]'>&#x2713;
-				&#xFE0E;
-				</a>"}
-			// show slots up to the limit
-			// extra people beyond the limit will be shown as a [+X] card, supposedly
-			for (var/i = shown, i > 0, i--)
-				// can you believe all these slot appendages were in one line before using nested ternaries? awful.
-				if (i <= c)
-					if (i == 1 && c > shown)
-						slots += {"
-						<div
-						class='latejoin-card latejoin-full'
-						style='border-color: [J.linkcolor]; background-color: [J.linkcolor];'
-						title='Slot filled.'
-						>+[c - maxslots]
-						</div>
-						"}
-					else
-						slots += {"
-						<div
-						class='latejoin-card latejoin-full'
-						style='border-color: [J.linkcolor]; background-color: [J.linkcolor];'
-						title='Slot filled.'
-						>&times;
-						</div>
-						"}
+		// probalby could be a define but dont give a shite
+		var/maxslots = 5
+		var/list/slots = list()
+		var/shown = clamp(c, (limit == -1 ? maxslots : limit), maxslots)
+		// if there's still an open space, show a final join link
+		if (limit == -1 || (limit > maxslots && c < limit))
+			slots += {"<a href='byond://?src=\ref[src];
+			SelectedJob=\ref[J];latejoin=join' class='latejoin-card' style='border-color: [J.linkcolor];
+			' title='[hover_text]'>&#x2713;
+			&#xFE0E;
+			</a>"}
+		// show slots up to the limit
+		// extra people beyond the limit will be shown as a [+X] card, supposedly
+		for (var/i = shown, i > 0, i--)
+			// can you believe all these slot appendages were in one line before using nested ternaries? awful.
+			if (i <= c)
+				if (i == 1 && c > shown)
+					slots += {"
+					<div
+					class='latejoin-card latejoin-full'
+					style='border-color: [J.linkcolor]; background-color: [J.linkcolor];'
+					title='Slot filled.'
+					>+[c - maxslots]
+					</div>
+					"}
 				else
 					slots += {"
-					<a
-					href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=join'
-					class='latejoin-card' style='border-color: [J.linkcolor];'
-					title='[hover_text]'
-					>&#x2713;&#xFE0E;
-					</a>
+					<div
+					class='latejoin-card latejoin-full'
+					style='border-color: [J.linkcolor]; background-color: [J.linkcolor];'
+					title='Slot filled.'
+					>&times;
+					</div>
 					"}
-			return {"
-				<tr><td class='latejoin-link'>
-					[(limit == -1 || c < limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=prompt' style='color: [J.linkcolor];' title='[hover_text]'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
-					</td>
-					<td class='latejoin-cards'>[jointext(slots, " ")]</td>
-				</tr>
+			else
+				slots += {"
+				<a
+				href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=join'
+				class='latejoin-card' style='border-color: [J.linkcolor];'
+				title='[hover_text]'
+				>&#x2713;&#xFE0E;
+				</a>
 				"}
-
-		return
+		return {"
+			<tr>
+				<td class='latejoin-link[J.is_highlighted() ? " highlighted" : ""]'>
+					[(limit == -1 || c < limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=prompt' style='color: [J.linkcolor];' title='[hover_text]'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
+				</td>
+				<td class='latejoin-cards'>[jointext(slots, " ")]</td>
+			</tr>
+			"}
 
 	proc/LateChoices()
 		// shut up
@@ -589,6 +589,10 @@ a.latejoin-card:hover {
 	display: inline-block;
 	vertical-align: top;
 	margin: 0 1em;
+}
+.highlighted {
+	border: 4px solid #FFE251;
+	border-radius: 3px;
 }
 </style>
 <h2 style='text-align: center; margin: 0 0 0.3em 0; font-size: 150%;'>You are joining a round in progress.</h2>

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -25,7 +25,7 @@
 	var/setup_drive_size = 64
 	var/setup_drive_type = null //Use this path for the hd
 	var/setup_frame_type = /obj/computer3frame //What kind of frame does it spawn while disassembled.  This better be a type of /obj/compute3frame !!
-	var/setup_starting_program = null //This program will start out installed on the drive
+	var/setup_starting_program = null //This program will start out installed on the drive (can be a path or a list of paths)
 	var/setup_starting_os = null //This program will start out installed AND AS ACTIVE PROGRAM
 	var/setup_starting_peripheral1 = null //Please note that the user cannot install more than 3.
 	var/setup_starting_peripheral2 = null //And the os tends to need that third one for the card reader
@@ -100,7 +100,7 @@
 		communications
 			name = "Communications Console"
 			icon_state = "comm"
-			setup_starting_program = /datum/computer/file/terminal_program/communications
+			setup_starting_program = list(/datum/computer/file/terminal_program/communications, /datum/computer/file/terminal_program/job_controls)
 			setup_starting_peripheral1 = /obj/item/peripheral/network/powernet_card
 			setup_starting_peripheral2 = /obj/item/peripheral/network/radio/locked/status
 			setup_drive_size = 80
@@ -305,13 +305,13 @@
 					src.hd = new /obj/item/disk/data/fixed_disk(src)
 				src.hd.file_amount = src.setup_drive_size
 
-			if(ispath(src.setup_starting_program))
-				var/datum/computer/file/terminal_program/starting = new src.setup_starting_program
+			for (var/program_path in (list() + src.setup_starting_program)) //neat hack to make it work with lists or a single path
+				if(ispath(program_path))
+					var/datum/computer/file/terminal_program/starting = new program_path
 
-				src.hd.file_amount = max(src.hd.file_amount, starting.size)
+					src.hd.file_amount = max(src.hd.file_amount, starting.size)
 
-				starting.transfer_holder(src.hd)
-				//src.processing_programs += src.active_program
+					starting.transfer_holder(src.hd)
 
 			if(ispath(src.setup_starting_os) && src.hd)
 				var/datum/computer/file/terminal_program/os/os = new src.setup_starting_os

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -27,7 +27,7 @@ var/datum/job/priority_job = null
 
 		switch(command)
 			if ("list")
-				var/list/output = list()
+				var/list/output = list("All roles currently being advertised:")
 				for (var/datum/job/job in job_controls.staple_jobs)
 					if (job.limit <= 0 || !job.add_to_manifest || job.no_late_join)
 						continue

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -43,6 +43,10 @@ var/datum/job/priority_job = null
 					else
 						src.print_text("No currently specified priority role.")
 					return
+				if (cmptext(job_name, "None"))
+					global.priority_job = null
+					src.print_text("Cleared priority job listing.")
+					return
 				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -1,0 +1,76 @@
+var/datum/job/priority_job = null
+/datum/computer/file/terminal_program/job_controls
+	name = "RoleControl" //bad pun "placeholder" name
+	size = 12 //idk
+	req_access = list(access_change_ids) //maybe should just be heads, but I like this being an HoP/captain thing
+
+	initialize()
+		..()
+		src.master.temp = null //clear the screen
+		var/intro_text = {"<br>Welcome to RoleControl!
+		<br>Recruitment management system.
+		<br><b>Commands:</b>
+		<br>(List) to view currently advertised roles.
+		<br>(Info) to view info on a specific role.
+		<br>(Prio role name) to prioritize recruiting a specific role. Call without arguments to display currently prioritized role.
+		<br>(Quit) to exit RoleControl.
+		"}
+		src.print_text(intro_text)
+
+	input_text(text)
+		if(..())
+			return TRUE
+
+		var/list/command_list = parse_string(text)
+		var/command = command_list[1]
+		command_list.Cut(1,2)
+
+		switch(command)
+			if ("list")
+				var/list/output = list()
+				for (var/datum/job/job in job_controls.staple_jobs)
+					if (job.limit <= 0 || !job.add_to_manifest || job.no_late_join)
+						continue
+
+					output += src.job_info(job)
+				src.print_text(output.Join("<br>"))
+
+			if ("prio")
+				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
+				if (!length(job_name))
+					if (global.priority_job)
+						src.print_text("Current priority role: [src.job_info(global.priority_job)]")
+					else
+						src.print_text("No currently specified priority role.")
+					return
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				if (!job)
+					src.print_text("Error: unable to identify role with name \[[job_name]\]")
+					return
+				global.priority_job = job
+				src.print_text("Success: priority role set to: \[[job.name]\]")
+				src.send_pda_message("RoleControl notification: priority role set to [job.name] by [src.account.assignment] [src.account.registered]")
+
+			if ("info")
+				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				if (!job)
+					src.print_text("Error: unable to identify role with name \[[job_name]\]")
+					return
+				src.print_text(src.job_info(job))
+
+			if("quit")
+				src.master.temp = ""
+				print_text("Now quitting...")
+				src.master.unload_program(src)
+
+	proc/job_info(datum/job/job)
+		var/job_text = "[job.name] \[[job.assigned]/[job.limit]\]"
+		if (job.is_highlighted())
+			job_text += " (PRIORITY)"
+		return job_text
+
+	proc/send_pda_message(message)
+		var/datum/signal/pdaSignal = get_free_signal()
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="COMMAND-MAILBOT", "group"=list(MGD_COMMAND), "sender"="00000000", "message"=message)
+		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -39,7 +39,7 @@ var/datum/job/priority_job = null
 				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
 				if (!length(job_name))
 					if (global.priority_job)
-						src.print_text("Current priority role: [src.job_info(global.priority_job)]")
+						src.print_text("Current priority role: [src.job_info(global.priority_job)]<br>Type \"prio none\" to clear.")
 					else
 						src.print_text("No currently specified priority role.")
 					return

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1519,6 +1519,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\networks\computer3\disks.dm"
 #include "code\modules\networks\computer3\emailclient.dm"
 #include "code\modules\networks\computer3\engine.dm"
+#include "code\modules\networks\computer3\job_controls.dm"
 #include "code\modules\networks\computer3\med_rec.dm"
 #include "code\modules\networks\computer3\peripherals.dm"
 #include "code\modules\networks\computer3\sec_rec.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a `RoleControl` terminal program to communications consoles that allows anyone with ID card modification access (Captain, HoP and HoS by default) to set one role as "priority" for latejoins:
![image](https://github.com/goonstation/goonstation/assets/20713227/5ffa065d-67e6-475f-aa80-ebfd9fef7692)
The role will appear highlighted in yellow on the latejoin menu:
![image](https://github.com/goonstation/goonstation/assets/20713227/e5c08c36-da0e-44d1-b439-ea535a642f0a)
Setting the priority role triggers a PDA message to the command mailgroup:
![image](https://github.com/goonstation/goonstation/assets/20713227/03b3bcb5-b896-4d6c-b63a-d20734451d74)

TODO:

- [ ] Figure out some kind of reward for joining as a priority role: spacebux/credit bonus?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think Sord suggested it? More things for captain/HoP to do, lets people have an idea of what departments really need backup when they're looking to join a round.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Added a new program to communications consoles: RoleControl. Requires ID computer access and allows you to set a priority role to be highlighted on the latejoin menu.
```
