### PR TITLE
Ghosts jump into mob occupying machines on Click

### DIFF
--- a/code/WorkInProgress/DrMelonsStuff.dm
+++ b/code/WorkInProgress/DrMelonsStuff.dm
@@ -139,6 +139,10 @@
 		else
 			. = ..()
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	mouse_drop(obj/over_object, src_location, over_location)
 		if (isintangible(usr))
 			return

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -292,6 +292,10 @@ TYPEINFO(/obj/submachine/laundry_machine)
 						processing_items.Add(src)
 	src.UpdateIcon()
 
+/obj/submachine/laundry_machine/Click(location, control, params)
+	if(!src.ghost_observe_occupant(usr, src.occupant))
+		. = ..()
+
 #undef PRE
 #undef WASH
 #undef DRY

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -82,6 +82,9 @@
 
 	src.try_push_in(target, user)
 
+/obj/machinery/atmospherics/unary/cryo_cell/Click(location, control, params)
+	if(!ghost_observe_occupant(usr, src.occupant))
+		. = ..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/Exited(atom/movable/AM, atom/newloc)
 	..()

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -60,6 +60,10 @@ TYPEINFO(/obj/machinery/genetics_scanner)
 		eject_occupant(user)
 
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	MouseDrop_T(mob/living/target, mob/user)
 		if (!istype(target) || isAI(user))
 			return

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -73,6 +73,10 @@
 		playsound(src.loc, 'sound/machines/sleeper_open.ogg', 50, 1)
 		return
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	MouseDrop_T(mob/living/target, mob/user)
 		if (!istype(target) || isAI(user))
 			return

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -182,6 +182,10 @@ TYPEINFO(/obj/machinery/recharge_station)
 	src.build_icon()
 	return TRUE
 
+/obj/machinery/recharge_station/Click(location, control, params)
+	if(!src.ghost_observe_occupant(usr, src.occupant))
+		. = ..()
+
 /obj/machinery/recharge_station/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
 	if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0)
 		return

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -464,3 +464,9 @@ ADMIN_INTERACT_PROCS(/obj, proc/admin_command_obj_speak)
 
 	for(var/mob/O in targets)
 		O.show_message(SPAN_SAY("[SPAN_NAME("[src.name]")] says, [SPAN_MESSAGE("\"[message]\"")]"), 2, assoc_maptext = chat_text)
+
+/obj/proc/ghost_observe_occupant(mob/viewer, mob/occupant)
+	if(istype(viewer, /mob/dead/observer) && viewer.client && !viewer.client.keys_modifier && occupant)
+		var/mob/dead/observer/O = viewer
+		O.insert_observer(occupant)
+		return TRUE

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -809,6 +809,10 @@ TYPEINFO(/obj/machinery/clonepod)
 		src.go_out()
 		return
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	ex_act(severity)
 		switch(severity)
 			if(1)

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -536,6 +536,10 @@ TYPEINFO(/obj/machinery/clone_scanner)
 			occupant = null
 		..()
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	MouseDrop_T(mob/living/target, mob/user)
 		if (!istype(target) || isAI(user))
 			return

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -379,6 +379,9 @@ TYPEINFO(/obj/machinery/port_a_brig)
 		if (req)
 			user.show_text(SPAN_ALERT("[src] [pick("cracks","bends","shakes","groans")]. Somehow, you know that it will unlock in [req/10] seconds."))
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
 
 	// Could be useful (Convair880).
 	mouse_drop(over_object, src_location, over_location)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -290,6 +290,10 @@ TYPEINFO(/obj/machinery/sleeper)
 			occupant = null
 		..()
 
+	Click(location, control, params)
+		if(!src.ghost_observe_occupant(usr, src.occupant))
+			. = ..()
+
 	update_icon()
 		ENSURE_IMAGE(src.image_lid, src.icon, "sleeperlid[!isnull(occupant)]")
 		src.UpdateOverlays(src.image_lid, "lid")

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -129,12 +129,8 @@ ABSTRACT_TYPE(/obj/vehicle)
 		if(thing == src.rider)
 			src.eject_rider(crashed=FALSE, selfdismount=TRUE, ejectall=FALSE)
 
-	Click(location,control,params)
-		if(istype(usr, /mob/dead/observer) && usr.client && !usr.client.keys_modifier)
-			var/mob/dead/observer/O = usr
-			if(src.rider)
-				O.insert_observer(src.rider)
-		else
+	Click(location, control, params)
+		if(!ghost_observe_occupant(usr, src.rider))
 			. = ..()
 
 	proc/eject_other_stuff() // override if there's some stuff integral to the vehicle that should not be ejected


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pulls the logic for ghosts viewing mobs in a vehicle into `/obj`, then implements a Click action for various single-occupancy machines i.e. port-a-brig, sleepers, etc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Observe people hiding/locked up in various station machines more easily.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Ghosts can click on most single-occupancy machines, like the port-a-brig, to observe the mob inside.
```
