### PR TITLE
Makes the ship alert button close bridge and AI shutters and enable turrets

### DIFF
--- a/code/obj/machinery/door/poddoor.dm
+++ b/code/obj/machinery/door/poddoor.dm
@@ -362,6 +362,14 @@
 
 	// meant for use inside station, or if connected to space, not a door
 	shutters
+		New()
+			..()
+			START_TRACKING
+
+		disposing()
+			STOP_TRACKING
+			..()
+
 
 /obj/machinery/door/poddoor/blast/pyro
 	icon = 'icons/obj/doors/SL_doors.dmi'

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -22,7 +22,8 @@ TYPEINFO(/obj/machinery/shipalert)
 
 	var/usageState = 0 // 0 = glass cover, hammer. 1 = glass cover, no hammer. 2 = cover smashed
 	var/working = FALSE //processing loops
-	var/cooldownPeriod = 2 MINUTES //2 minutes, change according to player abuse
+	var/cooldownPeriod = 5 MINUTES //5 minutes, change according to player abuse
+	var/deactivateCooldown = 30 SECONDS //no instantly taking it back
 
 	New()
 		..()
@@ -51,8 +52,8 @@ TYPEINFO(/obj/machinery/shipalert)
 			//activate
 			if (src.working)
 				return
-			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-			src.toggleActivate(user)
+			if (src.toggleActivate(user))
+				playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 
 /obj/machinery/shipalert/attackby(obj/item/W, mob/user)
 	if (user.stat)
@@ -84,30 +85,36 @@ TYPEINFO(/obj/machinery/shipalert)
 
 /obj/machinery/shipalert/proc/toggleActivate(mob/user)
 	if (!user)
-		return
+		return FALSE
 
 	if (src.working)
 		boutput(user, SPAN_ALERT("The alert coils are currently discharging, please be patient."))
-		return
+		return FALSE
 
 	src.working = TRUE
 
 	if (shipAlertState == SHIP_ALERT_BAD)
-		//centcom alert
-		command_alert("The emergency is over. Return to your regular duties.", "Alert - All Clear", alert_origin = ALERT_STATION)
+		if (GET_COOLDOWN(src, "deactivate_cooldown"))
+			boutput(user, SPAN_ALERT("The alert coils are still in high-power mode, please wait to lift alert."))
+			src.working = FALSE
+			return FALSE
+		else
+			//centcom alert
+			command_alert("The emergency is over. Return to your regular duties.", "Alert - All Clear", alert_origin = ALERT_STATION)
 
-		//toggle off
-		shipAlertState = SHIP_ALERT_GOOD
+			//toggle off
+			shipAlertState = SHIP_ALERT_GOOD
 
-		src.update_lights()
+			src.update_lights()
 
-		ON_COOLDOWN(src, "alert_cooldown", src.cooldownPeriod)
+			ON_COOLDOWN(src, "alert_cooldown", src.cooldownPeriod)
+			. = TRUE
 
 	else
 		if (GET_COOLDOWN(src, "alert_cooldown"))
 			boutput(user, SPAN_ALERT("The alert coils are still priming themselves."))
 			src.working = FALSE
-			return
+			return FALSE
 
 		//alert and siren
 #ifdef MAP_OVERRIDE_MANTA
@@ -115,11 +122,13 @@ TYPEINFO(/obj/machinery/shipalert)
 #else
 		command_alert("All personnel, this is not a test. There is a confirmed, hostile threat on-board and/or near the station. Report to your stations. Prepare for the worst.", "Alert - Condition Red", alert_origin = ALERT_STATION)
 #endif
-		playsound_global(world, soundGeneralQuarters, 100)
+		playsound_global(world, soundGeneralQuarters, 100, pitch = 0.9) //lower pitch = more serious or something idk
 		//toggle on
 		shipAlertState = SHIP_ALERT_BAD
-
+		ON_COOLDOWN(src, "deactivate_cooldown", src.deactivateCooldown)
 		src.update_lights()
+		src.do_lockdown(user)
+		. = TRUE
 
 	//alertWord stuff would go in a dedicated proc for extension
 	var/alertWord = "green"
@@ -127,13 +136,30 @@ TYPEINFO(/obj/machinery/shipalert)
 		alertWord = "red"
 
 	logTheThing(LOG_STATION, user, "toggled the ship alert to \"[alertWord]\"")
-	logTheThing(LOG_DIARY, user, "toggled the ship alert to \"[alertWord]\"", "station")
+	message_admins("[user] toggled the ship alert to \"[alertWord]\"")
 	src.working = FALSE
 
 /obj/machinery/shipalert/proc/update_lights()
 	for(var/obj/machinery/light/emergency/light in by_cat[TR_CAT_STATION_EMERGENCY_LIGHTS])
 		light.power_change()
 		LAGCHECK(LAG_LOW)
+
+/obj/machinery/shipalert/proc/do_lockdown(mob/user)
+	for_by_tcl(shutter, /obj/machinery/door/poddoor/pyro/shutters)
+		if (shutter.density)
+			continue
+		if (shutter.z != Z_LEVEL_STATION)
+			continue
+		if (!istypes(get_area(shutter), list(/area/station/turret_protected/ai, /area/station/bridge, /area/station/ai_monitored/armory)))
+			continue
+		shutter.close()
+
+	for_by_tcl(turret_control, /obj/machinery/turretid)
+		if (turret_control.lethal)
+			turret_control.toggle_lethal(user)
+		if (!turret_control.enabled)
+			turret_control.toggle_active(user)
+
 
 #undef COMPLETE
 #undef HAMMER_TAKEN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Also increases the cooldown from 2 to 5 minutes and adds a 30 second cooldown to deactivating it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives it a little bit more use and flavour, hopefully makes it less of a pointless button people push to make a funny sound.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The ship alert button now closes all bridge and AI shutters and activates all turret controls.
(+)The ship alert button now has a 5 minute cooldown and can't be revoked for 30 seconds after activating.
```
