### PR TITLE
Added checks to some common actions with Pods

### DIFF
--- a/code/modules/transport/pods/communications.dm
+++ b/code/modules/transport/pods/communications.dm
@@ -97,7 +97,7 @@
 
 	proc/External()
 		var/broadcast = copytext(html_encode(input(usr, "Please enter what you want to say over the external speaker.", "[src.name]")), 1, MAX_MESSAGE_LEN)
-		if(!broadcast)
+		if(!broadcast || !istype(usr.loc, /obj/machinery/vehicle/)) // need to check if something wasn't entered or if user isn't in a vehicle
 			return
 		logTheThing(LOG_DIARY, usr, "(POD) : [broadcast]", "say")
 		if (ishuman(usr))//istype(usr:wear_mask, /obj/item/clothing/mask/gas/voice))

--- a/code/modules/transport/pods/communications.dm
+++ b/code/modules/transport/pods/communications.dm
@@ -97,7 +97,7 @@
 
 	proc/External()
 		var/broadcast = copytext(html_encode(input(usr, "Please enter what you want to say over the external speaker.", "[src.name]")), 1, MAX_MESSAGE_LEN)
-		if(!broadcast || !istype(usr.loc, /obj/machinery/vehicle/)) // need to check if something wasn't entered or if user isn't in a vehicle
+		if(!broadcast || usr.loc != src.ship) // need to check if something wasn't entered or if user isn't in a vehicle
 			return
 		logTheThing(LOG_DIARY, usr, "(POD) : [broadcast]", "say")
 		if (ishuman(usr))//istype(usr:wear_mask, /obj/item/clothing/mask/gas/voice))

--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -109,7 +109,7 @@
 			beacons["[T.name][count[T.name] == 1 ? null : " #[count[T.name]]"]"] = T
 	wormholeQueued = 1
 	var/obj/target = beacons[tgui_input_list(usr, "Please select a location to warp to.", "Warp Computer", sortList(beacons, /proc/cmp_text_asc))]
-	if(!target)
+	if(!target || !istype(usr.loc, /obj/machinery/vehicle/)) // we need to make sure the user is still in the vehicle or selected a target
 		wormholeQueued = 0
 		return
 

--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -109,7 +109,7 @@
 			beacons["[T.name][count[T.name] == 1 ? null : " #[count[T.name]]"]"] = T
 	wormholeQueued = 1
 	var/obj/target = beacons[tgui_input_list(usr, "Please select a location to warp to.", "Warp Computer", sortList(beacons, /proc/cmp_text_asc))]
-	if(!target || !istype(usr.loc, /obj/machinery/vehicle/)) // we need to make sure the user is still in the vehicle or selected a target
+	if(!target || usr.loc != src.ship) // we need to make sure the user is still in the vehicle or selected a target
 		wormholeQueued = 0
 		return
 

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -61,7 +61,7 @@
 		user.Browse(dat, "window=ship_sec_system")
 		onclose(user, "ship_sec_system")
 		return
-	
+
 	run_component()
 		if (!src.ship.passengers)
 			src.deactivate()
@@ -176,6 +176,8 @@
 
 /obj/item/shipcomponent/secondary_system/cargo/activate()
 	var/loadmode = tgui_input_list(usr, "Unload/Load", "Unload/Load", list("Load", "Unload"))
+	if(!istype(usr.loc, /obj/machinery/vehicle/))
+		return
 	switch(loadmode)
 		if("Load")
 			var/atom/movable/AM = null
@@ -624,6 +626,8 @@
 		opencomputer(user)
 		return
 	opencomputer(mob/user as mob)
+		if(user.loc != src.ship)
+			return
 		src.add_dialog(user)
 
 		var/dat = "<TT><B>[src] Console</B><BR><HR><BR>"
@@ -648,6 +652,8 @@
 		return
 
 	opencomputer(mob/user as mob)
+		if(user.loc != src.ship)
+			return
 		var/dat = "<TT><B>[src] Console</B><BR><HR>"
 		for(var/mob/M in ship)
 			if(M == ship.pilot) continue

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -176,7 +176,7 @@
 
 /obj/item/shipcomponent/secondary_system/cargo/activate()
 	var/loadmode = tgui_input_list(usr, "Unload/Load", "Unload/Load", list("Load", "Unload"))
-	if(!istype(usr.loc, /obj/machinery/vehicle/))
+	if(usr.loc != src.ship)
 		return
 	switch(loadmode)
 		if("Load")


### PR DESCRIPTION
[Bug][Vehicles]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds some checks, to see if the player is in the pod, to things that most, if not all, pods do such as creating wormholes, using the communications array, or even unloading cargo. For example, this is to prevent a player from opening up the wormhole window, exiting the pod, and clicking confirm and still being able to create a wormhole despite not being in the pod anymore.

Fixes #12672 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents players from cheesing pods by being able to unload their cargo, create a wormhole, or use the communications array without being inside of the pod anymore.
