### PR TITLE
gang tweaks. lil things.

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -766,6 +766,7 @@ proc/broadcast_to_all_gangs(var/message)
 		var/datum/signal/newsignal = get_free_signal()
 		newsignal.source = src
 		newsignal.encryption = "GDFTHR+\ref[civvie.originalPDA]"
+		newsignal.encryption_full = TRUE // too easy to decipher these
 		newsignal.data["command"] = "text_message"
 		newsignal.data["sender_name"] = "Unknown Sender"
 		newsignal.data["message"] = "[message]"

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -2029,6 +2029,10 @@ proc/broadcast_to_all_gangs(var/message)
 	var/max_charges = 5
 	var/charges = 5
 
+	syndicate
+		max_charges = 10
+		charges = 10
+
 	update_icon()
 		if (charges > 0 )
 			inventory_counter?.update_number(charges)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -796,7 +796,10 @@ proc/broadcast_to_all_gangs(var/message)
 		potential_drop_zones = list()
 		var/list/area/areas = get_accessible_station_areas()
 		for(var/area in areas)
-			if(istype(areas[area], /area/station/security) || areas[area].teleport_blocked)
+			if(istype(areas[area], /area/station/security) || areas[area].teleport_blocked || istype(areas[area], /area/station/solar))
+				continue
+			var/typeinfo/area/typeinfo = areas[area].get_typeinfo()
+			if (!typeinfo.valid_bounty_area)
 				continue
 			potential_drop_zones += areas[area]
 

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -766,7 +766,7 @@ proc/broadcast_to_all_gangs(var/message)
 		var/datum/signal/newsignal = get_free_signal()
 		newsignal.source = src
 		newsignal.encryption = "GDFTHR+\ref[civvie.originalPDA]"
-		newsignal.encryption_full = TRUE // too easy to decipher these
+		newsignal.encryption_obfuscation = 90 // too easy to decipher these
 		newsignal.data["command"] = "text_message"
 		newsignal.data["sender_name"] = "Unknown Sender"
 		newsignal.data["message"] = "[message]"

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -822,7 +822,7 @@ proc/broadcast_to_all_gangs(var/message)
 					disposalList.Add(O)
 				else if (istype(O,/obj/storage))
 					var/obj/storage/crate = O
-					if (!crate.secure && !crate.locked)
+					if (!crate.secure && !crate.locked && !crate.open)
 						crateList.Add(O)
 				else if (istype(O,/obj/table) && !istype(O,/obj/table/glass))
 					tableList.Add(O)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -856,7 +856,7 @@ proc/broadcast_to_all_gangs(var/message)
 			target.contents.Add(loot)
 			message += " we left a bag in \the [target], [pick("somewhere around", "inside", "somewhere inside")] \the [loot_zone]. "
 			logTheThing(LOG_GAMEMODE, target, "Spawned at \the [loot_zone] for [src.gang_name], inside a chute: [target] at [target.x],[target.y]")
-		else if(length(tableList) && prob(65))
+		else if(length(tableList) && (length(uncoveredTurfList) > 0 || prob(65))) // only spawn on uncovered turf as a last resort
 			var/turf/target = get_turf(pick(tableList))
 			loot = new/obj/item/gang_loot/guns_and_gear
 			target.contents.Add(loot)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1373,3 +1373,15 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 	cost = 1
 	desc = "Just a standard-issue flash. Won't remove implants like the Revolutionary Flash."
 
+
+/datum/syndicate_buylist/surplus/switchblade
+	name = "Switchblade"
+	item = /obj/item/switchblade
+	cost = 2
+	desc = "A stylish knife you can hide in your clothes. Special attacks are exceptional at causing heavy bleeding"
+
+/datum/syndicate_buylist/surplus/quickhack
+	name = "Quickhack"
+	item = /obj/item/quickhack/syndicate
+	cost = 1
+	desc = "An illegal, home-made tool able to fake up to 10 AI 'open' signals to unbolted doors."

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1382,6 +1382,6 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic/head_rev)
 
 /datum/syndicate_buylist/surplus/quickhack
 	name = "Quickhack"
-	item = /obj/item/quickhack/syndicate
+	item = /obj/item/tool/quickhack/syndicate
 	cost = 1
 	desc = "An illegal, home-made tool able to fake up to 10 AI 'open' signals to unbolted doors."

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1969,10 +1969,7 @@
 				var/packets = ""
 				for(var/d in signal.data)
 					packets += "[d]=[signal.data[d]]; "
-				if (signal.encryption_full)
-					SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + "<MESSAGE UNREADABLE>")), null)
-				else
-					SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + stars(packets, 15))), null)
+				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + stars(packets, signal.encryption_obfuscation))), null)
 				animate_flash_color_fill(src,"#ff0000",2, 2)
 				return
 

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1969,7 +1969,10 @@
 				var/packets = ""
 				for(var/d in signal.data)
 					packets += "[d]=[signal.data[d]]; "
-				SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + stars(packets, 15))), null)
+				if (signal.encryption_full)
+					SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + "<MESSAGE UNREADABLE>")), null)
+				else
+					SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, strip_html_tags(html_decode("[signal.encryption]" + stars(packets, 15))), null)
 				animate_flash_color_fill(src,"#ff0000",2, 2)
 				return
 

--- a/code/modules/packets/signal.dm
+++ b/code/modules/packets/signal.dm
@@ -7,6 +7,8 @@
 	var/data = list()
 	///Set to the error message displayed when sniffing the encrypted packet
 	var/encryption
+	///Should this signal be entirely unreadable, even if sniffed by things that would partially read them? (Mechcomp)
+	var/encryption_full = FALSE
 	var/datum/computer/file/data_file
 
 	var/mob/author

--- a/code/modules/packets/signal.dm
+++ b/code/modules/packets/signal.dm
@@ -7,8 +7,8 @@
 	var/data = list()
 	///Set to the error message displayed when sniffing the encrypted packet
 	var/encryption
-	///Should this signal be entirely unreadable, even if sniffed by things that would partially read them? (Mechcomp)
-	var/encryption_full = FALSE
+	///How obfuscated is this encryption, if sniffed by things that can read it?
+	var/encryption_obfuscation = 15
 	var/datum/computer/file/data_file
 
 	var/mob/author

--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -268,8 +268,7 @@
 		// ruck kit lock packets use this
 		if(signal.encryption)
 			t += "[signal.encryption]"
-			if (!signal.encryption_full)
-				t2 = stars(t2, 15)
+			t2 = stars(t2, signal.encryption_obfuscation)
 
 		result += "[t][t2]"
 

--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -268,7 +268,8 @@
 		// ruck kit lock packets use this
 		if(signal.encryption)
 			t += "[signal.encryption]"
-			t2 = stars(t2, 15)
+			if (!signal.encryption_full)
+				t2 = stars(t2, 15)
 
 		result += "[t][t2]"
 

--- a/code/obj/storage/gang_crate.dm
+++ b/code/obj/storage/gang_crate.dm
@@ -331,6 +331,10 @@
 	/// Uses the boolean 'intact' value of the floor it's beneath to hide, if applicable
 	hide(var/floor_intact)
 		invisibility = floor_intact ? INVIS_ALWAYS : INVIS_NONE	// hide if floor is intact
+		if (invisibility)
+			anchored = ANCHORED
+		else
+			anchored = UNANCHORED
 		UpdateIcon()
 
 	proc/open(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE][GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Switchblade and a souped-up Quickhack spawn in Surplus crates
- Gang Duffles no longer spawn in non-bounty areas (so gangs stop having to rummage around the Combustion Chamber's floor tiles
- Gang duffles are anchored while not visible, and don't spawn under conveyors. Should mean less weird cases where, ahem... 
`'a duffle bag, that is under the floor tiles, gets sucked inside a crematorium while it is still under the floor. As it is both under the floor and in a crematorium, it is no longer able to be recovered from the floor, as it is stuck inside the crematorium'`
- Duffles no longer spawn, invisibly, in open crates & lockers.
- (late bugfix) encryption works better for gang messages

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
things people asked for nicely and bugfixes 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Gang members are no longer required to recover duffle bags from under the floortiles of a burning combustion chamber, etc.
(+)Duffle bags can no longer enter superpositions both above & below the floor.
(+)Switchblades and quickhacks can spawn in Surplus crates.
```
