### PR TITLE
Energy Drink changes

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2567,7 +2567,7 @@ datum
 			fluid_b = 20
 			taste = "bitter"
 
-		fooddrink/caffeinated/coffee/energydrink
+		fooddrink/caffeinated/energydrink
 			name = "energy drink"
 			id = "energydrink"
 			description = "An energy drink is a liquid plastic with a high amount of caffeine."

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2577,17 +2577,17 @@ datum
 			fluid_b = 45
 			transparency = 170
 			overdose = 25
-			depletion_rate = 0.4
+			depletion_rate = 0.5
 			addiction_prob = 4
 			addiction_prob2 = 10
 			var/tickcounter = 0
 			thirst_value = -0.2
 			bladder_value = 0.04
 			energy_value = 1
-			stun_resist = 25
+			stun_resist = 15
 			taste = "supercharged"
 			threshold = THRESHOLD_INIT
-			caffeine_content = 1
+			caffeine_content = 2.5
 
 
 			cross_threshold_over()
@@ -2605,26 +2605,26 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				if (ishuman(M))
-					tickcounter++
-
+					tickcounter += mult
 				..()
 
 			on_mob_life_complete(var/mob/M)
 				if(M)
-					if (tickcounter < 20)
+					if (tickcounter < 30)
 						return
 					else
 						M.show_message(SPAN_ALERT("You feel exhausted!"))
-						M.setStatus("drowsy", tickcounter SECONDS)
-						M.dizziness = tickcounter - 20
+						M.setStatus("slowed", tickcounter SECONDS, 2)
+						M.dizziness = tickcounter - 30
+						M.reagents.remove_reagent("caffeine", tickcounter - 30)
 					src.holder.del_reagent(id)
 
 
 			do_overdose(var/severity, var/mob/M, var/mult = 1)
 				if (severity == 1 && prob(10))
 					M.show_message(SPAN_ALERT("Your heart feels like it wants to jump out of your chest."))
-				else if (ishuman(M) && ((severity == 2 && probmult(3 + tickcounter / 25)) || (severity == 1 && probmult(tickcounter / 50))))
-					M:contract_disease(/datum/ailment/malady/heartfailure, null, null, 1)
+				else if (ishuman(M) && ((severity == 2 && probmult(3 + tickcounter / 5)) || (severity == 1 && probmult(tickcounter / 10))))
+					M.reagents.add_reagent("caffeine", 2 * mult)
 
 		fooddrink/caffeinated/tea
 			name = "tea"


### PR DESCRIPTION
[LABEL][chemistry][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes Energy Drink's behavior to be more dependant on it's caffeine output, similarly to how heavy alcohol value chems currently work. To achieve this, it:

- Increases it's depletion to 0.5, and caffeine content per unit to 2.5
- Decreases it's standalone stun resist to 15, from 25
- Makes it so overdose has a increasing chance of dumping out more caffeine
- Changes the on depletion effect to slow the player down, as well as remove a amount of caffeine based on how long it's been on you (to reinstall the now barely noticeable energy drink withdrawal effect)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It would be interesting to have a drink defined by it's caffeine output be more governed by it, instead of having it's own set of behaviors. I've tried to maintain something akin to current balance of effectiveness/risk, as well as reinstall the previous immediate downside upon having it run out that the pre-caffeine version had as well.

## Changelog 

```changelog
(u)Colossusqw
(+)Energy Drink now no longer has a random chance of causing heart failure, now the heart failure is handled via it's increased caffeine output.
```
