### PR TITLE
Update Chemaster Multiple Patch/Pill Grouping Logic

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -490,11 +490,11 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define CHEMMASTER_MINIMUM_REAGENT 5 // mininum reagent for pills, bottles and patches
-#define CHEMMASTER_CONTAINER_TRESHOLD 11 // equal or above this amount use container
-#define CHEMMASTER_ITEMNAME_MAXSIZE 16 // chosen by fair dice roll
-#define CHEMMASTER_MAX_PILL 22 // 22 pill icons
-#define CHEMMASTER_MAX_CANS 26 // 26 flavours of cans
+#define CHEMMASTER_MINIMUM_REAGENT 5 //!mininum reagent for pills, bottles and patches
+#define CHEMMASTER_CONTAINER_TRESHOLD 11 //!equal or above this amount use container
+#define CHEMMASTER_ITEMNAME_MAXSIZE 16 //!chosen by fair dice roll
+#define CHEMMASTER_MAX_PILL 22 //!22 pill icons
+#define CHEMMASTER_MAX_CANS 26 //!26 flavours of cans
 
 TYPEINFO(/obj/machinery/chem_master)
 	mats = 15
@@ -944,8 +944,8 @@ TYPEINFO(/obj/machinery/chem_master)
 
 				var/obj/item/chem_pill_bottle/pill_bottle = null
 				if(use_pill_bottle || pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-					if(pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-						boutput(ui.user, "The [src] output limit beeps sternly, and a pill bottle automatically dispensed!")
+					if(!use_pill_bottle && pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+						boutput(ui.user, SPAN_ALERT("The [src] output limit beeps sternly, and a pill bottle automatically dispensed!"))
 					pill_bottle = new(src)
 					pill_bottle.name = "[item_name] [pill_bottle.name]"
 
@@ -1071,7 +1071,7 @@ TYPEINFO(/obj/machinery/chem_master)
 				var/is_medical_patch = src.check_patch_whitelist()
 				var/obj/item/item_box/medical_patches/patch_box = null
 				if(use_box || patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-					if(patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+					if(!use_box && patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
 						boutput(ui.user, "The [src] output limit beeps sternly, and a patch box automatically dispensed!")
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -491,7 +491,7 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define CHEMMASTER_MINIMUM_REAGENT 5 // mininum reagent for pills, bottles and patches
-#define CHEMMASTER_CONTAINER_TRESHOLD 10 // equal or above this amount use container
+#define CHEMMASTER_CONTAINER_TRESHOLD 11 // equal or above this amount use container
 #define CHEMMASTER_ITEMNAME_MAXSIZE 16 // chosen by fair dice roll
 #define CHEMMASTER_MAX_PILL 22 // 22 pill icons
 #define CHEMMASTER_MAX_CANS 26 // 26 flavours of cans
@@ -944,6 +944,8 @@ TYPEINFO(/obj/machinery/chem_master)
 
 				var/obj/item/chem_pill_bottle/pill_bottle = null
 				if(use_pill_bottle || pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+					if(pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+						boutput(ui.user, "The [src] output limit beeps sternly, and a pill bottle automatically dispensed!")
 					pill_bottle = new(src)
 					pill_bottle.name = "[item_name] [pill_bottle.name]"
 
@@ -1069,6 +1071,8 @@ TYPEINFO(/obj/machinery/chem_master)
 				var/is_medical_patch = src.check_patch_whitelist()
 				var/obj/item/item_box/medical_patches/patch_box = null
 				if(use_box || patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+					if(patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
+						boutput(ui.user, "The [src] output limit beeps sternly, and a patch box automatically dispensed!")
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"
 					if (is_medical_patch)

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -491,7 +491,7 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define CHEMMASTER_MINIMUM_REAGENT 5 //!mininum reagent for pills, bottles and patches
-#define CHEMMASTER_CONTAINER_TRESHOLD 11 //!equal or above this amount use container
+#define CHEMMASTER_NO_CONTAINER_MAX 10 //!maximum number of unboxed pills/patches
 #define CHEMMASTER_ITEMNAME_MAXSIZE 16 //!chosen by fair dice roll
 #define CHEMMASTER_MAX_PILL 22 //!22 pill icons
 #define CHEMMASTER_MAX_CANS 26 //!26 flavours of cans
@@ -943,9 +943,9 @@ TYPEINFO(/obj/machinery/chem_master)
 				logTheThing(LOG_COMBAT, usr, "used [src] to create [pillcount] [item_name] pills containing [log_reagents(src.beaker)] at [log_loc(src)].")
 
 				var/obj/item/chem_pill_bottle/pill_bottle = null
-				if(use_pill_bottle || pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-					if(!use_pill_bottle && pillcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-						boutput(ui.user, SPAN_ALERT("The [src] output limit beeps sternly, and a pill bottle automatically dispensed!"))
+				if(use_pill_bottle || pillcount > CHEMMASTER_NO_CONTAINER_MAX)
+					if(!use_pill_bottle && pillcount > CHEMMASTER_NO_CONTAINER_MAX)
+						src.visible_message(SPAN_ALERT("The [src]'s output limit beeps sternly, and a pill bottle is automatically dispensed!"))
 					pill_bottle = new(src)
 					pill_bottle.name = "[item_name] [pill_bottle.name]"
 
@@ -1070,9 +1070,9 @@ TYPEINFO(/obj/machinery/chem_master)
 
 				var/is_medical_patch = src.check_patch_whitelist()
 				var/obj/item/item_box/medical_patches/patch_box = null
-				if(use_box || patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-					if(!use_box && patchcount >= CHEMMASTER_CONTAINER_TRESHOLD)
-						boutput(ui.user, "The [src] output limit beeps sternly, and a patch box automatically dispensed!")
+				if(use_box || patchcount > CHEMMASTER_NO_CONTAINER_MAX)
+					if(!use_box && patchcount > CHEMMASTER_NO_CONTAINER_MAX)
+						 src.visible_message("The [src] output limit beeps sternly, and a patch box is automatically dispensed!")
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"
 					if (is_medical_patch)
@@ -1162,7 +1162,7 @@ TYPEINFO(/obj/machinery/chem_master)
 			src.UpdateIcon()
 			global.tgui_process.update_uis(src)
 
-#undef CHEMMASTER_CONTAINER_TRESHOLD
+#undef CHEMMASTER_NO_CONTAINER_MAX
 #undef CHEMMASTER_ITEMNAME_MAXSIZE
 #undef CHEMMASTER_MAX_PILL
 #undef CHEMMASTER_MAX_CANS

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1072,7 +1072,7 @@ TYPEINFO(/obj/machinery/chem_master)
 				var/obj/item/item_box/medical_patches/patch_box = null
 				if(use_box || patchcount > CHEMMASTER_NO_CONTAINER_MAX)
 					if(!use_box && patchcount > CHEMMASTER_NO_CONTAINER_MAX)
-						 src.visible_message("The [src] output limit beeps sternly, and a patch box is automatically dispensed!")
+						 src.visible_message("The [src]'s output limit beeps sternly, and a patch box is automatically dispensed!")
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"
 					if (is_medical_patch)

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1072,7 +1072,7 @@ TYPEINFO(/obj/machinery/chem_master)
 				var/obj/item/item_box/medical_patches/patch_box = null
 				if(use_box || patchcount > CHEMMASTER_NO_CONTAINER_MAX)
 					if(!use_box && patchcount > CHEMMASTER_NO_CONTAINER_MAX)
-						 src.visible_message("The [src]'s output limit beeps sternly, and a patch box is automatically dispensed!")
+						src.visible_message("The [src]'s output limit beeps sternly, and a patch box is automatically dispensed!")
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"
 					if (is_medical_patch)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Move the limit of patches/pills before they're automatically boxed/bottled from 10 to 11.
* Give user feedback when a box/bottle is automatically created.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make a common act (100u beaker -> 10u patches) follow the user's intent.
Fix #18497 by way of adding feedback.