### PR TITLE
Bathsalts Recipe Change, Mugwort to Ghost Chili Juice

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4176,7 +4176,7 @@
 		name = "Bath Salts"
 		id= "bathsalts"
 		result = "bathsalts"
-		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "mugwort" = 1)
+		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "ghostchilijuice" = 1)
 		min_temperature = T0C + 100
 		result_amount = 6
 		mix_phrase = "Tiny cubic crystals precipitate out of the mixture. Huh."


### PR DESCRIPTION
## About the PR
This PR is to replace the reagent mugwort from the bath salts chemistry recipe with ghost chili juice for slightly easier manufacturing of the drug in chemistry.


## Why's this needed?
Having attempted to manufacture bath salts in a standard round as a chemistry scientist, I found that due to its reliance on mugwort, the amount you can make is completely based on luck and whether you get the kachup flavored Discount Dan's noodles from a vending machines. This in turn means very few players try to synthesize the drug in science, and it rarely ends up getting used for traitor and non traitor purposes. 

As a replacement, ghost chili juice would still be hard to acquire (requiring an understanding of botany mutations and use of the still), while not relying on the pure luck in acquiring mugwort.
Other reasons why ghost chili juice would act as a good replacement:

1. It's also a rare reagent found in Discount Dan's noodles (as well as bath bombs), meaning the description on the wiki about dumping "all the Discount Dan's flavors into a bathtub and heat it with a welder, you'll probably find it" is still valid, and even more so, as ghost chili juice is also found in bath bombs.

2. A chemist is able to synthesize it by working with botanists, allowing for department cooperation, more use of the drug and larger quantities to be manufactured.

3. It acts as a reference to the Simpsons episode where homer gets high from eating a super spicy chili. 
See: https://www.youtube.com/watch?v=Ji8oZTJAC5A



## Changelog

```changelog
(u)ithebinman
(*)Removed mugwort from the bathsalts chemistry recipe
(+)Added ghost chili juice to the bathsalts chemistry recipe
```
