### PR TITLE
Prevent dropping 2 handed items from your inventory with only 1 free hand.

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1417,3 +1417,11 @@ TYPEINFO(/atom/movable)
 		if("icon_state")
 			src.icon_state = oldval
 			src.set_icon_state(newval)
+
+/atom/movable/proc/is_that_in_this(atom/movable/target)
+	if (target.loc == src)
+		return TRUE
+	for(var/atom/movable/AM in container)
+		if(AM.contents.len && AM.is_that_in_this(target))
+			return TRUE
+	return FALSE

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1422,5 +1422,5 @@ TYPEINFO(/atom/movable)
 	if (target.loc == src)
 		return TRUE
 	if (istype(target.loc, /atom/movable))
-	    return src.is_that_in_this(target.loc)
+		return src.is_that_in_this(target.loc)
 	return FALSE

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1421,7 +1421,7 @@ TYPEINFO(/atom/movable)
 /atom/movable/proc/is_that_in_this(atom/movable/target)
 	if (target.loc == src)
 		return TRUE
-	for(var/atom/movable/AM in container)
+	for(var/atom/movable/AM in src)
 		if(AM.contents.len && AM.is_that_in_this(target))
 			return TRUE
 	return FALSE

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1421,7 +1421,6 @@ TYPEINFO(/atom/movable)
 /atom/movable/proc/is_that_in_this(atom/movable/target)
 	if (target.loc == src)
 		return TRUE
-	for(var/atom/movable/AM in src)
-		if(AM.contents.len && AM.is_that_in_this(target))
-			return TRUE
+	if (istype(target.loc, /atom/movable))
+	    return src.is_that_in_this(target.loc)
 	return FALSE

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1502,7 +1502,7 @@
 /mob/proc/put_in_hand(obj/item/I, hand)
 	. = 0
 
-/mob/proc/can_hold_two_handed(obj/item/I, hand)
+/mob/proc/can_hold_two_handed()
 	. = FALSE
 
 /mob/proc/get_damage()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1502,6 +1502,9 @@
 /mob/proc/put_in_hand(obj/item/I, hand)
 	. = 0
 
+/mob/proc/can_hold_two_handed(obj/item/I, hand)
+	. = FALSE
+
 /mob/proc/get_damage()
 	. = src.health
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1866,8 +1866,8 @@
 	return FALSE
 
 /mob/living/carbon/human/can_hold_two_handed()
-    . = ..()
-    if (src.r_hand || src.l_hand)
+	. = ..()
+	if (src.r_hand || src.l_hand)
 		return FALSE
 	if (src.limbs && (!src.limbs.r_arm || istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item)))
 		return FALSE

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1884,7 +1884,7 @@
 			return 1
 		return 0
 	if (I.two_handed) //MARKER1
-		if (src.can_hold_two_handed())
+		if (!src.can_hold_two_handed())
 			return FALSE
 		src.l_hand = I
 		src.r_hand = I

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1865,6 +1865,15 @@
 				return TRUE
 	return FALSE
 
+/mob/living/carbon/human/can_hold_two_handed()
+	if (src.r_hand || src.l_hand)
+		return FALSE
+	if (src.limbs && (!src.limbs.r_arm || istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item)))
+		return FALSE
+	if (src.limbs && (!src.limbs.l_arm || istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item)))
+		return FALSE
+	return TRUE
+
 /mob/living/carbon/human/put_in_hand(obj/item/I, hand)
 	if (!istype(I))
 		return 0
@@ -1875,12 +1884,8 @@
 			return 1
 		return 0
 	if (I.two_handed) //MARKER1
-		if (src.r_hand || src.l_hand)
-			return 0
-		if (src.limbs && (!src.limbs.r_arm || istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item)))
-			return 0
-		if (src.limbs && (!src.limbs.l_arm || istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item)))
-			return 0
+		if (src.can_hold_two_handed())
+			return FALSE
 		src.l_hand = I
 		src.r_hand = I
 		I.pickup(src)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1866,7 +1866,8 @@
 	return FALSE
 
 /mob/living/carbon/human/can_hold_two_handed()
-	if (src.r_hand || src.l_hand)
+    . = ..()
+    if (src.r_hand || src.l_hand)
 		return FALSE
 	if (src.limbs && (!src.limbs.r_arm || istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item)))
 		return FALSE

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1611,6 +1611,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 	. = ..()
 	wake_from_hibernation()
 
+/mob/living/carbon/human/can_hold_two_handed()
+	return TRUE // critters can hold two handed items in one hand
+
 ABSTRACT_TYPE(/mob/living/critter/robotic)
 /// Parent for robotic critters. Handles some traits that robots should have- damaged by EMPs, immune to fire and rads
 /mob/living/critter/robotic

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1611,7 +1611,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 	. = ..()
 	wake_from_hibernation()
 
-/mob/living/carbon/human/can_hold_two_handed()
+/mob/living/critter/can_hold_two_handed()
 	return TRUE // critters can hold two handed items in one hand
 
 ABSTRACT_TYPE(/mob/living/critter/robotic)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1211,6 +1211,9 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	if (src.stored)
 		src.stored.transfer_stored_item(src, user, user = user)
 		oldloc_sfx = oldloc.loc
+
+	if(src.two_handed && !user.can_hold_two_handed() && NOT_A_REAL_MACRO_TO_CHECK_IF_THE_ITEM_IS_ON_YOU_OR_IN_YOUR_STORAGE(src, user)) // prevent accidentally donating weapons to your enemies
+		return FALSE
 	user.put_in_hand_or_drop(src)
 
 	if (src.artifact)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1215,7 +1215,6 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	if (src.stored)
 		src.stored.transfer_stored_item(src, user, user = user)
 		oldloc_sfx = oldloc.loc
-
 	user.put_in_hand_or_drop(src)
 
 	if (src.artifact)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1168,6 +1168,10 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.storage?.storage_item_attack_hand(user)
 		return 0
 
+	if(src.two_handed && !user.can_hold_two_handed()) // prevent accidentally donating weapons to your enemies
+		boutput(user, SPAN_ALERT("You don't have the hands to hold this item."))
+		return FALSE
+
 	src.throwing = 0
 
 	if (isobj(src.loc))
@@ -1212,8 +1216,6 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.stored.transfer_stored_item(src, user, user = user)
 		oldloc_sfx = oldloc.loc
 
-	if(src.two_handed && !user.can_hold_two_handed() && NOT_A_REAL_MACRO_TO_CHECK_IF_THE_ITEM_IS_ON_YOU_OR_IN_YOUR_STORAGE(src, user)) // prevent accidentally donating weapons to your enemies
-		return FALSE
 	user.put_in_hand_or_drop(src)
 
 	if (src.artifact)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1168,7 +1168,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.storage?.storage_item_attack_hand(user)
 		return 0
 
-	if(src.two_handed && !user.can_hold_two_handed()) // prevent accidentally donating weapons to your enemies
+	if(src.two_handed && !user.can_hold_two_handed() && user.is_that_in_this(src)) // prevent accidentally donating weapons to your enemies
 		boutput(user, SPAN_ALERT("You don't have the hands to hold this item."))
 		return FALSE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently clicking on a 2 handed item while having only one hand drops it on the ground. This pr prevents that if the item is "in" you. So you can still take 2 handed items out of backpacks on the ground and pickpocket them from people you are pinning, but not take the Hadar heavy power-sword from your back while holding a sawfly remote.

If you have a 2 handed item on your back and you have lost one of your hands you are going to need some help.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
[Thread](https://forum.ss13.co/showthread.php?tid=22409)
Removes a bunch of accidentally dropping stuff, mostly weapons during combat, because you forgot you were holding an item.