### PR TITLE
Buffs captain's office

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -242,8 +242,7 @@ ABSTRACT_TYPE(/datum/job/command)
 
 	New()
 		..()
-		src.access = get_all_accesses()
-
+		src.access = get_access("Captain")
 
 	derelict
 		//name = "NT-SO Commander"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -16,10 +16,9 @@
 	var/list/supply_access_list = list(access_hangar, access_cargo, access_supply_console, access_mining, access_mining_shuttle, access_mining_outpost)
 	var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry, access_pathology, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
 	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
-	var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser)
+	var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser)
 	var/list/allowed_access_list
-	var/departmentcomp = FALSE
-	var/department = 0 //0 = standard, 1 = engineering, 2 = medical, 3 = research, 4 = security
+	var/department = 0 //0 = standard, 1 = engineering, 2 = medical, 3 = research, 4 = security, 5 = captain
 	req_access = list(access_change_ids)
 	desc = "A computer that allows an authorized user to change the identification of other ID cards."
 
@@ -201,32 +200,34 @@
 			if (access_name_lookup[A] in command_access_list)
 				command_access.Add(access_data(A))
 
-		if (src.departmentcomp)
-			switch(src.department)
-				if (1) // eng
-					civilian_jobs = list("Staff Assistant")
-					//stock engineering_jobs are good
-					research_jobs = null
-					security_jobs = null
-					command_jobs = null
-				if (2) // med
-					civilian_jobs = list("Staff Assistant")
-					engineering_jobs = null
-					research_jobs = list("Medical Doctor", "Geneticist", "Roboticist")
-					security_jobs = null
-					command_jobs = null
-				if (3) // research
-					civilian_jobs = list("Staff Assistant")
-					engineering_jobs = null
-					research_jobs = list("Scientist")
-					security_jobs = null
-					command_jobs = null
-				if (4) // sec
-					civilian_jobs = list("Staff Assistant", "Clown")
-					engineering_jobs = null
-					research_jobs = null
-					//stock security_jobs are good
-					command_jobs = null
+
+		switch(src.department)
+			if(0) // general
+				command_jobs = command_jobs - "Captain"
+			if (1) // eng
+				civilian_jobs = list("Staff Assistant")
+				//stock engineering_jobs are good
+				research_jobs = null
+				security_jobs = null
+				command_jobs = null
+			if (2) // med
+				civilian_jobs = list("Staff Assistant")
+				engineering_jobs = null
+				research_jobs = list("Medical Doctor", "Geneticist", "Roboticist")
+				security_jobs = null
+				command_jobs = null
+			if (3) // research
+				civilian_jobs = list("Staff Assistant")
+				engineering_jobs = null
+				research_jobs = list("Scientist")
+				security_jobs = null
+				command_jobs = null
+			if (4) // sec
+				civilian_jobs = list("Staff Assistant", "Clown")
+				engineering_jobs = null
+				research_jobs = null
+				//stock security_jobs are good
+				command_jobs = null
 
 		.["standard_jobs"] = list(
 			list(name = "Civilian", color = "blue", jobs = civilian_jobs),
@@ -594,7 +595,6 @@
 
 /obj/machinery/computer/card/department
 	name = "department identification computer"
-	departmentcomp = TRUE
 
 /obj/machinery/computer/card/department/engineering
 	color = "#ffffcc" // look there's a lot of icons to edit just to add a single stripe of color to these computers
@@ -654,3 +654,10 @@
 	security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
 	command_access_list = list(access_eva)
 	#endif
+
+/obj/machinery/computer/card/department/captain
+	name = "Captain's identification computer"
+	color = "#ffd700"
+	department = 5
+	req_access = list(access_captain)
+	command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_captain, access_teleporter, access_eva, access_heads, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -206,6 +206,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 
 /obj/storage/secure/closet/command/captain
 	name = "\improper Captain's locker"
+	reinforced = TRUE
 	req_access = list(access_captain)
 	spawn_contents = list(/obj/item/gun/energy/egun/captain,
 	/obj/item/storage/box/id_kit,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -211,6 +211,7 @@
 		if("Head of Security")
 #ifdef RP_MODE
 			var/list/hos_access = get_all_accesses()
+			hos_access = hos_access - access_captain
 			hos_access += access_maxsec
 			return hos_access
 #else
@@ -377,7 +378,7 @@
 	            access_medical, access_medlab, access_morgue, access_securitylockers,
 	            access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 	            access_emergency_storage, access_change_ids, access_ai_upload,
-	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
+	            access_teleporter, access_eva, access_heads, access_all_personal_lockers, access_head_of_personnel,
 	            access_chapel_office, access_kitchen, access_medical_lockers, access_pathology,
 	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_construction, access_hydro, access_ranch, access_mail,
 	            access_engineering, access_maint_tunnels, access_external_airlocks,
@@ -385,7 +386,7 @@
 	            access_engineering_power, access_engineering_engine, access_mining_shuttle,
 	            access_engineering_control, access_engineering_mechanic, access_engineering_chief, access_mining, access_mining_outpost,
 	            access_research, access_research_director, access_dwaine_superuser, access_engineering_atmos, access_hangar, access_medical_director, access_special_club,
-				access_researchfoyer, access_telesci, access_artlab, access_robotdepot)
+				access_researchfoyer, access_telesci, access_artlab, access_robotdepot, access_captain)
 
 /proc/syndicate_spec_ops_access() //syndie spec ops need to get out of the listening post.
 	return list(access_security, access_brig, access_forensics_lockers, access_armory,

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6410,6 +6410,7 @@
 /turf/simulated/floor/circuit/purple,
 /area/station/science/artifact)
 "axC" = (
+/obj/machinery/computer/card/department/captain,
 /turf/simulated/floor/blue,
 /area/station/bridge/captain)
 "axE" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14485,14 +14485,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cqH" = (
-/obj/machinery/computer/card{
-	dir = 4
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/blind_switch/area/west{
+	dir = 4
+	},
+/obj/machinery/computer/card/department/captain{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -51734,10 +51734,8 @@
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "nED" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/machinery/computer/card/department/captain{
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -62160,6 +62158,10 @@
 /obj/item/stamp/cap{
 	pixel_x = -7;
 	pixel_y = 5
+	},
+/obj/machinery/recharger{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /obj/item/item_box/gold_star{
 	pixel_x = 6;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -34921,9 +34921,6 @@
 /turf/simulated/floor,
 /area/station/teleporter)
 "bWn" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/item/rubberduck,
 /obj/blind_switch/area{
 	pixel_x = -24
 	},
@@ -34933,7 +34930,9 @@
 	pixel_x = -24;
 	pixel_y = 8
 	},
-/obj/item/stamp/cap,
+/obj/machinery/computer/card/department/captain{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bWo" = (
@@ -35363,6 +35362,9 @@
 "bXF" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/green,
+/obj/random_item_spawner/desk_stuff,
+/obj/item/rubberduck,
+/obj/item/stamp/cap,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bXG" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8633,24 +8633,17 @@
 	name = "Diplomatic Quarters"
 	})
 "aTg" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
 	dir = 4
 	},
-/obj/machinery/computer3/generic/communications{
+/obj/machinery/light/incandescent,
+/obj/machinery/computer/card/department/captain{
 	dir = 4
 	},
-/obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aTi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -8803,12 +8796,11 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aTS" = (
-/obj/table/wood/auto,
-/obj/machinery/recharger,
-/obj/item/hand_tele{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/machinery/computer3/generic/communications{
+	dir = 8
 	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aTT" = (
@@ -26797,6 +26789,14 @@
 	},
 /obj/item/stamp/cap,
 /obj/random_item_spawner/desk_stuff/one,
+/obj/machinery/recharger,
+/obj/item/hand_tele{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "iGp" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -18305,7 +18305,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/computer/card,
 /obj/machinery/light/incandescent/greenish{
 	dir = 1
 	},
@@ -18313,6 +18312,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/computer/card/department/captain,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -53435,16 +53435,12 @@
 /turf/simulated/floor/circuit/red,
 /area/ghostdrone_factory)
 "tCk" = (
-/obj/machinery/computer3/terminal/network{
-	dir = 4;
-	name = "CENTCOM Terminal";
-	pixel_x = -3;
-	pixel_y = 4;
-	setup_os_string = "MAIN_DISH_SS13"
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/computer/card/department/captain{
+	dir = 4
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/bridge/captain)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2474,6 +2474,10 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purpleblack,
 /area/station/science/hall)
+"bfM" = (
+/mob/living/critter/small_animal/cat/jones,
+/turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
+/area/station/bridge/captain)
 "bfW" = (
 /obj/machinery/manufacturer/mining,
 /obj/machinery/power/apc/autoname_east,
@@ -55603,7 +55607,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/mob/living/critter/small_animal/cat/jones,
+/obj/machinery/computer/card/department/captain,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/bridge/captain)
 "xUg" = (
@@ -97883,7 +97887,7 @@ jYP
 mnu
 mFG
 mRa
-nfo
+bfM
 nlW
 htt
 gow

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31474,7 +31474,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "cje" = (
-/turf/simulated/floor/carpet/purple/standard/narrow/T_north,
+/obj/machinery/computer/card/department/captain,
+/turf/simulated/floor/carpet/purple/standard/narrow/nw,
 /area/station/crew_quarters/captain)
 "cjf" = (
 /obj/machinery/light/incandescent,
@@ -43031,7 +43032,7 @@
 /obj/shrub/captainshrub,
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
 /obj/machinery/firealarm/north,
-/turf/simulated/floor/carpet/purple/standard/narrow/nw,
+/turf/simulated/floor/carpet/purple/standard/narrow/T_north,
 /area/station/crew_quarters/captain)
 "sak" = (
 /obj/machinery/drainage/big,
@@ -89748,8 +89749,8 @@ aqn
 aqn
 aqn
 aqn
-aqn
-ckk
+cjX
+aUp
 cjV
 bvA
 bvA
@@ -90050,9 +90051,9 @@ aqn
 aqn
 aqn
 aqn
-cjX
-aUp
-fML
+ckk
+ckC
+ckA
 bvA
 bwL
 bxL
@@ -90353,8 +90354,8 @@ aqn
 cjX
 ckg
 aUp
-ckC
-ckA
+fML
+bvA
 bvA
 bwM
 kSM
@@ -90657,8 +90658,8 @@ ckC
 cjZ
 ckA
 bvA
-bvA
 cje
+bwN
 oyv
 bvA
 bxK

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -9851,6 +9851,10 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
+/obj/machinery/recharger{
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /obj/item/item_box/gold_star{
 	pixel_x = -6;
 	pixel_y = -4
@@ -49874,10 +49878,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "cmE" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/machinery/computer/card/department/captain{
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -24824,6 +24824,9 @@
 /turf/space,
 /area/space)
 "kTr" = (
+/obj/machinery/computer/card/department/captain{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/captain)
 "kTu" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Reinforces captain's locker.
- Makes captain's office access almost exclusive to the captain (and the spare). RP HoS no longer has access to cap's office. The Regional Director and NTSO units still have the access.
- The standard ID console can no longer give out captain's office access.
- Adds a new departamental ID console : Captain's. It requires captain's access to work on, and is the only ID console that can issue new IDs with captain's access.
- The new console has been placed in captain's offices on every in rotation map.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes captain a more serious role.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(*) Captain's office access is now exclusive to the captain and CentCom employees.
(*) Captain's locker is now reinforced.
```
