### PR TITLE
standardize how to find 'safe' random station storage 

### DIFF
--- a/_std/defines/medical.dm
+++ b/_std/defines/medical.dm
@@ -4,3 +4,6 @@
 #define MEDREC_DISEASE_DEFAULT "No diseases have been diagnosed at the moment."
 #define MEDREC_CLONE_DEFECT_DEFAULT "No cloner defects have been recorded."
 #define MEDREC_NO_IMPLANT "No health implant detected."
+
+/// Maximum air temperature before default lungs start taking damage
+#define DEFAULT_LUNG_AIR_TEMP_TOLERANCE_MAX T0C + 66

--- a/code/mob/living/critter/cryptid_plushie.dm
+++ b/code/mob/living/critter/cryptid_plushie.dm
@@ -137,11 +137,11 @@
 			[SPAN_NOTICE("You can't move when being watched. As a plush, you have the following abilities:")]
 			<br>[SPAN_NOTICE("Plushie Talk allows you to communicate.")]
 			<br>[SPAN_NOTICE("Override Sensors lets you temporarily move a few steps, even if being watched.")]
-			<br>[SPAN_NOTICE("Teleport lets you teleport when you're not being watched.")]
-			<br>[SPAN_NOTICE("Disappear lets you teleport away and hide in a random station container.")]
+			<br>[SPAN_NOTICE("Teleport lets you jump to the targeted location, when you're not being watched.")]
+			<br>[SPAN_NOTICE("Disappear teleports you to a random station container.")]
 			<br>[SPAN_NOTICE("Vengeful Retreat will stun your recent attacker and teleport you away.")]
-			<br>[SPAN_NOTICE("Toggle Glowing Eyes a lets you toggle your eyes glowing at will.")]
-			<br>[SPAN_NOTICE("Set Glowing Eyes Color ability lets you set your eyes' glowing color.")]
+			<br>[SPAN_NOTICE("Toggle Glowing Eyes will toggle your eyes glowing at will.")]
+			<br>[SPAN_NOTICE("Set Glowing Eyes Color lets you set your eyes' glowing color.")]
 			<br>[SPAN_NOTICE("Access special emotes through *scream, *dance and *snap.")]"})
 
 	proc/plushie_speech(var/text_to_say)

--- a/code/mob/living/critter/cryptid_plushie.dm
+++ b/code/mob/living/critter/cryptid_plushie.dm
@@ -85,7 +85,7 @@
 			if (tgui_alert(ghost_mob, "You have fallen, but the curse is not lifted this easily. Do you wish to return to the physical realm?", "Resurrection",
 				list("Yes", "No"), timeout = 60 SECOND) == "Yes")
 				// get a random not locked station container
-				var/obj/storage/spawn_target = get_a_random_station_unlocked_container_with_no_others_on_the_turf()
+				var/obj/storage/spawn_target = pick(get_random_station_storage_list(no_others=TRUE))
 				if(isnull(spawn_target))
 					boutput(ghost_mob, SPAN_ALERT("<h3>Couldn't find a suitable location to respawn. Resurrection impossible.</h3>"))
 					return
@@ -134,14 +134,14 @@
 	Login()
 		..()
 		boutput(src, {"<h1>[SPAN_ALERT("You are NOT an antagonist unless stated otherwise through an obvious popup/message.")]</h1>
-			[SPAN_NOTICE("You can't move when being watched.")]
-			<br>[SPAN_NOTICE("Use your Plushie Talk ability to communicate.")]
-			<br>[SPAN_NOTICE("Your override sensors ability lets you temporarily move a few steps even if being watched.")]
-			<br>[SPAN_NOTICE("Your blink ability lets you teleport when you're not being watched.")]
-			<br>[SPAN_NOTICE("Your teleport away ability lets you teleport away and hide in a random station container.")]
-			<br>[SPAN_NOTICE("Your vengeful retreat will stun your recent attacker and teleport you away.")]
-			<br>[SPAN_NOTICE("Your toggle glowing eyes ability lets you toggle your eyes glowing at will.")]
-			<br>[SPAN_NOTICE("Your set glowing eyes color ability lets you set your eyes' glowing color.")]
+			[SPAN_NOTICE("You can't move when being watched. As a plush, you have the following abilities:")]
+			<br>[SPAN_NOTICE("Plushie Talk allows you to communicate.")]
+			<br>[SPAN_NOTICE("Override Sensors lets you temporarily move a few steps, even if being watched.")]
+			<br>[SPAN_NOTICE("Teleport lets you teleport when you're not being watched.")]
+			<br>[SPAN_NOTICE("Disappear lets you teleport away and hide in a random station container.")]
+			<br>[SPAN_NOTICE("Vengeful Retreat will stun your recent attacker and teleport you away.")]
+			<br>[SPAN_NOTICE("Toggle Glowing Eyes a lets you toggle your eyes glowing at will.")]
+			<br>[SPAN_NOTICE("Set Glowing Eyes Color ability lets you set your eyes' glowing color.")]
 			<br>[SPAN_NOTICE("Access special emotes through *scream, *dance and *snap.")]"})
 
 	proc/plushie_speech(var/text_to_say)
@@ -412,7 +412,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/cryptid_plushie/teleportation)
 	var/animation_waves = 3
 
 	proc/get_a_random_station_unlocked_container()
-		return get_a_random_station_unlocked_container_with_no_others_on_the_turf()
+		return pick(get_random_station_storage_list(no_others=TRUE))
 
 	proc/teleport_to_a_target(var/teleportation_target = null, var/target_a_random_container = FALSE)
 		playsound(get_turf(holder.owner), 'sound/effects/ghostbreath.ogg', 75, 1)

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -12,7 +12,7 @@
 	failure_disease = /datum/ailment/disease/respiratory_failure
 	surgery_flags = SURGERY_SNIPPING | SURGERY_CUTTING | SURGERY_SAWING
 	region = RIBS
-	var/temp_tolerance = T0C+66
+	var/temp_tolerance = DEFAULT_LUNG_AIR_TEMP_TOLERANCE_MAX
 
 	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
 	var/safe_co2_max = 9 // Yes it's an arbitrary value who cares?

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2611,3 +2611,40 @@ proc/message_ghosts(var/message, show_wraith = FALSE)
 	for (var/client/C in clients)
 		if (C.ckey == ckey)
 			return C
+
+/// Return a list of station-level storage objects that are safe to spawn things into
+/// * closed: if TRUE, only include storage objects that are closed
+/// * breathable: if TRUE, only include storage on breathable turfs
+/// * no_others: if TRUE, do not include multiple storage objects on the same turf
+/proc/get_random_station_storage_list(closed=FALSE, breathable=FALSE, no_others=FALSE)
+	RETURN_TYPE(/list/obj/storage)
+	. = list()
+	for_by_tcl(container, /obj/storage)
+		if (container.z != Z_LEVEL_STATION)
+			continue
+		if (closed && container.open)
+			continue
+		if (container.locked || container.welded || container.crunches_contents || container.needs_prying)
+			continue
+		if (istype(container, /obj/storage/secure) || istype(container, /obj/storage/crate/loot))
+			continue
+		// listening posts everywhere or martian ship (in station Z-level on Oshan)
+		if (istype(get_area(container), /area/listeningpost) || istype(get_area(container), /area/evilreaver))
+			continue
+
+		if (breathable)
+			var/turf/simulated/T = container.loc
+			if(istype(T) && (T.air?.oxygen <= (MOLES_O2STANDARD - 1) || T.air?.temperature <= T0C || T.air?.temperature >= DEFAULT_LUNG_AIR_TEMP_TOLERANCE_MAX))
+				continue
+
+		if (no_others)
+			var/turf/container_turf = get_turf(container)
+			var/duplicate_containers = FALSE
+			for (var/obj/storage/container_on_turf in container_turf)
+				if (container != container_on_turf)
+					duplicate_containers = TRUE
+					break
+			if (duplicate_containers)
+				continue
+
+		. += container

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -494,14 +494,7 @@ var/global/totally_random_jobs = FALSE
 			H.spawnId(JOB)
 		if (src.traitHolder && src.traitHolder.hasTrait("stowaway"))
 			//Has the stowaway trait - they're hiding in a random locker
-			var/list/obj/storage/SL = list()
-			for_by_tcl(S, /obj/storage)
-				// Only closed, unsecured lockers/crates on Z1 that are not inside the listening post (or the martian ship (on oshan))
-				if(S.z == 1 && !S.open && !istype(S, /obj/storage/secure) && !istype(S, /obj/storage/crate/loot) && !istype(get_area(S), /area/listeningpost) && !istype(get_area(S), /area/evilreaver))
-					var/turf/simulated/T = S.loc
-					//Simple checks done, now do some environment checks to make sure it's survivable
-					if(istype(T) && T.air && T.air.oxygen >= (MOLES_O2STANDARD - 1) && T.air.temperature >= T0C)
-						SL.Add(S)
+			var/list/obj/storage/SL = get_random_station_storage_list(closed=TRUE, breathable=TRUE)
 
 			if(length(SL) > 0)
 				src.set_loc(pick(SL))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Merge the logic for crate selection somewhat duplicated between stowaways and cryptid plushes. Atomized from work on another feature, would like to re-use there without copy/paste.

The following tweaks to spawns were made in the interest of avoiding stuck or instant-death situations:
* No longer spawn in syndicate hotdog stand or trash compactor.
* No longer spawn in a pryable-only crate, which is impossible to get out of
* For stowaways only, no longer spawn in too hot, lung-murdering temperatures (by way of a lung max temp define)

While I was testing with cryptid plushes, I noticed the help text on spawn was not up to date with the ability names, so that's rolled into this PR as well.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Standardize logic around finding a safe station crate to stuff things into.