### PR TITLE
Fix Slipping Hazard slipping on glue/slime

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -27,7 +27,7 @@
 			var/turf/T = NewLoc
 			if (T.turf_flags & MOB_SLIP)
 				var/wet_adjusted = T.wet
-				if (traitHolder?.hasTrait("super_slips") && T.wet) //non-zero wet
+				if (traitHolder?.hasTrait("super_slips") && (T.wet > 0)) //slippery when wet
 					wet_adjusted = max(wet_adjusted, 2) //whee
 
 				switch (wet_adjusted)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][traits]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check that the tile has a positive (i.e. slippery) wetness for super_slips trait


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18515
