### PR TITLE
Remove Unused Accesses from IDs

### DIFF
--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -350,7 +350,7 @@
 	var/obj/machinery/door/d1 = null
 	var/obj/machinery/door/d2 = null
 	anchored = ANCHORED
-	req_access = list(access_armory)
+	req_access = list(access_security)
 
 /obj/machinery/noise_switch
 	name = "Speaker Toggle"

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -201,7 +201,7 @@
 		if("Captain")
 			return get_all_accesses()
 		if("Head of Personnel")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers, access_armory,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
@@ -214,7 +214,7 @@
 			hos_access += access_maxsec
 			return hos_access
 #else
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue, access_medlab,
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
@@ -254,7 +254,7 @@
 		///////////////////////////// Security
 		if("Security Officer")
 #ifdef RP_MODE
-			return list(access_security, access_brig, access_forensics_lockers, access_armory,
+			return list(access_security, access_brig, access_forensics_lockers,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_emergency_storage, access_chapel_office, access_kitchen,
@@ -373,7 +373,7 @@
 			return list()
 
 /proc/get_all_accesses()  // not adding the special stuff to this
-	return list(access_security, access_brig, access_forensics_lockers, access_armory,
+	return list(access_security, access_brig, access_forensics_lockers,
 	            access_medical, access_medlab, access_morgue, access_securitylockers,
 	            access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 	            access_emergency_storage, access_change_ids, access_ai_upload,
@@ -388,7 +388,7 @@
 				access_researchfoyer, access_telesci, access_artlab, access_robotdepot)
 
 /proc/syndicate_spec_ops_access() //syndie spec ops need to get out of the listening post.
-	return list(access_security, access_brig, access_forensics_lockers, access_armory,
+	return list(access_security, access_brig, access_forensics_lockers,
 	            access_medical, access_medlab, access_morgue, access_securitylockers,
 	            access_tox, access_tox_storage, access_chemistry, access_carrypermit,
 	            access_emergency_storage, access_change_ids, access_ai_upload,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -206,7 +206,7 @@
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_supply_console,
-						access_research, access_hydro, access_ranch, access_mail, access_ai_upload, access_pathology, access_researchfoyer,
+						access_research, access_hydro, access_ranch, access_ai_upload, access_pathology, access_researchfoyer,
 						access_telesci, access_teleporter)
 		if("Head of Security")
 #ifdef RP_MODE
@@ -219,7 +219,7 @@
 						access_emergency_storage, access_change_ids, access_eva, access_heads, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo,
-						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
+						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_power, access_engineering_control,
 						access_mining, access_pathology, access_researchfoyer)
 #endif
@@ -258,7 +258,7 @@
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_emergency_storage, access_chapel_office, access_kitchen,
-				access_bar, access_janitor, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
+				access_bar, access_janitor, access_robotics, access_cargo, access_construction, access_hydro,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
 				access_tech_storage, access_engineering_storage, access_engineering_eva,
 				access_engineering_power, access_engineering_engine, access_mining_shuttle,
@@ -352,7 +352,7 @@
 		if("Assistant", "Staff Assistant", "Technical Assistant", "Radio Show Host")
 			return list(access_maint_tunnels, access_tech_storage)
 		if("Mail Courier")
-			return list(access_maint_tunnels, access_mail, access_heads, access_cargo, access_hangar)
+			return list(access_maint_tunnels, access_heads, access_cargo, access_hangar)
 
 		//////////////////////////// Other or gimmick
 		if("VIP")
@@ -379,7 +379,7 @@
 	            access_emergency_storage, access_change_ids, access_ai_upload,
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
 	            access_chapel_office, access_kitchen, access_medical_lockers, access_pathology,
-	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch, access_mail,
+	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch,
 	            access_engineering, access_maint_tunnels, access_external_airlocks,
 	            access_tech_storage, access_engineering_storage, access_engineering_eva,
 	            access_engineering_power, access_engineering_engine, access_mining_shuttle,
@@ -394,7 +394,7 @@
 	            access_emergency_storage, access_change_ids, access_ai_upload,
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
 	            access_chapel_office, access_kitchen, access_medical_lockers, access_pathology,
-	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch, access_mail,
+	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch,
 	            access_engineering, access_maint_tunnels, access_external_airlocks,
 	            access_tech_storage, access_engineering_storage, access_engineering_eva,
 	            access_engineering_power, access_engineering_engine, access_mining_shuttle,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the old armory access from the ID cards that still had it (AA, HoS, HoP) and changes an object I believe to be unused to instead just use security access.
Also removes access_mail from IDs

Anything "unused" but that had a mapping helper or was in ID computer wasnt touched

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
CE RCD can use any access in "get_all_accesses" and it probably shouldn't be able to make unused accesses. Specifically ones that can't be given out by the ID computer and are only available to a few roundstart roles.