### PR TITLE
Handsfree radiation collector array.

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1457,6 +1457,18 @@ TYPEINFO(/obj/machinery/power/collector_array)
 			UpdateIcon()
 		..()
 
+/obj/machinery/power/collector_array/MouseDrop_T(obj/item/W, mob/user) // For the armless and the harmless.
+	if (!istype(W, /obj/item/tank)) // Tanks only, please.
+		return
+	if (!in_interact_range(src, user)  || BOUNDS_DIST(W, user) > 0 || !can_act(user)) // No attaching tanks from across the world.
+		return
+	// No ghosts or AI eye or wraiths or blobs or flockminds shall be engineers. This is for the physical and the living.
+	if (iswraith(user) || isintangible(user) || is_incapacitated(user)|| isghostdrone(user) || isAI(user))
+		boutput(user, SPAN_ALERT("[src] refuses to interface with you!"))
+		return
+	else
+		src.Attackby(W, user)
+
 /obj/machinery/power/collector_array/attack_hand(mob/user)
 	if(src.active==1)
 		src.active = 0


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Engineering]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This allows tanks to be click-dragged to the radiation collector array.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
My friend Nuggets the Chief Engineer, who lost all their limbs, wants to make the best singularity. Would you really deny Nuggets their destiny?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MetaReferencer
(+)You can click-drag plasma tanks onto radiation collectors.
```
