### PR TITLE
Unify TEG valve names

### DIFF
--- a/assets/maps/engine_rooms/cogmap/TEG_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/TEG_100.dmm
@@ -163,7 +163,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary west"
+	name = "cold loop auxillary"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -186,7 +186,7 @@
 "iO" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary west"
+	name = "hot loop auxillary"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/assets/maps/engine_rooms/cogmap/TEG_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/TEG_100.dmm
@@ -163,7 +163,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary"
+	name = "cold loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -186,7 +186,7 @@
 "iO" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary"
+	name = "hot loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -262,7 +262,7 @@
 /area/station/engine/core)
 "pc" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "outlet purge valve"
+	name = "hot loop purge valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -620,11 +620,11 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "OQ" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "outlet purge valve"
-	},
 /obj/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop purge valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -15289,7 +15289,7 @@
 "aYV" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop pressure release valve"
+	name = "hot loop purge valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -17411,7 +17411,7 @@
 "jUG" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop pressure release valve"
+	name = "cold loop purge valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
@@ -18729,11 +18729,12 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "pVp" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 8
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -15289,7 +15289,7 @@
 "aYV" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop purge valve"
+	name = "hot loop pressure release valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -15786,7 +15786,7 @@
 "bxK" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop valve"
+	name = "cold loop outlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -16143,7 +16143,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "diS" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop inlet valve"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/coldloop)
 "dlS" = (
@@ -16494,12 +16496,14 @@
 /area/station/security/detectives_office)
 "fcV" = (
 /obj/machinery/power/apc/autoname_east,
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot loop inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/hotloop)
@@ -17407,7 +17411,7 @@
 "jUG" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop purge valve"
+	name = "cold loop pressure release valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
@@ -18850,9 +18854,11 @@
 "qyp" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/coldloop)
@@ -19084,7 +19090,9 @@
 /turf/simulated/floor/blueblack,
 /area/station/turret_protected/ai)
 "rFr" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot loop inlet valve"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/hotloop)
 "rKd" = (
@@ -19722,7 +19730,7 @@
 "uSJ" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop valve"
+	name = "hot radiator inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -19858,7 +19866,7 @@
 /area/station/engine/engineering)
 "vCI" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "hot loop bypass valve"
+	name = "burn chamber bypass valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -38151,7 +38151,8 @@
 /area/station/hydroponics/bay)
 "cHR" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "hot loop inlet valve"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
@@ -41282,7 +41283,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	desc = "cold reserve tank valve";
 	dir = 4;
-	name = "reserve tank valve"
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -45013,7 +45014,8 @@
 /area/station/ranch)
 "hLX" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -49654,7 +49656,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	desc = "furnace bypass valve";
 	dir = 4;
-	name = "furnace bypass valve"
+	name = "burn chamber bypass valve"
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
@@ -57000,7 +57002,8 @@
 /area/station/crew_quarters/catering)
 "ryf" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "hot loop inlet valve"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -146,7 +146,9 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aaN" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "freezer inlet valve"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "aaO" = (
@@ -37233,6 +37235,13 @@
 /obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/central)
+"cdV" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "freezer bypass valve"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "cdX" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -57187,7 +57196,9 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "ehC" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot loop inlet valve"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "eik" = (
@@ -57266,7 +57277,7 @@
 "enN" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop inlet valve"
+	name = "burn chamber bypass valve"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -57703,6 +57714,13 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/science/lab)
+"eNY" = (
+/obj/machinery/atmospherics/binary/valve{
+	desc = "hot radiator outlet valve";
+	name = "hot radiator outlet valve"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
 "eOg" = (
 /obj/grille/catwalk{
 	dir = 10
@@ -58317,7 +58335,9 @@
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
 "fDX" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold reserve tank valve"
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -59251,7 +59271,8 @@
 /area/station/crew_quarters/cafeteria)
 "gEv" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/caution/north{
 	dir = 8
@@ -61214,7 +61235,8 @@
 /area/station/mining/staff_room)
 "iEv" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
@@ -62001,16 +62023,6 @@
 /obj/decal/poster/wallsign/stencil/left/g,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
-"jmi" = (
-/obj/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "hot loop auxillary west"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "jnB" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -63008,6 +63020,12 @@
 	dir = 4
 	},
 /area/station/medical/medbay/lobby)
+"kin" = (
+/obj/machinery/atmospherics/binary/valve{
+	name = "freezer outlet valve"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "kix" = (
 /obj/machinery/light{
 	dir = 1;
@@ -64271,15 +64289,15 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "luz" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop auxillary west"
-	},
 /obj/cable/orange{
 	icon_state = "2-4"
 	},
 /obj/cable/orange{
 	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold loop auxillary"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -64656,7 +64674,7 @@
 "lOr" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary west"
+	name = "cold loop auxillary"
 	},
 /obj/cable/orange{
 	icon_state = "1-4"
@@ -64977,7 +64995,8 @@
 	})
 "mdZ" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop pressure release valve"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
@@ -68296,6 +68315,13 @@
 	pixel_y = 12
 	},
 /turf/simulated/floor/caution/south,
+/area/station/engine/hotloop)
+"pSs" = (
+/obj/machinery/atmospherics/binary/valve{
+	desc = "hot radiator inlet valve";
+	name = "hot radiator inlet valve"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "pSI" = (
 /obj/strip_door{
@@ -71751,7 +71777,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "tni" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "hot reserve tank valve"
+	},
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
 "tnE" = (
@@ -72072,12 +72101,12 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "tDZ" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "hot loop auxillary west"
-	},
 /obj/cable/orange{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop auxillary"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -73822,6 +73851,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/central)
+"vMl" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop pressure release valve"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "vNL" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
@@ -113425,10 +113461,10 @@ wat
 hVd
 bts
 bij
-mdZ
+vMl
 byV
 liE
-jmi
+tDZ
 bGc
 bGc
 gXp
@@ -115249,7 +115285,7 @@ sVT
 sju
 baQ
 bQv
-mdZ
+cdV
 bTE
 bVi
 bWK
@@ -115552,7 +115588,7 @@ bCy
 bPb
 bQu
 bRY
-aaN
+kin
 bVj
 bWL
 bYf
@@ -115836,7 +115872,7 @@ biR
 bjJ
 blp
 bmH
-ehC
+eNY
 bpU
 brM
 btA
@@ -117044,7 +117080,7 @@ biS
 bjJ
 bmG
 bmH
-ehC
+pSs
 bpX
 msj
 btE

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -64297,7 +64297,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary"
+	name = "cold loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -64674,7 +64674,7 @@
 "lOr" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary"
+	name = "cold loop auxiliary valve"
 	},
 /obj/cable/orange{
 	icon_state = "1-4"
@@ -64996,7 +64996,7 @@
 "mdZ" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop pressure release valve"
+	name = "cold loop purge valve"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
@@ -72106,7 +72106,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary"
+	name = "hot loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -73854,7 +73854,7 @@
 "vMl" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop pressure release valve"
+	name = "hot loop purge valve"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -34933,11 +34933,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/monitoring)
 "fyt" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "cold loop auxillary"
-	},
 /obj/cable{
 	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -48370,7 +48370,7 @@
 "pGm" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary"
+	name = "hot loop auxiliary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31308,7 +31308,10 @@
 	name = "News Office Bathroom"
 	})
 "dcI" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	desc = "hot radiator inlet valve";
+	name = "hot radiator inlet valve"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "ddx" = (
@@ -31480,7 +31483,8 @@
 /area/station/science/lab)
 "dkC" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "hot loop inlet valve"
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -32149,7 +32153,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "hot reserve tank valve"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "dHl" = (
@@ -33697,9 +33704,11 @@
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "eFf" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -34924,7 +34933,9 @@
 /turf/simulated/floor/plating,
 /area/station/engine/monitoring)
 "fyt" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop auxillary"
+	},
 /obj/cable{
 	icon_state = "4-10"
 	},
@@ -35467,10 +35478,11 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "fWT" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "burn chamber bypass valve"
+	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "fXg" = (
@@ -38684,7 +38696,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ivr" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold loop inlet valve"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -42294,7 +42308,8 @@
 /area/station/routing/security)
 "kYW" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
@@ -44356,7 +44371,8 @@
 /area/station/ai_monitored/armory)
 "mCG" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
@@ -47396,7 +47412,8 @@
 /area/station/routing/depot)
 "oVk" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop pressure release valve"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -48067,11 +48084,12 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/research_outpost/indigo_rye)
 "ptW" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "6-10"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -48349,6 +48367,13 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"pGm" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop auxillary"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "pGA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -49628,13 +49653,14 @@
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/arcade/dungeon)
 "qzL" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop inlet valve"
 	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
@@ -49921,9 +49947,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "qNo" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	desc = "hot radiator outlet valve";
+	name = "hot radiator outlet valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
@@ -50410,13 +50439,14 @@
 /turf/simulated/floor/airless/plating,
 /area/station/quartermaster/cargobay)
 "rhr" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold loop inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -51485,10 +51515,11 @@
 	},
 /area/station/hallway/primary/east)
 "rXe" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light/emergency,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot loop pressure release valve"
+	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "rXn" = (
@@ -53408,7 +53439,8 @@
 /area/station/science/chemistry)
 "tuS" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold loop outlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -54598,11 +54630,13 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "urm" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	desc = "cold reserve tank valve";
+	dir = 4;
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
@@ -105107,7 +105141,7 @@ auN
 wgj
 nLh
 ptW
-tuS
+pGm
 aBY
 iJY
 auL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes names for manual valves in the engine rooms of kondaru, cog1, cog2, and atlas to be the same across all of them and label what the valves actually do (e.g. inlet and outlet valves named explicitly).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accessibility through having valves describe what they are for allowing new players to learn how to set up an engine and have said skill be more easily transferable to other TEG layouts.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Knipje
(+)Centcom engineers have standardized TEG valve names.
```
