### PR TITLE
Gang gun adjustments

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1963,8 +1963,9 @@ datum/projectile/bullet/autocannon
 /datum/projectile/bullet/webley
 	name = "bullet"
 	damage = 45
-	damage_type = D_KINETIC
-	hit_type = DAMAGE_CUT
+	stun = 15
+	damage_type = D_PIERCING
+	armor_ignored = 0.5 //just enough to get past gang vests in 3 shots
 	implanted = /obj/item/implant/projectile/bullet_455
 	impact_image_state = "bullethole-small"
 	casing = /obj/item/casing/medium

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -718,9 +718,9 @@ toxic - poisons
 	damage = 18
 	stun = 6
 	hit_type = DAMAGE_CUT //birdshot mutilates your skin more, but doesnt hurt organs like shotties
-	dissipation_rate = 1 //spread handles most of this
+	dissipation_rate = 4 //spread handles most of this
 	shot_sound = 'sound/weapons/birdshot.ogg'
-	dissipation_delay = 3
+	dissipation_delay = 6
 	casing = /obj/item/casing/shotgun/red
 	on_launch(obj/projectile/O)
 		icon_state = "birdshot[rand(1,3)]"

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -716,8 +716,9 @@ toxic - poisons
 	hit_ground_chance = 66
 	implanted = null
 	damage = 18
+	stun = 6
 	hit_type = DAMAGE_CUT //birdshot mutilates your skin more, but doesnt hurt organs like shotties
-	dissipation_rate = 2
+	dissipation_rate = 1 //spread handles most of this
 	shot_sound = 'sound/weapons/birdshot.ogg'
 	dissipation_delay = 3
 	casing = /obj/item/casing/shotgun/red

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1963,7 +1963,7 @@ datum/projectile/bullet/autocannon
 /datum/projectile/bullet/webley
 	name = "bullet"
 	damage = 45
-	stun = 15
+	stun = 7
 	damage_type = D_PIERCING
 	armor_ignored = 0.5 //just enough to get past gang vests in 3 shots
 	implanted = /obj/item/implant/projectile/bullet_455

--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -729,7 +729,7 @@ toxic - poisons
 	shot_volume = 50
 	name = "single"
 	sname = "single"
-	damage = 11
+	damage = 14
 
 /datum/projectile/laser/lasergat/burst
 	name = "burst laser"

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1353,7 +1353,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 /obj/item/ammo/bullets/webley
 	sname = ".455 Webley"
 	name = ".455 Webley Bullets"
-	desc = "A small speedloader, full of ammunition for a Webley Revolver."
+	desc = "A small speedloader of reproduction .455 Webley ammunition, with a custom armor-penetrating core."
 	icon_state = "455-6"
 	amount_left = 6
 	max_amount = 6

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -555,8 +555,8 @@
 
 	lopoint
 		name = "9mm Lo-Point magazine"
-		amount_left = 12
-		max_amount = 12
+		amount_left = 10
+		max_amount = 10
 
 /obj/item/ammo/bullets/nine_mm_NATO
 	sname = "9mm frangible"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -898,9 +898,9 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	get_desc(dist, mob/user)
 		if (user.get_gang() != null)
-			. += "For when you need MOR' DAKKA. Uses 9mm NATO rounds."
+			. += "For when you need MOR' DAKKA. Uses 9mm Surplus rounds."
 		else
-			. += "Its firemodes are labelled 'DAKKA' and 'MOR'... Uses 9mm NATO rounds."
+			. += "Its firemodes are labelled 'DAKKA' and 'MOR'... Uses 9mm Surplus rounds."
 
 	New()
 		ammo = new default_magazine
@@ -1246,13 +1246,13 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	name = "Lo-Point"
 	icon_state = "hipoint"
 	item_state = "hipoint"
-	shoot_delay = 1
+	shoot_delay = 4
 	spread_angle = 3
 	throwforce = 14 // literally throw it away
 	w_class = W_CLASS_SMALL
 	force = MELEE_DMG_PISTOL
 	fire_animation = TRUE
-	max_ammo_capacity = 12
+	max_ammo_capacity = 10
 	auto_eject = TRUE
 	has_empty_state = TRUE
 	gildable = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes quirks with the lo-point. Brings up the other pistols a bit to be somewhat consistent in their damage potential.
Striker/revolver do stamina damage, as they're lacking real *oomph* despite their high damage
Revolver gets a slightly weaker AP effect, as it's currently a little wimpy vs a fully geared gang member.

Birdshot holds its' damage for longer - spread causes missed shots anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bring the pistols more in line with each other. Make the striker birdshot a bit more reliable.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)Gang firearms have been tweaked. Please feedback in the discord or forum.
(+)Lo-Point now has a sensible firerate & has 2 fewer rounds. 
(+)Burst laser does 3 more damage/laser.
(+)Webley Revolver now does stamina damage & has a weaker AP effect.
(+)Striker-7 does stamina damage, damage now falls off later, but a lot faster.
(+)The SMGs remain unchanged (They already have a lot of raw damage)
```
