### PR TITLE
[April Fools| Gives everyone an rcd in their oxygen box

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -48,7 +48,7 @@
 
 /obj/item/storage/box/starter // the one you get in your backpack
 	icon_state = "emergbox"
-	spawn_contents = list(/obj/item/clothing/mask/breath, /obj/item/tank/emergency_oxygen)
+	spawn_contents = list(/obj/item/clothing/mask/breath, /obj/item/tank/emergency_oxygen, /obj/item/rcd)
 	make_my_stuff(onlyMaskAndOxygen)
 		..()
 		if (prob(15) || ticker?.round_elapsed_ticks > 20 MINUTES && !onlyMaskAndOxygen) //aaaaaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Getting stuck as a spessmen is very unpleasant, especially if it's your own fault. This helps prevent that by giving everyone an rcd, something people rush anyways. I have not tested this, cause I couldn't be asked to.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeDude
(*)Gives spessmen a tool to prevent them from getting stuck.
(+)Drinking any kind of soda will cause you to burp violently.
```
