### PR TITLE
Sillier EMAG effects for the lawbringer

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1286,6 +1286,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	rechargeable = 0
 	can_swap_cell = 0
 	muzzle_flash = "muzzle_flash_elec"
+	var/emagged = FALSE
 
 	New(var/mob/M)
 		set_current_projectile(new/datum/projectile/energy_bolt/aoe)
@@ -1361,54 +1362,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		var/text = msg[1]
 		text = sanitize_talk(text)
 		if (fingerprints_can_shoot(M))
-			switch(text)
-				if ("detain")
-					set_current_projectile(projectiles["detain"])
-					item_state = "lawg-detain"
-					playsound(M, 'sound/vox/detain.ogg', 50)
-					src.toggle_recoil(FALSE)
-				if ("execute", "exterminate")
-					set_current_projectile(projectiles["execute"])
-					current_projectile.cost = 30
-					item_state = "lawg-execute"
-					playsound(M, 'sound/vox/exterminate.ogg', 50)
-					src.toggle_recoil(TRUE)
-				if ("smokeshot","fog")
-					set_current_projectile(projectiles["smokeshot"])
-					current_projectile.cost = 50
-					item_state = "lawg-smokeshot"
-					playsound(M, 'sound/vox/smoke.ogg', 50)
-					src.toggle_recoil(TRUE)
-				if ("knockout", "sleepshot")
-					set_current_projectile(projectiles["knockout"])
-					current_projectile.cost = 60
-					item_state = "lawg-knockout"
-					playsound(M, 'sound/vox/sleep.ogg', 50)
-					src.toggle_recoil(FALSE)
-				if ("hotshot","incendiary")
-					set_current_projectile(projectiles["hotshot"])
-					current_projectile.cost = 60
-					item_state = "lawg-hotshot"
-					playsound(M, 'sound/vox/hot.ogg', 50)
-					src.toggle_recoil(TRUE)
-				if ("bigshot","highexplosive","he")
-					set_current_projectile(projectiles["bigshot"])
-					current_projectile.cost = 170
-					item_state = "lawg-bigshot"
-					playsound(M, 'sound/vox/high.ogg', 50)
-					SPAWN(0.4 SECONDS)
-						playsound(M, 'sound/vox/explosive.ogg', 50)
-					src.toggle_recoil(TRUE)
-				if ("clownshot","clown")
-					set_current_projectile(projectiles["clownshot"])
-					item_state = "lawg-clownshot"
-					playsound(M, 'sound/vox/clown.ogg', 30)
-					src.toggle_recoil(FALSE)
-				if ("pulse", "push", "throw")
-					set_current_projectile(projectiles["pulse"])
-					item_state = "lawg-pulse"
-					playsound(M, 'sound/vox/push.ogg', 50)
-					src.toggle_recoil(FALSE)
+			src.change_mode(M, text)
 		else		//if you're not the owner and try to change it, then fuck you
 			switch(text)
 				if ("detain","execute","knockout","hotshot","incendiary","bigshot","highexplosive","he","clownshot","clown", "pulse", "punch")
@@ -1421,6 +1375,64 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		M.update_inhands()
 		UpdateIcon()
 
+	proc/change_mode(var/mob/M, var/text, var/sound = TRUE)
+		switch(text)
+			if ("detain")
+				set_current_projectile(projectiles["detain"])
+				item_state = "lawg-detain"
+				if (sound)
+					playsound(M, 'sound/vox/detain.ogg', 50)
+				src.toggle_recoil(FALSE)
+			if ("execute", "exterminate")
+				set_current_projectile(projectiles["execute"])
+				current_projectile.cost = 30
+				item_state = "lawg-execute"
+				if (sound)
+					playsound(M, 'sound/vox/exterminate.ogg', 50)
+				src.toggle_recoil(TRUE)
+			if ("smokeshot","fog")
+				set_current_projectile(projectiles["smokeshot"])
+				current_projectile.cost = 50
+				item_state = "lawg-smokeshot"
+				if (sound)
+					playsound(M, 'sound/vox/smoke.ogg', 50)
+				src.toggle_recoil(TRUE)
+			if ("knockout", "sleepshot")
+				set_current_projectile(projectiles["knockout"])
+				current_projectile.cost = 60
+				item_state = "lawg-knockout"
+				if (sound)
+					playsound(M, 'sound/vox/sleep.ogg', 50)
+				src.toggle_recoil(FALSE)
+			if ("hotshot","incendiary")
+				set_current_projectile(projectiles["hotshot"])
+				current_projectile.cost = 60
+				item_state = "lawg-hotshot"
+				if (sound)
+					playsound(M, 'sound/vox/hot.ogg', 50)
+				src.toggle_recoil(TRUE)
+			if ("bigshot","highexplosive","he")
+				set_current_projectile(projectiles["bigshot"])
+				current_projectile.cost = 170
+				item_state = "lawg-bigshot"
+				if (sound)
+					playsound(M, 'sound/vox/high.ogg', 50)
+					SPAWN(0.4 SECONDS)
+						playsound(M, 'sound/vox/explosive.ogg', 50)
+				src.toggle_recoil(TRUE)
+			if ("clownshot","clown")
+				set_current_projectile(projectiles["clownshot"])
+				item_state = "lawg-clownshot"
+				if (sound)
+					playsound(M, 'sound/vox/clown.ogg', 30)
+				src.toggle_recoil(FALSE)
+			if ("pulse", "push", "throw")
+				set_current_projectile(projectiles["pulse"])
+				item_state = "lawg-pulse"
+				if (sound)
+					playsound(M, 'sound/vox/push.ogg', 50)
+				src.toggle_recoil(FALSE)
+
 	//Are you really the law? takes the mob as speaker, and the text spoken, sanitizes it. If you say "i am the law" and you in fact are NOT the law, it's gonna blow. Moved out of the switch statement because it that switch is only gonna run if the owner speaks
 	proc/are_you_the_law(mob/M as mob, text)
 		text = sanitize_talk(text)
@@ -1428,7 +1440,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			//you must be holding/wearing the weapon
 			//this check makes it so that someone can't stun you, stand on top of you and say "I am the law" to kill you
 			if (src in M.contents)
-				if (M.job != "Head of Security")
+				if (M.job != "Head of Security" || src.emagged)
 					src.cant_self_remove = 1
 					playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 					logTheThing(LOG_COMBAT, src, "Is not the law. Caused explosion with Lawbringer.")
@@ -1512,6 +1524,14 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 		return 0
 
 	shoot(turf/target, turf/start, mob/user, POX, POY, is_dual_wield, atom/called_target = null)
+
+		if (src.emagged)
+			if (prob(1))
+				boutput(user, SPAN_ALERT("You let it slip."))
+				user.say("I AM THE LAW")
+				src.are_you_the_law(user, "I AM THE LAW") // the thoughts won
+			src.change_mode(user, pick(src.projectiles), sound = FALSE)
+
 		if (canshoot(user))
 			//removing this for now so anyone can shoot it. I PROBABLY will want it back, doing this for some light appeasement to see how it goes.
 			//shock the guy who tries to use this if they aren't the proper owner. (or if the gun is not emagged)
@@ -1531,6 +1551,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 
 /obj/item/gun/energy/lawbringer/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	if (user)
+		src.emagged = TRUE
 		boutput(user, SPAN_ALERT("Anyone can use this gun now. Be careful! (use it in-hand to register your fingerprints)"))
 		owner_prints = null
 		return TRUE

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1526,10 +1526,6 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	shoot(turf/target, turf/start, mob/user, POX, POY, is_dual_wield, atom/called_target = null)
 
 		if (src.emagged)
-			if (prob(1))
-				boutput(user, SPAN_ALERT("You let it slip."))
-				user.say("I AM THE LAW")
-				src.are_you_the_law(user, "I AM THE LAW") // the thoughts won
 			src.change_mode(user, pick(src.projectiles), sound = FALSE)
 
 		if (canshoot(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [Game-Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a more fitting set of emag effects for the lawbringer.
- When you shoot the lawbringer while it's emagged, it will pick between random modes for you.
- ~~There is a 1% chance to force you to scream out "I AM THE LAW" and trigger the explosion~~
- Emagged lawbringers have no sense of laws, and so the HoS is not immune to the explosion for saying these words.
- Moves over switching code to a proc so that it can be accessed from other places in the code. There's a lot of custom varediting in there, so it should be exposed to more parts of the code for use. Like this!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

https://github.com/goonstation/goonstation/assets/27376947/be5eff0f-2313-478e-9a43-c7cc8dc8bb65

NOTE: VIDEO SHOWS THE CHANCE TO BE FORCED TO SAY "I AM THE LAW". NO LONGER A FEATURE.


```changelog
(u)MeggalBozale
(+)The emag effect for the lawbringer has been modified slightly.
```
