### PR TITLE
Make unreadied players count for 1/2 a player for gamemode scaling purposes

### DIFF
--- a/code/datums/gamemodes/assday_classic.dm
+++ b/code/datums/gamemodes/assday_classic.dm
@@ -23,12 +23,7 @@
 
 /datum/game_mode/assday/pre_setup()
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-		if (player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/num_traitors = 1
 	var/num_wraiths = 1

--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -20,13 +20,7 @@
 
 /datum/game_mode/blob/pre_setup()
 	..()
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/i = rand(10, 15)
 	var/num_blobs = clamp(round((num_players + i) / 20), blobs_minimum, blobs_possible)

--- a/code/datums/gamemodes/changeling.dm
+++ b/code/datums/gamemodes/changeling.dm
@@ -21,13 +21,7 @@
 	boutput(world, "<B>There is a [SPAN_ALERT("CHANGELING")] on the station. Be on your guard! Trust no one!</B>")
 
 /datum/game_mode/changeling/pre_setup()
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/i = rand(5)
 	var/num_changelings = clamp(round((num_players + i) / pop_divisor), 1, changelings_possible)

--- a/code/datums/gamemodes/conspiracy.dm
+++ b/code/datums/gamemodes/conspiracy.dm
@@ -20,13 +20,7 @@
 	boutput(world, "<B>Trust no one.</B>")
 
 /datum/game_mode/conspiracy/pre_setup() // Presetup does selection and marking of antags before mobs are spawned, postsetup actually gives them objectives
-	var/numPlayers = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			numPlayers++
+	var/numPlayers = src.roundstart_player_count()
 
 	var/numConspirators = clamp(round(numPlayers / 5), 2, maxConspirators) // Selects number of conspirators
 

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -28,11 +28,7 @@
 #define PLAYERS_PER_GANG_GENERATED 12
 #endif
 /datum/game_mode/gang/pre_setup()
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-		if(player.ready) num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/num_teams = clamp(round((num_players) / PLAYERS_PER_GANG_GENERATED), setup_min_teams, setup_max_teams) //1 gang per 9 players, 15 on RP
 	logTheThing(LOG_GAMEMODE, src, "Counted [num_players] available, with [PLAYERS_PER_GANG_GENERATED] per gang that means [num_teams] gangs.")

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -297,6 +297,18 @@ ABSTRACT_TYPE(/datum/game_mode)
 
 	command_alert("Summary downloaded and printed out at all communications consoles.", "Enemy communication intercept. Security Level Elevated.")
 
+/datum/game_mode/proc/roundstart_player_count()
+	var/readied_count = 0
+	var/unreadied_count = 0
+	for (var/client/C in global.clients)
+		var/mob/new_player/mob = C.mob
+		if (istype(mob))
+			if (mob.ready)
+				readied_count++
+			else
+				unreadied_count++
+	return readied_count + (unreadied_count/2)
+
 ////////////////////////////
 // Objective related code //
 ////////////////////////////

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -297,7 +297,7 @@ ABSTRACT_TYPE(/datum/game_mode)
 
 	command_alert("Summary downloaded and printed out at all communications consoles.", "Enemy communication intercept. Security Level Elevated.")
 
-/datum/game_mode/proc/roundstart_player_count()
+/datum/game_mode/proc/roundstart_player_count(loud = TRUE)
 	var/readied_count = 0
 	var/unreadied_count = 0
 	for (var/client/C in global.clients)
@@ -307,7 +307,10 @@ ABSTRACT_TYPE(/datum/game_mode)
 				readied_count++
 			else
 				unreadied_count++
-	return readied_count + (unreadied_count/2)
+	var/total = readied_count + (unreadied_count/2)
+	if (loud)
+		logTheThing(LOG_GAMEMODE, "Found [readied_count] readied players and [unreadied_count] unreadied ones, total count being fed to gamemode datum: [total]")
+	return total
 
 ////////////////////////////
 // Objective related code //

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -29,13 +29,7 @@
 	boutput(world, "<B>Anything could happen! Be on your guard!</B>")
 
 /datum/game_mode/mixed/pre_setup()
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	if (num_players < werewolf_players_req || !has_werewolves)
 		traitor_types[ROLE_WEREWOLF] = 0;

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -46,13 +46,7 @@ var/global/list/nuke_op_camo_matrix = null
 		logTheThing(LOG_DEBUG, null, "Failed to find Syndicate spawn landmark, aborting nuke round pre-setup.")
 		return 0
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 #ifndef ME_AND_MY_40_ALT_ACCOUNTS
 	if (num_players < minimum_players)
 		boutput(world, SPAN_ALERT("<b>ERROR: Minimum player count of [minimum_players] required for Nuclear game mode, aborting nuke round pre-setup.</b>"))

--- a/code/datums/gamemodes/pirate.dm
+++ b/code/datums/gamemodes/pirate.dm
@@ -17,13 +17,7 @@
 		. = ..()
 		var/list/possible_pirates = list()
 
-		var/num_players = 0
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (player.ready)
-				num_players++
+		var/num_players = src.roundstart_player_count()
 
 		var/randomizer = rand(pop_divisor+1)
 		var/target_antag_count = clamp(round((num_players + randomizer )/ pop_divisor), minimum_pirates, maximum_pirates)

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -45,13 +45,7 @@
 /datum/game_mode/revolution/pre_setup()
 
 	var/list/revs_possible = get_possible_enemies(ROLE_HEAD_REVOLUTIONARY, 1)
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	if (!revs_possible.len)
 		return 0

--- a/code/datums/gamemodes/salvager.dm
+++ b/code/datums/gamemodes/salvager.dm
@@ -25,13 +25,7 @@
 	. = ..()
 	var/list/possible_salvagers = list()
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/randomizer = rand(pop_divisor+1)
 	var/target_antag_count = clamp( round((num_players + randomizer )/ pop_divisor ), 2, antags_possible)

--- a/code/datums/gamemodes/spy.dm
+++ b/code/datums/gamemodes/spy.dm
@@ -28,13 +28,7 @@
 	if (!leaders_possible.len)
 		return 0
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/i = rand(5)
 	var/num_teams = clamp(round((num_players + i) / 7), setup_min_teams, setup_max_teams)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -144,12 +144,7 @@
 	boutput(world, "<B>There are spies planted on [station_or_ship()]. They plan to steal valuables and assasinate rival spies  - Do not let them succeed!</B>")
 
 /datum/game_mode/spy_theft/pre_setup()
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (player.ready) num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/randomizer = rand(0,6)
 	var/num_spies = 2 //minimum

--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -23,13 +23,7 @@
 
 /datum/game_mode/traitor/pre_setup()
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/randomizer = rand(7)
 	var/num_traitors = 1

--- a/code/datums/gamemodes/wizard.dm
+++ b/code/datums/gamemodes/wizard.dm
@@ -19,13 +19,7 @@
 
 /datum/game_mode/wizard/pre_setup()
 
-	var/num_players = 0
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if(player.ready)
-			num_players++
+	var/num_players = src.roundstart_player_count()
 
 	var/num_wizards = clamp(round(num_players / 12), 1, wizards_possible)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Standardizes all the roundstart gamemode player counting logic and adds 1/2 the number of unreadied players to the total. Does not affect choosing modes like revs at low-pop.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Roundstart ready % hovers around 50-60% on RP3 these days, with most of the remaining players latejoining shortly afterwards. I think figuring out *why* and solving that is something worth doing but currently it means that there are about half as many antags as there should be, which is not good.
This should work as a bandaid to help the problem a bit in the meantime.
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Unreadied players now contribute 1/2 of a readied player to roundstart gamemode scaling. (Yes this means more antags on average)
```
