### PR TITLE
Fixes #17275: Reagents applying to overlays on turfs which cause errors in lighting

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -714,6 +714,9 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 								turf_reaction_success = 1
 								.+= current_id
 						if(isobj(A))
+
+							if (istype(A, /obj/overlay))
+								continue
 							// use current_reagent.reaction_obj for stuff that affects all objects
 							// and reagent_act for stuff that affects specific objects
 							if (!current_reagent.reaction_obj(A, current_reagent.volume*volume_fraction))


### PR DESCRIPTION
[BUG][CATERING][CHEMISTRY]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #17275 by not applying reagents to overlays.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not sure reagents should be applied to overlays so it seems like a good fix.
