### PR TITLE
Remove Cog1 Sauna Air Alarm

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -41907,9 +41907,6 @@
 /area/station/hallway/primary/east)
 "fFX" = (
 /obj/machinery/space_heater,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/pool)
 "fFY" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the air alarm from the sauna in Cogmap1


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Attached pool room already has one, other maps do not have air alarms inside of sauna, air alarm will create unneeded/unhelpful flags on the alert computer during normal function of sauna (sauna hot air = air alarm thinks there is crisis).  Amylizzle who did a pass of adding air alarms to cog1 recently agreed this one could be removed.

[Mapping]
