### PR TITLE
Wizard spell rebalance/rework

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -215,7 +215,7 @@
 	#define COMSIG_MOB_GRABBED "mob_grabbed"
 	/// Sent when a mob emotes (emote, voluntary, emote target)
 	#define COMSIG_MOB_EMOTE "mob_emote"
-	/// Sent when a mob is checking for an active energy shield
+	/// Sent when a mob is checking for an active shield
 	#define COMSIG_MOB_SHIELD_ACTIVATE "mob_shield_activate"
 	/// Sent when a mob flips, return TRUE to skip the rest of the flip emote coded, argument is (voluntary)
 	#define COMSIG_MOB_FLIP "mob_flip"

--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -73,6 +73,8 @@
 // ---- energy shield thing ----
 	/// Sent by the itemability to toggle the energyshield component
 	#define COMSIG_SHIELD_TOGGLE "energy_shield_toggle"
+	/// Used by the item to check if the shield is active or not
+	#define COMSIG_CHECK_SHIELD_ACTIVE "check_energy_shield_active"
 
 // ---- atom property signals ----
 

--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -70,8 +70,8 @@
 		/// Cell is fully charged
 		#define CELL_FULL 32
 
-// ---- energy shield thing ----
-	/// Sent by the itemability to toggle the energyshield component
+// ---- shield component signals ----
+	/// Sent by the itemability to toggle the shield component
 	#define COMSIG_SHIELD_TOGGLE "energy_shield_toggle"
 	/// Used by the item to check if the shield is active or not
 	#define COMSIG_CHECK_SHIELD_ACTIVE "check_energy_shield_active"

--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -988,9 +988,9 @@
 		updateObject()
 			return
 
-		doCooldown()
+		doCooldown(custom_cd)
 			var/datum/abilityHolder/localholder = src.holder
-			src.last_cast = world.time + src.cooldown
+			src.last_cast = world.time + custom_cd || src.cooldown
 			if(!QDELETED(localholder))
 				localholder.updateButtons()
 

--- a/code/datums/components/energy_shield.dm
+++ b/code/datums/components/energy_shield.dm
@@ -73,6 +73,11 @@ ABSTRACT_TYPE(/datum/component/wearertargeting/shield)
 	if((SLOT_L_HAND in valid_slots) || (SLOT_R_HAND in valid_slots))
 		parent:c_flags |= EQUIPPED_WHILE_HELD
 
+/datum/component/wearertargeting/shield/on_unequip(datum/source, mob/user)
+	if(src.active)
+		src.turn_off()
+	..()
+
 /datum/component/wearertargeting/shield/proc/activate(datum/source, incoming_damage, list/return_list)
 	if(!src.active)
 		return
@@ -101,11 +106,6 @@ ABSTRACT_TYPE(/datum/component/wearertargeting/shield)
 		src.internal_power -= cost
 
 	return //return code?
-
-/datum/component/wearertargeting/shield/on_unequip(datum/source, mob/user)
-	if(src.active)
-		src.turn_off()
-	..()
 
 /datum/component/wearertargeting/shield/proc/block_hit_fx()
 	return
@@ -176,8 +176,6 @@ ABSTRACT_TYPE(/datum/component/wearertargeting/shield)
 /datum/component/wearertargeting/shield/energy/on_unequip(datum/source, mob/user)
 	var/obj/item/I = parent
 	I.remove_item_ability(user, /obj/ability_button/toggle_shield)
-	if(active)
-		src.turn_off()
 	. = ..()
 
 /datum/component/wearertargeting/shield/energy/block_hit_fx()

--- a/code/modules/antagonists/wizard/abilities/_wizard_ability_holder.dm
+++ b/code/modules/antagonists/wizard/abilities/_wizard_ability_holder.dm
@@ -164,6 +164,8 @@
 	var/requires_being_on_turf = FALSE
 	var/requires_robes = 0
 	var/offensive = 0
+	/// if the spell is a defensive category wizard spell
+	var/defensive = FALSE
 	var/cooldown_staff = 0
 	var/prepared_count = 0
 	var/casting_time = 0
@@ -192,10 +194,11 @@
 			qdel(object)
 		..()
 
-	doCooldown()
-		src.last_cast = world.time + calculate_cooldown()
-		SPAWN(calculate_cooldown() + 5)
-			holder.updateButtons()
+	doCooldown(custom_cd)
+		if (!custom_cd)
+			..(src.calculate_cooldown())
+		else
+			..(custom_cd)
 
 	//mbc : i don't see why the wizard needs a specialized tryCast() proc. someone fix it later for me!
 	tryCast(atom/target)
@@ -299,3 +302,8 @@
 
 		var/log_target = constructTarget(target,"combat")
 		logTheThing(LOG_COMBAT, holder.owner, "casts [src.name] from [log_loc(holder.owner)][targeted ? ", at [log_target]" : ""].")
+
+		if (src.defensive)
+			for(var/datum/targetable/spell/spell in (src.holder.abilities - src))
+				if (spell.defensive && ((spell.last_cast - world.time) / 10 < 5 SECONDS))
+					spell.doCooldown(5 SECONDS)

--- a/code/modules/antagonists/wizard/abilities/animatedead.dm
+++ b/code/modules/antagonists/wizard/abilities/animatedead.dm
@@ -1,6 +1,6 @@
 /datum/targetable/spell/animatedead
 	name = "Animate Dead"
-	desc = "Turns a human corpse into a skeletal minion."
+	desc = "Turns a human corpse or monkey into a skeletal minion."
 	icon_state = "pet"
 	targeted = TRUE
 	max_range = 1
@@ -19,8 +19,9 @@
 		if(!holder)
 			return
 		if(!isdead(target))
-			boutput(holder.owner, SPAN_ALERT("That person is still alive! Find a corpse."))
-			return TRUE // No cooldown when it fails.
+			if (!istype(target, /mob/living/carbon/human/npc/monkey))
+				boutput(holder.owner, SPAN_ALERT("That person is still alive! Find a corpse or monkey."))
+				return TRUE // No cooldown when it fails.
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
 			holder.owner.say("EI NECRIS", FALSE, maptext_style, maptext_colors)
 		..()
@@ -29,6 +30,9 @@
 		skeleton.CustomiseSkeleton(target.real_name, ismonkey(target))
 
 		boutput(holder.owner, SPAN_NOTICE("You saturate [target] with dark magic!"))
+		if (istype(target, /mob/living/carbon/human/npc/monkey))
+			target.death()
+			sleep(0.5 SECONDS)
 		holder.owner.visible_message(SPAN_ALERT("[holder.owner] rips the skeleton from [target]'s corpse!"))
 
 		for(var/obj/item/I in target)
@@ -37,4 +41,4 @@
 				if(I)
 					I.set_loc(target.loc)
 					I.dropped(target)
-		target.gib(TRUE)
+		target.gib(TRUE, TRUE)

--- a/code/modules/antagonists/wizard/abilities/blink.dm
+++ b/code/modules/antagonists/wizard/abilities/blink.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 100
 	requires_robes = 1
+	defensive = TRUE
 	restricted_area_check = ABILITY_AREA_CHECK_ALL_RESTRICTED_Z
 	voice_grim = 'sound/voice/wizard/BlinkGrim.ogg'
 	voice_fem = 'sound/voice/wizard/BlinkFem.ogg'

--- a/code/modules/antagonists/wizard/abilities/doppelganger.dm
+++ b/code/modules/antagonists/wizard/abilities/doppelganger.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 300
 	requires_robes = 1
+	defensive = TRUE
 	restricted_area_check = ABILITY_AREA_CHECK_ALL_RESTRICTED_Z
 	voice_grim = 'sound/voice/wizard/DopplegangerGrim.ogg'
 	voice_fem = 'sound/voice/wizard/DopplegangerFem.ogg'

--- a/code/modules/antagonists/wizard/abilities/forcewall.dm
+++ b/code/modules/antagonists/wizard/abilities/forcewall.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 10 SECONDS
 	requires_robes = 1
+	defensive = TRUE
 	requires_being_on_turf = TRUE
 	voice_grim = 'sound/voice/wizard/ForcewallGrim.ogg'
 	voice_fem = 'sound/voice/wizard/ForcewallFem.ogg'

--- a/code/modules/antagonists/wizard/abilities/forcewall.dm
+++ b/code/modules/antagonists/wizard/abilities/forcewall.dm
@@ -3,7 +3,7 @@
 	desc = "Create a forcewall which extends out to your sides."
 	icon_state = "forcewall"
 	targeted = 0
-	cooldown = 20 SECONDS
+	cooldown = 10 SECONDS
 	requires_robes = 1
 	requires_being_on_turf = TRUE
 	voice_grim = 'sound/voice/wizard/ForcewallGrim.ogg'
@@ -40,7 +40,7 @@
 			if (holder.owner.wizard_spellpower(src)) forcefield4 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y + 2,holder.owner.z))
 			if (holder.owner.wizard_spellpower(src)) forcefield5 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y - 2,holder.owner.z))
 
-		SPAWN(30 SECONDS)
+		SPAWN(20 SECONDS)
 			qdel(forcefield1)
 			qdel(forcefield2)
 			qdel(forcefield3)

--- a/code/modules/antagonists/wizard/abilities/forcewall.dm
+++ b/code/modules/antagonists/wizard/abilities/forcewall.dm
@@ -3,7 +3,7 @@
 	desc = "Create a forcewall which extends out to your sides."
 	icon_state = "forcewall"
 	targeted = 0
-	cooldown = 10 SECONDS
+	cooldown = 20 SECONDS
 	requires_robes = 1
 	defensive = TRUE
 	requires_being_on_turf = TRUE
@@ -41,7 +41,7 @@
 			if (holder.owner.wizard_spellpower(src)) forcefield4 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y + 2,holder.owner.z))
 			if (holder.owner.wizard_spellpower(src)) forcefield5 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y - 2,holder.owner.z))
 
-		SPAWN(20 SECONDS)
+		SPAWN(10 SECONDS)
 			qdel(forcefield1)
 			qdel(forcefield2)
 			qdel(forcefield3)

--- a/code/modules/antagonists/wizard/abilities/magicmissile.dm
+++ b/code/modules/antagonists/wizard/abilities/magicmissile.dm
@@ -3,7 +3,7 @@
 	desc = "Attacks nearby foes with stunning projectiles."
 	icon_state = "missile"
 	targeted = 0
-	cooldown = 200
+	cooldown = 25 SECONDS
 	requires_robes = 1
 	requires_being_on_turf = TRUE
 	offensive = 1

--- a/code/modules/antagonists/wizard/abilities/magshield.dm
+++ b/code/modules/antagonists/wizard/abilities/magshield.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 600
 	requires_robes = 1
+	defensive = TRUE
 	cooldown_staff = 1
 	voice_grim = 'sound/voice/wizard/MagicShieldGrim.ogg'
 	voice_fem = 'sound/voice/wizard/MagicShieldFem.ogg'

--- a/code/modules/antagonists/wizard/abilities/magshield.dm
+++ b/code/modules/antagonists/wizard/abilities/magshield.dm
@@ -13,29 +13,23 @@
 	maptext_colors = list("#24639a", "#24bdc6")
 
 	cast()
-		if(!holder)
+		if(!istype(holder?.owner, /mob/living/carbon/human))
 			return
-		if(holder.owner.spellshield)
+
+		var/mob/living/carbon/human/H = src.holder.owner
+		var/obj/item/clothing/suit/wizrobe/robe = H.wear_suit
+
+		if(istype(robe, /obj/item/clothing/suit/wizrobe) && SEND_SIGNAL(robe, COMSIG_CHECK_SHIELD_ACTIVE))
 			boutput(holder.owner, SPAN_ALERT("You already have a Spell Shield active!"))
-			return
+			return TRUE
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
 			holder.owner.say("XYZZYX", FALSE, maptext_style, maptext_colors)
 		..()
 
-		var/image/shield_overlay = null
+		SEND_SIGNAL(robe, COMSIG_SHIELD_TOGGLE)
 
-		holder.owner.spellshield = 1
-		shield_overlay = image('icons/effects/effects.dmi', holder.owner, "enshield", MOB_LAYER+1)
-		holder.owner.underlays += shield_overlay
-		boutput(holder.owner, SPAN_NOTICE("<b>You are surrounded by a magical barrier!</b>"))
-		holder.owner.visible_message(SPAN_ALERT("[holder.owner] is encased in a protective shield."))
-		playsound(holder.owner, 'sound/effects/MagShieldUp.ogg', 50,1)
 		SPAWN(10 SECONDS)
-			if(holder.owner && holder.owner.spellshield)
-				holder.owner.spellshield = 0
-				holder.owner.underlays -= shield_overlay
-				shield_overlay = null
-				boutput(holder.owner, SPAN_NOTICE("<b>Your magical barrier fades away!</b>"))
-				holder.owner.visible_message(SPAN_ALERT("The shield protecting [holder.owner] fades away."))
-				playsound(usr, 'sound/effects/MagShieldDown.ogg', 50, TRUE)
+			if(!QDELETED(H) && !QDELETED(robe))
+				if (SEND_SIGNAL(robe, COMSIG_CHECK_SHIELD_ACTIVE))
+					SEND_SIGNAL(robe, COMSIG_SHIELD_TOGGLE)

--- a/code/modules/antagonists/wizard/abilities/magshield.dm
+++ b/code/modules/antagonists/wizard/abilities/magshield.dm
@@ -1,6 +1,6 @@
 /datum/targetable/spell/magshield
 	name = "Spell Shield"
-	desc = "Temporarily shield yourself from melee attacks and projectiles. It also absorbs some of the blast of explosions."
+	desc = "Temporarily shield yourself from melee attacks, projectiles, and explosions"
 	icon_state = "spellshield"
 	targeted = 0
 	cooldown = 600

--- a/code/modules/antagonists/wizard/abilities/mutate.dm
+++ b/code/modules/antagonists/wizard/abilities/mutate.dm
@@ -1,6 +1,6 @@
 /datum/targetable/spell/mutate
 	name = "Empower"
-	desc = "Temporarily superpowers your body."
+	desc = "Temporarily superpowers your body and grants a burst of strength"
 	icon_state = "mutate"
 	targeted = 0
 	cooldown = 30 SECONDS

--- a/code/modules/antagonists/wizard/abilities/mutate.dm
+++ b/code/modules/antagonists/wizard/abilities/mutate.dm
@@ -3,7 +3,7 @@
 	desc = "Temporarily superpowers your body."
 	icon_state = "mutate"
 	targeted = 0
-	cooldown = 400
+	cooldown = 30 SECONDS
 	requires_robes = 1
 	offensive = 1
 	voice_grim = 'sound/voice/wizard/MutateGrim.ogg'
@@ -25,9 +25,10 @@
 			holder.owner.bioHolder.AddEffect("hulk", 0, 0, 0, 1)
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_PASSIVE_WRESTLE, "empower")
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_STAMINA_REGEN_BONUS, "empower", 5)
-		var/SPtime = 150
+		holder.owner.changeStatus("knockdown", -10 SECONDS)
+		var/SPtime = 9 SECONDS
 		if (holder.owner.wizard_spellpower(src))
-			SPtime = 300
+			SPtime = 15 SECONDS
 		else
 			boutput(holder.owner, SPAN_ALERT("Your spell doesn't last as long without a staff to focus it!"))
 		SPAWN(SPtime)

--- a/code/modules/antagonists/wizard/abilities/phaseshift.dm
+++ b/code/modules/antagonists/wizard/abilities/phaseshift.dm
@@ -6,6 +6,7 @@
 	cooldown = 300
 	requires_robes = 1
 	cooldown_staff = 1
+	defensive = TRUE
 	restricted_area_check = ABILITY_AREA_CHECK_ALL_RESTRICTED_Z
 	voice_grim = 'sound/voice/wizard/MistFormGrim.ogg'
 	voice_fem = 'sound/voice/wizard/MistFormFem.ogg'

--- a/code/modules/antagonists/wizard/abilities/prismatic_spray.dm
+++ b/code/modules/antagonists/wizard/abilities/prismatic_spray.dm
@@ -43,11 +43,10 @@
 		return !(proj_type in src.blacklist)
 
 	cast(atom/target)
-		if (holder.owner.wizard_spellpower(src) && !istype(src, /datum/targetable/spell/prismatic_spray/admin))
-			src.num_projectiles = 5
+		var/projectiles_to_fire = src.num_projectiles
+		if (!holder.owner.wizard_spellpower(src) && !istype(src, /datum/targetable/spell/prismatic_spray/admin))
+			projectiles_to_fire = 5
 			boutput(holder.owner, SPAN_ALERT("Your spell isn't as strong without a staff to refract the light!"))
-		else
-			src.num_projectiles = initial(src.num_projectiles)
 		. = ..()
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
 			holder.owner.say("PROJEHK TUL IHNFERNUS", FALSE, maptext_style, maptext_colors) //incantation credit to Grifflez
@@ -55,7 +54,7 @@
 		logTheThing(LOG_COMBAT, holder.owner, "casts Prismatic spray at [constructTarget(target,"combat")].")
 		// Put voice stuff here in the future
 		if(src.random == 0)
-			for(var/i=0, i<num_projectiles, i++)
+			for(var/i = 0 to projectiles_to_fire)
 				var/turf/S = get_turf(holder.owner)
 				ps_proj.randomise()
 				if (get_turf(target) == S)
@@ -72,7 +71,7 @@
 						P.launch()
 						sleep(0.1 SECONDS)
 		else
-			for(var/i=0, i<num_projectiles, i++)
+			for(var/i = 0 to projectiles_to_fire)
 				var/turf/S = get_turf(holder.owner)
 				if (get_turf(target) == S)
 					var/obj/projectile/P = shoot_projectile_XY(S, pick(proj_types), cos(rand(0,360)), sin(rand(0,360)))

--- a/code/modules/antagonists/wizard/abilities/prismatic_spray.dm
+++ b/code/modules/antagonists/wizard/abilities/prismatic_spray.dm
@@ -43,49 +43,50 @@
 		return !(proj_type in src.blacklist)
 
 	cast(atom/target)
-		if (holder.owner.wizard_spellpower(src) || istype(src, /datum/targetable/spell/prismatic_spray/admin))
-			. = ..()
-			if(!istype(get_area(holder.owner), /area/sim/gunsim))
-				holder.owner.say("PROJEHK TUL IHNFERNUS", FALSE, maptext_style, maptext_colors) //incantation credit to Grifflez
-			//var/mob/living/carbon/human/O = holder.owner
-			logTheThing(LOG_COMBAT, holder.owner, "casts Prismatic spray at [constructTarget(target,"combat")].")
-			// Put voice stuff here in the future
-			if(src.random == 0)
-				for(var/i=0, i<num_projectiles, i++)
-					var/turf/S = get_turf(holder.owner)
-					ps_proj.randomise()
-					if (get_turf(target) == S)
-						var/obj/projectile/P = shoot_projectile_XY(S, ps_proj, cos(rand(0,360)), sin(rand(0,360)))
-						if (P)
-							P.mob_shooter = holder.owner
-							sleep(0.1 SECONDS)
-					else
-						var/obj/projectile/P = initialize_projectile_pixel_spread(holder.owner, ps_proj, target )
-						if (P)
-							P.mob_shooter = holder.owner
-							var/angle = (rand(spread * -1000, spread * 1000))/1000
-							P.rotateDirection(angle)
-							P.launch()
-							sleep(0.1 SECONDS)
-			else
-				for(var/i=0, i<num_projectiles, i++)
-					var/turf/S = get_turf(holder.owner)
-					if (get_turf(target) == S)
-						var/obj/projectile/P = shoot_projectile_XY(S, pick(proj_types), cos(rand(0,360)), sin(rand(0,360)))
-						if (P)
-							P.mob_shooter = holder.owner
-							sleep(0.1 SECONDS)
-					else
-						var/obj/projectile/P = initialize_projectile_pixel_spread(holder.owner, pick(proj_types), target )
-						if (P)
-							P.mob_shooter = holder.owner
-							var/angle = (rand(spread * -1000, spread * 1000))/1000
-							P.rotateDirection(angle)
-							P.launch()
-							sleep(0.1 SECONDS)
+		if (holder.owner.wizard_spellpower(src) && !istype(src, /datum/targetable/spell/prismatic_spray/admin))
+			src.num_projectiles = 5
+			boutput(holder.owner, SPAN_ALERT("Your spell isn't as strong without a staff to refract the light!"))
 		else
-			boutput(holder.owner, SPAN_ALERT("Your spell doesn't work without a staff to refract the light!"))
-			return 1
+			src.num_projectiles = initial(src.num_projectiles)
+		. = ..()
+		if(!istype(get_area(holder.owner), /area/sim/gunsim))
+			holder.owner.say("PROJEHK TUL IHNFERNUS", FALSE, maptext_style, maptext_colors) //incantation credit to Grifflez
+		//var/mob/living/carbon/human/O = holder.owner
+		logTheThing(LOG_COMBAT, holder.owner, "casts Prismatic spray at [constructTarget(target,"combat")].")
+		// Put voice stuff here in the future
+		if(src.random == 0)
+			for(var/i=0, i<num_projectiles, i++)
+				var/turf/S = get_turf(holder.owner)
+				ps_proj.randomise()
+				if (get_turf(target) == S)
+					var/obj/projectile/P = shoot_projectile_XY(S, ps_proj, cos(rand(0,360)), sin(rand(0,360)))
+					if (P)
+						P.mob_shooter = holder.owner
+						sleep(0.1 SECONDS)
+				else
+					var/obj/projectile/P = initialize_projectile_pixel_spread(holder.owner, ps_proj, target )
+					if (P)
+						P.mob_shooter = holder.owner
+						var/angle = (rand(spread * -1000, spread * 1000))/1000
+						P.rotateDirection(angle)
+						P.launch()
+						sleep(0.1 SECONDS)
+		else
+			for(var/i=0, i<num_projectiles, i++)
+				var/turf/S = get_turf(holder.owner)
+				if (get_turf(target) == S)
+					var/obj/projectile/P = shoot_projectile_XY(S, pick(proj_types), cos(rand(0,360)), sin(rand(0,360)))
+					if (P)
+						P.mob_shooter = holder.owner
+						sleep(0.1 SECONDS)
+				else
+					var/obj/projectile/P = initialize_projectile_pixel_spread(holder.owner, pick(proj_types), target )
+					if (P)
+						P.mob_shooter = holder.owner
+						var/angle = (rand(spread * -1000, spread * 1000))/1000
+						P.rotateDirection(angle)
+						P.launch()
+						sleep(0.1 SECONDS)
 
 /datum/targetable/spell/prismatic_spray/admin
 	random = 1

--- a/code/modules/antagonists/wizard/abilities/teleport.dm
+++ b/code/modules/antagonists/wizard/abilities/teleport.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 450
 	requires_robes = 1
+	defensive = TRUE
 	cooldown_staff = 1
 	restricted_area_check = ABILITY_AREA_CHECK_ALL_RESTRICTED_Z
 	maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")

--- a/code/modules/antagonists/wizard/abilities/warp.dm
+++ b/code/modules/antagonists/wizard/abilities/warp.dm
@@ -7,6 +7,7 @@
 	requires_robes = 1
 	requires_being_on_turf = TRUE
 	offensive = 1
+	defensive = TRUE
 	restricted_area_check = ABILITY_AREA_CHECK_ALL_RESTRICTED_Z
 	sticky = 1
 	voice_grim = 'sound/voice/wizard/WarpGrim.ogg'

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -38,7 +38,7 @@
 	<li>Teleportation scroll</li><dd><i>- Allows instant teleportation to an area of your choice. The scroll has four charges. Don't lose it though, or you can't get back to the shuttle without knowing the <b><i>teleport</b></i> spell, or dying while <b><i>soulguard</b></i> is active!</i></dd>
 	<li>Spellbook</li><dd><i>- This is your personal spellbook that gives you access to the Wizarding Archives, allowing you to choose 4 spells with which to complete your objectives. The spellbook only works for you, and can be discarded after its uses are expended.</i></dd>
 	<br><br><br><hr>Spells every wizard starts with:<br><br>
-	<li>Magic missile (20 seconds)</li><dd><i>- This spell fires several slow-moving projectiles at nearby targets. If they hit a target, it is stunned and takes minor damage.</i></dd>
+	<li>Magic missile (25 seconds)</li><dd><i>- This spell fires several slow-moving projectiles at nearby targets. If they hit a target, it is stunned and takes minor damage.</i></dd>
 	<li>Phase shift (30 seconds)</li><dd><i>- This spell briefly turns your form ethereal, allowing you to pass invisibly through anything.</i></dd>
 	<li>Clairvoyance (60 seconds)</li><dd><i>- This spell will tell you the location of those you target with it. It will also inform you if they are hiding inside something, or are dead.</i></dd>
 	<br><br><br>Click the question mark in your <b>spellbook</b> to learn more about certain spells.<br>Recommended loadout for beginners: <b><i>ice burst, blink, shocking touch, blind</i></b>

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -69,6 +69,16 @@
 		add_filter("motion blur", 1, motion_blur_filter(x=0, y=3))
 		..()
 
+/obj/decal/wizard_shield
+	name = ""
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "enshield"
+	layer = MOB_LAYER + 1
+	anchored = ANCHORED
+	mouse_opacity = 0
+	blend_mode = BLEND_ADD
+	plane = PLANE_NOSHADOW_ABOVE
+
 /obj/decal/floatingtiles
 	name = "floating tiles"
 	desc = "These tiles are just floating around in the void."

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -659,7 +659,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	New()
 		. = ..()
 		AddComponent(/datum/component/cell_holder, new /obj/item/ammo/power_cell/self_charging/disruptor, TRUE, 100, FALSE)
-		AddComponent(/datum/component/wearertargeting/energy_shield, list(SLOT_BELT, SLOT_L_HAND, SLOT_R_HAND), 0.75, 1, TRUE, 5) //blocks 75% of damage taken, up to 100 damage total
+		AddComponent(/datum/component/wearertargeting/shield/energy, list(SLOT_BELT, SLOT_L_HAND, SLOT_R_HAND), 0.75, 1, TRUE, 5) //blocks 75% of damage taken, up to 100 damage total
 
 
 // Merchant

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -739,6 +739,14 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	item_function_flags = IMMUNE_TO_ACID
 	duration_remove = 10 SECONDS
 
+	unequipped(mob/user)
+		if (istype(user, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = user
+			if (istype(H.wear_suit, /obj/item/clothing/suit/wizrobe) && SEND_SIGNAL(H.wear_suit, COMSIG_CHECK_SHIELD_ACTIVE))
+				SEND_SIGNAL(H.wear_suit, COMSIG_SHIELD_TOGGLE)
+		..()
+
+
 	setupProperties()
 		..()
 		setProperty("disorient_resist_eye", 15)

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -746,7 +746,6 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 				SEND_SIGNAL(H.wear_suit, COMSIG_SHIELD_TOGGLE)
 		..()
 
-
 	setupProperties()
 		..()
 		setProperty("disorient_resist_eye", 15)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1369,7 +1369,7 @@ TYPEINFO(/obj/item/clothing/suit/hazard/fire/armored)
 		. = ..()
 		var/obj/item/ammo/power_cell/self_charging/cell = new/obj/item/ammo/power_cell/self_charging{max_charge = 100; recharge_rate = 25; recharge_delay = 10 SECONDS}
 		AddComponent(/datum/component/cell_holder, cell, FALSE, 100, FALSE)
-		AddComponent(/datum/component/wearertargeting/energy_shield, list(SLOT_WEAR_SUIT), 1, 1, TRUE, 0) //blocks 100% of damage taken, up to 100 damage total. No drain
+		AddComponent(/datum/component/wearertargeting/shield/energy, list(SLOT_WEAR_SUIT), 1, 1, TRUE, 0) //blocks 100% of damage taken, up to 100 damage total. No drain
 
 /obj/item/clothing/suit/space/engineer
 	name = "engineering space suit"
@@ -1715,6 +1715,11 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	hides_from_examine = C_UNIFORM
 	contraband = 4
 	duration_remove = 10 SECONDS
+
+	New()
+		..()
+		// this can really be added on the hat or robe, but should be tied to a wizard clothing item to work with clothes being required for spells
+		AddComponent(/datum/component/wearertargeting/shield/wizard, list(SLOT_WEAR_SUIT), 1, 1, TRUE, 0, 250)
 
 	setupProperties()
 		..()

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -674,7 +674,7 @@
 
 	New()
 		..()
-		AddComponent(/datum/component/wearertargeting/energy_shield/ceshield, list(SLOT_BELT), 0.75, 0.3, FALSE, 5) //blocks 3/4 of incoming damage, up to 200 points, on a full charge, but loses charge quickly while active
+		AddComponent(/datum/component/wearertargeting/shield/energy/ceshield, list(SLOT_BELT), 0.75, 0.3, FALSE, 5) //blocks 3/4 of incoming damage, up to 200 points, on a full charge, but loses charge quickly while active
 		var/obj/item/ammo/power_cell/self_charging/cell = new/obj/item/ammo/power_cell/self_charging{recharge_rate = 3; recharge_delay = 10 SECONDS}
 		AddComponent(/datum/component/cell_holder, cell, FALSE, 100, FALSE)
 		cell.set_loc(null) //otherwise it takes a slot in the belt. aaaaa

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -212,8 +212,10 @@ TYPEINFO(/obj/item/baton)
 		else
 			dude_to_stun = victim
 
-
-		dude_to_stun.do_disorient(src.disorient_stamina_damage, knockdown = src.stun_normal_knockdown * 10, disorient = 60)
+		var/list/shield_amt = list()
+		SEND_SIGNAL(victim, COMSIG_MOB_SHIELD_ACTIVATE, src.stun_normal_knockdown * 2, shield_amt)
+		var/mod = max(0, 1 - shield_amt["shield_strength"])
+		dude_to_stun.do_disorient(src.disorient_stamina_damage * mod, knockdown = src.stun_normal_knockdown * 10 * mod, disorient = 60)
 
 		if (isliving(dude_to_stun))
 			var/mob/living/L = dude_to_stun

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1554,7 +1554,7 @@ ABSTRACT_TYPE(/datum/SWFuplinkspell)
 /datum/SWFuplinkspell/forcewall
 	name = "Forcewall"
 	eqtype = "Defensive"
-	desc = "This spell creates an unbreakable wall from where you stand that extends to your sides. It lasts for 30 seconds."
+	desc = "This spell creates an unbreakable wall from where you stand that extends to your sides. It lasts for 10 seconds."
 	assoc_spell = /datum/targetable/spell/forcewall
 
 /datum/SWFuplinkspell/blink
@@ -1602,7 +1602,7 @@ ABSTRACT_TYPE(/datum/SWFuplinkspell)
 /datum/SWFuplinkspell/empower
 	name = "Empower"
 	eqtype = "Utility"
-	desc = "This spell causes you to turn into a hulk, and gain passive wrestling powers for a short while."
+	desc = "This spell causes you to turn into a hulk, and gain passive wrestling powers for a short while. Also reduces active stuns on cast."
 	assoc_spell = /datum/targetable/spell/mutate
 
 /datum/SWFuplinkspell/summongolem

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1582,7 +1582,7 @@ ABSTRACT_TYPE(/datum/SWFuplinkspell)
 /datum/SWFuplinkspell/spellshield
 	name = "Spell Shield"
 	eqtype = "Defensive"
-	desc = "This spell encases you in a magical shield that protects you from melee attacks and projectiles for 10 seconds. It also absorbs some of the blast of explosions."
+	desc = "This spell encases you in a limited-health magical shield that can protect you from melee attacks, projectiles, and explosions for up to 10 seconds."
 	assoc_spell = /datum/targetable/spell/magshield
 
 /datum/SWFuplinkspell/doppelganger

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1621,7 +1621,7 @@ ABSTRACT_TYPE(/datum/SWFuplinkspell)
 /datum/SWFuplinkspell/animatedead
 	name = "Animate Dead"
 	eqtype = "Utility"
-	desc = "This spell infuses an adjacent human corpse with necromantic energy, creating a durable skeleton minion that seeks to pummel your enemies into oblivion."
+	desc = "This spell infuses an adjacent human corpse or monkey with necromantic energy, creating a durable skeleton minion that seeks to pummel your enemies into oblivion."
 	assoc_spell = /datum/targetable/spell/animatedead
 
 //------------ MISC SPELLS ------------//


### PR DESCRIPTION
[GAME MODES][BALANCE][REWORK][ADD TO WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does a rebalance/rework of wizard spells

See design doc here for all changes/reasoning:
https://hackmd.io/@FlameArrow57/rJzcf8vXA

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hopefully makes wizards game mode more enjoyable (see design doc for more details)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Large rebalance of Wizard spells. See minor changelog for details.
(+)Using a defensive spell now places all other defensive spells on a 5 second cooldown.
(+)Magic missile cooldown increased to 25 seconds.
(+)Empower spell duration and cooldown decreased to 15 and 30 seconds. It also removes 10 seconds of knockdown on use (relevant to stuns).
(+)Spell shield is reworked so that the shield has limited health, rather than 100% immunity, for its duration. Effectiveness from least to most is in the order of: melee attacks, baton stuns, ranged stuns, lethal projectiles, explosions.
(+)Forcewall duration decreased to 10 seconds.
(+)Animate Dead can now be used on alive monkeys.
(+)Prismatic Spray can now be used without a staff.
```
