### PR TITLE
Fix Atlas crusher door auto-opening

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10009,8 +10009,7 @@
 	id = "crusher";
 	name = "Crusher Door Control";
 	pixel_x = 24;
-	pixel_y = -8;
-	timer = 100
+	pixel_y = -8
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -18647,7 +18646,8 @@
 /obj/machinery/door/poddoor/pyro/shutters{
 	dir = 4;
 	id = "crusher";
-	name = "Crusher Door"
+	name = "Crusher Door";
+	autoclose = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/janitor/office)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the `timer` var on the crusher door button and enables the `autoclose` var on the door itself

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The timer variable on the button doesn't care what state the door is in, meaning that if someone presses the button to open and then presses again to close in <10 seconds, the timer will restart and then auto-open the door at the end, leading to people getting painfully crushed.