### PR TITLE
Remove cogmap1 extra cameras between podbay and ai

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -53339,15 +53339,6 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
-"oRJ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/market)
 "oRT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -64812,12 +64803,6 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -103038,7 +103023,7 @@ bAt
 bAt
 bAt
 fBI
-oRJ
+bAt
 bBq
 bAt
 adC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes two extra, unattached cameras placed in the hall on cog1


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18716