### PR TITLE
Deluxe Agent Card - HoP traitor item

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1046,7 +1046,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
 
-/datum/syndicate_buylist/traitor/ai_disguised_module
+/datum/syndicate_buylist/traitor/syndicard_deluxe
 	name = "DELUXE Agent Card"
 	item = /obj/item/card/id/syndicate/deluxe
 	cost = 3

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1046,6 +1046,14 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
 
+/datum/syndicate_buylist/traitor/ai_disguised_module
+	name = "DELUXE Agent Card"
+	item = /obj/item/card/id/syndicate/deluxe
+	cost = 3
+	vr_allowed = FALSE
+	desc = "A counterfeit identification card, designed to prevent tracking by the station's AI systems. Unlike the standard version, its programmable identification circuit can be used multiple times, allowing the entry of many custom false identities. It is also capable of scanning other ID cards and replicating their access credentials."
+	job = list("Head of Personnel")
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -301,9 +301,13 @@ TYPEINFO(/obj/item/card/emag)
 	name = "agent card"
 	access = list(access_maint_tunnels, access_syndicate_shuttle)
 	HELP_MESSAGE_OVERRIDE(null)
+	var/reusable = 0
+
+/obj/item/card/id/syndicate/deluxe
+	reusable = 1
 
 /obj/item/card/id/syndicate/attack_self(mob/user as mob)
-	if(!src.registered)
+	if(!src.registered || src.reusable)
 		var/reg = copytext(src.sanitize_name(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)), 1, 100)
 		var/ass = copytext(src.sanitize_name(input(user, "What occupation would you like to put on this card?\n Note: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Staff Assistant"), 1), 1, 100)
 		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","blue","red","green","purple","yellow","nanotrasen","syndicate","No band")

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -557,7 +557,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/voice_changer,
 		/obj/item/card/emag,
 		/obj/item/storage/backpack/chameleon,
-		/obj/item/card/id/syndicate/deluxe
+		/obj/item/card/id/syndicate/deluxe,
 		/obj/item/device/chameleon,
 		/obj/item/clothing/suit/space/syndicate/specialist,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -557,6 +557,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/voice_changer,
 		/obj/item/card/emag,
 		/obj/item/storage/backpack/chameleon,
+		/obj/item/card/id/syndicate/deluxe
 		/obj/item/device/chameleon,
 		/obj/item/clothing/suit/space/syndicate/specialist,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the "deluxe agent card", a reusable version of the agent card allowing for on the run identity crafting for 3 tc


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
HoP only has the AI law traitor items and thats kinda boring


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The Head of Personnel can now buy a reusable "Deluxe" agent card. Also available to spy thieves and nuclear operatives.
```
