### PR TITLE
Fix map created N.A.R.C.S. turrets appearing off

### DIFF
--- a/assets/maps/prefabs/space/prefab_secbot_academy.dmm
+++ b/assets/maps/prefabs/space/prefab_secbot_academy.dmm
@@ -325,9 +325,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/noGenerate)
 "nG" = (
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1;
+/obj/deployable_turret/riot/active{
 	desc = "A Nanotrasen Automatic Riot Control System repurposed for home security.";
 	dir = 4
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -28917,9 +28917,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1;
+/obj/deployable_turret/riot/active{
 	dir = 1
 	},
 /turf/simulated/floor/redblack,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -51003,10 +51003,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "mMm" = (
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1
-	},
+/obj/deployable_turret/riot/active,
 /obj/machinery/turretid{
 	name = "External perimeter turret deactivation control";
 	pixel_y = 28;

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29760,9 +29760,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/hos,
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1;
+/obj/deployable_turret/riot/active{
 	dir = 1
 	},
 /turf/simulated/floor/engine{

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -895,9 +895,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
 "aso" = (
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1;
+/obj/deployable_turret/riot/active{
 	dir = 8
 	},
 /obj/mapping_helper/access/hos,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -56171,10 +56171,7 @@
 	},
 /area/station/engine/hotloop)
 "fqj" = (
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1
-	},
+/obj/deployable_turret/riot/active,
 /obj/machinery/turretid{
 	name = "External perimeter turret deactivation control";
 	pixel_y = 28;

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -6088,10 +6088,7 @@
 /area/abandonedmedicalship)
 "aHh" = (
 /obj/decal/cleanable/dirt,
-/obj/deployable_turret/riot{
-	active = 1;
-	anchored = 1
-	},
+/obj/deployable_turret/riot/active,
 /turf/simulated/floor/airless/plating/damaged1,
 /area/abandonedmedicalship)
 "aHi" = (


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes N.A.R.C.S./NARCS turrets added through the map editor, so that they correctly appear on, as they actually are on. Currently they appear off until they first fire at someone


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix