### PR TITLE
Fix medicine category not showing up

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -409,7 +409,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 		for (var/datum/manufacture/M as anything in L)
 			if (!(M.category in src.categories)) // fix for not displaying blueprints/manudrives
 				M.category = "Miscellaneous"
-				// "WARN: bad category on TYPEPATH"
 			if (length(as_list[M.category]) == 0)
 				as_list[M.category] = list()
 			as_list[M.category] += list(manufacture_as_list(M, user, static_elements))

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -409,6 +409,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		for (var/datum/manufacture/M as anything in L)
 			if (isnull(M.category) || !(M.category in src.categories)) // fix for not displaying blueprints/manudrives
 				M.category = "Miscellaneous"
+				logTheThing(LOG_DEBUG, src, "Manufacturing blueprint [M] has category [M.category], which is not on the list of categories for [src]!")
 			if (length(as_list[M.category]) == 0)
 				as_list[M.category] = list()
 			as_list[M.category] += list(manufacture_as_list(M, user, static_elements))

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -407,7 +407,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	proc/blueprints_as_list	(var/list/L, mob/user, var/static_elements = FALSE)
 		var/list/as_list = list()
 		for (var/datum/manufacture/M as anything in L)
-			if (!(M.category in src.categories)) // fix for not displaying blueprints/manudrives
+			if (isnull(M.category) || !(M.category in src.categories)) // fix for not displaying blueprints/manudrives
 				M.category = "Miscellaneous"
 			if (length(as_list[M.category]) == 0)
 				as_list[M.category] = list()

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -76,7 +76,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	// Production options
 	var/search = null
 	var/category = null
-	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Miscellaneous", "Downloaded")
+	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Medicine", "Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE
 	var/list/available = list() //! A list of every option available in this unit subtype by default
 	var/list/download = list() //! Options gained from scanned blueprints
@@ -407,8 +407,9 @@ TYPEINFO(/obj/machinery/manufacturer)
 	proc/blueprints_as_list	(var/list/L, mob/user, var/static_elements = FALSE)
 		var/list/as_list = list()
 		for (var/datum/manufacture/M as anything in L)
-			if (isnull(M.category)) // fix for not displaying blueprints/manudrives
+			if (!(M.category in src.categories)) // fix for not displaying blueprints/manudrives
 				M.category = "Miscellaneous"
+				// "WARN: bad category on TYPEPATH"
 			if (length(as_list[M.category]) == 0)
 				as_list[M.category] = list()
 			as_list[M.category] += list(manufacture_as_list(M, user, static_elements))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Medicine category was forgotten and now anything which fits in there isnt shown

Also designates anything not in the known list of categories to be assigned to the "Miscellaneous" category where normally only those with null category vars would end up

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a bug that someone reported in imcoder but i dont think has been reported yet
https://discord.com/channels/182249960895545344/890226559691157524/1240814895247917077
Thank you Vanni!