### PR TITLE
Make airbridges use glassblock floortiles

### DIFF
--- a/code/modules/animation/AnimationLibrary.dm
+++ b/code/modules/animation/AnimationLibrary.dm
@@ -1679,7 +1679,7 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 
 /proc/animate_turf_slideout_cleanup(turf/T)
 	T.layer++
-	T.underlays.Cut()
+	T.reset_underlays()
 	var/obj/overlay/tile_effect/fake_fullbright/full_light = locate() in T
 	if(full_light)
 		qdel(full_light)

--- a/code/obj/airbridge.dm
+++ b/code/obj/airbridge.dm
@@ -34,7 +34,7 @@ ADMIN_INTERACT_PROCS(/obj/airbridge_controller, proc/toggle_bridge, proc/pressur
 	var/list/obj/machinery/computer/airbr/computers = null
 
 	var/original_turf = /turf/space
-	var/floor_turf = /turf/simulated/floor/airbridge
+	var/floor_turf = /turf/simulated/floor/glassblock/transparent/cyan
 	var/wall_turf = /turf/simulated/wall/airbridge
 	var/floor_light_type = /obj/machinery/light/small/floor
 

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -892,11 +892,16 @@ TYPEINFO(/turf/simulated/floor/glassblock)
 /turf/simulated/floor/glassblock/large
 	icon_state = "glass_large"
 
+ABSTRACT_TYPE(/turf/simulated/floor/glassblock/transparent)
 /turf/simulated/floor/glassblock/transparent
 	icon_state = "glasstr_cyan"
 	default_material = "glass"
 
 	New()
+		src.add_space_underlay()
+		..()
+
+	proc/add_space_underlay()
 		var/image/I
 		#ifdef UNDERWATER_MAP
 		var/sand_icon
@@ -917,7 +922,10 @@ TYPEINFO(/turf/simulated/floor/glassblock)
 		#endif
 		I.plane = PLANE_SPACE
 		src.underlays += I
+
+	reset_underlays()
 		..()
+		src.add_space_underlay()
 
 /turf/simulated/floor/glassblock/transparent/cyan
 	icon_state = "glasstr_cyan"

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -998,6 +998,12 @@ var/global/in_replace_with = 0
   var/area/AR = src.loc
   return AR.sanctuary
 
+/// used to reset turf underlays, when you are replacing a turf with some underlays on it with a new turf that has its own underlays
+/turf/proc/reset_underlays()
+	SHOULD_CALL_PARENT(TRUE)
+	src.underlays.Cut()
+	return
+
 ///turf/simulated/floor/Entered(atom/movable/A, atom/OL) //this used to run on every simulated turf (yes walls too!) -zewaka
 //	..()
 //moved step and slip functions into Carbon and Human files!


### PR DESCRIPTION
[MAPPING][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes map airbridges use cyan colored glassblock floortiles. Able to show both space (with shining stars) and parallax underneath

![image](https://github.com/goonstation/goonstation/assets/53062374/30a43e95-349f-48d2-8bf4-5f8e405d7da0)

![image](https://github.com/goonstation/goonstation/assets/53062374/279afcf0-2925-4fbf-bf3e-77540843663a)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Thought it would be cool to add them to airbridges, if it doesn't look bad?