### PR TITLE
Fix rockworms never actually "digesting" the rocks they eat

### DIFF
--- a/code/mob/living/critter/ai/rockworm.dm
+++ b/code/mob/living/critter/ai/rockworm.dm
@@ -16,7 +16,7 @@
 
 /datum/aiTask/sequence/goalbased/critter/eat/worm/New(parentHolder, transTask)
 	..()
-	src.subtasks -= /datum/aiTask/succeedable/critter/eat
+	remove_task(holder.get_instance(/datum/aiTask/succeedable/critter/eat, list(src.holder)))
 	add_task(holder.get_instance(/datum/aiTask/succeedable/critter/eat/worm, list(src.holder)))
 
 /datum/aiTask/succeedable/critter/eat/worm/on_tick()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Did you know that rockworms ~~pooping~~ vomiting gems after eating stuff was broken this whole time? I didn't!

This PR modifies the removing of the subtask to actually... do that, so they vomit out gems and uqill and stuff

To explain the bug that was happening as I did in the Discord:

> It ate, but it was eating like any other critter would eat. It had tasks in the following order:
> [1] wander
> [2] eat (critter)
> [3] eat (rockworm)
> so first it wanders to a rock, then it eats the rock (qdel and all), then it tries to eat the rock again, and do the special code things that increment the rockworm's variable for how much of rocks it ate so far

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://github.com/goonstation/goonstation/assets/27376947/77e9184e-10dd-43b3-905c-63248b407313)
Lets this feature actually work ;P

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)MeggalBozale
(+)Rockworms properly eat rocks again.
```
