### PR TITLE
Security fine improvements

### DIFF
--- a/_std/defines/security.dm
+++ b/_std/defines/security.dm
@@ -1,2 +1,5 @@
 // meant to be short
 #define SECHUD_FLAG_MAX_CHARS 10
+#define MAX_FINE_NO_APPROVAL 500
+#define JOBS_CAN_TICKET_SMALL list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant","Security Officer","Inspector")
+#define JOBS_CAN_TICKET_BIG list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant")

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -416,6 +416,7 @@
 	var/datum/db_record/bank_record = null
 	var/target_byond_key = null
 	var/issuer_byond_key = null
+	var/approver_byond_key = null
 
 	New()
 		..()
@@ -433,6 +434,7 @@
 
 	approver = approved_by
 	approver_job = their_job
+	approver_byond_key = usr.key
 	logTheThing(LOG_ADMIN, usr, "approved a fine using [approver]([their_job])'s PDA. It is a [amount] credit fine on <b>[target]</b> with the reason: [reason].")
 
 	if (bank_record["pda_net_id"])

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -400,6 +400,10 @@
 			var/datum/eventRecord/Ticket/ticketEvent = new()
 			ticketEvent.buildAndSend(src, usr)
 
+#define MAX_NO_APPROVAL 500
+#define JOBS_CAN_TICKET_SMALL list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant","Security Officer","Inspector")
+#define JOBS_CAN_TICKET_BIG list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant")
+
 /datum/fine
 	var/ID = null
 	var/name = "fine"
@@ -416,6 +420,9 @@
 	var/target_byond_key = null
 	var/issuer_byond_key = null
 	var/approver_byond_key = null
+	var/max_small = MAX_NO_APPROVAL
+	var/jobs_small = JOBS_CAN_TICKET_SMALL
+	var/jobs_big = JOBS_CAN_TICKET_BIG
 
 	New()
 		..()
@@ -428,8 +435,8 @@
 
 /datum/fine/proc/approve(var/approved_by,var/their_job)
 	if(approver || paid) return
-	if (amount > 500 && !(their_job in list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant"))) return
-	if (!(their_job in list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant","Security Officer","Inspector"))) return
+	if (amount > max_small && !(JOBS_CAN_TICKET_BIG)) return
+	if (!(their_job in JOBS_CAN_TICKET_SMALL)) return
 
 	approver = approved_by
 	approver_job = their_job
@@ -448,6 +455,10 @@
 		paid_amount += bank_record["current_money"]
 		bank_record["current_money"] = 0
 		SPAWN(30 SECONDS) process_payment()
+
+#undef MAX_NO_APPROVAL
+#undef JOBS_CAN_TICKET_SMALL
+#undef JOBS_CAN_TICKET_BIG
 
 /datum/fine/proc/process_payment()
 	if(bank_record["current_money"] >= (amount-paid_amount))

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -434,7 +434,7 @@
 
 	approver = approved_by
 	approver_job = their_job
-	approver_byond_key = usr.key
+	approver_byond_key = get_byond_key(approver)
 	logTheThing(LOG_ADMIN, usr, "approved a fine using [approver]([their_job])'s PDA. It is a [amount] credit fine on <b>[target]</b> with the reason: [reason].")
 
 	if (bank_record["pda_net_id"])

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -428,11 +428,17 @@
 
 /datum/fine/proc/approve(var/approved_by,var/their_job)
 	if(approver || paid) return
-	if(!(their_job in list("Captain","Head of Security","Head of Personnel"))) return
+	if (amount > 500 && !(their_job in list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant"))) return
+	if (!(their_job in list("Captain","Head of Security","Head of Personnel","Nanotrasen Security Consultant","Security Officer","Inspector"))) return
 
 	approver = approved_by
 	approver_job = their_job
 	approver_byond_key = get_byond_key(approver)
+
+	if (bank_record["pda_net_id"])
+		var/datum/signal/pdaSignal = get_free_signal()
+		pdaSignal.data = list("address_1"=bank_record["pda_net_id"], "command"="text_message", "sender_name"="FINE-MAILBOT", "sender"="00000000", "message"="Notification: You have been fined [amount] credits by [issuer] for [reason].")
+		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
 
 	if(bank_record["current_money"] >= amount)
 		bank_record["current_money"] -= amount

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1046,7 +1046,7 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 					for (var/datum/fine/F in data_core.fines)
 						if(!F.approver)
 							dat += "[F.target]: [F.amount] credits<br>Reason: [F.reason]<br>Requested by: [F.issuer] - [F.issuer_job]"
-							if((PDAownerjob in F.jobs_big) || ((PDAownerjob in F.jobs_small) && F.amount <= F.max_small)) dat += "<br><a href='byond://?src=\ref[src];approve=\ref[F]'>Approve Fine</a>"
+							if((PDAownerjob in JOBS_CAN_TICKET_BIG) || ((PDAownerjob in JOBS_CAN_TICKET_SMALL) && F.amount <= MAX_FINE_NO_APPROVAL)) dat += "<br><a href='byond://?src=\ref[src];approve=\ref[F]'>Approve Fine</a>"
 							dat += "<br><br>"
 
 				if(3) //unpaid fines
@@ -1145,12 +1145,9 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 			F.target_byond_key = get_byond_key(F.target)
 			F.issuer_byond_key = usr.key
 			data_core.fines += F
-			var/max_no_approval = F.max_small
-			var/jobs_can_ticket_small = F.jobs_small
-			var/jobs_can_ticket_big = F.jobs_big
 
-			logTheThing(LOG_ADMIN, usr, "fines <b>[ticket_target]</b> with the reason: [ticket_reason].")
-			if((fine_amount <= max_no_approval && (PDAownerjob in jobs_can_ticket_small)) || (PDAownerjob in jobs_can_ticket_big))
+			logTheThing(LOG_ADMIN, usr, "requested a fine using [PDAowner]([PDAownerjob])'s PDA. It is a [fine_amount] credit fine on <b>[ticket_target]</b> with the reason: [ticket_reason].")
+			if((fine_amount <= MAX_FINE_NO_APPROVAL && (PDAownerjob in JOBS_CAN_TICKET_SMALL)) || (PDAownerjob in JOBS_CAN_TICKET_BIG))
 				var/ticket_text = "[ticket_target] has been fined [fine_amount] credits by Nanotrasen Corporate Security for [ticket_reason] on [time2text(world.realtime, "DD/MM/53")].<br>Issued and approved by: [PDAowner] - [PDAownerjob]<br>"
 				playsound(src.master, 'sound/machines/printer_thermal.ogg', 50, 1)
 				SPAWN(3 SECONDS)
@@ -1161,10 +1158,10 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 					p.info = ticket_text
 					p.icon_state = "paper_caution"
 
-			else if(fine_amount <= max_no_approval)
-				message = "Fine request created, awaiting approval from one of the following personnel : [english_list(jobs_can_ticket_small)]."
+			else if(fine_amount <= MAX_FINE_NO_APPROVAL)
+				message = "Fine request created, awaiting approval from the [english_list(JOBS_CAN_TICKET_SMALL, "nobody", " or ")]."
 			else
-				message = "Fine request created, awaiting approval from one of the following personnel : [english_list(jobs_can_ticket_big)]."
+				message = "Fine request created, awaiting approval from the [english_list(JOBS_CAN_TICKET_BIG, "nobody", " or ")]."
 
 		else if(href_list["approve"])
 			var/PDAowner = src.master.owner


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Lets Security Officers and Inspectors issue fines for up to 500 credits without the approval of a head.
- Fines above 500 credits must be approved by one of: Captain, HoP, HoS, NTSC.
- When a fine is approved (or simply issued for fines of 500 and less) sends a PDA message to the person who got fined stating the issuer of the fine, amount fined and reason.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Gives secoffs a newish step of escalation between a simple warning and brig time.
- People should know when they get a fine.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(*)Security officers and Inspectors can now isssue fines for up to 500 credits without further approval.
(+)You will now be alerted by PDA when you recieve a fine.
```
