### PR TITLE
Tie Jetpack Mk2 water movement speed effect to activation

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -464,7 +464,7 @@
 
 /obj/ability_button/jetpack2_toggle
 	name = "Toggle jetpack MKII"
-	icon_state = "jetoff"
+	icon_state = "jet2off"
 	requires_equip = TRUE
 
 	execute_ability()

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -412,10 +412,18 @@ TYPEINFO(/obj/item/tank/jetpack)
 	item_state = "jetpack_mk2_0"
 	desc = "Suitable for underwater work, this back-mounted DPV lets you glide through the ocean depths with ease."
 	extra_desc = "It comes pre-loaded with oxygen, which is used for internals as well as to power its propulsion system."
+	abilities = list(/obj/ability_button/jetpack2_toggle, /obj/ability_button/tank_valve_toggle)
 
-	New()
-		..()
-		setProperty("negate_fluid_speed_penalty", 0.6)
+	toggle()
+		. = ..()
+		if (src.on)
+			src.setProperty("negate_fluid_speed_penalty", 0.6)
+		else
+			src.delProperty("negate_fluid_speed_penalty")
+		if (ismob(src.loc))
+			var/mob/M = src.loc
+			M.update_equipped_modifiers()
+
 
 /obj/item/tank/jetpack/syndicate
 	name = "jetpack (oxygen)"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2605,6 +2605,9 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/oresatchelL,
 		/datum/manufacture/microjetpack,
 		/datum/manufacture/jetpack,
+#ifdef UNDERWATER_MAP
+		/datum/manufacture/jetpackmkII,
+#endif
 		/datum/manufacture/geoscanner,
 		/datum/manufacture/geigercounter,
 		/datum/manufacture/eyes_meson,
@@ -2612,9 +2615,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 		/datum/manufacture/ore_accumulator,
 		/datum/manufacture/rods2,
 		/datum/manufacture/metal,
-#ifdef UNDERWATER_MAP
-		/datum/manufacture/jetpackmkII,
-#endif
 #ifndef UNDERWATER_MAP
 		/datum/manufacture/mining_magnet
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rework][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the Jetpack MK2 to only negate water movement speed delay if it's active, instead of free at all times.

Related changes:
* Fixed the iniital icon for jetpack mk2
* Move the Jetpack Mk2 directly after the other jetpacks in the mining fabricator

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18420 by way of making the button Do Something