### PR TITLE
Fix Incorrect areas around Clarion bridge

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -43457,13 +43457,14 @@
 /obj/mapping_helper/access/ai_upload,
 /obj/machinery/turretid{
 	pixel_x = 24;
-	req_access_txt = null
+	req_access_txt = null;
+	turretArea = /area/station/turret_protected/ai
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai)
+/area/station/bridge)
 "vZO" = (
 /obj/cable{
 	icon_state = "4-8"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13240,7 +13240,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/black,
-/area/station/teleporter)
+/area/station/hallway/primary/east)
 "blz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13402,7 +13402,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/black,
-/area/station/teleporter)
+/area/station/hallway/primary/east)
 "bmR" = (
 /obj/stool/chair/office/purple{
 	dir = 4
@@ -43816,7 +43816,7 @@
 /obj/stool/chair,
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor/black,
-/area/station/teleporter)
+/area/station/hallway/primary/east)
 "wtk" = (
 /obj/cable{
 	icon_state = "4-8"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes 3 tiles in Clarion east hall (the table and the tiles above and below it specifically outside computer core) being area command teleporter.
Also fixes one tile of AI core in the bridge that would cause the turrets to try shoot through the wall


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Incorrect area tiles

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Clarion AI turrets no longer try to shoot through the wall at bridge.
```

