### PR TITLE
Make phones chat text work like other chat sources

### DIFF
--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -337,6 +337,7 @@ TYPEINFO(/obj/machinery/phone)
 	var/obj/machinery/phone/parent = null
 	flags = TALK_INTO_HAND
 	w_class = W_CLASS_TINY
+	var/icon/handset_icon = null
 
 	New(var/obj/machinery/phone/parent_phone, var/mob/living/picker_upper)
 		if(!parent_phone)
@@ -349,6 +350,7 @@ TYPEINFO(/obj/machinery/phone)
 		stripe_image.appearance_flags = RESET_COLOR | PIXEL_SCALE
 		src.color = parent_phone.color
 		src.UpdateOverlays(stripe_image, "stripe")
+		src.handset_icon = getFlatIcon(src)
 		processing_items.Add(src)
 
 	proc/get_holder()
@@ -383,27 +385,35 @@ TYPEINFO(/obj/machinery/phone)
 		if(GET_DIST(src, get_holder()) > 0 || !src.parent.linked || !src.parent.linked.handset) // Guess they dropped it? *shrug
 			return
 
-		var/mob/T = src.parent.linked.handset.get_holder()
-		if(T?.client)
-			var/phone_ident = "\[<span style=\"color:[src.color]\"> [bicon(src)] [src.parent.phone_id]\]</span>"
-			var/said_message = SPAN_SAY("[SPAN_BOLD("[M.get_heard_name()] [phone_ident]")]  [SPAN_MESSAGE(M.say_quote(text[1]))]")
-			if (T.client.holder && ismob(M) && M.mind)
-				said_message = "<span class='adminHearing' data-ctx='[T.client.chatOutput.getContextFlags()]'>[said_message]</span>"
-			M.show_message(said_message, 2) // chat feedback to let talker know when they are speaking over the phone
+		var/heard_name = M.get_heard_name(just_name_itself=TRUE)
+		if(M.mind)
+			heard_name = "<span class='name' data-ctx='\ref[M.mind]'>[heard_name]</span>"
+
+		var/obj/item/phone_handset/listener_handset = src.parent.linked.handset
+
+		var/mob/listener = listener_handset.get_holder()
+		if(listener?.client)
+			var/phone_ident = "\[ <span style=\"color:[src.parent.stripe_color]\">[bicon(src.handset_icon)] [src.parent.phone_id]</span> \]"
+			var/said_message = SPAN_SAY("[SPAN_BOLD("[heard_name] [phone_ident]")]  [SPAN_MESSAGE(M.say_quote(text[1]))]")
+			if (listener.client.holder && ismob(M) && M.mind)
+				said_message = "<span class='adminHearing' data-ctx='[listener.client.chatOutput.getContextFlags()]'>[said_message]</span>"
+
+			// chat feedback to let talker know when they are speaking over the phone
+			M.show_message(said_message, 2)
 
 			if(GET_DIST(src.parent.linked.handset,src.parent.linked.handset.get_holder())<1)
-				var/heard_name = M.voice_name
+				var/heard_voice = M.voice_name
 				if(M.mind)
-					heard_name = "<span class='name' data-ctx='\ref[M.mind]'>[heard_name]</span>"
-				if(!T.say_understands(M, lang_id))
-					said_message = SPAN_SAY("[SPAN_BOLD("[heard_name] [phone_ident]")] [SPAN_MESSAGE(M.voice_message)]")
-					if (T.client.holder && ismob(M) && M.mind)
-						said_message = "<span class='adminHearing' data-ctx='[T.client.chatOutput.getContextFlags()]'>[said_message]</span>"
-				T.show_message(said_message, 2)
+					heard_voice = "<span class='name' data-ctx='\ref[M.mind]'>[heard_voice]</span>"
+				if(!listener.say_understands(M, lang_id))
+					said_message = SPAN_SAY("[SPAN_BOLD("[heard_voice] [phone_ident]")] [SPAN_MESSAGE(M.voice_message)]")
+					if (listener.client.holder && ismob(M) && M.mind)
+						said_message = "<span class='adminHearing' data-ctx='[listener.client.chatOutput.getContextFlags()]'>[said_message]</span>"
+				listener.show_message(said_message, 2)
 
 			// intercoms overhear phone conversations
-			for (var/obj/item/device/radio/intercom/I in range(3, T))
-				I.talk_into(M, text, null, M.get_heard_name(), lang_id)
+			for (var/obj/item/device/radio/intercom/I in range(3, listener))
+				I.talk_into(M, text, null, heard_name, lang_id)
 
 TYPEINFO(/obj/machinery/phone/wall)
 	mats = 25

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -385,24 +385,25 @@ TYPEINFO(/obj/machinery/phone)
 
 		var/mob/T = src.parent.linked.handset.get_holder()
 		if(T?.client)
-			var/prep_name = "[real_name ? real_name : M.real_name]"
-			if(M.vdisfigured)
-				prep_name = "Unknown"
-
 			var/phone_ident = "\[<span style=\"color:[src.color]\"> [bicon(src)] [src.parent.phone_id]\]</span>"
-			var/said_message = SPAN_SAY("[SPAN_BOLD("[prep_name] [phone_ident]")]  [SPAN_MESSAGE(M.say_quote(text[1]))]")
-
-			// chat feedback to let talker know when they are speaking over the phone
-			M.show_message(said_message, 2)
+			var/said_message = SPAN_SAY("[SPAN_BOLD("[M.get_heard_name()] [phone_ident]")]  [SPAN_MESSAGE(M.say_quote(text[1]))]")
+			if (T.client.holder && ismob(M) && M.mind)
+				said_message = "<span class='adminHearing' data-ctx='[T.client.chatOutput.getContextFlags()]'>[said_message]</span>"
+			M.show_message(said_message, 2) // chat feedback to let talker know when they are speaking over the phone
 
 			if(GET_DIST(src.parent.linked.handset,src.parent.linked.handset.get_holder())<1)
+				var/heard_name = M.voice_name
+				if(M.mind)
+					heard_name = "<span class='name' data-ctx='\ref[M.mind]'>[heard_name]</span>"
 				if(!T.say_understands(M, lang_id))
-					said_message = SPAN_SAY("[SPAN_BOLD("[M.voice_name] [phone_ident]")] [SPAN_MESSAGE(M.voice_message)]")
+					said_message = SPAN_SAY("[SPAN_BOLD("[heard_name] [phone_ident]")] [SPAN_MESSAGE(M.voice_message)]")
+					if (T.client.holder && ismob(M) && M.mind)
+						said_message = "<span class='adminHearing' data-ctx='[T.client.chatOutput.getContextFlags()]'>[said_message]</span>"
 				T.show_message(said_message, 2)
 
 			// intercoms overhear phone conversations
 			for (var/obj/item/device/radio/intercom/I in range(3, T))
-				I.talk_into(M, text, null, prep_name, lang_id)
+				I.talk_into(M, text, null, M.get_heard_name(), lang_id)
 
 TYPEINFO(/obj/machinery/phone/wall)
 	mats = 25

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -382,15 +382,27 @@ TYPEINFO(/obj/machinery/phone)
 		..()
 		if(GET_DIST(src, get_holder()) > 0 || !src.parent.linked || !src.parent.linked.handset) // Guess they dropped it? *shrug
 			return
-		var/processed = SPAN_SAY("[SPAN_BOLD("[M.name] \[<span style=\"color:[src.color]\"> [bicon(src)] [src.parent.phone_id]")]\] says, </span> [SPAN_MESSAGE("\"[text[1]]\"")]")
+
 		var/mob/T = src.parent.linked.handset.get_holder()
 		if(T?.client)
-			if(GET_DIST(src.parent.linked.handset,src.parent.linked.handset.get_holder())<1)
-				T.show_message(processed, 2)
-			M.show_message(processed, 2)
+			var/prep_name = "[real_name ? real_name : M.real_name]"
+			if(M.vdisfigured)
+				prep_name = "Unknown"
 
+			var/phone_ident = "\[<span style=\"color:[src.color]\"> [bicon(src)] [src.parent.phone_id]\]</span>"
+			var/said_message = SPAN_SAY("[SPAN_BOLD("[prep_name] [phone_ident]")]  [SPAN_MESSAGE(M.say_quote(text[1]))]")
+
+			// chat feedback to let talker know when they are speaking over the phone
+			M.show_message(said_message, 2)
+
+			if(GET_DIST(src.parent.linked.handset,src.parent.linked.handset.get_holder())<1)
+				if(!T.say_understands(M, lang_id))
+					said_message = SPAN_SAY("[SPAN_BOLD("[M.voice_name] [phone_ident]")] [SPAN_MESSAGE(M.voice_message)]")
+				T.show_message(said_message, 2)
+
+			// intercoms overhear phone conversations
 			for (var/obj/item/device/radio/intercom/I in range(3, T))
-				I.talk_into(M, text, null, M.real_name, lang_id)
+				I.talk_into(M, text, null, prep_name, lang_id)
 
 TYPEINFO(/obj/machinery/phone/wall)
 	mats = 25


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Phones respect heard names (e.g. voice changer, disfigured voice)
* Phones respect language barriers (e.g. hearing monkey chimpers w/o a translator)
* Phones display their handset color in chat text icons/name
* Admin context menu available for chat text sent via phone

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15428

## Screenshots
![Screenshot 2024-04-13 054209](https://github.com/goonstation/goonstation/assets/91498627/07b7efe7-24ae-42ac-8896-67b592cbf7ff)
![Screenshot 2024-04-13 054339](https://github.com/goonstation/goonstation/assets/91498627/9bf21fcb-0b52-4046-8c1c-087fd6c62eb9)
![Screenshot 2024-04-13 054516](https://github.com/goonstation/goonstation/assets/91498627/205d3564-cf1d-4a70-8985-16a9effca510)
