### PR TITLE
Update camera status and coverage on de/reconstruction

### DIFF
--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -182,20 +182,31 @@
 	if(!istype(src, /obj/machinery/camera/television)) //tv cams were getting messed up
 		src.icon_state = "cameraemp"
 	src.network = null //Not the best way but it will do. I think.
-	camera_status--
+	src.set_camera_status(FALSE)
 
 	SPAWN(90 SECONDS)
-		camera_status++
+		src.set_camera_status(TRUE)
 		src.network = initial(src.network)
 		if(!istype(src, /obj/machinery/camera/television))
 			src.icon_state = initial(src.icon_state)
 
-		update_coverage()
+		src.update_coverage()
 
 	src.disconnect_viewers()
 
 /obj/machinery/camera/blob_act(var/power)
 	return
+
+/obj/machinery/camera/was_deconstructed_to_frame(mob/user)
+	. = ..()
+	src.set_camera_status(FALSE)
+	src.update_coverage()
+	src.disconnect_viewers()
+
+/obj/machinery/camera/was_built_from_frame(mob/user, newly_built)
+	. = ..()
+	src.set_camera_status(TRUE)
+	src.update_coverage()
 
 /obj/machinery/camera/proc/set_camera_status(status)
 	src.camera_status = status


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][balance][game objects][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Implement the to/from frame procs on cameras to update status and refresh camera coverage.
* Update the `emp_act` proc to ensure it updates camera active/coverage consistently while we're here.

This implementation results in some game balance changes, notably:
* Removed cameras show as (deactivated), so antagonists removing a camera have a higher chance to be discovered.
* Viewers cannot tell whether a deactivated camera is broken or deconstructed, requiring investigation to confirm.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18186

## Test Plan
- [x] Viewers are disconnected when the camera is deconstructed
- [x] AI sees static when camera is deconstructed
- [x] Camera is usable after being constructed
- [x] AI gains sight when camera is constructed

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Deconstructed cameras now show as "Deactivated" instead of disappearing from the camera list.
```