### PR TITLE
Small fixes to broken bottle attacks

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -654,7 +654,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
 		// in this case m is the consumer and user is the one holding it
-		if (istype(src, /obj/item/reagent_containers/food/drinks/bottle/soda))
+		if (istype(src, /obj/item/reagent_containers/food/drinks/bottle))
 			var/obj/item/reagent_containers/food/drinks/bottle/W = src
 			if (W.broken)
 				return
@@ -1047,7 +1047,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 					take_bleeding_damage(user, null, damage)
 			else
 				src.shatter++
-				user.visible_message(SPAN_ALERT("<b>[user]</b> [pick("shanks","stabs","attacks")] [target] with the broken [src]!"))
+				user.visible_message(SPAN_ALERT("<b>[user]</b> [pick("shanks","stabs","attacks")] [target] with the broken [src.name]!"))
 				logTheThing(LOG_COMBAT, user, "attacks [constructTarget(target,"combat")] with a broken [src] at [log_loc(user)].")
 				playsound(target, 'sound/impact_sounds/Flesh_Stab_1.ogg', 60, TRUE)
 				var/damage = rand(1,10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Make broken beer/etc bottles no longer try to make the bottle stabbing victim drink from it
* use `src.name` instead of `src` so it doesn't prepend "the" before the bottle
  * current: `with the broken the white wine bottle`
  * this PR: `with the broken white wine bottle`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i was testing it and it's wrong and it bugged me