### PR TITLE
Ship Alert button targets doors by ID instead of area

### DIFF
--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -145,12 +145,12 @@ TYPEINFO(/obj/machinery/shipalert)
 		LAGCHECK(LAG_LOW)
 
 /obj/machinery/shipalert/proc/do_lockdown(mob/user)
-	for_by_tcl(shutter, /obj/machinery/door/poddoor/pyro/shutters)
+	for_by_tcl(shutter, /obj/machinery/door/poddoor)
 		if (shutter.density)
 			continue
 		if (shutter.z != Z_LEVEL_STATION)
 			continue
-		if (!istypes(get_area(shutter), list(/area/station/turret_protected/ai, /area/station/bridge, /area/station/ai_monitored/armory)))
+		if (shutter.id != "lockdown" && shutter.id != "ai_core" && shutter.id == "armory")
 			continue
 		shutter.close()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Check the shutter's ID value instead of area
* Check a wider base path for potential lockdown doors on various maps

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of bridge doors get out of sync

atlas bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/3e637ce7-028d-43ad-852f-d21fe35783a2)

clarion bridge uses blast doors
![image](https://github.com/goonstation/goonstation/assets/91498627/c2503f56-daae-470d-9aa4-75d75c239f36)

cogmap bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/f4b4586e-2dac-453f-b23c-a8dfcd78ba44)

cogmap2 bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/9b6c28d4-57be-449b-bbd9-ef389194a565)

kondaru AI core uses poddoors
![image](https://github.com/goonstation/goonstation/assets/91498627/7c95d660-f7fd-471b-86fa-cfe581954199)

oshan bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/9aa753e5-166f-44e6-8847-fdda8d40dfcc)

nadir AI core uses poddoors
![image](https://github.com/goonstation/goonstation/assets/91498627/a23653d4-25f0-4a0d-9da4-d5a68e6ff3f0)

donut2 bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/3abbcbea-6341-4df8-82cb-6e3ed0dc928b)

donut3 bridge out of area
![image](https://github.com/goonstation/goonstation/assets/91498627/971a4ef7-f6f6-47d0-a70d-a79d627a7359)

donut3 AI core uses different area
![image](https://github.com/goonstation/goonstation/assets/91498627/ef781e60-cadb-48f4-9c2f-4839b6b8ce1d)
