### PR TITLE
Using a plasma gas tank on a vehicle opens the parts panel

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -172,6 +172,11 @@
 			src.keyed++
 			src.add_fingerprint(user)
 			return
+
+		if (istype(W, /obj/item/tank))
+			src.open_parts_panel(user)
+			return
+
 		..()
 
 		attack_particle(user,src)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -173,7 +173,7 @@
 			src.add_fingerprint(user)
 			return
 
-		if (istype(W, /obj/item/tank))
+		if (istype(W, /obj/item/tank/plasma))
 			src.open_parts_panel(user)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][vehicles]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using any atmos tank on a vehicle, open the parts panel instead of bonking the tank against the vehicle.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier to replace air/fuel tanks in vehicles. Almost always the intent when using a gas tank on a vehicle