### PR TITLE
Fix runtime when disposing bunsen burner

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -1211,6 +1211,7 @@ proc/ui_describe_reagents(atom/A)
 		burning_light = src.AddComponent(/datum/component/loctargeting/simple_light, 255, 255, 255, 150)
 		burning_light.update(FALSE)
 		..()
+		START_TRACKING
 
 	get_desc()
 		if(!is_currently_burning)

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -1211,17 +1211,12 @@ proc/ui_describe_reagents(atom/A)
 		burning_light = src.AddComponent(/datum/component/loctargeting/simple_light, 255, 255, 255, 150)
 		burning_light.update(FALSE)
 		..()
-		START_TRACKING
 
 	get_desc()
 		if(!is_currently_burning)
 			. = " It's presently off."
 		else
 			. = " Its flame is set to [temperature_setting]."
-
-	disposing()
-		STOP_TRACKING
-		..()
 
 	process()
 		if (QDELETED(src.current_container))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS] [RUNTIME]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add `START_TRACKING` to bunsen burner to match `STOP_TRACKING` in `disposing()`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![image](https://github.com/goonstation/goonstation/assets/75404941/4511a54b-f754-493b-80f4-e8ef6d69d163)

