### PR TITLE
 Fix "Cant craft chemical barrel with tgui fabricator even with proper materials."

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1655,7 +1655,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 					mats_available[P_id] = P.amount * 10
 				if (mats_available[P_id] < required_amount)
 					continue
-				if (required_pattern == "ALL" || (required_pattern in src.material_patterns_by_id[P_id]))
+				if (required_pattern == "ALL" || (required_pattern in src.material_patterns_by_id[P_id]) || P_id == required_pattern)
 					mats_used[required_pattern] = P_id
 					mats_available[P_id] -= required_amount
 					break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Somehow I didnt notice this wasnt being checked on the DM side. Now you can make chembarrells and cerenkite batteries again. I fabricated them, it works.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18966 
