### PR TITLE
Penalize security deparmental score if Stirstir dies

### DIFF
--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -342,6 +342,10 @@
 			"value" = round(score_tracker.score_enemy_failure_rate),
 		),
 		list(
+			"name" = "Monsieur Stirstir Survived",
+			"value" = score_tracker.score_stirstir_alive ? "Yes" : "No",
+		),
+		list(
 			"name" = "Total Department Score",
 			"type" = "colorPercent",
 			"value" =  round(score_tracker.final_score_sec),

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -10,6 +10,7 @@ var/datum/score_tracker/score_tracker
 	// var/score_crew_evacuation_rate = 0 save this for later to keep categories balanced
 	var/score_crew_survival_rate = 0
 	var/score_enemy_failure_rate = 0
+	var/score_stirstir_alive = FALSE
 	var/final_score_sec = 0
 	// ENGINEERING DEPARTMENT
 	var/power_generated = 0
@@ -85,6 +86,14 @@ var/datum/score_tracker/score_tracker
 		score_enemy_failure_rate = clamp(score_enemy_failure_rate,0,100)
 
 		final_score_sec = (score_crew_survival_rate + score_enemy_failure_rate) * 0.5
+
+		for(var/mob/living/carbon/human/npc/monkey/stirstir/M in mobs)
+			if(isalive(M))
+				score_stirstir_alive = TRUE
+
+		if(!score_stirstir_alive)
+			// YOU FUCKED UP
+			final_score_sec /= 2
 
 		// ENGINEERING DEPARTMENT SECTION
 		// also civ cleanliness counted here cos fuck calling a world loop more than once


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [STATION SYSTEMS] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Halve final department score for security if they fail to protect Stirstir from death.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A bunch of sec players expressed how much they hate Stirstir even though he's just a little boy so this will incentivize them to show him the love he deserves. Also its funny

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)Security's departmental score is now influenced by the fate of Monsieur Stirstir.
```
