### PR TITLE
Clarion Mail Fixes The Squeakquel

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -36668,7 +36668,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/switch_junction/right/south{
-	mail_tag = "detectives"
+	mail_tag = "detective"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1535,7 +1535,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/disposal/mail/small/autoname/kitchen/south,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "apT" = (
@@ -42385,12 +42384,11 @@
 /obj/item/kitchen/utensil/fork,
 /obj/item/kitchen/utensil/spoon,
 /obj/item/reagent_containers/food/drinks/bowl,
-/obj/machinery/disposal/mail/small{
-	dir = 4;
-	pixel_x = -5
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 4
+	},
+/obj/machinery/disposal/mail/small/autoname/kitchen/east{
+	pixel_x = -5
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -10706,9 +10706,6 @@
 	},
 /area/station/hallway/primary/southeast)
 "brn" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/disposalpipe/switch_junction{
 	desc = "An underfloor mail pipe.";
 	dir = 8;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Remove duplicate mail chute in Kitchen and add proper tag to existing one
- Remove extra mail pipe on the mining router
- Change detective routing pipe tag from "detectives" to "detective"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The mail is sacred