### PR TITLE
Makes it so pest spawns don't happen on players

### DIFF
--- a/code/modules/events/minor/pests.dm
+++ b/code/modules/events/minor/pests.dm
@@ -12,7 +12,7 @@
 
 		if (length(hearers(5, pestlandmark)) != 0)
 			for (var/mob/living/C in hearers(5, pestlandmark))
-				if (C.client && !isdead(C)) // if the chosen spot is within 5 tiles of a player entity, ignore it
+				if (C.client && !isdead(C) && !isintangible(C)) // if the chosen spot is within 5 tiles of a player entity, ignore it
 					occupied = TRUE
 					break
 
@@ -27,10 +27,10 @@
 				occupiedlandmarks += pestlandmark
 				occupied = FALSE
 				for (var/mob/living/C in hearers(5, pestlandmark))
-					if (C.client && !isdead(C))
+					if (C.client && !isdead(C) && !isintangible(C))
 						occupied = TRUE
 
-			if (length(occupiedlandmarks) >= maxtests)
+			if (occupied)
 				logTheThing(LOG_DEBUG, null, "Minor pest event couldn't find a unoccupied LANDMARK_PESTSTART, spawning somewhere with people instead.")
 				pestlandmark = firstpestlandmark // goes back to the first option if none are available
 

--- a/code/modules/events/minor/pests.dm
+++ b/code/modules/events/minor/pests.dm
@@ -3,10 +3,37 @@
 
 	event_effect()
 		..()
+		var/occupied = FALSE // not occupied by default
 		var/pestlandmark = pick_landmark(LANDMARK_PESTSTART)
+
 		if(!pestlandmark)
 			logTheThing(LOG_DEBUG, null, "Minor pest event couldn't find a LANDMARK_PESTSTART!")
 			return
+
+		if (length(hearers(5, pestlandmark)) != 0)
+			for (var/mob/living/C in hearers(5, pestlandmark))
+				if (C.client && !isdead(C)) // if the chosen spot is within 5 tiles of a player entity, ignore it
+					occupied = TRUE
+					break
+
+
+		if (occupied)
+			var/firstpestlandmark = pestlandmark
+			var/occupiedlandmarks = list(pestlandmark) //makes list of options, as well as saves first option
+			var/maxtests = 18 //if no spots available, don't just test forever
+
+			while (length(occupiedlandmarks) < maxtests && occupied)
+				pestlandmark = pick_landmark(LANDMARK_PESTSTART, ignorespecific = occupiedlandmarks)
+				occupiedlandmarks += pestlandmark
+				occupied = FALSE
+				for (var/mob/living/C in hearers(5, pestlandmark))
+					if (C.client && !isdead(C))
+						occupied = TRUE
+
+			if (length(occupiedlandmarks) >= maxtests)
+				logTheThing(LOG_DEBUG, null, "Minor pest event couldn't find a unoccupied LANDMARK_PESTSTART, spawning somewhere with people instead.")
+				pestlandmark = firstpestlandmark // goes back to the first option if none are available
+
 		var/masterspawnamount = rand(4,12)
 		var/spawnamount = masterspawnamount
 		var/type

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -1,10 +1,13 @@
 
 var/global/list/list/turf/landmarks = list()
 
-proc/pick_landmark(name, default = null)
+proc/pick_landmark(name, default = null, ignorespecific = list())
 	if(!(name in landmarks))
 		return default
-	return pick(landmarks[name])
+	if (ignorespecific == list())
+		return pick(landmarks[name])
+	else
+		return pick(landmarks[name] - ignorespecific)
 
 /obj/landmark
 	name = "landmark"


### PR DESCRIPTION
[LABEL][AI][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes pest spawns check for any player controlled entity within five tiles of them before spawning the pests, stop dangerous critters such as wasps just randomly flooding onto people.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Walking into pests is significantly more manageable and fair than having them materialize on your exact tile.

## Changelog

```changelog
(u)Colossusqw
(+)Random pests cannot spawn directly onto players anymore.
```
