### PR TITLE
Prevent wizards from blinking out of their own shuttle

### DIFF
--- a/code/modules/antagonists/wizard/abilities/blink.dm
+++ b/code/modules/antagonists/wizard/abilities/blink.dm
@@ -47,6 +47,12 @@
 
 		var/turf/targetturf = locate(targetx, targety, holder.owner.z)
 
+		var/list/turf/passthrough_turfs = raytrace(get_turf(holder.owner), targetturf)
+		for(var/turf/T as anything in passthrough_turfs)
+			if (istype(T, /turf/cordon))
+				boutput(holder.owner, SPAN_ALERT("Your spell can't depart the universe!"))
+				return
+
 		playsound(holder.owner.loc, 'sound/effects/mag_teleport.ogg', 25, 1, -1)
 
 		var/list/turfs = new/list()

--- a/code/modules/antagonists/wizard/abilities/blink.dm
+++ b/code/modules/antagonists/wizard/abilities/blink.dm
@@ -47,11 +47,12 @@
 
 		var/turf/targetturf = locate(targetx, targety, holder.owner.z)
 
-		var/list/turf/passthrough_turfs = raytrace(get_turf(holder.owner), targetturf)
-		for(var/turf/T as anything in passthrough_turfs)
-			if (istype(T, /turf/cordon))
-				boutput(holder.owner, SPAN_ALERT("Your spell can't depart the universe!"))
-				return
+		if(isrestrictedz(holder.owner.z))
+			var/list/turf/passthrough_turfs = raytrace(get_turf(holder.owner), targetturf)
+			for(var/turf/T as anything in passthrough_turfs)
+				if (istype(T, /turf/cordon))
+					boutput(holder.owner, SPAN_ALERT("Your spell can't depart the universe!"))
+					return
 
 		playsound(holder.owner.loc, 'sound/effects/mag_teleport.ogg', 25, 1, -1)
 

--- a/code/modules/antagonists/wizard/abilities/blink.dm
+++ b/code/modules/antagonists/wizard/abilities/blink.dm
@@ -47,12 +47,9 @@
 
 		var/turf/targetturf = locate(targetx, targety, holder.owner.z)
 
-		if(isrestrictedz(holder.owner.z))
-			var/list/turf/passthrough_turfs = raytrace(get_turf(holder.owner), targetturf)
-			for(var/turf/T as anything in passthrough_turfs)
-				if (istype(T, /turf/cordon))
-					boutput(holder.owner, SPAN_ALERT("Your spell can't depart the universe!"))
-					return
+		if(isrestrictedz(holder.owner.z) && !istype(get_area(targetturf), /area/wizard_station))
+			boutput(holder.owner, SPAN_ALERT("It's too dangerous to blink there!"))
+			return
 
 		playsound(holder.owner.loc, 'sound/effects/mag_teleport.ogg', 25, 1, -1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[player actions][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On restricted Z levels, ensure the wizard will end up on the wizard den shuttle.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #17955