### PR TITLE
Fixes #18129: Makes Knock open the current secured storage you're in

### DIFF
--- a/code/modules/antagonists/wizard/abilities/knock.dm
+++ b/code/modules/antagonists/wizard/abilities/knock.dm
@@ -28,7 +28,8 @@
 		if (locked && istype(locked))
 			locked.locked = FALSE
 			locked.open()
-			src.holder.owner.set_loc(locked.loc)
+			if (!locked.welded)
+				src.holder.owner.set_loc(locked.loc)
 
 		for(var/obj/machinery/door/G in oview(SPrange, holder.owner))
 			SPAWN(1 DECI SECOND)

--- a/code/modules/antagonists/wizard/abilities/knock.dm
+++ b/code/modules/antagonists/wizard/abilities/knock.dm
@@ -23,17 +23,24 @@
 			SPrange = 5
 		else
 			boutput(holder.owner, SPAN_ALERT("Your spell only works at point blank without a staff to focus it!"))
+
+		var/obj/storage/secure/locked = src.holder.owner.loc
+		if (locked && istype(locked))
+			locked.locked = FALSE
+			locked.open()
+			src.holder.owner.set_loc(locked.loc)
+
 		for(var/obj/machinery/door/G in oview(SPrange, holder.owner))
 			SPAWN(1 DECI SECOND)
 				G.open()
 		for(var/obj/storage/F in oview(SPrange, holder.owner))
 			if (F.locked)
-				F.locked = 0
+				F.locked = FALSE
 			SPAWN(1 DECI SECOND)
 				F.open()
 		for(var/mob/living/silicon/robot/E in oview(SPrange, holder.owner))
 			SPAWN(1 DECI SECOND)
 				E.spellopen()
 		for(var/obj/machinery/bot/B in oview(SPrange, holder.owner))
-			B.locked = 0
+			B.locked = FALSE
 			B.req_access = null

--- a/code/modules/antagonists/wizard/abilities/knock.dm
+++ b/code/modules/antagonists/wizard/abilities/knock.dm
@@ -28,8 +28,6 @@
 		if (locked && istype(locked))
 			locked.unlock()
 			locked.open()
-			if (!locked.welded)
-				src.holder.owner.set_loc(locked.loc)
 
 		for(var/obj/machinery/door/G in oview(SPrange, holder.owner))
 			SPAWN(1 DECI SECOND)

--- a/code/modules/antagonists/wizard/abilities/knock.dm
+++ b/code/modules/antagonists/wizard/abilities/knock.dm
@@ -26,7 +26,7 @@
 
 		var/obj/storage/secure/locked = src.holder.owner.loc
 		if (locked && istype(locked))
-			locked.locked = FALSE
+			locked.unlock()
 			locked.open()
 			if (!locked.welded)
 				src.holder.owner.set_loc(locked.loc)
@@ -36,7 +36,7 @@
 				G.open()
 		for(var/obj/storage/F in oview(SPrange, holder.owner))
 			if (F.locked)
-				F.locked = FALSE
+				F.unlock()
 			SPAWN(1 DECI SECOND)
 				F.open()
 		for(var/mob/living/silicon/robot/E in oview(SPrange, holder.owner))


### PR DESCRIPTION
[BUG][ACTIONS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixed #18129: Now if a wizard is locked in a secure crate / locker Knock will open it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems unusual to me that an ability that unlocks things doesn't unlock the container you're in. You can still be welded in and Knock won't unlock the container.