### PR TITLE
Add cant_drop check for ABCU sheet intake

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -67,7 +67,7 @@
 			. += "<br>[SPAN_NOTICE("Someone has uploaded a blueprint named '[current_bp.room_name]'.")]"
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece))
+		if (!W.cant_drop && (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece)))
 			boutput(user, SPAN_NOTICE("You insert the material into the machine."))
 			user.drop_item()
 			W.set_loc(src)
@@ -78,7 +78,7 @@
 		if (!in_interact_range(src, user)  || BOUNDS_DIST(W, user) > 0 || !can_act(user))
 			return
 		else
-			if (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece))
+			if (!W.cant_drop && (istype(W, /obj/item/sheet) || istype(W, /obj/item/material_piece)))
 				boutput(user, SPAN_NOTICE("You insert [W] into the machine."))
 				W.set_loc(src)
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When checking if sheets are accepted into the ABCU, check first to see if they're droppable.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18411