### PR TITLE
Air scrubber charges power based on volume of collected reagents

### DIFF
--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -86,7 +86,7 @@ TYPEINFO(/obj/machinery/portable_atmospherics/scrubber)
 			var/obj/fluid/airborne/F = my_turf.active_airborne_liquid
 			if (F?.group)
 				F.group.drain(F, inlet_flow / 8, src.buffer)
-				active_power_usage += src.buffer.total_volume * 5 KILO WATTS
+				active_power_usage += src.buffer.reagents.total_volume * 5 KILO WATTS
 				// src.buffer.reagents.remove_any(src.buffer.reagents.total_volume/2)
 				if (src.reagents.total_volume < src.reagents.maximum_volume)
 					src.buffer.transfer_all_reagents(src)

--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -85,8 +85,8 @@ TYPEINFO(/obj/machinery/portable_atmospherics/scrubber)
 		if (my_turf)
 			var/obj/fluid/airborne/F = my_turf.active_airborne_liquid
 			if (F?.group)
-				active_power_usage += (inlet_flow / 8) * 5 KILO WATTS
 				F.group.drain(F, inlet_flow / 8, src.buffer)
+				active_power_usage += src.buffer.total_volume * 5 KILO WATTS
 				// src.buffer.reagents.remove_any(src.buffer.reagents.total_volume/2)
 				if (src.reagents.total_volume < src.reagents.maximum_volume)
 					src.buffer.transfer_all_reagents(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][atmos]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Charge power based on amount of smoke filtered out, not the amount potentially filtered. This will charge up to the current maximum power rate if the smoke is thick enough, but scales down with lighter and lighter clouds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18457 by way of making power drain feel more consistent with usage at lower volumes e.g. corpse rotting instead of what feels like an arbitrary spike.

Matches the pattern with air filters where it is charged per moles filtered out, not air processed.