### PR TITLE
Adds a hand tele to all the captain's office missing one.

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -35384,6 +35384,10 @@
 /obj/item/item_box/gold_star{
 	item_amount = 20
 	},
+/obj/item/hand_tele{
+	pixel_y = 6;
+	pixel_x = -14
+	},
 /obj/item/card/id/captains_spare,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -18802,6 +18802,10 @@
 /obj/machinery/recharger{
 	pixel_y = 3
 	},
+/obj/item/hand_tele{
+	pixel_y = 7;
+	pixel_x = 16
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "bzL" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -47037,6 +47037,9 @@
 	},
 /obj/machinery/phone,
 /obj/blind_switch/area/east,
+/obj/item/stamp/cap{
+	pixel_x = 6
+	},
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
 "uas" = (
@@ -48029,10 +48032,16 @@
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
 	},
-/obj/item/paper_bin,
-/obj/item/pen/fancy,
-/obj/item/stamp/cap{
-	pixel_x = 15
+/obj/item/paper_bin{
+	pixel_y = 2;
+	pixel_x = -1
+	},
+/obj/item/pen/fancy{
+	pixel_x = -3
+	},
+/obj/item/hand_tele{
+	pixel_x = 15;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge/captain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the hand teleporter to the captain's room of the maps lacking one: Cogmap 2, Kondaru and Nadir.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The hand teleporter is standard equipment for the captain. There should be one in their room, aside from the spare one(s) at the command teleporter.