### PR TITLE
Add defect before changing cloned puritan mutrace

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -307,10 +307,10 @@ TYPEINFO(/obj/machinery/clonepod)
 				// out of deep critical health before they turn into chunky salsa
 				// This should be really rare to have happen, but I want to leave it in
 				// just in case someone manages to pull off a miracle save
+				defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
 				src.occupant.bioHolder?.AddEffect("premature_clone")
 				src.occupant.take_toxin_damage(250)
 				random_brute_damage(src.occupant, 100, 0)
-				defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
 				if (ishuman(src.occupant))
 					var/mob/living/carbon/human/P = src.occupant
 					if (P.limbs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
apply the random cloner defect before adding the `premature_clone` bioEffect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
puricloned mobs could get a different mutantrace when cloned, and thus not explode when they died.