### PR TITLE
fix tanning bed colour

### DIFF
--- a/code/obj/machinery/traymachines.dm
+++ b/code/obj/machinery/traymachines.dm
@@ -633,15 +633,15 @@ ABSTRACT_TYPE(/obj/machine_tray)
 		tanningtube.name = "stock tanning light tube"
 		tanningtube.desc = "Fancy. But not really."
 		tanningtube.color_r = 0.7
-		tanningtube.color_g = 0.5
-		tanningtube.color_b = 0.3
+		tanningtube.color_g = 0.3
+		tanningtube.color_b = 0.5
 
 		light = new /datum/light/point
 		light.attach(src)
 		light.set_brightness(0.5)
 		light.set_color(tanningtube.color_r, tanningtube.color_g, tanningtube.color_b)
 
-		var/tanningtubecolor = rgb(tanningtube.color_r * 255, tanningtube.color_b * 255, tanningtube.color_g * 255)
+		var/tanningtubecolor = rgb(tanningtube.color_r * 255, tanningtube.color_g * 255, tanningtube.color_b * 255)
 
 		generate_overlay_icon(tanningtubecolor)
 
@@ -660,7 +660,7 @@ ABSTRACT_TYPE(/obj/machine_tray)
 			user.drop_item()
 			G.set_loc(src)
 			src.tanningtube = G
-			var/tanningtubecolor = rgb(tanningtube.color_r * 255, tanningtube.color_b * 255, tanningtube.color_g * 255)
+			var/tanningtubecolor = rgb(tanningtube.color_r * 255, tanningtube.color_g * 255, tanningtube.color_b * 255)
 			generate_overlay_icon(tanningtubecolor)
 			send_new_tancolor(tanningtubecolor)
 			if (src.light)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][small][a-game-objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an oversight in tanning bed tray code that'd swap the rube's green and blue components around. Also swaps the blue and green components for the stock tube around so that the default tanning colour remains the same. Not that the difference is that huge, it's pinkish now when it'd be orange otherwise.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The tanning bed would react unpredictably to swapping the tube, with a purple tube turning you bright yellow for instance.