### PR TITLE
BonePipeshot

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -724,6 +724,26 @@ toxic - poisons
 	implanted = /obj/item/implant/projectile/shrapnel
 	damage = 10
 
+/datum/projectile/bullet/improvbone
+	name = "bone"
+	sname = "bone"
+	icon_state = "trace"
+	dissipation_delay = 1
+	dissipation_rate = 3
+	damage_type = D_KINETIC
+	hit_type = DAMAGE_BLUNT
+	implanted = null
+	damage = 8
+	ricochets = TRUE
+	impact_image_state = null // in my mind these are just literal bones fragments being thrown at people, wouldn't stick into walls
+
+	on_hit(atom/hit)
+		var/turf/T = get_turf(hit)
+		T.fluid_react_single("calcium", 2) // Creates 5 units of calcium on hit
+	on_max_range_die(obj/projectile/O)
+		var/turf/T = get_turf(O)
+		T.fluid_react_single("calcium", 2) // Creates 5 units of caclium once it reaches max range.
+
 /datum/projectile/bullet/aex
 	name = "explosive slug"
 	shot_sound = 'sound/weapons/shotgunshot.ogg'
@@ -1120,7 +1140,6 @@ datum/projectile/bullet/autocannon
 		damage = 10
 
 		on_hit(atom/hit)
-			explosion_new(null,get_turf(hit), 8, 0.75)
 
 /datum/projectile/bullet/smoke
 	name = "smoke grenade"

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -735,7 +735,6 @@ toxic - poisons
 	implanted = null
 	damage = 9
 	hit_mob_sound = 'sound/effects/skeleton_break.ogg'
-	ricochets = TRUE
 	impact_image_state = null // in my mind these are just literal bones fragments being thrown at people, wouldn't stick into walls
 
 	on_hit(atom/hit)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -704,7 +704,7 @@ toxic - poisons
 	damage_type = D_PIERCING
 	armor_ignored = 0.66
 	implanted = null
-	damage = 8
+	damage = 13
 
 /datum/projectile/bullet/improvglass
 	name = "glass"

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -734,6 +734,7 @@ toxic - poisons
 	hit_type = DAMAGE_BLUNT
 	implanted = null
 	damage = 9
+	hit_mob_sound = 'sound/effects/skeleton_break.ogg'
 	ricochets = TRUE
 	impact_image_state = null // in my mind these are just literal bones fragments being thrown at people, wouldn't stick into walls
 

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -704,7 +704,7 @@ toxic - poisons
 	damage_type = D_PIERCING
 	armor_ignored = 0.66
 	implanted = null
-	damage = 13
+	damage = 8
 
 /datum/projectile/bullet/improvglass
 	name = "glass"
@@ -733,7 +733,7 @@ toxic - poisons
 	damage_type = D_KINETIC
 	hit_type = DAMAGE_BLUNT
 	implanted = null
-	damage = 8
+	damage = 9
 	ricochets = TRUE
 	impact_image_state = null // in my mind these are just literal bones fragments being thrown at people, wouldn't stick into walls
 
@@ -1140,7 +1140,7 @@ datum/projectile/bullet/autocannon
 		damage = 10
 
 		on_hit(atom/hit)
-
+			explosion_new(null,get_turf(hit), 8, 0.75)
 /datum/projectile/bullet/smoke
 	name = "smoke grenade"
 	sname = "smokeshot"

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1141,6 +1141,7 @@ datum/projectile/bullet/autocannon
 
 		on_hit(atom/hit)
 			explosion_new(null,get_turf(hit), 8, 0.75)
+
 /datum/projectile/bullet/smoke
 	name = "smoke grenade"
 	sname = "smokeshot"

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -250,6 +250,19 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	spread_angle_variance = 10
 	dissipation_variance = 10
 
+/datum/projectile/special/spreader/buckshot_burst/bone
+	spread_projectile_type = /datum/projectile/bullet/improvbone
+	name = "bone"
+	sname = "bone"
+	cost = 1
+	pellets_to_fire = 3
+	casing = /obj/item/casing/shotgun/pipe
+	shot_sound = 'sound/weapons/shotgunshot.ogg'
+	speed_max = 30
+	speed_min = 20
+	spread_angle_variance = 25
+	dissipation_variance = 40
+
 /datum/projectile/special/spreader/buckshot_burst/nails
 	name = "nails"
 	sname = "nails"

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -1069,6 +1069,13 @@ ABSTRACT_TYPE(/datum/pipeshotrecipe)
 	accepteditem = /obj/item/raw_material/shard
 	craftname = "shard"
 
+/datum/pipeshotrecipe/bone
+	thingsneeded = 2
+	result = /obj/item/ammo/bullets/pipeshot/bone
+	accepteditem = /obj/item/material_piece/bone
+	craftname = "bone chunk"
+
+
 /obj/item/assembly/pipehulls
 	name = "filled pipe hulls"
 	desc = "Four open pipe shells, with propellant in them. You wonder what you could stuff into them."

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -774,6 +774,10 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	amount_left = 5
 	max_amount = 5
 
+/obj/item/ammo/bullets/pipeshot/bone // scrap handmade bone shells
+	sname = "bone load"
+	desc = "This appears to be some bone fragments haphazardly shoved into a few cut open pipe frames - grotesque!"
+	ammo_type = new/datum/projectile/special/spreader/buckshot_burst/bone
 
 /obj/item/ammo/bullets/nails // oh god oh fuck
 	sname = "Nails"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[FEATURE]
[GAME-OBJECTS]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a craftable bone-shot bullet which is set at 9 damage with 3 bullets fired per shot with zero armour penetration 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mostly a gimmick item, but it does give the "Bits of bone" a use, as I dont believe they currently have a use (correct me if im wrong).

It is constructed with 2 bits of bones and a pipehull, each shot shoots 3 projectiles which have a short range, about 1-3 tiles. Each projectile would do is set at 9 damage without armour penetration

It shouldn't affect much other stuff though I am very open to changing any of the values as they're all pretty much arbitrary 

I do think this would be a good addition and pretty funny to use

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cindertroy
(+)Added a bone pipeshot, crafted with 2 "bits of bone"
```
