### PR TITLE
Add camera to top right of Cog1 Reactor

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -41902,6 +41902,13 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
 "fpA" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a camera to the top right of Cogmap 1's Inner Engineering


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So the AI can finally enable all the singularity field generators and emitters when ordered to without having to bring a shell.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Added a camera to the top right of Inner Engineering on Cog1. AIs rejoice.
```
