### PR TITLE
Foam darts no longer damage vehicles

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -509,27 +509,31 @@
 		var/damage = round(P.power, 1.0)
 
 		var/hitsound = null
-		switch(P.proj_data.damage_type)
-			if(D_KINETIC)
-				src.health -= damage/1.7
-				hitsound = 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg'
-			if(D_PIERCING)
-				src.health -= damage/1
-				hitsound = 'sound/impact_sounds/Generic_Hit_Heavy_1.ogg'
-			if(D_ENERGY)
-				src.health -= damage/1.5
-				hitsound = 'sound/impact_sounds/Energy_Hit_3.ogg'
-			if(D_SLASHING)
-				src.health -= damage/2
-				hitsound = 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg'
-			if(D_BURNING)
-				src.material_trigger_on_temp(5000)
-				src.health -= damage/3
-				hitsound = 'sound/items/Welder.ogg'
-			if(D_SPECIAL) //blob
-				src.health -= damage
-				hitsound = 'sound/impact_sounds/Slimy_Hit_2.ogg'
-		checkhealth()
+
+		if(istype(P.proj_data, /datum/projectile/bullet/foamdart)) // foam darts shouldn't hurt
+			hitsound = 'sound/impact_sounds/Glass_Hit_1.ogg'
+		else
+			switch(P.proj_data.damage_type)
+				if(D_KINETIC)
+					src.health -= damage/1.7
+					hitsound = 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg'
+				if(D_PIERCING)
+					src.health -= damage/1
+					hitsound = 'sound/impact_sounds/Generic_Hit_Heavy_1.ogg'
+				if(D_ENERGY)
+					src.health -= damage/1.5
+					hitsound = 'sound/impact_sounds/Energy_Hit_3.ogg'
+				if(D_SLASHING)
+					src.health -= damage/2
+					hitsound = 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg'
+				if(D_BURNING)
+					src.material_trigger_on_temp(5000)
+					src.health -= damage/3
+					hitsound = 'sound/items/Welder.ogg'
+				if(D_SPECIAL) //blob
+					src.health -= damage
+					hitsound = 'sound/impact_sounds/Slimy_Hit_2.ogg'
+			checkhealth()
 		if(P.proj_data && P.proj_data.disruption) //ZeWaka: Fix for null.disruption
 			src.disrupt(P.proj_data.disruption, P)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add an explicit check for foam darts in vehicle `bullet_act` code, and skip damaging the pod if so.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18094