### PR TITLE
More, smaller gangs

### DIFF
--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -1,4 +1,4 @@
-#define GANG_MAX_MEMBERS 4
+#define GANG_MAX_MEMBERS 3
 
 /// How long the leader must cryo before gang members can take their role
 #define GANG_CRYO_LOCKOUT 7.5 MINUTES

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -30,9 +30,9 @@
 		if(player.ready) num_players++
 
 #ifdef RP_MODE
-#define PLAYERS_PER_GANG_GENERATED 15
-#else
 #define PLAYERS_PER_GANG_GENERATED 12
+#else
+#define PLAYERS_PER_GANG_GENERATED 9
 #endif
 	var/num_teams = clamp(round((num_players) / PLAYERS_PER_GANG_GENERATED), setup_min_teams, setup_max_teams) //1 gang per 9 players, 15 on RP
 #undef PLAYERS_PER_GANG_GENERATED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers gang size from 5 -> 4 (1 leader, 3 members)
Lowers pop requirements per gang from:
- 15 -> 12 (RP)
- 12 -> 9 (Classic)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People aren't seeing 3 gangs. I think this is worth a testmerge to see how this affects gang counts.
It could also be a bug? This will make it more obvious.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)Gangs have been shrunk from 5 to 4 members. 
(*)More gangs will spawn, so an equal number of gang members will exist.
```
