### PR TITLE
Quality of life fixes for the Clarion operating theatre

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -6463,14 +6463,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/south)
 "aRw" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/computer/operating/small{
+	id = "OR1"
 	},
-/obj/machinery/manufacturer/medical,
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbay)
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/blood,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "aRz" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -13942,9 +13941,6 @@
 	},
 /area/station/medical/medbay)
 "bXJ" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -14490,10 +14486,6 @@
 	},
 /area/station/hallway/primary/north)
 "cqw" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 5;
-	icon_state = "xtra_bigstripe-corner2"
-	},
 /obj/machinery/light/small/floor,
 /obj/cable{
 	icon_state = "1-2"
@@ -15232,8 +15224,28 @@
 	},
 /area/station/medical/medbay/lobby)
 "cVE" = (
-/obj/machinery/computer/operating{
-	id = "OR2"
+/obj/surgery_tray,
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -24052,7 +24064,29 @@
 	pixel_x = 6
 	},
 /obj/machinery/camera,
-/obj/machinery/dialysis,
+/obj/surgery_tray,
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -24099,9 +24133,6 @@
 /area/station/medical/staff)
 "jZa" = (
 /obj/machinery/drainage,
-/obj/stool/chair/office{
-	dir = 8
-	},
 /obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -25679,10 +25710,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "lkd" = (
-/obj/item/device/radio/intercom/medical{
-	broadcasting = 1;
-	dir = 4
-	},
+/obj/table/auto,
+/obj/machinery/defib_mount,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -27387,7 +27416,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/south)
 "mxQ" = (
-/obj/storage/secure/closet/fridge/blood,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
@@ -27396,6 +27424,7 @@
 	dir = 4;
 	pixel_x = -8
 	},
+/obj/machinery/dialysis,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -29122,9 +29151,6 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "nPH" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -29446,12 +29472,14 @@
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/barber_shop)
 "obg" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 28
-	},
 /obj/machinery/computer/operating/small{
 	id = "OR1"
 	},
+/obj/item/device/radio/intercom/medical{
+	broadcasting = 1
+	},
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/blood,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -30635,7 +30663,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/storage/secure/closet/medical/anesthetic,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -30643,6 +30670,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/manufacturer/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
@@ -30729,8 +30757,6 @@
 	dir = 8
 	},
 /obj/item_dispenser/latex_gloves,
-/obj/table/auto,
-/obj/machinery/defib_mount,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -30991,10 +31017,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
 "pmh" = (
-/obj/machinery/drainage,
-/obj/stool/chair/office{
-	dir = 4
-	},
 /obj/landmark/start/job/medical_doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -31657,9 +31679,6 @@
 	},
 /area/station/hallway/primary/south)
 "pKq" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -33022,33 +33041,11 @@
 	},
 /area/station/bridge)
 "qOu" = (
-/obj/surgery_tray,
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/item_dispenser/medical_mask,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/redwhite{
 	dir = 5
 	},
@@ -34224,9 +34221,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "rKT" = (
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/blood,
-/obj/item/reagent_containers/iv_drip/blood,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
 	icon_state = "0-4"
@@ -37472,6 +37466,9 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = 28
+	},
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -37996,9 +37993,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "uwh" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -41452,9 +41446,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "xrp" = (
-/obj/machinery/optable{
-	id = "OR2"
-	},
+/obj/storage/secure/closet/fridge/blood,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -67331,8 +67323,8 @@ bsL
 gjs
 brX
 udJ
-sYc
 lkd
+sYc
 mxQ
 rKT
 wbK
@@ -67634,7 +67626,7 @@ lfY
 brX
 obg
 jZa
-thE
+aRw
 fAz
 lLh
 eGK
@@ -69149,7 +69141,7 @@ sVz
 lzT
 aXv
 oTM
-aRw
+aOw
 bXA
 ezo
 ffI

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -15224,29 +15224,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "cVE" = (
-/obj/surgery_tray,
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -24064,29 +24041,6 @@
 	pixel_x = 6
 	},
 /obj/machinery/camera,
-/obj/surgery_tray,
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -30757,6 +30711,29 @@
 	dir = 8
 	},
 /obj/item_dispenser/latex_gloves,
+/obj/surgery_tray,
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -42301,6 +42278,35 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
+"xYv" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/surgery_tray,
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "xYZ" = (
 /obj/machinery/firealarm/north,
 /obj/machinery/vending/cards,
@@ -67928,7 +67934,7 @@ lfY
 brX
 oYr
 oBI
-oBI
+xYv
 pre
 uCQ
 gNH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Changes the placement of a lot of things in the Clarion operating theatre. See the screenshot for a comparison.
- Removes the two chairs. 
- Removes the third operating table and it's corresponding drain and operating computer.
- Adds a second IV drip.
- Moves the anesthetics locker from the lobby into the operating theatre.
- Adds a second set of surgical tools.
![comparison](https://github.com/goonstation/goonstation/assets/114536206/51e64eb1-6fe5-4d69-a2ad-f0fe406a0759)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current Clarion operating theatre has a few really irrating design flaws.
There's three operating tables but only one set of tools, only one IV drip (that spawns with two blood bags next to it for some reason??) and a mounted defib that can only reach two of the tables.
This fixes all of those things and just generally cleans up the way the room is laid out.