### PR TITLE
Adds second chem heater to Nadir's bar

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -9233,7 +9233,8 @@
 	pixel_x = -10
 	},
 /obj/machinery/light/emergency,
-/obj/machinery/chem_master{
+/obj/machinery/chem_heater{
+	pixel_x = -4;
 	dir = 4
 	},
 /turf/simulated/floor/engine/caution/east,
@@ -12993,7 +12994,12 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/light_switch/west,
+/obj/item/storage/wall{
+	spawn_contents = list(/obj/item/storage/box/fruit_wedges,/obj/item/storage/box/cocktail_doodads,/obj/item/storage/box/cocktail_umbrellas,/obj/item/storage/box/glassbox,/obj/item/hand_labeler,/obj/item/storage/firstaid/toxin,/obj/item/device/reagentscanner,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/dropper/mechanical,/obj/item/storage/box/ic_cones=2,/obj/item/storage/toolbox/emergency);
+	pixel_x = -32;
+	dir = 4;
+	pixel_y = 4
+	},
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
 	},
@@ -22977,9 +22983,15 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "jMd" = (
-/obj/machinery/firealarm/west,
+/obj/machinery/firealarm/west{
+	pixel_y = -5
+	},
 /obj/machinery/chem_dispenser/alcohol/bar,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/machinery/light_switch/west{
+	pixel_y = 5;
+	pixel_x = -22
+	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
@@ -39671,10 +39683,8 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/table/auto,
-/obj/item/storage/box/glassbox{
-	pixel_x = 2;
-	pixel_y = 9
+/obj/machinery/chem_master{
+	dir = 8
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7846,21 +7846,13 @@
 /area/station/maintenance/southwest)
 "dAz" = (
 /obj/table/auto,
-/obj/item/storage/box/cocktail_doodads{
-	pixel_x = 6;
-	pixel_y = 17
-	},
-/obj/item/storage/box/fruit_wedges{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/storage/box/cocktail_umbrellas{
-	pixel_x = 6;
-	pixel_y = 3
-	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/item/storage/box/beer{
+	pixel_y = 6;
+	pixel_x = 3
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
@@ -11796,12 +11788,7 @@
 /obj/item/reagent_containers/food/drinks/juicer{
 	pixel_y = 5
 	},
-/obj/item/storage/box/fruit_wedges{
-	pixel_x = 6
-	},
-/obj/item/storage/box/beer{
-	pixel_x = -6
-	},
+/obj/item/storage/box/fruit_wedges,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "fpk" = (
@@ -18202,17 +18189,9 @@
 	name = "Drop Capsule"
 	})
 "hLA" = (
-/obj/storage/crate{
-	name = "Cone Crate"
+/obj/machinery/chem_master{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/ice_cream_cone,
-/obj/item/reagent_containers/food/snacks/condiment/chocchips,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "hLN" = (
@@ -27148,13 +27127,15 @@
 /area/station/hallway/primary/northeast)
 "lsm" = (
 /obj/table/auto,
-/obj/item/storage/box/glassbox{
-	pixel_x = 6;
-	pixel_y = 10
+/obj/item/gun/russianrevolver{
+	pixel_y = -9
 	},
-/obj/item/gun/russianrevolver,
 /obj/machinery/phone/wall{
 	pixel_y = 32
+	},
+/obj/item/reagent_containers/food/drinks/eggnog{
+	pixel_x = 5;
+	pixel_y = 13
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
@@ -31883,6 +31864,7 @@
 	pixel_x = 5;
 	pixel_y = 13
 	},
+/obj/item/reagent_containers/food/snacks/condiment/chocchips,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "nnN" = (
@@ -39682,9 +39664,6 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
-	},
-/obj/machinery/chem_master{
-	dir = 8
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -49392,7 +49371,6 @@
 /turf/simulated/floor,
 /area/pasiphae/bridge)
 "veT" = (
-/obj/item/storage/firstaid/toxin,
 /obj/item/device/reagentscanner{
 	pixel_x = 8;
 	pixel_y = -2

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7851,8 +7851,20 @@
 	icon_state = "0-8"
 	},
 /obj/item/storage/box/beer{
-	pixel_y = 6;
+	pixel_y = 4;
 	pixel_x = 3
+	},
+/obj/item/storage/box/cocktail_doodads{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/item/storage/box/cocktail_umbrellas{
+	pixel_y = 6;
+	pixel_x = -1
+	},
+/obj/item/storage/box/fruit_wedges{
+	pixel_y = 7;
+	pixel_x = -3
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
@@ -27134,8 +27146,8 @@
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/food/drinks/eggnog{
-	pixel_x = 5;
-	pixel_y = 13
+	pixel_x = 8;
+	pixel_y = 14
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7846,25 +7846,25 @@
 /area/station/maintenance/southwest)
 "dAz" = (
 /obj/table/auto,
+/obj/item/storage/box/cocktail_doodads{
+	pixel_x = 6;
+	pixel_y = 17
+	},
+/obj/item/storage/box/beer{
+	pixel_y = 17;
+	pixel_x = -4
+	},
+/obj/item/storage/box/fruit_wedges{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/storage/box/cocktail_umbrellas{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-8"
-	},
-/obj/item/storage/box/beer{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/storage/box/cocktail_doodads{
-	pixel_y = 5;
-	pixel_x = 1
-	},
-/obj/item/storage/box/cocktail_umbrellas{
-	pixel_y = 6;
-	pixel_x = -1
-	},
-/obj/item/storage/box/fruit_wedges{
-	pixel_y = 7;
-	pixel_x = -3
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
@@ -27140,14 +27140,10 @@
 "lsm" = (
 /obj/table/auto,
 /obj/item/gun/russianrevolver{
-	pixel_y = -9
+	pixel_y = 6
 	},
 /obj/machinery/phone/wall{
 	pixel_y = 32
-	},
-/obj/item/reagent_containers/food/drinks/eggnog{
-	pixel_x = 8;
-	pixel_y = 14
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
@@ -49383,6 +49379,7 @@
 /turf/simulated/floor,
 /area/pasiphae/bridge)
 "veT" = (
+/obj/item/storage/firstaid/toxin,
 /obj/item/device/reagentscanner{
 	pixel_x = 8;
 	pixel_y = -2


### PR DESCRIPTION
## About the PR <!-- [QoL] -->
Sure, it has one in the backroom chemlab, but that one's a pain to get to. Added a new one where the CheMaster was, and moved the CheMaster to the backroom.

Also adds a wall closet with a set of bartending gear, like what's seen in Atlas and Clarion. Some matching stuff on tables nearby has been removed to compensate.
![image](https://github.com/goonstation/goonstation/assets/120209597/f4f3eb42-90e4-42c9-bcef-ecef9dab835a)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cocktail shakers fit in these things now, which makes them pretty important for chilling drinks to have ice in them.
