### PR TITLE
Gang adjustments

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -45,7 +45,7 @@
 #ifdef RP_MODE
 #define PLAYERS_PER_GANG_GENERATED 15
 #else
-#define PLAYERS_PER_GANG_GENERATED 9
+#define PLAYERS_PER_GANG_GENERATED 12
 #endif
 	var/num_teams = clamp(round((num_players) / PLAYERS_PER_GANG_GENERATED), setup_min_teams, setup_max_teams) //1 gang per 9 players, 15 on RP
 #undef PLAYERS_PER_GANG_GENERATED

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1277,7 +1277,7 @@
 		maxDuration = null
 		effect_quality = STATUS_QUALITY_POSITIVE
 		var/const/max_health = 30
-		var/const/max_stam = 60
+		var/const/max_stam = 20
 		var/const/regen_stam = 5
 		var/mob/living/carbon/human/H
 		var/datum/gang/gang

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1277,7 +1277,7 @@
 		maxDuration = null
 		effect_quality = STATUS_QUALITY_POSITIVE
 		var/const/max_health = 30
-		var/const/max_stam = 20
+		var/const/max_stam = 40
 		var/const/regen_stam = 5
 		var/mob/living/carbon/human/H
 		var/datum/gang/gang


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODES] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

2 adjustments:
Gang density is now 41% on #1, down from 55%
Given gangs are a lot more sticky than before, this should probably be ok

Gangs in uniform can no longer eat 3 baton hits.
I don't think they need this any more. With the number of firearms, lethals and utilities they have, security needs a bit of an easier time stopping them.
