### PR TITLE
Runway light fixture and bulb fixes

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -500,10 +500,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 	desc = "A small light used to guide pods into hangars."
 	icon_state = "runway10"
 	base_state = "runway1"
-	fitting = "bulb"
+	fitting = "floor"
 	brightness = 0.5
-	light_type = /obj/item/light/bulb
-	allowed_type = /obj/item/light/bulb
+	light_type = /obj/item/light/bulb/runway
+	allowed_type = /obj/item/light/bulb/runway
 	plane = PLANE_NOSHADOW_BELOW
 	on = 1
 	wallmounted = 0
@@ -1609,6 +1609,9 @@ TYPEINFO(/obj/item/light)
 			color_r = 0.99
 			color_g = 0.81
 			color_b = 0.99
+
+	runway
+		burnprob = 0
 
 /obj/item/light/big_bulb
 	name = "beacon bulb"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes runway lights use a floor fitting, so they break into a floor-light sprite instead of a wall-mount sprite

Also makes a change to prevent runway lights from burning out; i.e. 'high duty' lights.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18229
Runway lights shouldn't burn out randomly because the bulbs are not user-servicable
