### PR TITLE
Replace power monitor computer on Clarion with one that works

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7838,9 +7838,6 @@
 	pixel_y = -5
 	},
 /obj/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/cable/orange{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
@@ -10980,15 +10977,12 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
-/obj/machinery/computer/power_monitor/smes{
-	dir = 1;
-	name = "Engine Output Monitoring"
-	},
 /obj/machinery/power/data_terminal,
-/obj/cable/orange{
-	icon_state = "0-4"
-	},
 /obj/machinery/disposal/mail/small/autoname/engineering/north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/power_monitor,
 /turf/simulated/floor/white,
 /area/station/engine/engineering)
 "btB" = (
@@ -11249,6 +11243,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/engine/engineering)
@@ -20594,9 +20591,6 @@
 "hrp" = (
 /obj/cable/blue{
 	icon_state = "1-2"
-	},
-/obj/cable/blue{
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor{
@@ -32368,16 +32362,6 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
-"qfO" = (
-/obj/machinery/computer/power_monitor{
-	dir = 8
-	},
-/obj/cable/blue{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/black,
-/area/station/engine/core/nuclear)
 "qfW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -76221,7 +76205,7 @@ ycm
 uVN
 wtl
 ezM
-qfO
+tJp
 tJp
 tJp
 gfl


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the Power Monitoring computer in the PTL room and replaces the Engine Output computer in the main engineering room with a Power Monitoring computer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The Power Monitoring computer in the PTL room displays nothing because it isn't hooked up to the main grid and there's no easy wire access to the main grid from in there, replacing the Engine Output computer in the Engineering room with a Power Monitoring one is best because there's already a working Engine Output computer in the PTL room.
