### PR TITLE
Fix lobby text status runtime

### DIFF
--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -69,7 +69,7 @@
 		var/map_name = istext(map_settings.display_name) ? "[map_settings.display_name]" : "[getMapNameFromID(map_setting)]"
 		//var/map_link_str = map_settings.goonhub_map ? "<a href=\"[map_settings.goonhub_map]\">[map_name]</a>" : "[map_name]"
 		statsus += "Map: <b>[map_name]</b>"
-		if(mapSwitcher.next)
+		if(mapSwitcher?.next)
 			statsus += " | Next: <b>[mapSwitcher.next]</b><br>"
 		else
 			statsus += "<br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add a null check to the `mapSwitcher.next` line in world.dm

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![image](https://github.com/goonstation/goonstation/assets/75404941/5b8ecd2a-bc85-49f0-86e2-8734a0336258)
Fixes this runtime that only happens when the server is launched in single-user mode (directly launching the dmb) that seems to happen because `world.update_status()` gets called before `world.init()` creates `mapSwitcher`
