### PR TITLE
Pod disruption changes

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1245,7 +1245,6 @@ datum/projectile/bullet/autocannon
 		var/max_turn_rate = 20
 		var/type_to_seek = /obj/critter/gunbot/drone //what are we going to seek
 		precalculated = 0
-		disruption = INFINITY //disrupt every system at once
 		on_hit(atom/hit, angle, obj/projectile/P)
 			if (P.data)
 				..()

--- a/code/modules/projectiles/disruptor_bolt.dm
+++ b/code/modules/projectiles/disruptor_bolt.dm
@@ -2,6 +2,7 @@
 	name = "disruptor"
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "disrupt"
+	damage = 10
 //How much of a punch this has, tends to be seconds/damage before any resist
 	power = 12.5
 	stun = 12.5
@@ -42,13 +43,6 @@ toxic - poisons
 	color_green = 0.2
 	color_blue = 1
 
-//Any special things when it hits shit?
-	on_hit(atom/hit)
-		if(istype(hit,/obj/window))
-			if(prob(80))
-				hit:smash()
-		return
-
 /datum/projectile/disruptor/burst
 	icon_state = "disrupt"
 	shot_sound = 'sound/weapons/rocket.ogg'
@@ -70,4 +64,10 @@ toxic - poisons
 	sname = "disruptor"
 
 	disruption = 20
+
+	on_hit(atom/hit)
+		if(istype(hit, /obj/window))
+			if(prob(80))
+				var/obj/window/win = hit
+				win.smash()
 

--- a/code/modules/transport/pods/shipcomponents.dm
+++ b/code/modules/transport/pods/shipcomponents.dm
@@ -16,6 +16,8 @@
 	var/component_class = 0
 	/// What system it is, to avoid a bunch of istype checks
 	var/system = "part"
+	/// The part is disrupted by an attack and is forced to be off
+	var/disrupted = FALSE
 
 // Code to clean up a shipcomponent that is no longer in use
 /obj/item/shipcomponent/disposing()
@@ -45,6 +47,11 @@
 			return FALSE
 	else
 		ship.powercurrent += power_used
+
+	if (src.disrupted)
+		for(var/mob/M in ship)
+			boutput(M, "[ship.ship_message("ALERT: [src] is temporarily disabled!")]")
+			return FALSE
 
 	src.active = 1
 	for(var/mob/M in src.ship)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -554,32 +554,28 @@
 		qdel(P)
 		return
 
-	proc/disrupt(var/disruption as num, var/obj/projectile/P)
-		if(disruption)
-			playsound(src.loc, pick('sound/machines/glitch1.ogg', 'sound/machines/glitch2.ogg', 'sound/machines/glitch3.ogg', 'sound/effects/electric_shock.ogg', 'sound/effects/elec_bzzz.ogg'), 50, 1)
-			if(pilot)
-				boutput(src.pilot, "[ship_message("WARNING! Electrical system disruption detected!")]")
-			//if (P)
-			//	for (var/mob/M in src)
-			//		M.bullet_act_indirect(P)
-			var/chance = disruption * 1
-			for(var/obj/item/shipcomponent/S in src.components)
-				var/my_chance = chance
-				if (istype(S, /obj/item/shipcomponent/engine))
-					my_chance += 40
+	proc/disrupt(disruption, obj/projectile/P)
+		if(disruption <= 0 || !length(src.components))
+			return
+		playsound(src.loc, pick('sound/machines/glitch1.ogg', 'sound/machines/glitch2.ogg', 'sound/machines/glitch3.ogg', 'sound/effects/electric_shock.ogg', 'sound/effects/elec_bzzz.ogg'), 50, 1)
+		if(pilot)
+			boutput(src.pilot, "[ship_message("WARNING! Electrical system disruption detected!")]")
 
-				if(prob(my_chance))
-					if (istype(S, /obj/item/shipcomponent/engine)) //dont turn off engine thats annoying. instead ddisable the wormhole func!!
-						var/obj/item/shipcomponent/engine/E = S
-						if (E.ready)
-							E.ready = 0
-							E.ready()
-					else
-						S.deactivate()
+		var/obj/item/shipcomponent/S = pick(src.components)
+		if (istype(S, /obj/item/shipcomponent/engine))
+			disruption += 40
 
-					chance -= 25
-					if (chance <= 0)
-						return
+		if(prob(disruption))
+			if (istype(S, /obj/item/shipcomponent/engine)) //dont turn off engine thats annoying. instead ddisable the wormhole func!!
+				var/obj/item/shipcomponent/engine/E = S
+				if (E.ready)
+					E.ready = 0
+					E.ready()
+			else
+				S.deactivate()
+				S.disrupted = TRUE
+				SPAWN(2 SECONDS)
+					S.disrupted = FALSE
 
 	emp_act()
 		src.disrupt(10)


### PR DESCRIPTION
[GAME OBJECTS][VEHICLES][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes a few changes to pod disruptor based attacks in general and to specific attacks (disruption meaning a pod system is disabled)

In general:
-Successful pod disruption effects now disable a pod component for 2 seconds, rather than just only turning it off
-Instead of rolling a chance to disrupt all components in the ship based on the ship's component list, now just picks a random component to disrupt
(Currently disruption is a rolling chance effect through pod components. Think a random pick would be a little better. Also, disruption is pretty simple right now since it only turns components off, you can turn them back on immediately)

Mk. 3 Disruptor:
-Removes window smash effect from Mk. 3 Disruptor
-Increases Mk. 3 Disruptor damage against pods from 8.66 to 15.33 (damage against mobs from 0 to 10)
(This is an armory weapon, window smashing doesn't seem very appropriate considering station damage? Also, damage is really low right now, really makes this weapon more of an annoyance rather than useful, especially considering scout lasers do at least 45 damage, and pod seekers do even more)

Pod seekers:
-Removes disruption from pod seeker grenades
(Pretty neutral on this change, just figured maybe disruption could be moved towards actual disruptor bolts?)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See above

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Increased armory Mk. 3 Disruptor pod weapon damage (from 0 to mobs, ~9 to vehicles -> 10 to mobs, ~15 to vehicles)
(+)Pod disruption from projectiles now causes a random picked pod component to be disabled for 2 seconds. Manual re-activation still required.
```
