### PR TITLE
Adds Job XP reward for completing crew objectives

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -71,6 +71,7 @@
 
 ABSTRACT_TYPE(/datum/objective/crew)
 /datum/objective/crew
+	var/XPreward = 50
 
 /datum/objective/crew/custom
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -649,6 +649,7 @@ var/global/current_state = GAME_STATE_INVALID
 			if(CO.check_completion())
 				crewMind.completed_objs++
 				boutput(crewMind.current, "<B>Objective #[count]</B>: [CO.explanation_text] [SPAN_SUCCESS("<B>Success</B>")]")
+				JOB_XP(crewMind.current, crewMind.assigned_role, 50)
 				logTheThing(LOG_DIARY, crewMind, "completed objective: [CO.explanation_text]")
 				if (!isnull(CO.medal_name) && !isnull(crewMind.current))
 					crewMind.current.unlock_medal(CO.medal_name, CO.medal_announce)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -649,7 +649,7 @@ var/global/current_state = GAME_STATE_INVALID
 			if(CO.check_completion())
 				crewMind.completed_objs++
 				boutput(crewMind.current, "<B>Objective #[count]</B>: [CO.explanation_text] [SPAN_SUCCESS("<B>Success</B>")]")
-				JOB_XP(crewMind.current, crewMind.assigned_role, 50)
+				JOB_XP(crewMind.current, crewMind.assigned_role, CO.XPreward)
 				logTheThing(LOG_DIARY, crewMind, "completed objective: [CO.explanation_text]")
 				if (!isnull(CO.medal_name) && !isnull(crewMind.current))
 					crewMind.current.unlock_medal(CO.medal_name, CO.medal_announce)


### PR DESCRIPTION
<!-- [player actions] [qol]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a crew objective is completed, it grants XP (Default 50) for whatever job the mind was assigned at the start of the round. This includes jobs that otherwise wouldn't be able to gain XP, like Captain.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes a good deal of sense for job XP to be awarded when you complete job-specific quests, and it helps out jobs that otherwise have little to no XP gain (like Bartender, whose top 20 players have a median of less that 1,500 XP). It still shouldn't be a major source of XP if you're grinding out hundreds of XP per shift, but it'll help a lot if the way you play your role doesn't involve repeatedly doing the things that give XP. This extra incentive to do objectives might also promote people adding new, interesting objectives, or just interacting with them more in general!

```changelog
(u)mintyphresh
(+)Completing a crew objective now grants 50 XP for that job.
```
