### PR TITLE
mark afterlife ghosts and virtual spirits as dead in observer menu

### DIFF
--- a/code/datums/observe_menu.dm
+++ b/code/datums/observe_menu.dm
@@ -78,7 +78,7 @@
 			if(isAIeye(M))
 				obs_data["name"] += "'s eye"
 				obs_data["real_name"] += "'s eye"
-			obs_data["dead"] = isdead(M)
+			obs_data["dead"] = isdead(M) || inafterlife(M) || isVRghost(M)
 			obs_data["job"] = M.job
 			obs_data["npc"] = (M.client == null && M.ghost == null) //dead players have no client, but should have a ghost
 			obs_data["player"] = (M.client != null || M.ghost != null) //okay, I know this is just !npc, but it won't ever get set for objects, so it's needed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mark afterlife and VR ghosts as dead (i.e. with a little skull) in ghosts' observe player menu

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More clear who's actively in the round from the observe menu, especially for the battle royale watching experience 🥺 