### PR TITLE
Fix inverted conditioning on pulse tool fail condition

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -542,7 +542,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 							src.mend(usr, text2num_safe(params["wire"]))
 						return TRUE
 				if ("pulse")
-					if (!ispulsingtool(usr.equipped()) || (isAI(usr) || isrobot(usr)))
+					if (!ispulsingtool(usr.equipped()) && !(isAI(usr) || isrobot(usr)))
 						src.grump_message(usr, "You need to be holding a pulsing tool or similar for that!")
 						return
 					if (!((src.can_use_ranged(usr) || src.has_physical_proximity(usr))))

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -542,7 +542,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 							src.mend(usr, text2num_safe(params["wire"]))
 						return TRUE
 				if ("pulse")
-					if (!ispulsingtool(usr.equipped()) && !(isAI(usr) || isrobot(usr)))
+					if (!ispulsingtool(usr.equipped()))
 						src.grump_message(usr, "You need to be holding a pulsing tool or similar for that!")
 						return
 					if (!((src.can_use_ranged(usr) || src.has_physical_proximity(usr))))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Must have forgot to invert when i condensed the fail condition, its supposed to not fail when they are an AI or robot for pulsing,

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

They should be able to pulse wires, fixes #18944

