### PR TITLE
Macho Touch won't turn target to statue if they escape grip

### DIFF
--- a/code/modules/antagonists/macho_man/abilities/gold_touch.dm
+++ b/code/modules/antagonists/macho_man/abilities/gold_touch.dm
@@ -47,14 +47,24 @@
 						if (N.client)
 							shake_camera(N, 6, 16)
 							N.show_message(SPAN_ALERT("<b>A blinding light envelops [holder.owner]!</b>"), 1)
-
 					playsound(holder.owner.loc, 'sound/weapons/flashbang.ogg', 50, 1)
-					qdel(G)
-					holder.owner.transforming = 0
-					holder.owner.bioHolder.RemoveEffect("fire_resist")
-					holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
-					SPAWN(0)
-						if (H)
-							H.desc = "A really dumb looking statue. Very shiny, though."
-							H.become_statue(getMaterial("gold"), survive=TRUE)
-							H.transforming = 0
+					/// Whoever got grabbed broke the grip so don't statue them, revert state
+					if(G.affecting == null)
+						H.transforming = 0
+						H.layer = holder.owner.layer
+						H.pixel_y = 0
+						H.pixel_x = 0
+						holder.owner.transforming = 0
+						holder.owner.bioHolder.RemoveEffect("fire_resist")
+						holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
+					else
+						qdel(G)
+						holder.owner.transforming = 0
+						holder.owner.bioHolder.RemoveEffect("fire_resist")
+						holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
+						SPAWN(0)
+							if (H)
+								H.desc = "A really dumb looking statue. Very shiny, though."
+								H.become_statue(getMaterial("gold"), survive=TRUE)
+								H.transforming = 0
+

--- a/code/modules/antagonists/macho_man/abilities/gold_touch.dm
+++ b/code/modules/antagonists/macho_man/abilities/gold_touch.dm
@@ -48,20 +48,17 @@
 							shake_camera(N, 6, 16)
 							N.show_message(SPAN_ALERT("<b>A blinding light envelops [holder.owner]!</b>"), 1)
 					playsound(holder.owner.loc, 'sound/weapons/flashbang.ogg', 50, 1)
+					holder.owner.transforming = 0
+					holder.owner.bioHolder.RemoveEffect("fire_resist")
+					holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
 					/// Whoever got grabbed broke the grip so don't statue them, revert state
 					if(G.affecting == null)
 						H.transforming = 0
 						H.layer = holder.owner.layer
 						H.pixel_y = 0
 						H.pixel_x = 0
-						holder.owner.transforming = 0
-						holder.owner.bioHolder.RemoveEffect("fire_resist")
-						holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
 					else
 						qdel(G)
-						holder.owner.transforming = 0
-						holder.owner.bioHolder.RemoveEffect("fire_resist")
-						holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_touch
 						SPAWN(0)
 							if (H)
 								H.desc = "A really dumb looking statue. Very shiny, though."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes a bug with the Macho Touch ability, that the machoman mob has, where if the target escaped machoman's grip right before it finished executing, then they would still turn into a statue. The only changes are with the Macho Touch move itself and does not affect any other code.

Issue: #10954 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A small, but nice to have bug fix so people aren't getting turned to statues unnecessarily.
