### PR TITLE
Fix ghost critters using ovens

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -396,6 +396,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 	density = 1
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	flags = NOSPLASH
+	object_flags = NO_GHOSTCRITTER
 	var/emagged = 0
 	var/working = 0
 	var/time = 5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the `NO_GHOSTCRITTER` flag to ovens

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18547