### PR TITLE
Fix Thrifty B.O.B cheating you out of Boogiebots

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -473,8 +473,8 @@
 		showswirl(pickedloc)
 		A.name = "Goods Crate ([src.name])"
 		if (!custom)
-			for(var/obj/O in shopping_cart)
-				O.set_loc(A)
+			for(var/atom/movable/purchased as anything in shopping_cart)
+				purchased.set_loc(A)
 			shopping_cart = new/list()
 		else
 			new custom(A)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CRITTERS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes NPC trader code to iterate over /atom/movable in the shopping cart instead of just /obj because we live in a post-mobbening world

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18218