### PR TITLE
Fix CO2 heating up too much from neutrons

### DIFF
--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -161,8 +161,8 @@ What are the archived variables for?
 	if(neutron_count && src.carbon_dioxide > 1) //CO2 acts like a gaseous control rod
 		var/co2_react_count = round((src.carbon_dioxide - (src.carbon_dioxide % (NEUTRON_CO2_REACT_MOLS_PER_LITRE*src.volume)))/(NEUTRON_CO2_REACT_MOLS_PER_LITRE*src.volume)) + prob(src.carbon_dioxide % (NEUTRON_CO2_REACT_MOLS_PER_LITRE*src.volume))
 		co2_react_count = rand(0, co2_react_count) //make it a little probabilistic
-		src.temperature += 5*co2_react_count
-		neutron_count -= co2_react_count
+		src.temperature += 5*min(neutron_count, co2_react_count)
+		neutron_count -= min(neutron_count, co2_react_count)
 
 	if(neutron_count && src.radgas > 1)
 		//rare chance for radgas to decompose into a random gas when hit by a neutron


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
One neutron is supposed to be absorbed by the CO2, and *that* produces heat. Not react with every mole of CO2 in the tank.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Little mistake, you shouldn't be able to heat up cans of CO2 by hundreds of degrees with a single neutron.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)CO2 will now heat up much less from neutrons.
```
