### PR TITLE
No need to call ui.open() if we already have a ui window

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -991,7 +991,7 @@ TYPEINFO(/obj/machinery/transception_pad)
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "TransceptionInterlink")
-	ui.open()
+		ui.open()
 
 /obj/machinery/computer/transception/ui_data(mob/user)
 	. = ..()

--- a/code/modules/admin/abilitymanager.dm
+++ b/code/modules/admin/abilitymanager.dm
@@ -11,7 +11,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "AbilityManager")
-	ui.open()
+		ui.open()
 
 /datum/abilitymanager/ui_data(mob/user)
 	var/list/ability_props = list()

--- a/code/modules/admin/bioeffectmanager.dm
+++ b/code/modules/admin/bioeffectmanager.dm
@@ -11,7 +11,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "BioEffectManager")
-	ui.open()
+		ui.open()
 
 /datum/bioeffectmanager/ui_data(mob/user)
 	var/list/bioEffects = list()

--- a/code/modules/admin/job_manager.dm
+++ b/code/modules/admin/job_manager.dm
@@ -11,7 +11,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "JobManager")
-	ui.open()
+		ui.open()
 
 /datum/job_manager/ui_data(mob/user)
 	var/list/staple_job_data = list()

--- a/code/modules/admin/region_allocator_panel.dm
+++ b/code/modules/admin/region_allocator_panel.dm
@@ -11,7 +11,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "RegionAllocatorPanel")
-	ui.open()
+		ui.open()
 
 /datum/region_allocator_panel/ui_data(mob/user)
 	var/region_data = list()

--- a/code/modules/polling/poll_ballot.dm
+++ b/code/modules/polling/poll_ballot.dm
@@ -25,7 +25,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "PollBallot")
-	ui.open()
+		ui.open()
 
 /datum/poll_ballot/ui_data(mob/user)
 	. = list(

--- a/code/modules/polling/poll_editor_panel.dm
+++ b/code/modules/polling/poll_editor_panel.dm
@@ -15,7 +15,7 @@
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "PollEditorPanel")
-	ui.open()
+		ui.open()
 
 /datum/poll_editor_panel/ui_static_data(mob/user)
 	. = list(


### PR DESCRIPTION
[UI][CODE QUALITY]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Indents `ui.open()` to only be called if a new `ui` was created.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Saves an unneeded call, the UI is going to update in <1s anyway in all of the cases changed.