### PR TITLE
Afterlife bar respects bald trait

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -634,6 +634,13 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 		role_override = "Staff Assistant"
 	newbody.JobEquipSpawned(role_override || src.mind.assigned_role, no_special_spawn = 1)
 
+	if (newbody.traitHolder && newbody.traitHolder.hasTrait("bald"))
+		newbody.stow_in_available(newbody.create_wig())
+		newbody.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
+		newbody.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
+		newbody.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+		newbody.update_colorful_parts()
+
 	// No contact between the living and the dead.
 	var/obj/to_del = newbody.ears
 	if(to_del)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the functionality that makes bald trait holder spawn with wig to the afterlife bar spawn proc

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Zamu said it would be fine just a matter of figuring out how to make afterlife bar do it and I figured it out with help from my talented and incredible best friend
https://forum.ss13.co/showthread.php?tid=22577

Feel free to rewrite this code if you think it could be better and I will just add that instead I am not attached
Tested with mutantrace and with human and both worked! 
![image](https://github.com/goonstation/goonstation/assets/142273065/b8b012b5-bb0f-4757-a9df-1c61fce48b48)


[feature][traits][respawning][joelBestHits2024]
