### PR TITLE
Add hat support to martians / blobs and fix offsets

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -663,6 +663,7 @@ TYPEINFO(/datum/mutantrace/blob)
 	human_compatible = 0
 	uses_human_clothes = 0
 	hand_offset = -1
+	head_offset = -3
 	body_offset = -8
 	voice_override = "bloop"
 	firevuln = 1.5
@@ -1695,6 +1696,9 @@ TYPEINFO(/datum/mutantrace/seamonkey)
 /datum/mutantrace/martian
 	name = "martian"
 	icon_state = "martian"
+	hand_offset = -6
+	head_offset = -2
+	body_offset = -9
 	human_compatible = 0
 	uses_human_clothes = 0
 	override_language = "martian"

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -20,6 +20,7 @@
 	wear_layer = MOB_HAIR_LAYER2 //it IS hair afterall
 	hat_offset_y = -15 // offsets for hattable component
 	hat_offset_x = 0
+	compatible_species = list("human", "cow", "werewolf", "flubber") // No wigs for martians / blobs
 
 	///Takes a list of style ids to colors and generates a wig from it
 	proc/setup_wig(var/style_list)

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -7,7 +7,7 @@
 	wear_image_icon = 'icons/mob/clothing/head.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	body_parts_covered = HEAD
-	compatible_species = list("human", "cow", "werewolf", "flubber")
+	compatible_species = list("human", "cow", "werewolf", "flubber", "martian", "blob")
 	wear_layer = MOB_HEAD_LAYER2
 	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
 	block_vision = 0

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -8,6 +8,7 @@
 	desc = "Somewhat protects your head from being bashed in."
 	protective_temperature = 500
 	duration_remove = 5 SECONDS
+	compatible_species = list("human", "cow", "werewolf", "flubber") // No helmets for martians / blobs
 
 	setupProperties()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [QoL] [Respawning]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds martians and blobs to `compatible_species` on hats.
Ensures that they cannot wear wigs or helmets however.

Adjusts some head_offsets, hand_offsets and body_offsets on martians to make them look better.
![image](https://github.com/goonstation/goonstation/assets/51779813/6aa4fc58-e717-4112-8646-c6bf9d877353)
![image](https://github.com/goonstation/goonstation/assets/51779813/f1b0aea2-7459-4aed-8a10-c44ae534e669)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While rare, it does happen that tourists or diplomats spawn as martians and blobs. Those jobs are limited enough as is since they cannot wear human clothing. For RP purposes however, it would be nice if they were able to wear hats.

Additionally, the hands of a martian are visible, so it'd be nice if the gloves were located where it made sense. Same with the backpack.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Martian and Blob ambassadors are now legally allowed to wear hats per a NT decree.
```
