### PR TITLE
Fixing cyanide bought from traders immediately gassing you.

### DIFF
--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -159,6 +159,15 @@
 		..()
 		reagents.add_reagent("cyanide", 50)
 
+/obj/item/reagent_containers/pill/toxlite // Small pill for the trader that sells cyanide. So as to not be offgassed instantly.
+	name = "small cyanide pill"
+	desc = "Smaller but still Highly lethal."
+	icon_state = "pill5"
+
+	New()
+		..()
+		reagents.add_reagent("cyanide", 30)
+
 /obj/item/reagent_containers/pill/stox
 	name = "morphine pill"
 	desc = "Used to treat severe pain. Highly addictive."

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -1375,7 +1375,7 @@
 
 /datum/commodity/medical/cyanide
 	comname = "Cyanide"
-	comtype = /obj/item/reagent_containers/glass/bottle/cyanide
+	comtype = /obj/item/reagent_containers/pill/toxlite
 	desc = "A rapidly acting and highly dangerous chemical."
 	price = PAY_EMBEZZLED
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cyanide Bottles are now Cyanide Pills (when bought from a trader). Bottles are considered open, whereas pills are not open.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While funny, you shouldn't get poisoned by the cyanide you just bought.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
```
