### PR TITLE
Allow local auth, log admin sign in

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -84,7 +84,7 @@
 	var/proc_logging = 0
 #endif
 
-	// authenticate = 0
+	authenticate = 0
 	// comment out the line below when debugging locally to enable the options & messages menu
 	control_freak = 1
 
@@ -709,6 +709,11 @@
 		onlineAdmins |= (src)
 		if (!NT.Find(src.ckey))
 			NT.Add(src.ckey)
+		var/ircmsg[] = new()
+		ircmsg["key"] =  src.key
+		ircmsg["name"] = src.ckey
+		ircmsg["msg"] = "Logged in as an Administrator"
+		ircbot.export_async("admin", ircmsg)
 		return 1
 
 	return 0

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -879,7 +879,7 @@
 #ifdef SHUT_UP_AND_GIVE_ME_MEDAL_STUFF
 	return TRUE
 #else
-	return src.mind.get_player().has_medal(medal)
+	return FALSE
 #endif
 
 /mob/verb/list_medals()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Allow local user authentication
* Admin sign-ins are logged to discord


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Allow game to be playable while HUB is offline, at least for some players