### PR TITLE
Gang tags are resistant to low severity explosions

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -176,8 +176,29 @@
 
 	..()
 
+/datum/game_mode/gang/proc/is_deceased(var/datum/mind/M)
+	if (!M?.current)
+		return TRUE
+	if(isdead(M.current))
+		return TRUE
+	if(inafterlife(M.current))
+		return TRUE
+	if(isVRghost(M.current))
+		return TRUE
+	if(!iscarbon(M.current))
+		return TRUE
+	return FALSE
+
 /datum/game_mode/gang/proc/check_winner()
 	var/datum/gang/victorius_gang = null
+
+	// Round is over. Grant points for living players.
+	for (var/datum/gang/gang in src.gangs)
+		if (is_deceased(gang.leader))
+			boutput(world, "leader alive for [gang.gang_name]")
+		for (var/datum/mind/member in gang.members)
+			if (!is_deceased(member))
+				boutput(world, "member [member.current] alive for [gang.gang_name]")
 
 	// Find the highest scoring gang.
 	for (var/datum/gang/gang in src.gangs)
@@ -2351,6 +2372,7 @@ proc/broadcast_to_all_gangs(var/message)
 	density = FALSE
 	anchored = TRUE
 	layer = TAG_LAYER
+	exploded = FALSE
 	icon = 'icons/obj/decals/graffiti.dmi'
 	icon_state = "gangtag0"
 	var/datum/gang/owners = null
@@ -2385,6 +2407,12 @@ proc/broadcast_to_all_gangs(var/message)
 		heat = round(heat * GANG_TAG_HEAT_DECAY_MUL, 0.01) //slowly decay heat
 		mobs = list()
 		return heat
+
+	ex_act()
+		if (!exploded)
+			exploded = TRUE
+			desc = desc + " So heavy, in fact, that this tag can't be exploded. Huh."
+		return //no!
 
 	proc/apply_score(var/largestHeat)
 		var/mappedHeat // the 'heat' value mapped to the scale of 0-5

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -2387,11 +2387,13 @@ proc/broadcast_to_all_gangs(var/message)
 		mobs = list()
 		return heat
 
-	ex_act()
-		if (!exploded)
-			exploded = TRUE
-			desc = desc + " So heavy, in fact, that this tag can't be exploded. Huh."
-		return //no!
+	ex_act(severity)
+		if (severity > 1)
+			if (!exploded)
+				exploded = TRUE
+				desc = desc + " So heavy, in fact, that this tag hasn't exploded. Huh."
+			return //no!
+		..()
 
 	proc/apply_score(var/largestHeat)
 		var/mappedHeat // the 'heat' value mapped to the scale of 0-5

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -176,29 +176,8 @@
 
 	..()
 
-/datum/game_mode/gang/proc/is_deceased(var/datum/mind/M)
-	if (!M?.current)
-		return TRUE
-	if(isdead(M.current))
-		return TRUE
-	if(inafterlife(M.current))
-		return TRUE
-	if(isVRghost(M.current))
-		return TRUE
-	if(!iscarbon(M.current))
-		return TRUE
-	return FALSE
-
 /datum/game_mode/gang/proc/check_winner()
 	var/datum/gang/victorius_gang = null
-
-	// Round is over. Grant points for living players.
-	for (var/datum/gang/gang in src.gangs)
-		if (is_deceased(gang.leader))
-			boutput(world, "leader alive for [gang.gang_name]")
-		for (var/datum/mind/member in gang.members)
-			if (!is_deceased(member))
-				boutput(world, "member [member.current] alive for [gang.gang_name]")
 
 	// Find the highest scoring gang.
 	for (var/datum/gang/gang in src.gangs)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -2372,9 +2372,9 @@ proc/broadcast_to_all_gangs(var/message)
 	density = FALSE
 	anchored = TRUE
 	layer = TAG_LAYER
-	exploded = FALSE
 	icon = 'icons/obj/decals/graffiti.dmi'
 	icon_state = "gangtag0"
+	var/exploded = FALSE
 	var/datum/gang/owners = null
 	var/list/mobs
 	var/heat = 0 // a rough estimation of how regularly this tag has people near it


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAMEMODES][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gang tags can no longer be exploded away, and instead have a little easter egg.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#18634
People are just blowing tags up. It's the same issue as cleaning it normally (but with extra steps).
It's also way easier to seether a tag than to do the tag - It's not fun and can turn territories into a slog again if I just refund the sprays.