### PR TITLE
Money trees mutate the seedless gene strain upon mutation.

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -778,6 +778,10 @@ ABSTRACT_TYPE(/datum/plantmutation)
 	PTrange = list(30, null)
 	chance = 50
 
+	HYPon_mutation_general(var/datum/plant/parent_plant, var/datum/plantgenes/passed_genes)
+		HYPaddCommut(passed_genes, /datum/plant_gene_strain/seedless)
+		return
+
 /datum/plantmutation/tree/paper
 	name = "Paper Tree"
 	dont_rename_crop = TRUE


### PR DESCRIPTION
[Balance][Hydroponics][input wanted]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When a paper tree seed/plant mutates into a money tree, it will be given the seedless gene strain.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Money trees give an extraordinary amount of money for very low effort if spammed over and over again. By giving these the seedless gene strain upon mutation, spamming them by getting one money tree and replating it's seeds won't be possible anymore. This means to spam these plants you need to mutate each one seperatly, making it take more effort to spam.

This change makes it more feasable to focus on a few but more advanced spliced/stat pumped plants instead of spamming multiple all around botany.

Also, this highly diminishes clutter with seeds being all over botany while working with money trees.

While it would be possible to only make the money tree mutation unable to grant seeds, this also enables to get the seedless mutation in a rather reliable way, if you don't want to work with melon plants for some reason.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)When paper trees mutate to money trees, they will gain the seedless gene strain. 
```
