### PR TITLE
Adds decorations to boxing rings

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7817,6 +7817,14 @@
 /obj/decal/boxingropeenter{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/grey{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aGk" = (
@@ -7827,6 +7835,10 @@
 	dir = 4
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aGm" = (
@@ -8083,6 +8095,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/decal/stage_edge{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aHq" = (
@@ -8090,11 +8105,19 @@
 	density = 0;
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aHr" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -8225,6 +8248,9 @@
 /area/station/crew_quarters/fitness)
 "aIq" = (
 /obj/disposalpipe/segment,
+/obj/decal/stage_edge{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aIr" = (
@@ -8233,6 +8259,10 @@
 	dir = 8
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aIs" = (
@@ -8543,6 +8573,9 @@
 /area/station/crew_quarters/fitness)
 "aJE" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aJF" = (
@@ -12755,6 +12788,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bhj" = (
@@ -13106,6 +13143,10 @@
 "bkr" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -18581,6 +18622,11 @@
 /obj/landmark/pest,
 /turf/simulated/floor,
 /area/station/science/artifact)
+"cIJ" = (
+/turf/simulated/floor/stairs{
+	dir = 4
+	},
+/area/station/crew_quarters/fitness)
 "cJB" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4;
@@ -30368,6 +30414,13 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"lTl" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "lTq" = (
 /obj/landmark/antagonist/blob,
 /turf/simulated/floor/plating,
@@ -75811,7 +75864,7 @@ azu
 aDh
 azu
 azu
-azu
+cIJ
 aHp
 aIq
 aIq
@@ -76325,7 +76378,7 @@ aCi
 aDj
 bka
 aFw
-aGk
+lTl
 aGk
 aGk
 aJE
@@ -76582,7 +76635,7 @@ aCj
 aDj
 hHP
 aFw
-aGk
+lTl
 aSf
 aGk
 aJE
@@ -76839,7 +76892,7 @@ aCk
 aDj
 aEs
 aFw
-aGk
+lTl
 aGk
 aGk
 aJE

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5721,6 +5721,14 @@
 /obj/decal/boxingropeenter{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/grey{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "avU" = (
@@ -5730,6 +5738,10 @@
 /obj/stool,
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -6154,6 +6166,10 @@
 	density = 0;
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "axo" = (
@@ -6162,6 +6178,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -6510,11 +6530,19 @@
 	density = 0;
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "ayJ" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -7064,20 +7092,34 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aAm" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aAn" = (
 /obj/decal/boxingrope,
 /obj/machinery/light,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aAo" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -42112,6 +42154,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
+"fxi" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "fxp" = (
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";
@@ -111026,7 +111075,7 @@ aqK
 akT
 atr
 auI
-avU
+fxi
 avU
 avU
 aAm
@@ -111328,7 +111377,7 @@ aqI
 akT
 ats
 auI
-avU
+fxi
 aoa
 ulX
 aAn
@@ -111630,7 +111679,7 @@ akT
 akT
 att
 auI
-avU
+fxi
 avU
 avU
 aAm

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -7797,15 +7797,26 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aya" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "ayb" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -8425,6 +8436,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "azJ" = (
@@ -8433,6 +8448,14 @@
 "azK" = (
 /obj/decal/boxingropeenter{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/grey{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -9026,6 +9049,10 @@
 	density = 0;
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aBg" = (
@@ -9042,6 +9069,10 @@
 "aBh" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -9664,6 +9695,10 @@
 	dir = 4
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aCC" = (
@@ -60735,6 +60770,13 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/science)
+"idN" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "ied" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -112129,7 +112171,7 @@ atG
 atG
 atG
 aww
-azJ
+idN
 azJ
 azJ
 aya
@@ -112431,7 +112473,7 @@ atH
 atG
 atG
 awx
-azJ
+idN
 asM
 azJ
 aya
@@ -112733,7 +112775,7 @@ atI
 atG
 awy
 awv
-azJ
+idN
 azJ
 azJ
 aya

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -14548,6 +14548,9 @@
 "emk" = (
 /obj/decal/boxingrope,
 /obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "emt" = (
@@ -16146,6 +16149,10 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "eOq" = (
@@ -26944,6 +26951,10 @@
 	dir = 10
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "iew" = (
@@ -29408,6 +29419,10 @@
 	},
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -34147,6 +34162,14 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/grey{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "krn" = (
@@ -46919,6 +46942,10 @@
 /obj/decal/boxingrope{
 	dir = 4
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "ome" = (
@@ -50126,6 +50153,10 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "piT" = (
@@ -56952,6 +56983,10 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "rlB" = (
@@ -60939,6 +60974,9 @@
 /area/station/engine/inner)
 "syG" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "syN" = (
@@ -62829,6 +62867,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "tfm" = (
@@ -63410,6 +63451,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"tok" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "tol" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/grasstodirt{
@@ -70208,6 +70256,10 @@
 	dir = 4
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "vpT" = (
@@ -122354,7 +122406,7 @@ gwZ
 lJa
 eFg
 ine
-hBW
+tok
 hBW
 vtH
 emk
@@ -122656,7 +122708,7 @@ uYk
 lJa
 eFg
 jCe
-hBW
+tok
 hBW
 vtH
 syG
@@ -122958,7 +123010,7 @@ weI
 lJa
 eFg
 bPa
-hBW
+tok
 hBW
 vtH
 tfk

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -5815,10 +5815,16 @@
 /area/station/hallway/primary/north)
 "avl" = (
 /obj/decal/boxingropeenter,
+/obj/decal/tile_edge/line/grey{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "avm" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "avo" = (
@@ -6801,6 +6807,10 @@
 /obj/decal/boxingrope{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "azC" = (
@@ -7325,6 +7335,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aBy" = (
@@ -7783,6 +7797,10 @@
 "aDp" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -8347,6 +8365,10 @@
 "aFC" = (
 /obj/decal/boxingrope{
 	dir = 8
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -10187,6 +10209,10 @@
 /obj/decal/boxingrope{
 	dir = 4
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aOo" = (
@@ -11265,6 +11291,10 @@
 /obj/stool,
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -27166,6 +27196,13 @@
 "cfu" = (
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
+"cfv" = (
+/obj/decal/tile_edge/line/grey{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "cfw" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
@@ -33640,6 +33677,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"ewU" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "exl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43441,6 +43485,16 @@
 	dir = 10
 	},
 /area/station/engine/monitoring)
+"lGP" = (
+/obj/decal/boxingrope{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "lGU" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -121055,7 +121109,7 @@ fdN
 xix
 atr
 aIO
-aHF
+cfv
 aHF
 aHF
 avm
@@ -121357,7 +121411,7 @@ hqk
 azn
 atr
 spC
-aHF
+ewU
 aHF
 aHF
 avm
@@ -121659,7 +121713,7 @@ fdN
 vSu
 atr
 spC
-aHF
+ewU
 aHF
 aHF
 avl
@@ -121961,7 +122015,7 @@ aEs
 aAa
 atr
 smb
-aOn
+lGP
 aOn
 aSp
 aBw

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -6306,6 +6306,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
+"cPz" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "cPI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -6603,6 +6612,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 6;
 	icon_state = "ringrope"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
@@ -10120,6 +10133,13 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/janitor/supply)
+"eBk" = (
+/obj/decal/boxingrope,
+/obj/grille/catwalk,
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "eBt" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -11016,6 +11036,10 @@
 /obj/decal/boxingropeenter{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -11251,6 +11275,10 @@
 	dir = 4
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "eXy" = (
@@ -14201,6 +14229,9 @@
 /area/station/storage/warehouse)
 "glb" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "gli" = (
@@ -14412,6 +14443,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/decal/stage_edge,
 /turf/simulated/floor/black/grime,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -15338,7 +15370,8 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 9
 	},
-/turf/simulated/floor/specialroom/gym/alt,
+/obj/grille/catwalk,
+/turf/simulated/floor/black/grime,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
@@ -16379,6 +16412,16 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/east)
+"hbx" = (
+/obj/grille/catwalk,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/stage_edge,
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "hbK" = (
 /obj/machinery/light,
 /obj/cable{
@@ -18068,6 +18111,14 @@
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/listeningpost/power)
+"hHS" = (
+/obj/decal/boxingropeenter,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "hIn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19855,6 +19906,10 @@
 /obj/decal/boxingrope{
 	dir = 4
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -20299,6 +20354,10 @@
 "izU" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
@@ -23785,6 +23844,18 @@
 /turf/simulated/floor,
 /area/station/quartermaster/storage{
 	name = "Cargo Auxiliary Endpoint"
+	})
+"kci" = (
+/obj/grille/catwalk,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/stage_edge{
+	dir = 8
+	},
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
 	})
 "kcx" = (
 /obj/machinery/camera{
@@ -29118,6 +29189,19 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"mcK" = (
+/obj/grille/catwalk,
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/stage_edge{
+	dir = 8
+	},
+/turf/simulated/floor/black/grime,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "mdl" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light{
@@ -32821,6 +32905,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "nHe" = (
@@ -32951,6 +33039,9 @@
 "nJl" = (
 /obj/decal/boxingrope,
 /obj/disposalpipe/segment/vertical,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "nJn" = (
@@ -34611,6 +34702,10 @@
 /obj/decal/boxingrope{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "ozU" = (
@@ -34920,6 +35015,15 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
+"oHc" = (
+/obj/decal/tile_edge/line/grey{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "oHj" = (
 /obj/machinery/manufacturer/robotics,
 /obj/item/device/radio/intercom/medical{
@@ -35940,6 +36044,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
+	})
+"pdd" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/stairs,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
 	})
 "pds" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -38199,6 +38311,9 @@
 	})
 "qcT" = (
 /obj/decal/boxingropeenter,
+/obj/decal/tile_edge/line/grey{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "qdz" = (
@@ -38505,6 +38620,9 @@
 /area/station/maintenance/inner/east)
 "qlx" = (
 /obj/decal/boxingropeenter,
+/obj/decal/tile_edge/line/grey{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -39089,6 +39207,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"qxX" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "qxZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39383,7 +39508,8 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 5
 	},
-/turf/simulated/floor/specialroom/gym/alt,
+/obj/grille/catwalk,
+/turf/simulated/floor/black/grime,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
@@ -43383,6 +43509,10 @@
 /obj/decal/boxingrope{
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -43939,6 +44069,16 @@
 /area/station/bridge/customs{
 	name = "Bridge Reception"
 	})
+"sNH" = (
+/obj/decal/boxingrope{
+	dir = 8
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "sNK" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -44546,6 +44686,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
+"tbf" = (
+/obj/decal/boxingrope{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/hallway/secondary/construction{
+	name = "The Warrens"
+	})
 "tbq" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/flute{
@@ -45574,6 +45726,10 @@
 "txs" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -48280,6 +48436,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "uDy" = (
@@ -49185,12 +49345,19 @@
 	dir = 10;
 	icon_state = "ringrope"
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
 "vbY" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
@@ -49709,6 +49876,10 @@
 	dir = 8
 	},
 /obj/stool,
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "vrF" = (
@@ -52492,6 +52663,14 @@
 	dir = 4
 	},
 /area/station/crew_quarters/market)
+"wAX" = (
+/obj/disposalpipe/segment/vertical,
+/obj/decal/tile_edge/line/grey{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "wBt" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/black/grime,
@@ -91966,7 +92145,7 @@ qmk
 bVu
 qxZ
 gfw
-ozL
+sNH
 ozL
 vrx
 uDj
@@ -92268,7 +92447,7 @@ hFL
 nlU
 eQn
 rax
-uzl
+qxX
 nSd
 uzl
 qcT
@@ -92570,7 +92749,7 @@ vhP
 fXA
 kbv
 oLp
-uzl
+qxX
 uzl
 uzl
 glb
@@ -92872,7 +93051,7 @@ nlU
 xhs
 fpY
 pBT
-pRy
+wAX
 fCR
 pRy
 nJl
@@ -108658,7 +108837,7 @@ eTx
 sCL
 sCL
 vbO
-oZL
+hbx
 nQG
 eIV
 jDV
@@ -108955,12 +109134,12 @@ mlm
 mlm
 mlm
 txY
-qlx
-pRb
+hHS
+oHc
 pRb
 pRb
 vbY
-oZL
+hbx
 bSU
 kcY
 kRh
@@ -109257,8 +109436,8 @@ nQG
 nQG
 bSU
 nQG
-vbY
-pRb
+eBk
+cPz
 ktO
 pRb
 vbY
@@ -109559,12 +109738,12 @@ fFt
 apM
 apM
 jTn
-vbY
-pRb
+eBk
+cPz
 pRb
 pRb
 qlx
-oZL
+pdd
 uod
 kRh
 kRh
@@ -109862,7 +110041,7 @@ kRh
 nQG
 oZL
 qEV
-izU
+tbf
 izU
 iti
 cVe
@@ -110164,10 +110343,10 @@ kRh
 nQG
 fhi
 apM
-kXF
-apM
-apM
-apM
+mcK
+kci
+kci
+kci
 uWj
 kRh
 kRh

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -19505,6 +19505,10 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/warm,
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bsB" = (
@@ -19512,11 +19516,19 @@
 /area/station/crew_quarters/fitness)
 "bsC" = (
 /obj/landmark/halloween,
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bsD" = (
 /obj/decal/boxingrope{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -19709,6 +19721,10 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "btl" = (
@@ -19819,11 +19835,19 @@
 	density = 0;
 	dir = 8
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "btI" = (
 /obj/decal/boxingropeenter{
 	dir = 4
+	},
+/obj/decal/tile_edge/line/grey{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -22186,6 +22210,10 @@
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bBE" = (
@@ -23517,6 +23545,9 @@
 /area/space)
 "bFZ" = (
 /obj/decal/boxingrope,
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bGa" = (
@@ -24829,6 +24860,10 @@
 "bKO" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -36196,6 +36231,16 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
+"hKO" = (
+/obj/decal/boxingrope{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "hLj" = (
 /obj/strip_door,
 /obj/machinery/conveyor/EW{
@@ -37363,6 +37408,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"jDV" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "jEl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -79121,7 +79173,7 @@ bpE
 bqv
 bqZ
 brS
-bsB
+jDV
 bsB
 bsB
 bFZ
@@ -79725,7 +79777,7 @@ bpG
 bqv
 bqZ
 brS
-bsB
+jDV
 bsB
 bsB
 bFZ
@@ -80027,7 +80079,7 @@ bpH
 bqv
 bra
 brT
-bsD
+hKO
 bsD
 btI
 bKO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds tile borders to boxing rings with gray edges where the ring is enterable, stairs and more stage edges as appropriate.

![image](https://github.com/goonstation/goonstation/assets/70909958/0c28ef8f-dbf9-4d3f-85b8-f86d63104628)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I felt like it looked better with a border.