### PR TITLE
Sec podbay consistency and QoL

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -46093,6 +46093,8 @@
 	},
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/mainweapon/taser,
+/obj/item/shipcomponent/mainweapon/taser,
+/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor/redblack{
 	dir = 4

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3846,32 +3846,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/lobby)
 "aoK" = (
-/obj/rack,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/item/tank/air{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/space/emerg{
-	pixel_x = 6
-	},
-/obj/item/crowbar{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 5;
-	pixel_y = 1
-	},
-/obj/item/clothing/head/emerg{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "aoN" = (
@@ -4832,6 +4810,9 @@
 	pixel_x = 10;
 	pixel_y = -2
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "asW" = (
@@ -5174,16 +5155,24 @@
 	},
 /area/station/hydroponics/bay)
 "aue" = (
-/obj/reagent_dispensers/fueltank,
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/table/auto,
+/obj/item/crowbar{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/hand_labeler{
+	pixel_x = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
@@ -5502,21 +5491,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "avo" = (
-/obj/table/auto,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/crowbar{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/hand_labeler{
-	pixel_x = 4
-	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "avp" = (
@@ -53307,8 +53285,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -53319,6 +53295,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big{
 	dir = 8
 	},
+/obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "oCM" = (
@@ -64019,7 +63996,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "wJN" = (
-/obj/storage/closet/welding_supply,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -64027,6 +64003,10 @@
 	dir = 10
 	},
 /obj/machinery/door_control/podbay/security/new_walls/east,
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "wKl" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -13464,7 +13464,6 @@
 /area/station/maintenance/east)
 "buh" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/light/incandescent,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "buj" = (
@@ -24687,6 +24686,10 @@
 "hoK" = (
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/west)
+"hoP" = (
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor/red,
+/area/station/hangar/sec)
 "hpu" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -28890,6 +28893,8 @@
 /obj/item/crowbar,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/device/multitool,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "kcB" = (
@@ -41196,7 +41201,7 @@
 	},
 /area/station/engine/inner)
 "rBB" = (
-/obj/item/device/multitool,
+/obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "rBH" = (
@@ -94631,7 +94636,7 @@ bns
 buh
 bvm
 sqd
-bvm
+rBB
 bxq
 apU
 aaa
@@ -94933,7 +94938,7 @@ bns
 cQm
 bvm
 sqd
-rBB
+hoP
 bxq
 apU
 aaa

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -35285,7 +35285,7 @@
 	},
 /area/station/engine/inner)
 "kKy" = (
-/obj/storage/closet/welding_supply,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -40704,6 +40704,7 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "mog" = (
+/obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -48104,7 +48105,7 @@
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai_upload)
 "oCX" = (
-/obj/reagent_dispensers/fueltank,
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds plasma vending machines and ship fabricators to sec podbays that were missing them.
- Removes fuel tanks from under lights because ion storms.
- Adds another taser to clarion podbay, because 1 taser for 4 pods is sad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I love consistency and I hate ion storms.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Nah