### PR TITLE
Donut 2's extra chaplain gear has a dedicated crate

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -37418,7 +37418,7 @@
 "piF" = (
 /obj/storage/crate{
 	name = "Special Syllogí";
-	desc = "Éna megálo metallikó koutí sto opoío boreíte na válete prágmata. Poios xérei, boreí na échei ídi prágmata mésa tou."
+	desc = "Ένα μεγάλο μεταλλικό κουτί στο οποίο μπορείτε να βάλετε πράγματα. Ποιος ξέρει, μπορεί να έχει ήδη πράγματα μέσα του."
 	},
 /obj/item/clothing/under/gimmick/toga,
 /obj/item/clothing/suit/greek,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -34408,15 +34408,6 @@
 /area/station/crew_quarters/catering)
 "nvT" = (
 /obj/machinery/vending/chapel,
-/obj/item/device/light/zippo,
-/obj/item/clothing/head/helmet/greek,
-/obj/item/clothing/suit/greek,
-/obj/item/clothing/under/gimmick/toga,
-/obj/item/clothing/head/laurels,
-/obj/item/clothing/head/laurels/gold,
-/obj/decal/poster/wallsign/poster_sol{
-	pixel_y = 31
-	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/office)
 "nwC" = (
@@ -37424,6 +37415,19 @@
 "piD" = (
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
+"piF" = (
+/obj/storage/crate{
+	name = "Special Syllogí";
+	desc = "Éna megálo metallikó koutí sto opoío boreíte na válete prágmata. Poios xérei, boreí na échei ídi prágmata mésa tou."
+	},
+/obj/item/clothing/under/gimmick/toga,
+/obj/item/clothing/suit/greek,
+/obj/item/clothing/head/helmet/greek,
+/obj/item/clothing/head/laurels/gold,
+/obj/item/device/light/zippo,
+/obj/item/clothing/head/laurels,
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/office)
 "piG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -93061,7 +93065,7 @@ wNr
 pCJ
 avj
 nvT
-axt
+piF
 hRa
 avj
 cay


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[Mapping][bug] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the vaguely Greek gear in donut2 chapel office into a distinctly Greek box.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18291

## Screenshot
![image](https://github.com/goonstation/goonstation/assets/91498627/a8138e39-5d0e-44ae-abcd-397282fc3e12)
