### PR TITLE
Bugfix for plate shattering leaving hanging signals

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -708,8 +708,6 @@ TRAYS
 
 	/// Removes a piece of food from the plate.
 	proc/remove_contents(obj/item/food)
-		if (!(food in src.contents))
-			return
 		MOVE_OUT_TO_TURF_SAFE(food, src)
 		src.vis_contents -= food
 		food.appearance_flags = initial(food.appearance_flags)
@@ -734,7 +732,7 @@ TRAYS
 		if (length(src.contents))
 			src.visible_message(SPAN_ALERT("Everything [src.is_plate ? "on" : "in"] \the [src] goes flying!"))
 		for (var/atom/movable/food in src)
-			food.set_loc(get_turf(src))
+			src.remove_contents(food)
 			if (istype(food, /obj/item/plate))
 				var/obj/item/plate/not_food = food
 				SPAWN(0.1 SECONDS) // This is rude but I want a small delay in smashing nested plates. More satisfying


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][catering]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes an issue where plates were not actually unregistering the signals from their food contents and removing the food from their vis_contents, the latter of which was hidden by their deletion when shattered.
This also fixes, less importantly but more noticeably, that pizza boxes were still visually holding things after being thrown across the room and spilling their contents, duplicating the icon of the contents.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad! Hanging signals real bad!
