### PR TITLE
add a small thirst increase for saline

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -622,6 +622,7 @@ datum
 			id = "saline"
 			description = "This saline and glucose solution can help stabilize critically injured patients and cleanse wounds."
 			reagent_state = LIQUID
+			thirst_value = 0.25
 			fluid_r = 220
 			fluid_g = 220
 			fluid_b = 220


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

saline glucose will now give 0.25 thirst_value. set on the lower end to keep it from being Too powerful of a thirst replenishing chem, since it isn't too difficult for medical to come by, but enough to be a relevant treatment to someone who is dehydrated. willing to lower it more, if its still too effective. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

mostly inspired by the fact that saline ivs can be used to treat irl cases of dehydration, and the flavor text your character gets about feeling like they're on the brink of death from thirst. it introduces an incentive to visit medical for more minor reasons (ie, you get more rp since your character isn't on a time sensitive emergency medical issue). 

the only issue i see coming up is doctors abusing it to restore their own thirst motive easier, but i think this could also be an opportunity for directors or other command staff reprimanding them/fining them for misuse of medical supplies. they also have a pharmacy where they can just create infinite water for themselves already, so

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)Saline-glucose can now be used as a treatment for dehydration.
```
