### PR TITLE
Early gang leader dropouts transfer their role

### DIFF
--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -3,6 +3,13 @@
 /// How long the leader must cryo before gang members can take their role
 #define GANG_CRYO_LOCKOUT 7.5 MINUTES
 
+/// How long into the shift gang leadership is transferable, in the case of the leader's suicide/death.
+// Note: this makes a member REPLACE the dead leader. The leader remains a member.
+#define GANG_LEADER_SOFT_DEATH_TIME 20 MINUTES
+/// If a gang locker exists, how long to wait before picing a new leader
+// This is for the use case where the leader has done the bare minimum.
+#define GANG_LEADER_SOFT_DEATH_DELAY 5 MINUTES
+
 // -------------------------
 // GANG ECONOMY
 // -------------------------

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -328,11 +328,28 @@ proc/broadcast_to_all_gangs(var/message)
 				result++
 		return result
 
+	/// how to handle the gang leader dying horribly early into the shift (suicide etc)
+	proc/handle_leader_early_death()
+		if (!src.locker)
+			choose_new_leader()
+			logTheThing(LOG_ADMIN, src.leader.ckey, "was given the role of leader for [gang_name], as their previous leader died early with no locker.")
+			message_admins("[src.leader.ckey] has been granted the role of leader for their gang, [gang_name], as the previous leader died early with no locker.")
+			broadcast_to_gang("Your leader has died early into the shift. Leadership has been transferred to [src.leader.current.real_name]")
+		else
+			broadcast_to_gang("Your leader has died early into the shift. If not revived, a new leader will be picked in [GANG_LEADER_SOFT_DEATH_DELAY/(1 MINUTE)] minutes.")
+			SPAWN (GANG_LEADER_SOFT_DEATH_DELAY)
+				if (!isalive(src.leader.current))
+					choose_new_leader()
+					logTheThing(LOG_ADMIN, src.leader.ckey, "was given the role of leader for [gang_name], as their previous leader died early and wasn't respawned/revived.")
+					message_admins("[src.leader.ckey] has been granted the role of leader for their gang, [gang_name], as the previous leader died early and wasn't respawned/revived.")
+					broadcast_to_gang("Your leader has died early into the shift. Leadership has been transferred to [src.leader.current.real_name]")
+
 	/// how to handle the gang leader entering cryo (but not guaranteed to be permanent)
 	proc/handle_leader_temp_cryo()
 		if (!src.locker)
 			choose_new_leader()
 		else
+			// the delay here is handled by the locker.
 			broadcast_to_gang("Your leader has entered temporary cryogenic storage. You can claim leadership at your locker in [GANG_CRYO_LOCKOUT/(1 MINUTE)] minutes.")
 
 	/// handle the gang leader entering cryo permanently
@@ -341,6 +358,9 @@ proc/broadcast_to_all_gangs(var/message)
 			broadcast_to_gang("Your leader has entered permanent cryogenic storage. You can claim leadership at your locker.")
 			leader_claimable = TRUE
 		else
+			logTheThing(LOG_ADMIN, src.leader.ckey, "was given the role of leader for [gang_name], as their leader cryo'd without a locker.")
+			message_admins("[src.leader.ckey] has been granted the role of leader for their gang, [gang_name], as leader cryo'd without a locker.")
+			broadcast_to_gang("As your leader has entered cryogenic storage without a locker, [src.leader.current.real_name] is now your new leader.")
 			choose_new_leader()
 
 	proc/choose_new_leader()
@@ -351,8 +371,8 @@ proc/broadcast_to_all_gangs(var/message)
 				if (!candidate.hibernating)
 					smelly_unfortunate = member
 		if (!smelly_unfortunate)
-			logTheThing(LOG_ADMIN, leader.ckey, "The leader of [gang_name] cryo'd with no living members to take the role.")
-			message_admins("The leader of [gang_name], [leader.ckey] cryo'd with no living members to take the role.")
+			logTheThing(LOG_ADMIN, leader.ckey, "The leader of [gang_name] cryo'd/died early with no living members to take the role.")
+			message_admins("The leader of [gang_name], [leader.ckey] cryo'd/died early with no living members to take the role.")
 			return
 
 		var/datum/mind/bad_leader = leader
@@ -363,9 +383,6 @@ proc/broadcast_to_all_gangs(var/message)
 		smelly_unfortunate.remove_antagonist(ROLE_GANG_MEMBER,ANTAGONIST_REMOVAL_SOURCE_OVERRIDE,FALSE)
 		leaderRole.transfer_to(smelly_unfortunate, FALSE, ANTAGONIST_REMOVAL_SOURCE_EXPIRED)
 		bad_leader.add_subordinate_antagonist(ROLE_GANG_MEMBER, master = smelly_unfortunate)
-		logTheThing(LOG_ADMIN, smelly_unfortunate.ckey, "was given the role of leader for [gang_name], as their leader entered cryo with no locker.")
-		message_admins("[smelly_unfortunate.ckey] has been granted the role of leader for their gang, [gang_name], as their leader entered cryo with no locker.")
-		broadcast_to_gang("As your leader has entered cryogenic storage without a locker, [smelly_unfortunate.current.real_name] is now your new leader.")
 
 	proc/get_dead_memberlist()
 		var/list/result = list()

--- a/code/modules/antagonists/gang/gang_leader.dm
+++ b/code/modules/antagonists/gang/gang_leader.dm
@@ -28,6 +28,11 @@
 
 		. = ..()
 
+	on_death()
+		if (GANG_LEADER_SOFT_DEATH_TIME > ticker.round_elapsed_ticks)
+			src.gang.handle_leader_early_death()
+		..()
+
 	handle_cryo()
 		src.gang.handle_leader_temp_cryo()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If gang leaders die less than 20 minutes into a shift, leadership will pass over instantly (if the leader has not placed a locker) or in 5 minutes if the gang leader has placed a locker.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Leaders don't always cryo - some suicide when they aren't up to the task of playing Gang Leader.

Gangs still lasts a full shift, even if the leader offs themself. And headless gangs suck. 
However, gangs should also still be stoppable later on if they're causing trouble. 20 minutes seems like a reasonable buffer.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Gangs will randomly elect a new leader if their current one dies early into a shift.
```
