### PR TITLE
Gives captain a mindshield

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -216,6 +216,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	announce_on_join = TRUE
 	allow_spy_theft = FALSE
 	allow_antag_fallthrough = FALSE
+	receives_implant = /obj/item/implant/health/security/anti_mindhack
 	wiki_link = "https://wiki.ss13.co/Captain"
 
 	slot_card = /obj/item/card/id/gold


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives captain a mindshield, the same one that secoffs currently have.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Captain is a very easy target for which a lot of people to mindhack for free AA + gun + instantly rogue AI, which is very unfun for the crew and the captain, and results in captains often getting treated with suspicion by crew.

The main aim is to aim a  more trusted and responsible role, especially now that # 18275 is coming.
(P.S. even if 18275 doesn't get merged, I would still propose this change, as currently both playing as and against mindhacked captains is very often considerably unfun.)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatausours
(*)Captains now recieve a mindshield implant.
```
