### PR TITLE
Fixes a runtime caused by recoil attempting to trigger on non-mob users

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -434,11 +434,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	SEND_SIGNAL(user, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
 
-	handle_recoil(user, start, target, POX, POY)
-
 	if (ismob(user))
-		var/mob/M = user
-		if (ishuman(M) && src.add_residue) // Additional forensic evidence for kinetic firearms (Convair880).
+		handle_recoil(user, start, target, POX, POY)
+		if (ishuman(user) && src.add_residue) // Additional forensic evidence for kinetic firearms (Convair880).
 			var/mob/living/carbon/human/H = user
 			H.gunshot_residue = 1
 

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -434,9 +434,11 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	SEND_SIGNAL(user, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
 
+	handle_recoil(user, start, target, POX, POY)
+
 	if (ismob(user))
-		handle_recoil(user, start, target, POX, POY)
-		if (ishuman(user) && src.add_residue) // Additional forensic evidence for kinetic firearms (Convair880).
+		var/mob/M = user
+		if (ishuman(M) && src.add_residue) // Additional forensic evidence for kinetic firearms (Convair880).
 			var/mob/living/carbon/human/H = user
 			H.gunshot_residue = 1
 
@@ -547,7 +549,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	recoil_stacks = 0
 
 /obj/item/gun/proc/handle_recoil(mob/user, turf/start, turf/target, POX, POY, first_shot = TRUE)
-	if (!recoil_enabled)
+	if (!recoil_enabled || !istype(user))
 		return
 	var/start_recoil = FALSE
 	if (recoil == 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`handle_recoil` now includes an `istype(user)` check to make sure it only runs on mobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

`handle_recoil` expects a mob user, but the place where it's called doesn't do a type check to make sure the user is actually human. This leads to runtimes when a gun goes off without a mob user (such as when it's fired by a gun component); it *seems* like a harmless error, but it does spam the log, so it's a good thing to fix anyway.

## Testing

I jumped into a local server and fired a few different types of spawned-in gun myself and as part of a gun component assembly. No runtimes anymore, and everything seemed to work as intended.