### PR TITLE
Make Lavender Essence cancel out miasma

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3804,6 +3804,18 @@
 			//This reaction does only happen in carbon-based beings and for only as long as there is less than 15u lungrot in the person
 			return holder.my_atom && iscarbon(holder.my_atom) && (holder.get_reagent_amount("lungrot_bloom") < 15)
 
+	// makes lavender and miasma destroy each other
+	miasma_neutralisation
+		name = "miasma neutralisation"
+		id = "miasma_neutralisation"
+		instant = 1
+		required_reagents = list("miasma" = 1, "lavender_essence" = 1)
+		mix_phrase = "The lavender counteracts the miasma."
+		on_reaction(var/datum/reagents/holder, var/created_volume)
+			if (holder)
+				holder.del_reagent("miasma")
+				holder.del_reagent("lavender_essence")
+			return
 
 	/*plant_nutrients_mutagenic
 		name = "Mutriant Plant Formula"


### PR DESCRIPTION
[CHEMISTRY]
## About the PR
Makes lavender essence and miasma reagents destroy each other.
May or may not work. havent coded in a while. heh

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seen some people try to flood areas with lavender gas and it didnt work :(