### PR TITLE
Change Cogmap 2 Pharmacy Access

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -52083,9 +52083,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/access/medlocker,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/pharmacy)
 "cYS" = (
@@ -64152,8 +64152,8 @@
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
 	},
-/obj/mapping_helper/access/medlocker,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/pharmacy)
 "lnj" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes cog2 pharmacy's doors from needing medical locker access to just medical access

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Inconsistent with the majority of maps in rotation
- Locks both janitors and medical assistants out of a part of medbay
- Sord (who did the cog2 medbay rework) said I could change it 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) Cogmap 2's pharmacy no longer requires medical locker access to enter.
```
