### PR TITLE
Replace unkeyed Fragment usages with shorthand

### DIFF
--- a/tgui/packages/tgui/interfaces/Airlock.js
+++ b/tgui/packages/tgui/interfaces/Airlock.js
@@ -5,7 +5,6 @@
 * @license ISC
 */
 
-import { Fragment } from "inferno";
 import { useBackend, useLocalState } from "../backend";
 import { truncate } from '../format';
 import { Box, Button, Divider, Flex, LabeledList, Modal, NoticeBox, ProgressBar, Section, Tabs } from "../components";

--- a/tgui/packages/tgui/interfaces/AntagonistPanel/AntagonistTypeTabBody.tsx
+++ b/tgui/packages/tgui/interfaces/AntagonistPanel/AntagonistTypeTabBody.tsx
@@ -5,7 +5,6 @@
  * @license MIT
  */
 
-import { Fragment } from 'inferno';
 import { useBackend } from '../../backend';
 import { toTitleCase } from 'common/string';
 import { Box, Button, Divider, Icon, LabeledList, ProgressBar, Section, Stack, Table, Tooltip } from '../../components';
@@ -25,7 +24,7 @@ export const AntagonistTypeTabBody = (props: AntagonistPanelData) => (
 );
 
 const GeneralInformation = (props: AntagonistPanelData) => (
-  <Fragment>
+  <>
     <Section>
       <Stack vertical align="center" my={3}>
         <Stack.Item mb={-2.5} italic>
@@ -80,7 +79,7 @@ const GeneralInformation = (props: AntagonistPanelData) => (
         </Section>
       </Stack.Item>
     </Stack>
-  </Fragment>
+  </>
 );
 
 const AntagonistTabSection = (props: TabSectionData) => {
@@ -136,7 +135,7 @@ const TableAntagonistEntry = (props: AntagonistData, context) => {
     a.real_name.localeCompare(b.real_name)) || [];
 
   return (
-    <Fragment>
+    <>
       <Table.Row>
         <Table.Cell py="0.5em">
           <Tooltip
@@ -199,7 +198,7 @@ const TableAntagonistEntry = (props: AntagonistData, context) => {
           <TableButtonsCell {...antagonist} />
         </Table.Row>
       ))}
-    </Fragment>
+    </>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/CrewCredits/AntagonistsTab.tsx
+++ b/tgui/packages/tgui/interfaces/CrewCredits/AntagonistsTab.tsx
@@ -5,7 +5,6 @@
  * @license MIT
 */
 
-import { Fragment } from 'inferno';
 import { useBackend } from '../../backend';
 import { Box, Collapsible, Divider, Icon, ItemList, LabeledList, Section, Stack } from '../../components';
 import { AntagonistStatisticsProps, AntagonistTabData, VerboseAntagonistProps } from './type';
@@ -14,7 +13,7 @@ export const AntagonistsTab = (props, context) => {
   const { data } = useBackend<AntagonistTabData>(context);
 
   return (
-    <Fragment>
+    <>
       <GameModeDisplay game_mode={data.game_mode} />
       {data.verbose_antagonist_data?.map((antagonist, index) =>
         (<Antagonist
@@ -29,7 +28,7 @@ export const AntagonistsTab = (props, context) => {
           />
         </Section>
       )}
-    </Fragment>
+    </>
   );
 };
 
@@ -105,7 +104,7 @@ const AntagonistObjectives = (props) => {
   const { objectives } = props;
 
   return (
-    <Fragment>
+    <>
       <Box
         fontSize={1.1}
         bold
@@ -127,7 +126,7 @@ const AntagonistObjectives = (props) => {
           </Stack.Item>
         ))}
       </Stack>
-    </Fragment>
+    </>
   );
 };
 
@@ -135,7 +134,7 @@ const AntagonistStatistics = (props) => {
   const { antagonist_statistics } = props;
 
   return (
-    <Fragment>
+    <>
       <Box
         fontSize={1.1}
         bold
@@ -153,7 +152,7 @@ const AntagonistStatistics = (props) => {
           />
         ))}
       </LabeledList>
-    </Fragment>
+    </>
   );
 };
 
@@ -189,7 +188,7 @@ const SubordinateAntagonists = (props) => {
   const { subordinate_antagonists } = props;
 
   return (
-    <Fragment>
+    <>
       <Box
         fontSize={1.1}
         bold
@@ -200,7 +199,7 @@ const SubordinateAntagonists = (props) => {
       <SuccinctAntagonistData
         succinct_antagonist_data={subordinate_antagonists}
       />
-    </Fragment>
+    </>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Filteriffic.js
+++ b/tgui/packages/tgui/interfaces/Filteriffic.js
@@ -6,7 +6,6 @@
 */
 
 import { useBackend, useLocalState } from "../backend";
-import { Fragment } from 'inferno';
 import { Box, Button, Collapsible, ColorBox, Dropdown, Input, LabeledList, NoticeBox, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 import { map } from 'common/collections';
@@ -37,7 +36,7 @@ const FilterFloatEntry = (props, context) => {
   const { act } = useBackend(context);
   const [step, setStep] = useLocalState(context, `${filterName}-${name}`, 0.01);
   return (
-    <Fragment>
+    <>
       <NumberInput
         value={value}
         minValue={-500}
@@ -64,7 +63,7 @@ const FilterFloatEntry = (props, context) => {
         format={value => toFixed(value, 4)}
         width="70px"
         onChange={(e, value) => setStep(value)} />
-    </Fragment>
+    </>
   );
 };
 
@@ -94,7 +93,7 @@ const FilterTransformEntry = (props, context) => {
     transMatrix = Array(1, 0, 0, 0, 1, 0);
   }
   return (
-    <Fragment>
+    <>
       Matrix:
       <Stack>
         {[0, 1, 2].map((col, key) => (
@@ -134,7 +133,7 @@ const FilterTransformEntry = (props, context) => {
           </Stack.Item>
         ))}
       </Stack>
-    </Fragment>
+    </>
   );
 };
 
@@ -161,7 +160,7 @@ const FilterColorEntry = (props, context) => {
       }
     }
     return (
-      <Fragment>
+      <>
         <Button
           icon="pencil-alt"
           onClick={() => act('modify_color_value', {
@@ -203,11 +202,11 @@ const FilterColorEntry = (props, context) => {
             </Stack.Item>
           ))}
         </Stack>
-      </Fragment>
+      </>
     );
   } else {
     return (
-      <Fragment>
+      <>
         {value.type}
         <Button
           icon="pencil-alt"
@@ -231,7 +230,7 @@ const FilterColorEntry = (props, context) => {
           onClick={() => act('convert_color_value_matrix', {
             name: filterName,
           })} />
-      </Fragment>
+      </>
     );
   }
 };
@@ -240,7 +239,7 @@ const FilterIconEntry = (props, context) => {
   const { value, filterName } = props;
   const { act } = useBackend(context);
   return (
-    <Fragment>
+    <>
       <Button
         icon="pencil-alt"
         onClick={() => act('modify_icon_value', {
@@ -249,7 +248,7 @@ const FilterIconEntry = (props, context) => {
       <Box inline ml={1}>
         {value}
       </Box>
-    </Fragment>
+    </>
   );
 };
 
@@ -373,7 +372,7 @@ const FilterEntry = (props, context) => {
     <Collapsible
       title={name + " (" + type + ")"}
       buttons={(
-        <Fragment>
+        <>
           <NumberInput
             value={priority}
             stepPixelSize={10}
@@ -394,7 +393,7 @@ const FilterEntry = (props, context) => {
           <Button.Confirm
             icon="minus"
             onClick={() => act("remove_filter", { name: name })} />
-        </Fragment>
+        </>
       )}>
       <Section>
         <LabeledList>
@@ -439,7 +438,7 @@ export const Filteriffic = (props, context) => {
         </NoticeBox>
         <Section
           title={hiddenSecret ? (
-            <Fragment>
+            <>
               <Box mr={0.5} inline>
                 MASS EDIT:
               </Box>
@@ -451,7 +450,7 @@ export const Filteriffic = (props, context) => {
                 content="Apply"
                 confirmContent="ARE YOU SURE?"
                 onClick={() => act('mass_apply', { path: massApplyPath })} />
-            </Fragment>
+            </>
           ) : (
             <Box
               inline

--- a/tgui/packages/tgui/interfaces/GeneTek/AppearanceEditor.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/AppearanceEditor.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend } from "../../backend";
 import { Box, Button, ByondUi, ColorBox, Dropdown, Flex, Knob, LabeledList, Section } from "../../components";
 
@@ -33,7 +32,7 @@ export const AppearanceEditor = (params, context) => {
     <Section
       title="Appearance Editor"
       buttons={
-        <Fragment>
+        <>
           <Button
             onClick={() => act("editappearance", { apply: true })}
             icon="user"
@@ -44,7 +43,7 @@ export const AppearanceEditor = (params, context) => {
             onClick={() => act("editappearance", { cancel: true })}
             icon="times"
             color="bad" />
-        </Fragment>
+        </>
       }>
       <Flex>
         <Flex.Item shrink="1">

--- a/tgui/packages/tgui/interfaces/GeneTek/BioEffect.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/BioEffect.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend, useSharedState } from "../../backend";
 import { Box, Button, Flex, Icon, Input, LabeledList, Modal, NumberInput, Section } from "../../components";
 import { UnlockModal } from "./modals/UnlockModal";
@@ -337,7 +336,7 @@ export const GeneList = (props, context) => {
   };
 
   return (
-    <Fragment>
+    <>
       <Flex wrap mb={1}>
         {genes.map(g => (
           <Flex.Item
@@ -363,6 +362,6 @@ export const GeneList = (props, context) => {
           showSequence
           {...rest} />
       )}
-    </Fragment>
+    </>
   );
 };

--- a/tgui/packages/tgui/interfaces/GeneTek/tabs/MutationsTab.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/tabs/MutationsTab.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend, useSharedState } from "../../../backend";
 import { Button, Section } from "../../../components";
 import { BioEffect } from "../BioEffect";
@@ -33,7 +32,7 @@ export const MutationsTab = (props, context) => {
   }
 
   return (
-    <Fragment>
+    <>
       <Section>
         <Button
           icon={sortMode === "time" ? "clock" : "sort-alpha-down"}
@@ -53,6 +52,6 @@ export const MutationsTab = (props, context) => {
           gene={be}
           showSequence={showSequence} />
       ))}
-    </Fragment>
+    </>
   );
 };

--- a/tgui/packages/tgui/interfaces/GeneTek/tabs/ResearchTab.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/tabs/ResearchTab.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend } from "../../../backend";
 import { AnimatedNumber, Button, LabeledList, Section } from "../../../components";
 import { Description } from "../BioEffect";
@@ -31,7 +30,7 @@ export const ResearchTab = (props, context) => {
   } = props;
 
   return (
-    <Fragment>
+    <>
       <Section
         title="Statistics"
         buttons={(
@@ -102,6 +101,6 @@ export const ResearchTab = (props, context) => {
           </Section>
         ))}
       </Section>
-    </Fragment>
+    </>
   );
 };

--- a/tgui/packages/tgui/interfaces/GeneTek/tabs/ScannerTab.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/tabs/ScannerTab.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend, useSharedState } from "../../../backend";
 import { Box, Button, ByondUi, Flex, LabeledList, Modal, Section } from "../../../components";
 import { AppearanceEditor } from "../AppearanceEditor";
@@ -53,7 +52,7 @@ export const ScannerTab = (props, context) => {
   }
 
   return (
-    <Fragment>
+    <>
       {!!changingMutantRace && (
         <Modal full>
           <Box bold width={20} mb={0.5}>
@@ -93,7 +92,7 @@ export const ScannerTab = (props, context) => {
       {modifyAppearance ? (
         <AppearanceEditor {...modifyAppearance} />
       ) : (
-        <Fragment>
+        <>
           <Section title="Occupant">
             <Flex>
               <Flex.Item mr={1}>
@@ -114,7 +113,7 @@ export const ScannerTab = (props, context) => {
                   <LabeledList.Item
                     label="Body Type"
                     buttons={!!human && (
-                      <Fragment>
+                      <>
                         <Button
                           icon="user"
                           color="blue"
@@ -127,7 +126,7 @@ export const ScannerTab = (props, context) => {
                           color="average"
                           disabled={!canAppearance}
                           onClick={() => act("editappearance")} />
-                      </Fragment>
+                      </>
                     )}>
                     {mutantRace}
                   </LabeledList.Item>
@@ -177,8 +176,8 @@ export const ScannerTab = (props, context) => {
               noGenes="Subject has no detected mutations."
               isActive />
           </Section>
-        </Fragment>
+        </>
       )}
-    </Fragment>
+    </>
   );
 };

--- a/tgui/packages/tgui/interfaces/GeneTek/tabs/StorageTab.js
+++ b/tgui/packages/tgui/interfaces/GeneTek/tabs/StorageTab.js
@@ -5,7 +5,6 @@
  * @license ISC
  */
 
-import { Fragment } from "inferno";
 import { useBackend, useSharedState } from "../../../backend";
 import { BioEffect, GeneList } from "../BioEffect";
 import { Box, Button, LabeledList, Section } from "../../../components";
@@ -39,7 +38,7 @@ export const StorageTab = (props, context) => {
   chromosomes.sort((a, b) => a.name > b.name ? 1 : -1);
 
   return (
-    <Fragment>
+    <>
       {saveSlots > 0 && (
         <Section
           title="Stored Mutations"
@@ -67,7 +66,7 @@ export const StorageTab = (props, context) => {
                 key={c.ref}
                 label={c.name}
                 buttons={
-                  <Fragment>
+                  <>
                     <Button
                       disabled={c.name === toSplice}
                       icon="map-marker-alt"
@@ -78,7 +77,7 @@ export const StorageTab = (props, context) => {
                       color="bad"
                       icon="trash"
                       onClick={() => act("deletechromosome", { ref: c.ref })} />
-                  </Fragment>
+                  </>
                 }>
                 {c.desc}
                 <Box mt={0.5}>
@@ -110,7 +109,7 @@ export const StorageTab = (props, context) => {
           ))}
         </LabeledList>
       </Section>
-    </Fragment>
+    </>
   );
 };
 
@@ -131,7 +130,7 @@ export const RecordTab = (props, context) => {
   } = record;
 
   return (
-    <Fragment>
+    <>
       <Section title={name}>
         <LabeledList>
           <LabeledList.Item label="Genetic Signature">
@@ -145,6 +144,6 @@ export const RecordTab = (props, context) => {
           noGenes="No genes found in sample."
           isSample />
       </Section>
-    </Fragment>
+    </>
   );
 };


### PR DESCRIPTION
[UI][CODE QUALITY]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces `<Fragment>` usage in interfaces with `<>` shorthand. Leaves keyed ones alone.

The good news is that this PR doesn't even change the bundle, it's the same under the hood.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The code quality PRs will continue until morale improves.