### PR TITLE
Fix lopoint having no ammo cats

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1191,7 +1191,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	has_empty_state = FALSE // non detachable mag, for now...
 	w_class = W_CLASS_BULKY
 	force = MELEE_DMG_RIFLE
-	ammo_cats = 0
+	ammo_cats = list(AMMO_PISTOL_22)
 	max_ammo_capacity = 177
 	two_handed = TRUE
 	auto_eject = TRUE
@@ -1276,6 +1276,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	icon_state = "hipoint"
 	item_state = "hipoint"
 	shoot_delay = 4
+	ammo_cats = list(AMMO_PISTOL_9MM)
 	spread_angle = 3
 	throwforce = 14 // literally throw it away
 	w_class = W_CLASS_SMALL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes #19091 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

its probably a bad thing, ha ha :)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)You can no longer load the Lo-point with ten RPG/40mm/AEX/20mm rounds. Just 9mm. 
```
