### PR TITLE
Add fanny pack as a spacebux purchase

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -330,6 +330,13 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			path = /obj/item/pixel_pass
 			icon_state = "pixel_pass"
 
+		fanny_pack
+			name = "Fanny Pack"
+			cost = 2500
+			path = /obj/item/storage/fanny
+			icon = 'icons/obj/items/belts.dmi'
+			icon_state = "fanny"
+
 	altjumpsuit
 		name = "Alternate Jumpsuit"
 		cost = 1500
@@ -646,13 +653,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					H.back.desc = "A thick, wearable container made of synthetic fibers. This brown variation is both rustic and adventurous!"
 					return 1
 				return 0
-
-	fanny_pack
-		name = "Fanny Pack"
-		cost = 2500
-		path = /obj/item/storage/fanny
-		icon = 'icons/obj/items/belts.dmi'
-		icon_state = "fanny"
 
 	lunchbox
 		name = "Lunchbox"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -24,6 +24,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/human_item/dabbing_license,\
 	new /datum/bank_purchaseable/human_item/chem_hint,\
 	new /datum/bank_purchaseable/human_item/pixel_pass,\
+	new /datum/bank_purchaseable/human_item/fanny_pack,\
 
 	new /datum/bank_purchaseable/altjumpsuit,\
 	new /datum/bank_purchaseable/altclown,\
@@ -645,6 +646,13 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					H.back.desc = "A thick, wearable container made of synthetic fibers. This brown variation is both rustic and adventurous!"
 					return 1
 				return 0
+
+	fanny_pack
+		name = "Fanny Pack"
+		cost = 2500
+		path = /obj/item/storage/fanny
+		icon = 'icons/obj/items/belts.dmi'
+		icon_state = "fanny"
 
 	lunchbox
 		name = "Lunchbox"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Feature]
[A-Traits]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mostly I made this just to test making PRS because I funked up my enviroment and I wanted to know if I'd even  be able to make them, fingers crossed I dont make a fool of myself by making this blank

This PR allows you to buy the Fanny pack as a spacebux purchase as they're super easy to get a hold already


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fanny packs are already super easy to get a hold of,  this just gives me something to sink my spacebux into and save like 1-3 minutes at most.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cindertroy
(+)Adds the Fanny Pack as a spacebux purchase
```
