### PR TITLE
Removes wizard name suggestions that are from a transphobe's book series

### DIFF
--- a/strings/names/wizard_female.txt
+++ b/strings/names/wizard_female.txt
@@ -7,8 +7,6 @@ names@=
 	Morgan le Fay
 	Circe
 	Maleficent
-	Hermione
-	Umbridge
 	The Worst Witch
 	Sabrina
 	Morrigan

--- a/strings/names/wizard_male.txt
+++ b/strings/names/wizard_male.txt
@@ -4,9 +4,6 @@ names@=
 	Rincewind
 	Shazam
 	Merlin
-	Voldemort
-	Dumbledore
-	Snape
 	Wizard Whitebeard
 	Prospero
 	Elminster


### PR DESCRIPTION
[GAMEMODES][REMOVAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes a few names from wizard name suggestions. I know there's probably some other references in the codebase somewhere, separate PRs to find better replacements for those welcome. Low-hanging fruit, and all that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Some lady wrote a children's book. That book became wildly popular, spawned some sequels and even a movie series, video games, etc. etc.. Turns out she's a massive transphobe and all round shitty person, so let's not keep references to those characters in our cool space game.

I'm not going to stop someone choosing to name themselves these, but we shouldn't "suggest" them as random names.