### PR TITLE
Airlocks with the ID wire cut will deny access to anyone who bumps to it

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -580,6 +580,7 @@ var/global/list/cycling_airlocks = list()
 /obj/machinery/door/airlock/bumpopen(atom/movable/AM)
 	if (src.isWireCut(AIRLOCK_WIRE_IDSCAN))
 		src.play_deny() // intentional nerf: idwire-cut doors won't respond to bumps. incentivizes people to fix it and makes them aware it is access hacked.
+		src.add_fingerprint(AM)
 		return
 	if (issilicon(AM))
 		if (!src.cyborgBumpAccess)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -578,7 +578,7 @@ var/global/list/cycling_airlocks = list()
 				return
 	..()
 /obj/machinery/door/airlock/bumpopen(atom/movable/AM)
-	if (src.isWireCut(AIRLOCK_WIRE_IDSCAN))
+	if (!src.requiresID()) // if the ID wire has been tampered with.
 		src.play_deny() // intentional nerf: idwire-cut doors won't respond to bumps. incentivizes people to fix it and makes them aware it is access hacked.
 		src.add_fingerprint(AM)
 		return

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -578,6 +578,9 @@ var/global/list/cycling_airlocks = list()
 				return
 	..()
 /obj/machinery/door/airlock/bumpopen(atom/movable/AM)
+	if (src.isWireCut(AIRLOCK_WIRE_IDSCAN))
+		src.play_deny() // intentional nerf: idwire-cut doors won't respond to bumps. incentivizes people to fix it and makes them aware it is access hacked.
+		return
 	if (issilicon(AM))
 		if (!src.cyborgBumpAccess)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR brings back the behavior that was patched out as a bug a little over a year ago. Airlocks with the ID wire cut will deny anyone bumping to the airlock, but clicking on the airlock lets anyone open it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As airlocks currently stand, there's no simple way to figure out if it was hijacked or not. This completely inutilizes the concept of accesses, since if you figure out the ID wire, it doesn't matter if it has access restrictions, or if someone wants to keep you out: you simply walk in. This change not only makes it easier to figure out if a door was hijacked, it also presents an active annoyance to fix the airlock if it is hijacked.

If this change proves to be controversial enough, I can slap the Input Wanted tag on it.

3 dislikes, 1 like, controversial enough for a forums post. [INPUT WANTED]
(also one of the dislikes came in sooner than a single minute of the PR going live. wow.)
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Caio029
(*) Due to a recent re-design of airlock circuitry, airlocks with a cut ID wire will not respond to any bumps, but pressing it will open or close it unconditionally.
```
