### PR TITLE
Adding action bar to signing a zoldorf burrito

### DIFF
--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -28,9 +28,6 @@
 	item_state = "scroll"
 	var/signing_state = UNSIGNED
 	var/signer
-	// New()
-	// 	..()
-	// 	src.signing_state =
 
 	attack_self(mob/user as mob)
 		if(src.icon_state == "scrollclosed")

--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -5,8 +5,6 @@
 
 /datum/action/bar/icon/callback/signingBar
 
-	New(owner, target, duration, proc_path, proc_args, icon, icon_state, end_message, interrupt_flags, call_proc_on)
-		. = ..(owner, target, duration, proc_path, proc_args, icon, icon_state, end_message, interrupt_flags, call_proc_on)
 	onInterrupt(flag)
 		. = ..(flag)
 		var/obj/item/zolscroll/scroll = src.target

--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -538,3 +538,8 @@
 /obj/item/zspellscroll/hat
 	icon_state = "scrollpurple"
 	scrolltype = "hat"
+
+#undef SIGNING_DURATION
+#undef UNSIGNED
+#undef SIGNING
+#undef SIGNED


### PR DESCRIPTION
[FEATURE][ACTIONS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an action bar to signing a weird burrito purchased from zoldorf.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Action bars are a great feedback tool for players and should be used anywhere where a player has to wait for their action to finish.
