### PR TITLE
Adds blood as an associated reagent to Killer Tomatos

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -104,6 +104,7 @@ ABSTRACT_TYPE(/datum/plantmutation)
 	name_prefix = "Suspicious "
 	crop = /obj/critter/killertomato
 	iconmod = "TomatoKiller"
+	assoc_reagents = list("blood")
 	harvest_cap = 3
 	infusion_chance = 50
 	infusion_reagents = list("strange_reagent")


### PR DESCRIPTION
[Hydroponics][Feature][Add to Wiki]

## About the PR
Killer tomato (tomato that smile and bites you) now has blood (reagnent "blood") in its genes. so if you add strange reagent to tomato seed, then splice seed with dominant regualar tomato/other plant, plant can have blood in it!


## Why's this needed? 
The other week, i was with botany friend - they wamted to make a rafflesia that put carpet on the floor (blood + fungus)
they thought that the blood orange would work to have blood in flower genes - BUT, blood oramge has monster blood ("bloodc"), not REAL blood. it did not work and it was sad. now it can work, but it will be more hard, becuase you need strange reagnent to have "real" blood. (it is still very hard to make carpet flooor flower - mushroom has big gene difference!)

also, it is based on commment from #11318 form "[Scaltra-Volpe](https://github.com/Scaltra-Volpe)"

> would also be cool if killer tomatoes had blood as an associated reagent for that mutation so there is a reason to ever splice with it as a non antag

i think it is good idea - real blood can be used in some chemiacles if botany does not have syringe to take own blood. (if you stab Krimpus/self, it is too messy!)
Bloody oramge should keep monster blood - chemistryists can use "bloodc" for secret things, and have asked for blood orange at times before.

I do not think it is more powerful for vampaires? monster blood and normal blood from plant should be teh same for getting vampire points (if drinking the blood), I think. tell me if that is not true.

## Changelog 
```changelog
(u)NibChocolateeny
(+)Killer tomatoes contain "Blood" as one of their associated reagents. 
```
