### PR TITLE
Update hivebot HUD and allow Hivebots to use harmintent

### DIFF
--- a/code/mob/living/life/hud.dm
+++ b/code/mob/living/life/hud.dm
@@ -15,6 +15,8 @@
 			robot_owner.hud.update_environment()
 
 		if (hivebot_owner)
+			hivebot_owner.hud.update_charge()
+			hivebot_owner.hud.update_pulling()
 			if (ticker?.mode && istype(ticker.mode, /datum/game_mode/construction))
 				hivebot_owner.see_invisible = INVIS_CONSTRUCTION
 

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -910,6 +910,14 @@ Frequency:
 				return src.module_states[i]
 	return 0
 
+/mob/living/silicon/hivebot/set_a_intent(intent)
+	. = ..()
+	src.hud?.update_intent()
+
+/mob/living/silicon/hivebot/set_pulling(atom/movable/A)
+	. = ..()
+	src.hud?.update_pulling()
+
 /*-----Actual AI Shells---------------------------------------*/
 
 /mob/living/silicon/hivebot/eyebot
@@ -1219,3 +1227,4 @@ Frequency:
 			else
 				hivebot_owner.setStatus("low_signal", INFINITE_STATUS)
 		..()
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][ui][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds HUD buttons for changing intent and pulling objects to the hivebot HUD
* Supporting code to update HUD elements
* Use maptext battery charge% (the same as robots)
* Re-order the HUD buttons to match the same order as robots (using "Tools" instead of "Module")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #13141
Brings hivebot and robot HUDs & capabilities more in-line with each other

## Screenshots

![Screenshot 2024-05-05 110421](https://github.com/goonstation/goonstation/assets/91498627/239d9e83-49e4-4212-864f-d2225e22ea41)

![Screenshot 2024-05-05 110500](https://github.com/goonstation/goonstation/assets/91498627/e1a8390d-7e8b-4ab6-897d-883be785f6c4)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)AI Eyebot Shells can swap between Help and Harm intent via HUD button.
```
