### PR TITLE
Syndicate Factory - Planet Prefab

### DIFF
--- a/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
+++ b/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
@@ -1,0 +1,698 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/decoration/junctionbox/junctionbox3{
+	pixel_y = 30
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"b" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "line-broken1";
+	dir = 4
+	},
+/obj/barricade/barbed/wire{
+	dir = 8
+	},
+/obj/barricade{
+	layer = 2.89
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"d" = (
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"g" = (
+/obj/table/reinforced/industrial/auto,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/weldingtool/yellow{
+	pixel_y = 3
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"i" = (
+/obj/decoration/vent/vent3{
+	pixel_y = 35
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"j" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "line-broken1";
+	dir = 8
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"k" = (
+/obj/decal/fakeobjects{
+	desc = "What was this thing even supposed to do?";
+	icon = 'icons/obj/machines/nuclear.dmi';
+	icon_state = "engineoff";
+	name = "broken machine"
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"l" = (
+/obj/decal/nav_danger,
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"m" = (
+/obj/barricade/barbed/wire,
+/obj/barricade{
+	layer = 2.89
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"n" = (
+/mob/living/critter/human/syndicate/rifle,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"o" = (
+/turf/simulated/wall/auto/reinforced/supernorn/blackred,
+/area/noGenerate)
+"p" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "line-broken1";
+	dir = 4
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"q" = (
+/obj/decal/nav_danger,
+/obj/barricade/barbed/wire{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"r" = (
+/obj/barricade/barbed/wire{
+	dir = 10
+	},
+/obj/barricade{
+	layer = 2.89
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"s" = (
+/obj/window/cubicle/railing{
+	dir = 2
+	},
+/obj/storage/cart/trash,
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"u" = (
+/mob/living/critter/human/syndicate/knife,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"w" = (
+/obj/storage/secure/closet/personal/empty,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"x" = (
+/obj/machinery/light/incandescent/cool,
+/obj/storage/crate/wooden{
+	icon_state = "packingcrate12"
+	},
+/obj/item/gun/kinetic/makarov,
+/obj/item/ammo/bullets/nine_mm_soviet,
+/obj/item/ammo/bullets/nine_mm_soviet,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"z" = (
+/obj/window/cubicle/railing{
+	dir = 2
+	},
+/obj/decoration/vent/vent3{
+	pixel_y = 35
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"A" = (
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"C" = (
+/obj/storage/crate/wooden,
+/obj/item/item_box/medical_patches/styptic,
+/obj/item/item_box/medical_patches/silver_sulf,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"D" = (
+/obj/machinery/door/unpowered/wood,
+/obj/machinery/drainage,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"F" = (
+/turf/variableTurf/clear,
+/area/allowGenerate)
+"G" = (
+/obj/stool/chair/moveable{
+	dir = 8
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"H" = (
+/obj/stool/bed,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"I" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"J" = (
+/obj/table/reinforced/industrial/auto,
+/obj/item/reagent_containers/food/drinks/bowl{
+	pixel_y = 8
+	},
+/obj/item/kitchen/utensil/spoon{
+	dir = 8
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"N" = (
+/obj/window/cubicle/railing{
+	dir = 2
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"Q" = (
+/obj/barricade/barbed/wire{
+	dir = 6
+	},
+/obj/barricade{
+	layer = 2.89
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"R" = (
+/obj/decal/tile_edge/line/orange{
+	icon_state = "line-broken1";
+	dir = 8
+	},
+/obj/barricade/barbed/wire{
+	dir = 8
+	},
+/obj/barricade{
+	layer = 2.89
+	},
+/turf/unsimulated/outdoors/concrete,
+/area/noGenerate)
+"T" = (
+/obj/stool/chair/moveable{
+	dir = 8
+	},
+/mob/living/critter/human/syndicate/knife,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"U" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A large rack of server modules.  It doesn't seem to be in service.";
+	icon = 'icons/obj/networked.dmi';
+	icon_state = "tapedrive-p";
+	name = "downed server"
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"V" = (
+/obj/table/reinforced/industrial/auto,
+/obj/item/reagent_containers/food/snacks/cereal_box/syndie{
+	pixel_y = 11;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/milk{
+	pixel_y = 17;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/drinks/bowl{
+	pixel_y = 2;
+	layer = 3.1
+	},
+/obj/item/kitchen/utensil/spoon{
+	dir = 8;
+	pixel_y = -4;
+	layer = 3.2
+	},
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"X" = (
+/obj/decal/nav_danger,
+/obj/storage/crate/trench_loot/drug,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"Y" = (
+/obj/decal/poster/wallsign/chsc{
+	pixel_y = -32
+	},
+/obj/machinery/light/incandescent/cool,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+"Z" = (
+/obj/fireworksbox,
+/turf/simulated/floor/concrete,
+/area/noGenerate)
+
+(1,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+"}
+(2,1,1) = {"
+F
+o
+o
+o
+o
+o
+o
+o
+o
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+"}
+(3,1,1) = {"
+F
+o
+k
+u
+A
+A
+A
+A
+o
+m
+r
+F
+F
+d
+d
+d
+d
+d
+d
+d
+"}
+(4,1,1) = {"
+F
+o
+I
+A
+H
+H
+A
+x
+o
+N
+R
+j
+j
+d
+d
+d
+d
+d
+d
+d
+"}
+(5,1,1) = {"
+F
+o
+u
+A
+w
+w
+A
+A
+o
+z
+b
+p
+p
+d
+d
+F
+F
+F
+F
+F
+"}
+(6,1,1) = {"
+F
+o
+Z
+A
+H
+H
+A
+A
+o
+a
+q
+l
+d
+d
+d
+F
+F
+F
+F
+F
+"}
+(7,1,1) = {"
+F
+o
+U
+A
+w
+w
+A
+A
+D
+N
+R
+j
+j
+d
+d
+F
+F
+F
+F
+F
+"}
+(8,1,1) = {"
+F
+o
+A
+A
+V
+J
+A
+A
+D
+N
+b
+p
+p
+d
+d
+F
+F
+F
+F
+F
+"}
+(9,1,1) = {"
+F
+o
+X
+A
+G
+G
+A
+g
+o
+i
+q
+l
+d
+d
+d
+F
+F
+F
+F
+F
+"}
+(10,1,1) = {"
+F
+o
+X
+C
+A
+n
+A
+T
+o
+s
+R
+j
+j
+d
+d
+F
+F
+F
+F
+F
+"}
+(11,1,1) = {"
+F
+o
+I
+A
+A
+A
+A
+Y
+o
+s
+b
+p
+p
+d
+d
+F
+F
+F
+F
+F
+"}
+(12,1,1) = {"
+F
+o
+A
+u
+A
+A
+A
+A
+o
+m
+Q
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(13,1,1) = {"
+F
+o
+o
+o
+o
+o
+o
+o
+o
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(14,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(15,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(16,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(17,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(18,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(19,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}
+(20,1,1) = {"
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+F
+d
+d
+F
+F
+F
+F
+F
+"}

--- a/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
+++ b/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
@@ -109,7 +109,7 @@
 /turf/simulated/floor/concrete,
 /area/noGenerate)
 "w" = (
-/obj/storage/secure/closet/personal/empty,
+/obj/landmark/spawner/loot,
 /turf/simulated/floor/concrete,
 /area/noGenerate)
 "x" = (
@@ -141,8 +141,8 @@
 /turf/simulated/floor/concrete,
 /area/noGenerate)
 "D" = (
-/obj/machinery/door/unpowered/wood,
 /obj/machinery/drainage,
+/obj/machinery/door/unpowered/shuttle,
 /turf/simulated/floor/concrete,
 /area/noGenerate)
 "F" = (

--- a/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
+++ b/assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm
@@ -80,7 +80,9 @@
 /turf/unsimulated/outdoors/concrete,
 /area/noGenerate)
 "q" = (
-/obj/decal/nav_danger,
+/obj/decal/nav_danger{
+	layer = 2.98
+	},
 /obj/barricade/barbed/wire{
 	dir = 8
 	},
@@ -240,7 +242,9 @@
 /turf/simulated/floor/concrete,
 /area/noGenerate)
 "X" = (
-/obj/decal/nav_danger,
+/obj/decal/nav_danger{
+	layer = 2.98
+	},
 /obj/storage/crate/trench_loot/drug,
 /turf/simulated/floor/concrete,
 /area/noGenerate)

--- a/code/modules/worldgen/prefab/mining/planet.dm
+++ b/code/modules/worldgen/prefab/mining/planet.dm
@@ -161,6 +161,13 @@ ABSTRACT_TYPE(/datum/mapPrefab/planet)
 		prefabSizeY = 3
 		required_biomes = list(/datum/biome/mars, /datum/biome/desert)
 
+	factory_syndicate_taken
+		prefabPath = "assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm"
+		prefabSizeX = 20
+		prefabSizeY = 20
+		maxNum = 2
+		probability = 30
+
 	rogue_syndicate
 		maxNum = 1
 		probability = 5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a factory prefab, available on planets. It is taken by syndicates and barricaded.
The Danger: 4 melee syndicates, 1 rifle syndicate
The Loot: 1 Makarov, 2 Makarov magazines, 2 patch boxes, one is for brute, and other is for burns. 2 drug crate spawners, 4 10% chance loot spawns
The Defense: Barricades surrounded by barbed wire. Building is made out of reinforced walls with concrete floors
![68747470733a2f2f616666656374656461726330372e626c6f622e636f72652e77696e646f77732e6e65742f6d6462322f696d616765732f3235323034373438332f32343638393534363934352f612f6173736574735f6d6170735f707265666162735f706c616e6574](https://github.com/goonstation/goonstation/assets/109891564/c90c90ab-1117-4ce3-9d01-66cf77e63962)
(outdated image, check mapdiff2 in checks tab)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More artemis ruins are good, i think

No changelog because yes
