### PR TITLE
Fix remote tableslamming

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -379,13 +379,13 @@ TYPEINFO_NEW(/obj/table)
 	hitby(atom/movable/AM, datum/thrown_thing/thr)
 		. = ..()
 		if (ismob(AM))
-			if (AM != thr.user && (BOUNDS_DIST(thr.user, src) <= 0))
+			if (AM != thr.thrown_by && (BOUNDS_DIST(thr.thrown_by, src) <= 0))
 				var/remove_tablepass = HAS_FLAG(AM.flags, TABLEPASS) ? FALSE : TRUE //this sucks and should be a mob property x2 augh
 				AM.flags |= TABLEPASS
 				step(AM, get_dir(AM, src))
 				if (remove_tablepass)
 					REMOVE_FLAG(AM.flags, TABLEPASS)
-				src.harm_slam(thr.user, AM)
+				src.harm_slam(thr.thrown_by, AM)
 
 
 //Replacement for monkies walking through tables: They now parkour over them.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Graviton launcher set the thrown object's user to the person who anchored it in order to preserve logging on thrown items, however thrown_by is only set via an active throw.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18070
