### PR TITLE
Componentizes putting hats on ghostdrones and AI cores, extends support to mechcomponent storages

### DIFF
--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -717,8 +717,7 @@ var/obj/manta_speed_lever/mantaLever = null
 	max_stack = 5
 	item_state = "cone_1"
 	wear_state = "cone_hat_1"
-	hat_offset_y = 11
-	hat_offset_x = 0
+	hat_offset_y = 8
 
 	setupProperties()
 		..()

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -717,6 +717,8 @@ var/obj/manta_speed_lever/mantaLever = null
 	max_stack = 5
 	item_state = "cone_1"
 	wear_state = "cone_hat_1"
+	hat_offset_y = 11
+	hat_offset_x = 0
 
 	setupProperties()
 		..()

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -1,0 +1,110 @@
+TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I'm sorry
+	initialization_args = list(
+		ARG_INFO("death_remove", DATA_INPUT_TEXT, "Remove component and signals on death?", FALSE), // Use this for things that don't revive, or explode on death
+		ARG_INFO("free_hat", DATA_INPUT_TEXT, "Should the parent get a free hat?", FALSE), // For AIs
+	)
+
+/datum/component/hattable  // Compatible stuff should be given hat_offset x and y vars in their own file
+	dupe_mode = COMPONENT_DUPE_HIGHLANDER
+	var/y_level = 0
+	var/x_level = 0
+	var/obj/item/hat = null
+	var/death_throw = FALSE
+	var/death_remove = FALSE
+	var/free_hat = FALSE
+	var/free_hat_lockout = FALSE
+
+/datum/component/hattable/Initialize(death_remove, free_hat)
+	. = ..()
+	RegisterSignal(src.parent, COMSIG_ATTACKBY, PROC_REF(hat_on_obj), override = TRUE)
+	src.death_throw = FALSE
+	src.death_remove = death_remove
+	src.free_hat = free_hat
+	if (free_hat && !free_hat_lockout) // If the thing gets a free hat (currently just AIs with spacebux) and they haven't received it yet, do that
+		var/free_hat_type = pick(childrentypesof(pick(childrentypesof(/obj/item/clothing/head))))
+		hat_on_obj(src.parent, free_hat_type)
+
+
+/datum/component/hattable/proc/hat_on_obj(mob/target as mob, obj/item/item as obj, mob/attacker)
+	var/obj/item/H = null
+	if (src.free_hat && !src.free_hat_lockout)
+		item = new item(get_turf(src)) // Make a new item, lockout future free hats
+		free_hat_lockout = TRUE
+	H = item
+
+	var/atom/movable/hatted = src.parent
+	var/obj/item/hatted_offset = src.parent
+	var/is_item_hat = FALSE
+	if (istype(H, /obj/item/clothing/head/))
+		is_item_hat = TRUE
+		ADD_FLAG(H.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
+		ADD_FLAG(H.vis_flags, VIS_INHERIT_DIR)
+
+	if (!src.hat && is_item_hat)
+		if (attacker)
+			attacker.drop_item()
+		else
+			target.drop_item(H) // you're going there whether you like it or not
+
+		src.y_level = 0 // Make ABSOLUTE SURE we're not adding onto a previous offset
+		src.x_level = 0
+		src.y_level = hatted_offset.hat_offset_y + H.hat_offset_y // If a specific hat appears in a strange place, give it its own hat_offset vars to edit the offset by
+		src.x_level = hatted_offset.hat_offset_x + H.hat_offset_x
+		H.pixel_y = src.y_level
+		H.pixel_x = src.x_level
+
+		src.hat = H
+		H.layer = hatted.layer + 7
+		H.set_loc(src.parent)
+		hatted.vis_contents += H
+		if (src.death_remove)
+			RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
+		RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
+		return
+	else
+		return
+
+/datum/component/hattable/proc/take_hat_off(mob/target, mob/user)
+	var/obj/item/H = src.hat
+	var/atom/movable/hatted = src.parent
+
+	if (H)
+		if (istype(user, /mob/living/silicon/ghostdrone))
+			SPAWN(0) // Magtractors use an action bar until they do stuff, and then they'll clone a ghost image of the item that's on the floor. Drop that!
+				var/mob/living/silicon/ghostdrone/drone = user
+				var/obj/item/magtractor/mag = locate(/obj/item/magtractor) in drone.tools
+				if (mag.holding)
+					mag.dropItem(src)
+		H.set_loc(get_turf(hatted))
+		hatted.vis_contents -= H
+		if(src.death_throw)
+			var/turf/T = get_ranged_target_turf(H, pick(alldirs), 3)
+			H.throw_at(T, 3, 1)
+			SPAWN(10)
+				UnregisterSignal(src.parent, list(COMSIG_MOB_DEATH, COMSIG_ATTACKBY))
+				UnregisterSignal(H, COMSIG_ITEM_PICKUP)
+				src.death_throw = FALSE
+				return
+		else
+			UnregisterSignal(H, COMSIG_ITEM_PICKUP)
+		H.pixel_y = 0
+		H.pixel_x = 0
+		src.y_level = 0
+		src.x_level = 0
+		src.hat = null
+		return
+	else
+		return
+
+/datum/component/hattable/proc/die()
+	if (src.hat)
+		src.death_throw = TRUE
+		take_hat_off(src.parent)
+	else
+		return
+
+
+
+
+
+

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -1,10 +1,10 @@
 TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I'm sorry
 	initialization_args = list(
-		ARG_INFO("death_remove", DATA_INPUT_TEXT, "Remove component and signals on death?", FALSE), // Use this for things that don't revive, or explode on death
-		ARG_INFO("free_hat", DATA_INPUT_TEXT, "Should the parent get a free hat?", FALSE), // For AIs
-		ARG_INFO("default_hat_y", "Y offset to start with", 0),
-		ARG_INFO("default_hat_x", "Y offset to start with", 0),
-		ARG_INFO("scale_amount", "Amount to change the size of the hat by", 0)
+		ARG_INFO("death_remove", DATA_INPUT_BOOL, "Remove component and signals on death?", FALSE), // Use this for things that don't revive, or explode on death
+		ARG_INFO("free_hat", DATA_INPUT_BOOL, "Should the parent get a free hat?", FALSE), // For AIs
+		ARG_INFO("default_hat_y", DATA_INPUT_NUM, "Y offset to start with", 0),
+		ARG_INFO("default_hat_x", DATA_INPUT_NUM, "X offset to start with", 0),
+		ARG_INFO("scale_amount", DATA_INPUT_NUM, "Amount to change the size of the hat by", 0)
 	)
 
 /datum/component/hattable  // Compatible stuff should be given hat_offset x and y vars in their own file
@@ -62,6 +62,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	if (src.death_remove)
 		RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
 	RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
+	return TRUE
 
 /datum/component/hattable/proc/take_hat_off(mob/target, mob/user)
 	if (!src.hat)

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -2,106 +2,102 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	initialization_args = list(
 		ARG_INFO("death_remove", DATA_INPUT_TEXT, "Remove component and signals on death?", FALSE), // Use this for things that don't revive, or explode on death
 		ARG_INFO("free_hat", DATA_INPUT_TEXT, "Should the parent get a free hat?", FALSE), // For AIs
+		ARG_INFO("default_hat_y", "Y offset to start with", 0),
+		ARG_INFO("default_hat_x", "Y offset to start with", 0),
+		ARG_INFO("scale_amount", "Amount to change the size of the hat by", 0)
 	)
 
 /datum/component/hattable  // Compatible stuff should be given hat_offset x and y vars in their own file
 	dupe_mode = COMPONENT_DUPE_HIGHLANDER
-	var/y_level = 0
-	var/x_level = 0
+	var/default_hat_y = 0
+	var/default_hat_x = 0
 	var/obj/item/hat = null
 	var/death_throw = FALSE
 	var/death_remove = FALSE
 	var/free_hat = FALSE
-	var/free_hat_lockout = FALSE
+	var/scale_amount = 0
 
-/datum/component/hattable/Initialize(death_remove, free_hat)
+/datum/component/hattable/Initialize(death_remove, free_hat, default_hat_y, default_hat_x, scale_amount)
 	. = ..()
-	RegisterSignal(src.parent, COMSIG_ATTACKBY, PROC_REF(hat_on_obj), override = TRUE)
+	RegisterSignal(src.parent, COMSIG_ATTACKBY, PROC_REF(hat_on_thing), override = TRUE)
 	src.death_throw = FALSE
 	src.death_remove = death_remove
-	src.free_hat = free_hat
-	if (free_hat && !free_hat_lockout) // If the thing gets a free hat (currently just AIs with spacebux) and they haven't received it yet, do that
-		var/free_hat_type = pick(childrentypesof(pick(childrentypesof(/obj/item/clothing/head))))
-		hat_on_obj(src.parent, free_hat_type)
+	src.default_hat_y = default_hat_y
+	src.default_hat_x = default_hat_x
+	src.scale_amount = scale_amount
+	if (free_hat) // If the thing gets a free hat (currently just AIs with spacebux) and they haven't received it yet, do that
+		var/free_hat_type = pick(filtered_concrete_typesof(/obj/item/clothing/head, /proc/filter_trait_hats))
+		free_hat_type = new free_hat_type(get_turf(src))
+		hat_on_thing(src.parent, free_hat_type)
 
 
-/datum/component/hattable/proc/hat_on_obj(mob/target as mob, obj/item/item as obj, mob/attacker)
-	var/obj/item/H = null
-	if (src.free_hat && !src.free_hat_lockout)
-		item = new item(get_turf(src)) // Make a new item, lockout future free hats
-		free_hat_lockout = TRUE
-	H = item
+/datum/component/hattable/proc/hat_on_thing(mob/target as mob, obj/item/item as obj, mob/attacker)
+	if (src.hat)
+		return
 
 	var/atom/movable/hatted = src.parent
-	var/obj/item/hatted_offset = src.parent
-	var/is_item_hat = FALSE
-	if (istype(H, /obj/item/clothing/head/))
-		is_item_hat = TRUE
-		ADD_FLAG(H.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
-		ADD_FLAG(H.vis_flags, VIS_INHERIT_DIR)
+	var/offsetBy_y = 0
+	var/offsetBy_x = 0
+	src.hat = item
 
-	if (!src.hat && is_item_hat)
-		if (attacker)
-			attacker.drop_item()
-		else
-			target.drop_item(H) // you're going there whether you like it or not
-
-		src.y_level = 0 // Make ABSOLUTE SURE we're not adding onto a previous offset
-		src.x_level = 0
-		src.y_level = hatted_offset.hat_offset_y + H.hat_offset_y // If a specific hat appears in a strange place, give it its own hat_offset vars to edit the offset by
-		src.x_level = hatted_offset.hat_offset_x + H.hat_offset_x
-		H.pixel_y = src.y_level
-		H.pixel_x = src.x_level
-
-		src.hat = H
-		H.layer = hatted.layer + 7
-		H.set_loc(src.parent)
-		hatted.vis_contents += H
-		if (src.death_remove)
-			RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
-		RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
-		return
+	if (istype(src.hat, /obj/item/clothing/head/))
+		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
+		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)
 	else
 		return
+
+	if (attacker)
+		attacker.drop_item()
+
+	offsetBy_y = src.default_hat_y + src.hat.hat_offset_y // Add a hat's own offsets if they have them
+	offsetBy_x = src.default_hat_x + src.hat.hat_offset_x
+	src.hat.pixel_y = offsetBy_y
+	src.hat.pixel_x = offsetBy_x
+
+	src.hat.transform *= src.scale_amount
+	src.hat.layer = hatted.layer + 1
+	src.hat.set_loc(src.parent)
+	hatted.vis_contents += src.hat
+
+	if (src.death_remove)
+		RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
+	RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
 
 /datum/component/hattable/proc/take_hat_off(mob/target, mob/user)
-	var/obj/item/H = src.hat
+	if (!src.hat)
+		return
 	var/atom/movable/hatted = src.parent
 
-	if (H)
-		if (istype(user, /mob/living/silicon/ghostdrone))
-			SPAWN(0) // Magtractors use an action bar until they do stuff, and then they'll clone a ghost image of the item that's on the floor. Drop that!
-				var/mob/living/silicon/ghostdrone/drone = user
-				var/obj/item/magtractor/mag = locate(/obj/item/magtractor) in drone.tools
-				if (mag.holding)
-					mag.dropItem(src)
-		H.set_loc(get_turf(hatted))
-		hatted.vis_contents -= H
-		if(src.death_throw)
-			var/turf/T = get_ranged_target_turf(H, pick(alldirs), 3)
-			H.throw_at(T, 3, 1)
-			SPAWN(10)
-				UnregisterSignal(src.parent, list(COMSIG_MOB_DEATH, COMSIG_ATTACKBY))
-				UnregisterSignal(H, COMSIG_ITEM_PICKUP)
-				src.death_throw = FALSE
-				return
-		else
-			UnregisterSignal(H, COMSIG_ITEM_PICKUP)
-		H.pixel_y = 0
-		H.pixel_x = 0
-		src.y_level = 0
-		src.x_level = 0
-		src.hat = null
+	src.hat.set_loc(get_turf(hatted))
+	hatted.vis_contents -= src.hat
+	src.hat.layer = OBJ_LAYER
+	src.hat.transform = 1
+	src.hat.pixel_y = 0
+	src.hat.pixel_x = 0
+
+	if(src.death_throw) // If the thing dies, this proc is called and death_throw is set to true, then false
+		var/turf/T = get_ranged_target_turf(src.hat, pick(alldirs), 3)
+		src.hat.throw_at(T, 3, 1)
+		UnregisterSignal(src.parent, list(COMSIG_MOB_DEATH, COMSIG_ATTACKBY))
+		UnregisterSignal(src.hat, COMSIG_ITEM_PICKUP)
+		src.death_throw = FALSE
 		return
 	else
-		return
+		UnregisterSignal(src.hat, COMSIG_ITEM_PICKUP)
+
+	if (istype(user, /mob/living/silicon/ghostdrone))
+		SPAWN(0) // Magtractors use an action bar until they do stuff, and then they'll clone a ghost image of the item that's on the floor. Drop that!
+			var/mob/living/silicon/ghostdrone/drone = user
+			var/obj/item/magtractor/mag = locate(/obj/item/magtractor) in drone.tools
+			if (mag.holding)
+				mag.dropItem(src)
+
+	src.hat = null
 
 /datum/component/hattable/proc/die()
 	if (src.hat)
 		src.death_throw = TRUE
 		take_hat_off(src.parent)
-	else
-		return
 
 
 

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -28,9 +28,6 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 
 	var/static/regex/monospace_say_regex = new(@"`([^`]+)`", "g")
 
-	var/hat_offset_y = 0
-	var/hat_offset_x = 0
-
 	can_bleed = FALSE
 	blood_id = "oil"
 	use_stamina = FALSE

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -28,6 +28,9 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 
 	var/static/regex/monospace_say_regex = new(@"`([^`]+)`", "g")
 
+	var/hat_offset_y = 0
+	var/hat_offset_x = 0
+
 	can_bleed = FALSE
 	blood_id = "oil"
 	use_stamina = FALSE

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -86,6 +86,8 @@ var/global/list/ai_emotions = list("Annoyed" = "ai_annoyed-dol", \
 	density = 1
 	emaggable = 0 // Can't be emagged...
 	syndicate_possible = 1 // ...but we can become a rogue computer.
+	hat_offset_y = 14
+	hat_offset_x = 0
 	var/datum/hud/silicon/ai/hud
 	var/last_notice = 0//attack notices
 	var/network = "SS13"
@@ -108,6 +110,7 @@ var/global/list/ai_emotions = list("Annoyed" = "ai_annoyed-dol", \
 	var/termMute = FALSE
 	var/canvox = 1
 	var/can_announce = 1
+	var/bought_hat = FALSE
 	var/last_announcement = -INFINITY
 	var/announcement_cooldown = 1200
 	var/dismantle_stage = 0
@@ -194,7 +197,6 @@ or don't if it uses a custom topopen overlay
 	sound_fart = 'sound/voice/farts/poo2_robot.ogg'
 
 	req_access = list(access_heads)
-	var/obj/item/clothing/head/hat = null
 
 	var/fire_res_on_core = 0
 
@@ -209,26 +211,6 @@ or don't if it uses a custom topopen overlay
 	var/deployed_to_eyecam = 0
 	var/datum/ai_hologram_data/holoHolder = new
 	var/list/hologramContextActions
-
-	proc/set_hat(obj/item/clothing/head/hat, var/mob/user as mob)
-		if( src.hat )
-			src.hat.wear_image.pixel_y = 0
-			src.UpdateOverlays(null, "hat")
-			if (user)
-				user.put_in_hand_or_drop(src.hat)
-			else
-				src.hat.set_loc(src.loc)
-			src.hat = null
-		// src.hat.wear_image.pixel_y = 10
-		// src.UpdateOverlays(src.hat.wear_image, "hat")
-		var/image/hat_image = SafeGetOverlayImage(hat.icon_state, hat.icon, hat.icon_state, src.layer+0.3)
-		hat_image.pixel_y = 12
-		if (istype(hat, /obj/item/clothing/head/bighat))
-			hat_image.pixel_y = 20
-
-		src.UpdateOverlays(hat_image, "hat")
-		src.hat = hat
-		hat.set_loc(src)
 
 /mob/living/silicon/ai/proc/give_feet()
 	animate(src, pixel_y = 14, time = 5, easing = SINE_EASING)
@@ -293,7 +275,11 @@ or don't if it uses a custom topopen overlay
 
 	ai_station_map = new /obj/minimap/ai
 	AddComponent(/datum/component/minimap_marker, MAP_AI | MAP_SYNDICATE, "ai")
-
+	SPAWN(0)
+		if (bought_hat || prob(5))
+			AddComponent(/datum/component/hattable, TRUE, TRUE)
+		else
+			AddComponent(/datum/component/hattable, TRUE, FALSE)
 	light = new /datum/light/point
 	light.set_color(0.4, 0.7, 0.95)
 	light.set_brightness(0.6)
@@ -340,9 +326,7 @@ or don't if it uses a custom topopen overlay
 		var/datum/contextAction/ai_hologram/action = new actionType(src)
 		hologramContextActions += action
 
-	if(prob(5))
-		var/hat_type = pick(childrentypesof(/obj/item/clothing/head))
-		src.set_hat(new hat_type)
+
 
 
 	SPAWN(0)
@@ -595,11 +579,6 @@ or don't if it uses a custom topopen overlay
 			user.visible_message(SPAN_ALERT("<b>[user.name]</b> uploads a moustache to [src.name]!"))
 		else if (src.dismantle_stage == 4 || isdead(src))
 			boutput(user, SPAN_ALERT("Using this on a deactivated AI would be silly."))
-	else if( istype(W,/obj/item/clothing/head))
-		user.drop_item()
-		src.set_hat(W, user)
-		user.visible_message( SPAN_NOTICE("[user] places the [W] on the [src]!") )
-		src.show_message( SPAN_NOTICE("[user] places the [W] on you!") )
 		if(istype(W, /obj/item/clothing/head/butt))
 			var/obj/item/clothing/head/butt/butt = W
 			if(butt.donor == user)
@@ -1010,8 +989,6 @@ or don't if it uses a custom topopen overlay
 		return list()
 
 	. = list("[SPAN_NOTICE("This is [bicon(src)] <B>[src.name]</B>!")] [skinsList[coreSkin]]<br>") // skinList[coreSkin] points to the appropriate desc for the current core skin
-	if (src.hat)
-		. += SPAN_NOTICE("[src.name] is wearing the [bicon(src.hat)] [src.hat.name].")
 
 	if (isdead(src))
 		. += SPAN_ALERT("[src.name] is nonfunctional...")

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -86,8 +86,7 @@ var/global/list/ai_emotions = list("Annoyed" = "ai_annoyed-dol", \
 	density = 1
 	emaggable = 0 // Can't be emagged...
 	syndicate_possible = 1 // ...but we can become a rogue computer.
-	hat_offset_y = 14
-	hat_offset_x = 0
+	var/default_hat_y = 14
 	var/datum/hud/silicon/ai/hud
 	var/last_notice = 0//attack notices
 	var/network = "SS13"
@@ -277,9 +276,9 @@ or don't if it uses a custom topopen overlay
 	AddComponent(/datum/component/minimap_marker, MAP_AI | MAP_SYNDICATE, "ai")
 	SPAWN(0)
 		if (bought_hat || prob(5))
-			AddComponent(/datum/component/hattable, TRUE, TRUE)
+			AddComponent(/datum/component/hattable, TRUE, TRUE, default_hat_y)
 		else
-			AddComponent(/datum/component/hattable, TRUE, FALSE)
+			AddComponent(/datum/component/hattable, TRUE, FALSE, default_hat_y)
 	light = new /datum/light/point
 	light.set_color(0.4, 0.7, 0.95)
 	light.set_brightness(0.6)

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -14,6 +14,8 @@
 	punchMessage = "whaps"
 	kickMessage = "bonks"
 
+	hat_offset_y = 7 // offset for hattable component
+
 	var/datum/hud/ghostdrone/hud
 	var/obj/item/device/radio/radio = null
 
@@ -25,17 +27,16 @@
 	var/faceType
 	var/charging = 0
 	var/newDrone = 0
-
 	var/jetpack = 1 //fuck whoever made this
 
 	var/sees_static = TRUE
 
 	//gimmicky things
-	var/obj/item/clothing/head/hat = null
 	var/obj/item/clothing/suit/bedsheet/bedsheet = null
 
 	New()
 		..()
+		AddComponent(/datum/component/hattable, TRUE)
 		remove_lifeprocess(/datum/lifeprocess/radiation)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 100)
 		START_TRACKING
@@ -163,7 +164,6 @@
 			src.visible_message(SPAN_COMBAT("[src.name] explodes in a shower of lost hopes and dreams."))
 			var/turf/T = get_ranged_target_turf(src, pick(alldirs), 3)
 			if (magHeld) magHeld.throw_at(T, 3, 1) //flying...anything
-			if (src.hat) src.takeoffHat(pick(alldirs)) //flying hats
 			if (src.bedsheet) //flying bedsheets
 				bedsheet.set_loc(get_turf(src))
 				bedsheet.throw_at(T, 3, 1)
@@ -180,7 +180,6 @@
 					msg = "[src.name]'s scream's gain echo and lose their electronic modulation as its soul is ripped monstrously from the cold metal body it once inhabited."
 
 			src.visible_message(SPAN_COMBAT("[msg]"))
-			if (src.hat) src.takeoffHat()
 			src.updateSprite()
 			..()
 
@@ -425,38 +424,7 @@
 				step(AM, t)
 			src.now_pushing = null
 
-	//Four very important procs follow
-	proc/putonHat(obj/item/clothing/head/W as obj, mob/user as mob)
-		src.hat = W
-		W.set_loc(src)
-		var/image/hatImage = null
-		// Treat wigs differently as their icon_state is always bald
-		if (istype(W, /obj/item/clothing/head/wig))
-			hatImage = W.wear_image
-			hatImage.layer = src.layer+0.1
-			hatImage.pixel_y = -7
-		else
-			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
-			hatImage.pixel_y = 5
-			hatImage.transform *= 0.9
-		UpdateOverlays(hatImage, "hat")
-		return 1
-
-	proc/takeoffHat(forcedDir = null)
-		UpdateOverlays(null, "hat")
-		src.hat.set_loc(get_turf(src))
-
-		var/turf/T
-		if (isnum(forcedDir))
-			T = get_ranged_target_turf(src, forcedDir, 3)
-		if (isturf(forcedDir))
-			T = forcedDir
-		if (isturf(T))
-			src.hat.throw_at(T, 3, 1)
-
-		src.hat = null
-		return 1
-
+	// Two important procs follow
 	proc/putonSheet(obj/item/clothing/suit/bedsheet/W as obj, mob/user as mob)
 		W.set_loc(src)
 		src.bedsheet = W
@@ -517,16 +485,6 @@
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			if (src.health >= 25)
 				boutput(user, SPAN_NOTICE("The wiring is fully repaired. Now you need to weld the external plating."))
-
-		else if (istype(W, /obj/item/clothing/head))
-			if(src.hat)
-				boutput(user, SPAN_ALERT("[src] is already wearing a hat!"))
-				return
-
-			user.drop_item()
-			src.putonHat(W, user)
-			if (user != src)
-				user.visible_message("<b>[user]</b> gently places a hat on [src]!", "You gently place a hat on [src]!")
 			return
 
 		else if (istype(W, /obj/item/clothing/suit/bedsheet))
@@ -551,10 +509,7 @@
 				if(INTENT_DISARM) //Shove
 					SPAWN(0) playsound(src.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 40, 1)
 					user.visible_message(SPAN_ALERT("<B>[user] shoves [src]! [prob(40) ? pick_string("descriptors.txt", "jerks") : null]</B>"))
-					if (src.hat)
-						user.visible_message("<b>[user]</b> knocks \the [src.hat] off [src]!", "You knock the hat off [src]!")
-						src.takeoffHat()
-					else if (src.bedsheet)
+					if (src.bedsheet)
 						user.visible_message("<b>[user]</b> pulls the sheet off [src]!", "You pull the sheet off [src]!")
 						src.takeoffSheet()
 				if(INTENT_GRAB) //Shake
@@ -1079,17 +1034,6 @@
 		var/stun = round((P.power*(1.0-P.proj_data.ks_ratio)), 1.0)
 
 		src.changeStatus("stunned", stun SECONDS)
-
-		if (src.hat) //For hats getting shot off
-			UpdateOverlays(null, "hat")
-			src.hat.set_loc(get_turf(src))
-			//get target turf
-			var/x = round(P.xo * 4)
-			var/y = round(P.yo * 4)
-			var/turf/target = get_offset_target_turf(src, x, y)
-
-			src.visible_message(SPAN_COMBAT("[src]'s [src.hat] goes flying!"))
-			src.takeoffHat(target)
 
 		if (damage < 1)
 			return

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -14,7 +14,7 @@
 	punchMessage = "whaps"
 	kickMessage = "bonks"
 
-	hat_offset_y = 7 // offset for hattable component
+	var/default_hat_y = 7
 
 	var/datum/hud/ghostdrone/hud
 	var/obj/item/device/radio/radio = null
@@ -36,7 +36,7 @@
 
 	New()
 		..()
-		AddComponent(/datum/component/hattable, TRUE)
+		AddComponent(/datum/component/hattable, TRUE, FALSE, default_hat_y, 0, 0.75)
 		remove_lifeprocess(/datum/lifeprocess/radiation)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 100)
 		START_TRACKING

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -18,6 +18,8 @@
 	desc = "You can't tell the difference, Honest!"
 	icon_state= "wig"
 	wear_layer = MOB_HAIR_LAYER2 //it IS hair afterall
+	hat_offset_y = -15 // offsets for hattable component
+	hat_offset_x = 0
 
 	///Takes a list of style ids to colors and generates a wig from it
 	proc/setup_wig(var/style_list)

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -127,11 +127,9 @@ var/global/list/persistent_bank_purchaseables =	list(\
 
 		if(isAI(M))
 			var/mob/living/silicon/ai/AI = M
-			if (ispath(path, /obj/item/clothing))
-				if(ispath(path,/obj/item/clothing/head))
-					AI.set_hat(new path(AI))
-					equip_success = 1
-
+			path = null
+			AI.bought_hat = TRUE
+			return
 
 
 		//The AI can't really wear items...
@@ -788,7 +786,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		Create(var/mob/living/M)
 			if (isAI(M))
 				var/mob/living/silicon/ai/A = M
-				var/picked = pick(filtered_concrete_typesof(/obj/item/clothing/head, /proc/filter_trait_hats))
-				A.set_hat(new picked())
+				A.bought_hat = TRUE
 				return 1
 			return 0

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -30,11 +30,11 @@
 	var/welded = FALSE
 	var/can_be_welded = FALSE
 	var/can_be_anchored = UNANCHORED
-	var/obj/hat = null
 	custom_suicide = TRUE
 	open_to_sound = TRUE
 
 	New()
+		AddComponent(/datum/component/hattable)
 		processing_items |= src
 		..()
 
@@ -48,48 +48,6 @@
 		src.light_time += CONTAINER_LIGHT_TIME
 		src.light_time = max(src.light_time, MAX_CONTAINER_LIGHT_TIME)
 		src.UpdateIcon()
-
-	proc/putonHat(obj/item/clothing/head/W as obj, mob/user as mob) // Hat code graciously swiped from ghostdrones
-		if(src.hat)
-			boutput(user, SPAN_ALERT("[src] is already wearing a hat!"))
-			return
-
-		user.drop_item()
-		src.hat = W
-		W.set_loc(src)
-		var/image/hatImage = null
-
-		// Treat wigs differently as their icon_state is always bald
-		if (istype(W, /obj/item/clothing/head/wig))
-			hatImage = W.wear_image
-			hatImage.layer = src.layer+0.1
-			if (src.name == "Component Cabinet")
-				hatImage.pixel_y = 6
-			else
-				hatImage.pixel_y = -7
-				hatImage.pixel_x = -1
-		else if (istype(W, /obj/item/clothing/head/constructioncone)) // Hats with bottom aligned inhand sprites go here for a boost
-			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
-			if(src.name == "Component Cabinet")
-				hatImage.pixel_y = 22
-			else
-				hatImage.pixel_y = 18
-				hatImage.pixel_x = -1
-		else
-			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
-			if(src.name == "Component Cabinet")
-				hatImage.pixel_y = 14
-			else
-				hatImage.pixel_y = 7
-				hatImage.pixel_x = -1
-		UpdateOverlays(hatImage, "hat")
-		return 1
-
-	proc/takeoffHat(mob/user as mob)
-		UpdateOverlays(null, "hat")
-		src.hat.set_loc(get_turf(src))
-		src.hat = null
-		return 1
 
 	ex_act(severity)
 		switch(severity)
@@ -145,11 +103,6 @@
 				src.light_time=0
 			src.UpdateIcon()
 			return 1
-
-		else if (istype(W, /obj/item/clothing/head))
-			src.putonHat(W, user)
-			return
-
 		else if (iswrenchingtool(W))
 			if(!src.can_be_anchored)
 				boutput(user,SPAN_ALERT("[src] cannot be anchored to the ground."))
@@ -247,9 +200,6 @@
 	mouse_drop(atom/target)
 		if(!istype(usr))
 			return
-		if(src.hat)
-			src.takeoffHat()
-			return
 		if(src.open && target == usr)
 			if(!(usr in src.users))
 				src.users+=usr
@@ -275,6 +225,8 @@
 		icon_state="housing_cabinet"
 		flags = FPRINT | EXTRADELAY | CONDUCT
 		light_color = list(0, 179, 255, 255)
+		hat_offset_y = 14
+		hat_offset_x = 0
 
 		attack_hand(mob/user)
 			if (istype(user,/mob/living/object) && user == src.loc) // prevent wacky nullspace bug
@@ -316,6 +268,8 @@
 		c_flags = ONBELT
 		light_color = list(51, 0, 0, 0)
 		spawn_contents=list(/obj/item/mechanics/trigger/trigger)
+		hat_offset_y = 7
+		hat_offset_x = -1
 
 		proc/find_trigger() // find the trigger comp, return 1 if found.
 			if (!istype(src.the_trigger))

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -30,11 +30,12 @@
 	var/welded = FALSE
 	var/can_be_welded = FALSE
 	var/can_be_anchored = UNANCHORED
+	var/default_hat_y = 0
+	var/default_hat_x = 0
 	custom_suicide = TRUE
 	open_to_sound = TRUE
 
 	New()
-		AddComponent(/datum/component/hattable)
 		processing_items |= src
 		..()
 
@@ -225,8 +226,11 @@
 		icon_state="housing_cabinet"
 		flags = FPRINT | EXTRADELAY | CONDUCT
 		light_color = list(0, 179, 255, 255)
-		hat_offset_y = 14
-		hat_offset_x = 0
+		default_hat_y = 14
+
+		New()
+			AddComponent(/datum/component/hattable, FALSE, FALSE, default_hat_y)
+			..()
 
 		attack_hand(mob/user)
 			if (istype(user,/mob/living/object) && user == src.loc) // prevent wacky nullspace bug
@@ -268,8 +272,12 @@
 		c_flags = ONBELT
 		light_color = list(51, 0, 0, 0)
 		spawn_contents=list(/obj/item/mechanics/trigger/trigger)
-		hat_offset_y = 7
-		hat_offset_x = -1
+		default_hat_y = 7
+		default_hat_x = -1
+
+		New()
+			AddComponent(/datum/component/hattable, FALSE, FALSE, default_hat_y, default_hat_x)
+			..()
 
 		proc/find_trigger() // find the trigger comp, return 1 if found.
 			if (!istype(src.the_trigger))

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -30,6 +30,7 @@
 	var/welded = FALSE
 	var/can_be_welded = FALSE
 	var/can_be_anchored = UNANCHORED
+	var/obj/hat = null
 	custom_suicide = TRUE
 	open_to_sound = TRUE
 
@@ -47,6 +48,48 @@
 		src.light_time += CONTAINER_LIGHT_TIME
 		src.light_time = max(src.light_time, MAX_CONTAINER_LIGHT_TIME)
 		src.UpdateIcon()
+
+	proc/putonHat(obj/item/clothing/head/W as obj, mob/user as mob) // Hat code graciously swiped from ghostdrones
+		if(src.hat)
+			boutput(user, SPAN_ALERT("[src] is already wearing a hat!"))
+			return
+
+		user.drop_item()
+		src.hat = W
+		W.set_loc(src)
+		var/image/hatImage = null
+
+		// Treat wigs differently as their icon_state is always bald
+		if (istype(W, /obj/item/clothing/head/wig))
+			hatImage = W.wear_image
+			hatImage.layer = src.layer+0.1
+			if (src.name == "Component Cabinet")
+				hatImage.pixel_y = 6
+			else
+				hatImage.pixel_y = -7
+				hatImage.pixel_x = -1
+		else if (istype(W, /obj/item/clothing/head/constructioncone)) // Hats with bottom aligned inhand sprites go here for a boost
+			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
+			if(src.name == "Component Cabinet")
+				hatImage.pixel_y = 22
+			else
+				hatImage.pixel_y = 18
+				hatImage.pixel_x = -1
+		else
+			hatImage = image(icon = W.icon, icon_state = W.icon_state, layer = src.layer+0.1)
+			if(src.name == "Component Cabinet")
+				hatImage.pixel_y = 14
+			else
+				hatImage.pixel_y = 7
+				hatImage.pixel_x = -1
+		UpdateOverlays(hatImage, "hat")
+		return 1
+
+	proc/takeoffHat(mob/user as mob)
+		UpdateOverlays(null, "hat")
+		src.hat.set_loc(get_turf(src))
+		src.hat = null
+		return 1
 
 	ex_act(severity)
 		switch(severity)
@@ -102,6 +145,11 @@
 				src.light_time=0
 			src.UpdateIcon()
 			return 1
+
+		else if (istype(W, /obj/item/clothing/head))
+			src.putonHat(W, user)
+			return
+
 		else if (iswrenchingtool(W))
 			if(!src.can_be_anchored)
 				boutput(user,SPAN_ALERT("[src] cannot be anchored to the ground."))
@@ -198,6 +246,9 @@
 		return
 	mouse_drop(atom/target)
 		if(!istype(usr))
+			return
+		if(src.hat)
+			src.takeoffHat()
 			return
 		if(src.open && target == usr)
 			if(!(usr in src.users))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1159,12 +1159,14 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 
 /obj/item/attack_hand(mob/user)
 	var/obj/item/checkloc = src.loc
-	while(checkloc && !istype(checkloc,/turf))
-		if(isliving(checkloc) && checkloc != user)
-			break
-		else
-			return 0
-		checkloc = checkloc.loc
+	if (!ismob(src.loc)) // Skip this loop if the FIRST loc is a mob, allowing component/hattable to proc take_hat_off on AIs/ghostdrones
+		while(checkloc && !istype(checkloc,/turf))
+			if(isliving(checkloc) && checkloc != user) // This heinous block is to make sure you're not swiping things from other people's backpacks
+				if(src in bible_contents) // Bibles share their contents globally, so magically taking stuff from them is fine
+					break
+				else
+					return 0
+			checkloc = checkloc.loc // Get the loc of the loc! The loop continues until it's the turf of what you clicked on
 
 	if(!src.can_pickup(user))
 		// unholdable storage items

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -22,6 +22,10 @@ ABSTRACT_TYPE(/obj/item)
 	var/inhand_color = null
 	/// storage datum holding it
 	var/datum/storage/stored = null
+	/// Used for the hattable component
+	var/hat_offset_y = 0
+	/// Used for the hattable component
+	var/hat_offset_x = 0
 
 	/*_______*/
 	/*Burning*/
@@ -1154,14 +1158,13 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	return "It is \an [t] item."
 
 /obj/item/attack_hand(mob/user)
-	var/checkloc = src.loc
+	var/obj/item/checkloc = src.loc
 	while(checkloc && !istype(checkloc,/turf))
-		if (isliving(checkloc) && checkloc != user)
-			if(src in bible_contents)
-				break
-			else
-				return 0
-		checkloc = checkloc:loc
+		if(isliving(checkloc) && checkloc != user)
+			break
+		else
+			return 0
+		checkloc = checkloc.loc
 
 	if(!src.can_pickup(user))
 		// unholdable storage items

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -2036,6 +2036,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/mushroomcap)
 	name = "mushroom cap"
 	desc = "Makes your lungs feel a little fuzzy."
 	var/additional_desc = ""
+	hat_offset_y = 4
 	icon_state = "mushroom-red"
 	item_state = "mushroom-red"
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -224,6 +224,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\glue_ready.dm"
 #include "code\datums\components\glued.dm"
 #include "code\datums\components\hallucinations.dm"
+#include "code\datums\components\hattable.dm"
 #include "code\datums\components\health_maptext.dm"
 #include "code\datums\components\legs.dm"
 #include "code\datums\components\light.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I've taken some code used for ghostdrones and mangled it to allow people to customise their mechcomp (demon) robot with hats and wigs. Currently it's just done with a click but I can make it specific to an intent, or see about letting you weld them on so they're not stolen. Do let me know if any code is bloated or vestigial.

![dreamseeker_53O2dDUyM7](https://github.com/goonstation/goonstation/assets/102558507/6c7adb9b-0d78-4964-8d6e-1cdaf32cbc7f)

Along with adding the component to something you want to be able to put hats on, you can now also set a hat_offset_y and x var there, and in a hat's code in order to correct its position. With this you can set the hat to the right place on the object, then adjust even more for things like wigs and hats with inhand sprites that aren't centred in frame. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mechcomp cabinets/frames are already personified a lot with movement components and dialogue, this allows for more customisation and fun. 

The component itself will ensure that adding behavior for putting hats onto things that isn't a player with slots will be easier to implement. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Hats and wigs now fit snugly onto mechcomp cabinets and frames. This changes the backend for placing hats on things like ghostdrones, report any bugs if found.
```
