### PR TITLE
Ensure the RCD is actively equipped before resolving use

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -544,7 +544,7 @@ TYPEINFO(/obj/item/rcd)
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 		boutput(user, "You start [what]... ([issilicon(user) ? "[ammo * src.silicon_cost_multiplier] charge" : "[ammo] matter units"][delay ? ", [delay / 10] seconds" : ""])")
 
-		if ((!delay || do_after(user, delay)) && ammo_check(user, ammo))
+		if ((!delay || do_after(user, delay)) && ammo_check(user, ammo) && src == user.equipped())
 			ammo_consume(user, ammo)
 			playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
 			shitSparks()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[bug][game objects]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the RCD checks if the action can be completed, add a check to ensure it's the currently equipped item.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18241