### PR TITLE
Adds gibber as fishing spot

### DIFF
--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -827,3 +827,17 @@ datum/fishing_spot/golden_toilet
 	/obj/item/cable_coil/blue/cut = 40,\
 	/obj/item/cell = 10,\
 	/obj/item/raw_material/cotton = 20, )
+
+//gibber
+/datum/fishing_spot/gibber
+	fishing_atom_type = /obj/machinery/gibber
+	rod_tier_required = 2
+	fish_available = list(/obj/decal/cleanable/blood/gibs = 25,\
+	/obj/decal/cleanable/blood/gibs/core = 25,\
+	/obj/item/reagent_containers/food/fish/meat_mutant = 10,\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 10,\
+	/obj/item/clothing/glasses/blindfold = 5,\
+	/obj/item/parts/human_parts/arm/mutant/monkey/left = 5,\
+	/obj/item/parts/human_parts/arm/mutant/monkey/right = 5,\
+	/obj/item/parts/human_parts/leg/mutant/monkey/left = 5,\
+	/obj/item/parts/human_parts/leg/mutant/monkey/right =5)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
lets you fish in the gibber, it has mostly the same pool as the cryopods/cloner but with monkey limbs instead of human limbs and with the inclusion of monkeymeat and blindfolds at a small rate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
more fishing spots = more fun, this seemed charming. also anglers are already incentivized to give fish to catering so more reasons for them to be over there is nice.  lets all do some inter departmental cooperation folks

![image](https://github.com/goonstation/goonstation/assets/142273065/d424dd4e-7f9b-4ddb-9148-34f8d64011aa)

[feature][game objects][joelsBestHits2024]
