### PR TITLE
Re-add notes command as alias to Notes - View

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1358,6 +1358,12 @@
 
 	W.dropped(src)
 
+/// shortcut for the Notes - View verb
+/mob/verb/notes_alias()
+	set name = "Notes"
+	set hidden = TRUE
+
+	src.memory()
 
 /mob/verb/memory()
 	set name = "Notes - View"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add a hidden "notes" verb that calls the "Notes - View" one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

#18532 split notes into two separate commands that are kind of unwieldy to type and notes is one of those commands that I have years of muscle memory built up doing in the command bar instead of clicking on in the tab