### PR TITLE
Makes donator figurines prioritize players

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -398,6 +398,7 @@
 	Z_LOG_DEBUG("Client/New", "[src.ckey] - Adding to clients")
 
 	clients += src
+	add_to_donator_list(src.ckey)
 
 	SPAWN(0) // to not lock up spawning process
 		src.has_contestwinner_medal = src.player.has_medal("Too Cool")

--- a/code/global.dm
+++ b/code/global.dm
@@ -43,6 +43,7 @@ var/global
 	list/aiImages = list() //List of images that are shown to all AIs. Management procs at the bottom of the file.
 	list/aiImagesLowPriority = list() //Same as above but these can wait a bit when sending to clients
 	list/clients = list()
+	list/figure_patreon_online = list()
 	list/mobs = list()
 	list/ai_mobs = list()
 	list/processing_items = list()

--- a/code/global.dm
+++ b/code/global.dm
@@ -43,7 +43,8 @@ var/global
 	list/aiImages = list() //List of images that are shown to all AIs. Management procs at the bottom of the file.
 	list/aiImagesLowPriority = list() //Same as above but these can wait a bit when sending to clients
 	list/clients = list()
-	list/figure_patreon_online = list()
+	list/donator_ckeys = list()
+	list/online_donator_ckeys = list()
 	list/mobs = list()
 	list/ai_mobs = list()
 	list/processing_items = list()

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -55,8 +55,8 @@
 						if (length(online_donator_ckeys_nouser))
 							fig_ckey = pick(online_donator_ckeys_nouser)
 					if (40 to 100)
-						fig_ckey = pick(online_donator_ckeys)
-				if (!fig_ckey) fig_ckey = pick(online_donator_ckeys)
+						fig_ckey = pick(donator_ckeys)
+				if (!fig_ckey) fig_ckey = pick(donator_ckeys)
 
 				//Now that we've picked the ckey to look for, find its randomInfo
 				for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -28,6 +28,7 @@
 
 	New(loc, var/datum/figure_info/newInfo)
 		..()
+		message_admins(json_encode(figure_patreon_online))
 		if (istype(newInfo))
 			src.info = newInfo
 		else if (!istype(src.info))
@@ -43,6 +44,8 @@
 			if (prob(src.patreon_prob))
 				if (donator_figtype && prob(30)) // 30% additional chance of donators getting their fig
 					randomInfo = donator_figtype
+				else if (prob(30) && figure_patreon_online)  // If someone doesn't get their own fig,
+					randomInfo = pick(figure_patreon_online) // then 30% chance it's someone's in the server
 				else
 					randomInfo = pick(figure_patreon_rarity)
 			else if (prob(src.rare_prob))
@@ -147,6 +150,12 @@
 			src.name = "[name_prefix(null, 1)][src.info.name] figure[name_suffix(null, 1)]"
 		else
 			return ..()
+
+proc/add_to_donator_list(var/potential_donator_ckey)
+	message_admins("Chosen game mode: DEBUG.")
+	for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
+		if (initial(fig.ckey) == potential_donator_ckey)
+			figure_patreon_online += fig
 
 var/list/figure_low_rarity = list(\
 /datum/figure_info/assistant,

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -28,7 +28,6 @@
 
 	New(loc, var/datum/figure_info/newInfo)
 		..()
-		message_admins(json_encode(figure_patreon_online))
 		if (istype(newInfo))
 			src.info = newInfo
 		else if (!istype(src.info))
@@ -36,18 +35,25 @@
 
 			var/potential_donator_ckey = usr?.mind?.ckey
 			var/donator_figtype = null
+			var/list/figure_patreon_online_nouser = figure_patreon_online
+
 			if (potential_donator_ckey) // check if the player has a figurine (therefore a donator)
 				for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
 					if (initial(fig.ckey) == potential_donator_ckey)
 						donator_figtype = fig
+						figure_patreon_online_nouser -= fig
 						src.patreon_prob *= 2	// x2 chance of getting patreon figure
+
 			if (prob(src.patreon_prob))
-				if (donator_figtype && prob(30)) // 30% additional chance of donators getting their fig
-					randomInfo = donator_figtype
-				else if (prob(30) && figure_patreon_online)  // If someone doesn't get their own fig,
-					randomInfo = pick(figure_patreon_online) // then 30% chance it's someone's in the server
-				else
-					randomInfo = pick(figure_patreon_rarity)
+					if (1 to 20)
+						randomInfo = donator_figtype
+					if (20 to 40)
+						if (figure_patreon_online_nouser.len)
+							randomInfo = pick(figure_patreon_online_nouser)
+					if (40 to 100)
+						randomInfo = pick(figure_patreon_rarity)
+				if (!randomInfo) randomInfo = pick(figure_patreon_rarity)
+
 			else if (prob(src.rare_prob))
 				randomInfo = pick(figure_high_rarity)
 			else
@@ -152,7 +158,6 @@
 			return ..()
 
 proc/add_to_donator_list(var/potential_donator_ckey)
-	message_admins("Chosen game mode: DEBUG.")
 	for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
 		if (initial(fig.ckey) == potential_donator_ckey)
 			figure_patreon_online += fig

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -15,7 +15,6 @@
 	var/patreon_prob = 9
 	var/rare_prob = 12
 	var/datum/figure_info/info = null
-	var/list/donator_ckeys
 
 	// grumble grumble
 	patreon
@@ -38,16 +37,15 @@
 			var/donator_fig_ckey = null
 			var/list/online_donator_ckeys_nouser = online_donator_ckeys.Copy()
 
-			if (potential_donator_ckey && length(online_donator_ckeys)) // check if the player has a figurine (therefore a donator)
-				for (var/ckey in online_donator_ckeys)
-					if (potential_donator_ckey == ckey)
-						donator_fig_ckey = ckey
-						online_donator_ckeys_nouser -= ckey
-						src.patreon_prob *= 2	// x2 chance of getting patreon figure
-						break
+			if (online_donator_ckeys.Find(potential_donator_ckey))//(potential_donator_ckey && length(online_donator_ckeys)) // check if the player has a figurine (therefore a donator)
+				//for (var/ckey in online_donator_ckeys)
+					//if (potential_donator_ckey == ckey)
+				donator_fig_ckey = potential_donator_ckey
+				online_donator_ckeys_nouser -= donator_fig_ckey
+				src.patreon_prob *= 2	// x2 chance of getting patreon figure
 
 			if (prob(src.patreon_prob))
-				var/fig_ckey
+				var/fig_ckey = null
 				switch (rand(1,100))
 					if (1 to 20)
 						fig_ckey = donator_fig_ckey
@@ -70,7 +68,7 @@
 				randomInfo = pick(figure_low_rarity)
 
 			src.info = new randomInfo(src)
-		src.name = "[src.info.name] figure"
+ 		src.name = "[src.info.name] figure"
 		src.icon_state = "fig-[src.info.icon_state]"
 		if (src.info.rare_varieties.len && prob(5))
 			src.icon_state = "fig-[pick(src.info.rare_varieties)]"

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -28,6 +28,10 @@
 
 	New(loc, var/datum/figure_info/newInfo)
 		..()
+		if (!length(donator_ckeys)) //creates a list of existing donator Ckeys if one does not already exist
+			for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
+				donator_ckeys += initial(fig.ckey)
+
 		if (istype(newInfo))
 			src.info = newInfo
 		else if (!istype(src.info))
@@ -51,7 +55,8 @@
 						if (length(online_donator_ckeys_nouser))
 							fig_ckey = pick(online_donator_ckeys_nouser)
 					if (40 to 100)
-						fig_ckey = pick(donator_ckeys)
+						if (length(donator_ckeys))
+							fig_ckey = pick(donator_ckeys)
 				if (!fig_ckey) fig_ckey = pick(donator_ckeys)
 
 				//Now that we've picked the ckey to look for, find its randomInfo
@@ -164,10 +169,6 @@
 			return ..()
 
 proc/add_to_donator_list(var/potential_donator_ckey)
-	if (!length(donator_ckeys)) //creates a list of existing donator Ckeys if one does not already exist
-		for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
-			donator_ckeys += initial(fig.ckey)
-
 	if (donator_ckeys.Find(potential_donator_ckey))
 		online_donator_ckeys += potential_donator_ckey
 

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -37,9 +37,7 @@
 			var/donator_fig_ckey = null
 			var/list/online_donator_ckeys_nouser = online_donator_ckeys.Copy()
 
-			if (online_donator_ckeys.Find(potential_donator_ckey))//(potential_donator_ckey && length(online_donator_ckeys)) // check if the player has a figurine (therefore a donator)
-				//for (var/ckey in online_donator_ckeys)
-					//if (potential_donator_ckey == ckey)
+			if (online_donator_ckeys.Find(potential_donator_ckey))
 				donator_fig_ckey = potential_donator_ckey
 				online_donator_ckeys_nouser -= donator_fig_ckey
 				src.patreon_prob *= 2	// x2 chance of getting patreon figure
@@ -170,9 +168,8 @@ proc/add_to_donator_list(var/potential_donator_ckey)
 		for (var/datum/figure_info/patreon/fig as anything in concrete_typesof(/datum/figure_info/patreon))
 			donator_ckeys += initial(fig.ckey)
 
-	for (var/ckey in donator_ckeys) //Adds to list of logged-in donator Ckeys
-		if (potential_donator_ckey == ckey)
-			online_donator_ckeys += potential_donator_ckey
+	if (donator_ckeys.Find(potential_donator_ckey))
+		online_donator_ckeys += potential_donator_ckey
 
 var/list/figure_low_rarity = list(\
 /datum/figure_info/assistant,

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -45,6 +45,7 @@
 						src.patreon_prob *= 2	// x2 chance of getting patreon figure
 
 			if (prob(src.patreon_prob))
+				switch (rand(1,100))
 					if (1 to 20)
 						randomInfo = donator_figtype
 					if (20 to 40)


### PR DESCRIPTION
## About the PR
Whenever a donator figurine is rolled from a capsule, there is a 20% chance it will be your own (if you have one), and a 20% chance it will be one that belongs to a donator (other than you) that logged in that round. 

This replaces the original 30% chance to get your own figurine.

## Why's this needed?
Having a figurine of an active coworker is far more fun than having one of a character that isn't in the round (and who you likely won't recognize). I've heard a horror story on the discord of a player opening [1500+ capsules](https://discord.com/channels/182249960895545344/890223118482800790/1201223607855095988) in search of a single player's figurine-- This should ease the search a little for future endeavors.


## Changelog 
```changelog
(u)Mintyphresh
(+)Increased chance to get figurines of donators that joined the round.
```
