### PR TITLE
Do not let tug carts fit in a crate

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -616,7 +616,7 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 			return 0
 		if (istype(A, /obj/decal/fakeobjects/skeleton)) // uuuuuuugh
 			return 1
-		if (isobj(A) && ((A.density && !istype(A, /obj/critter)) || A:anchored || A == src || istype(A, /obj/decal) || istype(A, /atom/movable/screen) || istype(A, /obj/storage)))
+		if (isobj(A) && ((A.density && !istype(A, /obj/critter)) || A:anchored || A == src || istype(A, /obj/decal) || istype(A, /atom/movable/screen) || istype(A, /obj/storage) || istype(A, /obj/tug_cart)))
 			return 0
 
 	var/obj/storage/entangled


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CRITICAL][BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add an explicit check on storage containers to prevent the carts for cargo tugs from going inside.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #12685
You can put crates inside crates.
You can permanently trap people inside of crates.
