### PR TITLE
Fixes Blind staff dropping their stuff in arrivals

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2282,7 +2282,7 @@
 			src.drop_from_slot(current, get_turf(current))
 	src.force_equip(I, slot)
 	return TRUE
-
+///Tries to put an item in an available backpack, pocket, or hand slot; will delete the item if unable to place.
 /mob/living/carbon/human/proc/stow_in_available(obj/item/I)
 	if (src.autoequip_slot(I, SLOT_IN_BACKPACK))
 		return

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2294,7 +2294,7 @@
 		return
 	if (src.autoequip_slot(I, SLOT_R_HAND))
 		return
-	else qdel(I)
+	qdel(I)
 
 /mob/living/carbon/human/swap_hand(var/specify=-1)
 	if(src.hand == specify)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2283,6 +2283,19 @@
 	src.force_equip(I, slot)
 	return TRUE
 
+/mob/living/carbon/human/proc/stow_in_available(obj/item/I)
+	if (src.autoequip_slot(I, SLOT_IN_BACKPACK))
+		return
+	if (src.autoequip_slot(I, SLOT_L_STORE))
+		return
+	if (src.autoequip_slot(I, SLOT_R_STORE))
+		return
+	if (src.autoequip_slot(I, SLOT_L_HAND))
+		return
+	if (src.autoequip_slot(I, SLOT_R_HAND))
+		return
+	else qdel(I)
+
 /mob/living/carbon/human/swap_hand(var/specify=-1)
 	if(src.hand == specify)
 		return

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -599,19 +599,13 @@ var/global/totally_random_jobs = FALSE
 /// Equip items from sensory traits
 /mob/living/carbon/human/proc/equip_sensory_items()
 	if (src.traitHolder.hasTrait("blind"))
-		if (src.autoequip_slot(src.glasses, SLOT_IN_BACKPACK))
-		else if (src.autoequip_slot(src.glasses, SLOT_L_HAND))
-		else qdel(src.glasses) 	//Should've brought less item :p, rarely happens and doesn't really matter since the original glasses can usually easily be obtained if they started with it
+		src.stow_in_available(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/visor(src), SLOT_GLASSES)
 	if (src.traitHolder.hasTrait("shortsighted"))
-		if (src.autoequip_slot(src.glasses, SLOT_IN_BACKPACK))
-		else if (src.autoequip_slot(src.glasses, SLOT_L_HAND))
-		else qdel(src.glasses)
+		src.stow_in_available(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/regular(src), SLOT_GLASSES)
 	if (src.traitHolder.hasTrait("deaf"))
-		if (src.autoequip_slot(src.ears, SLOT_IN_BACKPACK))
-		else if (src.autoequip_slot(src.ears, SLOT_R_HAND))
-		else qdel(src.ears)
+		src.stow_in_available(src.ears)
 		src.equip_if_possible(new /obj/item/device/radio/headset/deaf(src), SLOT_EARS)
 
 /mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -599,13 +599,19 @@ var/global/totally_random_jobs = FALSE
 /// Equip items from sensory traits
 /mob/living/carbon/human/proc/equip_sensory_items()
 	if (src.traitHolder.hasTrait("blind"))
-		src.drop_from_slot(src.glasses)
+		if (src.autoequip_slot(src.glasses, SLOT_IN_BACKPACK))
+		else if (src.autoequip_slot(src.glasses, SLOT_L_HAND))
+		else qdel(src.glasses) 	//Should've brought less item :p, rarely happens and doesn't really matter since the original glasses can usually easily be obtained if they started with it
 		src.equip_if_possible(new /obj/item/clothing/glasses/visor(src), SLOT_GLASSES)
 	if (src.traitHolder.hasTrait("shortsighted"))
-		src.drop_from_slot(src.glasses)
+		if (src.autoequip_slot(src.glasses, SLOT_IN_BACKPACK))
+		else if (src.autoequip_slot(src.glasses, SLOT_L_HAND))
+		else qdel(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/regular(src), SLOT_GLASSES)
 	if (src.traitHolder.hasTrait("deaf"))
-		src.drop_from_slot(src.ears)
+		if (src.autoequip_slot(src.ears, SLOT_IN_BACKPACK))
+		else if (src.autoequip_slot(src.ears, SLOT_R_HAND))
+		else qdel(src.ears)
 		src.equip_if_possible(new /obj/item/device/radio/headset/deaf(src), SLOT_EARS)
 
 /mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)


### PR DESCRIPTION
[FIX][CLOTHING][TRAIT]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
People with Either the Blind, Short-Sighted or Deaf Trait combined with a Background Trait no longer spawn their stuff in arrivals at roundstart

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Should Fix all of these:
#16758
#10323 
#12975 
#15270 
