### PR TITLE
Allows 3 Security Officers to revoke Armory access

### DIFF
--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -3,7 +3,7 @@
 	icon_state = "drawbr"
 	density = 0
 	glow_in_dark_screen = TRUE
-	var/auth_need = 1
+	var/auth_need = 3
 	var/list/authorized
 	var/list/authorized_registered = null
 	var/net_id = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
 ( Theres no A tag for Security 👎 and I was unsure which tag was right, thanks 444 )
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Applies Armory authorization rules to revoking authorization by allowing 3 people with security equipment access to unauthorize.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Security can gain access, but not lock it back up when they are done with it unless the HoS or Captain does it, they should be able to lock it themselves considering they can unlock it


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*) 3 Security Officers can now deauthorize Armory.
```
