### PR TITLE
Yet another batch of hemotoxin changes

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2131,7 +2131,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		return
 
 	death()
-		src.reagents.add_reagent("hemotoxin", 40, null)
+		src.reagents.add_reagent("hemotoxin", 20, null)
 		src.friends = null
 		return ..()
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1427,15 +1427,15 @@ datum
 				M.take_toxin_damage(mult)
 
 				switch(counter += clamp(our_amt/10, 1, 3) * mult)
-					if (1 to 30) // The more there is, the faster it progresses
+					if (1 to 40) // The more there is, the faster it progresses
 						bleeding_mult = 0.5 * mult
 						if (probmult(8))
 							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
-					if (30 to 70)
+					if (40 to 80)
 						bleeding_mult = 1 * mult
 						if (probmult(14))
 							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
-					if (70 to INFINITY)
+					if (80 to INFINITY)
 						bleeding_mult = 1.5  * mult
 						if (probmult(24))
 							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1427,18 +1427,16 @@ datum
 				M.take_toxin_damage(mult)
 
 				switch(counter += clamp(our_amt/10, 1, 3) * mult)
-					if (1 to 40) // The more there is, the faster it progresses
+					if (1 to 20) // The more there is, the faster it progresses
 						bleeding_mult = 0.5 * mult
-						if (probmult(8))
-							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
-					if (40 to 80)
+					if (20 to 40) // The more there is, the faster it progresses
+						bleeding_mult = 0.75 * mult
+					if (40 to 60)
 						bleeding_mult = 1 * mult
-						if (probmult(14))
-							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
+					if (60 to 80)
+						bleeding_mult = 1.25 * mult
 					if (80 to INFINITY)
 						bleeding_mult = 1.5  * mult
-						if (probmult(24))
-							make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
 
 				if (probmult(10) && counter > 25)
 					M.make_jittery(50)
@@ -1454,6 +1452,8 @@ datum
 					M.visible_message(pick(SPAN_ALERT("<B>[M]</B>'s [pick("eyes", "arms", "legs")] bleed!"),\
 											SPAN_ALERT("<B>[M]</B> bleeds [pick("profusely", "from every pore")]!"),\
 											SPAN_ALERT("<B>[M]</B>'s [pick("chest", "face", "whole body")] bleeds!")))
+				if (probmult(20) && counter > 10)
+					make_cleanable(/obj/decal/cleanable/blood/splatter,M.loc)
 
 				if (isliving(M))
 					var/mob/living/H = M

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1408,7 +1408,7 @@ datum
 			fluid_r = 210
 			fluid_g = 180
 			fluid_b = 25
-			depletion_rate = 0.2
+			depletion_rate = 0.3
 			blob_damage = 1
 			var/counter = 1
 			var/bleeding_mult = 1
@@ -1426,14 +1426,14 @@ datum
 
 				M.take_toxin_damage(mult)
 
-				switch(counter += clamp(our_amt/10, 1, 3) * mult)
-					if (1 to 20) // The more there is, the faster it progresses
+				switch(counter += clamp(our_amt/8, 1, 3) * mult)
+					if (1 to 15) // The more there is, the faster it progresses
 						bleeding_mult = 0.5 * mult
-					if (20 to 40) // The more there is, the faster it progresses
-						bleeding_mult = 0.75 * mult
-					if (40 to 60)
+					if (15 to 30) // The more there is, the faster it progresses
 						bleeding_mult = 1 * mult
-					if (60 to INFINITY)
+					if (30 to 45)
+						bleeding_mult = 1.25 * mult
+					if (45 to INFINITY)
 						bleeding_mult = 1.5  * mult
 
 				if (probmult(10) && counter > 25)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1433,9 +1433,7 @@ datum
 						bleeding_mult = 0.75 * mult
 					if (40 to 60)
 						bleeding_mult = 1 * mult
-					if (60 to 80)
-						bleeding_mult = 1.25 * mult
-					if (80 to INFINITY)
+					if (60 to INFINITY)
 						bleeding_mult = 1.5  * mult
 
 				if (probmult(10) && counter > 25)


### PR DESCRIPTION
[LABEL][chemistry][rework]

## About the PR
This PR does a few things:
- Make it so snakes are immune to hemotoxin
- Make it so small animals take more TOX from it, as well as have it progress 10x faster in them
- Make hemotoxin effects not as severe early on, but have them ramp up in severity, ramp up speed is based off of volume, and caps at 3x standard when above 24 units
- Reduce the message spam resulting from hemotox via adding a caffeine style message cooldown
- Make rattlesnakes only have 20 units of hemotoxin in them at death

## Why's this needed?
Hemotoxin isn't as immediately dangerous, or as chat spammy, while it's immediate threat scales with volume(scaling capped at 24 units to prevent exceedingly large doses being immediately deadly, and even still isn't as fast to kill you as something like cyanide, danger level of a single bite stays at about the same rate, while lower amounts are less dangerous than previously).

Besides that, rattlesnakes being immune is something that used to cause problems on resurected snakes, since they'd bleed out from the venom in them. And even if they hunted mice and whatnot, the effect of the venom on them was very underwhelming, and this fixes that.


## Changelog

```changelog
(u)Colossusqw
(+)Hemotoxin now has a wind up period that makes small amounts less dangerous, but has it's progression speed tied to volume. Small animals are much more affected by Hemotoxin.
(+)Rattlesnakes now only drop 20us of hemotoxin upon death, and are immune to it's effects.
```
