### PR TITLE
Mute cows use base human scream handling

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2219,7 +2219,9 @@ TYPEINFO(/datum/mutantrace/cow)
 	emote(var/act, var/voluntary)
 		switch(act)
 			if ("scream")
-				if (src.mob.emote_check(voluntary, 50) && !src.mob.bioHolder.HasEffect("mute"))
+				if (src.mob.bioHolder.HasEffect("mute"))
+					return // use muted scream emote handling
+				if (src.mob.emote_check(voluntary, 50))
 					. = "<B>[src.mob]</B> moos!"
 					playsound(src.mob, 'sound/voice/screams/moo.ogg', 50, 0, 0, src.mob.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
 			if ("milk")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mutantraces]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Have cows return early from their emote check if they're mute, which falls back to the base human emote handling for mute bioeffect (i.e. "tries to scream, but can't")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18750
Fix #18121 - pretty sure scream was causing emote cooldown