### PR TITLE
Ensure rubbers and organics have ORG|RUB added to the patterns they satisfy

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1587,8 +1587,11 @@ TYPEINFO(/obj/machinery/manufacturer)
 			return .
 		if (material_flags & MATERIAL_RUBBER)
 			. += "RUB"
+			. += "ORG|RUB"
 		if (material_flags & MATERIAL_ORGANIC)
 			. += "ORG"
+			if (!("ORG|RUB" in .))
+				. += "ORG|RUB"
 		if (material_flags & MATERIAL_WOOD)
 			. += "WOOD"
 		if (material_flags & MATERIAL_METAL)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Another weird edge case to material patterns which screams of not needing to exist but would be an undertaking vs. handling
Fixes not being able to make stuff like light space suits. Sorry powergamers 

