### PR TITLE
Add more projectile hit feedback for bots

### DIFF
--- a/code/modules/animation/AnimationLibrary.dm
+++ b/code/modules/animation/AnimationLibrary.dm
@@ -210,8 +210,11 @@
 	src.sprint_particle = new /obj/particle/attack/sprint //don't use pooling for these particles
 
 /obj/particle/attack
+	var/belongs_to_mob = TRUE
 
 	disposing() //kinda slow but whatever, block that gc ok
+		if (!src.belongs_to_mob)
+			return
 		for (var/mob/M in mobs)
 			if (M.attack_particle == src)
 				M.attack_particle = null
@@ -231,6 +234,9 @@
 		plane = PLANE_OVERLAY_EFFECTS
 		appearance_flags = TILE_BOUND | PIXEL_SCALE
 
+	bot_hit
+		icon = 'icons/mob/mob.dmi'
+		belongs_to_mob = FALSE
 
 
 /mob/var/obj/particle/attack/attack_particle

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -145,7 +145,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/bot, proc/admin_command_speak)
 	bullet_act(var/obj/projectile/P)
 		if (!P || !istype(P))
 			return
-		hit_twitch(src)
 
 		var/damage = 0
 		damage = round(((P.power/4)*P.proj_data.ks_ratio), 1.0)
@@ -216,11 +215,25 @@ ADMIN_INTERACT_PROCS(/obj/machinery/bot, proc/admin_command_speak)
 			. += SPAN_ALERT("<B>[src]'s parts look very loose!</B>")
 
 /obj/machinery/bot/proc/hitbyproj(source, obj/projectile/P)
-	if((P.proj_data.damage_type & (D_KINETIC | D_ENERGY | D_SLASHING)) && P.proj_data.ks_ratio > 0)
-		P.initial_power -= 10
-		if(P.initial_power <= 0)
-			src.bullet_act(P) // die() prevents the projectile from calling bullet_act normally
-			P.die()
+	hit_twitch(src)
+	if((P.proj_data.damage_type & (D_KINETIC | D_ENERGY | D_SLASHING)))
+		if (!ON_COOLDOWN(src, "projectile_bot_hit", 0.5 SECONDS))
+			var/obj/particle/attack/bot_hit/hit_particle = new
+			hit_particle.set_loc(src.loc)
+			hit_particle.transform.Turn(rand(0, 360))
+			if (P.proj_data.damage > 1)
+				flick("block_spark", hit_particle)
+				if (P.proj_data.damage_type & D_KINETIC)
+					playsound(src, "sound/weapons/ricochet/ricochet-[rand(1, 4)].ogg", 40, TRUE) // replace with more unique sound if found later
+			else
+				flick("block_spark_armor", hit_particle)
+				if (P.proj_data.damage_type & D_ENERGY)
+					playsound(src, 'sound/effects/sparks6.ogg', 40, TRUE)
+		if (P.proj_data.ks_ratio > 0)
+			P.initial_power -= 10
+			if(P.initial_power <= 0)
+				src.bullet_act(P) // die() prevents the projectile from calling bullet_act normally
+				P.die()
 	if(!src.density)
 		return PROJ_OBJ_HIT_OTHER_OBJS | PROJ_ATOM_PASSTHROUGH
 


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds more hit feedback for when projectiles hit bots like secbots, guardbuddies, and floorbots

They now have attack sparks and sound effects when hit. Secbots also now get hit twitches


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it easier to tell when one of your bullets or taser shots hits a secbot or other bot

Helps for nukies/traitors too when you are specifically trying to hit them


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Added attack sparks, sound effects, and hit twitches to bots, for projectile collisions
```
