### PR TITLE
Reduce RP-Mode unreadied player antag boost

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -307,7 +307,11 @@ ABSTRACT_TYPE(/datum/game_mode)
 				readied_count++
 			else
 				unreadied_count++
+#ifdef RP_MODE
+	var/total = readied_count + (unreadied_count/4)
+#else
 	var/total = readied_count + (unreadied_count/2)
+#endif
 	if (loud)
 		logTheThing(LOG_GAMEMODE, "Found [readied_count] readied players and [unreadied_count] unreadied ones, total count being fed to gamemode datum: [total]")
 	return total


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[RP][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduce the weight of unreadied players on RP from 2 to 4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
sec and antags have no time to breathe and do actual RP during RP rounds