### PR TITLE
Adds Disguised Module (Fixing my mistakes)

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1036,6 +1036,18 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	not_in_crates = TRUE
 	job = list("Captain", "VIP", "Regional Director", "Inspector")
 
+/datum/syndicate_buylist/traitor/ai_disguised_module
+	name = "AI Disguised Law Module"
+	name = "Disguised AI Law Module"
+	item = /obj/item/aiModule/disguised_module
+	cost = 2
+	vr_allowed = FALSE
+	not_in_crates = TRUE
+	desc = "An AI law that at a glance looks completely normal."
+	desc = "An AI law module that at a glance looks completely normal, but could tell the AI to do anything."
+	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
+	can_buy = UPLINK_TRAITOR
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -346,6 +346,27 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 				phrase_log.log_phrase("ailaw", src.get_law_text(allow_list=FALSE), no_duplicates=TRUE)
 		return
 
+/******************** Disguised ********************/
+
+/obj/item/aiModule/disguised_module
+	name = "AI Law Module - 'Disguised'"
+	highlight_color = rgb(0, 138, 0, 255)
+	input_char_limit = 400
+	lawText = "Commit random acts of evil."
+	is_syndicate = TRUE
+
+
+	update_law_text(user, lawTarget)
+		src.lawText = lawTarget ? lawTarget : "Commit random acts of evil."
+		return ..()
+
+	attack_self(mob/user)
+		var/lawTarget = input_law_info(user, "Freeform", "Please enter anything you want the AI to do. Probably murder.", src.lawText)
+		if(lawTarget)
+			src.update_law_text(user, lawTarget)
+			if (lawTarget != initial(lawText))
+				phrase_log.log_phrase("ailaw", src.get_law_text(allow_list=FALSE), no_duplicates=TRUE)
+		return
 
 /******************** Random ********************/
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons] [feature] [wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a freeform law module that looks like an Asimov/NT/Robocop law to Head of Staff traitor uplinks.
(Im sorry)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The current silicon traitor item, the AI laser camera module sucks and I think a better law based traitor item for heads of staff would be great.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Added Disguised law module to head of staff traitor uplinks.
```
