### PR TITLE
Standardize a few security things

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1796,8 +1796,7 @@
 /area/station/crewquarters/cryotron)
 "agC" = (
 /obj/machinery/light_switch/auto,
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/flamethrower/assembled/loaded,
+/obj/machinery/vending/security,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -2122,22 +2121,6 @@
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
-"aif" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	light_type = /obj/item/light/tube/reddish;
-	pixel_y = 21
-	},
-/obj/machinery/vending/security,
-/obj/noticeboard/persistent{
-	name = "Security persistent notice board";
-	persistent_id = "security"
-	},
-/turf/simulated/floor/red/side{
-	dir = 5
-	},
-/area/station/security/main)
 "aii" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -2503,10 +2486,22 @@
 	},
 /area/station/chapel/sanctuary)
 "ajK" = (
+/obj/machinery/disposal/small{
+	dir = 8
+	},
+/obj/decal/stripe_caution,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /obj/machinery/flasher/portable,
 /obj/item/wrench,
-/obj/machinery/recharger/wall/sticky,
-/obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/security/main)
 "ajL" = (
@@ -2696,13 +2691,8 @@
 /area/station/hallway/primary/west)
 "akC" = (
 /obj/storage/cart/forensic,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	light_type = /obj/item/light/tube/reddish;
-	pixel_x = 10
-	},
 /obj/decal/stripe_caution,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor,
 /area/station/security/main)
 "akD" = (
@@ -3170,6 +3160,12 @@
 	pixel_x = 32
 	},
 /obj/decal/stripe_caution,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	light_type = /obj/item/light/tube/reddish;
+	pixel_x = 10
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "amY" = (
@@ -11724,22 +11720,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"aSQ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/machinery/disposal/small{
-	dir = 8
-	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/stairs/wide/other,
-/area/station/security/main)
 "aSR" = (
 /obj/cable/yellow{
 	icon_state = "2-4"
@@ -14837,7 +14817,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/red/corner{
+	dir = 4
+	},
 /area/station/security/main)
 "eFq" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -15215,8 +15197,18 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/red/corner{
-	dir = 4
+/obj/noticeboard/persistent{
+	name = "Security persistent notice board";
+	persistent_id = "security"
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	light_type = /obj/item/light/tube/reddish;
+	pixel_y = 21
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
 	},
 /area/station/security/main)
 "fHe" = (
@@ -17957,15 +17949,9 @@
 	},
 /area/station/crew_quarters/kitchen)
 "ogd" = (
-/obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
-	name = "Armory"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/mapping_helper/access/hos,
-/turf/simulated/floor/black,
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/item/gun/flamethrower/assembled/loaded,
+/turf/simulated/floor/caution/west,
 /area/station/ai_monitored/armory)
 "ogX" = (
 /obj/machinery/power/terminal,
@@ -18184,12 +18170,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/door/airlock/pyro/security{
+	aiControlDisabled = 1;
+	name = "Armory"
 	},
-/turf/simulated/floor/stairs/wide,
-/area/station/security/main)
+/obj/mapping_helper/access/hos,
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "oWx" = (
 /obj/machinery/power/terminal,
 /obj/cable/orange{
@@ -18360,12 +18347,9 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 8
 	},
-/turf/simulated/floor/red/side{
-	dir = 5
-	},
+/turf/simulated/floor/stairs,
 /area/station/security/main)
 "pmb" = (
 /obj/machinery/alarm{
@@ -74720,7 +74704,7 @@ afz
 wJs
 aez
 aez
-aif
+aez
 fGv
 akz
 rzl
@@ -75021,7 +75005,7 @@ aez
 afE
 gTj
 upB
-ogd
+upB
 oVW
 plm
 ajI
@@ -75323,8 +75307,8 @@ aez
 aUL
 aTa
 agW
+ogd
 ahO
-aSQ
 ajK
 akC
 pHn
@@ -75626,7 +75610,7 @@ aez
 aez
 aez
 aez
-ahl
+aez
 ahl
 ahl
 ahl

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -21408,11 +21408,9 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "hTx" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological{
-	req_access = null
-	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/redblack{
-	dir = 8
+	dir = 4
 	},
 /area/station/ai_monitored/armory)
 "hUj" = (
@@ -23902,7 +23900,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/black,
+/obj/mapping_helper/access/hos,
+/turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "jMO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -33022,57 +33021,9 @@
 	},
 /area/station/medical/head)
 "qLR" = (
-/obj/rack,
-/obj/item/clothing/mask/gas{
-	pixel_x = -7;
-	pixel_y = 8
+/obj/storage/secure/crate/plasma/armory/anti_biological{
+	req_access = null
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -15;
-	pixel_y = 8
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = -13
-	},
-/obj/item/clothing/suit/armor/heavy{
-	pixel_x = -5
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -13;
-	pixel_y = 12
-	},
-/obj/item/clothing/suit/armor/EOD{
-	pixel_x = 9
-	},
-/obj/item/clothing/suit/armor/EOD{
-	pixel_x = 1
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/EOD{
-	pixel_x = 12;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/EOD{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/machinery/turretid{
-	name = "External perimeter turret deactivation control";
-	pixel_x = -24;
-	turretArea = /area/station/turret_protected/armory_outside
-	},
-/obj/mapping_helper/access/hos,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -41016,9 +40967,58 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "wPp" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -15;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -13;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/machinery/turretid{
+	name = "External perimeter turret deactivation control";
+	pixel_x = -24;
+	turretArea = /area/station/turret_protected/armory_outside
+	},
 /turf/simulated/floor/redblack{
-	dir = 4
+	dir = 8
 	},
 /area/station/ai_monitored/armory)
 "wQr" = (
@@ -85584,8 +85584,8 @@ bgz
 pop
 iyl
 uDF
-hTx
 qLR
+wPp
 txc
 oxR
 uPa
@@ -86491,7 +86491,7 @@ bHH
 kcn
 jOO
 cUY
-wPp
+hTx
 rTC
 hjZ
 uPa

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -21408,19 +21408,12 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "hTx" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
+/obj/storage/secure/crate/plasma/armory/anti_biological{
+	req_access = null
 	},
-/obj/deployable_turret/riot/active{
-	dir = 1
+/turf/simulated/floor/redblack{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "hUj" = (
 /obj/shrub{
@@ -23897,13 +23890,20 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "jMf" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir";
-	tag = "icon-lattice-dir (SOUTHEAST)"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
 	},
-/turf/space,
-/area/station/turret_protected/armory_outside)
+/obj/deployable_turret/riot/active{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "jMO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/window_blinds/cog2/left,
@@ -24688,9 +24688,18 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/alarm{
 	pixel_y = 23
+	},
+/obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_x = -2;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/food/snacks/donut/custom/robust{
+	pixel_x = -1;
+	pixel_y = 2;
+	rand_pos = 0
 	},
 /turf/simulated/floor/redblack/corner{
 	dir = 8
@@ -39527,7 +39536,6 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
@@ -41008,15 +41016,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "wPp" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/redblack{
+	dir = 4
 	},
-/turf/space,
-/area/station/turret_protected/armory_outside)
+/area/station/ai_monitored/armory)
 "wQr" = (
 /obj/machinery/manufacturer/general,
 /obj/cable{
@@ -85282,7 +85286,7 @@ csQ
 csQ
 csQ
 csQ
-bIO
+uPa
 bIO
 bIO
 bFo
@@ -85580,11 +85584,11 @@ bgz
 pop
 iyl
 uDF
+hTx
 qLR
 txc
 oxR
 uPa
-wPp
 bIO
 bIO
 bFo
@@ -85883,10 +85887,10 @@ rtM
 biM
 biM
 biM
-hTx
+biM
+jMf
 ozI
 uPa
-bIO
 bIO
 bIO
 bFo
@@ -86185,10 +86189,10 @@ kwA
 glL
 glL
 glL
+glL
 pzC
 hjZ
 uPa
-bIO
 bIO
 bIO
 bFo
@@ -86487,10 +86491,10 @@ bHH
 kcn
 jOO
 cUY
+wPp
 rTC
 hjZ
 uPa
-bIO
 bIO
 bIO
 bFo
@@ -86790,9 +86794,9 @@ sPv
 sPv
 sPv
 sPv
+sPv
 htj
 uPa
-bIO
 bIO
 bIO
 bFo
@@ -87094,7 +87098,7 @@ uPa
 uPa
 uPa
 uPa
-jMf
+uPa
 bXM
 bXM
 mUF

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3177,7 +3177,26 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/item/storage/box/flashbang_kit{
+	pixel_y = 13
+	},
+/obj/item/storage/box/flashbang_kit{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/table/auto,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "alQ" = (
@@ -7255,6 +7274,9 @@
 	},
 /obj/window/reinforced{
 	dir = 1
+	},
+/obj/item/device/radio/intercom/security{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
@@ -42484,12 +42506,20 @@
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "gdD" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological{
-	req_access = null
-	},
-/obj/mapping_helper/access/sec_lockers,
-/obj/item/gun/flamethrower/assembled/loaded,
 /obj/decal/stripe_caution,
+/obj/table/auto,
+/obj/item/storage/box/revimp_kit{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/chem_grenade/flashbang{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/chem_grenade/pepper{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "geM" = (
@@ -43438,6 +43468,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"gRy" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor,
+/area/station/ai_monitored/armory)
 "gRz" = (
 /obj/disposalpipe/segment,
 /obj/machinery/alarm{
@@ -65143,25 +65180,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/hotloop)
 "xOA" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/obj/table/auto,
-/obj/item/storage/box/revimp_kit{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/obj/item/chem_grenade/pepper{
-	pixel_x = 11;
-	pixel_y = 3
-	},
-/obj/item/chem_grenade/flashbang{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/decal/stripe_caution,
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/item/gun/flamethrower/assembled/loaded,
 /turf/simulated/floor,
-/area/station/security/main)
+/area/station/ai_monitored/armory)
 "xOJ" = (
 /turf/simulated/floor/red/corner{
 	dir = 8
@@ -94575,8 +94600,8 @@ adC
 adC
 adC
 adC
-nxc
 dHa
+eFW
 eFW
 eFW
 eFW
@@ -94877,8 +94902,8 @@ adC
 adC
 adC
 adC
-nxc
 gsU
+nxc
 nxc
 nxc
 nxc
@@ -94899,7 +94924,7 @@ shp
 qEI
 jIz
 sDK
-xOA
+avd
 gdD
 awK
 xra
@@ -95179,11 +95204,11 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 fju
 acU
+vjb
 vjb
 vjb
 vjb
@@ -95481,10 +95506,10 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 acp
+acV
 acV
 acV
 acV
@@ -95783,13 +95808,13 @@ adC
 adC
 adC
 adC
-nxc
 wwh
 eFW
 act
 acV
 foS
 jYE
+xOA
 fWA
 nPU
 niY
@@ -96085,12 +96110,12 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 act
 acV
 sgN
+adE
 adE
 adE
 adE
@@ -96387,12 +96412,12 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 act
 acV
 mMm
+adE
 adE
 adE
 adE
@@ -96689,13 +96714,13 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 isQ
 act
 acV
 vOf
 uvs
+ahr
 ahr
 ahr
 alP
@@ -96991,12 +97016,12 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 act
 acV
 fAd
+adE
 adE
 adE
 adE
@@ -97293,13 +97318,13 @@ adC
 adC
 adC
 adC
-nxc
 wwh
 eFW
 act
 acV
 ghV
 aeW
+gRy
 agc
 aim
 afR
@@ -97595,10 +97620,10 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 ado
+acV
 acV
 acV
 acV
@@ -97897,11 +97922,11 @@ adC
 adC
 adC
 adC
-nxc
 gsU
 nxc
 adF
 acU
+vjb
 vjb
 vjb
 vjb
@@ -98199,8 +98224,8 @@ adC
 adC
 adC
 adC
-nxc
 gsU
+nxc
 nxc
 gsU
 nxc
@@ -98501,8 +98526,8 @@ aar
 aar
 aar
 aar
-eFW
 kvm
+eFW
 eFW
 fML
 xuC

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -35777,9 +35777,7 @@
 	},
 /area/station/crew_quarters/quarters_south)
 "gjV" = (
-/obj/stool/chair/office/red{
-	dir = 4
-	},
+/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
 	},
@@ -36597,7 +36595,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine,
 /area/station/security/secwing)
 "gOK" = (
@@ -56959,9 +56956,7 @@
 	},
 /area/station/solar/east)
 "vXP" = (
-/obj/machinery/computer3/generic/communications{
-	dir = 8
-	},
+/obj/machinery/computer3/generic/communications,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -30784,7 +30784,6 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -33862,7 +33861,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "oip" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine/caution/east,
 /area/station/ai_monitored/armory)
 "oiD" = (
@@ -55128,24 +55127,7 @@
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "xDM" = (
-/obj/storage/secure/closet/immersion/security,
-/obj/item/clothing/suit/space/diving/security{
-	pixel_x = -4
-	},
-/obj/item/clothing/head/helmet/space/engineer/diving/security{
-	pixel_x = -4
-	},
-/obj/item/tank/mini_oxygen{
-	pixel_x = 8
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/device/nanoloom{
-	pixel_x = 4;
-	pixel_y = -4
-	},
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/engine/caution/west,
 /area/station/ai_monitored/armory)
 "xEe" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1017,6 +1017,12 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "adi" = (
@@ -4561,17 +4567,11 @@
 	},
 /area/station/medical/head)
 "apB" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor/red,
-/area/station/security/main)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ai_monitored/armory)
 "apD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment2)
@@ -23231,7 +23231,6 @@
 "bFX" = (
 /obj/disposalpipe/segment/mail,
 /obj/storage/secure/closet/brig,
-/obj/item/storage/box/prosthesis_kit/eye_laser,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/security/main)
@@ -27470,9 +27469,17 @@
 	},
 /area/station/ai_monitored/armory)
 "bVa" = (
-/obj/item/device/radio/intercom/security,
-/obj/machinery/vending/security_ammo,
-/turf/simulated/floor/black,
+/obj/storage/secure/crate/plasma/armory/anti_biological{
+	req_access = null
+	},
+/obj/item/gun/flamethrower/assembled/loaded,
+/obj/item/ammo/bullets/flare,
+/obj/item/ammo/bullets/flare,
+/obj/item/gun/kinetic/flaregun,
+/obj/machinery/recharger/wall{
+	pixel_y = 28
+	},
+/turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "bVc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -27498,6 +27505,9 @@
 /obj/item/device/audio_log,
 /obj/item/audio_tape,
 /obj/machinery/light_switch/auto,
+/obj/item/device/radio/intercom/security{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "bVk" = (
@@ -27941,9 +27951,7 @@
 /obj/stool/chair/red{
 	dir = 4
 	},
-/turf/simulated/floor/redblack{
-	dir = 10
-	},
+/turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bWK" = (
 /obj/cable{
@@ -28203,10 +28211,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/recharger/wall{
-	pixel_y = 28
-	},
-/turf/simulated/floor/redblack,
+/turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bXx" = (
 /obj/cable{
@@ -30310,12 +30315,8 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "ceT" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/kinetic/flaregun,
-/obj/item/ammo/bullets/flare,
-/obj/item/ammo/bullets/flare,
-/obj/item/gun/flamethrower/assembled/loaded,
 /obj/decal/stripe_delivery,
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor,
 /area/station/security/main)
 "ceU" = (
@@ -37322,8 +37323,9 @@
 /area/station/security/hos)
 "jWq" = (
 /obj/random_item_spawner/armory_breaching_supplies,
+/obj/item/device/radio/intercom/security,
 /turf/simulated/floor/redblack{
-	dir = 8
+	dir = 10
 	},
 /area/station/ai_monitored/armory)
 "jWV" = (
@@ -37534,9 +37536,8 @@
 	name = "Genetic Research"
 	})
 "krS" = (
-/turf/simulated/floor/redblack/corner{
-	dir = 8
-	},
+/obj/machinery/vending/security_ammo,
+/turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "ksg" = (
 /turf/simulated/floor/black,
@@ -41902,7 +41903,6 @@
 	})
 "quk" = (
 /obj/machinery/computer/secure_data/detective_computer,
-/obj/item/device/radio/intercom/security,
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
@@ -91064,7 +91064,7 @@ bRH
 bSN
 bTR
 jWq
-krS
+bVX
 bWH
 bVX
 bVX
@@ -91667,7 +91667,7 @@ kbS
 hmK
 bJR
 bTR
-bTR
+krS
 bXw
 bXx
 bVX


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does a few things:
- Expands the armories on Cogmap 1, Atlas, Oshan, and Clarion slightly. This was to fit the anti-bio crates in the armory, and is only by a tile in most cases. Pics below.
- Anti-bio crates are now no longer in the main security rooms and will always be found in the armory.
- Interrogation rooms without intercoms have been given them, so that the rest of security (or the AI) can listen in from outside.
- Removed a box of laser eyes from oshan's security locker, not sure why they even had those.
- fixes #18181

![Screenshot (719)](https://github.com/goonstation/goonstation/assets/73998720/d825abe4-19f3-41e3-b4a7-9f0d1ad4501a)
![Screenshot (720)](https://github.com/goonstation/goonstation/assets/73998720/7cc04969-c050-4968-909d-56332882135a)
![Screenshot (721)](https://github.com/goonstation/goonstation/assets/73998720/68ede4a7-1ee5-4dd2-89f1-b82b819790db)
![Screenshot (722)](https://github.com/goonstation/goonstation/assets/73998720/4ac520d8-9d42-4453-af99-06ecc75280fc)
![Screenshot (724)](https://github.com/goonstation/goonstation/assets/73998720/c3fbda17-1e68-415b-8056-b5902209556e)
![Screenshot (725)](https://github.com/goonstation/goonstation/assets/73998720/12630553-f49e-473c-afc5-9fafafda6f54)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bioweapon crates having armory access while being in secmain is kind of weird, and the access sometimes wasn't consistent (staring at cog1). They're now all in the armory. Intercoms being in interros was brought up the other day, so I went ahead and put them in the ones missing them. It was requested on discord for cog1, but oshan didn't have one either. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)Anti-bioweapon crates have been moved to their proper homes in the armory.
```
