### PR TITLE
Fix casing for tools that are available in cyborg modules

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -511,7 +511,7 @@ TYPEINFO(/obj/item/device/matanalyzer)
 
 /obj/item/device/matanalyzer
 	icon_state = "matanalyzer"
-	name = "Material analyzer"
+	name = "material analyzer"
 	desc = "This piece of equipment can detect and analyze materials."
 	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT
 	w_class = W_CLASS_SMALL

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -960,7 +960,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 #undef PRISONER_MODE_INCARCERATED
 
 /obj/item/device/ticket_writer
-	name = "Security TicketWriter 2000"
+	name = "security TicketWriter 2000"
 	desc = "A device used to issue tickets from the security department."
 	icon_state = "ticketwriter"
 	item_state = "electronic"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Name casing pass for tools that are available in cyborg modules, adjusts specifically:

- Material analyzer -> material analyzer
- Security TicketWriter 2000 -> security TicketWriter 2000

"security TicketWriter 2000" is comparable to "security RecordTrak", which is already in there.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Consistency.