### PR TITLE
Organizes pride wardrobe using pixel offsets

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -88,11 +88,15 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 		if (!islist(src.spawn_contents))
 			return 0
 
+		var/i = 0
 		for (var/thing in src.spawn_contents)
 			var/amt = 1
 			if (isnum(spawn_contents[thing])) //Instead of duplicate entries in the list, let's make them associative
 				amt = abs(spawn_contents[thing])
-			do new thing(src)
+			do
+				var/atom/A = new thing(src)
+				A.layer += 0.00001 * i
+				i++
 			while (--amt > 0)
 
 	proc/get_welding_positions()

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -90,11 +90,23 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 
 		for (var/thing in src.spawn_contents)
 			var/amt = 1
+			var/x_offset = 0
+			var/y_offset = 0
 			if (!ispath(thing))
 				continue
 			if (isnum(spawn_contents[thing])) //Instead of duplicate entries in the list, let's make them associative
 				amt = abs(spawn_contents[thing])
-			do new thing(src)	//Two lines! I TOLD YOU I COULD DO IT!!!
+			if (islist(spawn_contents[thing])) //Should hopefully support pixel offsets in spawn_contents
+				var/list/thinginfo = spawn_contents[thing]
+				amt = abs(thinginfo[1])
+				x_offset = thinginfo[2]
+				y_offset = thinginfo[3]
+			do
+				var/thing_i_made = new thing(src)
+				var/obj/I = thing_i_made
+				if (I)
+					I.pixel_x = x_offset
+					I.pixel_y = y_offset
 			while (--amt > 0)
 
 	proc/get_welding_positions()

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -90,23 +90,9 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 
 		for (var/thing in src.spawn_contents)
 			var/amt = 1
-			var/x_offset = 0
-			var/y_offset = 0
-			if (!ispath(thing))
-				continue
 			if (isnum(spawn_contents[thing])) //Instead of duplicate entries in the list, let's make them associative
 				amt = abs(spawn_contents[thing])
-			if (islist(spawn_contents[thing])) //Should hopefully support pixel offsets in spawn_contents
-				var/list/thinginfo = spawn_contents[thing]
-				amt = abs(thinginfo[1])
-				x_offset = thinginfo[2]
-				y_offset = thinginfo[3]
-			do
-				var/thing_i_made = new thing(src)
-				var/obj/I = thing_i_made
-				if (I)
-					I.pixel_x = x_offset
-					I.pixel_y = y_offset
+			do new thing(src)
 			while (--amt > 0)
 
 	proc/get_welding_positions()

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -19,7 +19,6 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "wardrobe"
 	desc = "It's a wardrobe closet! This one can be opened AND closed. Comes prestocked with some changes of clothes."
 	soundproofing = 10
-#define SHOE_Y -12
 
 /* ==================== */
 /* ----- Standard ----- */
@@ -30,97 +29,97 @@ TYPEINFO(/obj/storage/closet/dresser)
 	desc = "A label on it reads: In order to improve workplace efficiency, employees are encouraged to spend no more than 5 minutes in the closet at a time."
 	icon_state = "gay"
 	icon_closed = "gay"
-	spawn_contents = list(/obj/item/clothing/under/pride = list(2, 3, 6), //Quantity, X offset, Y offset
-	/obj/item/clothing/under/pride/ace = list(2, -3, 6),
-	/obj/item/clothing/under/pride/aro = list(2, 3, 3),
-	/obj/item/clothing/under/pride/bi = list(2, -3, 3),
-	/obj/item/clothing/under/pride/inter = list(2, 3, 0),
-	/obj/item/clothing/under/pride/pan = list(2, -3, 0),
-	/obj/item/clothing/under/pride/poly = list(2, 3, -3),
-	/obj/item/clothing/under/pride/nb = list(2, -3, -3),
-	/obj/item/clothing/under/pride/lesb = list(2, 3, -6),
-	/obj/item/clothing/under/pride/gaymasc = list(2, -3, -6),
-	/obj/item/clothing/under/pride/trans = list(2, 0, -9))
+	spawn_contents = list(/obj/item/clothing/under/pride{pixel_x = 3; pixel_y = 6} = 2,
+	/obj/item/clothing/under/pride/ace{pixel_x = -3; pixel_y = 6} = 2,
+	/obj/item/clothing/under/pride/aro{pixel_x = 3; pixel_y = 3} = 2,
+	/obj/item/clothing/under/pride/bi{pixel_x = -3; pixel_y = 3} = 2,
+	/obj/item/clothing/under/pride/inter{pixel_x = 3; pixel_y = 0} = 2,
+	/obj/item/clothing/under/pride/pan{pixel_x = -3; pixel_y = 0} = 2,
+	/obj/item/clothing/under/pride/poly{pixel_x = 3; pixel_y = -3} = 2,
+	/obj/item/clothing/under/pride/nb{pixel_x = -3; pixel_y = -3} = 2,
+	/obj/item/clothing/under/pride/lesb{pixel_x = 3; pixel_y = -6} = 2,
+	/obj/item/clothing/under/pride/gaymasc{pixel_x = -3; pixel_y = -6} = 2,
+	/obj/item/clothing/under/pride/trans{pixel_x = 0; pixel_y = -9} = 2)
 
 /obj/storage/closet/wardrobe/black
 	name = "black wardrobe"
 	icon_state = "black"
 	icon_closed = "black"
-	spawn_contents = list(/obj/item/clothing/under/color = list(4, 0, -3),
-	/obj/item/clothing/shoes/black = list(4, 0, -12),
-	/obj/item/clothing/head/black = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/black{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/black{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/grey
 	name = "grey wardrobe"
 	icon_state = "grey"
 	icon_closed = "grey"
-	spawn_contents = list(/obj/item/clothing/under/color/grey = list(4, 0, -3),
-	/obj/item/clothing/shoes/black = list(5, 0, -12))
+	spawn_contents = list(/obj/item/clothing/under/color/grey{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/black{pixel_x = 0; pixel_y = -12} = 4)
 
 /obj/storage/closet/wardrobe/white
 	name = "white wardrobe"
 	icon_state = "white"
 	icon_closed = "white"
-	spawn_contents = list(/obj/item/clothing/under/color/white = list(4, 0, -3),
-	/obj/item/clothing/shoes/brown = list(4, 0, -12),
-	/obj/item/clothing/head/white  = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/white{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/brown{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/white{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/pink
 	name = "pink wardrobe"
 	icon_state = "pink"
 	icon_closed = "pink"
-	spawn_contents = list(/obj/item/clothing/under/color/pink = list(4, 0, -3),
-	/obj/item/clothing/shoes/brown = list(4, 0, -12))
+	spawn_contents = list(/obj/item/clothing/under/color/pink{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/brown{pixel_x = 0; pixel_y = -12} = 4)
 
 /obj/storage/closet/wardrobe/red
 	name = "red wardrobe"
 	icon_state = "red"
 	icon_closed = "red"
-	spawn_contents = list(/obj/item/clothing/under/color/red = list(4, 0, -3),
-	/obj/item/clothing/shoes/brown = list(4, 0, -12),
-	/obj/item/clothing/head/red = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/red{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/brown{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/red{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/orange
 	name = "orange wardrobe"
 	icon_state = "orange"
 	icon_closed = "orange"
-	spawn_contents = list(/obj/item/clothing/under/color/orange = list(4, 3, -3),
-	/obj/item/clothing/under/misc/prisoner = list(4, -3, -3),
-	/obj/item/clothing/shoes/orange = list(4, 0, -12))
+	spawn_contents = list(/obj/item/clothing/under/color/orange{pixel_x = 3; pixel_y = -3} = 4,
+	/obj/item/clothing/under/misc/prisoner{pixel_x = -3; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/orange{pixel_x = 0; pixel_y = -12} = 4)
 
 /obj/storage/closet/wardrobe/yellow
 	name = "yellow wardrobe"
 	icon_state = "yellow"
 	icon_closed = "yellow"
-	spawn_contents = list(/obj/item/clothing/under/color/yellow = list(4, 0, -3),
-	/obj/item/clothing/shoes/orange = list(4, 0, -12),
-	/obj/item/clothing/head/yellow = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/yellow{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/orange{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/yellow{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/green
 	name = "green wardrobe"
 	icon_state = "green"
 	icon_closed = "green"
-	spawn_contents = list(/obj/item/clothing/under/color/green = list(4, 0, -3),
-	/obj/item/clothing/shoes/black = list(4, 0, -12),
-	/obj/item/clothing/head/green = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/green{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/black{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/green{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/blue
 	name = "blue wardrobe"
 	icon_state = "blue"
 	icon_closed = "blue"
-	spawn_contents = list(/obj/item/clothing/under/color/blue = list(4, 0, -3),
-	/obj/item/clothing/shoes/brown = list(4, 0, -12),
-	/obj/item/clothing/head/blue = list(2, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/blue{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/brown{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/blue{pixel_x = 0; pixel_y = 8} = 2)
 
 /obj/storage/closet/wardrobe/mixed
 	name = "mixed wardrobe"
 	icon_state = "mixed"
 	icon_closed = "mixed"
-	spawn_contents = list(/obj/item/clothing/under/color/blue = list(2, -3, -3),
-	/obj/item/clothing/under/color/pink = list(2, 3, -3),
-	/obj/item/clothing/shoes/brown = list(4, 0, -12),
-	/obj/item/clothing/head/blue = list(1, 0, 8),
-	/obj/item/clothing/head/red = list(1, 0, 8))
+	spawn_contents = list(/obj/item/clothing/under/color/blue{pixel_x = 3; pixel_y = -3} = 2,
+	/obj/item/clothing/under/color/pink{pixel_x = 3; pixel_y = -3} = 2,
+	/obj/item/clothing/shoes/brown{pixel_x = 0; pixel_y = -12} = 4,
+	/obj/item/clothing/head/blue{pixel_x = -3; pixel_y = 8},
+	/obj/item/clothing/head/red{pixel_x = 3; pixel_y = 8})
 
 /* =================== */
 /* ----- Special ----- */
@@ -161,18 +160,18 @@ TYPEINFO(/obj/storage/closet/dresser)
 /obj/storage/closet/wardrobe/black/formalwear
 	name = "formalwear closet"
 	desc = "It's a closet! This one can be opened AND closed. Comes with formal clothes"
-	spawn_contents = list(/obj/item/clothing/under/gimmick/maid = list(1, -3, -4),
-	/obj/item/clothing/head/maid = list(1, 3, 10),
-	/obj/item/clothing/under/gimmick/butler = list(1, 3, -4),
-	/obj/item/clothing/head/that = list(2, 3, 14),
-	/obj/item/clothing/under/rank/bartender = list(2, 3, 2),
-	/obj/item/clothing/suit/wcoat = list(2, -3, -4),
-	/obj/item/clothing/shoes/black = list(2, 0, -12))
+	spawn_contents = list(/obj/item/clothing/under/gimmick/maid{pixel_x = -3; pixel_y = -4},
+	/obj/item/clothing/head/maid{pixel_x = 3; pixel_y = 10},
+	/obj/item/clothing/under/gimmick/butler{pixel_x = 3; pixel_y = -4},
+	/obj/item/clothing/head/that{pixel_x = 3; pixel_y = 14} = 2,
+	/obj/item/clothing/under/rank/bartender{pixel_x = 3; pixel_y = 2} = 2,
+	/obj/item/clothing/suit/wcoat{pixel_x = -3; pixel_y = -4} = 2,
+	/obj/item/clothing/shoes/black{pixel_x = 0; pixel_y = -12} = 2)
 
 /obj/storage/closet/wardrobe/yellow/engineering
 	name = "\improper Engineering wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/engineer = list(4, 0, -3),
-	/obj/item/clothing/shoes/orange = list(4, 0, -12))
+	spawn_contents = list(/obj/item/clothing/under/rank/engineer{pixel_x = 0; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/orange{pixel_x = 0; pixel_y = -12} = 4)
 
 /obj/storage/closet/wardrobe/red/security_gimmick
 	name = "\improper Security wardrobe"
@@ -193,22 +192,22 @@ TYPEINFO(/obj/storage/closet/dresser)
 
 /obj/storage/closet/wardrobe/white/medical
 	name = "\improper Medical wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/medical = list(4, 3, -3),
-	/obj/item/clothing/shoes/red = list(4, 0, -12),
+	spawn_contents = list(/obj/item/clothing/under/rank/medical{pixel_x = 3; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/red{pixel_x = 0; pixel_y = -12} = 4,
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
+	/obj/item/clothing/suit/labcoat{pixel_x = -3; pixel_y = -3} = 4)
 
 /obj/storage/closet/wardrobe/white/research
 	name = "\improper Research wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/scientist = list(4, 3, -3),
-	/obj/item/clothing/shoes/white = list(4, 0, -12),
+	spawn_contents = list(/obj/item/clothing/under/rank/scientist{pixel_x = 3; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/white{pixel_x = 0; pixel_y = -12} = 4,
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
+	/obj/item/clothing/suit/labcoat{pixel_x = -3; pixel_y = -3} = 4)
 
 /obj/storage/closet/wardrobe/white/genetics
 	name = "\improper Genetics wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/geneticist = list(4, 3, -3),
-	/obj/item/clothing/shoes/white = list(4, 0, -12),
+	spawn_contents = list(/obj/item/clothing/under/rank/geneticist{pixel_x = 3; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/white{pixel_x = 0; pixel_y = -12} = 4,
 	/obj/item/storage/box/stma_kit,
 	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
 

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -209,7 +209,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	spawn_contents = list(/obj/item/clothing/under/rank/geneticist{pixel_x = 3; pixel_y = -3} = 4,
 	/obj/item/clothing/shoes/white{pixel_x = 0; pixel_y = -12} = 4,
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/shoes/white{pixel_x = -3; pixel_y = -3} = 4,
+	/obj/item/clothing/shoes/white{pixel_x = -3; pixel_y = -3} = 4)
 
 /obj/storage/closet/dresser/random
 	var/list/list_jump = list(/obj/item/clothing/under/color,

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -209,7 +209,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	spawn_contents = list(/obj/item/clothing/under/rank/geneticist{pixel_x = 3; pixel_y = -3} = 4,
 	/obj/item/clothing/shoes/white{pixel_x = 0; pixel_y = -12} = 4,
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
+	/obj/item/clothing/shoes/white{pixel_x = -3; pixel_y = -3} = 4,
 
 /obj/storage/closet/dresser/random
 	var/list/list_jump = list(/obj/item/clothing/under/color,

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -69,14 +69,14 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "pink wardrobe"
 	icon_state = "pink"
 	icon_closed = "pink"
-	spawn_contents = list(/obj/item/clothing/under/color/pink = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/pink = list(4, 0, -3),
 	/obj/item/clothing/shoes/brown = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/red
 	name = "red wardrobe"
 	icon_state = "red"
 	icon_closed = "red"
-	spawn_contents = list(/obj/item/clothing/under/color/red = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/red = list(4, 0, -3),
 	/obj/item/clothing/shoes/brown = list(4, 0, -12),
 	/obj/item/clothing/head/red = list(2, 0, 8))
 
@@ -84,15 +84,15 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "orange wardrobe"
 	icon_state = "orange"
 	icon_closed = "orange"
-	spawn_contents = list(/obj/item/clothing/under/color/orange = 4,
-	/obj/item/clothing/under/misc/prisoner = 3,
+	spawn_contents = list(/obj/item/clothing/under/color/orange = list(4, 3, -3),
+	/obj/item/clothing/under/misc/prisoner = list(4, -3, -3),
 	/obj/item/clothing/shoes/orange = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/yellow
 	name = "yellow wardrobe"
 	icon_state = "yellow"
 	icon_closed = "yellow"
-	spawn_contents = list(/obj/item/clothing/under/color/yellow = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/yellow = list(4, 0, -3),
 	/obj/item/clothing/shoes/orange = list(4, 0, -12),
 	/obj/item/clothing/head/yellow = list(2, 0, 8))
 
@@ -100,7 +100,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "green wardrobe"
 	icon_state = "green"
 	icon_closed = "green"
-	spawn_contents = list(/obj/item/clothing/under/color/green = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/green = list(4, 0, -3),
 	/obj/item/clothing/shoes/black = list(4, 0, -12),
 	/obj/item/clothing/head/green = list(2, 0, 8))
 
@@ -108,7 +108,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "blue wardrobe"
 	icon_state = "blue"
 	icon_closed = "blue"
-	spawn_contents = list(/obj/item/clothing/under/color/blue = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/blue = list(4, 0, -3),
 	/obj/item/clothing/shoes/brown = list(4, 0, -12),
 	/obj/item/clothing/head/blue = list(2, 0, 8))
 
@@ -116,8 +116,8 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "mixed wardrobe"
 	icon_state = "mixed"
 	icon_closed = "mixed"
-	spawn_contents = list(/obj/item/clothing/under/color/blue = 2,
-	/obj/item/clothing/under/color/pink = 2,
+	spawn_contents = list(/obj/item/clothing/under/color/blue = list(2, -3, -3),
+	/obj/item/clothing/under/color/pink = list(2, 3, -3),
 	/obj/item/clothing/shoes/brown = list(4, 0, -12),
 	/obj/item/clothing/head/blue = list(1, 0, 8),
 	/obj/item/clothing/head/red = list(1, 0, 8))
@@ -161,17 +161,17 @@ TYPEINFO(/obj/storage/closet/dresser)
 /obj/storage/closet/wardrobe/black/formalwear
 	name = "formalwear closet"
 	desc = "It's a closet! This one can be opened AND closed. Comes with formal clothes"
-	spawn_contents = list(/obj/item/clothing/under/gimmick/maid,
-	/obj/item/clothing/head/maid,
-	/obj/item/clothing/under/gimmick/butler,
-	/obj/item/clothing/head/that = 2,
-	/obj/item/clothing/under/rank/bartender = 2,
-	/obj/item/clothing/suit/wcoat = 2,
-	/obj/item/clothing/shoes/black = 2)
+	spawn_contents = list(/obj/item/clothing/under/gimmick/maid = list(1, -3, -4),
+	/obj/item/clothing/head/maid = list(1, 3, 10),
+	/obj/item/clothing/under/gimmick/butler = list(1, 3, -4),
+	/obj/item/clothing/head/that = list(2, 3, 14),
+	/obj/item/clothing/under/rank/bartender = list(2, 3, 2),
+	/obj/item/clothing/suit/wcoat = list(2, -3, -4),
+	/obj/item/clothing/shoes/black = list(2, 0, -12))
 
 /obj/storage/closet/wardrobe/yellow/engineering
 	name = "\improper Engineering wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/engineer = 4,
+	spawn_contents = list(/obj/item/clothing/under/rank/engineer = list(4, 0, -3),
 	/obj/item/clothing/shoes/orange = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/red/security_gimmick
@@ -193,24 +193,24 @@ TYPEINFO(/obj/storage/closet/dresser)
 
 /obj/storage/closet/wardrobe/white/medical
 	name = "\improper Medical wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/medical = 4,
+	spawn_contents = list(/obj/item/clothing/under/rank/medical = list(4, 3, -3),
 	/obj/item/clothing/shoes/red = list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = 3)
+	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
 
 /obj/storage/closet/wardrobe/white/research
 	name = "\improper Research wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/scientist = 4,
+	spawn_contents = list(/obj/item/clothing/under/rank/scientist = list(4, 3, -3),
 	/obj/item/clothing/shoes/white = list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = 4)
+	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
 
 /obj/storage/closet/wardrobe/white/genetics
 	name = "\improper Genetics wardrobe"
-	spawn_contents = list(/obj/item/clothing/under/rank/geneticist = 4,
-	/obj/item/clothing/shoes/white= list(4, 0, -12),
+	spawn_contents = list(/obj/item/clothing/under/rank/geneticist = list(4, 3, -3),
+	/obj/item/clothing/shoes/white = list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
-	/obj/item/clothing/suit/labcoat = 4)
+	/obj/item/clothing/suit/labcoat = list(4, -3, -3))
 
 /obj/storage/closet/dresser/random
 	var/list/list_jump = list(/obj/item/clothing/under/color,

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -161,11 +161,11 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "formalwear closet"
 	desc = "It's a closet! This one can be opened AND closed. Comes with formal clothes"
 	spawn_contents = list(/obj/item/clothing/under/gimmick/maid{pixel_x = -3; pixel_y = -4},
-	/obj/item/clothing/head/maid{pixel_x = 3; pixel_y = 10},
+	/obj/item/clothing/head/maid{pixel_x = -3; pixel_y = 10},
+	/obj/item/clothing/under/rank/bartender{pixel_x = 3; pixel_y = 2} = 2,
 	/obj/item/clothing/under/gimmick/butler{pixel_x = 3; pixel_y = -4},
 	/obj/item/clothing/head/that{pixel_x = 3; pixel_y = 14} = 2,
-	/obj/item/clothing/under/rank/bartender{pixel_x = 3; pixel_y = 2} = 2,
-	/obj/item/clothing/suit/wcoat{pixel_x = -3; pixel_y = -4} = 2,
+	/obj/item/clothing/suit/wcoat{pixel_x = -3; pixel_y = 4} = 2,
 	/obj/item/clothing/shoes/black{pixel_x = 0; pixel_y = -12} = 2)
 
 /obj/storage/closet/wardrobe/yellow/engineering

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -19,6 +19,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	name = "wardrobe"
 	desc = "It's a wardrobe closet! This one can be opened AND closed. Comes prestocked with some changes of clothes."
 	soundproofing = 10
+#define SHOE_Y -12
 
 /* ==================== */
 /* ----- Standard ----- */
@@ -29,7 +30,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 	desc = "A label on it reads: In order to improve workplace efficiency, employees are encouraged to spend no more than 5 minutes in the closet at a time."
 	icon_state = "gay"
 	icon_closed = "gay"
-	spawn_contents = list(/obj/item/clothing/under/pride = list(2, 3, 6),
+	spawn_contents = list(/obj/item/clothing/under/pride = list(2, 3, 6), //Quantity, X offset, Y offset
 	/obj/item/clothing/under/pride/ace = list(2, -3, 6),
 	/obj/item/clothing/under/pride/aro = list(2, 3, 3),
 	/obj/item/clothing/under/pride/bi = list(2, -3, 3),
@@ -61,23 +62,23 @@ TYPEINFO(/obj/storage/closet/dresser)
 	icon_state = "white"
 	icon_closed = "white"
 	spawn_contents = list(/obj/item/clothing/under/color/white = list(4, 0, -3),
-	/obj/item/clothing/shoes/brown = 4,
-	/obj/item/clothing/head/white  = 2)
+	/obj/item/clothing/shoes/brown = list(4, 0, -12),
+	/obj/item/clothing/head/white  = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/pink
 	name = "pink wardrobe"
 	icon_state = "pink"
 	icon_closed = "pink"
 	spawn_contents = list(/obj/item/clothing/under/color/pink = 4,
-	/obj/item/clothing/shoes/brown = 4)
+	/obj/item/clothing/shoes/brown = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/red
 	name = "red wardrobe"
 	icon_state = "red"
 	icon_closed = "red"
 	spawn_contents = list(/obj/item/clothing/under/color/red = 4,
-	/obj/item/clothing/shoes/brown = 4,
-	/obj/item/clothing/head/red = 2)
+	/obj/item/clothing/shoes/brown = list(4, 0, -12),
+	/obj/item/clothing/head/red = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/orange
 	name = "orange wardrobe"
@@ -85,31 +86,31 @@ TYPEINFO(/obj/storage/closet/dresser)
 	icon_closed = "orange"
 	spawn_contents = list(/obj/item/clothing/under/color/orange = 4,
 	/obj/item/clothing/under/misc/prisoner = 3,
-	/obj/item/clothing/shoes/orange = 4)
+	/obj/item/clothing/shoes/orange = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/yellow
 	name = "yellow wardrobe"
 	icon_state = "yellow"
 	icon_closed = "yellow"
 	spawn_contents = list(/obj/item/clothing/under/color/yellow = 4,
-	/obj/item/clothing/shoes/orange = 4,
-	/obj/item/clothing/head/yellow = 2)
+	/obj/item/clothing/shoes/orange = list(4, 0, -12),
+	/obj/item/clothing/head/yellow = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/green
 	name = "green wardrobe"
 	icon_state = "green"
 	icon_closed = "green"
 	spawn_contents = list(/obj/item/clothing/under/color/green = 4,
-	/obj/item/clothing/shoes/black = 4,
-	/obj/item/clothing/head/green = 2)
+	/obj/item/clothing/shoes/black = list(4, 0, -12),
+	/obj/item/clothing/head/green = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/blue
 	name = "blue wardrobe"
 	icon_state = "blue"
 	icon_closed = "blue"
 	spawn_contents = list(/obj/item/clothing/under/color/blue = 4,
-	/obj/item/clothing/shoes/brown = 4,
-	/obj/item/clothing/head/blue = 2)
+	/obj/item/clothing/shoes/brown = list(4, 0, -12),
+	/obj/item/clothing/head/blue = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/mixed
 	name = "mixed wardrobe"
@@ -117,9 +118,9 @@ TYPEINFO(/obj/storage/closet/dresser)
 	icon_closed = "mixed"
 	spawn_contents = list(/obj/item/clothing/under/color/blue = 2,
 	/obj/item/clothing/under/color/pink = 2,
-	/obj/item/clothing/shoes/brown = 4,
-	/obj/item/clothing/head/blue,
-	/obj/item/clothing/head/red)
+	/obj/item/clothing/shoes/brown = list(4, 0, -12),
+	/obj/item/clothing/head/blue = list(1, 0, 8),
+	/obj/item/clothing/head/red = list(1, 0, 8))
 
 /* =================== */
 /* ----- Special ----- */
@@ -171,7 +172,7 @@ TYPEINFO(/obj/storage/closet/dresser)
 /obj/storage/closet/wardrobe/yellow/engineering
 	name = "\improper Engineering wardrobe"
 	spawn_contents = list(/obj/item/clothing/under/rank/engineer = 4,
-	/obj/item/clothing/shoes/orange = 4)
+	/obj/item/clothing/shoes/orange = list(4, 0, -12))
 
 /obj/storage/closet/wardrobe/red/security_gimmick
 	name = "\improper Security wardrobe"
@@ -193,21 +194,21 @@ TYPEINFO(/obj/storage/closet/dresser)
 /obj/storage/closet/wardrobe/white/medical
 	name = "\improper Medical wardrobe"
 	spawn_contents = list(/obj/item/clothing/under/rank/medical = 4,
-	/obj/item/clothing/shoes/red = 4,
+	/obj/item/clothing/shoes/red = list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
 	/obj/item/clothing/suit/labcoat = 3)
 
 /obj/storage/closet/wardrobe/white/research
 	name = "\improper Research wardrobe"
 	spawn_contents = list(/obj/item/clothing/under/rank/scientist = 4,
-	/obj/item/clothing/shoes/white = 4,
+	/obj/item/clothing/shoes/white = list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
 	/obj/item/clothing/suit/labcoat = 4)
 
 /obj/storage/closet/wardrobe/white/genetics
 	name = "\improper Genetics wardrobe"
 	spawn_contents = list(/obj/item/clothing/under/rank/geneticist = 4,
-	/obj/item/clothing/shoes/white= 4,
+	/obj/item/clothing/shoes/white= list(4, 0, -12),
 	/obj/item/storage/box/stma_kit,
 	/obj/item/clothing/suit/labcoat = 4)
 

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -29,38 +29,38 @@ TYPEINFO(/obj/storage/closet/dresser)
 	desc = "A label on it reads: In order to improve workplace efficiency, employees are encouraged to spend no more than 5 minutes in the closet at a time."
 	icon_state = "gay"
 	icon_closed = "gay"
-	spawn_contents = list(/obj/item/clothing/under/pride = 2,
-	/obj/item/clothing/under/pride/ace = 2,
-	/obj/item/clothing/under/pride/aro = 2,
-	/obj/item/clothing/under/pride/bi = 2,
-	/obj/item/clothing/under/pride/inter = 2,
-	/obj/item/clothing/under/pride/pan = 2,
-	/obj/item/clothing/under/pride/poly = 2,
-	/obj/item/clothing/under/pride/nb = 2,
-	/obj/item/clothing/under/pride/lesb = 2,
-	/obj/item/clothing/under/pride/gaymasc = 2,
-	/obj/item/clothing/under/pride/trans = 2)
+	spawn_contents = list(/obj/item/clothing/under/pride = list(2, 3, 6),
+	/obj/item/clothing/under/pride/ace = list(2, -3, 6),
+	/obj/item/clothing/under/pride/aro = list(2, 3, 3),
+	/obj/item/clothing/under/pride/bi = list(2, -3, 3),
+	/obj/item/clothing/under/pride/inter = list(2, 3, 0),
+	/obj/item/clothing/under/pride/pan = list(2, -3, 0),
+	/obj/item/clothing/under/pride/poly = list(2, 3, -3),
+	/obj/item/clothing/under/pride/nb = list(2, -3, -3),
+	/obj/item/clothing/under/pride/lesb = list(2, 3, -6),
+	/obj/item/clothing/under/pride/gaymasc = list(2, -3, -6),
+	/obj/item/clothing/under/pride/trans = list(2, 0, -9))
 
 /obj/storage/closet/wardrobe/black
 	name = "black wardrobe"
 	icon_state = "black"
 	icon_closed = "black"
-	spawn_contents = list(/obj/item/clothing/under/color = 4,
-	/obj/item/clothing/shoes/black = 4,
-	/obj/item/clothing/head/black = 2)
+	spawn_contents = list(/obj/item/clothing/under/color = list(4, 0, -3),
+	/obj/item/clothing/shoes/black = list(4, 0, -12),
+	/obj/item/clothing/head/black = list(2, 0, 8))
 
 /obj/storage/closet/wardrobe/grey
 	name = "grey wardrobe"
 	icon_state = "grey"
 	icon_closed = "grey"
-	spawn_contents = list(/obj/item/clothing/under/color/grey = 4,
-	/obj/item/clothing/shoes/black = 5)
+	spawn_contents = list(/obj/item/clothing/under/color/grey = list(4, 0, -3),
+	/obj/item/clothing/shoes/black = list(5, 0, -12))
 
 /obj/storage/closet/wardrobe/white
 	name = "white wardrobe"
 	icon_state = "white"
 	icon_closed = "white"
-	spawn_contents = list(/obj/item/clothing/under/color/white = 4,
+	spawn_contents = list(/obj/item/clothing/under/color/white = list(4, 0, -3),
 	/obj/item/clothing/shoes/brown = 4,
 	/obj/item/clothing/head/white  = 2)
 


### PR DESCRIPTION
<!-- [QoL][game objects] [feature] -->
## About the PR
Assigns pixel offsets to items that spawn in the pride wardrobe, formalwear closet, and some other clothing closets. Changes default behavior of closets to put things lower on the list on a higher layer, so stuff like the pride locker gets that swanky solitaire card stack effect.
![image](https://github.com/goonstation/goonstation/assets/120209597/1313b4bb-e6e8-45d5-95da-c9877a8d411e)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I detest having to right-click lockers to find the items and tools I crave! This should make it a little easier to pull out the pride jumpsuit you want. This should make similarly reorganizing other closets much easier, too.