### PR TITLE
Commander cards now keep access when emagged

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -281,7 +281,7 @@ TYPEINFO(/obj/item/card/emag)
 		all_accesses -= new_access
 		if (istype(src, /obj/item/card/id/syndicate)) // Nuke ops unable to exit their station (Convair880).
 			src.access += access_syndicate_shuttle
-			if (istype(src, /obj/item/card/id/syndicate/commander)) // Commander unable to play their cool tunes
+		if (istype(src, /obj/item/card/id/syndicate/commander)) // Commander unable to play their cool tunes
 			src.access += access_syndicate_commander
 		DEBUG_MESSAGE("[get_access_desc(new_access)] added to [src]")
 	user?.show_text("You run [E] over [src], scrambling its access.", "red")

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -281,6 +281,8 @@ TYPEINFO(/obj/item/card/emag)
 		all_accesses -= new_access
 		if (istype(src, /obj/item/card/id/syndicate)) // Nuke ops unable to exit their station (Convair880).
 			src.access += access_syndicate_shuttle
+			if (istype(src, /obj/item/card/id/syndicate/commander)) // Commander unable to play their cool tunes
+			src.access += access_syndicate_commander
 		DEBUG_MESSAGE("[get_access_desc(new_access)] added to [src]")
 	user?.show_text("You run [E] over [src], scrambling its access.", "red")
 	logTheThing(LOG_STATION, user || usr, "emagged [src], scrambling its access and granting random access at [log_loc(user || usr)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Syndicate Operative Commander ID cards now keep their commander access after being emagged


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
How will they announce to the crew their intent to kill them all if they cant get in their room?
