### PR TITLE
fix ghosts being gang experts

### DIFF
--- a/code/datums/abilities/ghost_observer.dm
+++ b/code/datums/abilities/ghost_observer.dm
@@ -623,6 +623,10 @@ var/global/datum/spooktober_ghost_handler/spooktober_GH = new()
 	icon_state = "gang_overlay"
 	targeted = 0
 	cooldown = 0
+	proc/remove_self(mind)
+		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
+		if (imgroup.subscribed_minds_with_subcount[mind] > 0)
+			imgroup.remove_mind(mind)
 	cast()
 		if (!holder)
 			return TRUE
@@ -632,9 +636,11 @@ var/global/datum/spooktober_ghost_handler/spooktober_GH = new()
 		var/togglingOn = FALSE
 		if (imgroup.subscribed_minds_with_subcount[M.mind] > 0)
 			imgroup.remove_mind(M.mind)
+			UnregisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB)
 		else
 			togglingOn = TRUE
 			imgroup.add_mind(M.mind)
+			RegisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB, PROC_REF(remove_self))
 
 		boutput(M, "Gang territories turned [togglingOn ? "on" : "off"].")
 		return FALSE

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1383,7 +1383,10 @@ proc/broadcast_to_all_gangs(var/message)
 			message_admins("[target.key] respawned as a gang member for [src.gang.gang_name].")
 			log_respawn_event(target, "gang member respawn", src.gang.gang_name)
 			boutput(H, SPAN_NOTICE("<b>You have been respawned as a gang member!</b>"))
-			boutput(H, SPAN_ALERT("<b>You're allied with [src.gang.gang_name]! Work with your leader, [src.gang.leader.current.real_name], to become the baddest gang ever!</b>"))
+			if (src.gang.leader)
+				boutput(H, SPAN_ALERT("<b>You're allied with [src.gang.gang_name]! Work with your leader, [src.gang.leader.current.real_name], to become the baddest gang ever!</b>"))
+			else
+				boutput(H, SPAN_ALERT("<b>You're allied with [src.gang.gang_name]! Work to become the baddest gang ever!</b>"))
 			get_gang_gear(H)
 
 	/// Tries to find a ghost to respawn

--- a/code/modules/antagonists/gang/abilities/_gang_leader_ability_holder.dm
+++ b/code/modules/antagonists/gang/abilities/_gang_leader_ability_holder.dm
@@ -173,6 +173,7 @@
 	name = "Toggle gang territory overlay"
 	desc = "Toggles the colored gang overlay."
 	icon_state = "toggle_overlays"
+	var/datum/mind/ownerMind
 
 	proc/remove_self(mind)
 		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
@@ -190,19 +191,26 @@
 		if (!M.mind && !M.get_gang())
 			boutput(M, SPAN_ALERT("Gang territory? What? You'd need to be in a gang to get it."))
 			return TRUE
+
+		ownerMind = M.mind
 		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
 		var/togglingOn = FALSE
 		if (imgroup.subscribed_minds_with_subcount[M.mind] > 0)
-			imgroup.remove_mind(M.mind)
-			UnregisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB)
+			imgroup.remove_mind(ownerMind)
+			UnregisterSignal(ownerMind, COMSIG_MIND_DETACH_FROM_MOB)
 		else
 			togglingOn = TRUE
-			imgroup.add_mind(M.mind)
-			RegisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB, PROC_REF(remove_self))
+			imgroup.add_mind(ownerMind)
+			RegisterSignal(ownerMind, COMSIG_MIND_DETACH_FROM_MOB, PROC_REF(remove_self))
 
 		boutput(M, "Gang territories turned [togglingOn ? "on" : "off"].")
 		return FALSE
-
+	disposing()
+		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
+		if (imgroup.subscribed_minds_with_subcount[ownerMind] > 0)
+			imgroup.remove_mind(ownerMind)
+		UnregisterSignal(ownerMind, COMSIG_MIND_DETACH_FROM_MOB)
+		..()
 
 /datum/targetable/gang/set_gang_base
 	name = "Set Gang Base"

--- a/code/modules/antagonists/gang/abilities/_gang_leader_ability_holder.dm
+++ b/code/modules/antagonists/gang/abilities/_gang_leader_ability_holder.dm
@@ -174,6 +174,10 @@
 	desc = "Toggles the colored gang overlay."
 	icon_state = "toggle_overlays"
 
+	proc/remove_self(mind)
+		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
+		if (imgroup.subscribed_minds_with_subcount[mind] > 0)
+			imgroup.remove_mind(mind)
 	cast(mob/target)
 		if (!holder)
 			return TRUE
@@ -188,11 +192,13 @@
 			return TRUE
 		var/datum/client_image_group/imgroup = get_image_group(CLIENT_IMAGE_GROUP_GANGS)
 		var/togglingOn = FALSE
-		if (imgroup.subscribed_minds_with_subcount[M.mind] && imgroup.subscribed_minds_with_subcount[M.mind] > 0)
+		if (imgroup.subscribed_minds_with_subcount[M.mind] > 0)
 			imgroup.remove_mind(M.mind)
+			UnregisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB)
 		else
 			togglingOn = TRUE
 			imgroup.add_mind(M.mind)
+			RegisterSignal(M.mind, COMSIG_MIND_DETACH_FROM_MOB, PROC_REF(remove_self))
 
 		boutput(M, "Gang territories turned [togglingOn ? "on" : "off"].")
 		return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

ghosts can still see overlays on respawn. i removed all gang overlays on mind transfer (this should fix thing)