### PR TITLE
Remove Secbots from robotics cargo crates

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -634,6 +634,18 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Cocktail Party Supplies"
 
+/datum/supply_packs/robot
+	name = "Robotics Crate"
+	desc = "x1 Floorbot, x1 Cleanbot, x1 Medibot, x1 Firebot"
+	category = "Medical Department"
+	contains = list(/obj/machinery/bot/floorbot,
+					/obj/machinery/bot/cleanbot,
+					/obj/machinery/bot/medbot,
+					/obj/machinery/bot/firebot)
+	cost = PAY_TRADESMAN*5
+	containertype = /obj/storage/crate
+	containername = "Robotics Crate"
+
 /datum/supply_packs/mulebot
 	name = "Replacement Mulebot"
 	desc = "x1 Mulebot"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -634,19 +634,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Cocktail Party Supplies"
 
-/datum/supply_packs/robot
-	name = "Robotics Crate"
-	desc = "x1 Securitron, x1 Floorbot, x1 Cleanbot, x1 Medibot, x1 Firebot"
-	category = "Medical Department"
-	contains = list(/obj/machinery/bot/secbot,
-					/obj/machinery/bot/floorbot,
-					/obj/machinery/bot/cleanbot,
-					/obj/machinery/bot/medbot,
-					/obj/machinery/bot/firebot)
-	cost = PAY_TRADESMAN*5
-	containertype = /obj/storage/crate
-	containername = "Robotics Crate"
-
 /datum/supply_packs/mulebot
 	name = "Replacement Mulebot"
 	desc = "x1 Mulebot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the securitrons from the crates full of robots from cargo listing


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These are only ever annoying and gives robotics more to do


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Removed securitrons from robotics crates.
```
