### PR TITLE
Glass Recyclers come preloaded by default

### DIFF
--- a/assets/maps/prefabs/space/prefab_safehouse.dmm
+++ b/assets/maps/prefabs/space/prefab_safehouse.dmm
@@ -821,7 +821,6 @@
 "IS" = (
 /obj/table/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 10;
 	pixel_y = 6
 	},
 /obj/decal/cleanable/dirt/jen,

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -228,6 +228,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 
 /obj/machinery/glass_recycler/chemistry //Chemistry doesn't really need all of the drinking glass options and such so I'm limiting it down a notch.
 	name = "chemistry glass recycler"
+	glass_amt = 15
 
 	get_products()
 		product_list += new /datum/glass_product("beaker", /obj/item/reagent_containers/glass/beaker, 1)
@@ -242,6 +243,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 
 /obj/machinery/glass_recycler/bar //the bar should not have to scroll through all this chemmy crap to get to the glasses and pitchers they use
 	name = "kitchen glass recycler"
+	glass_amt = 20
 
 	get_products()
 		product_list += new /datum/glass_product("pitcher", /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher, 2)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -50,7 +50,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 	icon_state = "synthesizer"
 	anchored = ANCHORED
 	density = 0
-	var/glass_amt = 0
+	var/glass_amt = 5
 	var/list/product_list = list()
 	flags = NOSPLASH | FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -884,8 +884,6 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	req_access = list(access_bar)
 	spawn_contents = list(/obj/item/gun/russianrevolver,\
 	/obj/item/reagent_containers/food/drinks/bottle/vintage,\
-	/obj/item/reagent_containers/food/drinks/drinkingglass/shot = 4,\
-	/obj/item/reagent_containers/food/drinks/drinkingglass/wine = 2,\
 	/obj/item/storage/box/glassbox)
 
 /obj/storage/secure/closet/civilian/chaplain

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -784,7 +784,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 	name = "basic supply lab counter"
 	desc = "Everything an aspiring chemist needs to start making chemicals!"
 	drawer_contents = list(/obj/item/paper/book/from_file/pharmacopia,
-				/obj/item/storage/box/beakerbox = 2,
+				/obj/item/storage/box/beakerbox,
 				/obj/item/reagent_containers/glass/beaker/large = 2,
 				/obj/item/clothing/glasses/spectro,
 				/obj/item/device/reagentscanner = 2,
@@ -794,8 +794,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 /obj/table/reinforced/chemistry/auto/auxsup
 	name = "auxiliary supply lab counter"
 	desc = "Extra supplies for the discerning chemist."
-	drawer_contents = list(/obj/item/storage/box/beakerbox,
-				/obj/item/storage/box/patchbox,
+	drawer_contents = list(/obj/item/storage/box/patchbox,
 				/obj/item/storage/box/syringes,
 				/obj/item/clothing/glasses/spectro,
 				/obj/item/device/reagentscanner,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -31749,7 +31749,6 @@
 "pPk" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/item/storage/box/beakerbox,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17133,7 +17133,6 @@
 "coC" = (
 /obj/table/folding,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light/incandescent,
@@ -18898,7 +18897,6 @@
 	panel_open = 1
 	},
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12967,7 +12967,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light_switch/north{
@@ -55088,7 +55087,6 @@
 /obj/table/reinforced/auto,
 /obj/machinery/light,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
@@ -59366,7 +59364,6 @@
 "xQK" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 20;
 	pixel_y = 8
 	},
 /obj/machinery/camera{

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -22093,7 +22093,6 @@
 "jrG" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/engine/caution/north,
@@ -30237,9 +30236,7 @@
 	})
 "mAw" = (
 /obj/table/reinforced/auto,
-/obj/machinery/glass_recycler/bar{
-	glass_amt = 40
-	},
+/obj/machinery/glass_recycler/bar,
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/access/bar,
 /obj/forcefield/energyshield/perma/doorlink,
@@ -36119,7 +36116,6 @@
 "pjD" = (
 /obj/table/nanotrasen/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/power/apc/autoname_north/nopoweralert{
@@ -45030,7 +45026,6 @@
 "tiT" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/power/apc/autoname_north,

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -18137,7 +18137,6 @@
 	},
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/drinks/bottle/vintage,
@@ -35414,7 +35413,6 @@
 /obj/table/wood/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /turf/space,

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -6040,9 +6040,7 @@
 /area/station/medical/medbay/pharmacy)
 "aBF" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 7
-	},
+/obj/machinery/glass_recycler,
 /obj/item/device/reagentscanner{
 	pixel_x = -12
 	},

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -250,7 +250,6 @@
 /obj/table/wood/round/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/storage/box/cutlery{
@@ -709,7 +708,6 @@
 /obj/table/wood/round/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/storage/box/cutlery{
@@ -3538,7 +3536,6 @@
 /obj/table/wood/round/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/storage/box/cutlery{
@@ -7306,7 +7303,6 @@
 /obj/table/wood/round/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/storage/box/cutlery{

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -1050,7 +1050,6 @@
 /obj/table/wood/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood/two,
@@ -14576,7 +14575,6 @@
 	},
 /obj/machinery/glass_recycler{
 	density = 1;
-	glass_amt = 10;
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/drinks/bottle/vintage,

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -9764,9 +9764,7 @@
 /area/station/security/starboardtorpedoes)
 "aCq" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 5
-	},
+/obj/machinery/glass_recycler,
 /obj/decal/tile_edge/line/black{
 	dir = 4;
 	icon_state = "line1"

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -257,7 +257,6 @@
 	name = "wooden table"
 	},
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/wood/seven,
@@ -2152,7 +2151,6 @@
 "aEF" = (
 /obj/table/reinforced/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light/emergency{
@@ -3013,7 +3011,6 @@
 "aOY" = (
 /obj/table/reinforced/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/cable,
@@ -8552,7 +8549,6 @@
 "cpG" = (
 /obj/table/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/firealarm{
@@ -13792,7 +13788,6 @@
 "dKS" = (
 /obj/table/wood/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/item/device/radio/intercom/engineering{
@@ -14233,7 +14228,6 @@
 "dRz" = (
 /obj/table/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light{
@@ -43142,7 +43136,6 @@
 "lro" = (
 /obj/table/wood/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/black,
@@ -46217,7 +46210,6 @@
 "mdw" = (
 /obj/table/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/grey,
@@ -46597,7 +46589,6 @@
 "miw" = (
 /obj/table/reinforced/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light{
@@ -71670,7 +71661,6 @@
 	name = "wooden table"
 	},
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light/small{
@@ -75427,7 +75417,6 @@
 "tAD" = (
 /obj/table/wood/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/black,
@@ -89381,7 +89370,6 @@
 "wRe" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /turf/simulated/floor/blueblack/corner{
@@ -93029,7 +93017,6 @@
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/glass_recycler{
-	glass_amt = 5;
 	pixel_y = 4
 	},
 /obj/machinery/light_switch/west,


### PR DESCRIPTION
<!-- [game objects] [code quality] [qol]-->

## About the PR
Glass now comes pre-loaded into the glass recyclers, rather than having to have glass dumped in it, or being manually varedited when a mapper makes a map.

Chemistry - 15 glass
Bar - 20 glass
Untyped - 7 glass

To compensate, two of the three boxes of glass have been removed from the drawers in the chemlab, and the loose glasses in the bartending locker have been removed (barring those added manually by mappers, like on Cog1)

## Why's this needed?
Makes the glass recycler a little easier to use, removes varedits from code, and reduces ingame clutter.