### PR TITLE
Default AI primary radio to off

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -337,9 +337,9 @@ or don't if it uses a custom topopen overlay
 		src.radio2.name = "AI Intercom Monitor"
 		src.radio2.device_color = "#7F7FE2"
 		src.radio3.name = "Secure Channels Monitor"
-		src.radio1.broadcasting = 1
+		src.radio1.broadcasting = FALSE
 		src.radio2.set_frequency(R_FREQ_INTERCOM_AI)
-		src.radio3.broadcasting = 0
+		src.radio3.broadcasting = FALSE
 		src.internal_pda.name = "AI's Internal PDA Unit"
 		src.internal_pda.owner = "AI"
 		if (src.brain && src.key)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the AI's primary radio microphone to off by default.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's annoying and confusing if you don't know how it works, especially with the intercom override feature still broadcasting on general frequencies by default.
PRing this just in case someone goes "nooo it's like that because..."


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)The AI's primary radio microphone now defaults to off.
```
