### PR TITLE
Fix AI name defaulting to BYOND key

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -78,6 +78,8 @@
 
 /mob/new_player/AIize(var/mobile=0)
 	src.spawning = 1
+	src.name = "AI"
+	src.real_name = "AI"
 	return ..()
 
 /mob/living/carbon/AIize(var/mobile=0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

explicitly set `/mob/new_player`'s name to "AI" in `/mob/new_player/AIize` because the default name for new_player is the user's key and this is used as the new AI's name prior to choosing one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17995 