### PR TITLE
Show wizard's name instead of reader's name for spellbook

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1319,6 +1319,8 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	throw_range = 20
 	m_amt = 100
 	var/vr = FALSE
+	/// The name of the spellbook's wizard for display purposes
+	var/wizard_name = null
 #ifdef BONUS_POINTS
 	uses = 9999
 #endif
@@ -1340,14 +1342,11 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 			ui.open()
 
 	ui_data(mob/user)
-		. = list()
-		.["spell_slots"] = src.uses
+		. = list(
+			"spell_slots" = src.uses
+		)
 
 	ui_static_data(mob/user)
-		. = list()
-		.["owner_name"] = user.real_name
-		.["vr"] = src.vr
-
 		var/list/spellbook_contents = list()
 		for(var/datum/SWFuplinkspell/spell as anything in src.spells)
 			var/cooldown_contents = null
@@ -1368,12 +1367,18 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 				spell_img = spell_icon,
 				vr_allowed = spell.vr_allowed,
 			))
-		.["spellbook_contents"] = spellbook_contents
+		. = list(
+			"owner_name" = src.wizard_name,
+			"spellbook_contents" = spellbook_contents,
+			"vr" = src.vr
+		)
 
 	attack_self(mob/user)
 		if(!user.mind || (user.mind && user.mind.key != src.wizard_key))
 			boutput(user, SPAN_ALERT("<b>The spellbook is magically attuned to someone else!</b>"))
 			return
+		// update regardless, in case the wizard read their spellbook before setting their name
+		src.wizard_name = user.real_name
 		ui_interact(user)
 
 	ui_act(action, list/params)


### PR DESCRIPTION
[GAME OBJECTS][BUG]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Spellbooks know their owner's name and show it rather than the reader's.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18130.