### PR TITLE
Allow mindhack cloning module to clone puritans

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -950,7 +950,8 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/cloneModule/mindhack_module
 	cost = 6
 	vr_allowed = FALSE
-	desc = "An add on to the genetics cloning pod that make anyone cloned loyal to whoever installed it."
+	desc = {"An add-on to the genetics cloning pod that makes anyone cloned loyal to whoever installed it. Its unique technology allows cloning of those
+				who are incompatible with usual cloning methods."}
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
 
 /datum/syndicate_buylist/traitor/deluxe_mindhack_module

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -294,7 +294,7 @@ TYPEINFO(/obj/machinery/clonepod)
 				if(trait == "puritan")
 					is_puritan = TRUE
 
-			if (is_puritan)
+			if (is_puritan && !src.clonehack)
 				src.mess = TRUE
 				// Puritans have a bad time.
 				// This is a little different from how it was before:


### PR DESCRIPTION
[GAME OBJECTS][QoL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the traitor mindhack module to clone puritans


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Killing someone can already be a challenge in some cases, even more so for trying to perform a mindhack cloning set up. Not very fun when the person you manage to kill turns out to be a puritan

Also, if you aren't a medical doctor, such as if it's a spy round, and you get a mindhack module, by default you don't have access to check whether people are puritan or not

If not a good idea, PR at least sets up discussion/denial of the idea

Some possible alternatives if this doesn't sound good lorewise or any other reason:
-Only gives a reduced chance for cloning failure
-Installable module into the cloning computer


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Mindhack cloning modules now allow cloning of puritans.
```
