### PR TITLE
Change Lawbringer to apply DNA on redeem

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -325,6 +325,7 @@ mob/verb/checkrewards()
 		LG.set_loc(get_turf(C.mob))
 		C.mob.put_in_hand(LG)
 		boutput(C.mob, "Your E-Gun vanishes and is replaced with [LG]!")
+		LG.assign_name(C.mob)
 		C.mob.put_in_hand_or_drop(LGP)
 		boutput(C.mob, SPAN_EMOTE("A pamphlet flutters out."))
 		return

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1300,19 +1300,23 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		..()
 
 	attack_hand(mob/user)
-		src.assign_name(user)
+		if (!owner_prints)
+			src.assign_name(user)
 		..()
-
 
 	//if it has no owner prints scanned, the next person to attack_self it is the owner.
 	//you have to use voice activation to change modes. haha!
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
-		src.assign_name(user)
+		if (owner_prints)
+			boutput(user, SPAN_NOTICE("There don't seem to be any buttons on [src] to press."))
+		else
+			src.assign_name(user)
+		..()
+
 
 	proc/assign_name(var/mob/M)
 		if (owner_prints)
-			boutput(M, SPAN_NOTICE("There don't seem to be any buttons on [src] to press."))
 			return
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1291,7 +1291,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		// projectiles = list(current_projectile,new/datum/projectile/bullet/revolver_38/lb,new/datum/projectile/bullet/smoke,new/datum/projectile/bullet/tranq_dart/law_giver,new/datum/projectile/bullet/flare,new/datum/projectile/bullet/aex/lawbringer,new/datum/projectile/bullet/clownshot)
 
 		src.indicator_display = image('icons/obj/items/guns/energy.dmi', "")
-		assign_name(M)
+		src.assign_name(M)
 
 		..()
 
@@ -1300,7 +1300,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		..()
 
 	attack_hand(mob/user)
-		assign_name(user)
+		src.assign_name(user)
 		..()
 
 
@@ -1308,7 +1308,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	//you have to use voice activation to change modes. haha!
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
-		assign_name(user)
+		src.assign_name(user)
 
 	proc/assign_name(var/mob/M)
 		if (owner_prints)
@@ -1317,7 +1317,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if (H.bioHolder)
-				boutput(M, SPAN_ALERT("[src] has accepted the DNA string. [H.real_name] is now the owner!"))
+				boutput(M, SPAN_ALERT("[src] has accepted the DNA string. You are now the owner!"))
 				owner_prints = H.bioHolder.Uid
 				src.name = "HoS [H.real_name]'s Lawbringer"
 				tooltip_rebuild = 1

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1300,9 +1300,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		..()
 
 	attack_hand(mob/user)
-		if (!owner_prints)
-			boutput(user, SPAN_ALERT("[src] has accepted your DNA string. You are its owner!"))
-			assign_name(user)
+		assign_name(user)
 		..()
 
 
@@ -1310,16 +1308,16 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	//you have to use voice activation to change modes. haha!
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
-		if (!owner_prints)
-			boutput(user, SPAN_ALERT("[src] has accepted your DNA string. You are its owner!"))
-			assign_name(user)
-		else
-			boutput(user, SPAN_NOTICE("There don't seem to be any buttons on [src] to press."))
+		assign_name(user)
 
 	proc/assign_name(var/mob/M)
+		if (owner_prints)
+			boutput(M, SPAN_NOTICE("There don't seem to be any buttons on [src] to press."))
+			return
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if (H.bioHolder)
+				boutput(M, SPAN_ALERT("[src] has accepted the DNA string. [H.real_name] is now the owner!"))
 				owner_prints = H.bioHolder.Uid
 				src.name = "HoS [H.real_name]'s Lawbringer"
 				tooltip_rebuild = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Removal]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the Lawbringer to immediately apply the DNA string upon redeeming the job reward.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This means you won't have to activate / drop and re-grab the gun after redeeming and removes user error.
Additionally, it removes the chance for something to go horribly wrong on redemption or the HoS forgetting to DNA lock the gun. The gun is already supposed to be tied to the HoS, might as well ensure this properly.
