### PR TITLE
PTL now gives mechcomp output

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -150,8 +150,6 @@
 	if(online) // if it's switched on
 		if(!firing) //not firing
 
-			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[0]") //output 0 on mechcomp if beam is not firing
-
 			if(charge >= adj_output && (adj_output >= PTLMINOUTPUT)) //have power to fire
 				start_firing() //creates all the laser objects then activates the right ones
 				dont_update = 1 //so the firing animation runs
@@ -172,7 +170,7 @@
 				melt_blocking_objects()
 			power_sold(adj_output)
 
-			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[output]") //give theoretical output if beam is firing
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[output * firing]") //sends 0 if not firing else give theoretical output
 
 	// only update icon if state changed
 	if(dont_update == 0 && (last_firing != firing || last_disp != chargedisplay() || last_onln != online || ((last_llt > 0 && load_last_tick == 0) || (last_llt == 0 && load_last_tick > 0))))

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -56,6 +56,8 @@
 
 		terminal.master = src
 
+		AddComponent(/datum/component/mechanics_holder)
+
 		UpdateIcon()
 
 /obj/machinery/power/pt_laser/disposing()
@@ -147,6 +149,9 @@
 
 	if(online) // if it's switched on
 		if(!firing) //not firing
+
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[0]") //output 0 on mechcomp if beam is not firing
+
 			if(charge >= adj_output && (adj_output >= PTLMINOUTPUT)) //have power to fire
 				start_firing() //creates all the laser objects then activates the right ones
 				dont_update = 1 //so the firing animation runs
@@ -166,6 +171,8 @@
 			if(length(blocking_objects) > 0)
 				melt_blocking_objects()
 			power_sold(adj_output)
+
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[output]") //give theoretical output if beam is firing
 
 	// only update icon if state changed
 	if(dont_update == 0 && (last_firing != firing || last_disp != chargedisplay() || last_onln != online || ((last_llt > 0 && load_last_tick == 0) || (last_llt == 0 && load_last_tick > 0))))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The PTL is now able to connect to mechcomp devices to read its current output, will display 0 if the beam is not firing.
Didn't include setting the PTL because of potential balance concerns with fully automating the PTL too easily.

(also first attempt touching DM code so if there's a better way to do this please say so)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The PTL is usually quite a ways away and it is not always reasonable for people to keep an eye on it as the input fluctuates, this would allow people to read the current output of the PTL using mechcomp in order to track its state more easily. It could also lead players to make more interesting contraptions such as a running count for the crew to admire, or combining it with a singulo as a means to encourage crew to feed it more.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Knipje
(+)Current PTL output can now be read through MechComp.
```