### PR TITLE
(HEAVY WIP) a custom rifle for nuclear commanders

### DIFF
--- a/_std/defines/projectiles.dm
+++ b/_std/defines/projectiles.dm
@@ -54,6 +54,7 @@
 #define AMMO_TRANQ_308 "tranq_308"
 #define AMMO_TRANQ_ALL AMMO_TRANQ_9MM, AMMO_TRANQ_308
 
+#define AMMO_RIFLE_COMM "rifle_commander"
 
 #define AMMO_RIFLE_308 "rifle_308"
 #define AMMO_AUTO_308 "auto_308"

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -51,6 +51,7 @@
 			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate/leader(H), SLOT_EARS)
 			H.equip_if_possible(new /obj/item/swords_sheaths/nukeop(H), SLOT_BELT)
 			H.equip_if_possible(new /obj/item/device/nukeop_commander_uplink(H), SLOT_L_HAND)
+			H.equip_if_possible(new /obj/item/gun/kinetic/commander_rifle(H), SLOT_R_HAND)
 		else
 			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate(H), SLOT_EARS)
 

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1481,6 +1481,9 @@ datum/projectile/bullet/autocannon
 		else if (O)
 			src.has_det = 0
 
+	mist
+		var/obj/item/chem_grenade/fog
+
 /datum/projectile/bullet/breach_flashbang
 	name = "door-breaching flashbang"
 	window_pass = 0
@@ -1970,3 +1973,122 @@ datum/projectile/bullet/autocannon
 	impact_image_state = "bullethole-small"
 	casing = /obj/item/casing/medium
 	ricochets = TRUE
+
+/datum/projectile/bullet/commander_rifle
+	name = "shouldnt be seeing this!"
+	sname = "the useless barrel, call CODER!!"
+	shot_sound = 'sound/weapons/smartgun.ogg'
+	damage = 45
+	damage_type = D_PIERCING
+	implanted = /obj/item/implant/projectile/bullet_commander
+	impact_image_state = "bullethole-small"
+	casing = /obj/item/casing/medium
+	ricochets = FALSE
+
+	// if youre looking for the mist projectile see /datum/projectile/bullet/grenade_shell/mist
+
+	standard
+		name = "smart standard round"
+		sname = "the standard barrel"
+		damage = 45
+
+	penetrator
+		name = "smart penetrator round"
+		sname = "the penetrator barrel"
+		damage = 30
+		armor_ignored = 0.66
+		hit_type = DAMAGE_STAB
+
+		on_launch(obj/projectile/O)
+			O.AddComponent(/datum/component/sniper_wallpierce, 2, 20)
+
+	heavy //TODO: disorient user too
+		name = "smart heavy-duty round"
+		sname = "the heavy barrel"
+		damage = 70
+		armor_ignored = 0.33
+		hit_type = DAMAGE_STAB
+		cost = 2
+
+		#ifdef USE_STAMINA_DISORIENT
+		on_hit(atom/hit, dirflag, obj/projectile/proj)
+			if(ishuman(hit))
+				var/mob/living/carbon/human/H = hit
+				H.do_disorient(0, weakened = 0, stunned = 0, disorient = 10, remove_stamina_below_zero = 0)
+		#endif
+
+	ricochet
+		name = "smart LSR round"
+		sname = "the ricochet barrel"
+		damage = 30
+		var/max_bounce_count = 3
+		var/reflect_on_nondense_hits = FALSE
+		var/reflectcount = 0
+
+		on_hit(atom/hit, direction, obj/projectile/P)
+			if (!ismob(hit))
+				shoot_reflected_bounce(P, hit, max_bounce_count, PROJ_NO_HEADON_BOUNCE, reflect_on_nondense_hits)
+				reflectcount++
+
+		get_power(obj/projectile/P, atom/A)
+			if(reflectcount != 0)
+				return 30 + 20 * P.reflectcount
+			else
+				return 30
+
+	incendiary
+		name = "smart flare round"
+		sname = "the icendiary barrel"
+		damage = 20
+		icon_state = "flare"
+
+		on_hit(atom/hit, direction, obj/projectile/P)
+			if (isliving(hit))
+				fireflash(get_turf(hit) || get_turf(P), 0)
+				hit.changeStatus("staggered", clamp(P.power/8, 5, 1) SECONDS)
+
+	anticlown
+		name = "anti-humour round"
+		sname = "the anti-clown barrel"
+		damage = 10
+		icon_state = "random_thing"
+
+		on_hit(atom/hit, dirflag)
+			if (ishuman(hit))
+				var/mob/living/carbon/human/H = hit
+				var/clown_tally = 0
+				if(istype(H.w_uniform, /obj/item/clothing/under/misc/clown))
+					clown_tally += 1
+				if(istype(H.shoes, /obj/item/clothing/shoes/clown_shoes))
+					clown_tally += 1
+				if(istype(H.wear_mask, /obj/item/clothing/mask/clown_hat))
+					clown_tally += 1
+				if(clown_tally > 0)
+					playsound(H, 'sound/musical_instruments/Bikehorn_1.ogg', 50, TRUE)
+
+				if (H.job == "Clown" || clown_tally >= 2)
+					H.drop_from_slot(H.shoes)
+					H.ex_act(2)
+					H.emote("twitch_v")
+					JOB_XP(H, "Clown", 10)
+				return
+
+	acid
+		name = "smart acidic round"
+		sname = "the acidic barrel"
+		damage = 10
+		icon_state = "radbolt"
+
+		on_hit(atom/hit, direction, var/obj/projectile/projectile)
+			..()
+			var/power = projectile.power
+			hit.damage_corrosive(power)
+
+	doorbreach
+		name = "extra smart round"
+		sname = "the breaching barrel"
+		damage = 20
+		icon_state = "40mm_paint"
+
+		on_launch(obj/projectile/O)
+			O.AddComponent(/datum/component/proj_door_breach)

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1660,3 +1660,12 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 					overlays += "burst_laspistol-100"
 			return
 
+/obj/item/ammo/bullets/commander_rifle
+	sname = "custom smart round"
+	name = "H14-C Smart Magazine"
+	desc = "These must've been specially made, woah! The rounds inside seem to be lined with fancy electronics the guns barrel could program, somehow."
+	ammo_type = new/datum/projectile/bullet/commander_rifle
+	icon_state = "rifle_box_mag" //needs sprite, could modify nukie ak or rifle box mag, depends
+	amount_left = 14
+	max_amount = 14
+	ammo_cat = AMMO_RIFLE_COMM

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -3133,3 +3133,164 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 		UpdateIcon()
 
+// Kickass custom rifle for nukie commanders, needs to have barrels stuck onto it to work. Uplink will have barrel options, choose 3 out of however many
+/* TODO
+   - Sprites
+   - Fix barrel switch
+   - Debug
+   - fix ammo types lool
+   - ???
+   - Win
+*/
+/obj/item/gun/kinetic/commander_rifle
+	name = "\improper H14-C Scout Rifle Custom"
+	desc = "A highly versatile and customisable hunting rifle."
+	icon = 'icons/obj/items/guns/kinetic64x32.dmi'
+	icon_state = "sniper"
+	item_state = "sniper"
+	force = MELEE_DMG_RIFLE
+	ammo_cats = list(AMMO_RIFLE_COMM)
+	max_ammo_capacity = 14
+	auto_eject = 1
+	flags = FPRINT | TABLEPASS | CONDUCT | USEDELAY
+	slowdown = 0
+	slowdown_time = 0
+
+	can_dual_wield = FALSE
+	two_handed = FALSE
+	w_class = W_CLASS_NORMAL
+
+	default_magazine = /obj/item/ammo/bullets/commander_rifle
+	ammobag_magazines = list(/obj/item/ammo/bullets/commander_rifle)
+	ammobag_restock_cost = 3
+	ammobag_spec_required = TRUE
+	recoil_strength = 20
+	recoil_inaccuracy_max = 0
+
+	var/barrels = 0
+
+	HELP_MESSAGE_OVERRIDE({"This needs barrels attached to it to function! The Nuclear Commander Uplink will have barrel options for you to use."})
+
+	get_desc(dist, mob/user)
+		if(user.mind.special_role == "nukeop_commander")
+			. += "It's <i>your</i> old rifle from before you got promoted. Lovingly modified and kitted out to support anything you'll need."
+			. += SPAN_ALERT(" <b>Perfect.</b>")
+		else
+			. += "It's been <i>surprisingly</i> decently modified to fit extra barrels and lighting indicators. Yeesh."
+
+	canshoot(mob/user)
+		if(barrels == 0)
+			boutput(user,SPAN_ALERT("[src] needs a barrel to shoot! Duh."))
+			return FALSE
+		else
+			return TRUE
+
+	New(var/mob/M)
+		ammo = new default_magazine
+		set_current_projectile(new/datum/projectile/bullet/commander_rifle)
+		SPAWN(0.5 SECONDS)
+		assign_name(M)
+		..()
+
+	attackby(obj/item/b, mob/user)
+		if (istype(b, /obj/item/commander_barrel))
+			var/obj/item/commander_barrel/new_barrel = b
+			src.try_add_barrel(user, new_barrel)
+			return
+		..()
+
+	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+		if (istype(target, /obj/item/commander_barrel))
+			var/obj/item/commander_barrel/new_barrel = target
+			src.try_add_barrel(user, new_barrel)
+			return
+		..()
+
+	/* no cool light up indicators to leverage/barrels to swap, sprites needed?
+	attack_self(mob/user as mob)
+		..()
+		UpdateIcon()
+		M.update_inhands()
+
+	update_icon()
+		if (current_projectile.type == /datum/projectile/laser)
+			charge_icon_state = "energykill"
+			muzzle_flash = "muzzle_flash_laser"
+			item_state = "egun-kill"
+		else if (current_projectile.type == /datum/projectile/energy_bolt)
+			charge_icon_state = "energystun"
+			muzzle_flash = "muzzle_flash_elec"
+			item_state = "egun"
+		..()*/
+
+	proc/assign_name(var/mob/M) //stolen from lawbringer
+		if (ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if (H.bioHolder)
+				src.name = "[H.real_name]'s H14-C Scout Rifle Custom"
+				tooltip_rebuild = 1
+
+	proc/try_add_barrel(var/mob/user, var/obj/item/commander_barrel/new_barrel)
+		if(barrels == 3)
+			boutput(user, SPAN_ALERT("The gun already has 3 barrels! No more will fit!"))
+			return
+		set_barrel_stats(new_barrel)
+		qdel(new_barrel)
+
+	proc/set_barrel_stats(var/obj/item/commander_barrel/barrel)
+		src.projectiles += list(barrel.projectile)
+		barrels++
+		set_current_projectile(barrel.projectile)
+
+/obj/item/commander_barrel
+	name = "\improper H14-C Barrel"
+	desc = "An odd barrel for the H14 line of Scout Rifles, this one seems to... hey! you shouldn't see this!"
+	icon = 'icons/obj/electronics.dmi' // TODO - cool sprites for barrels?
+	icon_state = "dbox"
+	var/projectile = new/datum/projectile/bullet/commander_rifle
+	var/projname = "Dummy"
+
+	standard
+		name = "\improper H14 Standard-issue barrel"
+		desc = "A standard barrel for the H14 line of scout rifles. No, really! This one just is plain and standard-issue."
+		projectile = new/datum/projectile/bullet/commander_rifle/standard
+
+	penetrator
+		name = "\improper H14-C Penetrator barrel"
+		desc = "A violent custom barrel for the H14 line of scout rifles, this one seems to leverage the bullets ability to be programmed to make them pierce ammo and walls."
+		projectile = new/datum/projectile/bullet/commander_rifle/penetrator
+
+	heavy
+		name = "\improper H14-C Heavy-duty barrel"
+		desc = "A very heavy custom barrel for the H14 line of scout rifles, this one seems to be not only very heavy, but seems to shoot twice the rounds for one big high powered shot."
+		projectile = new/datum/projectile/bullet/commander_rifle/heavy
+
+	ricochet
+		name = "\improper H14-C Ricochet barrel"
+		desc = "A high-tech cusotm barrel for the H14 line of scout rifles, this one seems to take full control over the smart bullets loaded and ensure they bounce, gaining energy each time."
+		projectile = new/datum/projectile/bullet/commander_rifle/ricochet
+
+	incendiary
+		name = "\improper H14-C Incidenary barrel"
+		desc = "A fiesty barrel for the H14 line of scout rifles, this one seems to overheat the rounds to burn up whatever unlucky soul gets shot."
+		projectile = new/datum/projectile/bullet/commander_rifle/incendiary
+
+	anticlown
+		name = "\improper H14-Clown barrel"
+		desc = "A masterfully crafted barrel for the H14 line of anti-humour rifles, this one seems to react violently in contact of banana peels and honking."
+		projectile = new/datum/projectile/bullet/commander_rifle/anticlown
+
+	acid
+		name = "\improper H14-C Acid barrel"
+		desc = "An inspired barrel for the H14 line of scout rifles, after the Commander battled on Magus, they made sure to have the rounds tipped in acid to remove any masks or helmets."
+		projectile = new/datum/projectile/bullet/commander_rifle/acid
+
+	doorbreach
+		name = "\improper H14-C Masterkey barrel"
+		desc = "A tactical barrel for the H14 line of scout rifles, this one is designed to rip through doors and open them up."
+		projectile = new/datum/projectile/bullet/commander_rifle/doorbreach
+
+	mist
+		name = "\improper H14-C Mist barrel"
+		desc = "A shady barrel for the H14 line of scout rifles, this one bursts into a hard to see through, yet breathable fog."
+		projectile = new/datum/projectile/bullet/grenade_shell/mist

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -3165,7 +3165,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	ammobag_restock_cost = 3
 	ammobag_spec_required = TRUE
 	recoil_strength = 20
-	recoil_inaccuracy_max = 0
+	recoil_inaccuracy_max = 10
 
 	var/barrels = 0
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -908,6 +908,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		icon_state = "bulletexpanded"
 		desc = ".41? What the heck? Who even uses these anymore?"
 
+	bullet_commander
+		icon_state = "bulletbig" // needs some fancy hightech bullet sprite
+		desc = "A large bullet from a rifle cartridge. Seems to be coated in burnt-out electronics. Weird."
+
+
 	bullet_12ga
 		name = "buckshot"
 		icon_state = "buckshot"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nuclear Commanders will spawn with a new rifle, one which can't be fired since it lacks a barrel?? wtf..

basically, you spawn in, open your uplink which will have a seperate currency, and you'll get to choose 3 barrels to slot on your rifle, then you can swap between em like any firemode, it'll change the projectile

possibly could look into replacing the commander's class token? idk, itd need more thought put into it

half the projectiles are broken and exist purely as concept, ill be working on fixing them when i can
this PR also lacks sprites,  using device frames and the current nukies sniper. none of the barrels exist in the uplink either, nor are set in stone. this PR exists purely to gauge interest in the concept

- [ ] sprites
- [ ] fix ammo types
- [ ] fix weird bug of firing empty rifle spawns casing (??)
- [ ] find and fix the other bugs that probably exist
- [ ] explore options for more barrels
- [ ] add options to uplink

i also want to explore more 'out there' and gimmicky barrel types like a combined tranq dart and 'tracker' that reveals people who have them implanted through walls like the adv. thermal goggles do, but id like to get a 'i think this idea has some promise' from a handful of devs before moving on with that

## Why's this needed? 
i think the commander could use a unique ranged weapon past the launchers, itd be cool and lets them be more supporting/offensive depending on what the team lacks in. it's also a fun parrallel to the hos' lawbringer

## Changelog 

```changelog
(u)444explorer
(*)The Nuclear Commander has started bringing their custom rifle to showdowns, make sure to attach it with the right barrels for the job! Find them in the commander uplink. 
```
