### PR TITLE
Adds monkeys to the list of allowed mobs for pet carriers

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -253,6 +253,14 @@
 		. = ..()
 
 	ai_action()
+		if(istype(src.loc, /obj/item/pet_carrier))
+			var/obj/item/pet_carrier/carrier = src.loc
+			src.emote("scream")
+			src.emote("flip", TRUE)
+			if(ishuman(carrier.loc))
+				src.was_harmed(carrier.loc) // Monkey angry for being trapped
+			return
+
 		if(ai_aggressive)
 			return ..()
 

--- a/code/obj/item/pet_carrier.dm
+++ b/code/obj/item/pet_carrier.dm
@@ -22,7 +22,7 @@
 	w_class = W_CLASS_BULKY
 
 	/// Please override this in child types to specify what can actually fit in.
-	var/allowed_mob_types = list(/mob/living/critter/small_animal, /mob/living/critter/wraith/plaguerat)
+	var/allowed_mob_types = list(/mob/living/critter/small_animal, /mob/living/critter/wraith/plaguerat, /mob/living/carbon/human/npc/monkey, /mob/living/carbon/human/monkey)
 	/// Time it takes for each action (eg. grabbing, releasing).
 	var/actionbar_duration = 2 SECONDS
 	/// If FALSE, an occupant cannot escape the carrier on their own.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [AI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds both `/mob/living/carbon/human/npc/monkey` and `/mob/living/carbon/human/monkey` to `allowed_mob_types` of the pet carrier.

Adds some simple AI which will make monkeys try and escape from the pet carrier, and upon successful escape, assault the person who trapped them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More ways to deal with monkeys, also it's funny.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(*)Recent studies show monkeys do, in fact, fit inside of pet carriers.
```
