### PR TITLE
Prevents pickpocketing with storages

### DIFF
--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -274,6 +274,9 @@
 		if (issilicon(user))
 			src.storage_item_attack_by(target, user)
 			return
+		if(ismob(target.loc) && target.loc != user) // Prevent's storages to be used for quick-stealing
+			boutput(user, SPAN_NOTICE("You aren't able to stuff [target] into [src.linked_item.name]. Someone else is carrying it!"))
+			return
 		user.swap_hand()
 		if (user.equipped() == null)
 			target.Attackhand(user)


### PR DESCRIPTION
[player actions][balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR disables the ability to take items from other mobs inventories with boxes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was pointed out in #18824 that using boxes on items in other players inventories has a much shorter action bar than manually removing items (on top of directly scooping up the item instead of dropping it). This is unintuitive and extremly powerfull in comparison to normal stealing/stripping or mobs.

This PR stomps this interaction into the ground.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Boxes cannot be used for pickpocketing anymore.
```
