### PR TITLE
Remove "Contact CDC" option from QM Console

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -780,10 +780,7 @@ TYPEINFO(/obj/machinery/transception_pad)
 					thing2send.set_loc(src)
 					SPAWN(1 SECOND)
 
-						if (istype(thing2send, /obj/storage/crate/biohazard/cdc))
-							QM_CDC.receive_pathogen_samples(thing2send)
-
-						else if(istype(thing2send,/obj/storage/crate) || istype(thing2send,/obj/storage/secure/crate))
+						if(istype(thing2send,/obj/storage/crate) || istype(thing2send,/obj/storage/secure/crate))
 							var/sold_to_trader = FALSE
 							for (var/datum/trader/T in shippingmarket.active_traders)
 								if (T.crate_tag == thing2send.delivery_destination)

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -37,8 +37,6 @@ ABSTRACT_TYPE(/area/supply)
 			art = O.artifact
 		if(art)
 			shippingmarket.sell_artifact(AM, art)
-		else if (istype(AM, /obj/storage/crate/biohazard/cdc))
-			QM_CDC.receive_pathogen_samples(AM)
 		else if (istype(AM, /obj/storage/crate) || istype(AM, /obj/storage/secure/crate/))
 			if (AM.delivery_destination)
 				for (var/datum/trader/T in shippingmarket.active_traders)

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -472,25 +472,6 @@ Only trained personnel should operate station systems. Follow all procedures car
 	- B <br>
 	"}
 
-/obj/item/paper/cdc_pamphlet
-	name = "So you've contracted a pathogen!"
-	icon_state = "paper"
-	info = {"<center><h2>So you've contracted a pathogen!</h2></center>
-	Hello, dear customer!<hr>
-	Pathogens can be scary! But you can rest easy knowing that your health is in safe hands now that you have contacted the CDC. Simply place a pathogen
-	sample into the biohazard crate and send it back to us and we will have you cured in no time!<hr>
-	<h3>How to send a pathogen sample</h3><hr>
-	<ul style='list-style-type:disc'>
-		<li>1) Fill a reagent container with a blood sample from a person afflicted with the pathogen you are seeking to cure. (For instance, you could use the syringe we sent you!)</li>
-		<li>2) Deposit reagent container into the received biohazard crate and close it.</li>
-		<li>3) Send the biohazard crate back to us.</li>
-		<li>4) As soon as we receive your sample, you can contact us using your Quartermaster's Console to ask us to start analyzing it.</li>
-		<li>5) Once we are done analyzing your sample, we will offer to sell you cures. Buying a pack of multiple cures at a time will be cheaper for you!</li>
-	</ul>
-	We hope that you have found this pamphlet enlightening and we look forward to receiving your sample soon!<hr>
-	Remember, only you can prevent deadly pathogens!
-	"}
-
 /obj/item/paper/shipping_precautions
 	name = "Read this and check the cargo!"
 	icon_state = "paper_caution_bloody"

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -20,100 +20,6 @@ var/global/datum/rockbox_globals/rockbox_globals = new /datum/rockbox_globals
 				// gonna be real here it seems more useful to have the oft-used stuff at the top.
 				//global.QM_CategoryList.Insert(1,S.category) //So Misc. is not #1, reverse ordering.
 
-/datum/cdc_contact_analysis
-	var/uid = 0
-	var/time_factor = 0
-	var/time_done = 0
-	var/begun_at = 0
-	var/description_available = 0
-	var/cure_available = 0
-	var/cure_cost = 0
-	var/name = ""
-	var/desc = ""
-	var/datum/pathogen/assoc_pathogen = null
-
-/datum/cdc_contact_controller
-	var/list/analysis_by_uid = list()
-	var/list/ready_to_analyze = list()
-	var/list/completed_analysis = list()
-	var/datum/cdc_contact_analysis/current_analysis = null
-	var/datum/pathogen/working_on = null
-	var/working_on_time_factor = 0
-	var/next_cure_batch = 0
-	var/batches_left = 0
-	var/next_crate = 0
-	var/last_switch = 0
-
-	New()
-		..()
-		processing_items.Add(src)
-
-	proc/process()
-		if (next_cure_batch < ticker.round_elapsed_ticks && working_on)
-			var/obj/storage/crate/biohazard/B = new
-			var/count = rand(3,6)
-			for (var/i = 0, i < count, i++)
-				new/obj/item/serum_injector(B, working_on, 1, 0)
-			B.name = "CDC Pathogen cure crate ([working_on.name])"
-			shippingmarket.receive_crate(B)
-			batches_left--
-			if (batches_left)
-				next_cure_batch = round(rand(175, 233) / 100 * working_on_time_factor) + ticker.round_elapsed_ticks
-			else
-				working_on = null
-
-	proc/receive_pathogen_samples(obj/storage/crate/biohazard/cdc/sell_crate)
-		for (var/R in sell_crate)
-			var/list/patho = null
-			if (istype(R, /obj/item/reagent_containers))
-				var/obj/item/reagent_containers/RC = R
-				patho = RC.reagents.aggregate_pathogens()
-				qdel(RC)
-			else if (ishuman(R)) // heh
-				var/mob/living/carbon/human/H = R
-				patho = H.reagents.aggregate_pathogens()
-				H.ghostize()
-				qdel(H)
-			else
-				qdel(R)
-				continue
-			for (var/uid in patho)
-				if (!(uid in src.analysis_by_uid))
-					var/datum/pathogen/P = patho[uid]
-					var/datum/cdc_contact_analysis/D = new
-					D.uid = uid
-					var/sym_count = clamp(length(P.effects), 2, 7)
-					D.time_factor = sym_count * rand(10, 15) // 200, 600
-					D.cure_cost = sym_count * rand(25, 40) // 2100, 4300
-					D.name = P.name
-					var/rating = max(P.advance_speed, P.suppression_threshold, P.spread)
-					var/ds = "weak"
-					switch (P.stages)
-						if (4)
-							ds = "potent"
-						if (5)
-							ds = "deadly"
-					var/df = "a relatively one-sided"
-					switch (sym_count)
-						if (3 to 4)
-							df = "a somewhat colorful"
-						if (5 to 6)
-							df = "a rather diverse"
-						if (7)
-							df = "an incredibly symptomatic"
-					D.desc = "It is [df] pathogen with a hazard rating of [rating]. We identify it to be a [ds] organism made up of [P.body_type.plural]. [P.suppressant.desc]"
-					var/datum/pathogen/copy = new /datum/pathogen
-					copy.setup(0, P, 0, null)
-					D.assoc_pathogen = copy
-					src.analysis_by_uid[uid] = D
-					src.ready_to_analyze += D
-			qdel(sell_crate)
-		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Notification: Pathogen sample crate delivered to the CDC.")
-		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
-
-var/global/datum/cdc_contact_controller/QM_CDC = new()
-
 /obj/machinery/computer/supplycomp
 	name = "Quartermaster's Console"
 	icon = 'icons/obj/computer.dmi'
@@ -370,7 +276,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 			Order History &middot;
 			Shipping Market
 			<br>
-			Contact CDC &middot;
 			Traders
 			Requisitions
 			RockBox Controls
@@ -387,7 +292,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 			<a href='[topicLink("order_history")]'>Order History</a> &bull;
 			<a href='[topicLink("viewmarket")]'>Shipping Market</a>
 			<br>
-			<a href='[topicLink("contact_cdc")]'>Contact CDC</a> &bull;
 			<a href='[topicLink("trader_list")]'>Traders</a> &bull;
 			<a href='[topicLink("requis_list")]'>Requisitions</a> &bull;
 			<a href='[topicLink("rockbox_controls")]'>Rockbox Controls</a>
@@ -413,57 +317,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 // and part of it is that chui already sort of kind of eh maybe does it
 /obj/machinery/computer/supplycomp/proc/topicLink(action, subaction, var/list/extra)
 	return "?src=\ref[src]&action=[action][subaction ? "&subaction=[subaction]" : ""]&[extra && islist(extra) ? list2params(extra) : ""]"
-
-
-/obj/machinery/computer/supplycomp/proc/set_cdc()
-	src.temp = "<h2>Center for Disease Control</h2>"
-	src.temp += "<I>Greetings, [station_name]; how can we help you today?</I><br><br>"
-
-	if (src.last_cdc_message)
-		src.temp += "[last_cdc_message]<br><br>"
-
-	src.temp += "<B>Pathogen analysis services</B><br>"
-	src.temp += "To send us pathogen samples, you can <A href='[topicLink("req_biohazard_crate")]'>requisition a biohazardous materials crate</a> from us for 5 credits.<br>"
-	if (!QM_CDC.current_analysis)
-		src.temp += "Our researchers currently have free capacity to analyze pathogen and blood samples for you.<br>"
-		if (length(QM_CDC.ready_to_analyze))
-			src.temp += "We received your packages and are ready to <A href='[topicLink("cdc_analyze")]'>analyze some samples</A>. It will cost you, but hey, you would like to survive, right?<br>"
-		else
-			src.temp += "We have no unanalyzed pathogen samples from your station.<br>"
-	else
-		src.temp += "We're currently analyzing the pathogen sample [QM_CDC.current_analysis.name]. We can <A href='[topicLink("cdc_analyze")]'>analyze something different</A>, if you want."
-		if (QM_CDC.current_analysis.description_available <= ticker.round_elapsed_ticks)
-			src.temp += "Here's what we have so far: <br>[QM_CDC.current_analysis.desc]<br>"
-			if (QM_CDC.current_analysis.cure_available <= ticker.round_elapsed_ticks)
-				src.temp += "We've also discovered a method to synthesize a cure for this pathogen.<br>"
-				QM_CDC.completed_analysis += QM_CDC.current_analysis
-				QM_CDC.current_analysis = null
-			else
-				var/CA = round((QM_CDC.current_analysis.cure_available - ticker.round_elapsed_ticks) / 600)
-				src.temp += "We're really close to discovering a cure as well. It should be available a few [CA > 0 ? "minutes" : "seconds"].<br>"
-		else
-			var/DA = round((QM_CDC.current_analysis.description_available - ticker.round_elapsed_ticks) / 600)
-			src.temp += "We cannot tell you anything about this pathogen so far. Check back in [DA > 1 ? "[DA] minutes" : (DA > 0 ? "1 minute" : "a few seconds")].<br>"
-	src.temp += "<br>"
-	src.temp += "<B>Pathogen cure services</B><br>"
-	if (length(QM_CDC.working_on))
-		src.temp += "We are currently working on [QM_CDC.batches_left] batch[QM_CDC.batches_left > 1 ? "es" : null] of cures for the [QM_CDC.working_on.name] pathogen. The crate will be delivered soon."
-	else if (length(QM_CDC.completed_analysis))
-		src.temp += "We have cures ready to be synthesized for [length(QM_CDC.completed_analysis)] pathogen[length(QM_CDC.completed_analysis) > 1 ? "s" : null].<br>"
-		src.temp += "You can requisition in batches. The more batches you order, the less time per batch it takes for us to deliver and the less credits per batch it will cost you.<br>"
-		src.temp += "<table style='width:100%; border:none; cell-spacing: 0px'>"
-		for (var/datum/cdc_contact_analysis/analysis in QM_CDC.completed_analysis)
-			var/one_cost = analysis.cure_cost
-			var/five_cost = analysis.cure_cost * 4
-			var/ten_cost = analysis.cure_cost * 7
-			src.temp += "<tr><td><b>[analysis.assoc_pathogen.name]</b><td><a href='[topicLink("batch_cure", "\ref[analysis]", list(count = "1"))]'>1 batch for [one_cost] credits</a></td><td><a href='[topicLink("batch_cure", "\ref[analysis]", list(count = "5"))]'>5 batches for [five_cost] credits</a></td><td><a href='[topicLink("batch_cure", "\ref[analysis]", list(count = "10"))]'>10 batches for [ten_cost] credits</a></td></tr>"
-			src.temp += "<tr><td colspan='4' style='font-style:italic'>[analysis.desc]</td></tr>"
-			src.temp += "<tr><td colspan='4'>&nbsp;</td></tr>"
-		src.temp += "</table><br>"
-	else
-		src.temp += "We have no pathogen samples from your station that we can cure, yet.<br>"
-	src.temp += "<br>"
-	src.temp += "<A href='[topicLink("mainmenu")]'>Main Menu</A>"
 
 
 /obj/machinery/computer/supplycomp/proc
@@ -717,103 +570,6 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 						</tbody>
 					</table>
 						"}
-
-		if ("contact_cdc")
-			if (signal_loss >= 75)
-				boutput(usr, SPAN_ALERT("Severe signal interference is preventing contact with the CDC."))
-				return
-			set_cdc()
-			last_cdc_message = null
-
-		if ("req_biohazard_crate")
-			if (signal_loss >= 75)
-				boutput(usr, SPAN_ALERT("Severe signal interference is preventing contact with the CDC."))
-				return
-			if (ticker.round_elapsed_ticks < QM_CDC.next_crate)
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">We are fresh out of crates right now to send you. Check back in [ceil((QM_CDC.next_crate - ticker.round_elapsed_ticks) / (1 SECOND))] seconds!</span>"
-			else
-				if (wagesystem.shipping_budget < 5)
-					last_cdc_message = "<span style=\"color:red; font-style: italic\">You're completely broke. You cannot even afford a crate.</span>"
-				else
-					wagesystem.shipping_budget -= 5
-					last_cdc_message = "<span style=\"color:blue; font-style: italic\">We're delivering the crate right now. It should arrive shortly.</span>"
-					shippingmarket.receive_crate(new /obj/storage/crate/biohazard/cdc())
-					QM_CDC.next_crate = ticker.round_elapsed_ticks + 300
-			set_cdc()
-
-		if ("cdc_analyze")
-			if (signal_loss >= 75)
-				boutput(usr, SPAN_ALERT("Severe signal interference is preventing contact with the CDC."))
-				return
-			src.temp = "<B>Center for Disease Control communication line</B><HR>"
-			src.temp += "<i>These are the unanalyzed samples we have from you, [station_name].</i><br><br>"
-			if (QM_CDC.current_analysis)
-				src.temp += "We are currently researching the sample [QM_CDC.current_analysis.assoc_pathogen.name]. We can start on a new one if you like, but the analysis cost will not be refunded.<br><br>"
-			src.temp += "Analysis costs 100 credits to begin. Choose a pathogen sample to analyze:<br>"
-			for (var/datum/cdc_contact_analysis/C in QM_CDC.ready_to_analyze)
-				src.temp += "<a href='[topicLink("cdc_analyze_me", "\ref[C]")]'>[C.assoc_pathogen.name]</a> ([round(C.time_done / (2 * C.time_factor))]% done)<br>"
-			src.temp += "<br><A href='[topicLink("contact_cdc")]'>Back</A><br><A href='[topicLink("mainmenu")]'>Main Menu</A>"
-
-		if ("cdc_analyze_me")
-			if (signal_loss >= 75)
-				boutput(usr, SPAN_ALERT("Severe signal interference is preventing contact with the CDC."))
-				return
-			if (QM_CDC.last_switch > ticker.round_elapsed_ticks - 300)
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">We just switched projects. Hold on for a bit.</span>"
-			else if (wagesystem.shipping_budget < 100)
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">You cannot afford to start a new analysis.</span>"
-			else
-				var/datum/cdc_contact_analysis/C = locate(subaction)
-				if (!(C in QM_CDC.ready_to_analyze))
-					last_cdc_message = "<span style=\"color:red; font-style: italic\">That's not ready to analyze right now.</span>"
-				else
-					last_cdc_message = "<span style=\"color:blue; font-style: italic\">We'll begin the analysis and keep you updated.</span>"
-					wagesystem.shipping_budget -= 100
-					if (QM_CDC.current_analysis)
-						var/datum/cdc_contact_analysis/A = QM_CDC.current_analysis
-						A.time_done += ticker.round_elapsed_ticks - A.begun_at
-						if (A.cure_available <= ticker.round_elapsed_ticks)
-							QM_CDC.completed_analysis += A
-						else
-							QM_CDC.ready_to_analyze += A
-					QM_CDC.current_analysis = C
-					QM_CDC.ready_to_analyze -= C
-					C.begun_at = ticker.round_elapsed_ticks
-					C.description_available = C.begun_at + C.time_factor - C.time_done
-					C.cure_available = C.description_available + C.time_factor
-					QM_CDC.last_switch = C.begun_at
-
-			set_cdc()
-
-		if ("batch_cure")
-			if (signal_loss >= 75)
-				boutput(usr, SPAN_ALERT("Severe signal interference is preventing contact with the CDC."))
-				return
-			var/datum/cdc_contact_analysis/C = locate(subaction)
-			if (!(C in QM_CDC.completed_analysis))
-				last_cdc_message = "<span style=\"color:red; font-style: italic\">That's not ready to be cured yet.</span>"
-			var/count = text2num_safe(href_list["count"])
-			var/cost = 0
-			switch (count)
-				if (1)
-					cost = C.cure_cost
-				if (5)
-					cost = 4 * C.cure_cost
-				if (10)
-					cost = 7 * C.cure_cost
-				else
-					last_cdc_message = "<span style=\"color:red; font-style: italic\">No leet haxing, chump.</span>"
-			if (cost > 0)
-				if (wagesystem.shipping_budget < cost)
-					last_cdc_message = "<span style=\"color:red; font-style: italic\">You cannot afford these cures.</span>"
-				else
-					wagesystem.shipping_budget -= cost
-					QM_CDC.working_on = C.assoc_pathogen
-					QM_CDC.working_on_time_factor = C.time_factor
-					QM_CDC.next_cure_batch = round(rand(175, 233) / 100 * C.time_factor) + ticker.round_elapsed_ticks
-					QM_CDC.batches_left = count
-
-			set_cdc()
 
 		if ("trader_list")
 			if (!shippingmarket.active_traders.len)

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -168,12 +168,6 @@
 	icon_closed = "biohazardcrate"
 	weld_image_offset_Y = -2
 
-	cdc
-		name = "CDC pathogen sample crate"
-		desc = "A crate for sending pathogen or blood samples to the CDC for analysis."
-		spawn_contents = list(/obj/item/reagent_containers/syringe,
-		/obj/item/paper/cdc_pamphlet)
-
 /obj/storage/crate/freezer/milk
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/milk = 10, \
 	/obj/item/gun/russianrevolver)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "Contact CDC" link from the QM console, as well as its related functionality and supporting objects.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pathology was removed

## Screenshot
![image](https://github.com/goonstation/goonstation/assets/91498627/e2cb80ef-0b80-4a18-96ed-497a7380f647)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)NanoTrasen no longer has a direct line of contact with the CDC.
```
