### PR TITLE
Fix slightly malformed winset

### DIFF
--- a/code/modules/interface/skin_input_box.dm
+++ b/code/modules/interface/skin_input_box.dm
@@ -12,7 +12,7 @@
 
 	// Create a macro set for handling enter presses
 	winclone(src, "input_box_macro", "persist_[id]_macro")
-	winset(src, "[id]_macro_returnup", "parent=persist_[id]_macro;name=Return+UP;command=\".winset \\\"[id].is-visible=false\\\"\"")
+	winset(src, "[id]_macro_returnup", "parent=persist_[id]_macro;name=Return+UP;command=\".winset \\\"[id].is-visible=false\"")
 	// Return+UP allows us to close the window after typing in a command, pressing enter and releasing enter.
 	// Can't use just Return for this, because when there's text in the box Return is handled by BYOND and doesn't run the macro.
 
@@ -22,18 +22,18 @@
 
 	if(accept_verb)
 		winset(src, "[id].say-input", "command=\"[accept_verb] \\\"\"")
-		winset(src, "[id].accept", "command=\".winset \\\"command=\\\"[accept_verb] \\\\\\\"\[\[[id].say-input.text as escaped\]\]\\\";[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"") //Invokes the accept verb using the inputted text, and hides the window.
+		winset(src, "[id].accept", "command=\".winset \\\"command=\\\"[accept_verb] \\\\\\\"\[\[[id].say-input.text as escaped\]\]\\\";[id].is-visible=false;[id].say-input.text=\\\"\\\"\"") //Invokes the accept verb using the inputted text, and hides the window.
 	if(cancel_verb)
 		//All of these close the window and invoke the cancel verb, as well as clear the input box of all text. The second arg is the method of which the window was closed.
-		winset(src, "[id].cancel", "command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"")
-		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"")
-		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"")
+		winset(src, "[id].cancel", "command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
+		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
+		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
 		winset(src, id, "on-close=\"[cancel_verb]\"") //Invokes the cancel verb if you close the window
 	else
 		//Hides the window and does nothing else.
-		winset(src, "[id].cancel", "command=\".winset \\\"[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"")
-		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\\\"\"")
-		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false\\\";[id].say-input.text=\\\"\\\"\"")
+		winset(src, "[id].cancel", "command=\".winset \\\"[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
+		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\"")
+		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
 
 	//Window scaling!
 	//BYOND doesn't scale the window by DPI scaling, so it'll appear too big/too small with DPI scaling other than the one it was based on

--- a/code/modules/interface/skin_input_box.dm
+++ b/code/modules/interface/skin_input_box.dm
@@ -32,7 +32,7 @@
 	else
 		//Hides the window and does nothing else.
 		winset(src, "[id].cancel", "command=\".winset \\\"[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
-		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\"")
+		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\\\"\"")
 		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false;[id].say-input.text=\\\"\\\"\"")
 
 	//Window scaling!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
looks like a trailing quote got copied when it ought not to have been. This was setting `saywindow.is-visible=false"` which BYOND actually handles no problem but OD was complaining.
also why aren't these raw strings it would be so much easier