### PR TITLE
Fix syndicate shotglass throw

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1546,10 +1546,10 @@ ADMIN_INTERACT_PROCS(/obj/item/reagent_containers/food/drinks/drinkingglass, pro
 			if (src.reagents.total_volume)
 				logTheThing(LOG_CHEMISTRY, H, "is forced to drink from [src] [log_reagents(src)] at [log_loc(H)] thrown by [constructTarget(thr.thrown_by, "combat")].")
 				src.reagents.reaction(H, INGEST, clamp(reagents.total_volume, CHEM_EPSILON, min(reagents.total_volume/2, (H.reagents?.maximum_volume - H.reagents?.total_volume))))
-				SPAWN(0.5 SECONDS)
-					if (src?.reagents && H?.reagents)
-						src.reagents.trans_to(H, reagents.total_volume/2)
+				if (src?.reagents && H?.reagents)
+					src.reagents.trans_to(H, reagents.total_volume/2)
 		. = ..()
+
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/oldf
 	name = "old fashioned glass"


### PR DESCRIPTION
[BUG] [OBJECTS]

## About the PR 
removes a SPAWN(0.5 SECONDS) in the syndicate shotglass throw to let targets properly drink half their contents
im not completely sure of why the SPAWN was there or the implications of removing it past letting the transfer happen before the glass shatters but i did not run into any issues in testing so hopefully it is good

## Why's this needed? 
bug fix good, more funny traitor weapons good

## Changelog 
```changelog
(u)444explorer
(+)Syndicate Shotglasses now properly force people to drink half their reagents when they get hit by them
```
