### PR TITLE
Fix bug that doubled bites_left for vendor pizzas.

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -935,7 +935,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/mixer)
 /datum/cookingrecipe/oven/pizza_custom
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pizza_base
 	cookbonus = 18
-	output = /obj/item/reagent_containers/food/snacks/pizza
+	output = /obj/item/reagent_containers/food/snacks/pizza/bespoke
 	category = "Pizza"
 
 	specialOutput(obj/submachine/ourCooker)

--- a/code/modules/food_and_drink/pizza.dm
+++ b/code/modules/food_and_drink/pizza.dm
@@ -547,7 +547,7 @@
 	initial_reagents = list("bread" = 2, "juice_tomato" = 2, "cheese" = 1, "space_fungus" = 4)
 
 /obj/item/reagent_containers/food/snacks/pizzaslice/vendor
-	name = "slice of fresh basic pizza"
+	name = "slice of basic pizza"
 	desc = "A slice of base vendor pizza (you shouldn't see this)."
 	fill_amt = 1
 	bites_left = 1

--- a/code/modules/food_and_drink/pizza.dm
+++ b/code/modules/food_and_drink/pizza.dm
@@ -156,18 +156,18 @@
 	Eat(mob/M as mob, mob/user, by_matter_eater = TRUE)
 		if(!by_matter_eater)
 			return 0
-		var/obj/item/reagent_containers/food/snacks/pizza/unbaked_pizza = src.bake_pizza(TRUE)
+		var/obj/item/reagent_containers/food/snacks/pizza/bespoke/unbaked_pizza = src.bake_pizza(TRUE)
 		return unbaked_pizza.Eat(M, user, TRUE)
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		if (temperature >= T0C+3200) // syndicate zippos and raging plasmafires, for laughs
-			var/obj/item/reagent_containers/food/snacks/pizza/baked_pizza = src.bake_pizza()
+			var/obj/item/reagent_containers/food/snacks/pizza/bespoke/baked_pizza = src.bake_pizza()
 			baked_pizza.visible_message(SPAN_NOTICE("\The [baked_pizza.name] roasts from heat!"))
 			baked_pizza.quality = 5
 		. = ..()
 
 	proc/bake_pizza(var/matter_eater_fake_bake = FALSE)
-		var/obj/item/reagent_containers/food/snacks/pizza/baked_pizza = new(src.loc)
+		var/obj/item/reagent_containers/food/snacks/pizza/bespoke/baked_pizza = new(src.loc)
 
 		//locate a potential chef
 		var/mob/living/carbon/human/baker
@@ -296,9 +296,10 @@
 
 		return baked_pizza
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizza)
 /obj/item/reagent_containers/food/snacks/pizza
 	name = "pizza"
-	desc = "A sauceless, cheeseless pizza."
+	desc = "A sauceless, cheeseless pizza (you shouldn't see this)."
 	icon = 'icons/obj/foodNdrink/food_meals.dmi'
 	icon_state = "pizzacrust"
 	fill_amt = 1
@@ -365,9 +366,14 @@
 			pizza_slice.mat_changedesc = 1
 		..()
 
+/obj/item/reagent_containers/food/snacks/pizza/bespoke
+	desc = "A sauceless, cheeseless pizza."
+	slice_product = /obj/item/reagent_containers/food/snacks/pizzaslice/bespoke
+
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizzaslice)
 /obj/item/reagent_containers/food/snacks/pizzaslice
 	name = "pizza slice"
-	desc = "A slice of cheeseless, sauceless pizza."
+	desc = "A slice of cheeseless, sauceless pizza (you shouldn't see this)."
 	icon = 'icons/obj/foodNdrink/food_meals.dmi'
 	icon_state = "pizzacrustslice"
 	fill_amt = 1
@@ -435,6 +441,10 @@
 			take_bleeding_damage(hit_atom, null, 25, DAMAGE_STAB)
 		. = ..()
 
+/obj/item/reagent_containers/food/snacks/pizzaslice/bespoke
+	desc = "A slice of sauceless, cheeseless pizza."
+
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizza/standard)
 /obj/item/reagent_containers/food/snacks/pizza/standard
 	name = "fresh basic pizza"
 	desc = "Base non-bespoke oven pizza (you shouldn't see this)."
@@ -473,6 +483,7 @@
 	initial_reagents = list("bread" = 10, "juice_tomato" = 10, "cheese" = 5, "space_fungus" = 20)
 	slice_product = /obj/item/reagent_containers/food/snacks/pizzaslice/standard/mushroom
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizza/vendor)
 /obj/item/reagent_containers/food/snacks/pizza/vendor
 	name = "vendor pizza"
 	desc = "Base vendor pizza (you shouldn't see this)."
@@ -518,6 +529,7 @@
 	initial_reagents = list("bread" = 5, "juice_tomato" = 5, "cheese" = 5, "juice_pineapple" = 15, "badgrease" = 20)
 	slice_product = /obj/item/reagent_containers/food/snacks/pizzaslice/vendor/pineapple
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizzaslice/standard)
 /obj/item/reagent_containers/food/snacks/pizzaslice/standard
 	name = "slice of fresh basic pizza"
 	desc = "A slice of base oven pizza (you shouldn't see this)."
@@ -546,6 +558,7 @@
 	desc = "A cheesy pizza slice topped with fresh picked mushrooms."
 	initial_reagents = list("bread" = 2, "juice_tomato" = 2, "cheese" = 1, "space_fungus" = 4)
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizzaslice/vendor)
 /obj/item/reagent_containers/food/snacks/pizzaslice/vendor
 	name = "slice of basic pizza"
 	desc = "A slice of base vendor pizza (you shouldn't see this)."
@@ -580,6 +593,7 @@
 	contraband = 1
 	initial_reagents = list("bread" = 1, "juice_tomato" = 1, "cheese" = 1, "juice_pineapple" = 3, "badgrease" = 4)
 
+ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizza/cargo)
 /obj/item/reagent_containers/food/snacks/pizza/cargo
 	name = "soft serve base pizza"
 	desc = "A pizza shipped from god knows where straight to cargo."

--- a/code/modules/food_and_drink/pizza.dm
+++ b/code/modules/food_and_drink/pizza.dm
@@ -546,7 +546,7 @@
 	desc = "A cheesy pizza slice topped with fresh picked mushrooms."
 	initial_reagents = list("bread" = 2, "juice_tomato" = 2, "cheese" = 1, "space_fungus" = 4)
 
-/obj/item/reagent_containers/food/snacks/pizzaslice/standard
+/obj/item/reagent_containers/food/snacks/pizzaslice/vendor
 	name = "slice of fresh basic pizza"
 	desc = "A slice of base vendor pizza (you shouldn't see this)."
 	fill_amt = 1

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -295,7 +295,7 @@ ABSTRACT_TYPE(/datum/siphon_mineral)
 	tick_req = 21
 	shear = 69
 	sens_window = 0
-	product = /obj/item/reagent_containers/food/snacks/pizza
+	product = /obj/item/reagent_containers/food/snacks/pizza/standard/pepperoni
 
 /datum/siphon_mineral/weed
 	indexed = FALSE

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -34793,8 +34793,7 @@
 /obj/machinery/traymachine/morgue{
 	dir = 2
 	},
-/obj/item/reagent_containers/food/snacks/pizza{
-	icon_state = "pizza_m";
+/obj/item/reagent_containers/food/snacks/pizza/standard/meatball{
 	pixel_y = 10
 	},
 /obj/machinery/light/incandescent/cool{

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -36671,7 +36671,7 @@
 "kNM" = (
 /obj/storage/secure/closet/fridge,
 /obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/pizza,
+/obj/item/reagent_containers/food/snacks/pizza/standard/mushroom,
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
 	nostick = 1;

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -1600,7 +1600,7 @@
 /area/station/crew_quarters/bar)
 "aHO" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/snacks/pizza,
+/obj/item/reagent_containers/food/snacks/pizza/standard/mushroom,
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/fungus,
 /turf/simulated/floor/carpet/purple/standard/edge/se,
@@ -43736,7 +43736,7 @@
 /obj/storage/closet,
 /obj/item/razor_blade,
 /obj/item/scissors,
-/obj/item/reagent_containers/food/snacks/pizza,
+/obj/item/reagent_containers/food/snacks/pizza/standard/cheese,
 /obj/item/kitchen/utensil/knife/pizza_cutter,
 /obj/item/plate,
 /obj/machinery/light/small/cool{
@@ -46799,7 +46799,7 @@
 /area/station/maintenance/inner/central)
 "uGD" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/snacks/pizza{
+/obj/item/reagent_containers/food/snacks/pizza/standard/cheese{
 	pixel_y = -10
 	},
 /obj/item/paper/book/from_file/cookbook,

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -8031,7 +8031,7 @@
 	dir = 1
 	},
 /obj/table/auto,
-/obj/item/reagent_containers/food/snacks/pizza{
+/obj/item/reagent_containers/food/snacks/pizza/standard/cheese{
 	desc = "A plain cheese and tomato pizza. I wonder if you could fit this in a keyhole.";
 	name = "cheese keyzza"
 	},
@@ -29677,7 +29677,7 @@
 /turf/unsimulated/floor/carpet/arcade,
 /area/sim/racing_entry)
 "cmJ" = (
-/obj/item/reagent_containers/food/snacks/pizza,
+/obj/item/reagent_containers/food/snacks/pizza/standard/pepperoni,
 /obj/table/wood/round/auto,
 /turf/unsimulated/floor/carpet/arcade,
 /area/sim/racing_entry)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CATERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Very simple, just fixes a one word typo from my pizza rework that caused vendor pizza slices to inherit from the base pizza slice instead of the worse vendor pizzaslice I had as their parent. I wanted to fix this by making bites_left inherit from the sliced parent / slices, but that means the humble orange would have like 6 bites or something, so I couldn't.
Also because Zewaka knows I will never make a `size/XS` PR, this also abstracts pizzas that shouldn't exist.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Whoops, I accidentally made a vendor pizza have 2 bites per slice, which made the 100c pizzas roughly comparable to high tier chef food for RP server hunger restoration.
