### PR TITLE
Allow hivebots to deconstruct tables

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -253,7 +253,7 @@ TYPEINFO_NEW(/obj/table)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_ADJUST), user)
 				return
 
-		else if (iswrenchingtool(W) && !src.status && user.a_intent == "harm") // shouldn't have status unless it's reinforced, maybe? hopefully?
+		else if (iswrenchingtool(W) && !src.status && (user.a_intent == "harm" || ishivebot(user))) // shouldn't have status unless it's reinforced, maybe? hopefully?
 			if (istype(src, /obj/table/folding))
 				actions.start(new /datum/action/bar/icon/fold_folding_table(src, W), user)
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hivebots (Little ai robots) don't have a harm intent, and  thus the change to requiring harm intent to decon tables left them unable to do so. This adds an explicit hivebot check fro table wrenching. A brief search through other harm intent checks didn't reveal any other limitations of a hivebot's toolset.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13141