### PR TITLE
Extend donut3 AI Upload Foyer to stop camera from seeing rack

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -22006,27 +22006,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
-"gAw" = (
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/camera{
-	dir = 6
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload_foyer)
 "gAU" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -37057,12 +37036,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
 "lje" = (
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/circuit,
+/turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "ljE" = (
 /obj/indestructible/shuttle_corner,
@@ -51478,6 +51452,24 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"pAU" = (
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai_upload_foyer)
 "pBe" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
@@ -75019,6 +75011,17 @@
 	dir = 4
 	},
 /area/shuttle/arrival/station)
+"wGj" = (
+/obj/machinery/recharge_station,
+/obj/machinery/camera{
+	dir = 9
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai_upload_foyer)
 "wGD" = (
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/bathroom)
@@ -137849,7 +137852,7 @@ rhm
 rhm
 ojJ
 ouW
-gAw
+uwc
 lje
 avI
 yaq
@@ -138151,8 +138154,8 @@ gQk
 gDk
 gDk
 ouW
-ouW
-ouW
+pAU
+wGj
 avI
 xgx
 cPA
@@ -138452,8 +138455,8 @@ cCT
 gQk
 rdj
 rdj
-rdj
-rdj
+ouW
+ouW
 avI
 avI
 avI


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
extend the right-side depth of foyer by one tile and move the camera so it's not possible to see the lawrack from the foyer camera


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Don't let non-AI players see the lawrack from a security camera
Fix #18718

## Screenshot
![Screenshot 2024-05-03 010717](https://github.com/goonstation/goonstation/assets/91498627/2d579373-54d6-46ba-a037-e3535f00926a)
