### PR TITLE
fix gang vests being foldable into invisibleness

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -704,7 +704,7 @@ proc/broadcast_to_all_gangs(var/message)
 		if(istype(M.head, src.headwear) || istype(M.wear_mask, src.headwear))
 			count++
 
-		if (M.wear_suit && !istype(M.wear_suit, /obj/item/clothing/suit/armor/vest/gang))
+		if (M.wear_suit && !istype(M.wear_suit, /obj/item/clothing/suit/armor/gang))
 			count--
 		return count
 
@@ -2181,7 +2181,7 @@ proc/broadcast_to_all_gangs(var/message)
 	desc = "Grants you protection without cramping your style!"
 	class2 = "clothing"
 	price = 7500
-	item_path = /obj/item/clothing/suit/armor/vest/gang
+	item_path = /obj/item/clothing/suit/armor/gang
 
 /datum/gang_item/street/lead_pipe
 	name = "Lead Pipe"

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -499,7 +499,7 @@ TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
 
 /obj/item/clothing/suit/armor/vest/gang
 	name = "Light Armor Vest"
-	desc = "A stab & bullet-resistant vest, light enough to slip under a jumpsuit."
+	desc = "A minimalist plate carrier strapped to your torso. Provides as much protection as you can get without cramping your style."
 	icon = 'icons/obj/items/gang.dmi'
 	icon_state = "lightvest"
 	item_state = "lightvest"
@@ -510,4 +510,8 @@ TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
 		..()
 		setProperty("meleeprot", 5)
 		setProperty("rangedprot", 0.5)
+	attackby(obj/item/W, mob/user)
+		return
 
+	attack_self(mob/user)
+		return

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -497,8 +497,8 @@ TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
 		setProperty("coldprot", 5)
 		setProperty("heatprot", 35)
 
-/obj/item/clothing/suit/armor/vest/gang
-	name = "Light Armor Vest"
+/obj/item/clothing/suit/armor/gang
+	name = "light armor vest"
 	desc = "A minimalist plate carrier strapped to your torso. Provides as much protection as you can get without cramping your style."
 	icon = 'icons/obj/items/gang.dmi'
 	icon_state = "lightvest"
@@ -510,8 +510,3 @@ TYPEINFO(/obj/item/clothing/suit/armor/NT_alt)
 		..()
 		setProperty("meleeprot", 5)
 		setProperty("rangedprot", 0.5)
-	attackby(obj/item/W, mob/user)
-		return
-
-	attack_self(mob/user)
-		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CLOTHING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
gang vests can be folded because they're /vest. stop it. 
also changes description to match their new state (they dont disappear under jumpsuits)