### PR TITLE
remove null refs

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1367,7 +1367,7 @@
 
 		onRemove()
 			. = ..()
-			H.remove_stam_mod_max("ganger_debuff_max")
+			H?.remove_stam_mod_max("ganger_debuff_max")
 			REMOVE_ATOM_PROPERTY(H, PROP_MOB_STAMINA_REGEN_BONUS, "ganger_debuff_regen")
 			gang = null
 			H = null

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1374,7 +1374,7 @@
 			gang = null
 		onUpdate(timePassed)
 			if (prob(5))
-				H.emote(pick("shiver","flinch","twitch"))
+				H?.emote(pick("shiver","flinch","twitch"))
 
 		getTooltip()
 			. = "Your vitals have dropped from the shame you feel hiding your true colors inside enemy territory."


### PR DESCRIPTION
null refs bad. cause runtimes. waste time. beans