### PR TITLE
Lower frag grenade odds from gang crates

### DIFF
--- a/code/obj/storage/gang_crate.dm
+++ b/code/obj/storage/gang_crate.dm
@@ -834,6 +834,7 @@ ABSTRACT_TYPE(/obj/randomloot_spawner/short)
 
 	// GANG_CRATE_GUN:
 	webley
+		weight=10
 		tier = GANG_CRATE_GUN
 		spawn_loot(var/C,var/datum/loot_spawner_info/I)
 			var/obj/item/gun/kinetic/gun = spawn_item(C,I,/obj/item/gun/kinetic/webley,scale_x=0.65,scale_y=0.65)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the weighting of the revolver from gang crates


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The makarov helped dilute this pool, now people are getting too many grenades.
Lower their frequency some, instead.

