### PR TITLE
Tries to put crafted recipes into your hand before dropping

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -302,7 +302,7 @@
 			return
 		owner.visible_message(SPAN_NOTICE("[owner] assembles \the [obj_name]!"))
 		var/obj/item/R = new obj_type(obj_turf)
-		if (!R.density && !src.constructible_check(R) && ishuman(owner))
+		if (isitem(R))
 			var/mob/living/carbon/human/H = owner
 			H.put_in_hand_or_drop(R)
 		R.setMaterial(obj_mat)

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -249,13 +249,16 @@
 		if (!obj_turf)
 			return FALSE
 		for (var/obj/O in obj_turf)
-			// girder for soul, window for thindow (fuck thindow)
-			if (istype(O, /obj/structure/girder) || istype(O, /obj/window) || istype(O, /obj/railing))
+			if (src.constructible_check(O))
 				continue
 			if (O.density)
 				boutput(owner, SPAN_ALERT("You try to build \the [obj_name], but there's \the [O] in the way!"))
 				return TRUE
 		return FALSE
+
+	proc/constructible_check(var/obj/O)
+		// girder for soul, window for thindow (fuck thindow) <- ((I have no idea what this means))
+		return istype(O, /obj/structure/girder) || istype(O, /obj/window) || istype(O, /obj/railing)
 
 	onStart()
 		..()
@@ -299,7 +302,7 @@
 			return
 		owner.visible_message(SPAN_NOTICE("[owner] assembles \the [obj_name]!"))
 		var/obj/item/R = new obj_type(obj_turf)
-		if (ishuman(owner))
+		if (!R.density && !src.constructible_check(R) && ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			H.put_in_hand_or_drop(R)
 		R.setMaterial(obj_mat)

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -299,6 +299,9 @@
 			return
 		owner.visible_message(SPAN_NOTICE("[owner] assembles \the [obj_name]!"))
 		var/obj/item/R = new obj_type(obj_turf)
+		if (ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			H.put_in_hand_or_drop(R)
 		R.setMaterial(obj_mat)
 		if (istype(R))
 			R.amount = obj_amt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Materials]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attempts `put_in_hand_or_drop()` on the person crafting an item if they're human and if the object in question can be held.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm done looking like a FOOL when I craft rods. It's not fair, it's not my fault, I'm perfectly capable crafting objects like a professional, and I won't sit idle while you suggest otherwise. This is my villain arc.