### PR TITLE
Add client's BYOND version to in-game bug reports

### DIFF
--- a/code/procs/bug_report.dm
+++ b/code/procs/bug_report.dm
@@ -39,6 +39,7 @@
 [form.data["additional"]]
 
 Reported by: [user_client.key]
+Client version: [user_client.byond_version].[user_client.byond_build]
 On server: [global.config.server_name]
 Active test merges: [english_list(testmerges)]
 Round log date: [global.roundLog_date]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[PLAYER ACTIONS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make the in-game bug report button include the player's byond version in the report

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With 515 and the increase in players reporting crashes it'll help to rule out whether they're just out-of-date or not