### PR TITLE
Nadir PTL update

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -10,7 +10,7 @@
 	},
 /obj/cable/orange,
 /obj/cable/orange{
-	icon_state = "1-10"
+	icon_state = "0-10"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 4
@@ -863,9 +863,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/substation/pylon{
@@ -3721,9 +3718,6 @@
 /obj/forcefield/energyshield/perma/doorlink{
 	dir = 8
 	},
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/industrial,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -4033,14 +4027,6 @@
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"bKJ" = (
-/obj/cable/yellow{
-	icon_state = "4-10"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "bKL" = (
 /obj/landmark/halloween,
 /obj/machinery/drainage,
@@ -4647,9 +4633,6 @@
 /area/pasiphae/sys)
 "caB" = (
 /obj/landmark/gps_waypoint,
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -6910,15 +6893,6 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
-"dbo" = (
-/obj/disposalpipe/segment/transport,
-/obj/cable/yellow{
-	icon_state = "4-10"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "dbE" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/food_box/donut_box{
@@ -8098,9 +8072,6 @@
 /obj/cable/yellow{
 	icon_state = "1-10"
 	},
-/obj/cable/yellow{
-	icon_state = "4-10"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -8611,14 +8582,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
-	})
-"dQV" = (
-/obj/cable/yellow{
-	icon_state = "5-10"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
 	})
 "dRl" = (
 /obj/fitness/speedbag/wizard,
@@ -11735,17 +11698,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/surgery)
-"fkY" = (
-/obj/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/cable/yellow{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "fkZ" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -13275,14 +13227,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southwest)
-"fNZ" = (
-/obj/cable/yellow{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "fPl" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -13471,20 +13415,6 @@
 /obj/pool_springboard,
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"fSV" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "fTc" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/cable/orange{
@@ -14150,9 +14080,6 @@
 "giE" = (
 /obj/cable/yellow{
 	icon_state = "1-6"
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon{
@@ -25908,9 +25835,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/cable/yellow{
-	icon_state = "6-10"
-	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
 	name = "Southeast Breach Hull"
@@ -27789,17 +27713,6 @@
 "lDT" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
-"lDW" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/cable/yellow{
-	icon_state = "5-10"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "lDX" = (
 /obj/shrub{
 	dir = 1
@@ -31963,17 +31876,6 @@
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"nna" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "nny" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -38529,9 +38431,6 @@
 /obj/cable/yellow{
 	icon_state = "2-9"
 	},
-/obj/cable/yellow{
-	icon_state = "2-5"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -43623,18 +43522,6 @@
 /obj/item/paper/book/from_file/monster_manual,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/arcade/dungeon)
-"sFj" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/cable/yellow{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "sFr" = (
 /obj/decal/cleanable/dirt,
 /obj/table/reinforced/auto,
@@ -48196,9 +48083,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "uya" = (
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
@@ -49001,14 +48885,6 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
-"uTK" = (
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "uTO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49481,17 +49357,6 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
-"vil" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "viB" = (
 /obj/machinery/light/small/warm/very{
 	dir = 4;
@@ -51081,9 +50946,6 @@
 "vTb" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
-	},
-/obj/cable/yellow{
-	icon_state = "5-8"
 	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
@@ -55245,14 +55107,6 @@
 "xKn" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/east)
-"xKL" = (
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/substation/pylon{
-	name = "South Catalytic Substation"
-	})
 "xLu" = (
 /turf/simulated/floor/carpet/red/fancy/junction/sw_e,
 /area/pasiphae/crew)
@@ -56019,12 +55873,6 @@
 /turf/simulated/floor/black,
 /area/station/security/beepsky)
 "yel" = (
-/obj/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/cable/yellow{
-	icon_state = "4-10"
-	},
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/substation/pylon{
 	name = "South Catalytic Substation"
@@ -102756,7 +102604,7 @@ nsy
 dQM
 nlc
 psV
-xKL
+vtr
 qjE
 sQr
 laQ
@@ -104266,7 +104114,7 @@ mgm
 abz
 mif
 neB
-nna
+vTb
 elm
 dAB
 bzS
@@ -104568,7 +104416,7 @@ tBf
 abz
 neB
 neB
-nna
+vTb
 neB
 dAB
 hIJ
@@ -105171,7 +105019,7 @@ ihh
 cXD
 nFG
 cSH
-dbo
+cSH
 bWz
 rEP
 rEP
@@ -105473,7 +105321,7 @@ nve
 eRD
 nGd
 neB
-fNZ
+neB
 dAB
 dAB
 bzS
@@ -105774,7 +105622,7 @@ ouB
 tKo
 eRD
 nGi
-bKJ
+neB
 neB
 dAB
 hIJ
@@ -106076,7 +105924,7 @@ eRD
 eRD
 eRD
 nGm
-fNZ
+neB
 neB
 dAB
 bzS
@@ -106377,7 +106225,7 @@ lli
 glH
 gxN
 nCM
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -106679,7 +106527,7 @@ uJB
 eRD
 eRD
 fxH
-fSV
+fxH
 dAB
 dAB
 bzS
@@ -106981,7 +106829,7 @@ pCj
 eRD
 lCi
 neB
-fNZ
+neB
 dAB
 hIJ
 bzS
@@ -107282,7 +107130,7 @@ eRD
 eRD
 eRD
 neB
-dQV
+neB
 neB
 dAB
 bzS
@@ -107583,7 +107431,7 @@ gTI
 wYR
 eRD
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -107885,7 +107733,7 @@ bFf
 eRD
 eRD
 neB
-fNZ
+neB
 dAB
 dAB
 bzS
@@ -108186,7 +108034,7 @@ eRD
 usT
 eRD
 lCi
-bKJ
+neB
 neB
 dAB
 hIJ
@@ -108488,7 +108336,7 @@ eRD
 eRD
 eRD
 neB
-fNZ
+neB
 neB
 dAB
 bzS
@@ -108789,7 +108637,7 @@ eIV
 jDV
 lka
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -109091,7 +108939,7 @@ kcY
 kRh
 kRh
 fxH
-vil
+fxH
 dAB
 dAB
 bzS
@@ -109393,7 +109241,7 @@ iLs
 kRh
 lCi
 neB
-fNZ
+neB
 dAB
 hIJ
 bzS
@@ -109694,7 +109542,7 @@ uod
 kRh
 kRh
 neB
-dQV
+neB
 neB
 dAB
 bzS
@@ -109995,7 +109843,7 @@ goK
 tnw
 lka
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -110297,7 +110145,7 @@ uWj
 kRh
 kRh
 neB
-fNZ
+neB
 dAB
 dAB
 bzS
@@ -110598,7 +110446,7 @@ tQW
 ejL
 kRh
 lCi
-bKJ
+neB
 neB
 dAB
 hIJ
@@ -110900,7 +110748,7 @@ kRh
 kRh
 kRh
 neB
-fNZ
+neB
 neB
 dAB
 bzS
@@ -111201,7 +111049,7 @@ lqD
 mip
 kRh
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -111503,7 +111351,7 @@ xPH
 kRh
 kRh
 fxH
-vil
+fxH
 dAB
 dAB
 bzS
@@ -111805,7 +111653,7 @@ aXj
 kRh
 lCi
 neB
-fNZ
+neB
 dAB
 hIJ
 bzS
@@ -112106,7 +111954,7 @@ kRh
 kRh
 kRh
 neB
-dQV
+neB
 neB
 dAB
 bzS
@@ -112407,7 +112255,7 @@ cnT
 jvJ
 lka
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -112709,7 +112557,7 @@ kCh
 kRh
 kRh
 neB
-fNZ
+neB
 dAB
 dAB
 bzS
@@ -113010,7 +112858,7 @@ kXC
 aQD
 kRh
 lCi
-bKJ
+neB
 neB
 dAB
 hIJ
@@ -113312,7 +113160,7 @@ ntr
 kRh
 kRh
 neB
-fNZ
+neB
 neB
 dAB
 bzS
@@ -113613,7 +113461,7 @@ oZL
 cKo
 lka
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -113915,7 +113763,7 @@ oZL
 kRh
 kRh
 fxH
-vil
+fxH
 dAB
 dAB
 bzS
@@ -114217,7 +114065,7 @@ uWj
 kRh
 lCi
 neB
-fNZ
+neB
 dAB
 hIJ
 bzS
@@ -114518,7 +114366,7 @@ itp
 kRh
 kRh
 neB
-dQV
+neB
 neB
 dAB
 bzS
@@ -114819,7 +114667,7 @@ xhh
 fpW
 lka
 neB
-bKJ
+neB
 hOA
 rEP
 rEP
@@ -115121,7 +114969,7 @@ sju
 kRh
 kRh
 neB
-fNZ
+neB
 dAB
 dAB
 bzS
@@ -115422,7 +115270,7 @@ oZL
 gvr
 kRh
 lCi
-bKJ
+neB
 neB
 dAB
 pFh
@@ -115724,7 +115572,7 @@ nLI
 kRh
 kRh
 neB
-uTK
+neB
 neB
 dAB
 vnv
@@ -116026,7 +115874,7 @@ bru
 jIK
 ftE
 neB
-sFj
+hOA
 neB
 rEP
 hnw
@@ -116327,7 +116175,7 @@ txY
 kRh
 kRh
 dvF
-lDW
+fxH
 iXQ
 iXQ
 iXQ
@@ -116931,7 +116779,7 @@ kRh
 kRh
 neB
 pbM
-fkY
+xkP
 fgI
 pSG
 aat

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -8,8 +8,8 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/cable/orange,
-/obj/cable/orange{
+/obj/cable/blue,
+/obj/cable/blue{
 	icon_state = "0-10"
 	},
 /turf/simulated/floor/yellowblack{
@@ -1065,7 +1065,7 @@
 /area/station/mining/staff_room)
 "axj" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -1127,7 +1127,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -1395,7 +1395,7 @@
 "aEI" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/gps_waypoint,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-6"
 	},
 /turf/simulated/floor/black,
@@ -1868,12 +1868,6 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
-"aTf" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/ptl)
 "aTq" = (
 /obj/machinery/conveyor/EW{
 	id = "ghostdrone"
@@ -2164,10 +2158,10 @@
 /area/station/maintenance/north)
 "aYG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "0-9"
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -2404,7 +2398,7 @@
 /area/station/storage/tech)
 "bdB" = (
 /obj/disposalpipe/segment/transport,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack,
@@ -3809,7 +3803,7 @@
 /area/station/hallway/secondary/west)
 "bFd" = (
 /obj/grille/catwalk,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/grime,
@@ -4754,7 +4748,7 @@
 /area/station/medical/medbay/cloner)
 "cec" = (
 /obj/disposalpipe/segment/transport,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -6538,7 +6532,7 @@
 /area/station/hallway/primary/northwest)
 "cUo" = (
 /obj/random_item_spawner/junk/one_or_zero,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/industrial,
@@ -7598,7 +7592,7 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "6-8"
 	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
@@ -7820,7 +7814,7 @@
 "dyF" = (
 /obj/machinery/portable_reclaimer,
 /obj/decal/cleanable/dirt,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -8527,7 +8521,7 @@
 	})
 "dOr" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack,
@@ -9858,7 +9852,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "euK" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-10"
 	},
 /turf/simulated/floor/industrial,
@@ -10881,7 +10875,7 @@
 	dir = 4;
 	name = "Engine Output Monitoring"
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "0-5"
 	},
 /turf/simulated/floor/yellowblack{
@@ -11557,8 +11551,11 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "9-10"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/ptl)
@@ -11593,11 +11590,13 @@
 /area/station/storage/tech)
 "fhD" = (
 /obj/machinery/power/apc/autoname_west,
-/obj/cable,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "0-5"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 9
@@ -13417,7 +13416,7 @@
 /area/station/crew_quarters/pool)
 "fTc" = (
 /obj/random_item_spawner/junk/one_or_zero,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
@@ -16667,14 +16666,15 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/genpop)
 "hhO" = (
+/obj/cable/orange,
 /obj/cable/orange{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /obj/cable/orange{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/cable/orange{
-	icon_state = "4-10"
+/obj/cable/blue{
+	icon_state = "0-10"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/monitoring{
@@ -16700,7 +16700,7 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/disposalpipe/segment/transport,
 /obj/mapping_helper/firedoor_spawn,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack{
@@ -19463,7 +19463,7 @@
 /obj/mapping_helper/access/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/airlock/cycler{
@@ -20418,7 +20418,7 @@
 	name = "Northwest Breach Hull"
 	})
 "iDK" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/industrial,
@@ -21986,7 +21986,7 @@
 /turf/simulated/floor/grey,
 /area/station/crewquarters/cryotron)
 "jqr" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-9"
 	},
 /turf/simulated/floor/plating,
@@ -24340,7 +24340,7 @@
 "kmb" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/horizontal,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-6"
 	},
 /turf/simulated/floor/plating,
@@ -24509,7 +24509,7 @@
 	name = "Southwest Breach Hull"
 	})
 "kpw" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "2-9"
 	},
 /turf/simulated/floor/black,
@@ -25831,14 +25831,6 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
-"kPo" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/industrial,
-/area/station/maintenance/outer/se{
-	name = "Southeast Breach Hull"
-	})
 "kPR" = (
 /obj/table/wood/round/auto,
 /obj/item/device/light/candle{
@@ -25970,7 +25962,7 @@
 /area/station/engine/engineering)
 "kRD" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "6-9"
 	},
 /turf/simulated/floor/industrial,
 /area/station/maintenance/outer/se{
@@ -26588,7 +26580,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -26927,7 +26919,7 @@
 	name = "The Warrens"
 	})
 "llJ" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -29393,7 +29385,7 @@
 	})
 "mhP" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack{
@@ -34218,7 +34210,7 @@
 	},
 /obj/machinery/navbeacon/mule/engineering_north/east,
 /obj/decal/stripe_caution,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -35858,7 +35850,7 @@
 /turf/simulated/floor/blue,
 /area/pasiphae/bridge)
 "pbM" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/industrial,
@@ -36028,7 +36020,7 @@
 	name = "ratty blue couch"
 	},
 /obj/landmark/start/job/assistant,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/industrial,
@@ -36487,7 +36479,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/grime,
@@ -37690,7 +37682,7 @@
 /turf/simulated/floor/yellowblack,
 /area/station/hallway/primary/southeast)
 "pSG" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack{
@@ -38265,7 +38257,7 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
@@ -38374,7 +38366,7 @@
 	name = "Southwest Breach Hull"
 	})
 "qif" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack,
@@ -39764,7 +39756,7 @@
 /area/station/crew_quarters/pool)
 "qRe" = (
 /obj/random_item_spawner/junk/some,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/industrial,
@@ -41333,7 +41325,7 @@
 	},
 /area/station/security/main)
 "rGv" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/false_wall,
@@ -41744,7 +41736,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -44167,7 +44159,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -45054,7 +45046,7 @@
 /area/station/storage/warehouse)
 "tlH" = (
 /obj/decal/cleanable/dirt,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -46141,7 +46133,7 @@
 	})
 "tJc" = (
 /obj/storage/closet/wardrobe/yellow,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-9"
 	},
 /turf/simulated/floor/plating,
@@ -47289,7 +47281,7 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/gps_waypoint,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/black,
@@ -48297,7 +48289,7 @@
 /area/station/hallway/secondary/exit)
 "uEI" = (
 /obj/disposalpipe/segment/mail/bent/south,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
@@ -48448,7 +48440,7 @@
 	})
 "uJE" = (
 /obj/random_item_spawner/junk/one_or_zero,
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -50820,7 +50812,7 @@
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/cafeteria)
 "vPx" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black/grime,
@@ -53953,7 +53945,7 @@
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/northeast)
 "xkP" = (
-/obj/cable/orange{
+/obj/cable/blue{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/industrial,
@@ -116476,9 +116468,9 @@ mTx
 gYB
 kRh
 lCi
-kPo
+neB
 kRD
-aTf
+iXQ
 fhD
 sAj
 eRb


### PR DESCRIPTION
[MAPPING]
## About the PR
- Removes the connection to the south catalytic generators to the PTL on Nadir.
- Sets the long PTL cable line running through the station to be blue, to indicate its purpose.
- Also tweaks one bit of the station grid in the PTL room so it doesn't go through a wall. The PTL wire and the red wire don't connect.

## Why's this needed?
The catalytics are often described as "Nadir's Solars", and solars are not typically hooked up to the PTL due to pretty low power output anyway. Also, the northern catalytic generators aren't connected, so it's odd to have only the south connected anyway. #18115 added a line to the north station but I think it's better if the catalytics are simply not involved.

As for the blue cables, even though it's on the same engine grid as the orange cables, it's clearer to engineers that "this part leads away to the PTL". It's been implemented on other maps too so there's map parity.