### PR TITLE
Use consumer for grouping drink messages

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -686,7 +686,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	proc/take_a_drink(var/mob/consumer, var/mob/feeder)
 		var/tasteMessage = SPAN_NOTICE("[src.reagents.get_taste_string(consumer)]")
 		if (consumer == feeder)
-			consumer.visible_message(SPAN_NOTICE("[consumer] takes a sip from [src]."),"[SPAN_NOTICE("You take a sip from [src].")]\n[tasteMessage]", group = "drinkMessages")
+			consumer.visible_message(SPAN_NOTICE("[consumer] takes a sip from [src]."),"[SPAN_NOTICE("You take a sip from [src].")]\n[tasteMessage]", group = "[consumer]_drink_messages")
 		else
 			consumer.visible_message(SPAN_ALERT("[feeder] makes [consumer] drink from the [src]."),
 			"[SPAN_ALERT("[feeder] makes you drink from the [src].")]\n[tasteMessage]",


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Following the pattern in [melee_attack_procs.dm](https://github.com/goonstation/goonstation/blob/master/code/mob/melee_attack_procs.dm#L861), use the drink's `consumer` to group messages when you take a willing drink.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18177
