### PR TITLE
Replaces most instances of fake corpses with real corpses

### DIFF
--- a/assets/maps/prefabs/planet/prefab_planet_tomato_den.dmm
+++ b/assets/maps/prefabs/planet/prefab_planet_tomato_den.dmm
@@ -98,8 +98,8 @@
 /turf/simulated/floor/grass/random,
 /area/noGenerate)
 "U" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/saw,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/grass/random,
 /area/noGenerate)
 "W" = (

--- a/assets/maps/prefabs/space/prefab_beesanctuary.dmm
+++ b/assets/maps/prefabs/space/prefab_beesanctuary.dmm
@@ -1142,11 +1142,11 @@
 	tag = "icon-intact (NORTHEAST)";
 	color = "b4b4b4"
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/machinery/light/small/warm/very{
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "Jo" = (
@@ -1164,7 +1164,7 @@
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "Jv" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "JF" = (
@@ -1727,7 +1727,7 @@
 /area/prefab/bee_sanctuary)
 "XU" = (
 /obj/decal/cleanable/blood/drip/high,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "Yd" = (

--- a/assets/maps/prefabs/space/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/space/prefab_candy_shop.dmm
@@ -395,15 +395,12 @@
 /turf/simulated/wall/auto/reinforced/jen/cyan,
 /area/prefab/candy_shop)
 "Df" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a confectioner.";
-	name = "Carlisle"
-	},
 /obj/item/casing/derringer{
 	dir = 5;
 	pixel_x = -9;
 	pixel_y = 9
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "DL" = (

--- a/assets/maps/prefabs/space/prefab_cannibal.dmm
+++ b/assets/maps/prefabs/space/prefab_cannibal.dmm
@@ -17,7 +17,7 @@
 "e" = (
 /obj/decal/cleanable/blood/gibs,
 /obj/decal/cleanable/blood/drip/high,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fpurple1"
@@ -26,7 +26,7 @@
 "f" = (
 /obj/decal/cleanable/blood/splatter,
 /obj/decal/cleanable/blood/gibs/core,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fpurple1"

--- a/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
@@ -99,7 +99,13 @@
 /area/noGenerate)
 "fd" = (
 /obj/decal/cleanable/vomit,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	randomise_decomp_stage = 1;
+	delete_id = 0;
+	break_headset = 0;
+	empty_bag = 0;
+	empty_pockets = 0
+	},
 /turf/simulated/floor/carpet/purple/standard/edge/east,
 /area/prefab/crashed_hop_shuttle)
 "go" = (

--- a/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
@@ -101,10 +101,7 @@
 /obj/decal/cleanable/vomit,
 /obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
 	randomise_decomp_stage = 1;
-	delete_id = 0;
-	break_headset = 0;
-	empty_bag = 0;
-	empty_pockets = 0
+	
 	},
 /turf/simulated/floor/carpet/purple/standard/edge/east,
 /area/prefab/crashed_hop_shuttle)

--- a/assets/maps/prefabs/space/prefab_dans_asteroid.dmm
+++ b/assets/maps/prefabs/space/prefab_dans_asteroid.dmm
@@ -863,7 +863,9 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "Jr" = (
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/mapping_helper/mob_spawn/corpse/human/chef{
+	randomise_decomp_stage = 1
+	},
 /turf/variableTurf/clear,
 /area/noGenerate)
 "Jx" = (
@@ -1142,13 +1144,10 @@
 "QS" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/orange,
-/obj/decal/fakeobjects/skeleton{
-	pixel_x = 2;
-	pixel_y = 1
-	},
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood,
 /area/prefab/discount_dans_asteroid)
 "Rg" = (

--- a/assets/maps/prefabs/space/prefab_dreamplaza.dmm
+++ b/assets/maps/prefabs/space/prefab_dreamplaza.dmm
@@ -46,10 +46,7 @@
 /obj/decal/cleanable/blood{
 	desc = "It looks like it's been here for months."
 	},
-/obj/decal/fakeobjects/skeleton{
-	name = "mall employee skeleton";
-	pixel_y = 12
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/terrazzo/white,
 /area/prefab/dreamplaza)
 "bj" = (
@@ -416,10 +413,7 @@
 /obj/storage/crate/packing{
 	name = "merchandise samples"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Looks like they were trapped here for some time.";
-	name = "employee skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor,
 /area/prefab/dreamplaza)
 "nu" = (

--- a/assets/maps/prefabs/space/prefab_ksol.dmm
+++ b/assets/maps/prefabs/space/prefab_ksol.dmm
@@ -650,14 +650,10 @@
 /area/noGenerate)
 "bF" = (
 /obj/decal/cleanable/vomit,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Still has her monitor headset on...";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 12
-	},
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human{
+	randomise_decomp_stage = 1
+	},
 /turf/simulated/floor/airless/carpet{
 	dir = 4;
 	icon_state = "fred2"
@@ -1018,13 +1014,9 @@
 /turf/simulated/floor/airless/plating,
 /area/noGenerate)
 "cE" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "He hasn't got a leg to stand on.";
-	dir = 4;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "half corpse";
-	pixel_x = -10
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	legless = 1;
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/airless/wood,
 /area/noGenerate)
@@ -1091,13 +1083,14 @@
 /area/noGenerate)
 "cN" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "50% of a rotten corpse.";
+/obj/item/parts/human_parts/leg/left{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 10
+	},
+/obj/item/parts/human_parts/leg/right{
 	dir = 8;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "pair of legs";
-	pixel_x = 14
+	pixel_x = 12
 	},
 /turf/simulated/floor/airless/wood,
 /area/noGenerate)

--- a/assets/maps/prefabs/space/prefab_larrys_laundromat.dmm
+++ b/assets/maps/prefabs/space/prefab_larrys_laundromat.dmm
@@ -301,13 +301,10 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "Et" = (
-/obj/decal/fakeobjects/skeleton{
-	name = "larry";
-	pixel_y = -7
-	},
 /obj/decal/cleanable/blood/tracks{
 	dir = 4
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/twotone/black,
 /area/prefab/larrys_laundry)
 "HY" = (

--- a/assets/maps/prefabs/space/prefab_mauxite_hideout.dmm
+++ b/assets/maps/prefabs/space/prefab_mauxite_hideout.dmm
@@ -146,11 +146,13 @@
 /mob/living/critter/fermid{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/gemstone,
 /obj/item/raw_material/uqill{
 	pixel_y = 5;
 	pixel_x = -5
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/miner{
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/plating/airless/asteroid/comet/iron,
 /area/prefab/mauxite_hideout)

--- a/assets/maps/prefabs/space/prefab_sequestered_cloner.dmm
+++ b/assets/maps/prefabs/space/prefab_sequestered_cloner.dmm
@@ -95,7 +95,7 @@
 /turf/simulated/floor/purple/side,
 /area/prefab/sequestered_cloner)
 "hw" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/variableTurf/clear,
 /area/noGenerate)
 "hB" = (
@@ -407,6 +407,10 @@
 	pixel_y = -4
 	},
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	armless = 1;
+	legless = 1
+	},
 /turf/simulated/floor/plating,
 /area/prefab/sequestered_cloner)
 "ym" = (

--- a/assets/maps/prefabs/space/prefab_shuttle.dmm
+++ b/assets/maps/prefabs/space/prefab_shuttle.dmm
@@ -23,14 +23,11 @@
 /turf/simulated/floor/airless/scorched,
 /area/prefab/crashed_shuttle)
 "aD" = (
-/obj/decal/fakeobjects/skeleton{
-	name = "decomposed corpse";
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor3"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human{
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/airless{
 	icon_state = "floorgrime"
@@ -255,14 +252,11 @@
 	icon_state = "floattiles1";
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
+/obj/item/raw_material/rock,
+/obj/item/raw_material/rock,
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	max_limbs_removed = 2
 	},
-/obj/item/raw_material/rock,
-/obj/item/raw_material/rock,
 /turf/variableTurf/clear,
 /area/prefab/crashed_shuttle)
 "lc" = (
@@ -479,12 +473,6 @@
 /area/prefab/crashed_shuttle)
 "Ga" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The head seems to be gone.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body2";
-	name = "corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor3"
 	},
@@ -493,6 +481,11 @@
 	},
 /obj/machinery/light/incandescent/broken{
 	dir = 1
+	},
+/obj/stool/chair,
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	headless = 1;
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/prefab/crashed_shuttle)
@@ -572,11 +565,8 @@
 /area/prefab/crashed_shuttle)
 "OQ" = (
 /obj/item/device/analyzer/atmosanalyzer_upgrade,
-/obj/decal/fakeobjects/skeleton{
-	name = "decomposed corpse";
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	skeletonized = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/prefab/crashed_shuttle)

--- a/assets/maps/prefabs/space/prefab_space_casino.dmm
+++ b/assets/maps/prefabs/space/prefab_space_casino.dmm
@@ -302,7 +302,9 @@
 /obj/decal/cleanable/blood/gibs{
 	icon_state = "gib4"
 	},
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/mapping_helper/mob_spawn/corpse/human/chef{
+	randomise_decomp_stage = 1
+	},
 /turf/simulated/floor/plating,
 /area/prefab/space_casino)
 "Gp" = (
@@ -330,11 +332,16 @@
 /turf/simulated/floor/stairs/wood2/wide,
 /area/prefab/space_casino)
 "In" = (
-/obj/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
 /obj/machinery/light/incandescent{
 	dir = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	armless = 1;
+	legless = 1;
+	skeletonized = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/prefab/space_casino)

--- a/assets/maps/prefabs/space/prefab_von_ricken.dmm
+++ b/assets/maps/prefabs/space/prefab_von_ricken.dmm
@@ -73,12 +73,7 @@
 "cX" = (
 /obj/item/clothing/suit/bedsheet/green,
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. At least whoever it was died while snuggled into a warm and fuzzy bed.";
-	name = "Cozy skeleton";
-	pixel_x = 4;
-	pixel_y = 2
-	},
+/obj/mapping_helper/mob_spawn/corpse/human,
 /turf/simulated/floor/wood,
 /area/prefab/von_ricken)
 "db" = (

--- a/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
@@ -16,9 +16,9 @@
 	},
 /area/noGenerate)
 "aN" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/cobweb,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/diner/backroom)
 "aU" = (
@@ -1487,11 +1487,11 @@
 	})
 "WZ" = (
 /obj/decal/cleanable/blood/splatter,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/shard/glass{
 	pixel_x = -5;
 	pixel_y = 9
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/diner/backroom)
 "Xi" = (

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_beesanctuary.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_beesanctuary.dmm
@@ -366,7 +366,7 @@
 /turf/unsimulated/floor/void,
 /area/prefab/bee_sanctuary)
 "px" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "pH" = (
@@ -739,11 +739,11 @@
 	tag = "icon-intact (NORTHEAST)";
 	color = "b4b4b4"
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/machinery/light/small/warm/very{
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "FG" = (
@@ -950,7 +950,7 @@
 /area/prefab/bee_sanctuary)
 "Lp" = (
 /obj/decal/cleanable/blood/drip/high,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/prefab/bee_sanctuary)
 "LC" = (

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_crashed.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_crashed.dmm
@@ -170,14 +170,12 @@
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
 "aR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	max_organs_removed = 6;
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/grime,
 /area/station/turret_protected/sea_crashed)
@@ -425,8 +423,7 @@
 /area/station/turret_protected/sea_crashed)
 "bM" = (
 /mob/living/critter/robotic/gunbot{
-	dir = 4;
-	
+	dir = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/turret_protected/sea_crashed)
@@ -448,8 +445,7 @@
 /area/station/turret_protected/sea_crashed)
 "bQ" = (
 /mob/living/critter/robotic/gunbot{
-	dir = 8;
-	
+	dir = 8
 	},
 /turf/simulated/floor/black/grime,
 /area/station/turret_protected/sea_crashed)
@@ -734,14 +730,14 @@
 	},
 /area/station/turret_protected/sea_crashed)
 "cN" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	skeletonized = 1;
+	max_limbs_removed = 2;
+	max_organs_removed = 6;
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/red,
 /area/station/turret_protected/sea_crashed)
@@ -880,11 +876,11 @@
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	skeletonized = 1;
+	max_limbs_removed = 2;
+	max_organs_removed = 6;
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
@@ -1288,8 +1284,7 @@
 /area/noGenerate)
 "sR" = (
 /mob/living/critter/robotic/gunbot{
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/item/implantcase/robust,
 /turf/simulated/floor/black/grime,

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_torpedo_deposit.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_torpedo_deposit.dmm
@@ -63,8 +63,8 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "il" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/storage/pill_bottle/cyberpunk,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/variableTurf/clear,
 /area/noGenerate)
 "jj" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_ghosthouse.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_ghosthouse.dmm
@@ -523,11 +523,7 @@
 	pixel_y = 11
 	},
 /obj/item/clothing/suit/bedsheet/royal,
-/obj/mapping_helper/mob_spawn/corpse/human/chaplain{
-	empty_bag = 1;
-	empty_pockets = 1;
-	delete_id = 1
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/chaplain,
 /turf/simulated/floor/carpet/purple/fancy,
 /area/prefab/ghost_house)
 "cf" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_ghosthouse.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_ghosthouse.dmm
@@ -523,7 +523,11 @@
 	pixel_y = 11
 	},
 /obj/item/clothing/suit/bedsheet/royal,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/mapping_helper/mob_spawn/corpse/human/chaplain{
+	empty_bag = 1;
+	empty_pockets = 1;
+	delete_id = 1
+	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/prefab/ghost_house)
 "cf" = (
@@ -544,8 +548,10 @@
 /turf/simulated/floor/wood/two,
 /area/prefab/ghost_house)
 "ci" = (
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
 /obj/item/gun/energy/ghost,
+/obj/mapping_helper/mob_spawn/corpse/human/chaplain{
+	randomise_decomp_stage = 1
+	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/prefab/ghost_house)
 "cj" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_honk.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_honk.dmm
@@ -835,9 +835,11 @@
 /turf/simulated/floor/carpet/arcade/blank,
 /area/prefab/slimy_honk)
 "db" = (
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
 /obj/decal/ballpit,
 /obj/decal/cleanable/slime,
+/obj/mapping_helper/mob_spawn/corpse/human/clown{
+	randomise_decomp_stage = 1
+	},
 /turf/unsimulated/floor/ballpit,
 /area/prefab/slimy_honk)
 "dc" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_racetrack.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_racetrack.dmm
@@ -368,7 +368,11 @@
 	},
 /area/prefab/raceway)
 "bc" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	armless = 1;
+	legless = 1;
+	skeletonized = 0
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_seamonkey.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_seamonkey.dmm
@@ -612,13 +612,14 @@
 /turf/simulated/floor/plating/random,
 /area/prefab/sea_monkey_hideout)
 "cg" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "50% of a rotten corpse.";
+/obj/item/parts/human_parts/leg/left{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 10
+	},
+/obj/item/parts/human_parts/leg/right{
 	dir = 8;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "pair of legs";
-	pixel_x = 14
+	pixel_x = 12
 	},
 /turf/simulated/floor/plating/random,
 /area/prefab/sea_monkey_hideout)
@@ -853,11 +854,10 @@
 /obj/decal/cleanable/blood/gibs{
 	icon_state = "gibmid3"
 	},
-/turf/simulated/floor/plating/random,
-/area/prefab/sea_monkey_hideout)
-"cS" = (
-/obj/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	armless = 1;
+	legless = 1;
+	skeletonized = 0
 	},
 /turf/simulated/floor/plating/random,
 /area/prefab/sea_monkey_hideout)
@@ -1870,7 +1870,7 @@ bX
 aa
 cx
 cH
-cS
+bV
 aa
 aa
 aw

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_strangeprison.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_strangeprison.dmm
@@ -264,8 +264,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/prefab/sea_prison)
 "aW" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/implantcase/robust,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor,
 /area/prefab/sea_prison)
 "aX" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_watertreatment.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_watertreatment.dmm
@@ -30,8 +30,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/prefab/water_treatment)
 "aj" = (
-/obj/decal/fakeobjects/skeleton,
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/drip/high,
 /obj/item/toy/sponge_capsule/syndicate{
 	pixel_y = 9;
@@ -43,6 +41,7 @@
 	},
 /obj/decal/cleanable/cobweb,
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/prefab/water_treatment)
 "al" = (
@@ -92,6 +91,7 @@
 /obj/decal/cleanable/blood/gibs{
 	color = "#990000"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/prefab/water_treatment)
 "as" = (
@@ -915,12 +915,12 @@
 "ZL" = (
 /obj/item/sponge,
 /obj/decal/cleanable/blood/drip/high,
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/cobweb,
 /obj/decal/cleanable/blood/drip/high{
 	icon_state = "gibdown1"
 	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/prefab/water_treatment)
 

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_zoo.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_zoo.dmm
@@ -163,10 +163,7 @@
 /turf/simulated/floor/plating,
 /area/prefab/zoo)
 "X" = (
-/obj/decal/fakeobjects/skeleton,
-/obj/item/clothing/shoes/clown_shoes/blue,
-/obj/item/clothing/under/misc/clown/blue,
-/obj/item/clothing/mask/clown_hat/blue,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},

--- a/assets/maps/random_rooms/3x3/clown.dmm
+++ b/assets/maps/random_rooms/3x3/clown.dmm
@@ -3,10 +3,10 @@
 /obj/decal/cleanable/blood{
 	icon_state = "gib2"
 	},
-/obj/decal/fakeobjects/skeleton/decomposed_corpse{
-	icon_state = "clowncorpse"
-	},
 /mob/living/critter/spider/clown,
+/obj/mapping_helper/mob_spawn/corpse/human/clown{
+	randomise_decomp_stage = 1
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/dmm_suite/clear_area)
 "n" = (

--- a/assets/maps/random_rooms/3x3/cowboy.dmm
+++ b/assets/maps/random_rooms/3x3/cowboy.dmm
@@ -24,9 +24,6 @@
 /turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "G" = (
-/obj/decal/fakeobjects/skeleton{
-	pixel_x = -2
-	},
 /obj/item/clothing/shoes/cowboy{
 	pixel_x = -8;
 	pixel_y = -8
@@ -43,6 +40,7 @@
 /obj/railing{
 	dir = 4
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/damaged1,
 /area/dmm_suite/clear_area)
 "L" = (

--- a/assets/maps/random_rooms/3x3/custodialcloset.dmm
+++ b/assets/maps/random_rooms/3x3/custodialcloset.dmm
@@ -4,7 +4,9 @@
 /area/dmm_suite/clear_area)
 "d" = (
 /obj/storage/closet,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/janitor{
+	skeletonized = 1
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/dmm_suite/clear_area)
 "k" = (

--- a/assets/maps/random_rooms/3x3/drydesert_65.dmm
+++ b/assets/maps/random_rooms/3x3/drydesert_65.dmm
@@ -10,12 +10,12 @@
 /turf/simulated/floor/marslike,
 /area/dmm_suite/clear_area)
 "t" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/suit/poncho/leaf,
 /obj/item/clothing/head/westhat{
 	pixel_x = 11;
 	pixel_y = 2
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/marslike,
 /area/dmm_suite/clear_area)
 "D" = (

--- a/assets/maps/random_rooms/3x3/sadsanta_80.dmm
+++ b/assets/maps/random_rooms/3x3/sadsanta_80.dmm
@@ -11,8 +11,8 @@
 	pixel_x = -11;
 	pixel_y = 18
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/fakeobjects/lightbulb_broken,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "l" = (

--- a/assets/maps/random_rooms/3x3/tomato.dmm
+++ b/assets/maps/random_rooms/3x3/tomato.dmm
@@ -12,11 +12,8 @@
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "s" = (
-/obj/decal/fakeobjects/skeleton{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "t" = (

--- a/assets/maps/random_rooms/3x3/undyingcomputer_80.dmm
+++ b/assets/maps/random_rooms/3x3/undyingcomputer_80.dmm
@@ -16,14 +16,11 @@
 	uses_default_material_appearance = 1;
 	insulator_default = "flesh"
 	},
-/obj/dialogueobj/engineerscorpse{
-	pixel_y = -5;
-	desc = "A dead engineer with a gnarly dent in their head and a floppy disc...embedded in their chest. Eugh..."
-	},
 /obj/decal/cleanable/blood/drip/high{
 	pixel_y = -18;
 	dry = 1
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer,
 /turf/simulated/floor/industrial,
 /area/dmm_suite/clear_area{
 	sound_fx_1 = 'sound/ambience/station/Machinery_Computers1.ogg';

--- a/assets/maps/random_rooms/3x5/coffins.dmm
+++ b/assets/maps/random_rooms/3x5/coffins.dmm
@@ -4,9 +4,7 @@
 /obj/random_item_spawner/shoe/one_or_zero,
 /obj/random_item_spawner/snacks/one_or_zero,
 /obj/random_item_spawner/medicine/one_or_zero,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse{
-	icon_state = "body8"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "r" = (

--- a/assets/maps/random_rooms/3x5/enginetest.dmm
+++ b/assets/maps/random_rooms/3x5/enginetest.dmm
@@ -44,8 +44,10 @@
 /turf/simulated/floor/airless/caution/corner/se,
 /area/dmm_suite/clear_area)
 "C" = (
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
 /obj/decal/cleanable/dirt/jen,
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	max_limbs_removed = 4
+	},
 /turf/simulated/floor/airless/caution/south,
 /area/dmm_suite/clear_area)
 "F" = (

--- a/assets/maps/random_rooms/3x5/grossquarters.dmm
+++ b/assets/maps/random_rooms/3x5/grossquarters.dmm
@@ -19,11 +19,11 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/random,
 /obj/decal/cleanable/vomit,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse{
-	icon_state = "body6"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "drip4d"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human{
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor/carpet/grime,
 /area/dmm_suite/clear_area)

--- a/assets/maps/random_rooms/3x5/skeletonbox_80.dmm
+++ b/assets/maps/random_rooms/3x5/skeletonbox_80.dmm
@@ -3,7 +3,7 @@
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "e" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "g" = (

--- a/assets/maps/random_rooms/3x5/starvingartist_60.dmm
+++ b/assets/maps/random_rooms/3x5/starvingartist_60.dmm
@@ -17,13 +17,11 @@
 /area/dmm_suite/clear_area)
 "E" = (
 /obj/item/clothing/suit/bedsheet/green,
-/obj/decal/fakeobjects/skeleton/unanchored{
-	pixel_y = -4
-	},
 /obj/item/paper/artists_anger{
 	pixel_x = -8;
 	pixel_y = 9
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/artist,
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "G" = (

--- a/assets/maps/random_rooms/3x5/winecellar.dmm
+++ b/assets/maps/random_rooms/3x5/winecellar.dmm
@@ -77,7 +77,7 @@
 /turf/simulated/floor/wood/five,
 /area/dmm_suite/clear_area)
 "T" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/five,
 /area/dmm_suite/clear_area)
 "W" = (

--- a/assets/maps/random_rooms/5x3/clown_funeral.dmm
+++ b/assets/maps/random_rooms/5x3/clown_funeral.dmm
@@ -66,10 +66,8 @@
 "Y" = (
 /obj/item/spraybottle/clown_flower,
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/under/misc/clown/fancy,
-/obj/item/clothing/shoes/clown_shoes,
-/obj/item/clothing/mask/clown_hat,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/carpet/clowncarpet,
 /area/dmm_suite/clear_area)
 

--- a/assets/maps/random_rooms/5x3/library.dmm
+++ b/assets/maps/random_rooms/5x3/library.dmm
@@ -3,14 +3,14 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/six,
 /area/dmm_suite/clear_area)
 "h" = (
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/six,
 /area/dmm_suite/clear_area)
 "m" = (
@@ -54,7 +54,7 @@
 /obj/stool/chair/comfy/yellow{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/six,
 /area/dmm_suite/clear_area)
 

--- a/assets/maps/random_rooms/5x3/mechcomedy_80.dmm
+++ b/assets/maps/random_rooms/5x3/mechcomedy_80.dmm
@@ -70,17 +70,8 @@
 /area/dmm_suite/clear_area)
 "U" = (
 /obj/disposalpipe/segment/bent/north,
-/obj/decal/fakeobjects/skeleton,
-/obj/item/clothing/mask/clown_hat/yellow{
-	pixel_y = 6;
-	pixel_x = 7
-	},
-/obj/item/clothing/shoes/clown_shoes/yellow{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/under/misc/clown/yellow,
 /obj/machinery/light/emergencyflashing,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 

--- a/assets/maps/random_rooms/5x3/notamimic.dmm
+++ b/assets/maps/random_rooms/5x3/notamimic.dmm
@@ -109,10 +109,6 @@
 /turf/simulated/floor/purple/side,
 /area/dmm_suite/clear_area)
 "N" = (
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
-/obj/item/clothing/suit/labcoat/science{
-	pixel_y = -4
-	},
 /obj/item/clothing/glasses/thermal{
 	pixel_x = 7
 	},
@@ -120,6 +116,9 @@
 	info = "oh god, the notes, they do nothing!";
 	pixel_y = -10;
 	pixel_x = -14
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	randomise_decomp_stage = 1
 	},
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)

--- a/assets/maps/random_rooms/5x3/skeletonbox_80.dmm
+++ b/assets/maps/random_rooms/5x3/skeletonbox_80.dmm
@@ -4,7 +4,7 @@
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "s" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "B" = (

--- a/assets/maps/random_rooms/5x3/winecellar.dmm
+++ b/assets/maps/random_rooms/5x3/winecellar.dmm
@@ -40,7 +40,7 @@
 /turf/simulated/floor/wood/five,
 /area/dmm_suite/clear_area)
 "u" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/wood/five,
 /area/dmm_suite/clear_area)
 "D" = (

--- a/assets/maps/shuttles/east/east_disaster.dmm
+++ b/assets/maps/shuttles/east/east_disaster.dmm
@@ -113,11 +113,8 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "dd" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -416,13 +413,7 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "mM" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "mY" = (
@@ -440,11 +431,8 @@
 	},
 /area/centcom/outside)
 "oC" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
@@ -467,13 +455,6 @@
 	layer = 9.1
 	},
 /obj/decal/cleanable/paper,
-/turf/unsimulated/floor/plating,
-/area/shuttle/escape/centcom)
-"pq" = (
-/obj/stool/chair/comfy/shuttle/brown{
-	dir = 4
-	},
-/obj/decal/fakeobjects/skeleton,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "px" = (
@@ -739,11 +720,8 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -805,13 +783,7 @@
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
 "BC" = (
@@ -1018,7 +990,9 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "HU" = (
@@ -1162,8 +1136,10 @@
 	},
 /area/centcom/outside)
 "My" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "ME" = (
@@ -1172,12 +1148,10 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "MT" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
-	},
 /obj/decal/cleanable/vomit,
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "NK" = (
@@ -1237,11 +1211,8 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1389,11 +1360,8 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1898,7 +1866,7 @@ wT
 YQ
 BX
 hm
-pq
+zl
 TH
 hu
 Rb

--- a/assets/maps/shuttles/east/oshan_disaster.dmm
+++ b/assets/maps/shuttles/east/oshan_disaster.dmm
@@ -111,7 +111,9 @@
 	},
 /area/shuttle/escape/centcom)
 "cW" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/void,
 /area/shuttle/escape/centcom)
 "dw" = (
@@ -538,7 +540,6 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "wm" = (
@@ -647,7 +648,9 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "AD" = (
@@ -688,11 +691,8 @@
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -773,11 +773,8 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -909,16 +906,6 @@
 	icon_state = "5"
 	},
 /area/shuttle/escape/centcom)
-"HR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
-/turf/unsimulated/floor/void,
-/area/shuttle/escape/centcom)
 "IW" = (
 /obj/rack,
 /obj/random_item_spawner/tools/maybe_few,
@@ -936,6 +923,9 @@
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1012,13 +1002,10 @@
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "Op" = (
@@ -1112,13 +1099,11 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1796,7 +1781,7 @@ kK
 wm
 kB
 sT
-HR
+cW
 sT
 sT
 Rl

--- a/assets/maps/shuttles/north/donut3_disaster.dmm
+++ b/assets/maps/shuttles/north/donut3_disaster.dmm
@@ -68,15 +68,12 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -121,13 +118,17 @@
 	},
 /area/centcom/outside)
 "cP" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "cX" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
@@ -407,10 +408,12 @@
 /area/shuttle/escape/centcom)
 "kX" = (
 /obj/decal/cleanable/dirt/dirt3,
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -824,16 +827,14 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/centcom)
 "CP" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1013,7 +1014,9 @@
 /obj/machinery/sleeper/compact{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "KQ" = (
@@ -1124,14 +1127,11 @@
 /turf/unsimulated/floor/black,
 /area/centcom/outside)
 "OX" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
@@ -1220,14 +1220,11 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
@@ -1477,15 +1474,10 @@
 /area/shuttle/escape/centcom)
 "Zz" = (
 /obj/stool/chair/comfy/shuttle/brown,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "ZD" = (

--- a/assets/maps/shuttles/north/manta_disaster.dmm
+++ b/assets/maps/shuttles/north/manta_disaster.dmm
@@ -113,14 +113,11 @@
 /area/shuttle/escape/centcom)
 "eX" = (
 /obj/machinery/light/small/floor,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -234,16 +231,10 @@
 /obj/machinery/sleeper/compact{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "kL" = (
@@ -268,19 +259,13 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "lA" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "lX" = (
@@ -532,14 +517,11 @@
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -726,10 +708,8 @@
 /obj/stool/chair/comfy/shuttle/pilot{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
@@ -1035,11 +1015,13 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/dirt/dirt3,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "UP" = (
@@ -1206,17 +1188,11 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/centcom/outside)
 "ZT" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 

--- a/assets/maps/shuttles/north/north_disaster.dmm
+++ b/assets/maps/shuttles/north/north_disaster.dmm
@@ -140,13 +140,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "de" = (
@@ -619,11 +613,8 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -984,12 +975,10 @@
 /obj/stool/chair/comfy/shuttle/pilot{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
-	},
 /obj/decal/cleanable/vomit,
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "Ko" = (
@@ -1087,11 +1076,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1135,11 +1121,8 @@
 	},
 /area/shuttle/escape/centcom)
 "Pe" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/void,
 /area/shuttle/escape/centcom)
@@ -1161,11 +1144,8 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1303,7 +1283,9 @@
 	},
 /area/centcom)
 "Tf" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "Tl" = (
@@ -1394,7 +1376,9 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "Xe" = (
@@ -1434,13 +1418,6 @@
 	dir = 1
 	},
 /mob/living/critter/crunched,
-/turf/unsimulated/floor/plating,
-/area/shuttle/escape/centcom)
-"Zy" = (
-/obj/stool/chair/comfy/shuttle/brown{
-	dir = 1
-	},
-/obj/decal/fakeobjects/skeleton,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "ZQ" = (
@@ -1821,7 +1798,7 @@ Jh
 UQ
 tU
 Ah
-Zy
+PJ
 Xj
 sW
 Fx

--- a/assets/maps/shuttles/north/small/destiny_disaster.dmm
+++ b/assets/maps/shuttles/north/small/destiny_disaster.dmm
@@ -27,14 +27,8 @@
 /area/shuttle/escape/centcom)
 "bR" = (
 /obj/stool/chair/comfy/shuttle,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/machinery/light/small/floor,
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "cp" = (
@@ -70,8 +64,10 @@
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
 "dY" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "ew" = (
@@ -85,14 +81,11 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -170,7 +163,6 @@
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "md" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
@@ -178,6 +170,9 @@
 	icon_state = "gib7"
 	},
 /obj/decal/cleanable/oil,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "mn" = (
@@ -254,16 +249,13 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
 	},
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "tV" = (
@@ -279,16 +271,10 @@
 /obj/machinery/sleeper/compact{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "wj" = (
@@ -384,10 +370,8 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "Jf" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -476,17 +460,14 @@
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "TR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -512,16 +493,10 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "We" = (

--- a/assets/maps/shuttles/north/small/manta_disaster.dmm
+++ b/assets/maps/shuttles/north/small/manta_disaster.dmm
@@ -34,25 +34,24 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/dirt/dirt3,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "fs" = (
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -78,17 +77,11 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "gQ" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "hE" = (
@@ -164,19 +157,13 @@
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
 "sG" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "sL" = (
@@ -241,10 +228,8 @@
 /obj/stool/chair/comfy/shuttle/pilot{
 	dir = 1
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
@@ -273,16 +258,10 @@
 /obj/machinery/sleeper/compact{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "Cd" = (
@@ -483,14 +462,11 @@
 /area/shuttle/escape/centcom)
 "XR" = (
 /obj/machinery/light/small/floor,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)

--- a/assets/maps/shuttles/south/south_disaster.dmm
+++ b/assets/maps/shuttles/south/south_disaster.dmm
@@ -110,10 +110,8 @@
 /obj/stool/chair/comfy/shuttle/pilot,
 /obj/decal/cleanable/blood/splatter,
 /obj/decal/cleanable/vomit,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -205,13 +203,10 @@
 /area/shuttle/escape/centcom)
 "hX" = (
 /obj/decal/cleanable/blood/splatter,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/scorched,
 /area/shuttle/escape/centcom)
 "hY" = (
@@ -346,14 +341,8 @@
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "ma" = (
@@ -371,21 +360,14 @@
 /obj/stool/chair/comfy/shuttle/red{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "mS" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -555,7 +537,9 @@
 /area/shuttle/escape/centcom)
 "sZ" = (
 /obj/stool/chair/comfy/shuttle/brown,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "uh" = (
@@ -607,11 +591,9 @@
 /area/shuttle/escape/centcom)
 "wI" = (
 /obj/stool/chair/comfy/shuttle/pilot,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1;
+	
 	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
@@ -930,13 +912,7 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged2,
 /area/shuttle/escape/centcom)
 "Gj" = (
@@ -1114,10 +1090,6 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/mug_rack{
-	pixel_x = -26;
-	pixel_y = 4
-	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "KU" = (
@@ -1128,16 +1100,6 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
-	},
-/turf/unsimulated/floor/plating,
-/area/shuttle/escape/centcom)
-"Lt" = (
-/obj/stool/chair/comfy/shuttle/brown,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1851,7 +1813,7 @@ op
 sZ
 iG
 Zb
-Lt
+sZ
 os
 TL
 ZL

--- a/assets/maps/shuttles/west/small/donut2_disaster.dmm
+++ b/assets/maps/shuttles/west/small/donut2_disaster.dmm
@@ -67,13 +67,11 @@
 /area/centcom)
 "iy" = (
 /obj/machinery/sleeper/compact,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -90,13 +88,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "mi" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "ou" = (
@@ -143,12 +135,6 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor2"
 	},
@@ -156,6 +142,9 @@
 	icon_state = "gibbl2"
 	},
 /obj/decal/cleanable/dirt/dirt2,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "tm" = (
@@ -169,8 +158,10 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "uw" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "vY" = (
@@ -222,19 +213,13 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "DA" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/random,
 /turf/unsimulated/floor/void,
 /area/shuttle/escape/centcom)
 "DO" = (
@@ -317,13 +302,10 @@
 /obj/stool/chair/comfy/shuttle/pilot{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "KD" = (

--- a/assets/maps/shuttles/west/west_disaster.dmm
+++ b/assets/maps/shuttles/west/west_disaster.dmm
@@ -1,7 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "at" = (
 /obj/stool/chair/comfy/shuttle/red,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "aJ" = (
@@ -45,7 +47,9 @@
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "bH" = (
@@ -128,11 +132,8 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged3,
 /area/shuttle/escape/centcom)
@@ -514,7 +515,7 @@
 /area/shuttle/escape/centcom)
 "qU" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/plating/damaged1,
 /area/shuttle/escape/centcom)
 "re" = (
@@ -639,11 +640,8 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/blood/splatter,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -924,11 +922,8 @@
 	dir = 4
 	},
 /obj/item/raw_material/shard/glass,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
@@ -1019,7 +1014,9 @@
 /area/shuttle/escape/centcom)
 "Ht" = (
 /obj/machinery/light/small/floor,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "HM" = (
@@ -1072,11 +1069,8 @@
 	},
 /obj/decal/cleanable/machine_debris,
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating/damaged2,
 /area/shuttle/escape/centcom)
@@ -1342,9 +1336,6 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
-/obj/mug_rack{
-	pixel_x = 26
-	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)
 "QW" = (
@@ -1439,10 +1430,8 @@
 	icon_state = "gibbl2"
 	},
 /obj/decal/cleanable/vomit,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/escape/centcom)

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -1158,7 +1158,10 @@
 				src.visible_message(SPAN_ALERT("<b>[src] devours [src.target]! Holy shit!</b>"))
 				playsound(src.loc, 'sound/impact_sounds/Flesh_Break_1.ogg', 50, 1)
 				M.ghostize()
-				new /obj/decal/fakeobjects/skeleton(M.loc)
+				var/mob/living/carbon/human/H = new /mob/living/carbon/human/normal(M.loc)
+				H.name = M.name
+				H.real_name = M.real_name
+				H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 				M.gib()
 				src.target = null
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2193,8 +2193,8 @@
 		if (SLOT_BACK)
 			if (I.c_flags & ONBACK)
 				return TRUE
-		if (SLOT_WEAR_MASK) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
-			if (!src.organHolder.head)
+		if (SLOT_WEAR_MASK)
+			if (!src.organHolder || !src.organHolder.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/mask))
 				var/obj/item/clothing/M = I
@@ -2204,12 +2204,12 @@
 				else
 					return TRUE
 		if (SLOT_EARS)
-			if (!src.organHolder.head)
+			if (!src.organHolder || !src.organHolder.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/ears) || istype(I,/obj/item/device/radio/headset))
 				return TRUE
 		if (SLOT_GLASSES)
-			if (!src.organHolder.head)
+			if (!src.organHolder || !src.organHolder.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/glasses))
 				return TRUE
@@ -2219,7 +2219,7 @@
 			if (istype(I, /obj/item/clothing/gloves))
 				return TRUE
 		if (SLOT_HEAD)
-			if (!src.organHolder.head)
+			if (!src.organHolder || !src.organHolder.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/head))
 				var/obj/item/clothing/H = I

--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -101,6 +101,11 @@
 		..()
 		JobEquipSpawned("Bartender")
 
+/mob/living/carbon/human/normal/artist
+	New()
+		..()
+		JobEquipSpawned("Artist")
+
 /mob/living/carbon/human/normal/botanist
 	New()
 		..()

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -36,14 +36,15 @@
 	var/maptext_out = 0
 	var/message = null
 
-	var/list/mutantrace_emote_stuff = src.mutantrace.emote(act, voluntary)
-	if(!islist(mutantrace_emote_stuff))
-		message = mutantrace_emote_stuff
-	else
-		if(length(mutantrace_emote_stuff) >= 1)
-			message = mutantrace_emote_stuff[1]
-		if(length(mutantrace_emote_stuff) >= 2)
-			maptext_out = mutantrace_emote_stuff[2]
+	if (src.mutantrace)
+		var/list/mutantrace_emote_stuff = src.mutantrace.emote(act, voluntary)
+		if(!islist(mutantrace_emote_stuff))
+			message = mutantrace_emote_stuff
+		else
+			if(length(mutantrace_emote_stuff) >= 1)
+				message = mutantrace_emote_stuff[1]
+			if(length(mutantrace_emote_stuff) >= 2)
+				maptext_out = mutantrace_emote_stuff[2]
 
 	if (!message)
 		switch (act)

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -133,22 +133,6 @@
 				S.buckle_in(src.corpse, src.corpse, TRUE)
 				src.corpse.dir = S.dir // Face properly
 
-		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
-		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
-		src.corpse.death(FALSE)
-		src.corpse.traitHolder.addTrait("puritan")
-		src.corpse.is_npc = TRUE
-
-		if (src.no_decomp)
-			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
-		if (src.no_miasma)
-			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
-
-		if (src.randomise_decomp_stage)
-			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
-		else
-			src.corpse.decomp_stage = src.decomp_stage
-
 		if (src.husked)
 			src.corpse.disfigured = TRUE
 			src.corpse.UpdateName()
@@ -210,6 +194,22 @@
 			var/obj/container = new container_type(src.loc)
 			src.corpse.set_loc(container)
 			container.UpdateIcon()
+
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
+		src.corpse.traitHolder.addTrait("puritan")
+		src.corpse.death(FALSE)
+		src.corpse.is_npc = TRUE
+
+		if (src.no_decomp)
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
+		if (src.no_miasma)
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
+
+		if (src.randomise_decomp_stage)
+			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
+		else
+			src.corpse.decomp_stage = src.decomp_stage
 
 		if (src.appearance_override)
 			src.corpse.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -112,18 +112,26 @@
 		if (src.corpse.r_hand)
 			qdel(src.corpse.r_hand)
 
-		if (src.try_buckle)
-			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
-			if (S)
-				S.buckle_in(src.corpse, src.corpse, TRUE)
-				src.corpse.dir = S.dir // Face properly
-
 		SPAWN(1)
 			for (var/obj/item/implant/health/implant as anything in src.corpse.implant)
 				qdel(implant)
 			src.corpse.implant = list()
 			for (var/obj/item/device/pda2/pda in src.corpse.contents)
 				pda.scannable = FALSE
+
+		if (src.skeletonized)
+			src.corpse.decomp_stage = DECOMP_STAGE_SKELETONIZED
+			src.corpse.set_mutantrace(/datum/mutantrace/skeleton)
+			if (prob(90))
+				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+
+		if (src.try_buckle)
+			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
+			if (S)
+				S.buckle_in(src.corpse, src.corpse, TRUE)
+				src.corpse.dir = S.dir // Face properly
 
 		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
 		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
@@ -145,14 +153,6 @@
 			src.corpse.disfigured = TRUE
 			src.corpse.UpdateName()
 			src.corpse.bioHolder?.AddEffect("husk")
-
-		if (src.skeletonized)
-			src.corpse.decomp_stage = DECOMP_STAGE_SKELETONIZED
-			src.corpse.set_mutantrace(/datum/mutantrace/skeleton)
-			if (prob(90))
-				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
 
 		if (src.do_damage)
 			src.do_damage(src.corpse)

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -59,6 +59,16 @@
 
 	/// If TRUE we husk the corpse on spawn and disfigure face
 	var/husked = FALSE
+	/// If TRUE we skeletonize the corpse on spawn
+	var/skeletonized = FALSE
+	/// If TRUE we decapitate the corpse on spawn
+	var/headless = FALSE
+	/// If TRUE we sever the arms of the corpse on spawn
+	var/armless = FALSE
+	/// If TRUE we sever the legs of the corpse on spawn
+	var/legless = FALSE
+	/// If TRUE we buckle corpse to chair if there is one
+	var/try_buckle = TRUE
 	/// If TRUE randomise the decomp stage of the body after spawning
 	var/randomise_decomp_stage = FALSE
 	/// Override this if you want a specific decomp stage
@@ -72,6 +82,8 @@
 	var/do_damage = TRUE
 	/// If this has a value, remove a random number of organs between 0 and this max
 	var/max_organs_removed = 4
+	/// If this has a value, remove a random number of limbs between 0 and this max
+	var/max_limbs_removed = 1
 
 	/// If TRUE we delete the contents of the backpack after spawning
 	var/empty_bag = FALSE
@@ -83,97 +95,190 @@
 	var/break_headset = FALSE
 	/// Sent in if we are spawned by a human critter that drops a spawner
 	var/datum/bioHolder/appearance_override = null
+	/// Used to track the created corpse after setup
+	var/mob/living/carbon/human/corpse = null
 
 	setup()
 		if (isnull(src.spawn_type))
 			CRASH("Spawner [src] at [src.x] [src.y] [src.z] had no type.")
 
-		var/mob/living/carbon/human/H = new spawn_type(src.loc)
+		src.corpse = new spawn_type(src.loc)
 
-		if (!istype(H))
+		if (!istype(src.corpse))
 			CRASH("Human corpse spawner [src] at [src.x] [src.y] [src.z] had non-human type.")
 
-		if (H.l_hand)
-			qdel(H.l_hand)
-		if (H.r_hand)
-			qdel(H.r_hand)
+		if (src.corpse.l_hand)
+			qdel(src.corpse.l_hand)
+		if (src.corpse.r_hand)
+			qdel(src.corpse.r_hand)
+
+		if (src.try_buckle)
+			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
+			if (S)
+				S.buckle_in(src.corpse, src.corpse, TRUE)
+				src.corpse.dir = S.dir // Face properly
 
 		SPAWN(1)
-			for (var/obj/item/implant/health/implant as anything in H.implant)
+			for (var/obj/item/implant/health/implant as anything in src.corpse.implant)
 				qdel(implant)
-			H.implant = list()
-			for (var/obj/item/device/pda2/pda in H.contents)
+			src.corpse.implant = list()
+			for (var/obj/item/device/pda2/pda in src.corpse.contents)
 				pda.scannable = FALSE
 
-		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
-		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
-		H.death(FALSE)
-		H.traitHolder.addTrait("puritan")
-		H.is_npc = TRUE
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
+		src.corpse.death(FALSE)
+		src.corpse.traitHolder.addTrait("puritan")
+		src.corpse.is_npc = TRUE
 
 		if (src.no_decomp)
-			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
 		if (src.no_miasma)
-			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_MIASMA, "corpse_spawn")
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
 
 		if (src.randomise_decomp_stage)
-			H.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
+			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
 		else
-			H.decomp_stage = src.decomp_stage
+			src.corpse.decomp_stage = src.decomp_stage
 
 		if (src.husked)
-			H.disfigured = TRUE
-			H.UpdateName()
-			H.bioHolder?.AddEffect("husk")
+			src.corpse.disfigured = TRUE
+			src.corpse.UpdateName()
+			src.corpse.bioHolder?.AddEffect("husk")
+
+		if (src.skeletonized)
+			src.corpse.decomp_stage = DECOMP_STAGE_SKELETONIZED
+			src.corpse.set_mutantrace(/datum/mutantrace/skeleton)
+			if (prob(90))
+				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
 
 		if (src.do_damage)
-			src.do_damage(H)
+			src.do_damage(src.corpse)
 
 		if (src.max_organs_removed)
 			for (var/i in 1 to rand(0, src.max_organs_removed))
-				var/obj/item/organ/organ = H.drop_organ(pick("left_eye","right_eye","left_lung","right_lung","butt","left_kidney","right_kidney","liver","stomach","intestines","spleen","pancreas","appendix"))
+				var/obj/item/organ/organ = src.corpse.drop_organ(pick("left_eye","right_eye","left_lung","right_lung","butt","left_kidney","right_kidney","liver","stomach","intestines","spleen","pancreas","appendix"))
 				qdel(organ)
 
+		if (src.max_limbs_removed)
+			var/list/obj/item/parts/limb_list = list(src.corpse.limbs.l_arm, src.corpse.limbs.r_arm, src.corpse.limbs.l_leg, src.corpse.limbs.r_leg)
+			for (var/i in 1 to rand(0, src.max_limbs_removed))
+				var/obj/item/parts/limb_to_delete = pick(limb_list)
+				limb_to_delete.delete()
+				limb_list -= limb_to_delete
+
+		if (src.headless)
+			var/obj/item/organ/head/noggin = src.corpse.organHolder.drop_organ("head")
+			qdel(noggin)
+
+		if (src.armless)
+			for (var/obj/item/parts/limb in list(src.corpse.limbs.l_arm, src.corpse.limbs.r_arm))
+				limb.delete()
+
+		if (src.legless)
+			for (var/obj/item/parts/limb in list(src.corpse.limbs.l_leg, src.corpse.limbs.r_leg))
+				limb.delete()
+
 		if (src.delete_id)
-			qdel(H.wear_id)
+			qdel(src.corpse.wear_id)
 
 		if (src.empty_bag)
-			if (istype(H.back, /obj/item/storage/backpack))
-				var/obj/item/storage/backpack/backpack = H.back
+			if (istype(src.corpse.back, /obj/item/storage/backpack))
+				var/obj/item/storage/backpack/backpack = src.corpse.back
 				for (var/obj/item as anything in backpack)
 					qdel(item)
-			else if (istype(H.belt, /obj/item/storage/fanny))
-				var/obj/item/storage/fanny/fanny = H.belt
+			else if (istype(src.corpse.belt, /obj/item/storage/fanny))
+				var/obj/item/storage/fanny/fanny = src.corpse.belt
 				for (var/obj/item as anything in fanny)
 					qdel(item)
 
 		if (src.empty_pockets)
-			if (H.l_store)
-				qdel(H.l_store)
-			if (H.r_store)
-				qdel(H.r_store)
+			if (src.corpse.l_store)
+				qdel(src.corpse.l_store)
+			if (src.corpse.r_store)
+				qdel(src.corpse.r_store)
 
 		if (src.break_headset)
-			if (istype(H.ears, /obj/item/device/radio/headset))
-				var/obj/item/device/radio/headset/headset = H.ears
+			if (istype(src.corpse.ears, /obj/item/device/radio/headset))
+				var/obj/item/device/radio/headset/headset = src.corpse.ears
 				headset.bricked = TRUE
 				headset.mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED // No getting smart
 
 		if (src.container_type)
 			var/obj/container = new container_type(src.loc)
-			H.set_loc(container)
+			src.corpse.set_loc(container)
 			container.UpdateIcon()
 
 		if (src.appearance_override)
-			H.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
+			src.corpse.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
 
 	do_damage(var/mob/living/carbon/human/H) // Override if you want specific damage numbers / types
 		H.TakeDamage("all", brute = rand(100, 150), burn = rand(100, 150), tox = rand(40, 80), disallow_limb_loss = TRUE)
 		H.take_oxygen_deprivation(rand(250, 300))
 
+	clown
+		spawn_type = /mob/living/carbon/human/normal/clown
+
+	engineer
+		spawn_type = /mob/living/carbon/human/normal/engineer
+
+	miner
+		spawn_type = /mob/living/carbon/human/normal/miner
+
+	janitor
+		spawn_type = /mob/living/carbon/human/normal/janitor
+
+	chaplain
+		spawn_type = /mob/living/carbon/human/normal/chaplain
+
+	artist
+		spawn_type = /mob/living/carbon/human/normal/artist
+
+	botanist
+		spawn_type = /mob/living/carbon/human/normal/botanist
+
+	chef
+		spawn_type = /mob/living/carbon/human/normal/chef
+
+	bartender
+		spawn_type = /mob/living/carbon/human/normal/bartender
+
+	security_officer
+		spawn_type = /mob/living/carbon/human/normal/securityofficer
+
+	scientist
+		spawn_type = /mob/living/carbon/human/normal/scientist
+
+	roboticist
+		spawn_type = /mob/living/carbon/human/normal/roboticist
+
+	geneticist
+		spawn_type = /mob/living/carbon/human/normal/geneticist
+
+	medical_doctor
+		spawn_type = /mob/living/carbon/human/normal/medicaldoctor
+
+	captain
+		spawn_type = /mob/living/carbon/human/normal/captain
+		empty_bag = TRUE
+		empty_pockets = TRUE
+		delete_id = TRUE
+		break_headset = TRUE
+
+	head_of_personnel
+		spawn_type = /mob/living/carbon/human/normal/headofpersonnel
+		empty_bag = TRUE
+		empty_pockets = TRUE
+		delete_id = TRUE
+		break_headset = TRUE
+
 /obj/mapping_helper/mob_spawn/corpse/human/random
 	name = "Random Human Corpse Spawn"
 	icon_state = "corpse-human-rand"
+	randomise_decomp_stage = TRUE
+
 	var/static/list/spawns = list(
 		/mob/living/carbon/human/normal/assistant = 30,
 		/mob/living/carbon/human/normal/miner = 20,
@@ -187,9 +292,15 @@
 		/mob/living/carbon/human/normal/engineer = 30,
 		/mob/living/carbon/human/normal/clown = 25,
 		/mob/living/carbon/human/normal/medicaldoctor = 15,
-		/mob/living/carbon/human/normal/bartender = 5)
+		/mob/living/carbon/human/normal/bartender = 5,
+		/mob/living/carbon/human/normal/securityofficer = 1)
 
 	initialize()
+		if (prob(20))
+			src.max_limbs_removed = 4
+			src.max_organs_removed = 10
+		if (prob(5))
+			src.headless = TRUE
 		if (prob(5))
 			src.spawn_type = weighted_pick(rare_spawns)
 			src.delete_id = TRUE
@@ -222,7 +333,7 @@
 
 /obj/mapping_helper/mob_spawn/corpse/human/skeleton
 	spawn_type = /mob/living/carbon/human/normal
-	decomp_stage = DECOMP_STAGE_SKELETONIZED
+	skeletonized = TRUE
 
 /obj/mapping_helper/mob_spawn/corpse/human/syndicate/old
 	spawn_type = /mob/living/carbon/human/normal/syndicate_old
@@ -245,6 +356,24 @@
 
 	assistant
 		spawn_type = /mob/living/carbon/human/normal/securityassistant
+
+/obj/mapping_helper/mob_spawn/corpse/human/soviet
+	spawn_type = /mob/living/carbon/human/normal
+	skeletonized = TRUE
+
+	setup()
+		..()
+		src.corpse.equip_new_if_possible(/obj/item/clothing/suit/space/soviet, SLOT_W_UNIFORM)
+		src.corpse.equip_new_if_possible(/obj/item/clothing/head/helmet/space/soviet, SLOT_HEAD)
+
+/obj/mapping_helper/mob_spawn/corpse/human/hazmat
+	spawn_type = /mob/living/carbon/human/normal
+	skeletonized = TRUE
+
+	setup()
+		..()
+		src.corpse.equip_new_if_possible(/obj/item/clothing/suit/hazard/rad/iomoon, SLOT_W_UNIFORM)
+		src.corpse.equip_new_if_possible(/obj/item/clothing/head/rad_hood/iomoon, SLOT_HEAD)
 
 //////////////////////// Critter corpses ////////////////////////
 

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -86,13 +86,13 @@
 	var/max_limbs_removed = 1
 
 	/// If TRUE we delete the contents of the backpack after spawning
-	var/empty_bag = FALSE
+	var/empty_bag = TRUE
 	/// If TRUE delete the pocket contents if any
-	var/empty_pockets = FALSE
+	var/empty_pockets = TRUE
 	/// If TRUE we delete the ID slot contents after spawning
-	var/delete_id = FALSE
+	var/delete_id = TRUE
 	/// If TRUE we break the headset and make it unscannable after spawning
-	var/break_headset = FALSE
+	var/break_headset = TRUE
 	/// Sent in if we are spawned by a human critter that drops a spawner
 	var/datum/bioHolder/appearance_override = null
 	/// Used to track the created corpse after setup
@@ -119,6 +119,28 @@
 			for (var/obj/item/device/pda2/pda in src.corpse.contents)
 				pda.scannable = FALSE
 
+		if (src.try_buckle)
+			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
+			if (S)
+				S.buckle_in(src.corpse, src.corpse, TRUE)
+				src.corpse.dir = S.dir // Face properly
+
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
+		src.corpse.traitHolder.addTrait("puritan")
+		src.corpse.death(FALSE)
+		src.corpse.is_npc = TRUE
+
+		if (src.no_decomp)
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
+		if (src.no_miasma)
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
+
+		if (src.randomise_decomp_stage)
+			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
+		else
+			src.corpse.decomp_stage = src.decomp_stage
+
 		if (src.skeletonized)
 			src.corpse.decomp_stage = DECOMP_STAGE_SKELETONIZED
 			src.corpse.set_mutantrace(/datum/mutantrace/skeleton)
@@ -126,12 +148,6 @@
 				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
 				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
 				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
-
-		if (src.try_buckle)
-			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
-			if (S)
-				S.buckle_in(src.corpse, src.corpse, TRUE)
-				src.corpse.dir = S.dir // Face properly
 
 		if (src.husked)
 			src.corpse.disfigured = TRUE
@@ -195,22 +211,6 @@
 			src.corpse.set_loc(container)
 			container.UpdateIcon()
 
-		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
-		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
-		src.corpse.traitHolder.addTrait("puritan")
-		src.corpse.death(FALSE)
-		src.corpse.is_npc = TRUE
-
-		if (src.no_decomp)
-			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
-		if (src.no_miasma)
-			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
-
-		if (src.randomise_decomp_stage)
-			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
-		else
-			src.corpse.decomp_stage = src.decomp_stage
-
 		if (src.appearance_override)
 			src.corpse.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
 
@@ -262,17 +262,9 @@
 
 	captain
 		spawn_type = /mob/living/carbon/human/normal/captain
-		empty_bag = TRUE
-		empty_pockets = TRUE
-		delete_id = TRUE
-		break_headset = TRUE
 
 	head_of_personnel
 		spawn_type = /mob/living/carbon/human/normal/headofpersonnel
-		empty_bag = TRUE
-		empty_pockets = TRUE
-		delete_id = TRUE
-		break_headset = TRUE
 
 /obj/mapping_helper/mob_spawn/corpse/human/random
 	name = "Random Human Corpse Spawn"

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -303,7 +303,10 @@
 			logTheThing(LOG_COMBAT, M, "was gibbed by [src] at [log_loc(src)].") // Some logging for instakill critters would be nice (Convair880).
 			playsound(src.loc, 'sound/impact_sounds/Flesh_Break_1.ogg', 50, 1)
 			doomedMob.ghostize()
-			new /obj/decal/fakeobjects/skeleton(doomedMob.loc)
+			var/mob/living/carbon/human/H = new /mob/living/carbon/human/normal(doomedMob.loc)
+			H.name = doomedMob.name
+			H.real_name = doomedMob.real_name
+			H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 			doomedMob.gib()
 			src.target = null
 

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -54,7 +54,8 @@ ABSTRACT_TYPE(/obj/item/clothing)
 				for (var/datum/hud/hud in H.huds)
 					if (src in hud.objects)
 						hud.remove_object(src)
-				H.hud.remove_object(src)
+				if (H.hud)
+					H.hud.remove_object(src)
 		//fucky way of doing this but whatever
 		..()
 

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -43865,10 +43865,6 @@
 /area/mining/magnet)
 "hni" = (
 /obj/decal/cleanable/rust/jen,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse{
-	icon_state = "body5";
-	name = "unfortunate guy"
-	},
 /obj/item/kitchen/utensil/knife,
 /obj/decal/cleanable/blood{
 	icon_state = "armorblood_c"
@@ -43879,6 +43875,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "drip1a"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human,
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/maintenance/northeast)
 "hnu" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -19090,14 +19090,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The partially decomposed corpse of some poor chump.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	layer = 4;
-	name = "corpse"
-	},
 /obj/disposalpipe/segment/morgue,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/airless/grime,
 /area/station/wreckage{
 	name = "Restricted Area"

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -25505,7 +25505,6 @@
 	},
 /area/station/engine/inner)
 "hOa" = (
-/obj/decal/fakeobjects/skeleton/unanchored,
 /obj/decal/cleanable/blood/tracks{
 	dir = 4
 	},
@@ -25518,6 +25517,7 @@
 	r_speed = 0
 	},
 /obj/item/rubber_chicken,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
 "hOo" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -3639,10 +3639,7 @@
 	},
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of an idea.";
-	name = "\proper Jenny's hopes and dreams"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "aXY" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -90,11 +90,9 @@
 	icon_state = "hvent";
 	name = "air vent"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. There seem to be a few bits missing."
-	},
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/damaged4,
 /area/space)
 "aas" = (
@@ -54541,10 +54539,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/pool)
 "uqp" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
-	name = "sticky skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quarters_south)
 "uqR" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1089,9 +1089,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "axX" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. There are little bits of corroded suit wafting around them."
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/space/fluid/acid/clear,
 /area/space)
 "ayc" = (
@@ -18415,12 +18413,6 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Well, there's your problem.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body4";
-	name = "crispy corpse"
-	},
 /obj/decal/cleanable/generic{
 	alpha = 200;
 	desc = "Toasted.";
@@ -18433,6 +18425,9 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	skeletonized = 1
 	},
 /turf/simulated/floor/grey,
 /area/pasiphae/survey)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1828,8 +1828,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
 "afY" = (
-/obj/decal/fakeobjects/skeleton,
-/obj/item/clothing/suit/labcoat/genetics,
+/obj/mapping_helper/mob_spawn/corpse/human/geneticist,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
 "agb" = (
@@ -13744,7 +13743,7 @@
 /area/space)
 "aUj" = (
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/space/fluid,
 /area/space)
 "aUk" = (
@@ -14233,8 +14232,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/genetics)
 "aWN" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/genetics)
 "aWO" = (
@@ -14295,18 +14294,12 @@
 /turf/simulated/floor/white,
 /area/evilreaver/genetics)
 "aXn" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/evilreaver/genetics)
 "aXp" = (
-/obj/overlay{
-	desc = "Oh.  So THAT'S where he went off to.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	layer = 4;
-	name = "skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating/scorched,
 /area/evilreaver/genetics)
 "aXu" = (
@@ -18159,7 +18152,7 @@
 /area/station/engine/power)
 "bon" = (
 /obj/item/reagent_containers/food/snacks/hardtack,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "boo" = (
@@ -29515,7 +29508,7 @@
 /area/diner/backroom)
 "cbC" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/diner/backroom)
 "cbD" = (
@@ -37166,7 +37159,6 @@
 /turf/simulated/floor,
 /area/station/ranch)
 "jll" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/pharosium,
 /obj/item/raw_material/bohrum,
 /obj/item/raw_material/bohrum,
@@ -37175,6 +37167,7 @@
 /obj/item/raw_material/claretine,
 /obj/item/raw_material/uqill,
 /mob/living/critter/fermid,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "jlM" = (
@@ -42621,9 +42614,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "rcn" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/cobryl,
 /obj/item/raw_material/cobryl,
+/obj/mapping_helper/mob_spawn/corpse/human/miner{
+	skeletonized = 1
+	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "rcz" = (
@@ -42812,13 +42807,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "rwc" = (
-/obj/overlay{
-	desc = "Oh.  So THAT'S where he went off to.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	layer = 4;
-	name = "skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "rwt" = (
@@ -44523,8 +44512,8 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
 "uBc" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/diner/backroom)
 "uBh" = (
@@ -44605,9 +44594,11 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "uIq" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/mining_tool/powered/hammer,
 /mob/living/critter/fermid,
+/obj/mapping_helper/mob_spawn/corpse/human/miner{
+	skeletonized = 1
+	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "uIr" = (
@@ -45977,8 +45968,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "wPY" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/oreprospector,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "wRa" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -60950,9 +60950,6 @@
 /area/station/medical/staff)
 "oGd" = (
 /obj/decal/cleanable/rust/jen,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse{
-	icon_state = "body5"
-	},
 /obj/item/kitchen/utensil/knife,
 /obj/decal/cleanable/blood{
 	icon_state = "armorblood_c"
@@ -60962,6 +60959,9 @@
 	},
 /obj/decal/cleanable/blood{
 	icon_state = "drip1a"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	headless = 1
 	},
 /turf/simulated/floor/grey/whitegrime/other,
 /area/station/maintenance/northwest)

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -27397,13 +27397,9 @@
 /area/russian/radiation)
 "cQb" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of an engineer. not very handsome.";
-	interesting = "Something isn't right here... This guy wasn't alive when he was shot";
-	name = "engineer's skeleton"
-	},
 /obj/item/casing,
 /obj/disposalpipe/junction/right/east,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating{
 	desc = " It is made of steel.";
 	icon_state = "platingdmg1";
@@ -54626,12 +54622,6 @@
 	},
 /area/russian/radiation)
 "mTO" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "not much of a chef";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "shredded remains of Flesh Utopia"
-	},
 /obj/item/reagent_containers/food/snacks/cereal_box{
 	contraband = 1;
 	desc = "Couldn't be simpler! Just add water, mix, and bake! DO NOT CONSUME RAW";
@@ -54644,6 +54634,7 @@
 	icon_state = "gibhead"
 	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/space,
 /area/russian/radiation)
 "mUe" = (
@@ -62702,7 +62693,9 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
 	name = "steel shuttle floor"
@@ -62749,10 +62742,12 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
@@ -63777,13 +63772,10 @@
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/dirt/dirt5,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
 	icon_state = "floor3";
@@ -63890,15 +63882,10 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "smear3"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/soviet,
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
 	name = "steel shuttle floor"
@@ -64303,18 +64290,13 @@
 /area/russian/radiation)
 "rzR" = (
 /obj/item/clothing/head/emerg,
-/obj/decal/fakeobjects/skeleton{
-	desc = "still has his... uh... bedsheet?";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "what used to be Twenty Second Elephant"
-	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "hard to believe...";
 	icon_state = "bedsheet-captain";
 	name = "clown's bedsheet"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/black{
 	broken = 1;
 	desc = " It is made of steel.";
@@ -64392,11 +64374,8 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
@@ -65023,17 +65002,14 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The partially decomposed corpse of some poor chump.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "corpse"
-	},
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
 	},
 /obj/decal/cleanable/greenpuke,
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
 	icon_state = "floor2";
@@ -65759,7 +65735,7 @@
 	},
 /area/russian/radiation)
 "sho" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/space,
 /area/space)
 "shH" = (
@@ -66169,15 +66145,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "ssC" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "She seems to have bled out from her injuries.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	interesting = "large number of bites and scratches";
-	name = "mangled corpse"
-	},
 /obj/decal/cleanable/dirt/dirt2,
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	desc = " It is made of steel.";
 	name = "steel shuttle floor"
@@ -70032,16 +70004,11 @@
 	},
 /area/russian/radiation)
 "uBR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "this is not right. this is NOT right.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "Eldritch Horror the clowne"
-	},
 /obj/item/razor_blade,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor5"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/space,
 /area/russian/radiation)
 "uCl" = (
@@ -70878,13 +70845,7 @@
 /area/russian/radiation)
 "vfo" = (
 /obj/item/clothing/shoes/moon,
-/obj/decal/fakeobjects/skeleton{
-	desc = "This is very important.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "Bill-Bo's body, barely..."
-	},
-/obj/item/clothing/mask/clown_hat,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/space,
 /area/russian/radiation)
 "vfx" = (

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -105,11 +105,9 @@
 	icon_state = "hvent";
 	name = "air vent"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. There seem to be a few bits missing."
-	},
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/damaged4,
 /area/space)
 "at" = (

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -47625,13 +47625,7 @@
 /area/station/security/main)
 "eye" = (
 /obj/item/clothing/shoes/moon,
-/obj/decal/fakeobjects/skeleton{
-	desc = "This is very important.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "Bill-Bo's body, barely..."
-	},
-/obj/item/clothing/mask/clown_hat,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating/airless/random,
 /area/station/security/checkpoint/podbay{
 	name = "NanoTrasen Labor Camp Shuttle"
@@ -47667,13 +47661,9 @@
 /area/station/engine/engineering)
 "eBc" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of an engineer. not very handsome.";
-	interesting = "Something isn't right here... This guy wasn't alive when he was shot";
-	name = "engineer's skeleton"
-	},
 /obj/item/casing,
 /obj/disposalpipe/junction/right/east,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -48641,11 +48631,8 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/station/hallway/secondary/exit)
@@ -49502,18 +49489,13 @@
 /area/station/hallway/secondary/entry)
 "hKo" = (
 /obj/item/clothing/head/emerg,
-/obj/decal/fakeobjects/skeleton{
-	desc = "still has his... uh... bedsheet?";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "what used to be Twenty Second Elephant"
-	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "hard to believe...";
 	icon_state = "bedsheet-captain";
 	name = "clown's bedsheet"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/black,
 /area/station/storage/auxillary)
 "hKJ" = (
@@ -49622,17 +49604,14 @@
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The partially decomposed corpse of some poor chump.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "corpse"
-	},
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
 	},
 /obj/decal/cleanable/greenpuke,
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -50823,10 +50802,12 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
 	},
 /turf/simulated/floor/shuttle,
 /area/station/hallway/secondary/exit)
@@ -51922,13 +51903,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "lNx" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Ironic, really";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "burntnerd";
-	name = "charred icecream vendor"
-	},
 /obj/decal/cleanable/blood/drip,
+/obj/mapping_helper/mob_spawn/corpse/human/hazmat,
 /turf/simulated/floor/airless,
 /area/space)
 "lOt" = (
@@ -53715,12 +53691,6 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
@@ -53728,6 +53698,7 @@
 /obj/decal/cleanable/blood{
 	icon_state = "smear3"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/soviet,
 /turf/simulated/floor/shuttle,
 /area/station/hallway/secondary/exit)
 "ozO" = (
@@ -55633,15 +55604,11 @@
 /turf/space,
 /area/station/ranch)
 "rHB" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "She seems to have bled out from her injuries.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	interesting = "large number of bites and scratches";
-	name = "mangled corpse"
-	},
 /obj/decal/cleanable/dirt/dirt2,
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle,
 /area/station/hallway/secondary/exit)
 "rHD" = (
@@ -55711,17 +55678,14 @@
 /obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
 /obj/decal/cleanable/dirt/dirt5,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
@@ -56948,7 +56912,9 @@
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	skeletonized = 1
+	},
 /turf/simulated/floor/shuttle,
 /area/station/hallway/secondary/exit)
 "uav" = (
@@ -57904,12 +57870,6 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "not much of a chef";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "shredded remains of Flesh Utopia"
-	},
 /obj/item/reagent_containers/food/snacks/cereal_box{
 	contraband = 1;
 	desc = "Couldn't be simpler! Just add water, mix, and bake! DO NOT CONSUME RAW";
@@ -57922,6 +57882,7 @@
 	icon_state = "gibhead"
 	},
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/storage/emergency2{
 	name = "Hilarious Storage B"
@@ -58883,7 +58844,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "wMY" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
 "wNj" = (
@@ -58911,16 +58872,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "wOR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "this is not right. this is NOT right.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "Eldritch Horror the clowne"
-	},
 /obj/item/razor_blade,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor5"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/shuttle,
 /area/station/security/checkpoint/podbay{
 	name = "NanoTrasen Labor Camp Shuttle"

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -38676,10 +38676,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "wVZ" = (
-/obj/decal/fakeobjects/skeleton,
-/obj/item/clothing/suit/chef,
-/obj/item/clothing/head/chefhat,
 /obj/decal/cleanable/cobweb,
+/obj/mapping_helper/mob_spawn/corpse/human/chef,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "wXN" = (

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -8022,10 +8022,7 @@
 	name = "Dockside Restroom"
 	})
 "ciU" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "It's all covered in a sticky mess, and there are chunks of uniform fused to the bone.";
-	name = "sticky skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/clown{
 	name = "Honkington's Abode"
@@ -70165,11 +70162,9 @@
 	icon_state = "hvent";
 	name = "air vent"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. There seem to be a few bits missing."
-	},
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/damaged4,
 /area/space)
 "sow" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -45566,7 +45566,7 @@
 /area/station/medical/dome)
 "udG" = (
 /obj/decal/cleanable/rust,
-/obj/decal/fakeobjects/skeleton/decomposed_corpse,
+/obj/mapping_helper/mob_spawn/corpse/human,
 /turf/simulated/floor/airless/black,
 /area/abandonedship{
 	name = "Crashed Limo"
@@ -49582,7 +49582,7 @@
 /area/station/hallway/secondary/exit)
 "vRO" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/plating,
 /area/abandonedship{
 	name = "Crashed Limo"

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -1149,11 +1149,8 @@
 /turf/unsimulated/floor/caution/north,
 /area/hospital/samostrel)
 "ago" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Oh.  Gross.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "emaciated corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	delete_id = 1
 	},
 /turf/unsimulated/floor{
 	icon = 'icons/turf/shuttle.dmi';
@@ -2764,11 +2761,7 @@
 /turf/unsimulated/floor/engine,
 /area/hospital/samostrel)
 "anN" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Human remains.  Probably related to all this burnt science equipment and general bad vibes.";
-	layer = 2.5;
-	pixel_y = 8
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/engine,
 /area/hospital/samostrel)
 "anO" = (
@@ -4175,11 +4168,7 @@
 /turf/unsimulated/floor/specialroom/freezer,
 /area/hospital)
 "atO" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Human remains.  Probably related to all this burnt science equipment and general bad vibes.";
-	layer = 2.5;
-	pixel_y = 8
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor,
 /area/hospital/samostrel)
 "atQ" = (
@@ -8218,7 +8207,7 @@
 /obj/stool/bed,
 /obj/window/cubicle,
 /obj/item/clothing/suit/bedsheet,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/carpet/grime,
 /area/upper_arctic/pod2)
 "aNF" = (
@@ -8884,18 +8873,15 @@
 	},
 /area/upper_arctic/exterior/surface)
 "aPA" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The partially decomposed corpse of some poor chump.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "corpse"
-	},
 /obj/decal/cleanable/vomit{
 	desc = "Someone lost their lunch.  A long time ago.";
 	name = "dried vomit"
 	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/black/side{
 	dir = 1
@@ -10887,11 +10873,8 @@
 	},
 /area/marsoutpost)
 "aWt" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	delete_id = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "plating_dusty1"
@@ -12881,12 +12864,12 @@
 "bcN" = (
 /obj/decal/cleanable/dirt,
 /obj/item/whip,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/head/det_hat,
 /obj/item/coin{
 	desc = "You don't recognize the language on this coin. Huh.";
 	name = "old coin"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/cave,
 /area/crater/cave)
 "bcO" = (
@@ -13653,8 +13636,8 @@
 /obj/decal/cleanable/blood/gibs{
 	icon_state = "gibdown1"
 	},
-/obj/decal/fakeobjects/skeleton,
 /obj/item/paper/mission_outline,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/cave,
 /area/crater/cave)
 "bfp" = (
@@ -13925,10 +13908,12 @@
 /turf/unsimulated/floor/arctic/snow/ice,
 /area/lower_arctic/lower)
 "bgk" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood,
 /obj/item/gun/kinetic/flaregun,
 /obj/decal/cleanable/blood/tracks,
+/obj/mapping_helper/mob_spawn/corpse/human{
+	randomise_decomp_stage = 1
+	},
 /turf/unsimulated/floor/arctic/snow/ice,
 /area/lower_arctic/lower)
 "bgm" = (
@@ -14455,12 +14440,12 @@
 /area/precursor)
 "bil" = (
 /obj/item/clothing/glasses/monocle,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/under/gimmick/safari,
 /obj/spacevine{
 	icon_state = "vine-light3"
 	},
 /obj/item/boomerang,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/green/side{
 	dir = 1
 	},
@@ -20446,12 +20431,7 @@
 /turf/unsimulated/iomoon/ancient_floor,
 /area/iomoon/robot_ruins)
 "bEZ" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Apparently, there is a limit to the electrical protection offered by environment suits.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "burntnerd";
-	name = "charred corpse"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/hazmat,
 /turf/unsimulated/iomoon/ancient_floor,
 /area/iomoon/robot_ruins)
 "bFa" = (
@@ -20464,12 +20444,7 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor5"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The FineBargain Model 8 environment suit also doubles as a handy body bag.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "nerd";
-	name = "corpse"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/hazmat,
 /turf/unsimulated/iomoon/ancient_floor,
 /area/iomoon/robot_ruins)
 "bFc" = (
@@ -20738,26 +20713,18 @@
 /area/iomoon/robot_ruins/boss_chamber)
 "bGe" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/clothing/under/misc/syndicate,
 /obj/item/card/id/syndicate,
 /obj/item/clothing/gloves/fingerless,
 /obj/item/clothing/mask/balaclava,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/dirt,
 /area/catacombs)
 "bGg" = (
 /obj/storage/closet/coffin,
 /obj/item/alchemy/symbol/air,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/clothing/under/shorts/black,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "bGi" = (
@@ -20895,12 +20862,8 @@
 /area/crypt/graveyard)
 "bGJ" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/paper/alchemy/southwest,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/dirt,
 /area/catacombs)
 "bGL" = (
@@ -21308,11 +21271,6 @@
 /area/iomoon/robot_ruins/boss_chamber)
 "bIi" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/coin{
 	desc = "Through the corrosion, you can  vaguely make out a symbol of a circle with four triangular spokes and four wavy spokes. Huh.";
 	name = "older coin";
@@ -21320,6 +21278,7 @@
 	pixel_y = 9
 	},
 /obj/item/clothing/suit/cultist,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/dirt,
 /area/catacombs)
 "bIj" = (
@@ -21532,21 +21491,13 @@
 /area/iomoon/robot_ruins/boss_chamber)
 "bIU" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/dirt,
 /area/catacombs)
 "bIW" = (
 /obj/storage/closet/coffin,
 /obj/item/alchemy/symbol/incin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "bIY" = (
@@ -22044,12 +21995,8 @@
 /area/catacombs)
 "bKN" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/clothing/under/rank/det,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "bKO" = (
@@ -22063,14 +22010,10 @@
 /area/catacombs)
 "bKQ" = (
 /obj/storage/closet/coffin,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Seems like it's been here for hundreds of years. How the hell is that even possible?";
-	icon_state = "skeleton_s";
-	name = "crumbly skeleton"
-	},
 /obj/item/wrench,
 /obj/item/clothing/under/gimmick/mario/wario,
 /obj/item/clothing/head/mario/wario,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "bKR" = (
@@ -22125,14 +22068,11 @@
 /turf/unsimulated/floor/ancient,
 /area/crunch)
 "bLb" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
-	},
 /obj/item/remote/busted{
 	name = "West-A-Medbay Remote"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/void,
 /area/crunch)
@@ -22878,11 +22818,8 @@
 	desc = "It has little wheels underneath! How does the plumbing still work? Who the hell knows.";
 	name = "mobile bathtub"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/specialroom/freezer,
 /area/crypt/sigma/crew)
@@ -23471,16 +23408,12 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. The skull has a hole in it.  An extra one, I mean.";
-	layer = 2.5;
-	pixel_y = 8
-	},
 /obj/decal/cleanable/blood/splatter,
 /obj/item/spook,
 /obj/window/cubicle{
 	dir = 2
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/carpet{
 	icon_state = "fred1"
 	},
@@ -27051,8 +26984,8 @@
 /area/crunch)
 "cdo" = (
 /obj/decal/cleanable/blood/splatter,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/spook,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/white,
 /area/crunch)
 "cdp" = (
@@ -27151,13 +27084,11 @@
 /area/meat_derelict/guts)
 "cdI" = (
 /obj/stool/chair,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Human remains in the fittings of a Head of Personnel.  Judging by the missing skull chunks, they didn't win.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8"
-	},
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "gibbl2"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor,
 /area/meat_derelict/guts)
@@ -27287,10 +27218,8 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/unsimulated/floor,
 /area/meat_derelict/guts)
@@ -29501,8 +29430,8 @@
 /area/meat_derelict/guts)
 "cma" = (
 /obj/stomachacid,
-/obj/decal/fakeobjects/skeleton,
 /obj/map/light/meatland,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/setpieces/bloodfloor/stomach,
 /area/meat_derelict/guts)
 "cmb" = (
@@ -32112,11 +32041,8 @@
 	dir = 1
 	},
 /obj/item/clothing/suit/bedsheet,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Uh oh.";
-	icon = 'icons/misc/exploration.dmi';
-	icon_state = "husk_l";
-	name = "unknown"
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	husked = 1
 	},
 /turf/unsimulated/floor/carpet/grime,
 /area/upper_arctic/pod2)
@@ -32969,13 +32895,9 @@
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/staffhall)
 "cxO" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "He hasn't got a leg to stand on.";
-	dir = 4;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "half corpse";
-	pixel_x = -10
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	legless = 1;
+	delete_id = 1
 	},
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/staffhall)
@@ -33613,11 +33535,8 @@
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/staffhall)
 "czR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/chef{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/staffhall)
@@ -34145,13 +34064,13 @@
 /area/owlery/gangzone)
 "cBp" = (
 /obj/stool/chair,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/head/flatcap,
 /obj/item/instrument/saxophone,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 16
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/blackwhite{
 	dir = 1
 	},
@@ -34622,14 +34541,12 @@
 /turf/unsimulated/floor/white,
 /area/owlery/lab)
 "cCF" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse"
-	},
 /obj/item/paper/cleanerorder,
 /obj/item/clothing/under/misc/syndicate,
+/obj/mapping_helper/mob_spawn/corpse/human/janitor{
+	delete_id = 1;
+	max_limbs_removed = 3
+	},
 /turf/unsimulated/floor/white,
 /area/owlery/lab)
 "cCI" = (
@@ -36847,14 +36764,11 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Rest in peace.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body2";
-	name = "Personnel"
-	},
 /obj/decal/cleanable/blood{
 	icon_state = "floor5"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human{
+	headless = 1
 	},
 /turf/unsimulated/floor/blackwhite{
 	dir = 1
@@ -38598,11 +38512,8 @@
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	delete_id = 1
 	},
 /turf/unsimulated/grass,
 /area/owlery/owllock)
@@ -39066,18 +38977,14 @@
 /area/owlery/owllock)
 "cPU" = (
 /obj/decal/cleanable/blood/gibs,
-/obj/decal/fakeobjects/skeleton{
-	desc = "He hasn't got a leg to stand on.";
-	dir = 4;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "half corpse";
-	pixel_x = -10
-	},
 /obj/window{
 	desc = "A window.  For a museum exhibit.";
 	dir = 4;
 	name = "exhibit window"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1;
+	legless = 1
 	},
 /turf/unsimulated/grass,
 /area/owlery/owllock)
@@ -39228,13 +39135,9 @@
 /obj/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "He hasn't got a leg to stand on.";
-	dir = 4;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "half corpse";
-	pixel_x = -10
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1;
+	legless = 1
 	},
 /turf/unsimulated/floor/stairs/dark{
 	dir = 4
@@ -40044,14 +39947,11 @@
 /obj/decal/cleanable/blood{
 	icon_state = "floor6"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/tracks{
 	dir = 6
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/green,
 /area/owlery/owllock)
@@ -40757,11 +40657,8 @@
 /turf/unsimulated/grass,
 /area/owlery/owllock)
 "cUf" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	delete_id = 1
 	},
 /turf/unsimulated/grass,
 /area/owlery/owllock)
@@ -40942,13 +40839,6 @@
 /obj/decal/cleanable/blood/tracks{
 	icon_state = "drip5"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "She seems to have bled out from her injuries.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	interesting = "large number of bites and scratches";
-	name = "mangled corpse"
-	},
 /obj/decal/cleanable/blood/tracks{
 	icon_state = "drip5"
 	},
@@ -40958,6 +40848,9 @@
 	},
 /obj/machinery/light/emergency{
 	dir = 4
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/owleryhall)
@@ -41040,8 +40933,10 @@
 /area/owlery/owleryhall)
 "cVa" = (
 /obj/item/clothing/suit/bedsheet,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/reagent_containers/food/snacks/granola_bar,
+/obj/mapping_helper/mob_spawn/corpse/human/random{
+	delete_id = 1
+	},
 /turf/unsimulated/grass,
 /area/owlery/owllock)
 "cVe" = (
@@ -41573,19 +41468,20 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "50% of a rotten corpse.";
-	dir = 8;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "pair of legs";
-	pixel_x = 14
-	},
 /obj/decal/cleanable/blood/gibs{
 	icon_state = "gibdown1"
 	},
 /obj/machinery/light/emergency{
 	dir = 8
+	},
+/obj/item/parts/human_parts/leg/left{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/item/parts/human_parts/leg/right{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -10
 	},
 /turf/unsimulated/grass,
 /area/owlery/owllock)
@@ -42357,11 +42253,8 @@
 "cYq" = (
 /obj/item/raw_material/shard/glass,
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/pool/no_animate,
 /area/owlery/Owlmait2)
@@ -48251,10 +48144,7 @@
 	name = "DANGER DO NOT OPEN"
 	},
 /obj/item/material_piece/slag,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remnants of lag.";
-	name = "lag"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/drsingh)
 "dxY" = (
@@ -48272,13 +48162,7 @@
 /area/centcom/offices/lyra)
 "dyc" = (
 /obj/machinery/optable,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse";
-	pixel_y = 4
-	},
+/obj/mapping_helper/mob_spawn/corpse/human,
 /turf/unsimulated/floor/white/checker,
 /area/centcom/offices/gerhazo)
 "dyd" = (
@@ -49020,7 +48904,7 @@
 	dir = 1;
 	on = 1
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/wood/two{
 	desc = " It is made of wood.";
 	explosion_protection = 1;
@@ -61531,7 +61415,7 @@
 /turf/unsimulated/floor/carpet/wizard/standard/edge/nw,
 /area/wizard_station)
 "kmZ" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/hufflaw)
 "kna" = (
@@ -62201,11 +62085,8 @@
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "kQR" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The burnt remains of some poor sod.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body4";
-	name = "crispy corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/industrial,
 /area/iomoon/base/underground)
@@ -62390,11 +62271,8 @@
 /area/moon/museum)
 "kZz" = (
 /obj/item/crowbar,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The partially decomposed corpse of some poor chump.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/plating,
 /area/iomoon/base)
@@ -64915,12 +64793,6 @@
 	},
 /area/centcom)
 "nwz" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
-	},
 /obj/decal/cleanable/blood/tracks,
 /obj/cable{
 	icon_state = "1-4"
@@ -64929,6 +64801,9 @@
 /obj/decal/cleanable/blood,
 /obj/decal/cleanable/blood/gibs/body{
 	icon_state = "gibdown1"
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1
 	},
 /turf/unsimulated/floor/white,
 /area/owlery/owleryhall)
@@ -66421,7 +66296,7 @@
 	},
 /area/sim/racing_track)
 "oSa" = (
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/arctic/snow,
 /area/upper_arctic/exterior/surface)
 "oSb" = (
@@ -66919,12 +66794,7 @@
 /turf/unsimulated/floor/plating,
 /area/shuttle/icebase_elevator/upper)
 "pmE" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of some poor cosmonaut fellow.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body9";
-	name = "corpse"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/soviet,
 /turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
 "pmV" = (
@@ -71477,10 +71347,6 @@
 /turf/unsimulated/floor/caution/north,
 /area/drone/office)
 "tiD" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. How'd they get out there?";
-	name = "human's skeleton"
-	},
 /obj/item/clothing/head/headband/nyan/random{
 	desc = "Did these belong to that skeleton?";
 	pixel_x = 12;
@@ -71498,6 +71364,7 @@
 	dir = 4;
 	name = "replica of that one chair on cogmap 1"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/outdoors/grass,
 /area/centcom/outside)
 "tje" = (
@@ -71622,13 +71489,9 @@
 /area/crypt/sigma/crew)
 "trs" = (
 /obj/decal/cleanable/blood/splatter,
-/obj/decal/fakeobjects/skeleton{
-	desc = "He hasn't got a leg to stand on.";
-	dir = 4;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "half corpse";
-	pixel_x = -10
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	delete_id = 1;
+	legless = 1
 	},
 /turf/unsimulated/floor,
 /area/iomoon/base/underground)
@@ -72943,13 +72806,14 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "50% of a rotten corpse.";
+/obj/item/parts/human_parts/leg/left{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/item/parts/human_parts/leg/right{
 	dir = 8;
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body5";
-	name = "pair of legs";
-	pixel_x = 14
+	pixel_x = 12;
+	pixel_y = -10
 	},
 /turf/unsimulated/floor/caution/north,
 /area/iomoon/base/underground)
@@ -75049,13 +74913,13 @@
 /turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "wuv" = (
-/obj/decal/fakeobjects/skeleton/unanchored,
 /obj/item/clothing/head/wizard,
 /obj/item/reagent_containers/glass/water_pipe/filled,
 /obj/lattice{
 	dir = 10;
 	icon_state = "lattice-dir-b"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/space,
 /area/wizard_station_space)
 "wvp" = (
@@ -75455,16 +75319,11 @@
 	bcolor = "green";
 	icon_state = "bedsheet-green"
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
-	},
 /mob/living/critter/small_animal/bird/owl{
 	desc = "This Owl seems to be staring at you with both a smug, yet angry face. Somehow.";
 	name = "smug looking space owl"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel,
 /turf/unsimulated/grass,
 /area/owlery/owllock)
 "wLj" = (

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -2373,12 +2373,7 @@
 /turf/simulated/floor/airless/black/grime,
 /area/space)
 "akZ" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "honk";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	name = "Tooty, but dry and dead"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/airless/black/grime,
 /area/space)
 "alb" = (
@@ -5617,11 +5612,8 @@
 	layer = 29
 	},
 /obj/machinery/door/window/eastleft,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body1";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton{
+	skeletonized = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/abandonedoutpostthing)
@@ -5793,7 +5785,9 @@
 /obj/window/cubicle{
 	dir = 2
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	skeletonized = 1
+	},
 /turf/simulated/floor,
 /area/abandonedoutpostthing)
 "aGc" = (
@@ -6085,16 +6079,11 @@
 /area/space)
 "aHs" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Gross.";
-	icon = 'icons/mob/human.dmi';
-	icon_state = "husk_l";
-	name = "dessicated husk"
-	},
 /obj/storage/crate/medical,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/plating/damaged3,
 /area/abandonedmedicalship)
 "aHt" = (
@@ -6132,11 +6121,8 @@
 /turf/simulated/floor/black,
 /area/radiostation/engineering)
 "aHz" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body7";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/captain{
+	skeletonized = 1
 	},
 /turf/simulated/floor,
 /area/abandonedoutpostthing)
@@ -6149,13 +6135,8 @@
 /obj/decal/cleanable/oil,
 /obj/decal/cleanable/dirt,
 /obj/machinery/optable,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Gross.";
-	icon = 'icons/mob/human.dmi';
-	icon_state = "husk_l";
-	name = "dessicated husk"
-	},
 /obj/map/light/white,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/damaged2,
 /area/abandonedmedicalship)
 "aHG" = (
@@ -6413,8 +6394,8 @@
 /turf/simulated/floor/airless/plating/damaged2,
 /area/abandonedship)
 "aIw" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/paper/printout/emerg1,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/plating/damaged3,
 /area/space)
 "aIx" = (
@@ -6920,11 +6901,8 @@
 /turf/simulated/floor/airless/white,
 /area/abandonedmedicalship)
 "aJZ" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body3";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/engineer{
+	skeletonized = 1
 	},
 /turf/simulated/floor/plating/random,
 /area/abandonedoutpostthing)
@@ -7032,14 +7010,9 @@
 /area/abandonedmedicalship)
 "aKo" = (
 /obj/decal/cleanable/dirt,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Gross.";
-	icon = 'icons/mob/human.dmi';
-	icon_state = "husk_l";
-	name = "dessicated husk"
-	},
 /obj/table/reinforced/auto,
 /obj/item/clothing/gloves/latex,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/airless/plating/damaged2,
 /area/abandonedmedicalship)
 "aKp" = (
@@ -8155,7 +8128,9 @@
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor5"
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/scientist{
+	skeletonized = 1
+	},
 /turf/simulated/floor,
 /area/h7/computer_core)
 "aOe" = (
@@ -8268,12 +8243,7 @@
 /turf/simulated/floor/orangeblack,
 /area/h7/storage)
 "aOv" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Gross.";
-	icon = 'icons/mob/human.dmi';
-	icon_state = "husk_l";
-	name = "dessicated husk"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "aOw" = (
@@ -9290,6 +9260,13 @@
 /area/fermid_hive)
 "aRH" = (
 /obj/storage/secure/closet/security/equipment,
+/obj/mapping_helper/mob_spawn/corpse/human/security_officer{
+	skeletonized = 1;
+	break_headset = 1;
+	empty_bag = 1;
+	empty_pockets = 1;
+	delete_id = 1
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -9596,7 +9573,6 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aSE" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/pharosium,
 /obj/item/raw_material/bohrum,
 /obj/item/raw_material/bohrum,
@@ -9605,6 +9581,7 @@
 /obj/item/raw_material/claretine,
 /obj/item/raw_material/uqill,
 /mob/living/critter/fermid,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aSF" = (
@@ -9964,12 +9941,6 @@
 /area/derelict_ai_sat)
 "aTD" = (
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body6";
-	name = "decomposed corpse"
-	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -9983,6 +9954,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/item/device/radio/electropack,
+/obj/mapping_helper/mob_spawn/corpse/human,
 /turf/simulated/floor/airless/grime,
 /area/abandonedship)
 "aTE" = (
@@ -9998,18 +9970,12 @@
 /area/abandonedship)
 "aTG" = (
 /obj/stool/bed,
-/obj/overlay{
-	desc = "Oh.  So THAT'S where he went off to.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	layer = 4;
-	name = "Iji"
-	},
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
 	},
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/airless/damaged3,
 /area/abandonedship)
 "aTH" = (
@@ -10091,9 +10057,11 @@
 /turf/simulated/floor/plating,
 /area/derelict_ai_sat)
 "aTY" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/mining_tool/powered/hammer,
 /mob/living/critter/fermid,
+/obj/mapping_helper/mob_spawn/corpse/human/miner{
+	skeletonized = 1
+	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aTZ" = (
@@ -10142,13 +10110,7 @@
 /turf/simulated/floor,
 /area/h7)
 "aUj" = (
-/obj/overlay{
-	desc = "Oh.  So THAT'S where he went off to.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	layer = 4;
-	name = "skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aUk" = (
@@ -10217,8 +10179,8 @@
 /turf/simulated/floor,
 /area/iss)
 "aUs" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/oreprospector,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aUt" = (
@@ -10282,9 +10244,11 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aUD" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/item/raw_material/cobryl,
 /obj/item/raw_material/cobryl,
+/obj/mapping_helper/mob_spawn/corpse/human/miner{
+	skeletonized = 1
+	},
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aUE" = (
@@ -10760,11 +10724,11 @@
 /area/abandonedoutpostthing)
 "aVT" = (
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/suit/bedsheet,
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor3"
 	},
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fpurple2"
@@ -11741,11 +11705,8 @@
 /area/abandonedoutpostthing)
 "aZd" = (
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 6
@@ -12874,7 +12835,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/h7/lab)
 "bdn" = (
@@ -13412,11 +13373,9 @@
 /area/helldrone)
 "bga" = (
 /obj/decal/cleanable/blood,
-/obj/decal/fakeobjects/skeleton{
-	desc = "The head seems to be gone.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body2";
-	name = "corpse"
+/obj/stool/chair,
+/obj/mapping_helper/mob_spawn/corpse/human/chef{
+	headless = 1
 	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 1
@@ -14845,11 +14804,8 @@
 /obj/item/storage/secure/ssafe/pilot_cargo1{
 	pixel_y = 32
 	},
-/obj/decal/fakeobjects/skeleton{
-	desc = "Rest in peace.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "dead pilot"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/simulated/floor/airless/plating/damaged1,
 /area/abandonedship)
@@ -18558,13 +18514,11 @@
 /turf/simulated/floor/plating,
 /area/diner/hangar)
 "kdj" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The head seems to be gone.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body2";
-	name = "corpse"
-	},
 /obj/item/clothing/under/gimmick/donkini,
+/obj/mapping_helper/mob_spawn/corpse/human/medical_doctor{
+	headless = 1
+	},
+/obj/stool/chair,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "kdO" = (
@@ -22305,10 +22259,15 @@
 	name = "air vent"
 	},
 /obj/stool/bed,
-/obj/decal/fakeobjects/skeleton,
 /obj/item/reagent_containers/pill/tox{
 	pixel_x = -8;
 	pixel_y = 16
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/syndicate{
+	skeletonized = 1;
+	delete_id = 1;
+	empty_bag = 1;
+	empty_pockets = 1
 	},
 /turf/simulated/floor,
 /area/helldrone)
@@ -22748,6 +22707,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/diner/kitchen)
+"vks" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "green";
+	icon_state = "bedsheet-green"
+	},
+/obj/window/cubicle{
+	dir = 2
+	},
+/obj/mapping_helper/mob_spawn/corpse/human/security_officer{
+	delete_id = 1;
+	empty_bag = 1;
+	empty_pockets = 1;
+	break_headset = 1;
+	skeletonized = 1
+	},
+/turf/simulated/floor,
+/area/abandonedoutpostthing)
 "vkQ" = (
 /obj/storage/secure/closet/medical/medicine,
 /turf/unsimulated/floor/white,
@@ -23071,17 +23048,14 @@
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "wnW" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "The remains of a human. The skull has a hole in it.  An extra one, I mean.";
-	layer = 2.5;
-	pixel_y = 8
-	},
 /obj/decal/cleanable/oil,
 /obj/decal/cleanable/dirt,
-/obj/item/mop,
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
+/obj/mapping_helper/mob_spawn/corpse/human/janitor{
+	skeletonized = 1
+	},
 /turf/simulated/floor/airless/damaged2,
 /area/abandonedship)
 "woo" = (
@@ -23316,7 +23290,7 @@
 /area/diner/motel)
 "wIr" = (
 /obj/item/screwdriver,
-/obj/decal/fakeobjects/skeleton,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/unsimulated/floor/black,
 /area/timewarp/ship)
 "wKo" = (
@@ -104187,7 +104161,7 @@ aDy
 aFf
 aFv
 aDy
-aGb
+vks
 aGV
 aFg
 aFg

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -798,8 +798,8 @@
 	},
 /area/mining/hangar)
 "oL" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/genetics)
 "oM" = (
@@ -909,8 +909,8 @@
 /turf/simulated/floor/grime,
 /area/mining/power)
 "pu" = (
-/obj/decal/fakeobjects/skeleton,
 /obj/decal/cleanable/blood/splatter,
+/obj/mapping_helper/mob_spawn/corpse/human/skeleton,
 /turf/simulated/floor/plating,
 /area/evilreaver/genetics)
 "pw" = (
@@ -1645,11 +1645,8 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/noGenerate)
 "tH" = (
-/obj/decal/fakeobjects/skeleton{
-	desc = "Eugh, the stench is horrible!";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "body8";
-	name = "decomposed corpse"
+/obj/mapping_helper/mob_spawn/corpse/human/head_of_personnel{
+	skeletonized = 1
 	},
 /turf/simulated/floor/plating/damaged3,
 /area/spyshack)
@@ -5826,13 +5823,7 @@
 /turf/simulated/floor/plating/damaged2,
 /area/evilreaver/genetics)
 "Vg" = (
-/obj/overlay{
-	desc = "Oh.  So THAT'S where he went off to.";
-	icon = 'icons/misc/hstation.dmi';
-	icon_state = "clowncorpse";
-	layer = 4;
-	name = "skeleton"
-	},
+/obj/mapping_helper/mob_spawn/corpse/human/clown,
 /turf/simulated/floor/plating/scorched,
 /area/evilreaver/genetics)
 "Vh" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Internal] [Secret] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces most instances of `/obj/decal/fakeobjects/skeleton` with an instance of `/obj/mapping_helper/mob_spawn/corpse/human`.

Adds additional variables and behaviors to `/obj/mapping_helper/mob_spawn/corpse/human`, namely skeletonized, armless, headless, legless, try_buckle and `var/mob/living/carbon/human/corpse`.

Corpses via corpse spawner will now, on default, attempt to buckle themselves onto any `/obj/stool` when spawned.

Also adds several subtypes to `/obj/mapping_helper/mob_spawn/corpse/human` based on a variety of jobs.

I've manually replaced every instance and have taken great care in preserving the original vibe of most replacements. i.e. when replacing a skeleton in a clown suit, replace it with `/obj/mapping_helper/mob_spawn/corpse/human/clown` and so forth.

All Captain / HoP corpses have by default their pockets, bags, IDs and headsets removed, with the exception of the HoP in the customs shuttle. The same is true for all Security Officer corpses, safe for those that may spawn randomly with a 1% chance.

All corpse replacements inside the Owlery have their IDs removed.

Additionally, a few fake corpses remain due to perhaps unique stuff based around them, particularly on the ice moon.

Note:
There are a handful of maps, such as `ships.dmm`, `lunaport.dmm`, `xg6_fermidzone.dmm` and `ships.ancienttradevessel.dmm` that I was unable to edit due to missing files, perhaps a dev could do those instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The corpse spawner is a powerful tool to generate more dynamic content, and also allows players to interact with corpses, whereas previously they were merely decoration.
