### PR TITLE
Add material ID checks for high-grade cloth stacks

### DIFF
--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -611,6 +611,14 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 	typepath = /obj/item/material_piece/cloth/carbon
 	typepath_alt = /obj/item/material_piece/cloth/beewool
 
+	rc_eval(obj/item/eval_item)
+		. = ..()
+		if (.) return
+		if (istype(eval_item, /obj/item/material_piece/cloth))
+			if(eval_item.material?.getID() == "carbonfibre" || eval_item.material?.getID() == "beewool")
+				rollcount += eval_item.amount
+				. = TRUE
+
 /datum/rc_entry/stack/uqill_minprice
 	name = "uqill"
 	commodity = /datum/commodity/ore/uqill


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a custom evaluation for `/datum/rc_entry/stack/fancy_cloth` that check against the two potential material IDs, in addition to the existing two material typepaths. Since there are two different material IDs, it's not possible to use the existing `mat_id` field in req contract checks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18635