### PR TITLE
Add armor pierce to syndicate dagger

### DIFF
--- a/code/datums/gamemodes/pod_wars.dm
+++ b/code/datums/gamemodes/pod_wars.dm
@@ -949,7 +949,7 @@ proc/setup_pw_crate_lists()
 		/obj/item/material_piece/steel{amount=10} = 1, /obj/item/material_piece/copper{amount=10} = 1, /obj/item/material_piece/glass{amount=10} = 1)
 
 	pw_rewards_tier2 = list(/obj/item/tank/jetpack = 1, /obj/item/old_grenade/smoke = 2,/obj/item/chem_grenade/flashbang = 2, /obj/item/barrier = 1,
-		/obj/item/old_grenade/emp = 3, /obj/item/sword/discount = 4, /obj/item/storage/firstaid/crit = 1, /obj/item/fireaxe = 1, /obj/item/dagger/syndicate/specialist = 2,
+		/obj/item/old_grenade/emp = 3, /obj/item/sword/discount = 4, /obj/item/storage/firstaid/crit = 1, /obj/item/fireaxe = 1, /obj/item/dagger/specialist = 2,
 		/obj/item/shipcomponent/mainweapon/mining = 2, /obj/item/shipcomponent/mainweapon/laser = 4, /obj/item/shipcomponent/mainweapon/disruptor_light = 4,/obj/item/ammo/power_cell/higher_power = 3, /obj/item/ammo/power_cell/self_charging/pod_wars_standard = 3,
 		/obj/item/material_piece/cerenkite{amount=5} = 1, /obj/item/material_piece/claretine{amount=5} = 1, /obj/item/material_piece/bohrum{amount=10} = 1, /obj/item/material_piece/plasmastone{amount=10} = 1, /obj/item/material_piece/uqill{amount=10} = 1, /obj/item/material_piece/telecrystal{amount=10})
 

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -536,15 +536,11 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	stamina_crit_chance = 50
 	pickup_sfx = 'sound/items/blade_pull.ogg'
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
-
-	var/pierces_armor = FALSE
+	HELP_MESSAGE_OVERRIDE({"Throw the dagger at someone to instantly incapacitate them for a short while."})
 
 	New()
 		..()
 		BLOCK_SETUP(BLOCK_KNIFE)
-
-		if (src.pierces_armor)
-			src.setProperty("piercing", 80)
 
 /obj/item/dagger/overwrite_impact_sfx(original_sound, hit_atom, thr)
 	. = ..()
@@ -584,10 +580,12 @@ TYPEINFO(/obj/item/sword/pink/angel)
 /obj/item/dagger/syndicate
 	name = "syndicate dagger"
 	desc = "An ornamental dagger for syndicate higher-ups. It sounds fancy, but it's basically the munitions company equivalent of those glass cubes with the company logo frosted on."
-	pierces_armor = TRUE
-	HELP_MESSAGE_OVERRIDE({"Throw the dagger at someone to instantly incapacitate them for a short while."})
 
-/obj/item/dagger/syndicate/specialist //Infiltrator class knife
+	New()
+		..()
+		src.setProperty("piercing", 80)
+
+/obj/item/dagger/specialist //Infiltrator class knife
 	name = "syndicate fighting utility knife"
 	desc = "A light but robust combat knife that allows you to move faster in fights. Knocks down targets when thrown."
 	icon_state = "combat_knife"
@@ -595,7 +593,6 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	throwforce = 20
 	stamina_cost = 5
 	c_flags = EQUIPPED_WHILE_HELD
-	pierces_armor = FALSE
 	setupProperties()
 		..()
 		setProperty("movespeed", -0.5)
@@ -611,6 +608,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	throw_range = 10
 	flags = FPRINT | TABLEPASS | USEDELAY //| NOSHIELD
 	desc = "Like many knives, these can be thrown. Unlike many knives, these are made to be thrown."
+	HELP_MESSAGE_OVERRIDE({"Throw the dagger at someone to take out a chunk of their stamina."})
 	gang
 		name = "familiar fighting knife"
 		force = 17

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -537,9 +537,14 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	pickup_sfx = 'sound/items/blade_pull.ogg'
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
 
+	var/pierces_armor = FALSE
+
 	New()
 		..()
 		BLOCK_SETUP(BLOCK_KNIFE)
+
+		if (src.pierces_armor)
+			src.setProperty("piercing", 80)
 
 /obj/item/dagger/overwrite_impact_sfx(original_sound, hit_atom, thr)
 	. = ..()
@@ -579,6 +584,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 /obj/item/dagger/syndicate
 	name = "syndicate dagger"
 	desc = "An ornamental dagger for syndicate higher-ups. It sounds fancy, but it's basically the munitions company equivalent of those glass cubes with the company logo frosted on."
+	pierces_armor = TRUE
 	HELP_MESSAGE_OVERRIDE({"Throw the dagger at someone to instantly incapacitate them for a short while."})
 
 /obj/item/dagger/syndicate/specialist //Infiltrator class knife
@@ -589,6 +595,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	throwforce = 20
 	stamina_cost = 5
 	c_flags = EQUIPPED_WHILE_HELD
+	pierces_armor = FALSE
 	setupProperties()
 		..()
 		setProperty("movespeed", -0.5)

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -542,7 +542,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/clothing/glasses/nightvision,
 		/obj/item/cloaking_device,
 		/obj/item/old_grenade/smoke = 2,
-		/obj/item/dagger/syndicate/specialist,
+		/obj/item/dagger/specialist,
 		/obj/item/card/emag,
 		/obj/item/clothing/suit/space/syndicate/specialist/infiltrator,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -526,7 +526,7 @@
 
 /datum/materiel/utility/knife
 	name = "Combat Knife"
-	path = /obj/item/dagger/syndicate/specialist
+	path = /obj/item/dagger/specialist
 	description = "A field-tested 10 inch combat knife, helps you move faster when held & knocks down targets when thrown."
 
 /datum/materiel/utility/rpg_ammo


### PR DESCRIPTION
[GAME OBJECTS][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 80% armor pierce to the syndicate dagger (mostly affecting revs game mode)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Syndicate dagger does 5 base damage and has no AP, meaning it actually does 0 dmg against an armor vest. Scalpel in comparison does 5 damage and has 80% armor pierce, so it does 4 dmg against armor vest

Seems pretty common that revheads will attack a security officer without knowing it's doing 0 damage, while still expecting something


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Syndicate dagger now has 80% armor pierce.
```
