### PR TITLE
Add a bit more time for comm dish detection for comms console

### DIFF
--- a/code/modules/networks/computer3/communication.dm
+++ b/code/modules/networks/computer3/communication.dm
@@ -87,7 +87,7 @@
 
 						if(!src.comm_net_id)
 							src.detect_comm_dish()
-							sleep(0.8 SECONDS)
+							sleep(0.9 SECONDS) // gives enough time for comm dish detection
 							if (!src.comm_net_id)
 								src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 								return
@@ -110,7 +110,7 @@
 
 						if(!src.comm_net_id)
 							src.detect_comm_dish()
-							sleep(0.8 SECONDS)
+							sleep(0.9 SECONDS)
 							if (!src.comm_net_id)
 								src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 								return
@@ -129,7 +129,7 @@
 
 						if(!src.comm_net_id)
 							src.detect_comm_dish()
-							sleep(0.8 SECONDS)
+							sleep(0.9 SECONDS)
 							if (!src.comm_net_id)
 								src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 								return
@@ -150,7 +150,7 @@
 
 						if(!src.comm_net_id)
 							src.detect_comm_dish()
-							sleep(0.8 SECONDS)
+							sleep(0.9 SECONDS)
 							if (!src.comm_net_id)
 								src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 								return
@@ -215,7 +215,7 @@
 
 				if(!src.comm_net_id)
 					src.detect_comm_dish()
-					sleep(0.8 SECONDS)
+					sleep(0.9 SECONDS)
 					if (!src.comm_net_id)
 						src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 						return
@@ -254,7 +254,7 @@
 
 				if(!src.comm_net_id)
 					src.detect_comm_dish()
-					sleep(0.8 SECONDS)
+					sleep(0.9 SECONDS)
 					if (!src.comm_net_id)
 						src.print_text("<b>Error:</b> Unable to detect comm dish.  Please check network cabling.")
 						return


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Really minor, but for the communications console, the first time you login, run commaster, and then use the call command, it will give you an error message that the comms dish can't be connected, then a second after that comms were established. Typing call again, it will find it, and then ask you to enter your shuttle call reason

This just adds a bit more time so that you don't have to type call twice, just once, before entering the shuttle call reason


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL