### PR TITLE
Fix typing for polls with relative expiry times

### DIFF
--- a/code/modules/polling/poll_editor_panel.dm
+++ b/code/modules/polling/poll_editor_panel.dm
@@ -74,11 +74,11 @@
 		if ("never")
 			return null
 		if ("minutes")
-			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), minutes = value))
+			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), minutes = text2num(value)))
 		if ("hours")
-			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), hours = value))
+			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), hours = text2num(value)))
 		if ("days")
-			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), days = value))
+			return toIso8601(addTime(subtractTime(world.realtime, hours = world.timezone), days = text2num(value)))
 		if ("timestamp")
 			if (validateIso8601(value))
 				return value


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[Admin][Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Converts stringified numbers back into numbers when pulling them out of where they're used in `ui_act` for player poll creation.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Polls don't work for relative times otherwise.