### PR TITLE
cpu tick lag

### DIFF
--- a/_std/defines/lag.dm
+++ b/_std/defines/lag.dm
@@ -42,6 +42,10 @@
 #define TICKLAG_DILATION_INC 0.2
 /// how much to decrease by when appropriate //MBCX I DONT KNOW WHY BUT MOST VALUES CAUSE ROUNDING ERRORS, ITS VERY IMPORTANT THAT THIS REMAINS 0.2 FIOR NOW
 #define TICKLAG_DILATION_DEC 0.2
+/// what cpu percent is too high in the dilation check
+#define TICKLAG_CPU_MAX 90
+/// what cpu percent is low enough in the dilation check
+#define TICKLAG_CPU_MIN 70
 /// what map_cpu percent is too high in the dilation check
 #define TICKLAG_MAPCPU_MAX 70
 /// what map_cpu percent is low enough in the dilation check

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -485,6 +485,7 @@ var/global/current_state = GAME_STATE_INVALID
 				// the networking. do not spam change world.tick_lag! you will regret it!
 				if (world.tick_lag != dilated_tick_lag)
 					world.tick_lag = dilated_tick_lag
+					highCpuCount = 0
 					highMapCpuCount = 0
 
 		// Minds are sometimes kicked out of the global list, hence the fallback (Convair880).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Considers server cpu rather than just mapcpu for determining ticklag


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* With the split of mapcpu onto its own thread with byond 515 ticklag is sometimes not increasing when it may otherwise be beneficial to do so
