### PR TITLE
Fixes Holy Water, Bubble Bath, & Other Reagent Overlays

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -215,6 +215,7 @@ proc/ui_describe_reagents(atom/A)
 	New()
 		. = ..()
 		src.container_style ||= src.icon_state
+		src.UpdateIcon()
 
 	on_reagent_change()
 		. = ..()

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -15,16 +15,6 @@
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
 	object_flags = NO_GHOSTCRITTER
 	fluid_overlay_states = 6
-	var/bottle_style = null
-
-	New()
-		if (!src.bottle_style)
-			src.bottle_style = "[rand(1,4)]"
-
-		. = ..()
-
-		src.container_style = "bottle_[src.bottle_style]"
-		src.UpdateIcon()
 
 /* =================================================== */
 /* -------------------- Sub-Types -------------------- */
@@ -42,91 +32,91 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine
 	name = "bottle (epinephrine)"
 	desc = "A small bottle. Contains epinephrine, also known as adrenaline. Used for stabilizing critical patients and as an antihistamine in severe allergic reactions."
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 10
 	initial_reagents = "epinephrine"
 
 /obj/item/reagent_containers/glass/bottle/toxin
 	name = "toxin bottle"
 	desc = "A small bottle containing toxic compounds."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "toxin"
 
 /obj/item/reagent_containers/glass/bottle/atropine
 	name = "bottle (atropine)"
 	desc = "A small bottle containing atropine, used for cardiac emergencies and as a stabilizer in extreme medical cases.  It has a warning label on it about dizziness and minor toxicity."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "atropine"
 
 /obj/item/reagent_containers/glass/bottle/saline
 	name = "bottle (saline-glucose)"
 	desc = "A small bottle containing saline-glucose solution, used for treating blood loss and shock. It also speeds up recovery from small injuries."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "saline"
 
 /obj/item/reagent_containers/glass/bottle/aspirin
 	name = "bottle (salicylic acid)"
 	desc = "A small bottle containing salicyclic acid, used as a painkiller and for treating moderate injuries."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "salicylic_acid"
 
 /obj/item/reagent_containers/glass/bottle/insulin
 	name = "bottle (insulin)"
 	desc = "A small bottle of insulin, for treating hyperglycaemic shock."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "insulin"
 
 /obj/item/reagent_containers/glass/bottle/heparin
 	name = "bottle (heparin)"
 	desc = "A small bottle of anticoagulant, for helping with blood clots and heart disease. It has a warning label on it about hypotension."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "heparin"
 
 /obj/item/reagent_containers/glass/bottle/proconvertin
 	name = "bottle (proconvertin)"
 	desc = "A small bottle of coagulant, for reducing blood loss and increasing blood pressure. It has a warning label on it about hypertension."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "proconvertin"
 
 /obj/item/reagent_containers/glass/bottle/filgrastim
 	name = "bottle (filgrastim)"
 	desc = "A small bottle of filgrastim, for stimulating blood production in cases with heavy blood loss. It has a warning label on it about hypertension."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "filgrastim"
 
 /obj/item/reagent_containers/glass/bottle/calomel
 	name = "bottle (calomel)"
 	desc = "A small bottle of calomel, for flushing chemicals from the blood stream in cases with severe poisoning. It has a warning label on it about toxicity."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "calomel"
 
 /obj/item/reagent_containers/glass/bottle/spaceacillin
 	name = "bottle (spaceacillin)"
 	desc = "A small bottle of spaceacillin, for curing minor diseases."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "spaceacillin"
 
 /obj/item/reagent_containers/glass/bottle/morphine
 	name = "bottle (morphine)"
 	desc = "A small bottle of morphine, a powerful painkiller and sedative. It has a warning label on it about addiction and minor toxicity."
-	bottle_style = "4"
+	icon_state = "bottle_4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "morphine"
 
 /obj/item/reagent_containers/glass/bottle/coldmedicine
 	name = "bottle (robustissin)"
 	desc = "A small bottle containing robustissin, for treating common ailments.  It has a warning label on it about dizziness and minor toxicity."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "cold_medicine"
 
@@ -165,14 +155,14 @@
 /obj/item/reagent_containers/glass/bottle/pfd
 	name = "perfluorodecalin bottle"
 	desc = "A small bottle of perfluorodecalin, an experimental liquid-breathing medicine."
-	bottle_style = "4"
+	icon_state = "bottle_4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "perfluorodecalin"
 
 /obj/item/reagent_containers/glass/bottle/omnizine
 	name = "omnizine bottle"
 	desc = "A small bottle of an experimental and expensive herbal compound."
-	bottle_style = "4"
+	icon_state = "bottle_4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "omnizine"
 
@@ -191,7 +181,7 @@
 /obj/item/reagent_containers/glass/bottle/pentetic
 	name = "pentetic acid bottle"
 	desc = "A small bottle of pentetic acid, an experimental and aggressive chelation agent."
-	bottle_style = "4"
+	icon_state = "bottle_4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "penteticacid"
 
@@ -200,70 +190,70 @@
 /obj/item/reagent_containers/glass/bottle/sulfonal
 	name = "sulfonal bottle"
 	desc = "A small bottle of sulfonal, an extreme muscle relaxant. It has a warning label on it about impaired breathing and drowsiness."
-	bottle_style = "4"
+	icon_state = "bottle_4"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "sulfonal"
 
 /obj/item/reagent_containers/glass/bottle/synaptizine
 	name = "bottle (synaptizine)"
 	desc = "A small bottle of synaptizine, a non-addictive stimulant whose side effects can cause regeneration of brain tissue."
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "synaptizine"
 
 /obj/item/reagent_containers/glass/bottle/pancuronium
 	name = "pancuronium bottle"
 	desc = "A small bottle of pancuronium, an extreme muscle relaxant. It has a warning label on it about impaired breathing and unconciousness."
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "pancuronium"
 
 /obj/item/reagent_containers/glass/bottle/antitoxin
 	name = "bottle (charcoal)"
 	desc = "A small bottle of charcoal, a general purpose antitoxin."
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "charcoal"
 
 /obj/item/reagent_containers/glass/bottle/antihistamine
 	name = "bottle (diphenhydramine)"
 	desc = "A small bottle of diphenhydramine, useful for reducing the severity of allergic reactions."
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "antihistamine"
 
 /obj/item/reagent_containers/glass/bottle/eyedrops
 	name = "bottle (oculine)"
 	desc = "A small bottle of combined eye and ear medication. A label on it reads: \"For ease of usage, apply topically.\""
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "oculine"
 
 /obj/item/reagent_containers/glass/bottle/antirad
 	name = "bottle (potassium iodide)"
 	desc = "A small bottle of potassium iodide, a weak antitoxin that serves mainly to treat or reduce the effects of radiation poisoning."
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "anti_rad"
 
 /obj/item/reagent_containers/glass/bottle/pacid
 	name = "fluorosulfuric acid bottle"
 	desc = "A small bottle of fluorosulfuric acid, a potent acid."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "pacid"
 
 /obj/item/reagent_containers/glass/bottle/cyanide
 	name = "cyanide bottle"
 	desc = "A small bottle of cyanide, a potent poison that prevents the production of ATP, causing cellular suffocation."
-	bottle_style = "2"
+	icon_state = "bottle_2"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "cyanide"
 
 /obj/item/reagent_containers/glass/bottle/fluorosurfactant
 	name = "fluorosurfactant bottle"
 	desc = "A small bottle of fluorosurfactant, a chemical that foams rapidly when mixed with water."
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 5
 	initial_reagents = "fluorosurfactant"
 
@@ -280,7 +270,7 @@
 /obj/item/reagent_containers/glass/bottle/mercury
 	name = "mercury bottle"
 	desc = "A small bottle with a 'Do Not Drink' label on it."
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	initial_volume = 50
 	amount_per_transfer_from_this = 5
 	initial_reagents = "mercury"
@@ -414,6 +404,7 @@
 	initial_volume = 50
 	initial_reagents = list("fluorosurfactant"=30,"pepperoni"=10,"bourbon"=10)
 	amount_per_transfer_from_this = 5
+	fluid_overlay_states = 0
 	rc_flags = RC_FULLNESS
 
 /obj/item/reagent_containers/glass/bottle/holywater
@@ -423,6 +414,7 @@
 	icon_state = "holy_water"
 	initial_reagents = "water_holy"
 	amount_per_transfer_from_this = 10
+	fluid_overlay_states = 0
 
 /obj/item/reagent_containers/glass/bottle/cleaner
 	name = "cleaner bottle"
@@ -432,3 +424,4 @@
 	initial_volume = 100
 	initial_reagents = "cleaner"
 	amount_per_transfer_from_this = 10
+	fluid_overlay_states = 0

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -574,7 +574,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "weedkiller"
 	desc = "A small bottle filled with Atrazine, an effective weedkiller."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "1"
+	icon_state = "bottle_1"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 
@@ -586,7 +586,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "Mutagenic Plant Formula"
 	desc = "An unstable radioactive mixture that stimulates genetic diversity."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 
@@ -598,7 +598,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "Ammonia Plant Formula"
 	desc = "A nutrient-rich plant formula that encourages quick plant growth."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 
@@ -610,7 +610,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "Potash Plant Formula"
 	desc = "A nutrient-rich plant formula that encourages large crop yields."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 
@@ -622,7 +622,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "Saltpetre Plant Formula"
 	desc = "A nutrient-rich plant formula that encourages more potent crops."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 
@@ -634,7 +634,7 @@ TYPEINFO(/obj/item/plantanalyzer)
 	name = "Mutadone Plant Formula"
 	desc = "A nutrient-rich formula that attempts to rectify genetic problems."
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
-	bottle_style = "3"
+	icon_state = "bottle_3"
 	amount_per_transfer_from_this = 10
 	initial_volume = 40
 


### PR DESCRIPTION
[Bug] [Sprites]


## About The PR:
Removes fluid overlays from holy water and bubble bath bottles.
Removes the `/obj/item/reagent_containers/glass/bottle/var/bottle_style` variable, and replaces it with regular `icon_state` overriding.

Fixes #18061, and fixes #18072.