### PR TITLE
Fix ampoules

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3326,7 +3326,8 @@
 	src.mind?.add_antagonist(role_id, do_equip, do_objectives, do_relocate, silent, source, respect_mutual_exclusives, do_pseudo, do_vr, late_setup)
 
 /mob/proc/inhale_ampoule(obj/item/reagent_containers/ampoule/amp, mob/user)
-	user.visible_message(SPAN_ALERT("[user] forces [src] to inhale [amp]!"), SPAN_ALERT("You force [src] to inhale [amp]!"))
+	if(user != src)
+		user.visible_message(SPAN_ALERT("[user] forces [src] to inhale [amp]!"), SPAN_ALERT("You force [src] to inhale [amp]!"))
 	logTheThing(LOG_COMBAT, user, "[user == src ? "inhales" : "makes [constructTarget(src,"combat")] inhale"] an ampoule [log_reagents(amp)] at [log_loc(user)].")
 	amp.reagents.reaction(src, INGEST, 5, paramslist = list("inhaled"))
 	amp.reagents.trans_to(src, 5)

--- a/code/modules/chemistry/tools/ampoules.dm
+++ b/code/modules/chemistry/tools/ampoules.dm
@@ -23,12 +23,12 @@
 	if(expended || reagents.total_volume <= 0)
 		boutput(user, SPAN_ALERT("[src] is empty!"))
 		return
-	else if(target == user)
+	if(target == user)
 		boutput(user, SPAN_NOTICE("You crack open and inhale [src]."))
 	else
 		user.visible_message(SPAN_ALERT("[user] attempts to force [target] to inhale [src]!"))
-		SETUP_GENERIC_ACTIONBAR(user, target, 3 SECONDS, /mob/proc/inhale_ampoule, list(src, user), src.icon, src.icon_state, null, \
-			list(INTERRUPT_MOVE, INTERRUPT_ATTACKED, INTERRUPT_STUNNED, INTERRUPT_ACTION))
+	SETUP_GENERIC_ACTIONBAR(user, target, 3 SECONDS, /mob/proc/inhale_ampoule, list(src, user), src.icon, src.icon_state, null, \
+		list(INTERRUPT_MOVE, INTERRUPT_ATTACKED, INTERRUPT_STUNNED, INTERRUPT_ACTION))
 
 /obj/item/reagent_containers/ampoule/on_reagent_change()
 	..()

--- a/code/modules/chemistry/tools/ampoules.dm
+++ b/code/modules/chemistry/tools/ampoules.dm
@@ -25,10 +25,11 @@
 		return
 	if(target == user)
 		boutput(user, SPAN_NOTICE("You crack open and inhale [src]."))
+		user.inhale_ampoule(src, user)
 	else
 		user.visible_message(SPAN_ALERT("[user] attempts to force [target] to inhale [src]!"))
-	SETUP_GENERIC_ACTIONBAR(user, target, 3 SECONDS, /mob/proc/inhale_ampoule, list(src, user), src.icon, src.icon_state, null, \
-		list(INTERRUPT_MOVE, INTERRUPT_ATTACKED, INTERRUPT_STUNNED, INTERRUPT_ACTION))
+		SETUP_GENERIC_ACTIONBAR(user, target, 3 SECONDS, /mob/proc/inhale_ampoule, list(src, user), src.icon, src.icon_state, null, \
+			list(INTERRUPT_MOVE, INTERRUPT_ATTACKED, INTERRUPT_STUNNED, INTERRUPT_ACTION))
 
 /obj/item/reagent_containers/ampoule/on_reagent_change()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix the `if` in ampoule `attack` so it actually runs the actionbar if you use them on yourself

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18669
