### PR TITLE
Fix applying items on people's inventories not working

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -639,7 +639,7 @@
 			if(existing_item && in_start) // if they have something there, smack it with held item
 				logTheThing(LOG_COMBAT, source, "uses the inventory menu while holding [log_object(item)] to interact with \
 													[log_object(existing_item)] equipped by [log_object(target)].")
-				actions.start(new /datum/action/bar/icon/callback(source, target, item.duration_remove > 0 ? item.duration_remove : 2.5 SECONDS, /mob/living/click, list(existing_item, list()),  item.icon, item.icon_state, null, null, source), source) //this is messier
+				actions.start(new /datum/action/bar/icon/callback(source, target, item.duration_remove > 0 ? item.duration_remove : 2.5 SECONDS, TYPE_PROC_REF(/mob/living, click), list(existing_item, list()),  item.icon, item.icon_state, null, null, source), source) //this is messier
 				interrupt(INTERRUPT_ALWAYS)
 				return
 			if(item != source.equipped())

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -639,7 +639,7 @@
 			if(existing_item && in_start) // if they have something there, smack it with held item
 				logTheThing(LOG_COMBAT, source, "uses the inventory menu while holding [log_object(item)] to interact with \
 													[log_object(existing_item)] equipped by [log_object(target)].")
-				actions.start(new /datum/action/bar/icon/callback(source, target, item.duration_remove > 0 ? item.duration_remove : 2.5 SECONDS, /mob/proc/click, list(existing_item, list()),  item.icon, item.icon_state, null, null, source), source) //this is messier
+				actions.start(new /datum/action/bar/icon/callback(source, target, item.duration_remove > 0 ? item.duration_remove : 2.5 SECONDS, /mob/living/click, list(existing_item, list()),  item.icon, item.icon_state, null, null, source), source) //this is messier
 				interrupt(INTERRUPT_ALWAYS)
 				return
 			if(item != source.equipped())


### PR DESCRIPTION
[Bug][player actions]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a bug that caused people to be unable to use items on items carried by other mobs. the actin bar called 'mob/proc/click' instead of 'mob/living/click', thus did absolutely nothing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's an interaction that was broken, so i gotta fix it. I was not able to see exactly what commit broke it, and noone made an issue about it, so i think that's an odd thing. But oh well
