### PR TITLE
Removes occupancy sign from floor of Clarion barber shop

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18145,11 +18145,6 @@
 	},
 /area/station/hydroponics/bay)
 "fvU" = (
-/obj/machinery/illuminated_sign/occupancy{
-	id = "nadirstall_shw2";
-	pixel_x = 11;
-	pixel_y = -6
-	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/barber_shop)
 "fwG" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the occupancy sign that was accidentally left behind when Clarion was remodeled


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18848

[mapping][bug]
