### PR TITLE
Adds typeinfo to mutantraces.

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -6,6 +6,21 @@
 /// mutant races: cheap way to add new "types" of mobs
 TYPEINFO(/datum/mutantrace)
 	var/list/special_styles // special styles which currently change the icon (sprite sheet)
+	/// icon definitions for mutantrace clothing variants. one icon file per slot.
+	var/list/clothing_icons = list()
+	/// list of the icon states for each icon file, put here because for some ungodly reason `icon_states()` can take 200ms randomly
+	var/list/clothing_icon_states = list()
+	/// This is used for static icons if the mutant isn't built from pieces
+	/// For chunked mutantraces this must still point to a valid full-body image to generate a staticky sprite for ghostdrones.
+	var/icon = 'icons/effects/genetics.dmi'
+	///The icon states of the above icon, cached because byond is bad
+	var/icon_states
+TYPEINFO_NEW(/datum/mutantrace) ///Load all the clothing override icons, should call parent AFTER populating `clothing_icons`
+	..()
+	for (var/category in src.clothing_icons)
+		src.clothing_icon_states[category] = icon_states(src.clothing_icons[category])
+	src.icon_states = icon_states(src.icon)
+
 ABSTRACT_TYPE(/datum/mutantrace)
 /datum/mutantrace
 	var/name = null				// used for identification in diseases, clothing, etc
@@ -73,11 +88,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	var/genetics_removable = TRUE
 	/// Should they be able to walk on shards barefoot
 	var/can_walk_on_shards = FALSE
-	/// This is used for static icons if the mutant isn't built from pieces
-	/// For chunked mutantraces this must still point to a valid full-body image to generate a staticky sprite for ghostdrones.
-	var/icon = 'icons/effects/genetics.dmi'
-	///The icon states of the above icon, cached because byond is bad
-	var/icon_states = null
 	var/icon_state = "blank_c"
 	/// The icon used to render their eyes
 	var/eye_icon = 'icons/mob/human_hair.dmi'
@@ -99,11 +109,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	var/list/mutant_organs = list()
 	/// If our mutant has a female variant that has different organs, these will be used instead
 	var/list/mutant_organs_f = null
-
-	/// icon definitions for mutantrace clothing variants. one icon file per slot.
-	var/clothing_icons = list()
-	/// list of the icon states for each icon file, put here because for some ungodly reason `icon_states()` can take 200ms randomly
-	var/clothing_icon_states = list()
 
 	var/head_offset = 0 // affects pixel_y of clothes
 	var/hand_offset = 0
@@ -224,12 +229,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 	var/self_click_fluff //used when clicking self on help intent
 
-	///Load all the clothing override icons, should call parent AFTER populating `clothing_icons`
-	proc/load_clothing_icons()
-		SHOULD_CALL_PARENT(TRUE)
-		for (var/category in src.clothing_icons)
-			src.clothing_icon_states[category] = icon_states(src.clothing_icons[category])
-
 	/// Called by /mob/living/carbon/human/update_clothing()'s slot-specific sub-procs.
 	/// Each sub-proc passes its obj to this proc, which you can then operate on.
 	/// Should return a filter or list of filters, to be added to the obj's wear_image.filters
@@ -323,12 +322,8 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 	New(var/mob/living/carbon/human/M)
 		..() // Cant trust not-humans with a mutantrace, they just runtime all over the place
-		if(ishuman(M) && M?.bioHolder?.mobAppearance)
-			src.load_clothing_icons()
-			src.icon_states = icon_states(src.icon)
-		else
+		if(!(ishuman(M) && M.bioHolder?.mobAppearance))
 			qdel(src)
-		return
 
 	disposing()
 		if (src.mob)
@@ -648,9 +643,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			if(src.detail_oversuit_1_color_f)
 				src.detail_oversuit_1_color = src.detail_oversuit_1_color_f
 
+TYPEINFO(/datum/mutantrace/human)
+	icon = 'icons/mob/human.dmi'
 /datum/mutantrace/human
 	name = "human"
-	icon = 'icons/mob/human.dmi'
 	mutant_folder = 'icons/mob/human.dmi'
 	icon_state = "body_m"
 	human_compatible = TRUE
@@ -658,9 +654,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	dna_mutagen_banned = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/human
 
+TYPEINFO(/datum/mutantrace/blob)
+	icon = 'icons/mob/blob_ambassador.dmi'
 /datum/mutantrace/blob // podrick's july assjam submission, it's pretty cute
 	name = "blob"
-	icon = 'icons/mob/blob_ambassador.dmi'
 	mutant_folder = 'icons/mob/blob_ambassador.dmi'
 	icon_state = "blob"
 	human_compatible = 0
@@ -674,9 +671,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	say_verb()
 		return pick("burbles", "gurgles", "blurbs", "gloops")
 
+TYPEINFO(/datum/mutantrace/flubber)
+	icon = 'icons/mob/flubber.dmi'
 /datum/mutantrace/flubber
 	name = "flubber"
-	icon = 'icons/mob/flubber.dmi'
 	mutant_folder = 'icons/mob/flubber.dmi'
 	icon_state = "flubber"
 	uses_human_clothes = 0
@@ -721,9 +719,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	say_verb()
 		return "flubbers"
 
+TYPEINFO(/datum/mutantrace/flashy)
+	icon = 'icons/mob/flashy.dmi'
 /datum/mutantrace/flashy
 	name = "flashy"
-	icon = 'icons/mob/flashy.dmi'
 	icon_state = "body_m"
 	mutant_appearance_flags = (HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HEAD_HAS_OWN_COLORS | HAS_HUMAN_EYES | WEARS_UNDERPANTS | BUILT_FROM_PIECES)
 	override_attack = 0
@@ -735,10 +734,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/left
 	dna_mutagen_banned = FALSE
 
-
+TYPEINFO(/datum/mutantrace/virtual)
+	icon = 'icons/mob/virtual.dmi'
 /datum/mutantrace/virtual
 	name = "virtual"
-	icon = 'icons/mob/virtual.dmi'
 	icon_state = "body_m"
 	override_attack = 0
 	mutant_folder = 'icons/mob/virtual.dmi'
@@ -795,9 +794,16 @@ ABSTRACT_TYPE(/datum/mutantrace)
 		else
 			..()
 
+TYPEINFO(/datum/mutantrace/lizard)
+	icon = 'icons/mob/lizard.dmi'
+TYPEINFO_NEW(/datum/mutantrace/lizard)
+	clothing_icons["overcoats"] = 'icons/mob/lizard/overcoats.dmi'
+	clothing_icons["eyes"] = 'icons/mob/lizard/eyes.dmi'
+	clothing_icons["mask"] = 'icons/mob/lizard/mask.dmi'
+	clothing_icons["head"] = 'icons/mob/lizard/head.dmi'
+	..()
 /datum/mutantrace/lizard
 	name = "lizard"
-	icon = 'icons/mob/lizard.dmi'
 	icon_state = "body_m"
 	override_attack = 0
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HAS_EXTRA_DETAILS | FIX_COLORS | SKINTONE_USES_PREF_COLOR_1 | HAS_SPECIAL_HAIR | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS | HAS_LONG_NOSE)
@@ -825,13 +831,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	color_channel_names = list("Episcutus", "Ventral Aberration", "Sagittal Crest")
 	dna_mutagen_banned = FALSE
 	self_click_fluff = "scales"
-
-	load_clothing_icons()
-		clothing_icons["overcoats"] = 'icons/mob/lizard/overcoats.dmi'
-		clothing_icons["eyes"] = 'icons/mob/lizard/eyes.dmi'
-		clothing_icons["mask"] = 'icons/mob/lizard/mask.dmi'
-		clothing_icons["head"] = 'icons/mob/lizard/head.dmi'
-		..()
 
 	on_attach(var/mob/living/carbon/human/H)
 		..()
@@ -1026,9 +1025,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			H.abilityHolder.removeAbility(/datum/targetable/zombie/infect)
 		..()
 
+TYPEINFO(/datum/mutantrace/vampiric_thrall)
+	icon = 'icons/mob/vampiric_thrall.dmi'
 /datum/mutantrace/vampiric_thrall
 	name = "vampiric thrall"
-	icon = 'icons/mob/vampiric_thrall.dmi'
 	icon_state = "body_m"
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
 	r_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/vampiric_thrall/right
@@ -1074,9 +1074,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 		src.mob?.mind?.remove_antagonist(ROLE_VAMPTHRALL, ANTAGONIST_REMOVAL_SOURCE_DEATH)
 		..()
 
+TYPEINFO(/datum/mutantrace/skeleton)
+	icon = 'icons/mob/skeleton.dmi'
 /datum/mutantrace/skeleton
 	name = "skeleton"
-	icon = 'icons/mob/skeleton.dmi'
 	mutant_folder = 'icons/mob/skeleton.dmi'
 	icon_state = "skeleton"
 	voice_override = "skelly"
@@ -1218,11 +1219,11 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_SKINTONE | HAS_NO_EYES | HAS_NO_HEAD | USES_STATIC_ICON)
 	override_attack = 0
 
-
+TYPEINFO(/datum/mutantrace/abomination)
+	icon = 'icons/mob/abomination.dmi'
 /datum/mutantrace/abomination
 	name = "abomination"
 	mutant_folder = 'icons/mob/abomination.dmi'
-	icon = 'icons/mob/abomination.dmi'
 	icon_state = "abomination"
 	human_compatible = 0
 	uses_human_clothes = 0
@@ -1326,9 +1327,14 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 /// Probability someone gets bit when patting a werewolf
 #define SNAP_PROB 50
+TYPEINFO(/datum/mutantrace/werewolf)
+	icon = 'icons/mob/werewolf.dmi'
+TYPEINFO_NEW(/datum/mutantrace/werewolf)
+	clothing_icons["back"] = 'icons/mob/werewolf/back.dmi'
+	clothing_icons["mask"] = 'icons/mob/werewolf/mask.dmi'
+	..()
 /datum/mutantrace/werewolf
 	name = "werewolf"
-	icon = 'icons/mob/werewolf.dmi'
 	icon_state = "body_m"
 	human_compatible = 0
 	uses_human_clothes = 0
@@ -1351,11 +1357,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	head_offset = 5
 	hand_offset = 3
 	arm_offset = 3
-
-	load_clothing_icons()
-		clothing_icons["back"] = 'icons/mob/werewolf/back.dmi'
-		clothing_icons["mask"] = 'icons/mob/werewolf/mask.dmi'
-		..()
 
 	on_attach()
 		..()
@@ -1459,10 +1460,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 #undef SNAP_PROB
 
-
+TYPEINFO(/datum/mutantrace/hunter)
+	icon = 'icons/mob/hunter.dmi'
 /datum/mutantrace/hunter
 	name = "hunter"
-	icon = 'icons/mob/hunter.dmi'
 	icon_state = "full"
 	human_compatible = 0
 	jerk = TRUE
@@ -1496,9 +1497,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	say_verb()
 		return "snarls"
 
+TYPEINFO(/datum/mutantrace/ithillid)
+	icon = 'icons/mob/ithillid.dmi'
 /datum/mutantrace/ithillid
 	name = "ithillid"
-	icon = 'icons/mob/ithillid.dmi'
 	icon_state = "body_m"
 	jerk = FALSE
 	override_attack = 0
@@ -1523,9 +1525,23 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	say_verb()
 		return "glubs"
 
+TYPEINFO(/datum/mutantrace/monkey)
+	icon = 'icons/mob/monkey.dmi'
+TYPEINFO_NEW(/datum/mutantrace/monkey)
+	src.clothing_icons["uniform"] = 'icons/mob/monkey/jumpsuits.dmi'
+	src.clothing_icons["id"] = 'icons/mob/monkey/card.dmi'
+	src.clothing_icons["hands"] = 'icons/mob/monkey/hands.dmi'
+	src.clothing_icons["feet"] = 'icons/mob/monkey/feet.dmi'
+	src.clothing_icons["overcoats"] = 'icons/mob/monkey/overcoats.dmi'
+	src.clothing_icons["back"] = 'icons/mob/monkey/back.dmi'
+	src.clothing_icons["eyes"] = 'icons/mob/monkey/eyes.dmi'
+	src.clothing_icons["ears"] = 'icons/mob/monkey/ears.dmi'
+	src.clothing_icons["mask"] = 'icons/mob/monkey/mask.dmi'
+	src.clothing_icons["head"] = 'icons/mob/monkey/head.dmi'
+	src.clothing_icons["belt"] = 'icons/mob/monkey/belt.dmi'
+	..()
 /datum/mutantrace/monkey
 	name = "monkey"
-	icon = 'icons/mob/monkey.dmi'
 	mutant_folder = 'icons/mob/monkey.dmi'
 	icon_state = "monkey"
 	eye_state = "eyes_monkey"
@@ -1554,20 +1570,6 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	dna_mutagen_banned = FALSE
 	self_click_fluff = "fur"
 	override_limb_icons = TRUE
-
-	load_clothing_icons()
-		src.clothing_icons["uniform"] = 'icons/mob/monkey/jumpsuits.dmi'
-		src.clothing_icons["id"] = 'icons/mob/monkey/card.dmi'
-		src.clothing_icons["hands"] = 'icons/mob/monkey/hands.dmi'
-		src.clothing_icons["feet"] = 'icons/mob/monkey/feet.dmi'
-		src.clothing_icons["overcoats"] = 'icons/mob/monkey/overcoats.dmi'
-		src.clothing_icons["back"] = 'icons/mob/monkey/back.dmi'
-		src.clothing_icons["eyes"] = 'icons/mob/monkey/eyes.dmi'
-		src.clothing_icons["ears"] = 'icons/mob/monkey/ears.dmi'
-		src.clothing_icons["mask"] = 'icons/mob/monkey/mask.dmi'
-		src.clothing_icons["head"] = 'icons/mob/monkey/head.dmi'
-		src.clothing_icons["belt"] = 'icons/mob/monkey/belt.dmi'
-		..()
 
 	on_attach(var/mob/living/carbon/human/M)
 		. = ..()
@@ -1674,10 +1676,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 					src.mob.expel_fart_gas(0)
 					src.mob.add_karma(0.5)
 
-
+TYPEINFO(/datum/mutantrace/seamonkey)
+	icon = 'icons/mob/monkey.dmi'
 /datum/mutantrace/monkey/seamonkey
 	name = "sea monkey"
-	icon = 'icons/mob/monkey.dmi'
 	mutant_folder = 'icons/mob/seamonkey.dmi'
 	icon_state = "seamonkey"
 	special_head = HEAD_SEAMONKEY
@@ -1715,9 +1717,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			src.mob.stuttering = 120
 			src.mob.contract_disease(/datum/ailment/disability/clumsy,null,null,1)
 
+TYPEINFO(/datum/mutantrace/premature_clone)
+	icon = 'icons/mob/human.dmi'
 /datum/mutantrace/premature_clone
 	name = "premature clone"
-	icon = 'icons/mob/human.dmi'
 	mutant_folder = 'icons/mob/human.dmi'
 	icon_state = "mutant3"
 	human_compatible = 1
@@ -1778,10 +1781,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	icon_state = "cyclops"
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_NO_EYES | HAS_NO_HEAD | WEARS_UNDERPANTS | USES_STATIC_ICON)
 
-
+TYPEINFO(/datum/mutantrace/roach)
+	icon = 'icons/mob/roach.dmi'
 /datum/mutantrace/roach
 	name = "roach"
-	icon = 'icons/mob/roach.dmi'
 	icon_state = "body_m"
 	override_attack = 0
 	voice_override = "roach"
@@ -1820,9 +1823,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			REMOVE_ATOM_PROPERTY(src.mob, PROP_MOB_RADPROT_INT, src)
 		. = ..()
 
+TYPEINFO(/datum/mutantrace/cat)
+	icon = 'icons/mob/cat.dmi'
 /datum/mutantrace/cat // we have the sprites so ~why not add them~? (I fully expect to get shit for this)
 	name = "cat"
-	icon = 'icons/mob/cat.dmi'
 	icon_state = "body_m"
 	jerk = TRUE
 	override_attack = 0
@@ -1854,9 +1858,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			src.mob.mob_flags &= ~SHOULD_HAVE_A_TAIL
 		. = ..()
 
+TYPEINFO(/datum/mutantrace/cat/bingus)
+	icon = 'icons/mob/bingus.dmi'
 /datum/mutantrace/cat/bingus // our beloved
 	name = "bingus"
-	icon = 'icons/mob/bingus.dmi'
 	race_mutation = /datum/bioEffect/mutantrace/cat/bingus
 	mutant_organs = list("tail" = /obj/item/organ/tail/cat/bingus)
 	mutant_folder = 'icons/mob/bingus.dmi'
@@ -1869,9 +1874,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/bingus/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/bingus/left
 
+TYPEINFO(/datum/mutantrace/amphibian)
+	icon = 'icons/mob/amphibian.dmi'
 /datum/mutantrace/amphibian
 	name = "amphibian"
-	icon = 'icons/mob/amphibian.dmi'
 	icon_state = "body_m"
 	firevuln = 1.3
 	brutevuln = 0.7
@@ -1939,9 +1945,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 					return message
 			else ..()
 
+TYPEINFO(/datum/mutantrace/amphibian/shelter)
+	icon = 'icons/mob/shelterfrog.dmi'
 /datum/mutantrace/amphibian/shelter
 	name = "Shelter Amphibian"
-	icon = 'icons/mob/shelterfrog.dmi'
 	icon_state = "body_m"
 	human_compatible = 1
 	jerk = FALSE
@@ -1955,9 +1962,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
 	blood_color = "#91b978"
 
+TYPEINFO(/datum/mutantrace/kudzu)
+	icon = 'icons/mob/kudzu.dmi'
 /datum/mutantrace/kudzu
 	name = "kudzu"
-	icon = 'icons/mob/kudzu.dmi'
 	icon_state = "kudzu-w"
 	human_compatible = 0
 	uses_human_clothes = 0
@@ -2100,9 +2108,10 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	icon = 'icons/mob/cow.dmi'
 	icon_state = "backpack_mask"
 
+TYPEINFO(/datum/mutantrace/cow)
+	icon = 'icons/mob/cow.dmi'
 /datum/mutantrace/cow
 	name = "cow"
-	icon = 'icons/mob/cow.dmi'
 	icon_state = "body_m"
 	human_compatible = TRUE
 	uses_human_clothes = FALSE
@@ -2259,13 +2268,13 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			T.react_all_cleanables()
 
 TYPEINFO(/datum/mutantrace/pug)
+	icon = 'icons/mob/pug/fawn.dmi'
 	special_styles = list("apricot" = 'icons/mob/pug/apricot.dmi',
 	"black" = 'icons/mob/pug/black.dmi',
 	"chocolate" = 'icons/mob/pug/chocolate.dmi',
 	"fawn" = 'icons/mob/pug/fawn.dmi')
 /datum/mutantrace/pug
 	name = "pug"
-	icon = 'icons/mob/pug/fawn.dmi'
 	icon_state = "body_m"
 	human_compatible = TRUE
 	override_attack = 0

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -112,8 +112,9 @@
 		suit_image.filters = src.w_uniform.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.w_uniform)
 
 		var/wear_state = src.w_uniform.wear_state || src.w_uniform.icon_state
-		if (wear_state in src.mutantrace?.clothing_icon_states?["uniform"])
-			suit_image.icon = src.mutantrace.clothing_icons["uniform"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["uniform"])
+			suit_image.icon = typeinfo.clothing_icons["uniform"]
 		else
 			suit_image.icon = src.w_uniform.wear_image_icon
 		suit_image.icon_state = wear_state
@@ -138,8 +139,9 @@
 		wear_sanity_check(src.wear_id)
 		var/wear_state = src.wear_id.wear_state || src.wear_id.icon_state
 		var/no_offset = 0
-		if (wear_state in src.mutantrace?.clothing_icon_states?["id"])
-			src.wear_id.wear_image.icon = src.mutantrace.clothing_icons["id"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["id"])
+			src.wear_id.wear_image.icon = typeinfo.clothing_icons["id"]
 			no_offset = 1
 		else
 			src.wear_id.wear_image.icon = src.wear_id.wear_image_icon
@@ -164,12 +166,12 @@
 		var/icon_name = src.gloves.wear_state || src.gloves.item_state || src.gloves.icon_state
 		var/no_offset = FALSE
 		src.gloves.wear_image.layer = src.gloves.wear_layer
-		src.gloves.wear_image.filters = src.gloves.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.gloves)
-
+		src.gloves.wear_image.filters = src.gloves.filters.Copy() + src.mutantrace.apply_clothing_filters(src.gloves)
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
 		if (src.limbs && src.limbs.l_arm && src.limbs.l_arm.accepts_normal_human_overlays) //src.bioHolder && !src.bioHolder.HasEffect("robot_left_arm"))
 			var/icon_local = (src.gloves.which_hands & GLOVE_HAS_LEFT) ? icon_name : "transparent"
-			if ("left_[icon_local]" in src.mutantrace?.clothing_icon_states?["hands"]) //checking if the wearer is a mutant, and if so swaps the left glove with the special sprite if there is one.
-				src.gloves.wear_image.icon = src.mutantrace.clothing_icons["hands"]
+			if ("left_[icon_local]" in typeinfo?.clothing_icon_states["hands"]) //checking if the wearer is a mutant, and if so swaps the left glove with the special sprite if there is one.
+				src.gloves.wear_image.icon = typeinfo.clothing_icons["hands"]
 				no_offset = TRUE
 				src.gloves.wear_image.pixel_x = initial(src.gloves.wear_image.pixel_x)
 				src.gloves.wear_image.pixel_y = initial(src.gloves.wear_image.pixel_y)
@@ -185,8 +187,8 @@
 
 		if (src.limbs && src.limbs.r_arm && src.limbs.r_arm.accepts_normal_human_overlays) //src.bioHolder && !src.bioHolder.HasEffect("robot_right_arm"))
 			var/icon_local = (src.gloves.which_hands & GLOVE_HAS_RIGHT) ? icon_name : "transparent"
-			if ("right_[icon_local]" in src.mutantrace?.clothing_icon_states?["hands"]) //above but right glove
-				src.gloves.wear_image.icon = src.mutantrace.clothing_icons["hands"]
+			if ("right_[icon_local]" in typeinfo?.clothing_icon_states["hands"]) //above but right glove
+				src.gloves.wear_image.icon = typeinfo.clothing_icons["hands"]
 				no_offset = TRUE
 				src.gloves.wear_image.pixel_x = initial(src.gloves.wear_image.pixel_x)
 				src.gloves.wear_image.pixel_y = initial(src.gloves.wear_image.pixel_y)
@@ -217,10 +219,11 @@
 		src.shoes.wear_image.overlays = null
 
 		var/shoes_count = 0
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
 		if (src.limbs && src.limbs.l_leg && src.limbs.l_leg.accepts_normal_human_overlays)
 			shoes_count++
-			if ("left_[wear_state]" in src.mutantrace?.clothing_icon_states?["feet"]) //checks if they are a mutantrace with special left shoe sprites and then replaces them if they do
-				src.shoes.wear_image.icon = src.mutantrace.clothing_icons["feet"]
+			if ("left_[wear_state]" in typeinfo?.clothing_icon_states["feet"]) //checks if they are a mutantrace with special left shoe sprites and then replaces them if they do
+				src.shoes.wear_image.icon = typeinfo.clothing_icons["feet"]
 			else
 				src.shoes.wear_image.icon = src.shoes.wear_image_icon
 			src.shoes.wear_image.icon_state = "left_[wear_state]"
@@ -228,14 +231,14 @@
 		if (src.limbs && src.limbs.r_leg && src.limbs.r_leg.accepts_normal_human_overlays)
 			shoes_count++
 			if(shoes_count == 1)
-				if ("right_[wear_state]" in src.mutantrace?.clothing_icon_states?["feet"]) //like above, but for right shoes
-					src.shoes.wear_image.icon = src.mutantrace.clothing_icons["feet"]
+				if ("right_[wear_state]" in typeinfo?.clothing_icon_states["feet"]) //like above, but for right shoes
+					src.shoes.wear_image.icon = typeinfo.clothing_icons["feet"]
 				else
 					src.shoes.wear_image.icon = src.shoes.wear_image_icon
 				src.shoes.wear_image.icon_state = "right_[wear_state]"
 			else
-				if ("right_[wear_state]" in src.mutantrace?.clothing_icon_states?["feet"])
-					src.shoes.wear_image.icon = src.mutantrace.clothing_icons["feet"]
+				if ("right_[wear_state]" in typeinfo?.clothing_icon_states?["feet"])
+					src.shoes.wear_image.icon = typeinfo.clothing_icons["feet"]
 				else
 					src.shoes.wear_image.icon = src.shoes.wear_image_icon
 				var/image/right_shoe_overlay = image(src.shoes.wear_image.icon, "right_[wear_state]")
@@ -258,10 +261,10 @@
 		src.wear_suit.wear_image.layer = src.wear_suit.wear_layer
 		src.wear_suit.wear_image.filters = src.wear_suit.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.wear_suit)
 		//src.wear_suit.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.wear_suit)
-
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
 		var/wear_state = src.wear_suit.wear_state || src.wear_suit.icon_state
-		if (wear_state in src.mutantrace?.clothing_icon_states?["overcoats"])
-			src.wear_suit.wear_image.icon = src.mutantrace.clothing_icons["overcoats"]
+		if (wear_state in typeinfo?.clothing_icon_states["overcoats"])
+			src.wear_suit.wear_image.icon = typeinfo.clothing_icons["overcoats"]
 		else
 			src.wear_suit.wear_image.icon = src.wear_suit.wear_image_icon
 		src.wear_suit.wear_image.icon_state = wear_state
@@ -303,8 +306,9 @@
 		wear_sanity_check(src.back)
 		var/wear_state = src.back.wear_state || src.back.icon_state
 		var/no_offset = FALSE
-		if (wear_state in src.mutantrace?.clothing_icon_states?["back"]) //checks if they are a mutantrace with special back sprites and then replaces them if they do
-			src.back.wear_image.icon = src.mutantrace.clothing_icons["back"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["back"]) //checks if they are a mutantrace with special back sprites and then replaces them if they do
+			src.back.wear_image.icon = typeinfo.clothing_icons["back"]
 			no_offset = TRUE
 			src.back.wear_image.pixel_x = initial(src.back.wear_image.pixel_x)
 			src.back.wear_image.pixel_y = initial(src.back.wear_image.pixel_y)
@@ -337,8 +341,9 @@
 		wear_sanity_check(src.glasses)
 		var/wear_state = src.glasses.wear_state || src.glasses.icon_state
 		var/no_offset = FALSE
-		if (wear_state in src.mutantrace?.clothing_icon_states?["eyes"]) //checks for special glasses sprites for mutantraces and replaces the sprite with it if there is one.
-			src.glasses.wear_image.icon = src.mutantrace.clothing_icons["eyes"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["eyes"]) //checks for special glasses sprites for mutantraces and replaces the sprite with it if there is one.
+			src.glasses.wear_image.icon = typeinfo.clothing_icons["eyes"]
 			no_offset = TRUE
 			src.glasses.wear_image.pixel_x = initial(src.glasses.wear_image.pixel_x)
 			src.glasses.wear_image.pixel_y = initial(src.glasses.wear_image.pixel_y)
@@ -367,8 +372,9 @@
 		wear_sanity_check(src.ears)
 		var/no_offset = FALSE
 		var/wear_state = src.ears.wear_state || src.ears.icon_state
-		if (wear_state in src.mutantrace?.clothing_icon_states?["ears"]) //checks if they are a mutantrace with special earwear sprites and then replaces them if they do
-			src.ears.wear_image.icon = src.mutantrace.clothing_icons["ears"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states?["ears"]) //checks if they are a mutantrace with special earwear sprites and then replaces them if they do
+			src.ears.wear_image.icon = typeinfo.clothing_icons["ears"]
 			no_offset = TRUE
 			src.ears.wear_image.pixel_x = initial(src.ears.wear_image.pixel_x)
 			src.ears.wear_image.pixel_y = initial(src.ears.wear_image.pixel_y)
@@ -398,8 +404,9 @@
 		var/no_offset = FALSE
 
 		var/wear_state = src.wear_mask.wear_state || src.wear_mask.icon_state
-		if (wear_state in src.mutantrace?.clothing_icon_states?["mask"])
-			src.wear_mask.wear_image.icon = src.mutantrace.clothing_icons["mask"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states?["mask"])
+			src.wear_mask.wear_image.icon = typeinfo.clothing_icons["mask"]
 			no_offset = TRUE
 			src.wear_mask.wear_image.pixel_x = initial(src.wear_mask.wear_image.pixel_x)
 			src.wear_mask.wear_image.pixel_y = initial(src.wear_mask.wear_image.pixel_y)
@@ -431,8 +438,9 @@
 
 		var/no_offset = FALSE
 		var/wear_state = src.head.wear_state || src.head.icon_state
-		if (wear_state in src.mutantrace?.clothing_icon_states?["head"])
-			src.head.wear_image.icon = src.mutantrace.clothing_icons["head"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["head"])
+			src.head.wear_image.icon = typeinfo.clothing_icons["head"]
 			no_offset = TRUE
 			src.head.wear_image.pixel_x = initial(src.head.wear_image.pixel_x)
 			src.head.wear_image.pixel_y = initial(src.head.wear_image.pixel_y)
@@ -462,8 +470,9 @@
 		wear_sanity_check(src.belt)
 		var/wear_state = src.belt.wear_state || src.belt.item_state || src.belt.icon_state
 		var/no_offset = FALSE
-		if (wear_state in src.mutantrace?.clothing_icon_states?["belt"]) //checks if they are a mutantrace with special belt sprites and then replaces them if they do
-			src.belt.wear_image.icon = src.mutantrace.clothing_icons["belt"]
+		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+		if (wear_state in typeinfo?.clothing_icon_states["belt"]) //checks if they are a mutantrace with special belt sprites and then replaces them if they do
+			src.belt.wear_image.icon = typeinfo.clothing_icons["belt"]
 			no_offset = TRUE
 			src.belt.wear_image.pixel_x = initial(src.belt.wear_image.pixel_x)
 			src.belt.wear_image.pixel_y = initial(src.belt.wear_image.pixel_y)
@@ -660,11 +669,11 @@
 			//src.fire_lying = image('icons/mob/human.dmi', "fire3_l", MOB_EFFECT_LAYER)
 		if (ismonkey(src))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/monkey.dmi', istate, MOB_EFFECT_LAYER)
-		else if (istype(src:mutantrace, /datum/mutantrace/lizard))
+		else if (istype(src.mutantrace, /datum/mutantrace/lizard))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/lizard.dmi', istate, MOB_EFFECT_LAYER)
-		else if (istype(src:mutantrace, /datum/mutantrace/werewolf))
+		else if (istype(src.mutantrace, /datum/mutantrace/werewolf))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/werewolf.dmi', istate, MOB_EFFECT_LAYER)
-		else if (istype(src:mutantrace, /datum/mutantrace/abomination))
+		else if (istype(src.mutantrace, /datum/mutantrace/abomination))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/abomination.dmi', istate, MOB_EFFECT_LAYER)
 		else
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/human.dmi', istate, MOB_EFFECT_LAYER)
@@ -901,8 +910,9 @@ var/list/update_body_limbs = list("r_leg" = "stump_leg_right", "l_leg" = "stump_
 					var/armleg_offset = (name == "r_arm" || name == "l_arm") ? arm_offset : leg_offset
 					if (limb)
 						var/mutantrace_override = null
-						if (!limb.decomp_affected && src.mutantrace?.override_limb_icons && (limb.getMobIconState() in src.mutantrace.icon_states))
-							mutantrace_override = src.mutantrace.icon
+						var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
+						if (!limb.decomp_affected && src.mutantrace?.override_limb_icons && (limb.getMobIconState() in typeinfo?.icon_states))
+							mutantrace_override = typeinfo.icon
 						var/image/limb_pic = limb.getMobIcon(src.decomp_stage, mutantrace_override, force)	// The limb, not the hand/foot
 						var/limb_skin_tone = "#FFFFFF"	// So we dont stomp on any limbs that arent supposed to be colorful
 						if (limb.skintoned && limb.skin_tone)	// Get the limb's stored skin tone, if its skintoned and has a skin_tone

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1063,7 +1063,7 @@
 		var/customization_second_r = null
 		var/customization_third_r = null
 
-		src.preview_icon = new /icon(src.mutantrace.icon, src.mutantrace.icon_state) //todo: #14465
+		src.preview_icon = new /icon(src.mutantrace.get_typeinfo().icon, src.mutantrace.icon_state) //todo: #14465
 
 		if(!src.mutantrace?.override_skintone)
 			// Skin tone

--- a/code/obj/posters.dm
+++ b/code/obj/posters.dm
@@ -205,7 +205,7 @@ var/global/icon/wanted_poster_unknown = icon('icons/obj/decals/posters.dmi', "wa
 /mob/living/carbon/human/build_flat_icon(var/direction)
 	var/icon/return_icon
 	if (src.mutantrace) //TODO: #14465
-		return_icon = icon(src.mutantrace.icon, src.mutantrace.icon_state, direction ? direction : null)
+		return_icon = icon(src.mutantrace.get_typeinfo().icon, src.mutantrace.icon_state, direction ? direction : null)
 	else
 		return_icon = icon('icons/mob/human.dmi', "body_[src.gender == MALE ? "m" : "f"]", direction ? direction : null)
 


### PR DESCRIPTION
[PERFORMANCE][INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves some shared vars into typeinfo to save speed. This means that rather than icon_states being run every time a mutantrace is made, it is run only once per unique typeinfo. This probably also saves a bit of memory I guess.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Speed good :)