### PR TITLE
Makes security officer a limited high-priority job

### DIFF
--- a/_std/compare.dm
+++ b/_std/compare.dm
@@ -52,3 +52,6 @@
 /proc/cmp_chemical_reaction_priotity(datum/chemical_reaction/a, datum/chemical_reaction/b)
 	return a.priority > b.priority
 #endif
+
+/proc/cmp_job_order_priority(datum/job/a, datum/job/b)
+	return cmp_numeric_asc(a.order_priority, b.order_priority)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -568,6 +568,7 @@ ABSTRACT_TYPE(/datum/job/security)
 		name = "Security Assistant"
 		limit = 3
 		lower_limit = 2
+		high_priority_job = FALSE //nope
 		cant_spawn_as_con = TRUE
 		wages = PAY_UNTRAINED
 		receives_implant = /obj/item/implant/health/security

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -27,6 +27,8 @@
 	var/needs_college = 0
 	var/assigned = 0
 	var/high_priority_job = FALSE
+	///Fill up to this limit, then drop this job out of high priotity
+	var/high_priority_limit = INFINITY
 	var/low_priority_job = FALSE
 	var/cant_allocate_unwanted = FALSE //! Job cannot be set to "unwanted" in player preferences.
 	var/receives_miranda = FALSE
@@ -526,6 +528,8 @@ ABSTRACT_TYPE(/datum/job/security)
 	limit = 5
 	lower_limit = 3
 	variable_limit = TRUE
+	high_priority_job = TRUE
+	high_priority_limit = 2 //always try to make sure there's at least a couple of secoffs
 	wages = PAY_TRADESMAN
 	allow_traitors = FALSE
 	allow_spy_theft = FALSE

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -30,6 +30,7 @@
 	///Fill up to this limit, then drop this job out of high priotity
 	var/high_priority_limit = INFINITY
 	var/low_priority_job = FALSE
+	var/order_priority = 1 //! What order jobs are filled in within their priority tier, lower number = higher priority
 	var/cant_allocate_unwanted = FALSE //! Job cannot be set to "unwanted" in player preferences.
 	var/receives_miranda = FALSE
 	var/receives_implant = null //! Object path to the implant type given on spawn.
@@ -530,6 +531,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	variable_limit = TRUE
 	high_priority_job = TRUE
 	high_priority_limit = 2 //always try to make sure there's at least a couple of secoffs
+	order_priority = 2 //fill secoffs after captain and AI
 	wages = PAY_TRADESMAN
 	allow_traitors = FALSE
 	allow_spy_theft = FALSE

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -136,6 +136,11 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 	// Wiggle the players too so that priority isn't determined by key alphabetization
 	shuffle_list(unassigned)
 
+	//Shuffle them and *then* sort them according to their order priority
+	sortList(high_priority_jobs, PROC_REF(cmp_job_order_priority))
+
+	sortList(available_job_roles, PROC_REF(cmp_job_order_priority))
+
 	// First we deal with high-priority jobs like Captain or AI which generally will always
 	// be present on the station - we want these assigned first just to be sure
 	// Though we don't want to do this in sandbox mode where it won't matter anyway

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -146,7 +146,7 @@ var/global/totally_random_jobs = FALSE
 			// horrible multicore PC station round.. (i HOPE anyway)
 			for(var/mob/new_player/candidate in pick1)
 				if(!candidate.client) continue
-				if (JOB.assigned >= JOB.limit || !length(unassigned)) break
+				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv1")
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
@@ -154,7 +154,7 @@ var/global/totally_random_jobs = FALSE
 				JOB.assigned++
 			for(var/mob/new_player/candidate in pick2)
 				if(!candidate.client) continue
-				if (JOB.assigned >= JOB.limit || !length(unassigned)) break
+				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv2")
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
@@ -162,12 +162,19 @@ var/global/totally_random_jobs = FALSE
 				JOB.assigned++
 			for(var/mob/new_player/candidate in pick3)
 				if(!candidate.client) continue
-				if (JOB.assigned >= JOB.limit || !length(unassigned)) break
+				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv3")
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
 				unassigned -= candidate
 				JOB.assigned++
+
+			//we've filled out the high priority section of this job, drop it down to being a normal role for the rest
+			if (JOB.assigned >= JOB.high_priority_limit && JOB.assigned < JOB.limit)
+				high_priority_jobs -= JOB
+				available_job_roles |= JOB
+				shuffle_list(available_job_roles)
+
 	else
 		// if we are in sandbox mode just roll the hi-pri jobs back into the regular list so
 		// people can still get them if they chose them

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -148,7 +148,12 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		for(var/datum/job/JOB in high_priority_jobs)
 			if (!length(unassigned)) break
 
-			if (JOB.limit > 0 && JOB.assigned >= JOB.limit) continue
+			if (JOB.limit > 0 && JOB.assigned >= JOB.limit)
+				continue
+
+			//single digit pop rounds can be exempt from more than one high priority assignment per role
+			if (length(unassigned) < 10)
+				JOB.high_priority_limit = 1
 
 			// get all possible candidates for it
 			pick1 = FindOccupationCandidates(unassigned,JOB.name,1)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -62,6 +62,15 @@ var/global/totally_random_jobs = FALSE
 
 	return candidates
 
+#define ASSIGN_STAFF_LISTS(JOB, player) if (istype(JOB, /datum/job/engineering/engineer))\
+	{engineering_staff += player}\
+else if (istype(JOB, /datum/job/research/scientist))\
+	{research_staff += player}\
+else if (istype(JOB, /datum/job/research/medical_doctor))\
+	{medical_staff += player}\
+else if (istype(JOB, /datum/job/security/security_officer))\
+	{security_officers += player}
+
 /proc/DivideOccupations()
 	set background = 1
 
@@ -148,6 +157,7 @@ var/global/totally_random_jobs = FALSE
 				if(!candidate.client) continue
 				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv1")
+				ASSIGN_STAFF_LISTS(JOB, candidate)
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
 				unassigned -= candidate
@@ -156,6 +166,7 @@ var/global/totally_random_jobs = FALSE
 				if(!candidate.client) continue
 				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv2")
+				ASSIGN_STAFF_LISTS(JOB, candidate)
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
 				unassigned -= candidate
@@ -164,6 +175,7 @@ var/global/totally_random_jobs = FALSE
 				if(!candidate.client) continue
 				if (JOB.assigned >= JOB.limit || JOB.assigned >= JOB.high_priority_limit || !length(unassigned)) break
 				logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from High Priority Job Picker Lv3")
+				ASSIGN_STAFF_LISTS(JOB, candidate)
 				candidate.mind.assigned_role = JOB.name
 				logTheThing(LOG_DEBUG, candidate, "assigned job: [candidate.mind.assigned_role]")
 				unassigned -= candidate
@@ -211,14 +223,7 @@ var/global/totally_random_jobs = FALSE
 		// If there's an open job slot for it, give the player the job and remove them from
 		// the list of unassigned players, hey presto everyone's happy (except clarks probly)
 		if (JOB.limit < 0 || !(JOB.assigned >= JOB.limit))
-			if (istype(JOB, /datum/job/engineering/engineer))
-				engineering_staff += player
-			else if (istype(JOB, /datum/job/research/scientist))
-				research_staff += player
-			else if (istype(JOB, /datum/job/research/medical_doctor))
-				medical_staff += player
-			else if (istype(JOB, /datum/job/security/security_officer))
-				security_officers += player
+			ASSIGN_STAFF_LISTS(JOB, player)
 
 			logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [player] took [JOB.name] from favorite selector")
 			player.mind.assigned_role = JOB.name
@@ -241,15 +246,7 @@ var/global/totally_random_jobs = FALSE
 		for(var/mob/new_player/candidate in pick2)
 			if (JOB.assigned >= JOB.limit || !length(unassigned))
 				break
-
-			if (istype(JOB, /datum/job/engineering/engineer))
-				engineering_staff += candidate
-			else if (istype(JOB, /datum/job/research/scientist))
-				research_staff += candidate
-			else if (istype(JOB, /datum/job/research/medical_doctor))
-				medical_staff += candidate
-			else if (istype(JOB, /datum/job/security/security_officer))
-				security_officers += candidate
+			ASSIGN_STAFF_LISTS(JOB, candidate)
 
 			logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from Level 2 Job Picker")
 			candidate.mind.assigned_role = JOB.name
@@ -272,15 +269,7 @@ var/global/totally_random_jobs = FALSE
 		for(var/mob/new_player/candidate in pick3)
 			if (JOB.assigned >= JOB.limit || !length(unassigned))
 				break
-
-			if (istype(JOB, /datum/job/engineering/engineer))
-				engineering_staff += candidate
-			else if (istype(JOB, /datum/job/research/scientist))
-				research_staff += candidate
-			else if (istype(JOB, /datum/job/research/medical_doctor))
-				medical_staff += candidate
-			else if (istype(JOB, /datum/job/security/security_officer))
-				security_officers += candidate
+			ASSIGN_STAFF_LISTS(JOB, candidate)
 
 			logTheThing(LOG_DEBUG, null, "<b>I Said No/Jobs:</b> [candidate] took [JOB.name] from Level 3 Job Picker")
 			candidate.mind.assigned_role = JOB.name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes security officer "high priority" during initial job selection until there are at least two security officers selected.
This will mean you may roll security officer more often from lower priorities if there is a need for it, but you still won't roll it if you have it set to unwanted.
Also adds an `order_priority` var so that secoffs can be high priority but not prioritize over captains and AIs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The game functions a lot better when there is at least *some* security and currently with the way the job code works it's possible for there to be 5 people with security on med priority and still no secoffs because the game decided to make them all engineers. This change will hopefully make it more consistent and reduce the number of zero secoff shifts where no-one wants to late-join as solo-sec.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Security Officer is now a limited high priority role, meaning the game will attempt to ensure there are a minimum number of them in each shift. Having the role disabled will still prevent you from rolling it.
```
