### PR TITLE
Fix gun tooltip not updating on mode switch

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -506,6 +506,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 ///setter for current_projectile so we can have a signal attached. do not set current_projectile on guns without this proc
 /obj/item/gun/proc/set_current_projectile(datum/projectile/newProj)
 	src.current_projectile = newProj
+	src.tooltip_rebuild = TRUE
 	SEND_SIGNAL(src, COMSIG_GUN_PROJECTILE_CHANGED, newProj)
 
 /obj/item/gun/proc/do_camera_recoil(mob/user, turf/start, turf/target, POX, POY)


### PR DESCRIPTION
[GAME OBJECTS][PLAYER ACTIONS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the gun tooltip that shows stuff like bullet power and lethality not updating on switching the weapon mode


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix