### PR TITLE
Fix manta jetpacks

### DIFF
--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -351,7 +351,7 @@ TYPEINFO(/obj/item/tank/jetpack)
 	#if defined(MAP_OVERRIDE_MANTA)
 	icon_state = "jetpack_mag0"
 	item_state = "jetpack_mag"
-	c_flags = IS_JETPACK
+	c_flags = IS_JETPACK | ONBACK
 	var/base_icon_state = "jetpack_mag"
 	#else
 	icon_state = "jetpack0"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensure ONBACK is added to c_flags  in the manta jetpack define

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #12942