### PR TITLE
Stop old names from appearing on robotics console

### DIFF
--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -75,10 +75,10 @@
 		dat += " *------------------------------------------------*<BR>"
 
 		for(var/mob/living/silicon/robot/R in A.connected_robots)
-			dat += "[R.name] |"
 			if(R.disposed)
 				continue
-			else if(isnull(R.part_head?.brain))
+			dat += "[R.name] |"
+			if(isnull(R.part_head?.brain))
 				dat += " Intelligence Cortex Missing |"
 			else if(R.stat)
 				dat += " Not Responding |"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Do the check to see if a silicon robot is disposed before adding the name to the robotics console output.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
nothing ever removes stuff from `connected_robots`. This just prevents old names from being prepended to the current active cyborg name e.g. "Cyborg | Cyborg | Cyborg |" etc.
Fixes #16443