### PR TITLE
Fix click-dragging from tile to fitness machine causing runtime

### DIFF
--- a/code/obj/item/fitness.dm
+++ b/code/obj/item/fitness.dm
@@ -53,7 +53,7 @@
 
 	MouseDrop_T(var/mob/M, var/mob/user)
 		// Do not attempt to distantly pump iron.
-		if (!can_reach(user, src) || !can_reach(user, M))
+		if (M != user || !can_reach(user, src) || !can_reach(user, M))
 			return
 		src.attack_hand(M)
 
@@ -107,7 +107,7 @@
 
 	MouseDrop_T(var/mob/M, var/mob/user)
 		// Do not attempt to distantly pump iron.
-		if (!can_reach(user, src) || !can_reach(user, M))
+		if (M != user || !can_reach(user, src) || !can_reach(user, M))
 			return
 		src.attack_hand(M)
 

--- a/code/obj/item/fitness.dm
+++ b/code/obj/item/fitness.dm
@@ -51,7 +51,7 @@
 	deconstruct_flags = DECON_WRENCH
 	var/in_use = 0
 
-	MouseDrop_T(var/mob/M, var/mob/user)
+	MouseDrop_T(mob/M, mob/user)
 		// Do not attempt to distantly pump iron.
 		if (M != user || !can_reach(user, src) || !can_reach(user, M))
 			return
@@ -105,7 +105,7 @@
 	deconstruct_flags = DECON_WRENCH
 	var/in_use = 0
 
-	MouseDrop_T(var/mob/M, var/mob/user)
+	MouseDrop_T(mob/M, mob/user)
 		// Do not attempt to distantly pump iron.
 		if (M != user || !can_reach(user, src) || !can_reach(user, M))
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensure you're click-dragging yourself and not turfs, which cause a runtime here.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18483
