### PR TITLE
Material based pipe reinforcement

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -355,6 +355,9 @@
 		return
 	sheet.change_stack_amount(-5)
 	src.setMaterial(sheet.material)
+	if (!("reinforced" in src.name_prefixes))
+		src.name_prefix("reinforced") // so it says "bohrum reinforced pipe"
+	src.UpdateName()
 
 /obj/machinery/atmospherics/pipe/simple/disposing()
 	node1?.disconnect(src)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -337,11 +337,17 @@
 		list(user, S), W.icon, W.icon_state, "[user] finishes working with \the [src].")
 		actions.start(action_bar, user)
 
-	else if (!src.destroyed && !src.ruptured && istype(W, /obj/item/sheet))
+	else if (istype(W, /obj/item/sheet))
 		if (actions.hasAction(user, /datum/action/bar/private/welding))
+			return
+		if (src.destroyed || src.ruptured)
+			boutput(user, SPAN_ALERT("You should repair [src] first."))
 			return
 		if (!(W.material?.getMaterialFlags() & MATERIAL_METAL))
 			boutput(user, SPAN_ALERT("You can't weld that!"))
+			return
+		if (W.material?.isSameMaterial(src.material))
+			boutput(user, SPAN_ALERT("[src] is already reinforced with [src.material.getName()]!"))
 			return
 		var/obj/item/weldingtool/welder = user.find_tool_in_hand(TOOL_WELDING)
 		if (W.amount < 5)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -177,7 +177,8 @@
 		return
 
 	if(pressure && src.fatigue_pressure)
-		var/iterations = clamp(log(pressure/src.fatigue_pressure)/log(2),0,20)
+		var/effective_fatigue_pressure = src.fatigue_pressure * ((src.material?.getProperty("density") ** 2) || 1)
+		var/iterations = clamp(log(pressure/effective_fatigue_pressure)/log(2),0,20)
 		for(var/i = iterations; i>0 && i>=ruptured; i--)
 			if(prob(5/i))
 				new_rupture = i + 1
@@ -335,7 +336,25 @@
 		var/datum/action/bar/icon/callback/action_bar = new /datum/action/bar/icon/callback(user, src, duration, /obj/machinery/atmospherics/pipe/simple/proc/reconstruct_pipe,\
 		list(user, S), W.icon, W.icon_state, "[user] finishes working with \the [src].")
 		actions.start(action_bar, user)
+	else if (!src.destroyed && !src.ruptured && istype(W, /obj/item/sheet))
+		if (!(W.material?.getMaterialFlags() & MATERIAL_METAL))
+			boutput(user, SPAN_ALERT("You can't weld that!"))
+			return
+		var/obj/item/weldingtool/welder = user.find_tool_in_hand(TOOL_WELDING)
+		if (W.amount < 5)
+			boutput(user, SPAN_ALERT("You need at least 10 sheets to reinforce [src]."))
+		if (!welder || !welder.welding)
+			boutput(user, SPAN_ALERT("You need something to weld [W] to [src] with!"))
+			return
+		if (!welder.try_weld(user, 0.8, noisy=2))
+			return
+		SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, PROC_REF(weld_sheet), list(W, user), welder.icon, welder.icon_state, SPAN_NOTICE("[user] welds [W] to [src]"), INTERRUPT_STUNNED)
 
+/obj/machinery/atmospherics/pipe/simple/proc/weld_sheet(obj/item/sheet/sheet, mob/user)
+	if (sheet.amount < 5)
+		return
+	sheet.change_stack_amount(-5)
+	src.setMaterial(sheet.material)
 
 /obj/machinery/atmospherics/pipe/simple/disposing()
 	node1?.disconnect(src)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -310,6 +310,7 @@
 			if (prob(50))
 				rupture()
 
+#define SHEETS_TO_REINFORCE 5
 /obj/machinery/atmospherics/pipe/simple/attackby(var/obj/item/W, var/mob/user)
 	if(isweldingtool(W))
 		if(!ruptured)
@@ -350,7 +351,7 @@
 			boutput(user, SPAN_ALERT("[src] is already reinforced with [src.material.getName()]!"))
 			return
 		var/obj/item/weldingtool/welder = user.find_tool_in_hand(TOOL_WELDING)
-		if (W.amount < 5)
+		if (W.amount < SHEETS_TO_REINFORCE)
 			boutput(user, SPAN_ALERT("You need at least 10 sheets to reinforce [src]."))
 		if (!welder || !welder.welding)
 			boutput(user, SPAN_ALERT("You need something to weld [W] to [src] with!"))
@@ -362,13 +363,15 @@
 				list(W, user), SPAN_NOTICE("[user] welds [W] to [src]"), positions[1], positions[2]),user)
 
 /obj/machinery/atmospherics/pipe/simple/proc/weld_sheet(obj/item/sheet/sheet, mob/user)
-	if (sheet.amount < 5)
+	if (sheet.amount < SHEETS_TO_REINFORCE)
 		return
-	sheet.change_stack_amount(-5)
+	sheet.change_stack_amount(-SHEETS_TO_REINFORCE)
 	src.setMaterial(sheet.material)
 	if (!("reinforced" in src.name_prefixes))
 		src.name_prefix("reinforced") // so it says "bohrum reinforced pipe"
 	src.UpdateName()
+
+#undef SHEETS_TO_REINFORCE
 
 /obj/machinery/atmospherics/pipe/simple/disposing()
 	node1?.disconnect(src)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -336,7 +336,10 @@
 		var/datum/action/bar/icon/callback/action_bar = new /datum/action/bar/icon/callback(user, src, duration, /obj/machinery/atmospherics/pipe/simple/proc/reconstruct_pipe,\
 		list(user, S), W.icon, W.icon_state, "[user] finishes working with \the [src].")
 		actions.start(action_bar, user)
+
 	else if (!src.destroyed && !src.ruptured && istype(W, /obj/item/sheet))
+		if (actions.hasAction(user, /datum/action/bar/private/welding))
+			return
 		if (!(W.material?.getMaterialFlags() & MATERIAL_METAL))
 			boutput(user, SPAN_ALERT("You can't weld that!"))
 			return
@@ -348,7 +351,9 @@
 			return
 		if (!welder.try_weld(user, 0.8, noisy=2))
 			return
-		SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, PROC_REF(weld_sheet), list(W, user), welder.icon, welder.icon_state, SPAN_NOTICE("[user] welds [W] to [src]"), INTERRUPT_STUNNED)
+		var/positions = src.get_welding_positions()
+		actions.start(new /datum/action/bar/private/welding(user, src, 2 SECONDS, PROC_REF(weld_sheet), \
+				list(W, user), SPAN_NOTICE("[user] welds [W] to [src]"), positions[1], positions[2]),user)
 
 /obj/machinery/atmospherics/pipe/simple/proc/weld_sheet(obj/item/sheet/sheet, mob/user)
 	if (sheet.amount < 5)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INPUT WANTED] [BALANCE] [OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you weld 5 sheets of any metal to a pipe to set its material to that material, scaling the pipe's rupture pressure by the square of the material's density (stacks with GHC)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More interesting ways to do high pressure TEG setups without going insane, more uses for ore and material science.
Input wanted from TEG nerds to say if this will be useful/effective/unbalanced etc.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Gas pipes can now be reinforced with metal sheets to increase their pressure tolerance based on the material's density.
```
