### PR TITLE
Reverts botany harvest nerf and tweaks produce satchels instead

### DIFF
--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -80,7 +80,7 @@ proc/HYPadd_harvest_reagents(var/obj/item/I,var/datum/plant/growing,var/datum/pl
 	if(I.reagents.maximum_volume)
 		var/putamount = round(to_add / putreagents.len)
 		for(var/X in putreagents)
-			I?.reagents?.add_reagent(X,putamount) // ?. runtime fix
+			I?.reagents?.add_reagent(X,putamount,,, 1) // ?. runtime fix
 	// And finally put them in there. We figure out the max volume and add an even amount of
 	// all reagents into the item.
 

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -7,16 +7,13 @@
 	health = 6
 	w_class = W_CLASS_TINY
 	event_handler_flags = USE_FLUID_ENTER | NO_MOUSEDROP_QOL
-	var/maxitems = 50
+	var/maxitems = 30
 	var/max_stack_scoop = 20 //! if you try to put stacks inside the item, this one limits how much you can in one action. Creating 100 items out of a stack in a single action should not happen.
 	var/list/allowed = null
 	var/list/exceptions = null //! this list are for items that are in the allowed-list for other reasons, but should not be able to be put in satchels
 	var/maximal_w_class = W_CLASS_BULKY //! the maximum weight class the satchels should be able to carry.
 	var/itemstring = "items"
 	inventory_counter_enabled = 1
-
-	HELP_MESSAGE_OVERRIDE("Click on it to pull out a random item, or click on it with <b>Grab Intent</b> to search for a specific item.")
-
 
 	New()
 		..()
@@ -62,69 +59,6 @@
 			src.UpdateIcon()
 			tooltip_rebuild = 1
 		else ..()
-
-	attack_hand(mob/user)
-		// There's a hilarious bug in here - if you're searching through the container
-		// and then throw it, after you finish searching the container will just.
-		// warp back to your hands.
-		// This is probably easily fixable by just running the check again
-		// but to be honest this is one of those funny bugs that can be fixed later
-
-		if (GET_DIST(user, src) <= 0 && length(src.contents))
-			if (user.l_hand == src || user.r_hand == src)
-				var/obj/item/getItem = null
-
-				if (length(src.contents) > 1)
-					if (user.a_intent == INTENT_GRAB)
-						getItem = src.search_through(user)
-
-					else
-						user.visible_message(SPAN_NOTICE("<b>[user]</b> rummages through \the [src]."),\
-						SPAN_NOTICE("You rummage through \the [src]."))
-
-						getItem = pick(src.contents)
-
-				else if (length(src.contents) == 1)
-					getItem = src.contents[1]
-
-				if (getItem)
-					user.visible_message(SPAN_NOTICE("<b>[user]</b> takes \a [getItem.name] out of \the [src]."),\
-					SPAN_NOTICE("You take \a [getItem.name] from [src]."))
-					user.put_in_hand_or_drop(getItem)
-					src.UpdateIcon()
-			tooltip_rebuild = 1
-		return ..(user)
-
-	proc/search_through(mob/user as mob)
-
-		if(!istype(user))
-			return
-
-		// attack_hand does all the checks for if you can do this
-		user.visible_message(SPAN_NOTICE("<b>[user]</b> looks through \the [src]..."),\
-		SPAN_NOTICE("You look through \the [src]."))
-		var/list/satchel_contents = list()
-		var/list/has_dupes = list()
-		var/temp = ""
-		for (var/obj/item/I in src.contents)
-			temp = ""
-			if (satchel_contents[I.name])
-				if (has_dupes[I.name])
-					has_dupes[I.name] = has_dupes[I.name] + 1
-				else
-					has_dupes[I.name] = 2
-				temp = "[I.name] ([has_dupes[I.name]])"
-				satchel_contents += temp
-				satchel_contents[temp] = I
-			else
-				temp = "[I.name]"
-				satchel_contents += temp
-				satchel_contents[temp] = I
-		sortList(satchel_contents, /proc/cmp_text_asc)
-		var/chosenItem = input("Select an item to pull out.", "Choose Item") as null|anything in satchel_contents
-		if (!chosenItem || !(satchel_contents[chosenItem] in src.contents))
-			return
-		return satchel_contents[chosenItem]
 
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
@@ -273,7 +207,7 @@
 
 		large
 			desc = "A leather satchel for carrying around crops and seeds. This one happens to be <em>really</em> big."
-			maxitems = 200
+			maxitems = 100
 
 
 	mining

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -179,7 +179,6 @@
 		name = "produce satchel"
 		desc = "A leather satchel for carrying around crops and seeds."
 		icon_state = "hydrosatchel"
-		maxitems = 30
 		itemstring = "items of produce"
 
 		New()

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -7,7 +7,7 @@
 	health = 6
 	w_class = W_CLASS_TINY
 	event_handler_flags = USE_FLUID_ENTER | NO_MOUSEDROP_QOL
-	var/maxitems = 30
+	var/maxitems = 50
 	var/max_stack_scoop = 20 //! if you try to put stacks inside the item, this one limits how much you can in one action. Creating 100 items out of a stack in a single action should not happen.
 	var/list/allowed = null
 	var/list/exceptions = null //! this list are for items that are in the allowed-list for other reasons, but should not be able to be put in satchels
@@ -179,7 +179,7 @@
 		name = "produce satchel"
 		desc = "A leather satchel for carrying around crops and seeds."
 		icon_state = "hydrosatchel"
-
+		maxitems = 30
 		itemstring = "items of produce"
 
 		New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [HYDROPONICS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reverts c0c9958 and instead removes the ability to quickly pull individual items out of produce satchels.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The original change was made to nerf water-potassium/seething tomato spam, but also removes one of the more unique aspects of botany: delayed reactions.
This change affects seething tomatoes as well, reducing the possibility to easily chain stun someone with near-infinite tomato spam from a massive produce satchel, while retaining the ability to splice interesting delayed reactions.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Botany produce no longer triggers reactions on harvest.
(+)You can no longer quickly remove single items from a produce satchel.
```
