### PR TITLE
add cargo purchase for ballroom clothing

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1246,6 +1246,15 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/packing
 	containername = "Shoe Crate"
 
+/datum/supply_packs/ballroom
+	name = "Ballroom Supplies"
+	desc = "Host your very own HR approved ball."
+	contains = list(/obj/random_item_spawner/formalclothes,
+					/obj/item/clothing/shoes/dress_shoes/dance = 4)
+	cost = PAY_IMPORTANT*2
+	containertype = /obj/storage/crate
+	containername = "Ballroom Supplies"
+
 /datum/supply_packs/kendo
 	name = "Kendo Crate"
 	desc = "A crate containing two full sets of kendo equipment."

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1691,6 +1691,75 @@
 		min_amt2spawn = 5
 		max_amt2spawn = 7
 
+/obj/random_item_spawner/formalclothes
+	name = "formal clothing spawner"
+	icon_state = "rand_gimmick"
+	min_amt2spawn = 5
+	max_amt2spawn = 10
+	items2spawn = list(/obj/item/clothing/under/gimmick/red_wcoat,
+						/obj/item/clothing/under/gimmick/black_wcoat,
+						/obj/item/clothing/under/gimmick/blue_wcoat,
+						/obj/item/clothing/under/rank/bartender/tuxedo,
+						/obj/item/clothing/under/redtie,
+						/obj/item/clothing/under/shirt_pants_w/blacktie,
+						/obj/item/clothing/under/shirt_pants_w/bluetie,
+						/obj/item/clothing/under/shirt_pants_w/redtie,
+						/obj/item/clothing/under/shirt_pants_w,
+						/obj/item/clothing/under/shirt_pants_br/blacktie,
+						/obj/item/clothing/under/shirt_pants_br/bluetie,
+						/obj/item/clothing/under/shirt_pants_br/redtie,
+						/obj/item/clothing/under/shirt_pants_br,
+						/obj/item/clothing/under/shirt_pants_b/blacktie,
+						/obj/item/clothing/under/shirt_pants_b/redtie,
+						/obj/item/clothing/under/shirt_pants_b/bluetie,
+						/obj/item/clothing/under/shirt_pants_b,
+						/obj/item/clothing/under/gimmick/butler,
+						/obj/item/clothing/under/misc/dress,
+						/obj/item/clothing/under/misc/dress/red,
+						/obj/item/clothing/suit/dressb,
+						/obj/item/clothing/under/misc/fancy_vest)
+
+	one
+		amt2spawn = 1
+
+	two
+		amt2spawn = 2
+
+	three
+		amt2spawn = 3
+
+	four
+		amt2spawn = 4
+
+	five
+		amt2spawn = 5
+
+	six
+		amt2spawn = 6
+
+	seven
+		amt2spawn = 7
+
+	one_or_zero
+		min_amt2spawn = 0
+		max_amt2spawn = 1
+
+	maybe_few
+		min_amt2spawn = 0
+		max_amt2spawn = 2
+
+	few
+		min_amt2spawn = 1
+		max_amt2spawn = 3
+
+	some
+		min_amt2spawn = 3
+		max_amt2spawn = 5
+
+	lots
+		min_amt2spawn = 5
+		max_amt2spawn = 7
+
 /obj/random_item_spawner/furniture_parts
 	name = "furniture parts spawner"
 	icon_state = "rand_furniture"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

does a couple things:
- makes a new random spawner for formal clothes, just to give some variety to what comes in the crate
- adds azrun's subtype of dress shoes (the ones that give you the ability to use social dancing abilities) to the crate
if adjustments need to be made to the pricing, or what is included besides the shoes, im willing to adjust it. the point of the pr is mainly to make the shoes available for purchase

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

social dancing is a really neat feature, having a player accessible way for the ability to be utilized would be really fun for things like company parties or events

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino, Azrun
(*)Adds a new "Ballroom Supplies" crate to cargo, containing dress shoes that allow players to use Azrun's social dancing feature.
```
