### PR TITLE
Make thermite breaching charges use chemfire

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1502,29 +1502,13 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 			playsound(location, 'sound/effects/bamf.ogg', 100, 0.5)
 			src.invisibility = INVIS_ALWAYS
 
+			fireflash(location, src.expl_range, 2000, checkLos = FALSE, chemfire = CHEM_FIRE_DARKRED)
+
 			for (var/turf/T in range(src.expl_range, location))
 				if( T?.loc:sanctuary ) continue
 				if (!istype(T, /turf/simulated/wall) && !istype(T, /turf/simulated/floor))
 					continue
 
-				T.hotspot_expose(2000, 125)
-
-				var/obj/overlay/O = new/obj/overlay(T)
-				O.name = "Thermite"
-				O.desc = "A searing wall of flames."
-				O.icon = 'icons/effects/fire.dmi'
-				O.anchored = ANCHORED
-				O.layer = TURF_EFFECTS_LAYER
-				O.color = "#ff9a3a"
-				var/datum/light/point/light = new
-				light.set_brightness(1)
-				light.set_color(0.5, 0.3, 0.0)
-				light.attach(O)
-
-				if (istype(T,/turf/simulated/wall))
-					O.set_density(1)
-				else
-					O.set_density(0)
 
 				var/distance = GET_DIST(T, location)
 				if (distance < 2)
@@ -1533,7 +1517,6 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 					if (istype(T, /turf/simulated/wall/auto/feather))
 						var/turf/simulated/wall/auto/feather/flockwall = T
 						flockwall.takeDamage("fire", 1)
-						O.icon_state = "2"
 						if (flockwall.health <= 0)
 							flockwall.destroy()
 					else if (istype(T, /turf/simulated/wall))
@@ -1544,12 +1527,6 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 
 					if (F && istype(F))
 						F.to_plating()
-						F.burn_tile()
-						O.icon_state = "2"
-				else
-					O.icon_state = "1"
-					if (istype(T, /turf/simulated/floor))
-						var/turf/simulated/floor/F = T
 						F.burn_tile()
 
 			for (var/obj/machinery/door/DR in src.loc)
@@ -1586,11 +1563,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 				M.update_burning(damage)
 
 			SPAWN(10 SECONDS)
-				if (src)
-					for (var/obj/overlay/O in range(src.expl_range, location))
-						if (O.name == "Thermite")
-							qdel(O)
-					qdel(src)
+				qdel(src)
 		else
 			qdel(src)
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1502,8 +1502,6 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 			playsound(location, 'sound/effects/bamf.ogg', 100, 0.5)
 			src.invisibility = INVIS_ALWAYS
 
-			fireflash(location, src.expl_range, 2000, checkLos = FALSE, chemfire = CHEM_FIRE_DARKRED)
-
 			for (var/turf/T in range(src.expl_range, location))
 				if( T?.loc:sanctuary ) continue
 				if (!istype(T, /turf/simulated/wall) && !istype(T, /turf/simulated/floor))
@@ -1555,6 +1553,9 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 					var/obj/machinery/door/firedoor/firelock = O
 					qdel(firelock)
 					continue
+
+			// placed here so that fire appears in place of destroyed turfs
+			fireflash(location, src.expl_range, 2000, checkLos = FALSE, chemfire = CHEM_FIRE_DARKRED)
 
 			for (var/mob/living/M in range(src.expl_range, location))
 				if(check_target_immunity(M)) continue


### PR DESCRIPTION
[GAME OBJECTS][REWORK][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes thermite breaching charges use chemfires instead of overlays

![image](https://github.com/goonstation/goonstation/assets/53062374/07bb4581-341b-4ea8-b64b-662b3aa80394)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wanted to use the darkred fire for thermite fires

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Thermite breaching charges now create a dark red chemical fire and are a bit more dangerous
```