### PR TITLE
Fixes neutron loaf typo

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -1391,7 +1391,7 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 
 			if (7)
 				src.name = "neutron loaf"
-				src.desc = "Oh good, the flavor atoms in this prison loaf have collapsed down to a a solid lump of neutrons."
+				src.desc = "Oh good, the flavor atoms in this prison loaf have collapsed down to a solid lump of neutrons."
 				src.icon_state = "ploaf4"
 				src.force = 32
 				src.throwforce = 32


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removed one entire letter from `/modules/disposals/disposal.dm`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes https://github.com/goonstation/goonstation/issues/18113