### PR TITLE
Fix welding 2x2 pods from the top and right sides

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -946,8 +946,6 @@
 	var/atom/movable/target = null
 	/// what string is broadcast once the action bar finishes
 	var/end_message = ""
-	/// what is the maximum range target and owner can be apart? need to modify before starting the action.
-	var/maximum_range = 1
 	/// a list of args for the proc thats called once the action bar finishes, if needed.
 	var/list/proc_args = null
 	bar_on_owner = FALSE
@@ -989,7 +987,7 @@
 		..()
 		if (!src.owner)
 			interrupt(INTERRUPT_ALWAYS)
-		if (src.target && !IN_RANGE(src.owner, src.target, src.maximum_range))
+		if (src.target && (BOUNDS_DIST(src.owner, src.target) > 0))
 			interrupt(INTERRUPT_ALWAYS)
 		src.make_welding_effect()
 
@@ -1006,7 +1004,7 @@
 		if (!src.owner)
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		if (src.target && !IN_RANGE(src.owner, src.target, src.maximum_range))
+		if (src.target && (BOUNDS_DIST(src.owner, src.target) > 0))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		if (end_message)
@@ -1037,7 +1035,7 @@
 		if (!src.owner)
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		if (src.target && !IN_RANGE(src.owner, src.target, src.maximum_range))
+		if (src.target && (BOUNDS_DIST(src.owner, src.target) > 0))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		var/mob/M = owner

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -125,7 +125,6 @@
 			start=positions[1], \
 			stop=positions[2], \
 			tool=W)
-			action_bar.maximum_range = 2
 			actions.start(action_bar, user)
 			return
 

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -125,6 +125,7 @@
 			start=positions[1], \
 			stop=positions[2], \
 			tool=W)
+			action_bar.maximum_range = 2
 			actions.start(action_bar, user)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
use BOUNDS_DIST instead of IN_RANGE when checking if the welding action bar should continue

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
welding should work on all sides of vehicle