### PR TITLE
Fixes hattable component breaking if parent is clicked with a non-hat

### DIFF
--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -34,7 +34,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 /datum/component/hattable/proc/hat_on_thing(mob/target as mob, obj/item/item as obj, mob/attacker)
 	if (src.hat)
 		item = null
-		return TRUE
+		return
 
 	var/atom/movable/hatted = src.parent
 	var/offsetBy_y = 0
@@ -47,7 +47,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)
 	else
 		item = null
-		return TRUE
+		return
 	if (attacker)
 		attacker.drop_item()
 

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -33,19 +33,21 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 
 /datum/component/hattable/proc/hat_on_thing(mob/target as mob, obj/item/item as obj, mob/attacker)
 	if (src.hat)
-		return
+		item = null
+		return TRUE
 
 	var/atom/movable/hatted = src.parent
 	var/offsetBy_y = 0
 	var/offsetBy_x = 0
-	src.hat = item
 
-	if (istype(src.hat, /obj/item/clothing/head/))
+
+	if (istype(item, /obj/item/clothing/head/))
+		src.hat = item
 		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)
 	else
-		return
-
+		item = null
+		return TRUE
 	if (attacker)
 		attacker.drop_item()
 
@@ -62,6 +64,8 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	if (src.death_remove)
 		RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
 	RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
+	UnregisterSignal(src.parent, COMSIG_ATTACKBY)
+	item = null
 	return TRUE
 
 /datum/component/hattable/proc/take_hat_off(mob/target, mob/user)
@@ -85,6 +89,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 		return
 	else
 		UnregisterSignal(src.hat, COMSIG_ITEM_PICKUP)
+		RegisterSignal(src.parent, COMSIG_ATTACKBY, PROC_REF(hat_on_thing), override = TRUE)
 
 	if (istype(user, /mob/living/silicon/ghostdrone))
 		SPAWN(0) // Magtractors use an action bar until they do stuff, and then they'll clone a ghost image of the item that's on the floor. Drop that!

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -33,7 +33,6 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 
 /datum/component/hattable/proc/hat_on_thing(mob/target as mob, obj/item/item as obj, mob/attacker)
 	if (src.hat)
-		item = null
 		return
 
 	var/atom/movable/hatted = src.parent
@@ -46,7 +45,6 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)
 	else
-		item = null
 		return
 	if (attacker)
 		attacker.drop_item()
@@ -65,7 +63,6 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 		RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
 	RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
 	UnregisterSignal(src.parent, COMSIG_ATTACKBY)
-	item = null
 	return TRUE
 
 /datum/component/hattable/proc/take_hat_off(mob/target, mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The item argument wasn't being removed at the end of put_hat_on. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

