### PR TITLE
Fixes: #18237 - Printing from WizWrite not working

### DIFF
--- a/_std/defines/access.dm
+++ b/_std/defines/access.dm
@@ -2,6 +2,7 @@
 //       when you re-enable old credentials or add new ones.
 //       Also check proc/get_access_desc() (ID computer lookup) in access.dm
 
+/// This is useful for scenarios where login is required but no particular access is needed.
 #define access_fuck_all 0 // Because completely empty access lists can make things grump
 #define access_security 1
 #define access_brig 2

--- a/code/modules/networks/computer3/base_program.dm
+++ b/code/modules/networks/computer3/base_program.dm
@@ -494,6 +494,10 @@
 			if(!check_list || !istype(check_list, /list)) //invalid or no access
 				return 0
 			for(var/req in src.req_access)
+				if (req == access_fuck_all)
+					// access_fuck_all means no special access but needs authentication anyway
+					// and everyone should implicitly have that
+					continue
 				if(!(req in check_list)) //doesn't have this access
 					return 0
 			return 1

--- a/code/modules/networks/computer3/emailclient.dm
+++ b/code/modules/networks/computer3/emailclient.dm
@@ -27,7 +27,7 @@
 /datum/computer/file/terminal_program/email
 	name = "ViewPoint"
 	size = 4
-
+	req_access = list(access_fuck_all)
 	var/tmp/obj/item/peripheral/network/netCard = null
 	var/tmp/server_netid = null
 	var/tmp/potential_server_netid = null

--- a/code/modules/networks/computer3/emailclient.dm
+++ b/code/modules/networks/computer3/emailclient.dm
@@ -27,6 +27,9 @@
 /datum/computer/file/terminal_program/email
 	name = "ViewPoint"
 	size = 4
+
+	// No special permissions required, but authentication is required to send email as *someone* and obviously
+	// to recieve email
 	req_access = list(access_fuck_all)
 	var/tmp/obj/item/peripheral/network/netCard = null
 	var/tmp/server_netid = null

--- a/code/modules/networks/computer3/writer.dm
+++ b/code/modules/networks/computer3/writer.dm
@@ -21,6 +21,9 @@
 	var/tmp/list/known_printers = list()
 	var/tmp/printer_status = "???"
 
+	// No special permissions required, but authentication is required to use print server
+	req_access = list(access_fuck_all)
+
 	initialize()
 		if (..())
 			return TRUE


### PR DESCRIPTION
[BUG] [STATION SYSTEMS] [OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes: #18237 - WizWrite not being able to query the print server. This was caused by WizWrite not needing any access, which it shouldn't need however if a program has no req_access set then base_program won't authenticate, which is a problem then if you try to send a packet that requires authentication. Also found a similar issue in ViewPoint where due to the lack of authentication it was impossible to send or recieve emails. How was anyone able to do their jobs without email!!!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
WizWrite should be able to print as expected.