### PR TITLE
Remove duplicate disposal unit in Kondaru medbay

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11857,7 +11857,6 @@
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/medbay)
 "aVa" = (
-/obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /obj/machinery/disposal,
 /obj/machinery/light/emergency{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes second disposal unit on tile in Kondaru medbay

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18551
