### PR TITLE
Make syndicate shrub mechscannable

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -410,8 +410,11 @@
 		icon_state = "shrub-dead"
 
 //It'll show up on multitools
+TYPEINFO(/obj/shrub/syndicateplant)
+	mats = 2
 /obj/shrub/syndicateplant
 	var/net_id
+	is_syndicate = TRUE
 	New()
 		. = ..()
 		var/turf/T = get_turf(src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make the syndicate shrub scannable with the syndicate mech scanner

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

why not