### PR TITLE
Blacklist plasmalung trait from afterlife

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -288,6 +288,7 @@
 	icon_state = "placeholder"
 	category = list("body")
 	points = 1
+	afterlife_blacklisted = TRUE
 	disability_type = TRAIT_DISABILITY_MAJOR
 	disability_name = "Plasma Lungs"
 	disability_desc = "Only capable of breathing plasma in a gaseous state"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
block the plasmalung trait from being applied in the afterlife bar

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18796
