### PR TITLE
Lower surplus crate cost from 12 to 11 telecrystals

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -428,7 +428,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 /datum/syndicate_buylist/traitor/surplus
 	name = "Surplus Crate"
 	item = /obj/storage/crate/syndicate_surplus
-	cost = 12
+	cost = 11
 	vr_allowed = FALSE
 	desc = "A crate containing 18-24 credits worth of whatever junk we had lying around."
 	can_buy = UPLINK_TRAITOR


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the cost of a surplus crate from 12 to 11 tokens.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Surplus crates are cool. However, taking one, means not getting an agent card, and as such not access to the syndicate outpost, which is arguably a really neat RP-friendly part of being a traitor. As such, people have to make the awkward decision of deciding to go lone wolf with a surplus, or instead skipping it altogether in favor of the agent card.

An alternate approach to this could be to lower the surplus content amount to a value closer to 20, and then dropping the price cost to 10, I'm open to suggestions, but figured this is the easiest way to approach it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Surplus crates now only cost 11 telecrystals.
```
