### PR TITLE
Add action bar for forced ampoule inhaling

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3312,3 +3312,12 @@
 
 /mob/proc/add_antagonist(role_id, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_OTHER, respect_mutual_exclusives = TRUE, do_pseudo = FALSE, do_vr = FALSE, late_setup = FALSE)
 	src.mind?.add_antagonist(role_id, do_equip, do_objectives, do_relocate, silent, source, respect_mutual_exclusives, do_pseudo, do_vr, late_setup)
+
+/mob/proc/inhale_ampoule(obj/item/reagent_containers/ampoule/amp, mob/user)
+	user.visible_message(SPAN_ALERT("[user] forces [src] to inhale [amp]!"), SPAN_ALERT("You force [src] to inhale [amp]!"))
+	logTheThing(LOG_COMBAT, user, "[user == src ? "inhales" : "makes [constructTarget(src,"combat")] inhale"] an ampoule [log_reagents(amp)] at [log_loc(user)].")
+	amp.reagents.reaction(src, INGEST, 5, paramslist = list("inhaled"))
+	amp.reagents.trans_to(src, 5)
+	amp.expended = TRUE
+	amp.icon_state = "amp-broken"
+	playsound(user.loc, 'sound/impact_sounds/Generic_Snap_1.ogg', 50, TRUE)

--- a/code/modules/chemistry/tools/ampoules.dm
+++ b/code/modules/chemistry/tools/ampoules.dm
@@ -27,20 +27,8 @@
 		boutput(user, SPAN_NOTICE("You crack open and inhale [src]."))
 	else
 		user.visible_message(SPAN_ALERT("[user] attempts to force [target] to inhale [src]!"))
-		logTheThing(LOG_COMBAT, user, "tries to make [constructTarget(target,"combat")] inhale [src] [log_reagents(src)] at [log_loc(user)].")
-		if(!do_mob(user, target))
-			if(user && ismob(user))
-				boutput(user, SPAN_ALERT("You were interrupted!"))
-			return
-		user.visible_message(SPAN_ALERT("[user] forces [target] to inhale [src]!"), \
-								SPAN_ALERT("You force [target] to inhale [src]!"))
-	logTheThing(LOG_COMBAT, user, "[user == target ? "inhales" : "makes [constructTarget(target,"combat")] inhale"] an ampoule [log_reagents(src)] at [log_loc(user)].")
-	reagents.reaction(target, INGEST, 5, paramslist = list("inhaled"))
-	reagents.trans_to(target, 5)
-	expended = TRUE
-	icon_state = "amp-broken"
-	playsound(user.loc, 'sound/impact_sounds/Generic_Snap_1.ogg', 50, 1)
-	return
+		SETUP_GENERIC_ACTIONBAR(user, target, 3 SECONDS, /mob/proc/inhale_ampoule, list(src, user), src.icon, src.icon_state, null, \
+			list(INTERRUPT_MOVE, INTERRUPT_ATTACKED, INTERRUPT_STUNNED, INTERRUPT_ACTION))
 
 /obj/item/reagent_containers/ampoule/on_reagent_change()
 	..()


### PR DESCRIPTION
[PLAYER ACTIONS][GAME OBJECTS][BALANCE][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes applying ampoules to others use an action bar


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More visible/clear on when its happening

Probably affects smelling salts most, but lets you see when someone is already applying one when more than one person tries to. Also gives antags a visible time on their sabotage window