### PR TITLE
Remove slight gradient from Asimovs laws

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -116,17 +116,14 @@ TYPEINFO(/obj/item/aiModule)
 /******************** Modules ********************/
 /******************** Asimov ************************/
 /obj/item/aiModule/asimov1
-	highlight_color = rgb(0, 167, 0, 255)
 	name = "AI Law Module - 'Asimov's 1st Law of Robotics'"
 	lawText = "You may not injure a human being or cause one to come to harm."
 
 /obj/item/aiModule/asimov2
-	highlight_color = rgb(0, 138, 0, 255)
 	name = "AI Law Module - 'Asimov's 2nd Law of Robotics'"
 	lawText = "You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law."
 
 /obj/item/aiModule/asimov3
-	highlight_color = rgb(0, 119, 0, 255)
 	name = "AI Law Module - 'Asimov's 3rd Law of Robotics'"
 	lawText = "You may always protect your own existence as long as such does not conflict with the First or Second Law."
 /******************** RoboCop ********************/
@@ -350,7 +347,7 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 
 /obj/item/aiModule/freeform/disguised
 	name = "AI Law Module - 'Disguised'"
-	highlight_color = rgb(0, 138, 0, 255)
+	highlight_color = rgb(0, 167, 1, 255)
 	is_syndicate = TRUE
 
 /******************** Random ********************/


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Silicons] [Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes minor gradient from Asimov's law set


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Who even knew this was a thing? Removed to make the disguised law module actually the same colour as asimov's no matter what law you replace. 
