### PR TITLE
Fix runtime for armoring hazard suits with no fingerprints

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -284,6 +284,8 @@ TYPEINFO(/obj/item/clothing/suit/hazard)
 
 		boutput(user, SPAN_NOTICE("You attach [W] to [src]."))
 		src.armor()
+		if(!src.fingerprints)
+			src.fingerprints = list()
 		src.fingerprints |= W.fingerprints
 		qdel(W)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensures the hazard suit has fingerprints before merging the armor vest's fingerprints into its list.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18606
