### PR TITLE
Fix Clarion robotics wall phone being inaccessible

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -8382,10 +8382,6 @@
 /obj/landmark/random_room/size5x3,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
-"bbs" = (
-/obj/machinery/phone/wall,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/robotics)
 "bbt" = (
 /obj/machinery/vending/cola/blue,
 /obj/machinery/light{
@@ -23253,6 +23249,9 @@
 	name = "autoname  - SS13";
 	pixel_y = 18;
 	tag = ""
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -69444,7 +69443,7 @@ gRH
 bkJ
 wCP
 uCt
-bbs
+bkJ
 jme
 hnd
 hnd


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the robotics wall phone south one tile, and then gives it an offset so it looks like it's in the same place. Same trick is used in kitchen.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Robotics, pick up the phone!!!
Fix #18712