### PR TITLE
Fix cell swap callback for powered mining tools

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1671,7 +1671,7 @@ TYPEINFO(/turf/simulated/floor/plating/airless/asteroid)
 		..()
 		if(src.default_cell)
 			AddComponent(/datum/component/cell_holder, new default_cell)
-			RegisterSignal(src, COMSIG_CELL_SWAP, PROC_REF(power_down))
+			RegisterSignal(src, COMSIG_CELL_SWAP, PROC_REF(power_down_callback))
 		src.setItemSpecial(unpowered_item_special)
 		src.power_up()
 
@@ -1768,6 +1768,9 @@ TYPEINFO(/turf/simulated/floor/plating/airless/asteroid)
 		playsound(user, 'sound/items/miningtool_on.ogg', 30, 1)
 		src.setItemSpecial(src.powered_item_special)
 		return
+
+	proc/power_down_callback(obj/item/mining_tool/powered/tool, obj/item/ammo/power_cell/cell, mob/user)
+		src.power_down(user)
 
 	proc/power_down(var/mob/user = null)
 		ON_COOLDOWN(src, "depowered", 1 SECOND)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][gameobjects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The `COMSIG_CELL_SWAP` callback sends the src, cell, and user, which confuses the `power_down` proc. Add a callback-specific proc to handle the arguments sent over, and properly forward them to the powered mining tool's `power_down` proc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18940