### PR TITLE
Revolution rounds end faster on brigging the last revolutionary head

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -426,6 +426,12 @@ TYPEINFO(/obj/stool/wooden)
 		to_buckle.set_clothing_icon_dirty()
 		playsound(src, 'sound/misc/belt_click.ogg', 50, TRUE)
 		to_buckle.setStatus("buckled", duration = INFINITE_STATUS)
+
+		if (istype(ticker?.mode, /datum/game_mode/revolution) && to_buckle.mind.get_antagonist(ROLE_HEAD_REVOLUTIONARY))
+			to_buckle.update_canmove()
+			SPAWN(1 SECOND) // so no abrupt ending
+				ticker.mode.check_win()
+
 		return TRUE
 
 	unbuckle()


### PR DESCRIPTION
[GAME MODES][BALANCE][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that after buckle-cuffing the last revhead in a brig cell, the round will immediately end in a crew victory

(Not sure if there should be some sort of grace period after, but considering rev rounds end immediately after killing the last revhead, and usually the only way a revhead is brigged is close to the same circumstances, I thought maybe it would be okay)

Possibly a bug fix, seems brig endings don't occur when they should be? Only other victory check was through a game mode process, not sure if there's issues with that maybe, but that seems to occur 30 seconds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Brig endings for rev rounds are supposed to be a possible ending, but (correct me if I'm wrong) don't seem to happen too often because when brigging the last revhead, it seems almost like it's bugged and it takes too long for the round end. This would hopefully make brig endings more common


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Revolution rounds now properly end immediately after buckle-cuffing the last revolutionary head in a brig cell.
```
