### PR TITLE
UI Update after Announcement Compter Card Insertion

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -42,6 +42,7 @@
 			src.unlocked = check_access(ID, 1)
 			boutput(user, SPAN_NOTICE("You insert [W]."))
 			update_status()
+			tgui_process.update_uis(src)
 			return
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug][QoL][UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I noticed that after putting an ID card in an Announcement Computer by clicking the computer, the UI wouldn't update instantly. A timely `update_uis()` makes it snappier.

https://github.com/goonstation/goonstation/assets/6396368/9c7586c1-80cf-4146-9f60-c80ff436921a




## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Is more responsive

