### PR TITLE
power monitor comp sprite fix

### DIFF
--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -568,13 +568,6 @@ datum/pump_ui/circulator_ui
 		return our_circ
 
 
-/obj/machinery/computer/power_monitor
-	name = "Power Monitoring Computer"
-	icon = 'icons/obj/computer.dmi'
-	icon_state = "power"
-	density = 1
-	anchored = ANCHORED
-
 /obj/machinery/teg_connector
 	name = "\improper TEG connector"
 	desc = "Connects a Thermo-Electric Generator to its turbines."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes a stub override for the power monitor computer, which only really changed the sprite to that of the SMES monitor and left the bespoke sprite for this computer unused.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Can now tell the two computers apart visually.
![image](https://github.com/goonstation/goonstation/assets/31984217/54417109-e5c5-4d82-a6f9-9bc71ca70ef5)
Orange keyboard is now main powernet monitor, Yellow is SMES monitor.