### PR TITLE
Refactors the transparium reagent and makes its duration visible

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2647,7 +2647,7 @@ datum
 		transparium
 			name = "transparium"
 			id = "transparium"
-			description = "Fading into obscurity..."
+			description = "An exotic compound that intimidates nearby photons upon exiting the body, rendering the user invisible for a period of time proportional to how long it was present in their bloodstream."
 			reagent_state = LIQUID
 			fluid_r = 255
 			fluid_g = 255
@@ -2659,32 +2659,23 @@ datum
 			overdose = 30
 			var/effect_length = 0
 
-			on_mob_life(var/mob/living/M, var/mult = 1) // humans only! invisible critters would be awful...
-				if(!M)
-					holder.remove_reagent("transparium")
+			on_mob_life(mob/M, mult = 1) // humans only! invisible critters would be awful...
+				if (!ishuman(M))
+					src.holder.remove_reagent(src.id)
 					return
-
-				if (effect_length < 100) // because 30/0.4 = 75; give them a little more time spent invisible, but don't allow them to try and beat the system too much
-					effect_length+= 1 * mult
+				if (src.effect_length < 100) // because 30/0.4 = 75; give them a little more time spent invisible, but don't allow them to try and beat the system too much
+					src.effect_length += 1 * mult
 				..()
 
-			on_mob_life_complete(var/mob/living/M)
-				if(M)
-					boutput(M, SPAN_ALERT("You feel yourself fading away."))
-					M.alpha = 0
-					APPLY_ATOM_PROPERTY(M, PROP_MOB_HIDE_ICONS, src.id)
-					if(effect_length > 75)
-						M.take_brain_damage(10) // there!
-					SPAWN(effect_length * 10)
-						if(M.alpha != 255)
-							boutput(M, SPAN_NOTICE("You feel yourself returning back to normal. Phew!"))
-							M.alpha = 255
-							REMOVE_ATOM_PROPERTY(M, PROP_MOB_HIDE_ICONS, src.id)
+			on_mob_life_complete(mob/M)
+				if (src.effect_length > 75)
+					M.take_brain_damage(10)
+				M.setStatusMin("transparium", src.effect_length * 1 SECOND, 0)
 
-			do_overdose(var/severity, var/mob/living/M, var/mult = 1)
+			do_overdose(severity, mob/M, mult = 1)
 				var/effect = ..(severity, M)
 				if (severity == 1)
-					if(effect <= 4)
+					if (effect <= 4)
 						M.setStatusMin("knockdown", 5 SECONDS * mult)
 					else if (effect <= 8)
 						M.change_misstep_chance(12 * mult)
@@ -2692,7 +2683,7 @@ datum
 					else if (effect <= 20)
 						M.emote("faint")
 				else if (severity == 2)
-					if(effect <= 6)
+					if (effect <= 6)
 						M.setStatusMin("knockdown", 5 SECONDS * mult)
 					else if (effect <= 12)
 						M.change_misstep_chance(12 * mult)
@@ -2700,31 +2691,18 @@ datum
 					else if (effect <= 24)
 						M.emote("faint")
 
-		diluted_transparium
+		transparium/dilute
 			name = "diluted transparium"
 			id = "diluted_transparium"
-			description = "This looks a lot like plain water. Are you sure you didn't mess up?"
+			description = "Transparium that has been diluted with water to weaken its effects."
 			fluid_r = 10
 			fluid_g = 254
 			fluid_b = 254
-			transparency = 30
-			var/effect_length = 0
+			addiction_prob = 0
+			overdose = 0
 
-			on_mob_life(var/mob/M, var/mult = 1) // now this is ok
-				if(!M) M = holder.my_atom
-
-				effect_length += 1 * mult
-
-				..()
-
-			on_mob_life_complete(var/mob/living/M)
-				if(M)
-					boutput(M, SPAN_ALERT("You feel yourself fading."))
-					M.alpha = rand(80,200)
-					SPAWN(effect_length * 10)
-						if(M.alpha != 255)
-							boutput(M, SPAN_NOTICE("You feel yourself returning back to normal. Phew!"))
-							M.alpha = 255
+			on_mob_life_complete(mob/living/M)
+				M.setStatusMin("transparium", src.effect_length * 1 SECOND, rand(80, 200))
 
 		fartonium // :effort:
 			name = "fartonium"

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2860,3 +2860,41 @@
 		. = ..()
 		if (!istype(A, /mob/living))
 			return FALSE
+
+/datum/statusEffect/transparium
+	id = "transparium"
+	name = "Faded"
+	icon_state = "cloaked0"
+	unique = TRUE
+	var/alpha = 0
+	/// This is an unintentional interaction turned into a feature
+	/// Patches apply reagents very slowly, meaning that a transparium patch would constantly cause its user to flicker, spamming messages all the while
+	/// This variable is set whenever the duration is less than one second, and prevents message spam as well as not invoking some of the logic
+	var/flickering = FALSE
+
+	onAdd(optional)
+		..()
+		if (isnum(optional))
+			src.alpha = clamp(optional, 0, 255)
+			animate(src.owner, alpha = src.alpha, time = 2 SECONDS, flags = ANIMATION_PARALLEL, easing = BOUNCE_EASING)
+			if (src.duration < 1 SECOND)
+				if (!GET_COOLDOWN(src.owner, "[src.id]_flicker_message"))
+					boutput(src.owner, SPAN_ALERT("You're flickering [pick("crazily", "randomly", "wildly", "wackily", "out of control")]![pick(" Woah!", "")]"))
+				visible = FALSE
+				flickering = TRUE
+				// This should let the message start fresh for new patches/etc, but only show once for any given source
+				OVERRIDE_COOLDOWN(src.owner, "[src.id]_flicker_message", 5 SECONDS)
+			else
+				boutput(src.owner, SPAN_ALERT("You feel yourself fading away."))
+				if (src.alpha == 0)
+					APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_HIDE_ICONS, src.id)
+
+	onRemove()
+		..()
+		animate(src.owner, alpha = 255, time = 2 SECONDS, flags = ANIMATION_PARALLEL, easing = SINE_EASING | EASE_OUT)
+		if (!flickering)
+			boutput(src.owner, SPAN_NOTICE("You feel yourself returning back to normal. Phew!"))
+			REMOVE_ATOM_PROPERTY(src.owner, PROP_MOB_HIDE_ICONS, src.id)
+
+	getTooltip()
+		return "You've [alpha == 0 ? "completely" : "partially"] faded from view! People can still hear you and see light from anything you're carrying."


### PR DESCRIPTION
[QoL][Internal][Code Quality][Secret]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this PR makes the following changes:
* gives transparium a new description
* transparium's effects are now handled with a visible status effect instead of being in a `SPAWN()`. all of the internal logic has been moved into this effect. I used a (seemingly) unused state from `statussystem.dmi` for the icon state.
  * this effect contains logic for a "flickering" state, which makes it invisible and blocks off some of the logic. at the moment, transparium patches cause the mob to rapidly appear and disappear, spamming messages the whole time; I decided it'd be more fun to make this a deliberate feature instead of disabling it outright, and so now whenever the effect has a very low duration, it will appear differently.
  * if the potential for a status effect being added and then removed every tick is too heavyweight, I could disable the application entirely when the duration is very low.
* transparium now has a visible fade in/fade out, instead of setting the mob's alpha with no fanfare.
* diluted transparium is now a subtype of regular transparium with overdose threshold and addiction probably set to zero (i.e. disabled). this is for code cleanliness, so that the logic isn't copy-pasted from one to another.
* general syntax and style refinements across the board.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
transparium's a pretty old reagent and the code's a bit yucky. this should hopefully make it a lot cleaner, as well as more intuitive to use.

I could potentially foresee the "visible duration" part of this PR being undesirable, so if so, I'll happily axe it and just keep the cleanliness parts. no sense in wasting a perfectly good refactor!

## Media

### General showcase of appearing and disappearing **(discord ping warning, sorry!!)**
https://github.com/goonstation/goonstation/assets/47678781/dc65de8d-b30c-443e-b859-b7c77a5334f2

### Showcase of the "flickering" effect caused by a transparium patch (the audio's a bit crackly on this clip and I'm not sure why. oops!)
[transparium showcase.webm](https://github.com/goonstation/goonstation/assets/47678781/cd1d9b1c-ff99-439e-b491-539c3781aa8e)
