### PR TITLE
Makes security slots scale at lower population

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -52,6 +52,7 @@ var/datum/job_controller/job_controls
 		for (var/datum/job/J in staple_jobs)
 			if (J.limit > 0)
 				J.limit *= 4
+				J.upper_limit = J.limit
 		#endif
 
 
@@ -198,6 +199,7 @@ var/datum/job_controller/job_controls
 			if (isnull(newcap))
 				return
 			JOB.limit = newcap
+			JOB.admin_set_limit = TRUE
 			message_admins("Admin [key_name(usr)] altered [JOB.name] job cap to [newcap]")
 			logTheThing(LOG_ADMIN, usr, "altered [JOB.name] job cap to [newcap]")
 			logTheThing(LOG_DIARY, usr, "altered [JOB.name] job cap to [newcap]", "admin")

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -89,7 +89,7 @@
 		var/old_limit = src.limit
 		//basic linear scale between upper and lower limits
 		var/scalar = (player_count - SLOT_SCALING_LOWER_THRESHOLD) / (SLOT_SCALING_UPPER_THRESHOLD - SLOT_SCALING_LOWER_THRESHOLD)
-		src.limit = round(src.lower_limit + scalar * (src.upper_limit - src.lower_limit))
+		src.limit = round(src.lower_limit + scalar * (src.upper_limit - src.lower_limit), 1)
 		src.limit = clamp(src.limit, src.lower_limit, src.upper_limit) //paranoia clamp, probably not needed
 		if (src.limit != old_limit)
 			logTheThing(LOG_DEBUG, src, "Altering variable job limit for [src.name] from [old_limit] to [src.limit] at [player_count] player count.")

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -77,7 +77,7 @@
 		if (isnull(src.upper_limit))
 			src.upper_limit = src.limit
 
-#define SLOT_SCALING_UPPER_THRESHOLD 60 //the point at which we have maximum slots open
+#define SLOT_SCALING_UPPER_THRESHOLD 50 //the point at which we have maximum slots open
 #define SLOT_SCALING_LOWER_THRESHOLD 20 //the point at which we have minimum slots open
 
 	proc/recalculate_limit(player_count)
@@ -86,10 +86,13 @@
 		if (player_count >= SLOT_SCALING_UPPER_THRESHOLD) //above this just open everything up
 			src.limit = src.upper_limit
 			return src.limit
+		var/old_limit = src.limit
 		//basic linear scale between upper and lower limits
 		var/scalar = (player_count - SLOT_SCALING_LOWER_THRESHOLD) / (SLOT_SCALING_UPPER_THRESHOLD - SLOT_SCALING_LOWER_THRESHOLD)
 		src.limit = round(src.lower_limit + scalar * (src.upper_limit - src.lower_limit))
 		src.limit = clamp(src.limit, src.lower_limit, src.upper_limit) //paranoia clamp, probably not needed
+		if (src.limit != old_limit)
+			logTheThing(LOG_DEBUG, src, "Altering variable job limit for [src.name] from [old_limit] to [src.limit] at [player_count] player count.")
 		return src.limit
 
 #undef SLOT_SCALING_UPPER_THRESHOLD

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -5,6 +5,10 @@
 	var/linkcolor = "#0FF"
 	var/wages = 0
 	var/limit = -1
+	var/upper_limit = null //! defaults to `limit`
+	var/lower_limit = 0
+	var/admin_set_limit = FALSE //! has an admin manually set the limit to something
+	var/variable_limit = FALSE //! does this job scale down at lower population counts
 	var/add_to_manifest = 1
 	var/no_late_join = 0
 	var/no_jobban_from_this_job = 0
@@ -70,6 +74,31 @@
 	New()
 		..()
 		initial_name = name
+		if (isnull(src.upper_limit))
+			src.upper_limit = src.limit
+
+#define SLOT_SCALING_UPPER_THRESHOLD 60 //the point at which we have maximum slots open
+#define SLOT_SCALING_LOWER_THRESHOLD 20 //the point at which we have minimum slots open
+
+	proc/recalculate_limit(player_count)
+		if (src.limit < 0 || src.admin_set_limit) //don't mess with infinite slot or admin limit set jobs
+			return src.limit
+		if (player_count >= SLOT_SCALING_UPPER_THRESHOLD) //above this just open everything up
+			src.limit = src.upper_limit
+			return src.limit
+		//basic linear scale between upper and lower limits
+		var/scalar = (player_count - SLOT_SCALING_LOWER_THRESHOLD) / (SLOT_SCALING_UPPER_THRESHOLD - SLOT_SCALING_LOWER_THRESHOLD)
+		src.limit = round(src.lower_limit + scalar * (src.upper_limit - src.lower_limit))
+		src.limit = clamp(src.limit, src.lower_limit, src.upper_limit) //paranoia clamp, probably not needed
+		return src.limit
+
+#undef SLOT_SCALING_UPPER_THRESHOLD
+#undef SLOT_SCALING_LOWER_THRESHOLD
+
+	onVarChanged(variable, oldval, newval)
+		. = ..()
+		if (variable == "limit")
+			src.admin_set_limit = TRUE
 
 	proc/special_setup(var/mob/M, no_special_spawn)
 		if (!M)
@@ -479,11 +508,9 @@ ABSTRACT_TYPE(/datum/job/security)
 
 /datum/job/security/security_officer
 	name = "Security Officer"
-#ifdef MAP_OVERRIDE_MANTA
-	limit = 4
-#else
 	limit = 5
-#endif
+	lower_limit = 3
+	variable_limit = TRUE
 	wages = PAY_TRADESMAN
 	allow_traitors = 0
 	allow_spy_theft = 0
@@ -521,6 +548,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	assistant
 		name = "Security Assistant"
 		limit = 3
+		lower_limit = 2
 		cant_spawn_as_con = 1
 		wages = PAY_UNTRAINED
 		receives_implant = /obj/item/implant/health/security

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -89,7 +89,9 @@
 		var/old_limit = src.limit
 		//basic linear scale between upper and lower limits
 		var/scalar = (player_count - SLOT_SCALING_LOWER_THRESHOLD) / (SLOT_SCALING_UPPER_THRESHOLD - SLOT_SCALING_LOWER_THRESHOLD)
-		src.limit = round(src.lower_limit + scalar * (src.upper_limit - src.lower_limit), 1)
+		src.limit = src.lower_limit + scalar * (src.upper_limit - src.lower_limit)
+		logTheThing(LOG_DEBUG, src, "Variable job limit for [src.name] calculated as [src.limit] slots at [player_count] player count")
+		src.limit = round(src.limit, 1)
 		src.limit = clamp(src.limit, src.lower_limit, src.upper_limit) //paranoia clamp, probably not needed
 		if (src.limit != old_limit)
 			logTheThing(LOG_DEBUG, src, "Altering variable job limit for [src.name] from [old_limit] to [src.limit] at [player_count] player count.")

--- a/code/map.dm
+++ b/code/map.dm
@@ -191,10 +191,12 @@ var/global/list/mapNames = list(
 			for(var/datum/job/J in job_controls.staple_jobs)
 				if(J.map_can_autooverride && (J.name in job_start_locations))
 					J.limit = length(job_start_locations[J.name])
+					J.upper_limit = J.limit
 
 		for(var/datum/job/J in job_controls.staple_jobs + job_controls.special_jobs)
 			if(J.type in src.job_limits_override)
 				J.limit = src.job_limits_override[J.type]
+				J.upper_limit = J.limit
 
 		SPAWN(5 SECONDS)
 			src.load_shuttle()

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -388,6 +388,14 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 				starting_loc = pick_landmark(LANDMARK_LATEJOIN, locate(round(world.maxx / 2), round(world.maxy / 2), 1))
 				character.set_loc(starting_loc)
 
+			var/player_count = 0
+			for (var/client/client in clients)
+				if (istype(client.mob.loc, /obj/cryotron) || istype(client.mob, /mob/new_player)) //don't count cryoed or lobby players
+					player_count++
+			for(var/datum/job/staple_job in job_controls.staple_jobs) //we'll just assume only staple jobs have variable limits for now
+				if (staple_job.variable_limit)
+					staple_job.recalculate_limit(player_count)
+
 			if (isliving(character))
 				var/mob/living/LC = character
 				if(!istype(JOB,/datum/job/battler) && !istype(JOB, /datum/job/football))

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -390,7 +390,7 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 
 			var/player_count = 0
 			for (var/client/client in clients)
-				if (istype(client.mob.loc, /obj/cryotron) || istype(client.mob, /mob/new_player)) //don't count cryoed or lobby players
+				if (!istype(client.mob.loc, /obj/cryotron) && !istype(client.mob, /mob/new_player)) //don't count cryoed or lobby players
 					player_count++
 			for(var/datum/job/staple_job in job_controls.staple_jobs) //we'll just assume only staple jobs have variable limits for now
 				if (staple_job.variable_limit)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -106,6 +106,8 @@ var/global/totally_random_jobs = FALSE
 
 
 	for(var/datum/job/JOB in job_controls.staple_jobs)
+		if (JOB.variable_limit)
+			JOB.recalculate_limit(length(unassigned))
 		// If it's hi-pri, add it to that list. Simple enough
 		if (JOB.high_priority_job)
 			high_priority_jobs.Add(JOB)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes security officer slots scale down from 5 at 60 players to 3 at 20 players, counted as players readied at roundstart and then all living + dead players who are not in cryo afterwards.
Also makes security assistant slots scale down from 3 to 2 over the same population interval.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
On lower population RP shifts it's not uncommon to have an overwhelming amount of security officers for 1 or 2 antagonists, this PR aims to reduce that a little bit while still allowing full security teams on more populated rounds.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Security officer and assistant job slots are now reduced at lower populations.
```