### PR TITLE
Refinements and bugfixes for zombie bites

### DIFF
--- a/code/modules/antagonists/zombie/abilities/infect.dm
+++ b/code/modules/antagonists/zombie/abilities/infect.dm
@@ -1,38 +1,44 @@
 /datum/targetable/zombie/infect
 	name = "Infect"
-	desc = "After a short delay, infect a human. If they are damaged enough or dead this will convert them instantly."
+	desc = "After a short delay, infect a human. If they are dead or very damaged, they will become a zombie instantly; otherwise, they will succumb gradually unless treated quickly."
 	icon = 'icons/mob/critter_ui.dmi'
 	icon_state = "critter_bite"
-	cooldown = 200
+	cooldown = 20 SECONDS
 	cooldown_after_action = TRUE
 	disabled = FALSE
 	targeted = TRUE
 	target_anything = TRUE
 
+	castcheck(atom/target)
+		return !src.disabled
+
 	cast(atom/target)
 		if (..())
-			return 1
-		if (disabled)
-			return 1
+			return TRUE
+		if (src.holder.owner == target)
+			boutput(src.holder.owner, SPAN_ALERT("You try to give yourself a zombie infection."))
+			boutput(src.holder.owner, SPAN_ALERT("But you're already totally sick."))
+			return TRUE
 		if (isobj(target))
 			target = get_turf(target)
 		if (isturf(target))
 			target = locate(/mob/living/) in target
 			if (!target)
-				boutput(holder.owner, SPAN_ALERT("Nothing to zombify there."))
-				return 1
+				boutput(src.holder.owner, SPAN_ALERT("Nothing to zombify there."))
+				return TRUE
 		if (!ishuman(target))
-			boutput(holder.owner, SPAN_ALERT("Invalid target."))
-			return 1
-		if (BOUNDS_DIST(holder.owner, target) > 0)
-			boutput(holder.owner, SPAN_ALERT("That is too far away to zombify."))
-			return 1
+			boutput(src.holder.owner, SPAN_ALERT("Invalid target."))
+			return TRUE
+		if (BOUNDS_DIST(src.holder.owner, target) > 0)
+			boutput(src.holder.owner, SPAN_ALERT("That is too far away to zombify."))
+			return TRUE
 		var/mob/living/carbon/human/H = target
 		if (istype(H.mutantrace, /datum/mutantrace/zombie))
-			boutput(holder.owner, SPAN_ALERT("You can't infect another zombie!"))
-			return 1
-		actions.start(new/datum/action/bar/icon/infect_ability(target, src), holder.owner)
-		return 0
+			boutput(src.holder.owner, SPAN_ALERT("You can't infect another zombie!"))
+			return TRUE
+		src.holder.owner.set_dir(get_dir(src.holder.owner, target))
+		actions.start(new/datum/action/bar/icon/infect_ability(target, src), src.holder.owner)
+		return
 
 /datum/action/bar/icon/infect_ability
 	duration = 4 SECONDS
@@ -43,41 +49,60 @@
 	var/datum/targetable/zombie/infect/zombify
 
 	New(Target, Zombify)
-		target = Target
-		zombify = Zombify
+		src.target = Target
+		src.zombify = Zombify
 		..()
 
 	onUpdate()
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || target == null || owner == null || target == owner || !zombify || !zombify.cooldowncheck())
-			zombify.disabled = FALSE
+		if(BOUNDS_DIST(src.owner, src.target) > 0 || src.target == null || src.owner == null || src.target == owner || !src.zombify || !src.zombify.cooldowncheck())
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 	onStart()
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || target == null || owner == null || target == owner || !zombify || !zombify.cooldowncheck())
+		if(BOUNDS_DIST(src.owner, src.target) > 0 || src.target == null || src.owner == null || src.target == owner || !src.zombify || !src.zombify.cooldowncheck())
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		zombify.disabled = TRUE
-		owner.visible_message(SPAN_ALERT("<B>[owner] attempts to gnaw into [target]!</B>"))
+		src.zombify.disabled = TRUE
+		src.owner.tri_message(src.target,
+			SPAN_ALERT("<b>[src.owner]</b> attempts to gnaw into [src.target]!"),
+			SPAN_ALERT("You start trying to gnaw into [src.target]!"),
+			SPAN_ALERT(SPAN_BOLD("[src.owner] is trying to [pick("gnaw on you like a dog bone", "sink [his_or_her(src.owner)] teeth into you", "bite you")]!!!"))
+		)
+
+	onInterrupt()
+		src.zombify.disabled = FALSE
+		src.owner.tri_message(src.target,
+			SPAN_ALERT("<b>[src.owner]</b> gnashes [his_or_her(src.owner)] teeth in frustration!"),
+			SPAN_ALERT("[src.target != null ? "Your attempt to infect [src.target] was" : "You were"] interrupted!"),
+			SPAN_ALERT(SPAN_BOLD("[src.owner] was unable to bite you!"))
+		)
+		..()
 
 	onEnd()
 		..()
-		var/mob/ownerMob = owner
-		if(!ownerMob || !target || (BOUNDS_DIST(ownerMob , target) > 0) || !zombify?.cooldowncheck())
+		var/mob/ownerMob = src.owner
+		if(!ownerMob || !src.target || (BOUNDS_DIST(ownerMob , src.target) > 0) || !src.zombify?.cooldowncheck())
 			return
-		if(isdead(target) || target.health <= -100) //If basically dead, instaconvert.
-			target.set_mutantrace(/datum/mutantrace/zombie/can_infect)
-			if (target.ghost?.mind && !target.mind.get_player()?.dnr) // if they have dnr set don't bother shoving them back in their body (Shamelessly ripped from SR code. Fight me.)
-				target.ghost.show_text(SPAN_ALERT("<B>You feel yourself being dragged out of the afterlife!</B>"))
-				target.ghost.mind.transfer_to(target)
-		logTheThing(LOG_COMBAT, ownerMob, "zombifies [constructTarget(target,"combat")].")
+		var/insta_convert
+		if(isdead(src.target) || src.target.health <= -100) //If basically dead, instaconvert.
+			insta_convert = TRUE
+			src.target.set_mutantrace(/datum/mutantrace/zombie/can_infect)
+			if (src.target.ghost?.mind && !src.target.mind.get_player()?.dnr) // if they have dnr set don't bother shoving them back in their body (Shamelessly ripped from SR code. Fight me.)
+				src.target.ghost.show_text(SPAN_ALERT("<B>You feel yourself being dragged out of the afterlife!</B>"))
+				src.target.ghost.mind.transfer_to(src.target)
+		logTheThing(LOG_COMBAT, ownerMob, "zombifies [constructTarget(src.target,"combat")].")
 		playsound(ownerMob, 'sound/impact_sounds/Flesh_Crush_1.ogg', 50, FALSE)
-		ownerMob.visible_message(SPAN_ALERT("<B>[ownerMob ] successfully infected [target]!</B>"))
+		src.owner.tri_message(src.target,
+			SPAN_ALERT("<b>[src.owner]</b> [pick("bites [src.target] as hard as [he_or_she(src.owner)] can", "sinks [his_or_her(src.owner)] teeth deep into [src.target]")]!!!"),
+			SPAN_ALERT("You successfully [insta_convert ? "turn [src.target] into a zombie" : "infect [src.target]"]!"),
+			SPAN_ALERT(SPAN_BOLD("<font size=+2>[src.owner] sinks [his_or_her(src.owner)] teeth deep into your flesh! OH GOD!!!</font>"))
+		)
 		ownerMob.health = ownerMob.max_health
-		target.TakeDamageAccountArmor("head", 30, 0, 0, DAMAGE_CRUSH)
-		target.changeStatus("stunned", 4 SECONDS)
-		target.contract_disease(/datum/ailment/disease/necrotic_degeneration/can_infect_more, null, null, 1) // path, name, strain, bypass resist
-		zombify.disabled = FALSE
-		zombify.afterAction()
+		src.target.TakeDamageAccountArmor("head", 30, 0, 0, DAMAGE_CRUSH)
+		src.target.changeStatus("stunned", 4 SECONDS)
+		src.target.contract_disease(/datum/ailment/disease/necrotic_degeneration/can_infect_more, null, null, 1) // path, name, strain, bypass resist
+		src.zombify.disabled = FALSE
+		src.zombify.afterAction()
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BUG][CODE QUALITY]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

First PR in a long time, hopefully this is doing stuff right:
* Did a general cleanliness pass on `infect.dm` -- turning 0/1 into TRUE/FALSE, adding `src.` where applicable, replacing implicit deciseconds with `SECONDS` defines, that sort of thing.
* Replaced the single visible message for each step with a `tri_message` that includes a big scary text popup if you get bitten successfully.
* Rewrote the description of the ability to more clearly define what it does.
* Prevents spamming the ability multiple times (and interrupting yourself each time) by adding a `castcheck()` override to prevent it if the ability is disabled (i.e. in use).
* Added a wacky message if you try to infect yourself.
* Added an `onInterrupt()` handler that sets `src.disabled = FALSE`, as otherwise the ability will break and become permanently unusable if interrupted. 
* Initiating a bite will cause you to face towards your victim.

Tested locally on the devmap by using my own client and a guest client, with attempts at bites and trying different ways to interrupt them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17566

Zombie biting in general is slightly clunky from a game feel perspective, since it lacks feedback and has a few weird things with it, like not changing the zombie's direction or not displaying a message when they fail a bite. These changes are broadly meant to modernize it and make it feel a bit better to use, but I'm happy to just keep the bugfix aspects if desired.

## Media

### Message shown when being bitten, including some interrupted attempts:
![dreamseeker_JNVZCS6sLr](https://github.com/goonstation/goonstation/assets/47678781/8733828b-4a39-4348-bf7a-4432be4dbd23)

### Message shown to other players when biting happens, including some interrupted attempts:
![dreamseeker_XqQYpRDlSx](https://github.com/goonstation/goonstation/assets/47678781/40c9691c-c2c1-4032-851c-88930d3b44b3)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ilysen
(+)Fixed zombies' Infect ability breaking when interrupted. Also added a new big message in chat when you get infected!
```
