### PR TITLE
Limit gang weed point bonuses

### DIFF
--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -36,6 +36,8 @@
 
 /// /// Each drug is worth GANG_DRUG_BONUS_MULT * their value until this many units are provided
 #define GANG_DRUG_BONUS_CAP 200
+/// How many weed leaves provide a points bonus
+#define GANG_WEED_LIMIT 200 //gang weed
 /// Each drug then has this much market behind it after GANG_DRUG_BONUS_CAP is used up.
 #define GANG_DRUG_LIMIT 1000
 /// The multiplier for drugs that a gang has handed in less than GANG_DRUG_BONUS_CAP units of

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1186,6 +1186,8 @@ proc/broadcast_to_all_gangs(var/message)
 	var/list/tracked_drugs_list = list()
 	/// Tracks how many points' worth of drugs have been inserted, after the GANG_DRUG_BONUS_CAP
 	var/untracked_drugs_score = 0
+	/// How many leaves of weed have been given in
+	var/gang_weed = 0
 
 	New()
 		START_TRACKING
@@ -1731,7 +1733,9 @@ proc/broadcast_to_all_gangs(var/message)
 		score += do_drug_score(O,"catdrugs", GANG_DRUG_SCORE_CATDRUGS)
 		score += do_drug_score(O,"methamphetamine", GANG_DRUG_SCORE_METH)
 		//uncapped because weed is cool
-		if(istype(O, /obj/item/plant/herb/cannabis))
+		//now capped because weed was too cool
+		if(istype(O, /obj/item/plant/herb/cannabis) && gang_weed < GANG_WEED_LIMIT)
+			gang_weed++
 			score += 10
 		return round(score)
 
@@ -1754,9 +1758,7 @@ proc/broadcast_to_all_gangs(var/message)
 		message_admins("[user.key] has claimed the role of leader for their gang, [src.gang.gang_name].")
 
 	proc/print_drug_prices(var/mob/living/carbon/human/user)
-		var/multiplier = 3/((untracked_drugs_score/1000)+1)
-		var/text = {"Given the current market saturation, drugs are worth [round(multiplier,0.1)]x<br>
-		The going prices for drugs are as follows:<br>
+		var/text = {"The going prices for drugs are as follows:<br>
 		[drug_hotness("bathsalts") ? "*HIGH DEMAND: [drug_hotness("bathsalts")]u* - " : ""] 1u of bathsalts = [get_drug_score("bathsalts", GANG_DRUG_SCORE_BATHSALTS)]<br>
 		[drug_hotness("morphine") ? "*HIGH DEMAND: [drug_hotness("morphine")]u* - " : ""]1u of morphine = [get_drug_score("morphine", GANG_DRUG_SCORE_MORPHINE)]<br>
 		[drug_hotness("crank") ? "*HIGH DEMAND: [drug_hotness("crank")]u* - " : ""]1u of crank = [get_drug_score("crank", GANG_DRUG_SCORE_CRANK)] <br>
@@ -1767,7 +1769,8 @@ proc/broadcast_to_all_gangs(var/message)
 		[drug_hotness("psilocybin") ? "*HIGH DEMAND: [drug_hotness("psilocybin")]u* - " : ""]1u of psilocybin = [get_drug_score("psilocybin", GANG_DRUG_SCORE_PSILOCYBIN)] <br>
 		[drug_hotness("krokodil") ? "*HIGH DEMAND: [drug_hotness("krokodil")]u* - " : ""]1u of krokodil = [get_drug_score("krokodil", GANG_DRUG_SCORE_KROKODIL)] <br>
 		[drug_hotness("catdrugs") ? "*HIGH DEMAND: [drug_hotness("catdrugs")]u* - " : ""]1u of cat drugs = [get_drug_score("catdrugs", GANG_DRUG_SCORE_CATDRUGS)] <br>
-		[drug_hotness("methamphetamine") ? "*HIGH DEMAND: [drug_hotness("methamphetamine")]u* - " : ""]1u of methamphetamine = [get_drug_score("methamphetamine", GANG_DRUG_SCORE_METH)] <br>"}
+		[drug_hotness("methamphetamine") ? "*HIGH DEMAND: [drug_hotness("methamphetamine")]u* - " : ""]1u of methamphetamine = [get_drug_score("methamphetamine", GANG_DRUG_SCORE_METH)] <br>
+		There is additional demand for [GANG_WEED_LIMIT-gang_weed] leaves of cannabis, for 10 points each."}
 		boutput(user, SPAN_ALERT(text))
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODES][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
gang weeders were making tens of thousands of points sitting on their rear in Botany.
a few thousand is ok. but when you annihilate all the competition without leaving your department it's a bit silly

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)One particularly aspirational gang has flooded the whole cannabis market. Gangs can now only get the 10 point bonus for the first 200 leaves. 
```
