### PR TITLE
Sawing tools can cut open coconuts

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -1305,7 +1305,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 		reagents.add_reagent("coconut_milk",30)
 
 	attackby(obj/item/W, mob/user)
-		if (iscuttingtool(W))
+		if (istool(W, TOOL_CUTTING | TOOL_SAWING))
 			user.visible_message("[user] cracks [src] open.", "You crack open [src].")
 			src.split()
 		..()


### PR DESCRIPTION
[Hydroponics][Feature][QoL]
## About the PR
Makes it so that the botany coconuts can be opened with saw tool (chaisaw) or cut tool (knife, glass piece, et c)

## Why's this needed?
sensical, i think. it is a chainsaw. Chainsaw can open trees....why not coconuts? (same thing for the other saw imstruments - surgury saw, deoconstructor saw...)

it is also funny that piece of glass is more better at opening coconut than chaimsaw. Funny, but not good

## Changelog 
```changelog
(u)NibChocolateeny
(+)Coconuts can now be opened with saw-like tools. 
```
