### PR TITLE
Do not scream if nervous and under the effects of capulettium

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1954,7 +1954,7 @@
 		if (!IN_RANGE(src,V, 6))
 			continue
 		if(prob(8) && src)
-			if(src != V && !V.reagents?.has_reagent("CBD"))
+			if(src != V && !V.reagents?.has_reagent("CBD") && !V.reagents?.has_reagent("capulettium"))
 				V.emote("scream")
 				V.changeStatus("stunned", 2 SECONDS)
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1954,7 +1954,7 @@
 		if (!IN_RANGE(src,V, 6))
 			continue
 		if(prob(8) && src)
-			if(src != V && !V.reagents?.has_reagent("CBD") && !V.reagents?.has_reagent("capulettium"))
+			if(src != V && !V.reagents?.has_reagent("CBD") && !V.hasStatus("paralysis"))
 				V.emote("scream")
 				V.changeStatus("stunned", 2 SECONDS)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nervous mobs do not react nervously if they have capulettium in their system.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18809