### PR TITLE
Adds a Nuclear Prep Closet to Cairngorm

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -65249,6 +65249,14 @@
 	},
 /turf/space,
 /area/syndicate_station_space)
+"ncT" = (
+/obj/landmark{
+	name = "Nuclear-Closet"
+	},
+/turf/unsimulated/floor/redblack{
+	dir = 4
+	},
+/area/syndicate_station/battlecruiser)
 "ndE" = (
 /obj/lattice{
 	dir = 6;
@@ -108538,7 +108546,7 @@ fgY
 lzl
 cwk
 dhN
-dhN
+ncT
 dhN
 cwn
 lzl


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "Nuclear Preparations Closet" to the cairngorm like the wiki says https://wiki.ss13.co/Syndicate_Items#Nuclear_Preparations_Closet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The wiki said this existed and also the closet was unused.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Added a Nuclear Preparations closet to the Cairngorm.
```
