### PR TITLE
Specify whether antagonists are silicon at end of round crew credits

### DIFF
--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -254,12 +254,18 @@
 	// Determine whether this antagonist is dead or alive, and where they currently are.
 	var/status = "Unknown"
 	if (!isdead(mind.current))
-		if (mind.current.z == Z_LEVEL_STATION)
-			status = "Alive, On Station"
-		else if (istype(get_area(mind.current), /area/centcom) || istype(get_area(mind.current), /area/shuttle/escape) )
-			status = "Alive, At CentComm"
+		// status
+		if(issilicon(mind.current))
+			status = "Silicon, " // you made it, but not really
 		else
-			status = "Alive, Off Station"
+			status = "Alive, "
+		// where
+		if (mind.current.z == Z_LEVEL_STATION)
+			status += "On Station"
+		else if (istype(get_area(mind.current), /area/centcom) || istype(get_area(mind.current), /area/shuttle/escape) )
+			status += "At CentComm"
+		else
+			status += "Off Station"
 
 	else
 		var/mob/corpse


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ui][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If an antagonist is alive at end of round, specify if they are "Silicon" instead of "Alive".

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being a silicon does not count as "alive" for antag objectives, so the word "Alive" in the antag status next to a failed "Stay alive until end of shift" objective confused someone.

