### PR TITLE
Replace free upgrade for civilian cyborgs with a recharge pack

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2348,10 +2348,10 @@
 					src.upgrades += new /obj/item/roboupgrade/spectro(src)
 			if("Civilian")
 				src.freemodule = 0
-				boutput(src, SPAN_NOTICE("You chose the Civilian module. It comes with a free Efficiency Upgrade."))
+				boutput(src, SPAN_NOTICE("You chose the Civilian module. It comes with a free recharge pack."))
 				src.set_module(new /obj/item/robot_module/civilian(src))
 				if(length(src.upgrades) < src.max_upgrades)
-					src.upgrades += new /obj/item/roboupgrade/efficiency(src)
+					src.upgrades += new /obj/item/roboupgrade/rechargepack(src)
 			if("Engineering")
 				src.freemodule = 0
 				boutput(src, SPAN_NOTICE("You chose the Engineering module. It comes with a free Meson Vision Upgrade."))


### PR DESCRIPTION
[Silicons][Balance]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the Efficiency upgrade that cyborgs get when they pick "Civilian" as their freebie module to a Recharge Pack upgrade.

A recharge pack is still the same "theme" as an efficiency upgrade, while also being manufacturable at roundstart. This will mean that (once people realize) they will stop picking civilian for the freebie then immediately changing the module.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Efficiency upgrades are the only free upgrade that is not able to be produced in robotics manufacturers at roundstart, due to having a requirement for a high-energy conductor.

As such, it is common for cyborgs to pick a Civilian module for the free Efficiency upgrade then have a human (roboticst, whoever) change their module for the one they actually wanted.

This is not an ideal feature of the freebie upgrade, which is (as far as I understand it) intended to include "required" gear for the cyborg to do its task well as a convenience (i.e. avoids them having to print their own upgrade that they would do 95%+ of the time because it's a no-brainer choice for that module).

This will improve our understanding of cyborg module choices, reducing the noise of people picking civilian at roundstart in our logs, and overall reduce some of the roundstart churn as people actually do pick the module they want to operate as.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mordent
(*)Civilian cyborgs get a free Recharge Pack instead of an Efficiency upgrade.
```