### PR TITLE
include alt job names for manifest categorization

### DIFF
--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -85,11 +85,13 @@ var/list/science_jobs = list("Research Director", "Scientist")
 var/list/medsci_jobs = medical_jobs + science_jobs
 var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist", "Rancher", "Angler", "Clown", "Chaplain", "Janitor")
 
+// we have to include alt names for jobs or they won't be sorted into categories correctly
 var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
 var/list/security_gimmicks = list("Vice Officer", "Forensic Technician")
 var/list/engineering_gimmicks = list("Head of Mining", "Station Builder", "Atmospherish Technician", "Technical Assistant")
-var/list/medical_gimmicks = list("Medical Specialist", "Medical Assistant", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")
+var/list/medical_gimmicks = list("Medical Specialist", "Neurological Specialist", "Ophthalmic Specialist", "Thoracic Specialist", "Orthopaedic Specialist", "Maxillofacial Specialist",
+	  "Vascular Specialist", "Anaesthesiologist", "Acupuncturist", "Medical Director's Assistant", "Medical Assistant", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")
 var/list/science_gimmicks = list("Toxins Researcher", "Chemist", "Research Assistant", "Test Subject")
 var/list/medsci_gimmicks = medical_gimmicks + science_gimmicks
-var/list/service_gimmicks = list("Lawyer", "Barber", "Mail Courier", "Mime", "Musician", "Apiculturist", "Apiarist", "Sous-Chef", "Waiter", "Life Coach")
+var/list/service_gimmicks = list("Lawyer", "Barber", "Mail Courier", "Head of Deliverying", "Mail Bringer", "Mime", "Musician", "Apiculturist", "Apiarist", "Sous-Chef", "Waiter", "Life Coach")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the alt names for Medical Specialist and Mail Courier to the job name list.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Manifest categorization matches by string name 
Fixes #18207
