### PR TITLE
Allow partially constructed floorbot to install into engineer vaccum

### DIFF
--- a/code/obj/item/tool/engivac.dm
+++ b/code/obj/item/tool/engivac.dm
@@ -55,6 +55,7 @@ obj/item/engivac/update_icon(mob/M = null)
 ///Change worn sprite depending on slot
 obj/item/engivac/equipped(var/mob/user, var/slot)
 	..()
+UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	if (slot == SLOT_BACK)
 		wear_image = image('icons/mob/clothing/back.dmi')

--- a/code/obj/item/tool/engivac.dm
+++ b/code/obj/item/tool/engivac.dm
@@ -55,7 +55,7 @@ obj/item/engivac/update_icon(mob/M = null)
 ///Change worn sprite depending on slot
 obj/item/engivac/equipped(var/mob/user, var/slot)
 	..()
-UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	if (slot == SLOT_BACK)
 		wear_image = image('icons/mob/clothing/back.dmi')
@@ -110,6 +110,14 @@ obj/item/engivac/attackby(obj/item/I, mob/user)
 		held_toolbox = I
 		I.set_loc(src)
 		UpdateIcon(user)
+		return
+	if (istype(I, /obj/item/toolbox_tiles) && !held_toolbox)
+		for(var/obj/item/storage/toolbox/T in I.contents)
+			user.u_equip(I)
+			src.held_toolbox = T
+			T.set_loc(src)
+			UpdateIcon(user)
+			qdel(I)
 		return
 	..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you put floor tiles in a toolbox, you get a weird constuct that can only be advanced to a floorbot. If you're trying to use the engivac to replace flooring, it's rather frustrating for your toolbox to be eaten because you clicked the floor tiles on the toolbox instead of the toolbox on the floor tiles.

This allows you to slap the first stage of a floorbot construction onto an engineer vaccum, which is likely the ultimate intent if a player is trying to do so.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11833