### PR TITLE
Prevent hacked mining charges from being set in arrivals

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2002,7 +2002,10 @@ TYPEINFO(/obj/item/mining_tool/powered/hedron_beam)
 									qdel(target)
 							qdel(src)
 							return
-					else if (src.hacked) ..()
+					else if (src.hacked)
+						var/turf/T = get_turf(target)
+						if(!IS_ARRIVALS(T.loc))
+							..()
 					else boutput(user, SPAN_ALERT("These will only work on asteroids."))
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On hacked charges, check if the target is in an arrivals area before allowing the bomb to be planted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Arrivals shouldn't be directly bombable
Fix #18985