### PR TITLE
Fix disppearing cone when making ice cream with no hands 

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -312,7 +312,7 @@ TYPEINFO(/obj/submachine/ice_cream_dispenser)
 					return
 
 				var/flavor = params["flavor"]
-				var/obj/item/reagent_containers/food/snacks/ice_cream/newcream = new
+				var/obj/item/reagent_containers/food/snacks/ice_cream/newcream = new(src)
 				if(flavor == "beaker")
 					if(!beaker.reagents.total_volume)
 						boutput(usr, SPAN_ALERT("The beaker is empty!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When dispensing ice cream, set the initial location of the filled ice cream cone to inside the ice cream maker. This allows the `put_in_hand_or_drop` to find teh right turf and place the ice cream atop the dispenser if it can't be put into a hand.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18308