### PR TITLE
Adds bar subtype for wall storage

### DIFF
--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -194,6 +194,19 @@ TYPEINFO(/obj/item/storage/wall)
 	/obj/item/hand_labeler,
 	/obj/item/cargotele)
 
+/obj/item/storage/wall/bar
+	name = "bartending supplies"
+	spawn_contents = list(/obj/item/storage/box/fruit_wedges,
+	/obj/item/storage/box/cocktail_doodads,
+	/obj/item/storage/box/cocktail_umbrellas,
+	/obj/item/storage/box/glassbox,
+	/obj/item/hand_labeler,
+	/obj/item/storage/firstaid/toxin,
+	/obj/item/device/reagentscanner,
+	/obj/item/reagent_containers/dropper,
+	/obj/item/reagent_containers/dropper/mechanical,
+	/obj/item/storage/box/ic_cones = 2)
+
 /obj/item/storage/wall/clothingrack
 	name = "clothing rack"
 	icon = 'icons/obj/large_storage.dmi'


### PR DESCRIPTION
## About the PR
Title does a decent job. This set of items is already found on Atlas and Clarion's bar, except those also have an emergency toolbox:
![image](https://github.com/goonstation/goonstation/assets/120209597/840dba1f-a729-4f4b-a225-23f65a9feac6)

## Why's this needed?
Makes mappers' lives (me) easier and makes it easier to edit the contents of these across all maps. Future PR utilizing this will reduce stinky var edits by making all bar wall storages this type.