### PR TITLE
Random Event: "Illegal" trinkets count as contraband

### DIFF
--- a/code/modules/events/minor/illegal_trinkets.dm
+++ b/code/modules/events/minor/illegal_trinkets.dm
@@ -1,0 +1,38 @@
+/datum/random_event/minor/illegal_trinkets
+	name = "Illegal Trinkets"
+	centcom_headline = "Security Review Notice"
+	centcom_message = "The NanoTrasen Logistics Screening Team has confirmed the possibility of stolen, smuggled, or counterfit items aboard."
+	weight = 10
+	var/list/obj/item/criminal_items = list()
+
+	is_event_available(ignore_time_lock = 0)
+		. = ..()
+		if (.)
+			for_by_tcl(H, /mob/living/carbon/human)
+				if (isdead(H)) continue
+				if (isnpc(H)) continue
+				if (isvirtual(H)) continue
+				if (inafterlife(H)) continue
+				if (istype(H.loc, /obj/cryotron)) continue
+				var/datum/deref = H?.trinket?.deref()
+				if (istype(deref, /obj/item))
+					var/obj/item/trinket = H.trinket.deref()
+					if (
+						findtext(trinket.name, "stolen") \
+						|| findtext(trinket.name, "smuggled") \
+						|| findtext(trinket.name, "counterfeit") \
+						|| findtext(trinket.name, "ex's")  \
+						|| findtext(trinket.name, "shameful") \
+					 )
+						src.criminal_items += trinket
+
+			if (!length(src.criminal_items))
+				return FALSE
+
+			return TRUE
+
+	event_effect(source)
+		. = ..()
+
+		for(var/obj/item/trinket in src.criminal_items)
+			trinket.AddComponent(/datum/component/contraband, 3, 0) // set off item scans, but not mob scans

--- a/code/modules/events/minor/illegal_trinkets.dm
+++ b/code/modules/events/minor/illegal_trinkets.dm
@@ -1,7 +1,7 @@
 /datum/random_event/minor/illegal_trinkets
 	name = "Illegal Trinkets"
 	centcom_headline = "Security Review Notice"
-	centcom_message = "The NanoTrasen Logistics Screening Team has confirmed the possibility of stolen, smuggled, or counterfit items aboard."
+	centcom_message = "The NanoTrasen Logistics Screening Team has confirmed the possibility of stolen, smuggled, or counterfeit items aboard."
 	weight = 10
 	var/list/obj/item/criminal_items = list()
 

--- a/code/modules/events/minor/illegal_trinkets.dm
+++ b/code/modules/events/minor/illegal_trinkets.dm
@@ -7,6 +7,7 @@
 
 	is_event_available(ignore_time_lock = 0)
 		. = ..()
+		src.criminal_items = list()
 		if (.)
 			for_by_tcl(H, /mob/living/carbon/human)
 				if (isdead(H)) continue

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1144,6 +1144,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\events\minor\artifact.dm"
 #include "code\modules\events\minor\buddy_time.dm"
 #include "code\modules\events\minor\gimmick_flood.dm"
+#include "code\modules\events\minor\illegal_trinkets.dm"
 #include "code\modules\events\minor\pests.dm"
 #include "code\modules\events\minor\special_order.dm"
 #include "code\modules\events\minor\trader.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Random event to mark all player trinkets named with a specific set of "illegal" words as level 3 contraband.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Give security some low-stakes cases to tackle.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)NanoTrasen randomly screens trinkets for contraband.
```