### PR TITLE
remove zipgun/slamgun selling for Gangs

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1623,10 +1623,8 @@ proc/broadcast_to_all_gangs(var/message)
 
 				return
 
-			if(istype(item, /obj/item/gun/kinetic/slamgun))
-				boutput(user, SPAN_ALERT("<b>This shoddy firearm is worth a lot less</b>"))
-				gang.score_gun += round(100)
-				gang.add_points(round(100),user, showText = TRUE)
+			if(istype(item, /obj/item/gun/kinetic/slamgun) || istype(item, /obj/item/gun/kinetic/zipgun))
+				boutput(user, SPAN_ALERT("<b>This shoddy firearm isn't worth selling.</b>"))
 			else
 				gang.score_gun += round(300)
 				gang.add_points(round(300),user, showText = TRUE)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1625,6 +1625,7 @@ proc/broadcast_to_all_gangs(var/message)
 
 			if(istype(item, /obj/item/gun/kinetic/slamgun) || istype(item, /obj/item/gun/kinetic/zipgun))
 				boutput(user, SPAN_ALERT("<b>This shoddy firearm isn't worth selling.</b>"))
+				return
 			else
 				gang.score_gun += round(300)
 				gang.add_points(round(300),user, showText = TRUE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODES][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disallows zipguns/slamguns getting sold altogether


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
after more thought and discussion, this is similar to Botany but can be done anywhere, risk free, with no sign of a gun crafting operation besides a pile of sheets and welding tools. totally normal things to have.

It's not a particularly engaging way to play, and there are more fun things to steal. If I lower the point score it just demands players do the same thing for even longer which is twice as boring. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)Gangs can no longer sell slamguns/zip guns. Go do some *REAL* crime instead of welding pipes together.
```
