### PR TITLE
Table frame density fix

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -1191,6 +1191,7 @@ TYPEINFO(/obj/table/glass)
 			src.UpdateOverlays(null, "SEcorner")
 			src.UpdateOverlays(null, "NEcorner")
 			src.UpdateOverlays(null, "NWcorner")
+			src.set_density(0)
 			return
 
 		// check it out a new piece of hacky nonsense


### PR DESCRIPTION
Fixes glass table frames having density on construction, bringing them in line with broken tables, which have no density.