### PR TITLE
Puritan clones get an additional major clone defect

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -280,9 +280,6 @@ TYPEINFO(/obj/machinery/clonepod)
 					// First cloning can't get major defects
 					defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MINOR)
 
-		if (length(defects.active_cloner_defects) > 7)
-			src.occupant.unlock_medal("Quit Cloning Around")
-
 		src.mess = FALSE
 		var/is_puritan = FALSE
 		if (!isnull(traits) && src.occupant.traitHolder)
@@ -322,6 +319,9 @@ TYPEINFO(/obj/machinery/clonepod)
 							if (prob(50))
 								P.limbs.sever(limb)
 			#endif
+
+		if (length(defects.active_cloner_defects) > 7)
+			src.occupant.unlock_medal("Quit Cloning Around")
 
 		if (src.mess)
 			boutput(src.occupant, "[SPAN_NOTICE("<b>Clone generation process initi&mdash;</b>")][SPAN_ALERT(" oh fuck oh god oh no no NO <b>NO NO THIS IS NOT GOOD</b>")]")

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -302,6 +302,7 @@ TYPEINFO(/obj/machinery/clonepod)
 				// Puritans have a bad time.
 				// This is a little different from how it was before:
 				// - Immediately take 250 tox and 100 random brute
+				// - Always get a major cloning defect
 				// - 50% chance, per limb, to lose that limb
 				// - enforced premature_clone, which gibs you on death
 				// If you have a clone body that's been allowed to fully heal before
@@ -312,6 +313,7 @@ TYPEINFO(/obj/machinery/clonepod)
 				src.occupant.bioHolder?.AddEffect("premature_clone")
 				src.occupant.take_toxin_damage(250)
 				random_brute_damage(src.occupant, 100, 0)
+				defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
 				if (ishuman(src.occupant))
 					var/mob/living/carbon/human/P = src.occupant
 					if (P.limbs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][feature][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the cloned person is puritan, add a major defect in addition to the other puritan cloning issues. Move the medal check 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Puritan cloning can be done relatively consistently with prepared medbay staff. Adding a random, major cloning defect requires diagnosing and reacting to severe issues by attending doctors, alongside the prepwork it takes to try saving a puritan clone.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Puritans recieve major cloning defects when cloned.
```
