### PR TITLE
Remove Thermals from Donut Security

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11527,7 +11527,6 @@
 /obj/item/device/audio_log{
 	pixel_y = 8
 	},
-/obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/escape/corner{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -33573,10 +33573,6 @@
 /area/station/quartermaster/office)
 "kfJ" = (
 /obj/table/auto,
-/obj/item/clothing/glasses/thermal{
-	pixel_x = -4;
-	pixel_y = 9
-	},
 /obj/item/storage/box/revimp_kit{
 	pixel_x = 3;
 	pixel_y = -6


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes Thermal goggles from the tables in donut 2 and 3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These should be Det/HoS/Armory exclusive, and not just on the table
