### PR TITLE
fix runtime on null area for airlock init

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -85,7 +85,7 @@ var/global/list/cycling_airlocks = list()
 	..()
 	if(!isrestrictedz(src.z) && src.name == initial(src.name)) //The second half prevents varedited names being overwritten
 		var/area/station/A = get_area(src)
-		if (!isnull(A)) // Fabricators
+		if (!isnull(A))
 			src.name = A.name
 	src.net_access_code = rand(1, NET_ACCESS_OPTIONS)
 	START_TRACKING

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -85,7 +85,8 @@ var/global/list/cycling_airlocks = list()
 	..()
 	if(!isrestrictedz(src.z) && src.name == initial(src.name)) //The second half prevents varedited names being overwritten
 		var/area/station/A = get_area(src)
-		src.name = A.name
+		if (!isnull(A)) // Fabricators
+			src.name = A.name
 	src.net_access_code = rand(1, NET_ACCESS_OPTIONS)
 	START_TRACKING
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Discovered when I was initializing things with fabricator code to get their material names and tried an airlock

This just adds a simple null check before doing src.name = A.name to prevent this runtime, it should be fine to init these things in null areas

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it easier to check vars/icons of things which change after init when you dont need to give them the right conditions to init without runtimes