### PR TITLE
De-duplicate logic for finding bank accounts by a list of jobs

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -820,5 +820,12 @@ proc/FindBankAccountByName(var/nametosearch)
 	if (!nametosearch) return
 	return data_core.bank.find_record("name", nametosearch)
 
+/// Given a list of jobs, return the associated bank account records. Does not de-duplicate bank account records.
+proc/FindBankAccountsByJobs(var/list/job_list)
+	RETURN_TYPE(/list/datum/db_record)
+	. = list()
+	for (var/each_job in job_list)
+		. += data_core.bank.find_records("job", each_job)
+
 #undef STATE_LOGGEDOFF
 #undef STATE_LOGGEDIN

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -204,11 +204,8 @@
 	generated_moolah += undistributed_earnings
 	undistributed_earnings = 0
 
-	// the double chief engineer seems to be intentional however silly it may seem
-	var/list/accounts = \
-		data_core.bank.find_records("job", "Chief Engineer") + \
-		data_core.bank.find_records("job", "Chief Engineer") + \
-		data_core.bank.find_records("job", "Engineer")
+	// CE gets double the payout share from the PTL
+	var/list/accounts = FindBankAccountsByJobs(list("Chief Engineer", "Chief Engineer", "Engineer"))
 
 	if(!length(accounts)) // no engineering staff but someone still started the PTL
 		wagesystem.station_budget += generated_moolah

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -873,12 +873,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 							account["current_money"] -= total
 							storage.eject_ores(ore, get_output_location(), quantity, transmit=1, user=usr)
 
-							 // This next bit is stolen from PTL Code
-							var/list/accounts = \
-								data_core.bank.find_records("job", "Chief Engineer") + \
-								data_core.bank.find_records("job", "Chief Engineer") + \
-								data_core.bank.find_records("job", "Miner")
-
+							 // Chief gets a bigger cut
+							var/list/accounts = FindBankAccountsByJobs(list("Chief Engineer", "Chief Engineer", "Miner"))
 
 							var/datum/signal/minerSignal = get_free_signal()
 							minerSignal.source = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Code Quality][Internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a new proc related to the banking system that returns a list of matching bank records for a provided list of jobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This logic was duplicated between the PTL and Manufactuer mineral purchase code.

Making this easy to do can spur on other ideas for departmental bonuses/fines/lookups.