### PR TITLE
Fix ejecting less than a full stack of material from fabs voiding instead of doing its job

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1062,7 +1062,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 			P.setMaterial(target.material)
 			P.change_stack_amount(ejectamt - P.amount)
 			target.change_stack_amount(-ejectamt)
-			src.storage.transfer_stored_item(P, ejectturf)
+			P.set_loc(ejectturf)
 
 	proc/scan_card(obj/item/I)
 		var/obj/item/card/id/ID = get_id_card(I)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, honestly, changes the check to transfer from storage (WRONG) to transfer the item that was JUST created to the ejectturf (CORRECT)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18952
