### PR TITLE
Buffs bladed gloves

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -51,8 +51,7 @@
 		LAZYLISTINIT(src.fingerprints)
 
 		if (H.gloves) // Fixed: now adds distorted prints even if 'fingerprintslast == ckey'. Important for the clean_forensic proc (Convair880).
-			if (!H.gloves.no_prints) // Stops very sneaky gloves from creating prints
-				seen_print = H.gloves.distort_prints(H.bioHolder.fingerprints, TRUE)
+			seen_print = H.gloves.distort_prints(H.bioHolder.fingerprints, TRUE)
 		else
 			seen_print = H.bioHolder.fingerprints
 

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -51,7 +51,7 @@
 		LAZYLISTINIT(src.fingerprints)
 
 		if (H.gloves) // Fixed: now adds distorted prints even if 'fingerprintslast == ckey'. Important for the clean_forensic proc (Convair880).
-			if (!(H.gloves.no_prints)) // Stops very sneaky gloves from creating prints
+			if (!H.gloves.no_prints) // Stops very sneaky gloves from creating prints
 				seen_print = H.gloves.distort_prints(H.bioHolder.fingerprints, TRUE)
 		else
 			seen_print = H.bioHolder.fingerprints

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -51,7 +51,8 @@
 		LAZYLISTINIT(src.fingerprints)
 
 		if (H.gloves) // Fixed: now adds distorted prints even if 'fingerprintslast == ckey'. Important for the clean_forensic proc (Convair880).
-			seen_print = H.gloves.distort_prints(H.bioHolder.fingerprints, TRUE)
+			if (!(H.gloves.no_prints)) // Stops very sneaky gloves from creating prints
+				seen_print = H.gloves.distort_prints(H.bioHolder.fingerprints, TRUE)
 		else
 			seen_print = H.bioHolder.fingerprints
 

--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1211,6 +1211,10 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 
 		return
 
+	gloves  // More agile attacks with bladed gloves
+		moveDelay = 2
+		moveDelayDuration = 2
+
 /datum/item_special/barrier
 	cooldown = 0
 	staminaCost = 0

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -22,6 +22,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
 	var/scramble_prints = 0
 	var/material_prints = null
+	var/no_prints = FALSE // For extra sneaky prints
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
 	var/glove_ID = null
@@ -509,6 +510,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "transparent"
 	item_state = "transparent"
 	material_prints = "transparent high-quality synthetic fibers"
+	no_prints = TRUE // leaves no trace behind
 	var/deployed = FALSE
 
 	nodescripition = TRUE
@@ -548,7 +550,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		if(check_target_immunity( target ))
 			return 0
 		logTheThing(LOG_COMBAT, user, "slashes [constructTarget(target,"combat")] with hand blades at [log_loc(user)].")
-		var/datum/attackResults/msgs = user.calculate_melee_attack(target, 16, 16, 0, 0.8, 0, can_punch = 0, can_kick = 0)
+		var/datum/attackResults/msgs = user.calculate_melee_attack(target, 15, 15, 0, 0.8, 0, can_punch = 0, can_kick = 0)
 		user.attack_effects(target, user.zone_sel?.selecting)
 		var/action = pick("stab", "slashe")
 		msgs.base_attack_message = SPAN_ALERT("<b>[user] [action]s [target] with their hand blades!</b>")
@@ -558,7 +560,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		user.lastattacked = target
 
 	proc/sheathe_blades_toggle(mob/living/user)
-		playsound(src.loc, 'sound/effects/sword_unsheath1.ogg', 50, 1)
+		playsound(src.loc, 'sound/effects/sword_unsheath1.ogg', 35, 1, -3)
 
 		if(deployed)
 			deployed = FALSE
@@ -584,12 +586,12 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		else
 			deployed = TRUE
 			hit_type = DAMAGE_CUT
-			force = 11
+			force = 15
 			stamina_damage = 20
 			stamina_cost = 10
 			stamina_crit_chance = 0
 			activeweapon = TRUE
-			setSpecialOverride(/datum/item_special/double, src)
+			setSpecialOverride(/datum/item_special/double/gloves, src)
 
 			attack_verbs = "slashes"
 			hitsound = 'sound/impact_sounds/Blade_Small_Bloody.ogg'

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -22,7 +22,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
 	var/scramble_prints = 0
 	var/material_prints = null
-	var/no_prints = FALSE // For extra sneaky prints
+	var/no_prints = FALSE
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
 	var/glove_ID = null

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -22,7 +22,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	var/hide_prints = 1 // Seems more efficient to do this with one global proc and a couple of vars (Convair880).
 	var/scramble_prints = 0
 	var/material_prints = null
-	var/no_prints = FALSE
+	var/no_prints = FALSE // Specifically used so worn gloves cannot be scanned unless removed first
 
 	var/can_be_charged = 0 // Currently, there are provisions for icon state "yellow" only. You have to update this file and mob_procs.dm if you're wanna use other glove sprites (Convair880).
 	var/glove_ID = null
@@ -509,15 +509,15 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	name = "transparent gloves"
 	icon_state = "transparent"
 	item_state = "transparent"
-	material_prints = "transparent high-quality synthetic fibers"
-	no_prints = TRUE // leaves no trace behind
+	material_prints = "insulative fibers"
+	no_prints = TRUE
 	var/deployed = FALSE
-
 	nodescripition = TRUE
 
 	custom_suicide = TRUE
 	suicide_in_hand = FALSE
 	HELP_MESSAGE_OVERRIDE(null)
+
 
 	get_help_message(dist, mob/user)
 		var/keybind = "Default: CTRL + Z"

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -552,7 +552,7 @@
 
 		if (!isnull(H.gloves))
 			var/obj/item/clothing/gloves/WG = H.gloves
-			if (WG.glove_ID)
+			if (WG.glove_ID && !(WG.no_prints))
 				glove_data += "[WG.glove_ID] ([SPAN_NOTICE("[H]'s worn [WG.name]")])"
 			if (!WG.hide_prints)
 				fingerprint_data += "<br>[SPAN_NOTICE("[H]'s fingerprints:")] [H.bioHolder.fingerprints]"


### PR DESCRIPTION
[LABEL][balance][clothing]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This pull request buffs the bladed gloves traitor item in a few minor to significant ways:
- Decreases the single attack from 16 to 15 cut damage, while buffing the double attack from 11 to 15 damage
- Lowers the sound range of the unsheathing effect by 3 tiles
- Reduces the movement slowdown from the double strike gloves attack
- Changes bladed gloves inprints to those of regular insulated gloves, and makes the gloves themselves unscannable when worn

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bladed gloves entered the game in a overtuned state, being able to being stacked with a variety of items that caused them to be pretty good high end 'nerd' options. After this was remedied, however, it slowly became clear the bladed gloves aren't cut to part for a 3 TC traitor item,  and these small fixes should make it's usability floor a lot more consistent, as well as making it truer to it's agile yet discrete option identity.

- The reduced slowdown will allow players to make better use of the glove's inconspicuous nature in hit-and-run attacks, as well as better utilize it in a defensive runaway manner.
- The increased damage will give it a bit of the bite it was previously lacking, and make it not distinctively underperform when compared to other close cost-ed traitor items and even a few regular weapons.
- The lack of distinct prints will help users not fear having them on more often, since it was a major weakness of the item and dead giveaway that someone had one.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)colossusqw
(+)Bladed gloves now create standard insulated glove markings, have a smaller attack slowdown, and deal 15 damage(previous 11).
```
