### PR TITLE
Engage the brake by default in pods and subs

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -23,7 +23,8 @@
 	var/obj/item/shipcomponent/sensor/sensors = null
 	var/obj/item/shipcomponent/secondary_system/lock/lock = null
 	var/obj/item/shipcomponent/pod_lights/lights = null
-	var/rcs = 0		//bool, 1 for active, 0 for inactive
+	/// brake toggle
+	var/rcs = TRUE
 	var/uses_weapon_overlays = 0
 	var/health = 200
 	var/maxhealth = 200


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Change pods and subs to have the brakes engaged by default


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Less confusing for new players. New players often struggle when flying pods and are unaware of the existence of the brake feature - which makes piloting/driving significantly easier to control. This is most evident when observing newbee nuke ops players struggling to keep up with their team. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)The brake is now engaged by default in pods and subs
```
