### PR TITLE
Fixex: #18341 - Sending force shield message to silicon player instead of attacking player

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -834,7 +834,7 @@
 					damage -= damage_reduced_by
 					playsound(src, 'sound/impact_sounds/Energy_Hit_1.ogg', 40, TRUE)
 			if (damage <= 0)
-				boutput(usr, SPAN_NOTICE("Your shield completely blocks the attack!"))
+				boutput(src, SPAN_NOTICE("Your shield completely blocks the attack!"))
 				return 1
 			boutput(src, SPAN_ALERT("The blob attacks you!"))
 			for (var/obj/item/parts/robot_parts/RP in src.contents)
@@ -2932,7 +2932,7 @@
 				playsound(src, 'sound/impact_sounds/Energy_Hit_1.ogg', 40, TRUE)
 				continue
 		if (burn == 0 && brute == 0)
-			boutput(usr, SPAN_NOTICE("Your shield completely blocks the attack!"))
+			boutput(src, SPAN_NOTICE("Your shield completely blocks the attack!"))
 			return 0
 		if (zone == "All")
 			var/list/zones = get_valid_target_zones()


### PR DESCRIPTION
[BUG][TRIVIAL][SILICONS]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #18341.On hit if a silicon player receives no damage a message is sent saying "Your shield completely blocks the attack!". This message clearly addressing the silicon player is sent to `usr` i.e. the attacking player, rather than the silicon player.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slightly confusing message, clearly is meant to go to silicon player.