### PR TITLE
Disable crew shortage shuttle call for #define NO_SHUTTLE_CALLS

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -199,6 +199,7 @@
 	if (src.key)
 		var/datum/eventRecord/Death/deathEvent = new
 		deathEvent.buildAndSend(src, gibbed)
+	#ifndef NO_SHUTTLE_CALLS
 	if (src.client && ticker.round_elapsed_ticks >= 12000 && VALID_MOB(src))
 		var/num_players = 0
 		for(var/client/C)
@@ -213,6 +214,7 @@
 					boutput(world, SPAN_NOTICE("<B>Alert: The emergency shuttle has been called.</B>"))
 					boutput(world, SPAN_NOTICE("- - - <b>Reason:</b> Crew shortages and fatalities."))
 					boutput(world, SPAN_NOTICE("<B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B>"))
+	#endif
 	#undef VALID_MOB
 
 	// Active if XMAS or manually toggled.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Disable the auto shuttle call when a crewmember dies if the NO_SHUTTLE_CALLS build flag is set

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Annoying to recall the shuttle if you're testing something involving player deaths
