### PR TITLE
Makes cryoing free up slots for non-unique jobs

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -68,6 +68,9 @@
 	var/wiki_link = null //! Link to the wiki page for this job
 
 	var/counts_as = null //! Name of a job that we count towards the cap of
+	///if true, cryoing won't free up slots, only ghosting will
+	///basically there should never be two of these
+	var/unique = FALSE
 
 	New()
 		..()
@@ -157,6 +160,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_card = /obj/item/card/id/command
 	map_can_autooverride = 0
 	can_join_gangs = FALSE
+	unique = TRUE
 
 	special_setup(mob/M, no_special_spawn)
 		. = ..()
@@ -2613,6 +2617,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	linkcolor = "#3348ff"
 	name = "Nanotrasen Security Consultant"
 	limit = 1 // backup during HELL WEEK. players will probably like it
+	unique = TRUE
 	wages = PAY_TRADESMAN
 	requires_whitelist = 1
 	requires_supervisor_job = "Head of Security"

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -186,6 +186,9 @@
 		var/datum/db_record/crew_record = data_core.general.find_record("id", L.datacore_id)
 		if (!isnull(crew_record))
 			crew_record["p_stat"] = "In Cryogenic Storage"
+		var/datum/job/job = find_job_in_controller_by_string(L.job, soft=TRUE)
+		if (job && !job.unique)
+			job.assigned = max(0, job.assigned - 1)
 		logTheThing(LOG_STATION, L, "entered cryogenic storage at [log_loc(src)].")
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Marks some jobs (heads of staff) as unique, cryoing as a non-unique job will now immediately free up the slot instead of requiring ghosting. Cryo-ghosting will still free up a unique job slot.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feedback from the #18096 testmerge, people were having issues with secoffs cryoing and still taking up slots. Yes this allows for circumventing slot restrictions by cryoing, but this was already possible under the old system by dying and being cloned so 🤷 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Cryoing as a non-unique job will now immediately free up the slot.
```
