### PR TITLE
Adjust Kondaru's cargo backroom areas

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -14923,7 +14923,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "biz" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/mail/bent/east,
@@ -27676,7 +27676,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cif" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -27688,7 +27688,7 @@
 "cii" = (
 /obj/machinery/launcher_loader/north,
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cij" = (
 /obj/machinery/launcher_loader/north,
 /turf/simulated/floor/airless/plating,
@@ -27696,11 +27696,11 @@
 "cil" = (
 /obj/machinery/launcher_loader/west,
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cim" = (
 /obj/machinery/cargo_router/kd_shunt_nw,
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cip" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -27715,7 +27715,7 @@
 /area/space)
 "cir" = (
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cit" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -27730,7 +27730,7 @@
 	name = "autoname - SS13"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "ciw" = (
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/airless/plating,
@@ -30799,7 +30799,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "cMy" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -31126,7 +31126,7 @@
 "cVR" = (
 /obj/machinery/r_door_control/podbay/qm,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "cVY" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -31160,7 +31160,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "cXY" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -31276,7 +31276,7 @@
 /area/station/crew_quarters/quarters_south)
 "daf" = (
 /turf/simulated/floor/caution/corner/sw,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "daF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -32036,11 +32036,14 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "dDs" = (
-/obj/machinery/door_control/podbay/qm/new_walls/north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "dDK" = (
 /obj/machinery/computer3/generic/radio,
 /obj/cable{
@@ -32569,7 +32572,7 @@
 /turf/simulated/floor/shuttlebay{
 	icon_state = "engine_caution_south"
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "dUm" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom/catering{
@@ -33052,7 +33055,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/engine,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "ekv" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
@@ -33261,6 +33264,9 @@
 "etp" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
@@ -34376,6 +34382,9 @@
 /obj/strip_door,
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
+"fdF" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/qm)
 "fdN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
@@ -34416,7 +34425,7 @@
 	id = "kd_qmnorth"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "fhx" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -34555,7 +34564,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "fle" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
@@ -34884,7 +34893,7 @@
 "fwR" = (
 /obj/machinery/vehicle/pod_smooth/industrial,
 /turf/simulated/floor/engine,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "fxg" = (
 /obj/machinery/door_control{
 	id = "imports_door";
@@ -36017,7 +36026,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/engine,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "gnU" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/unsimulated/floor/circuit/vintage,
@@ -36546,7 +36555,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "gGB" = (
 /obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/grey,
@@ -37290,7 +37299,7 @@
 	name = "Cargo Bay"
 	},
 /turf/simulated/floor/caution/northsouth,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "heQ" = (
 /obj/stool/chair{
 	dir = 1
@@ -37679,7 +37688,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "hvX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -37938,11 +37947,19 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door_control/podbay/qm/new_walls/north{
+	pixel_x = -8
+	},
 /turf/simulated/floor/grey/side{
 	dir = 5
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "hJP" = (
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -38267,6 +38284,9 @@
 /obj/mapping_helper/access/cargo,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
@@ -38712,7 +38732,7 @@
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/caution/south,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "ixo" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
@@ -38901,7 +38921,7 @@
 "iDs" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "iDK" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
@@ -39256,7 +39276,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "iMh" = (
 /obj/machinery/light{
 	dir = 4;
@@ -40339,7 +40359,7 @@
 /area/station/mining/staff_room)
 "jAw" = (
 /turf/simulated/floor/caution/west,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "jAA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41910,7 +41930,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "kMV" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/caution/north,
@@ -42941,7 +42961,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "lxi" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43389,7 +43409,7 @@
 	id = "kd_qmwest"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "lJY" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/grey,
@@ -45116,7 +45136,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "nhF" = (
 /obj/stool/chair{
 	dir = 4
@@ -45299,7 +45319,7 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "nnO" = (
 /obj/machinery/conveyor/NS{
 	name = "cargo belt - south";
@@ -45476,7 +45496,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "nBe" = (
 /obj/storage/secure/closet/research/chemical,
 /obj/machinery/light,
@@ -48881,7 +48901,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "pZM" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/landmark/halloween,
@@ -48950,7 +48970,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/caution/south,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "qcN" = (
 /obj/machinery/light{
 	dir = 8;
@@ -49455,7 +49475,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "quE" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -49924,7 +49944,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "qON" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
@@ -50395,7 +50415,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "rhr" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -50909,6 +50929,9 @@
 	allows_vehicles = 0
 	},
 /area/station/ai_monitored/armory)
+"rAe" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/qm)
 "rAg" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/supernorn,
@@ -51832,7 +51855,7 @@
 	operating = 1
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/office)
+/area/station/quartermaster/cargobay)
 "snN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -52140,7 +52163,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "szp" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -53652,6 +53675,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "tFN" = (
@@ -54705,7 +54731,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/grey,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "uvh" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -55134,7 +55160,7 @@
 /area/station/hallway/primary/east)
 "uLg" = (
 /turf/simulated/floor/engine,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "uLm" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -56082,6 +56108,9 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "vsV" = (
@@ -56421,7 +56450,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "vGH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -56816,7 +56845,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "wbJ" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/atmospherics/pipe/simple{
@@ -58056,7 +58085,7 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
-/area/station/quartermaster/cargobay)
+/area/station/hangar/qm)
 "wWN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -103338,14 +103367,14 @@ bWq
 bXh
 bYc
 bYR
-nel
-nel
-nel
-nel
-nel
-nel
-nel
-nel
+rAe
+rAe
+rAe
+rAe
+rAe
+rAe
+rAe
+rAe
 acO
 aaa
 aaa
@@ -103637,10 +103666,10 @@ bSL
 bUd
 bVg
 bWr
-nel
-nel
+rAe
+rAe
 iLW
-nel
+rAe
 eku
 gnJ
 uLg
@@ -103939,7 +103968,7 @@ bXi
 bXi
 bVg
 bWr
-nel
+rAe
 szl
 iwQ
 uLg
@@ -104241,7 +104270,7 @@ bSN
 bXi
 bVg
 bWr
-nel
+rAe
 bix
 qcE
 uLg
@@ -104543,7 +104572,7 @@ bSO
 bXi
 bVg
 bWr
-nel
+rAe
 cLB
 qcE
 uLg
@@ -104845,7 +104874,7 @@ bSP
 bXi
 bVi
 bWr
-nel
+rAe
 kMH
 qcE
 uLg
@@ -105147,7 +105176,7 @@ bSQ
 bXi
 bVg
 bWr
-nel
+rAe
 pZc
 nnt
 daf
@@ -105157,7 +105186,7 @@ uLg
 uLg
 uLg
 wbB
-nel
+rAe
 aaf
 aaf
 abZ
@@ -105449,7 +105478,7 @@ bSR
 bXi
 bVg
 bWr
-nel
+rAe
 dDs
 qOw
 wWG
@@ -105458,8 +105487,8 @@ jAw
 jAw
 jAw
 iDs
-eAt
-nel
+fdF
+rAe
 aaf
 awS
 aaa
@@ -105751,7 +105780,7 @@ bSS
 bXi
 dHJ
 iuH
-nel
+rAe
 hJL
 vGv
 qub
@@ -109398,7 +109427,7 @@ cid
 cid
 rgY
 cit
-bXi
+eAt
 acO
 aaa
 aaa
@@ -109699,8 +109728,8 @@ aaa
 cXR
 cXR
 nAP
-bXi
-bXi
+eAt
+eAt
 acO
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the following changes to Kondaru's rear cargo bay:
* Change the QM podbay into `hangar/qm` area
    * Add new APC & wiring connection
    * Adjust some buttons to fit
* Change the small outside routing area to quartermaster/cargobay

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fixes #18433
* In nuclear mode, the small router area in space could be planted on, as it technically counted as QM office.
* Parity with all other rotation maps using QM Podbay area where appropriate.

## Screenshot of Area Changes
![image](https://github.com/goonstation/goonstation/assets/91498627/e6516bb4-73da-4d6c-9a1a-ed316caeb6c3)
