### PR TITLE
Fix AtmosAlerter PDA App

### DIFF
--- a/code/obj/machinery/computer/general_air_control.dm
+++ b/code/obj/machinery/computer/general_air_control.dm
@@ -354,7 +354,7 @@ Rate: <A href='?src=\ref[src];change_vol=-10'>--</A> <A href='?src=\ref[src];cha
 	New()
 		..()
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT("control", frequency)
-		MAKE_SENDER_RADIO_PACKET_COMPONENT("respond", respond_frequency)
+		MAKE_DEFAULT_RADIO_PACKET_COMPONENT("respond", respond_frequency)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT("receive", receive_frequency)
 
 	receive_signal(datum/signal/signal)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the radio component on general alert computers to not be send only so they can actually receive the `report_alerts` packets that PDAs send.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18829