### PR TITLE
Allow robotic critters to throw items

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1618,6 +1618,7 @@ ABSTRACT_TYPE(/mob/living/critter/robotic)
 	name = "a fucked up robot"
 	butcherable = BUTCHER_NOT_ALLOWED
 	can_bleed = FALSE
+	can_throw = TRUE
 	metabolizes = FALSE
 	var/emp_vuln = 1
 	blood_id = null


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows robotic critters to throw items they pick up, if applicable.
This primarily affects player-controlled antagonist critters, such as gunbots, emagged cleanbots/firebots.
Scuttlebots already could throw items.

I was going to try and enable spacemove too but it seems they carry momentum in space just fine. Just so happens they don't have as easy a time finding items to throw due to only having a handslot, so this happens a lot to them vs. humans.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Quite often it is a complaint (and something I have experienced a few times myself) that these bots can fail to drift in space, and get eternally stuck even when holding an item. This makes it possible for, well, mainly emagged bot critters to initiate some sort of spacemove when otherwise they'd be stuck forever.

Fixes #18955, even though it was intended by omission to begin with.
Fixes #11611, same as above.
Fixes #13040, not really but it should be closed incidentally since they can move in space now.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MeggalBozale
(+)Robotic critters can now throw items.
```
