### PR TITLE
Shaking salt in someones eyes hurts said eyes ow ow ouch

### DIFF
--- a/code/modules/food_and_drink/condiments.dm
+++ b/code/modules/food_and_drink/condiments.dm
@@ -202,9 +202,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/condiment)
 				switch (src.stuff)
 					if ("salt")
 						H.tri_message(user, SPAN_ALERT("<b>[user]</b> [myVerb]s something into [H]'s eyes!"),\
-							SPAN_ALERT("[H == user ? "You [myVerb]" : "[user] [myVerb]s"] some salt into your eyes! <B>FUCK!</B>"),\
-							SPAN_ALERT("You [myVerb] some salt into [user == H ? "your" : "[H]'s"] eyes![user == H ? " <B>FUCK!</B>" : null]"))
+							SPAN_ALERT("[H == user ? "You [myVerb]" : "[user] [myVerb]s"] some salt into your eyes! <B>FUCK THAT STINGS!</B>"),\
+							SPAN_ALERT("You [myVerb] some salt into [user == H ? "your" : "[H]'s"] eyes![user == H ? " <B>FUCK THAT STINGS!</B>" : null]"))
 						random_brute_damage(user, 1)
+						H.change_eye_blurry(rand(10, 16))
+						H.take_eye_damage(rand(6, 8))
 						src.shakes ++
 						return
 					if ("pepper")

--- a/code/modules/food_and_drink/condiments.dm
+++ b/code/modules/food_and_drink/condiments.dm
@@ -206,7 +206,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/condiment)
 							SPAN_ALERT("You [myVerb] some salt into [user == H ? "your" : "[H]'s"] eyes![user == H ? " <B>FUCK THAT STINGS!</B>" : null]"))
 						random_brute_damage(user, 1)
 						H.change_eye_blurry(rand(10, 16))
-						H.take_eye_damage(rand(6, 8))
+						H.take_eye_damage(rand(12, 16))
 						src.shakes ++
 						return
 					if ("pepper")


### PR DESCRIPTION
[FEATURE] [OBJECT] [MEDICAL]
## About the PR 
Using a salt shaker in someones eyes now does some random eye damage, comparable to using a Welder with NVGs or Thermals. The blurriness has been toned down compared to the Welder, however. I'll adjust the numbers if needed

## Why's this needed?
Sounded funny, makes sense and maybe adds some extra utility/pranking potentional in fights and such? Also Cal said he wanted it and tdhooligan told me to do it so I did smiley face

## Changelog 

```changelog
(u)444explorer
(+)Shaking salt in someones eyes hurts their eyes badly! Ouch!
```
