### PR TITLE
Click-drag conveyor switch to change direction

### DIFF
--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -996,6 +996,8 @@ TYPEINFO(/obj/machinery/conveyor_switch) {
 	mouse_drop(atom/over_object, src_location, over_location, src_control, over_control, params)
 		if (!isliving(usr)) return
 		if (!can_act(usr) || !can_reach(usr, src)) return
+		var/mob/M = usr
+		if (ispulsingtool(M.equipped()) && istype(over_object, /obj/machinery/conveyor)) return // linking handled in conveyor MouseDrop_T
 		if (ON_COOLDOWN(src, "switch", CONVEYOR_SWITCH_COOLDOWN)) return
 		switch (over_location:x - src_location:x)
 			if (0)

--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -909,6 +909,8 @@ TYPEINFO(/obj/machinery/conveyor_switch) {
 	///How much speed boost this switch is getting
 	VAR_PROTECTED/speedup = 0
 
+	HELP_MESSAGE_OVERRIDE("Click to cycle between forward, stop, and reverse.<br>Click-drag right or left to set the direction forward or reverse.")
+
 	New()
 		. = ..()
 		UnsubscribeProcess()

--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -1,5 +1,7 @@
 // conveyor belt
 
+#define CONVEYOR_SWITCH_COOLDOWN 0.5 SECONDS
+
 // moves items/mobs/movables in set direction every ptick
 TYPEINFO(/obj/machinery/conveyor) {
 	mats = list("MET-1" = 1, "CON-1" = 1, "CRY-1" = 1)
@@ -902,8 +904,6 @@ TYPEINFO(/obj/machinery/conveyor_switch) {
 	/// the list of converyors that are controlled by this switch
 	var/list/conveyors
 	anchored = ANCHORED
-	/// time last used
-	var/last_used = 0
 	///How much this switch is configured to manually slow down by
 	VAR_PROTECTED/slowdown = 0
 	///How much speed boost this switch is getting
@@ -976,34 +976,60 @@ TYPEINFO(/obj/machinery/conveyor_switch) {
 
 	// attack with hand, switch position
 	attack_hand(mob/user)
-		if (TIME < (last_used + 0.5 SECONDS))
+		if(ON_COOLDOWN(src, "switch", CONVEYOR_SWITCH_COOLDOWN))
 			return
-		last_used = TIME
 		if(position == CONVEYOR_STOPPED)
 			if (last_pos == CONVEYOR_REVERSE)
-				position = CONVEYOR_FORWARD
-				last_pos = CONVEYOR_STOPPED
+				src.go_forward()
 			else
-				position = CONVEYOR_REVERSE
-				last_pos = CONVEYOR_STOPPED
+				src.go_reverse()
 			logTheThing(LOG_STATION, user, "turns the conveyor switch on in [last_pos == CONVEYOR_REVERSE ? "forward" : "reverse"] mode at [log_loc(src)].")
 		else
-			last_pos = position
-			position = CONVEYOR_STOPPED
+			src.stop()
 			logTheThing(LOG_STATION, user, "turns the conveyor switch off at [log_loc(src)].")
-		UpdateIcon()
+		src.UpdateIcon()
+		src.update_others()
 
-		// find any switches with same id as this one, and set their positions to match us
+	// click-drag to set direction left/right
+	mouse_drop(atom/over_object, src_location, over_location, src_control, over_control, params)
+		if (!isliving(usr)) return
+		if (!can_act(usr) || !can_reach(usr, src)) return
+		if (ON_COOLDOWN(src, "switch", CONVEYOR_SWITCH_COOLDOWN)) return
+		switch (over_location:x - src_location:x)
+			if (0)
+				return
+			if (1 to INFINITY)
+				src.go_forward()
+			if (-INFINITY to -1)
+				src.go_reverse()
+		logTheThing(LOG_STATION, usr, "turns the conveyor switch to [src.position == CONVEYOR_REVERSE ? "forward" : "reverse"] mode at [log_loc(src)].")
+		src.UpdateIcon()
+		src.update_others()
+
+	proc/go_forward()
+		src.last_pos = src.position
+		src.position = CONVEYOR_FORWARD
+
+	proc/go_reverse()
+		src.last_pos = src.position
+		src.position = CONVEYOR_REVERSE
+
+	proc/stop()
+		src.last_pos = src.position
+		src.position = CONVEYOR_STOPPED
+
+	/// Update matching switches and conveyors to our position
+	proc/update_others()
 		for_by_tcl(S, /obj/machinery/conveyor_switch)
 			if (S == src) continue
-			if(S.id == src.id)
-				S.position = position
+			if (S.id == src.id)
+				S.position = src.position
 				S.UpdateIcon()
 			LAGCHECK(LAG_MED)
 
 		for (var/obj/machinery/conveyor/C as anything in conveyors)
 			if (C.id == src.id)
-				C.operating = position
+				C.operating = src.position
 				C.setdir()
 				C.move_lag = CALC_DELAY(C)
 
@@ -1175,3 +1201,5 @@ TYPEINFO(/obj/machinery/conveyor_switch) {
 		if (!src.activation_area.active)
 			return
 		. = ..()
+
+#undef CONVEYOR_SWITCH_COOLDOWN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a `click_drag` implementation for conveyor switches.
Reduce duplication by moving some shared logic into procs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier to set the direction you want. Feels like you're really moving the lever. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Click-dragging a conveyor switch to the left or right will change its direction to match.
```
