### PR TITLE
Jailbird trait changes

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -168,35 +168,18 @@
 								"Excessive swearing",\
 								"Cutting in line.",\
 								"Tying the captain's shoelaces together.",\
-								"Forgetting the captain's birthday.")
-		S["mi_crim_d"] = "No details provided."
-		S["ma_crim"] = pick(\
 								"Grand theft apidae.",\
 								"Bee murder.",\
 								"Superfarted on the captain.",\
-								"Released the singularity.",\
-								"Stole the captain's spare ID.",\
-								"Arson, murder, jaywalking.",\
-								"Arson.",\
-								"Murder.",\
-								"Jaywalking.",\
 								"Skating right through the bounds of real-space. Wicked sick, but highly illegal.",\
 								"Being a really really bad surgeon.",\
-								"Distributing meth.",\
-								"Dismemberment and decapitation.",\
-								"Running around with a chainsaw.",\
-								"Throwing explosive tomatoes at people.",\
 								"Caused multiple seemingly unrelated accidents.",\
 								"Dabbing.",\
-								"Assembling explosives.",\
 								"Being in the wrong place at the wrong time.",\
-								"Assault.",\
-								"Tossing someone in space.",\
-								"Over-escalation.",\
-								"Manslaughter",\
-								"Refusing to share their meth.",\
-								"Grand larceny.")
-		S["ma_crim_d"] = "No details provided."
+								"Forgetting the captain's birthday.")
+		S["mi_crim_d"] = "No details provided."
+		S["ma_crim"] = "None"
+		S["ma_crim_d"] = "No major crime convictions."
 
 
 		var/randomNote = pick("Huge nerd.", "Total jerkface.", "Absolute dingus.", "Insanely endearing.", "Worse than clown.", "Massive crapstain.");
@@ -207,11 +190,9 @@
 
 		boutput(H, SPAN_NOTICE("You are currently on the run because you've committed the following crimes:"))
 		boutput(H, SPAN_NOTICE("- [S["mi_crim"]]"))
-		boutput(H, SPAN_NOTICE("- [S["ma_crim"]]"))
 
 		H.mind.store_memory("You've committed the following crimes before arriving on the station:")
 		H.mind.store_memory("- [S["mi_crim"]]")
-		H.mind.store_memory("- [S["ma_crim"]]")
 	else
 		if (H.mind?.assigned_role == "Clown")
 			S["criminal"] = "Clown"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -727,6 +727,14 @@ ABSTRACT_TYPE(/datum/trait/job)
 	category = list("background")
 	points = 0
 
+/datum/trait/jailbird
+	name = "Jailbird"
+	desc = "You have a criminal record and are currently on the run!"
+	id = "jailbird"
+	icon_state = "jail"
+	category = list("background")
+	points = -1
+
 // NO CATEGORY - Grey Border
 
 /datum/trait/hemo
@@ -896,13 +904,6 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "You start with a higher paycheck than normal."
 	id = "unionized"
 	icon_state = "handshake"
-	points = -1
-
-/datum/trait/jailbird
-	name = "Jailbird"
-	desc = "You have a criminal record and are currently on the run!"
-	id = "jailbird"
-	icon_state = "jail"
 	points = -1
 
 /datum/trait/clericalerror


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Moves the jailbird trait into the background category, so it is impossible to pick both stoaway and jailbird.
- Removes the major crimes from the jailbird (some of the sillier crimes were moved into the minor crimes).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- It makes no sense that someone who is not the records (stoaway) is somehow in the records and wanted.
- Major crimes like murder, arson and etc are often used by ill intentioned people to haze new secoffs.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(+)The jailbird trait has been moved into the background category of traits.
```
