### PR TITLE
implement find last needle helpers and map file measurement procs

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2644,3 +2644,47 @@ proc/message_ghosts(var/message, show_wraith = FALSE)
 				continue
 
 		. += container
+
+/// returns the position of the last matching needle in haystack, case sensitive
+/proc/findLastMatch(haystack, needle)
+	var/last_index = length(haystack)  // Start at the end of the data
+	var/last_match_found = 0
+
+	// Search from the end towards the beginning
+	while(last_index > 0)
+	{
+		last_index = findtext(haystack, needle, -last_index)  // Search from near the end
+		if(last_index > last_match_found)
+		{
+			last_match_found = last_index  // Update the last valid match
+			last_index = length(haystack) - last_index  // Adjust search start closer to the beginning
+		}
+		else
+		{
+			break  // Exit the loop if no further matches are found
+		}
+	}
+
+	return last_match_found
+
+/// returns the position of the last matching needle in haystack, case insensitive
+/proc/findLastMatchEx(haystack, needle)
+	var/last_index = length(haystack)  // Start at the end of the data
+	var/last_match_found = 0
+
+	// Search from the end towards the beginning
+	while(last_index > 0)
+	{
+		last_index = findtextEx(haystack, needle, -last_index)  // Search from near the end
+		if(last_index > last_match_found)
+		{
+			last_match_found = last_index  // Update the last valid match
+			last_index = length(haystack) - last_index  // Adjust search start closer to the beginning
+		}
+		else
+		{
+			break  // Exit the loop if no further matches are found
+		}
+	}
+
+	return last_match_found

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2688,3 +2688,41 @@ proc/message_ghosts(var/message, show_wraith = FALSE)
 	}
 
 	return last_match_found
+
+/// returns the maxx value of a TGM formatted map. Accepts either a map file or preread map text data
+/proc/get_tgm_maxx(map_data)
+	if (isfile(map_data))
+		map_data = file2text(map_data)
+	var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
+	var/x_max = 0
+
+	// Extract X from the last valid match
+	if(idx > 0)
+	{
+		var/end_of_tuple = findtextEx(map_data, ")", idx)  // Find the end of the tuple
+		x_max = text2num(copytext(map_data, idx + 1, end_of_tuple))  // Extract the X value
+	}
+	return x_max
+
+/// returns the maxy value of a TGM formatted map. Accepts either a map file or preread map text data
+/proc/get_tgm_maxy(map_data)
+	if (isfile(map_data))
+		map_data = file2text(map_data)
+	var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
+	var/y_max = 0
+
+	// Start counting newlines from the first newline after the last match
+	if(idx > 0)
+	{
+		var/line_start = findtextEx(map_data, "\n", idx) + 1
+		while(line_start > 0 && line_start < length(map_data))
+		{
+			line_start = findtextEx(map_data, "\n", line_start + 1)  // Find the next newline
+			if(line_start)
+				y_max++
+		}
+		// Decrement Y count if there's an extra newline at the end of the data
+		if(map_data[length(map_data)] == "\n")
+			y_max--
+	}
+	return y_max

--- a/code/z_dmm_suite/reader.dm
+++ b/code/z_dmm_suite/reader.dm
@@ -290,6 +290,43 @@ dmm_suite
 					else
 						. += loadAttribute(trimtext(key_str), strings)
 
+		/// returns the maxx value of a TGM formatted map. Accepts either a map file or preread map text data
+		get_tgm_maxx(map_data)
+			if (isfile(map_data))
+				map_data = file2text(map_data)
+			var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
+			var/x_max = 0
+
+			// Extract X from the last valid match
+			if(idx > 0)
+			{
+				var/end_of_tuple = findtextEx(map_data, ")", idx)  // Find the end of the tuple
+				x_max = text2num(copytext(map_data, idx + 1, end_of_tuple))  // Extract the X value
+			}
+			return x_max
+
+		/// returns the maxy value of a TGM formatted map. Accepts either a map file or preread map text data
+		get_tgm_maxy(map_data)
+			if (isfile(map_data))
+				map_data = file2text(map_data)
+			var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
+			var/y_max = 0
+
+			// Start counting newlines from the first newline after the last match
+			if(idx > 0)
+			{
+				var/line_start = findtextEx(map_data, "\n", idx) + 1
+				while(line_start > 0 && line_start < length(map_data))
+				{
+					line_start = findtextEx(map_data, "\n", line_start + 1)  // Find the next newline
+					if(line_start)
+						y_max++
+				}
+				// Decrement Y count if there's an extra newline at the end of the data
+				if(map_data[length(map_data)] == "\n")
+					y_max--
+			}
+			return y_max
 
 //-- Preloading ----------------------------------------------------------------
 

--- a/code/z_dmm_suite/reader.dm
+++ b/code/z_dmm_suite/reader.dm
@@ -290,43 +290,6 @@ dmm_suite
 					else
 						. += loadAttribute(trimtext(key_str), strings)
 
-		/// returns the maxx value of a TGM formatted map. Accepts either a map file or preread map text data
-		get_tgm_maxx(map_data)
-			if (isfile(map_data))
-				map_data = file2text(map_data)
-			var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
-			var/x_max = 0
-
-			// Extract X from the last valid match
-			if(idx > 0)
-			{
-				var/end_of_tuple = findtextEx(map_data, ")", idx)  // Find the end of the tuple
-				x_max = text2num(copytext(map_data, idx + 1, end_of_tuple))  // Extract the X value
-			}
-			return x_max
-
-		/// returns the maxy value of a TGM formatted map. Accepts either a map file or preread map text data
-		get_tgm_maxy(map_data)
-			if (isfile(map_data))
-				map_data = file2text(map_data)
-			var/idx = findLastMatchEx(map_data, regex(@"\((\d+),1,1\)"))
-			var/y_max = 0
-
-			// Start counting newlines from the first newline after the last match
-			if(idx > 0)
-			{
-				var/line_start = findtextEx(map_data, "\n", idx) + 1
-				while(line_start > 0 && line_start < length(map_data))
-				{
-					line_start = findtextEx(map_data, "\n", line_start + 1)  // Find the next newline
-					if(line_start)
-						y_max++
-				}
-				// Decrement Y count if there's an extra newline at the end of the data
-				if(map_data[length(map_data)] == "\n")
-					y_max--
-			}
-			return y_max
 
 //-- Preloading ----------------------------------------------------------------
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements four new procs

`findLastMatch` and `findLastMatchEx` nearly identical other than their case-sensitivity. Return the index of the final needle in a haystack, used by the measurement procs to identify the final tuple in a tgm map file

`get_tgm_maxx` and `get_tgm_maxx` accept either a tgm formatted dmm file or text of an already read map. Return the maxx/y value in integer form.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* No pre-existing method of determining a map files size before loading it into the game
