### PR TITLE
fix stock exchange computers having no computer chip

### DIFF
--- a/code/modules/economy/stocks/stock_machine.dm
+++ b/code/modules/economy/stocks/stock_machine.dm
@@ -8,6 +8,7 @@
 	light_r =1
 	light_g = 0.7
 	light_b = 0.03
+	circuit_type = /obj/item/circuitboard/stockexchange
 
 /obj/machinery/computer/stockexchange/proc/balance()
 	if (!logged_in)

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -160,6 +160,9 @@ TYPEINFO(/obj/item/circuitboard)
 /obj/item/circuitboard/qmsupply
 	name = "Circuit board (Quartermaster's Console)"
 	computertype = "/obj/machinery/computer/supplycomp"
+/obj/item/circuitboard/stockexchange
+	name = "Circuit board (Stock Exchange)"
+	computertype = "/obj/machinery/computer/stockexchange"
 /obj/item/circuitboard/transception
 	name = "Circuit board (Transception Interlink)"
 	computertype = "/obj/machinery/computer/transception"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

stock exchange computers spawn with no circuit type, making them unable to be disassembled like other computers

map changes could be done later but i dont see it being of critical importance, considering it was overlooked as-is

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes #18558
