### PR TITLE
Improve recoil camera reset speed

### DIFF
--- a/code/modules/recoil/recoil_controller.dm
+++ b/code/modules/recoil/recoil_controller.dm
@@ -13,9 +13,9 @@
 
 	// Reset/damping rates
 	var/recoilcamera_sway_damp = 0.85 //! how much sway delta should be multiplied by every 10th of a second
-	var/recoilcamera_damp = 0.5 //! how much recoil delta should be multiplied by every 10th of a second
-	var/recoilcamera_damp_distance = 0.3 //! how much recoil delta should be decreased by, per pixel away from the centre
-	var/recoilcamera_flat_reset_speed = 1 //! how much recoil_delta is reduced by, every 10th of a second
+	var/recoilcamera_damp = 0.6 //! how much recoil delta should be multiplied by every 10th of a second
+	var/recoilcamera_damp_distance = 0.4 //! how much recoil delta should be decreased by, per pixel away from the centre
+	var/recoilcamera_flat_reset_speed = 2 //! how much recoil_delta is reduced by, every 10th of a second
 
 /datum/recoil_controller/New(client/owner)
 	. = ..()

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -57,7 +57,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	// RECOIL STRENGTH
 	// Basic recoil strength, this is how hard the weapon kicks by default
 	// recoil_strength is added to recoil every shot, and kicks the camera similarly.
-	var/recoil_strength = 9 //! How strong this gun's base recoil impulse is.
+	var/recoil_strength = 10 //! How strong this gun's base recoil impulse is.
 	var/recoil_max = 50		//! What's the max cumulative recoil this gun can hit?
 	var/recoil_inaccuracy_max = 0 //! at recoil_max, the weapon has this much additional spread
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
recoil is getting a few 'hmms', i sped it up and people approve

this makes recoil reset a lot more per tick at lower recoil_strengths. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
recoil getting all its values lowered meant the camera reset (which scales with recoil) was a bit slow

before:

https://github.com/goonstation/goonstation/assets/6061314/6b7836e8-b810-4486-aa32-394898033ead

after:

https://github.com/goonstation/goonstation/assets/6061314/9c3e1044-40a1-4e1a-84d4-d53bc738bbc6

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)Firearm recoil now resets faster; please feedback in the discord. 
(*)It can also be toggled off via the 'Effects' menu.
```
