### PR TITLE
See SecHUD Flag regardless of arrest icon status

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -127,13 +127,12 @@
 				else
 					. += "<br>[SPAN_NOTICE("[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(desc_id_card)] [desc_id_card.name] in it.")]"
 
-	if (src.arrestIcon?.icon_state)
-		if(global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount[usr]) // are you in the list of people who can see arrest icons??
-			var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
-			if(sec_record)
-				var/sechud_flag = sec_record["sec_flag"]
-				if (lowertext(sechud_flag) != "none")
-					. += "<br>[SPAN_NOTICE("[src.name] has a Security HUD flag set:")] [SPAN_ALERT("[sechud_flag]")]"
+	if(global.client_image_groups?[CLIENT_IMAGE_GROUP_ARREST_ICONS]?.subscribed_mobs_with_subcount[usr]) // are you in the list of people who can see arrest icons??
+		var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
+		if(sec_record)
+			var/sechud_flag = sec_record["sec_flag"]
+			if (lowertext(sechud_flag) != "none")
+				. += "<br>[SPAN_NOTICE("[src.name] has a Security HUD flag set:")] [SPAN_ALERT("[sechud_flag]")]"
 
 	if (locate(/obj/item/implant/projectile/body_visible/dart) in src.implant)
 		var/count = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][station-systems][possibly-intended]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
No longer check for arrest status (via icon_state) for adding SecHUD Flag text to a person's description.

Will result in more data_core usage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18479

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)SecHUD users can see a person's SecHUD Flag regardless of criminal status.
```
