### PR TITLE
Stop AI Eyes from playing the claw machine

### DIFF
--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -46,6 +46,8 @@ TYPEINFO(/obj/submachine/claw_machine)
 		return
 
 /obj/submachine/claw_machine/attack_ai(mob/user)
+	if (isAIeye(user))
+		return
 	src.attack_hand(user)
 
 /obj/submachine/claw_machine/get_desc(dist)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an isaieye check for the claw machine's `attack_ai` check, returning early if so

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18286