### PR TITLE
Karma affects *snap and *twirl fuckups

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1480,7 +1480,7 @@
 						if (src.bioHolder.HasEffect("chime_snaps"))
 							src.sound_fingersnap = 'sound/musical_instruments/WeirdChime_5.ogg'
 							src.sound_snap = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
-						if (prob(5) && !istype(src.gloves, /obj/item/clothing/gloves/bladed))
+						if (prob(5) && src.mind.karma < 0 && !istype(src.gloves, /obj/item/clothing/gloves/bladed))
 							message = SPAN_ALERT("<B>[src]</B> snaps [his_or_her(src)] fingers RIGHT OFF!")
 							/*
 							if (src.bioHolder)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1574,7 +1574,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	if(src in user.juggling)
 		return ""
 
-	if (((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || prob(5)) && !src.cant_drop)
+	if (((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50)) || (user.reagents && prob(user.reagents.get_reagent_amount("ethanol") / 2)) || (user.mind.karma < 20 && prob(5))) && !src.cant_drop)
 		. = "<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand, and drops it right on the ground.[prob(10) ? " What an oaf." : null]"
 		user.u_equip(src)
 		src.set_loc(user.loc)


### PR DESCRIPTION
<!-- [player actions] [qol] -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Accidentally dropping items you twirl will never happen if your karma is above 30. (below that point, default 5% chance to fail remains)
Snapping your fingers will never snap them off if your karma is above 0. (below that point, default 5% chance to fail remains)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Emotes are great for RP, but the fingersnap causing relatively grievous injury can disrupt flow and just... doesn't really add much. Twirl probably doesn't need this as badly as fingersnap, but having a nice little passive reward for people with good karma seems cool.
