### PR TITLE
Fixes: #18260 - Repairing Nadir Siphon Control Computer

### DIFF
--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -101,6 +101,8 @@
 	icon_state = "engine1"
 	req_access = list(access_research)
 	object_flags = CAN_REPROGRAM_ACCESS
+	circuit_type = /obj/item/circuitboard/siphon_control
+
 	var/net_id
 	var/temp = null
 	///list of devices known to the siphon control device

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -173,6 +173,10 @@ TYPEINFO(/obj/item/circuitboard)
 	name = "Circuit board (Announcement Computer)"
 	computertype = "/obj/machinery/computer/announcement"
 
+/obj/item/circuitboard/siphon_control
+	name = "Circuit board (Siphon Control)"
+	computertype = /obj/machinery/computer/siphon_control
+
 /obj/computerframe/meteorhit(obj/O as obj)
 	qdel(src)
 

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -21644,6 +21644,10 @@
 /area/station/security/main)
 "jfZ" = (
 /obj/rack/organized/techstorage_med,
+/obj/item/circuitboard/siphon_control{
+	pixel_x = 5;
+	pixel_y = -7
+	},
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "jge" = (


### PR DESCRIPTION
[BUG][OBJECTS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates new circuitboard type that allows the Nadir Siphon Control computer to be repaired if damaged in explosion.
Also adds a spare Siphon Control circuitboard to Nadir tech storage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Most computers are repairable, this one ought to be too.
