### PR TITLE
Prevent cutting attached sponges into cheese shape

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -539,7 +539,7 @@ TRASH BAG
 			boutput(user, "You can't quite angle your [W.name] into your [src.name].")
 			return
 		if (src.cant_drop || src.cant_self_remove)
-			boutput(user, "You can't bring yourself to cut away your own personal sponge!")
+			boutput(user, "You can't bring yourself to cut away your own personal [src.name]!")
 			return
 		user.visible_message(SPAN_NOTICE("[user] cuts [src] into the shape of... cheese?"))
 		if(src.loc == user)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -535,6 +535,12 @@ TRASH BAG
 
 /obj/item/sponge/attackby(obj/item/W, mob/user)
 	if (istool(W, TOOL_CUTTING | TOOL_SNIPPING))
+		if (src.loc == user && isrobot(user))
+			boutput(user, "You can't quite angle your [W.name] into your [src.name].")
+			return
+		if (src.cant_drop || src.cant_self_remove)
+			boutput(user, "You can't bring yourself to cut away your own personal sponge!")
+			return
 		user.visible_message(SPAN_NOTICE("[user] cuts [src] into the shape of... cheese?"))
 		if(src.loc == user)
 			user.u_equip(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevent attached sponges (both item-arms and silicon) from being made into cheese-shaped sponges and falling onto the ground.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11496