### PR TITLE
Reduce heat bleed of Clarion's Toxins burn chamber

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -738,8 +738,8 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "acH" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	name = "chamber inlet connector west"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
 	},
 /obj/machinery/light_switch/west{
 	dir = 4
@@ -750,8 +750,7 @@
 	name = "autoname  - SS13";
 	pixel_x = -10
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/blue,
+/turf/simulated/floor,
 /area/station/science/lab)
 "acQ" = (
 /turf/simulated/floor/black,
@@ -1557,6 +1556,12 @@
 	name = "very reinforced wall"
 	},
 /area/station/turret_protected/ai_upload)
+"aqr" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "aqu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
@@ -7158,12 +7163,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "aVa" = (
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/obj/machinery/networked/test_apparatus/gas_sensor{
-	setup_tag = "LEFT"
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 4
 	},
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "aVd" = (
 /turf/simulated/floor/blackwhite{
@@ -9233,17 +9236,7 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/lab)
-"bgX" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor,
-/area/station/science/lab)
 "bgY" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
 /obj/table/reinforced/auto,
 /obj/item/clipboard,
 /obj/item/paper_bin,
@@ -9474,7 +9467,6 @@
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/atmospheric,
 /obj/item/device/analyzer/atmospheric,
@@ -9630,10 +9622,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bkG" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor,
-/area/station/science/lab)
 "bkH" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor,
@@ -9790,28 +9778,27 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "blL" = (
-/obj/machinery/atmospherics/binary/pump/active{
-	frequency = 1229;
-	id = "Chamber Inlet";
-	name = "chamber inlet pump";
-	target_pressure = 1000
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/meter,
+/obj/machinery/door_control{
+	id = "tox_one";
+	name = "Chamber Exhaust";
+	pixel_x = -24;
+	pixel_y = 8
 	},
-/obj/machinery/activation_button/ignition_switch{
-	id = "tox_ignition1";
-	name = "Chamber Ignition Switch";
-	pixel_x = -24
+/obj/machinery/door_control{
+	id = "tox_hs_one";
+	name = "Chamber Heat Shield";
+	pixel_x = -24;
+	pixel_y = -8
 	},
-/turf/simulated/floor/blue,
+/turf/simulated/floor,
 /area/station/science/lab)
 "blM" = (
-/obj/machinery/atmospherics/binary/pump/active{
-	dir = 1;
-	frequency = 1229;
-	id = "Chamber Outlet";
-	name = "chamber outlet pump";
-	target_pressure = 1000
+/obj/machinery/atmospherics/binary/valve{
+	name = "mixing valve"
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/science/lab)
 "blN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -9948,30 +9935,13 @@
 "bmX" = (
 /turf/simulated/floor/grime,
 /area/station/science/artifact)
-"bna" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/obj/machinery/meter,
-/obj/machinery/door_control{
-	id = "tox_one";
-	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/door_control{
-	id = "tox_hs_one";
-	name = "Chamber Heat Shield";
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/turf/simulated/floor/blue,
-/area/station/science/lab)
 "bnb" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/red,
-/area/station/science/lab)
-"bnc" = (
-/obj/machinery/light,
+/obj/machinery/atmospherics/binary/pump/active{
+	frequency = 1229;
+	id = "Chamber Inlet";
+	name = "chamber inlet pump";
+	target_pressure = 1000
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "bnd" = (
@@ -10382,35 +10352,34 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bpw" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/outlet_injector/active{
-	dir = 1
-	},
-/obj/machinery/sparker{
-	id = "tox_ignition1";
-	layer = 7;
-	name = "Mounted Igniter";
-	pixel_x = -20
-	},
-/turf/simulated/floor/engine/vacuum{
-	dir = 8;
-	icon_state = "engine_caution_corners"
-	},
-/area/station/science/lab)
-"bpz" = (
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 8
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
-"bpA" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
+	dir = 8;
 	level = 2
 	},
 /turf/simulated/floor/plating,
+/area/station/science/lab)
+"bpz" = (
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"bpA" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/simulated/floor/engine/vacuum{
+	dir = 4;
+	icon_state = "engine_caution_corners"
+	},
 /area/station/science/lab)
 "bpC" = (
 /obj/cable{
@@ -10485,41 +10454,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "bqz" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -10
+/turf/simulated/floor/plating,
+/area/station/science/lab)
+"bqB" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
 /turf/simulated/floor/engine/vacuum{
 	icon_state = "engine_caution_west"
 	},
 /area/station/science/lab)
-"bqA" = (
-/obj/machinery/door/poddoor/blast/single{
-	id = "tox_one";
-	layer = 4;
-	name = "Mixture Vent"
-	},
-/turf/simulated/floor/engine/vacuum{
-	icon_state = "engine_caution_north"
-	},
-/area/station/science/lab)
-"bqB" = (
+"bqC" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+	dir = 10
 	},
 /turf/simulated/floor/engine/vacuum{
 	icon_state = "engine_caution_east"
 	},
-/area/station/science/lab)
-"bqC" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 9
-	},
-/turf/simulated/floor/plating,
 /area/station/science/lab)
 "bqE" = (
 /obj/table/auto,
@@ -11170,7 +11124,8 @@
 	icon_state = "bdoornoblasts1";
 	id = "artlabgun";
 	layer = 4;
-	name = "Emergency Mass Driver"
+	name = "Emergency Mass Driver";
+	dir = 4
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -12634,6 +12589,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"bId" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	name = "chamber outlet connector west"
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "bIi" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack{
@@ -14887,6 +14849,10 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"cGO" = (
+/obj/machinery/atmospherics/unary/portables_connector,
+/turf/simulated/floor,
+/area/station/science/lab)
 "cIi" = (
 /obj/landmark/pest,
 /turf/simulated/floor,
@@ -15916,6 +15882,21 @@
 "dBj" = (
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/barber_shop)
+"dBQ" = (
+/obj/machinery/door/poddoor/blast/single{
+	density = 0;
+	icon_state = "bdoorsingle0";
+	id = "tox_hs_one";
+	layer = 4;
+	name = "Chamber One Heat Shield";
+	opacity = 0
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "dBR" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -17151,6 +17132,17 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
+"eEj" = (
+/obj/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/station/solar/east)
 "eES" = (
 /obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side{
@@ -18108,6 +18100,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"frV" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "fsr" = (
 /obj/machinery/light{
 	dir = 8;
@@ -18343,6 +18341,21 @@
 /obj/machinery/chem_heater/chemistry,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
+"fCF" = (
+/obj/machinery/atmospherics/binary/pump/active{
+	dir = 1;
+	frequency = 1229;
+	id = "Chamber Outlet";
+	name = "chamber outlet pump";
+	target_pressure = 1000
+	},
+/obj/machinery/activation_button/ignition_switch{
+	id = "tox_ignition1";
+	name = "Chamber Ignition Switch";
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "fCY" = (
 /obj/machinery/turret,
 /obj/machinery/alarm{
@@ -18410,7 +18423,7 @@
 	pixel_x = -8;
 	pixel_y = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless,
 /area/station/science/artifact)
 "fGX" = (
 /obj/machinery/door/window/northright{
@@ -18987,12 +19000,8 @@
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "gaK" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
-	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
 	},
 /obj/machinery/meter,
 /turf/simulated/floor,
@@ -20509,6 +20518,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"hod" = (
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/east)
 "hoj" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -21492,6 +21510,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "hXn" = (
@@ -21541,11 +21562,11 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "hZj" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -21642,9 +21663,6 @@
 /obj/landmark/pest,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -21894,6 +21912,13 @@
 /mob/living/carbon/human/npc/monkey/mr_rathen,
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
+"ilc" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/beacon,
+/turf/simulated/floor,
+/area/station/science/lab)
 "ilz" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/shoes/flippers,
@@ -23295,6 +23320,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"jmZ" = (
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/east)
 "jnl" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23491,12 +23527,16 @@
 /area/station/medical/medbay)
 "jvN" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/door/airlock/pyro/glass/toxins{
-	name = "Chamber Access"
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/machinery/door/poddoor/blast/single{
+	density = 0;
+	icon_state = "bdoorsingle0";
+	id = "tox_hs_one";
+	layer = 4;
+	name = "Chamber One Heat Shield";
+	opacity = 0
 	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/tox,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "jvV" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -24042,24 +24082,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"jSd" = (
-/obj/machinery/door/airlock/pyro/toxins_alt{
-	dir = 4;
-	name = "Chamber Access"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/tox,
-/obj/machinery/door/poddoor/blast/single{
-	density = 0;
-	icon_state = "bdoorsingle0";
-	id = "tox_hs_one";
-	layer = 4;
-	name = "Chamber One Heat Shield";
-	opacity = 0;
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/science/lab)
 "jSI" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -25231,14 +25253,20 @@
 /turf/simulated/floor/engine,
 /area/station/mining/staff_room)
 "kSL" = (
+/obj/machinery/atmospherics/unary/outlet_injector/active{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent{
-	dir = 1
+/obj/machinery/sparker{
+	id = "tox_ignition1";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_x = -20
 	},
 /turf/simulated/floor/engine/vacuum{
-	dir = 4;
+	dir = 8;
 	icon_state = "engine_caution_corners"
 	},
 /area/station/science/lab)
@@ -25941,21 +25969,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
-"lrt" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/blast/single{
-	density = 0;
-	icon_state = "bdoorsingle0";
-	id = "tox_hs_one";
-	layer = 4;
-	name = "Chamber One Heat Shield";
-	opacity = 0
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/lab)
 "lrX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/blast{
@@ -26966,14 +26979,14 @@
 /area/station/storage/tools)
 "meH" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "mixing valve"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -10;
 	tag = ""
 	},
-/turf/simulated/floor/blue,
+/turf/simulated/floor,
 /area/station/science/lab)
 "meW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -28165,6 +28178,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/south)
+"mYZ" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/east)
 "mZB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30267,6 +30294,17 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/storage/tools)
+"oEq" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
+/area/station/solar/east)
 "oEr" = (
 /obj/machinery/light{
 	dir = 4;
@@ -31510,7 +31548,6 @@
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/southeast)
 "pBV" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
 	},
@@ -31681,13 +31718,8 @@
 /area/station/crew_quarters/kitchen)
 "pIz" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
+	level = 2;
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -32758,18 +32790,6 @@
 "qzB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/secwing)
-"qzG" = (
-/obj/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/east)
 "qAd" = (
 /obj/blind_switch/area/east{
 	pixel_y = 4
@@ -34614,6 +34634,15 @@
 /obj/landmark/pest,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"rYH" = (
+/obj/machinery/door/poddoor/blast/single{
+	id = "tox_one";
+	layer = 4;
+	name = "Mixture Vent"
+	},
+/obj/grille/steel,
+/turf/simulated/floor/plating/airless,
+/area/station/science/lab)
 "rZA" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -36460,8 +36489,14 @@
 "tqb" = (
 /obj/warp_beacon/research,
 /obj/lattice,
-/turf/space,
-/area/space)
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/east)
 "tqQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36524,6 +36559,19 @@
 	icon_state = "fgreen2"
 	},
 /area/station/garden/aviary)
+"ttj" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/east)
 "ttk" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39175,6 +39223,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "vhL" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/machinery/door/poddoor/blast/single{
 	density = 0;
@@ -39184,8 +39233,7 @@
 	name = "Chamber One Heat Shield";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "vhP" = (
 /obj/table/auto,
@@ -39634,6 +39682,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"vKu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum{
+	icon_state = "engine_caution_north"
+	},
+/area/station/science/lab)
 "vLs" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -41276,6 +41335,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"xdH" = (
+/obj/grille/catwalk,
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/east)
 "xed" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -41346,10 +41414,7 @@
 /area/station/science/artifact)
 "xja" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -41680,11 +41745,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side,
 /area/station/mining/staff_room)
-"xww" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
-/turf/simulated/floor,
-/area/station/science/lab)
 "xxz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42226,16 +42286,12 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "xSu" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/blast/single{
-	density = 0;
-	icon_state = "bdoorsingle0";
-	id = "tox_hs_one";
-	layer = 4;
-	name = "Chamber One Heat Shield";
-	opacity = 0
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	name = "Chamber Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/mapping_helper/access/tox,
+/obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "xSU" = (
@@ -42363,17 +42419,6 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/listeningpost)
-"xXc" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine/vacuum{
-	icon_state = "engine_caution_north"
-	},
-/area/station/science/lab)
 "xXj" = (
 /obj/machinery/door/poddoor/blast{
 	density = 0;
@@ -42515,6 +42560,24 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/engine,
 /area/station/engine/core/nuclear)
+"ycY" = (
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	dir = 4;
+	name = "Chamber Access"
+	},
+/obj/mapping_helper/access/tox,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/poddoor/blast/single{
+	density = 0;
+	icon_state = "bdoorsingle0";
+	id = "tox_hs_one";
+	layer = 4;
+	name = "Chamber One Heat Shield";
+	opacity = 0;
+	dir = 4
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "ydu" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -93111,13 +93174,13 @@ tvK
 acH
 meH
 blL
-bna
+bkH
 xSu
 bpw
 bqz
-brN
-bsD
-ozL
+brR
+bnd
+aIZ
 bvb
 bJQ
 kZO
@@ -93407,19 +93470,19 @@ baZ
 bci
 pzi
 icK
-igh
+bfU
 gaK
 pIz
-igh
-igh
-igh
-igh
-lrt
-xXc
+frV
+bfU
+bfU
+bfU
+bnd
 aVa
-brO
-bqA
-ozL
+aVa
+ycY
+bsD
+aaa
 aaa
 aaa
 dhY
@@ -93710,18 +93773,18 @@ bcj
 bdC
 eYI
 vNj
-lWq
+cGO
 xja
-cMs
-iPP
+aqr
+bId
 blM
 bnb
 vhL
 kSL
 bqB
-brP
-bsD
-ozL
+brN
+rYH
+aaa
 aaa
 aaa
 ukN
@@ -94011,24 +94074,24 @@ igh
 igh
 muO
 hXj
-bfU
-bgX
+igh
+igh
 hZj
-bfU
-bkG
-bfU
-bnc
-bnd
+ilc
+igh
+igh
+igh
+dBQ
+vKu
 bpz
-bpz
-jSd
-bnd
-qzG
-jgP
-jgP
-jgP
-jgP
-grc
+brO
+rYH
+aaa
+aaa
+aaa
+dhY
+aaa
+xdH
 aaa
 aaa
 aaa
@@ -94317,20 +94380,20 @@ xOE
 bgY
 pBV
 bju
-bkH
-xww
-bkH
+cMs
+iPP
+fCF
 jvN
 bpA
 bqC
-brR
-bnd
-oMK
+brP
+rYH
+aaa
 aaa
 aaa
 dhY
 aaa
-aaa
+jmZ
 aaa
 aaa
 aaa
@@ -94626,13 +94689,13 @@ bnd
 bnd
 bnd
 bnd
-bnd
-oMK
-aaa
-lXB
+bsD
+oEq
+hod
+ttj
 tqb
-mfK
-aaa
+mYZ
+eEj
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adjusts the east solar catwalks such that chamber exhaust does not dump heat into the catwalk
* Moves the burn chamber to the outer (east) side, so the chamber heat does not leak through the walls into maints
* Adds vacuum floors under the connecting windows/walls to prevent heat from bleeding into the room (it will still slowly bleed in via walls, as with other maps)
* Adds grilles to the exhaust area ala cogmap
* Reroutes cable/wiring to overlap less/go under fewer objects

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Clarion's toxin burn chamber was not properly isolated from the rest of the ship, causing any toxins burn to severely impact the station. These changes bring the toxins burn chamber more in line with other maps.

## Screenshot
![image](https://github.com/goonstation/goonstation/assets/91498627/27d893d9-c072-421e-8f01-fbbb987ad7d6)
