### PR TITLE
Announcement Computers can be disassembled like other computers

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -42,6 +42,8 @@
 			src.unlocked = check_access(ID, 1)
 			boutput(user, SPAN_NOTICE("You insert [W]."))
 			update_status()
+			return
+		..()
 
 	ui_interact(mob/user, datum/tgui/ui)
 		ui = tgui_process.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUGFIX][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a return for the ID card handling for announcements. For other cases, call the parent proc to support screwing tools (i.e. glass repair/replacement).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18149

## Test Plan
- [x] ID card is ejected on disassembly
- [x] UI works / can make announcement after reassembly