### PR TITLE
Makes Stowaway a latejoin role

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1487,6 +1487,31 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		src.access = get_access("Mail Courier")
 		return
 
+/datum/job/special/stowaway
+	name = "Stowaway"
+	limit = 2
+	wages = 0
+	low_priority_job = TRUE
+	slot_back = list(/obj/item/storage/backpack/satchel/anello)
+	slot_belt = list(/obj/item/crowbar)
+	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_jump = list(/obj/item/clothing/under/color/grey)
+	slot_head = list(/obj/item/clothing/head/green)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
+	slot_poc1 = list(/obj/item/currency/spacecash/fivehundred)
+	slot_poc2 = list(/obj/item/scissors)
+	slot_lhan = list(/obj/item/screwdriver)
+
+	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)
+	rounds_needed_to_play = 10 // It would really suck ass to play this as a new player
+	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("stowaway")
+
 // randomizd gimmick jobs
 
 /datum/job/special/random
@@ -1915,30 +1940,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_lhan = list(/obj/item/storage/toolbox/artistic)
 	items_in_backpack = list(/obj/item/canvas, /obj/item/canvas, /obj/item/storage/box/crayon/basic ,/obj/item/paint_can/random)
 	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
-
-/datum/job/special/random/stowaway
-	name = "Stowaway"
-	limit = 3
-	wages = 0
-	slot_back = list(/obj/item/storage/backpack/satchel/anello)
-	slot_belt = list(/obj/item/crowbar)
-	slot_foot = list(/obj/item/clothing/shoes/brown)
-	slot_jump = list(/obj/item/clothing/under/color/grey)
-	slot_head = list(/obj/item/clothing/head/green)
-	slot_ears = list(/obj/item/device/radio/headset/civilian)
-	slot_poc1 = list(/obj/item/currency/spacecash/fivehundred)
-	slot_poc2 = list(/obj/item/scissors)
-	slot_lhan = list(/obj/item/screwdriver)
-
-	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)
-	rounds_needed_to_play = 10 // It would really suck ass to play this as a new player
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
-
-	special_setup(var/mob/living/carbon/human/M)
-		..()
-		if (!M)
-			return
-		M.traitHolder.addTrait("stowaway")
 
 #ifdef HALLOWEEN
 /*

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1572,18 +1572,15 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_poc1 = list(/obj/item/currency/spacecash/fivehundred)
 	slot_poc2 = list(\
 	/obj/item/scissors,
-	/obj/item/wirecutters/red,
+	/obj/item/wirecutters,
 	/obj/item/wirecutters/yellow,
-	/obj/item/wirecutters/blue,
-	/obj/item/wirecutters/gray,
+	/obj/item/wirecutters/grey,
 	/obj/item/wirecutters/orange,
 	/obj/item/scissors/surgical_scissors)
 	slot_lhan = list(\
 	/obj/item/screwdriver,
-	/obj/item/screwdriver/red,
 	/obj/item/screwdriver/yellow,
-	/obj/item/screwdriver/blue,
-	/obj/item/screwdriver/gray,
+	/obj/item/screwdriver/grey,
 	/obj/item/screwdriver/orange)
 
 	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1492,15 +1492,99 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	limit = 2
 	wages = 0
 	low_priority_job = TRUE
-	slot_back = list(/obj/item/storage/backpack/satchel/anello)
-	slot_belt = list(/obj/item/crowbar)
-	slot_foot = list(/obj/item/clothing/shoes/brown)
-	slot_jump = list(/obj/item/clothing/under/color/grey)
-	slot_head = list(/obj/item/clothing/head/green)
-	slot_ears = list(/obj/item/device/radio/headset/civilian)
+	slot_back = list(\
+	/obj/item/storage/backpack,
+	/obj/item/storage/backpack/anello,
+	/obj/item/storage/backpack/security,
+	/obj/item/storage/backpack/engineering,
+	/obj/item/storage/backpack/robotics,
+	/obj/item/storage/backpack/research)
+	slot_belt = list(\
+	/obj/item/crowbar = 6,
+	/obj/item/crowbar/red,
+	/obj/item/crowbar/yellow,
+	/obj/item/crowbar/blue,
+	/obj/item/crowbar/grey,
+	/obj/item/crowbar/orange)
+	slot_foot = list(\
+	/obj/item/clothing/shoes/brown = 6,
+	/obj/item/clothing/shoes/red,
+	/obj/item/clothing/shoes/white,
+	/obj/item/clothing/shoes/black = 4,
+	/obj/item/clothing/shoes/swat,
+	/obj/item/clothing/shoes/orange,
+	/obj/item/clothing/shoes/westboot/brown/rancher,
+	/obj/item/clothing/shoes/galoshes,
+	0)
+	slot_jump = list(\
+	/obj/item/clothing/under/color/grey,
+	/obj/item/clothing/under/rank/security/assistant,
+	/obj/item/clothing/under/rank/roboticist,
+	/obj/item/clothing/under/rank/engineer,
+	/obj/item/clothing/under/rank/orangeoveralls,
+	/obj/item/clothing/under/rank/orangeoveralls/yellow,
+	/obj/item/clothing/under/gimmick/maid,
+	/obj/item/clothing/under/rank/bartender,
+	/obj/item/clothing/under/misc/souschef,
+	/obj/item/clothing/under/rank/hydroponics,
+	/obj/item/clothing/under/rank/rancher,
+	/obj/item/clothing/under/rank/overalls,
+	/obj/item/clothing/under/rank/cargo,
+	/obj/item/clothing/under/rank/assistant = 10,
+	/obj/item/clothing/under/rank/janitor)
+	slot_suit = list(\
+	/obj/item/clothing/suit/wintercoat/engineering,
+	/obj/item/clothing/suit/wintercoat/robotics,
+	/obj/item/clothing/suit/labcoat,
+	/obj/item/clothing/suit/labcoat/robotics,
+	/obj/item/clothing/suit/wintercoat/research,
+	0)
+	slot_head = list(\
+	/obj/item/clothing/head/green,
+	/obj/item/clothing/head/red,
+	/obj/item/clothing/head/constructioncone,
+	/obj/item/clothing/head/helmet/welding,
+	/obj/item/clothing/head/helmet/hardhat,
+	/obj/item/clothing/head/serpico,
+	/obj/item/clothing/head/souschefhat,
+	/obj/item/clothing/head/maid,
+	/obj/item/clothing/head/cowboy,
+	0 = 8)
+	slot_mask = list(\
+	/obj/item/clothing/mask/gas,
+	/obj/item/clothing/mask/surgical,
+	/obj/item/clothing/mask/skull,
+	/obj/item/clothing/mask/bandana/white,
+	0 = 6)
+	slot_glov = list(\
+	/obj/item/clothing/gloves/yellow/unsulated,
+	/obj/item/clothing/gloves/black,
+	/obj/item/clothing/gloves/fingerless,
+	/obj/item/clothing/gloves/long,
+	0 = 4)
+	slot_ears = list(\
+	/obj/item/device/radio/headset/civilian = 8,
+	/obj/item/device/radio/headset/engineer,
+	/obj/item/device/radio/headset/research,
+	/obj/item/device/radio/headset/shipping,
+	/obj/item/device/radio/headset/medical,
+	/obj/item/device/radio/headset/miner)
 	slot_poc1 = list(/obj/item/currency/spacecash/fivehundred)
-	slot_poc2 = list(/obj/item/scissors)
-	slot_lhan = list(/obj/item/screwdriver)
+	slot_poc2 = list(\
+	/obj/item/scissors,
+	/obj/item/wirecutters/red,
+	/obj/item/wirecutters/yellow,
+	/obj/item/wirecutters/blue,
+	/obj/item/wirecutters/gray,
+	/obj/item/wirecutters/orange,
+	/obj/item/scissors/surgical_scissors)
+	slot_lhan = list(\
+	/obj/item/screwdriver,
+	/obj/item/screwdriver/red,
+	/obj/item/screwdriver/yellow,
+	/obj/item/screwdriver/blue,
+	/obj/item/screwdriver/gray,
+	/obj/item/screwdriver/orange)
 
 	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)
 	rounds_needed_to_play = 10 // It would really suck ass to play this as a new player

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1584,7 +1584,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	/obj/item/screwdriver/orange)
 
 	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)
-	rounds_needed_to_play = 10 // It would really suck ass to play this as a new player
 	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
 
 	special_setup(var/mob/living/carbon/human/M)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1916,6 +1916,65 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	items_in_backpack = list(/obj/item/canvas, /obj/item/canvas, /obj/item/storage/box/crayon/basic ,/obj/item/paint_can/random)
 	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
 
+/datum/job/special/random/stowaway
+	name = "Stowaway"
+	limit = 3
+	wages = 0
+	slot_back = list(/obj/item/storage/backpack/satchel/anello)
+	slot_belt = list(/obj/item/crowbar)
+	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_jump = list(/obj/item/clothing/under/color/grey)
+	slot_head = list(/obj/item/clothing/head/green)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
+	slot_poc1 = list(/obj/item/currency/spacecash/fivehundred)
+	slot_poc2 = list(/obj/item/scissors)
+	slot_lhan = list(/obj/item/screwdriver)
+
+	items_in_backpack = list()
+	rounds_needed_to_play = 0 // It would really suck ass to play this as a new player
+	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("stowaway")
+
+/datum/job/special/random/private_eye
+	name = "Private Eye"
+	wages = PAY_TRADESMAN
+	receives_badge = TRUE
+	cant_spawn_as_rev = TRUE
+	can_join_gangs = FALSE
+	allow_antag_fallthrough = FALSE
+	slot_back = list(/obj/item/storage/backpack)
+	slot_belt = list(/obj/item/storage/belt/security/shoulder_holster)
+	slot_poc1 = list(/obj/item/device/pda2/forensic)
+	slot_jump = list(/obj/item/clothing/under/rank/det)
+	slot_foot = list(/obj/item/clothing/shoes/detective)
+	slot_head = list(/obj/item/clothing/head/det_hat)
+	slot_glov = list(/obj/item/clothing/gloves/black)
+	slot_suit = list(/obj/item/clothing/suit/det_suit)
+	slot_ears = list(/obj/item/device/radio/headset/detective)
+	items_in_backpack = list(/obj/item/clothing/glasses/vr,/obj/item/storage/box/detectivegun)
+	map_can_autooverride = FALSE
+	rounds_needed_to_play = 30 // it's stowaway detective, it's intrinsically problematic
+	wiki_link = "https://wiki.ss13.co/Detective"
+
+	New()
+		..()
+		src.access = get_access("Detective")
+		return
+
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("training_drinker")
+		M.traitHolder.addTrait("stowaway")
+
+		if (M.traitHolder && !M.traitHolder.hasTrait("smoker"))
+			items_in_backpack += list(/obj/item/device/light/zippo) //Smokers start with a trinket version
 #ifdef HALLOWEEN
 /*
  * Halloween jobs

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1930,8 +1930,8 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_poc2 = list(/obj/item/scissors)
 	slot_lhan = list(/obj/item/screwdriver)
 
-	items_in_backpack = list()
-	rounds_needed_to_play = 0 // It would really suck ass to play this as a new player
+	items_in_backpack = list(/obj/item/currency/spacecash/buttcoin = 2)
+	rounds_needed_to_play = 10 // It would really suck ass to play this as a new player
 	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
 
 	special_setup(var/mob/living/carbon/human/M)
@@ -1940,41 +1940,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 			return
 		M.traitHolder.addTrait("stowaway")
 
-/datum/job/special/random/private_eye
-	name = "Private Eye"
-	wages = PAY_TRADESMAN
-	receives_badge = TRUE
-	cant_spawn_as_rev = TRUE
-	can_join_gangs = FALSE
-	allow_antag_fallthrough = FALSE
-	slot_back = list(/obj/item/storage/backpack)
-	slot_belt = list(/obj/item/storage/belt/security/shoulder_holster)
-	slot_poc1 = list(/obj/item/device/pda2/forensic)
-	slot_jump = list(/obj/item/clothing/under/rank/det)
-	slot_foot = list(/obj/item/clothing/shoes/detective)
-	slot_head = list(/obj/item/clothing/head/det_hat)
-	slot_glov = list(/obj/item/clothing/gloves/black)
-	slot_suit = list(/obj/item/clothing/suit/det_suit)
-	slot_ears = list(/obj/item/device/radio/headset/detective)
-	items_in_backpack = list(/obj/item/clothing/glasses/vr,/obj/item/storage/box/detectivegun)
-	map_can_autooverride = FALSE
-	rounds_needed_to_play = 30 // it's stowaway detective, it's intrinsically problematic
-	wiki_link = "https://wiki.ss13.co/Detective"
-
-	New()
-		..()
-		src.access = get_access("Detective")
-		return
-
-	special_setup(var/mob/living/carbon/human/M)
-		..()
-		if (!M)
-			return
-		M.traitHolder.addTrait("training_drinker")
-		M.traitHolder.addTrait("stowaway")
-
-		if (M.traitHolder && !M.traitHolder.hasTrait("smoker"))
-			items_in_backpack += list(/obj/item/device/light/zippo) //Smokers start with a trinket version
 #ifdef HALLOWEEN
 /*
  * Halloween jobs

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -754,6 +754,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	icon_state = "stowaway"
 	category = list("background")
 	points = 1
+	unselectable = TRUE
 
 /datum/trait/pilot
 	name = "Pilot"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -753,7 +753,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "stowaway"
 	icon_state = "stowaway"
 	category = list("background")
-	points = 1
+	points = 0
 	unselectable = TRUE
 
 /datum/trait/pilot

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -87,11 +87,11 @@ var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist
 
 // we have to include alt names for jobs or they won't be sorted into categories correctly
 var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
-var/list/security_gimmicks = list("Vice Officer", "Forensic Technician")
+var/list/security_gimmicks = list("Vice Officer", "Forensic Technician","Private Eye")
 var/list/engineering_gimmicks = list("Head of Mining", "Station Builder", "Atmospherish Technician", "Technical Assistant")
 var/list/medical_gimmicks = list("Medical Specialist", "Neurological Specialist", "Ophthalmic Specialist", "Thoracic Specialist", "Orthopaedic Specialist", "Maxillofacial Specialist",
 	  "Vascular Specialist", "Anaesthesiologist", "Acupuncturist", "Medical Director's Assistant", "Medical Assistant", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")
 var/list/science_gimmicks = list("Toxins Researcher", "Chemist", "Research Assistant", "Test Subject")
 var/list/medsci_gimmicks = medical_gimmicks + science_gimmicks
-var/list/service_gimmicks = list("Lawyer", "Barber", "Mail Courier", "Head of Deliverying", "Mail Bringer", "Mime", "Musician", "Apiculturist", "Apiarist", "Sous-Chef", "Waiter", "Life Coach")
+var/list/service_gimmicks = list("Lawyer", "Barber", "Mail Courier", "Head of Deliverying", "Mail Bringer", "Mime", "Musician", "Apiculturist", "Apiarist", "Sous-Chef", "Waiter", "Life Coach","Stowaway")
 

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -87,7 +87,7 @@ var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist
 
 // we have to include alt names for jobs or they won't be sorted into categories correctly
 var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
-var/list/security_gimmicks = list("Vice Officer", "Forensic Technician","Private Eye")
+var/list/security_gimmicks = list("Vice Officer", "Forensic Technician")
 var/list/engineering_gimmicks = list("Head of Mining", "Station Builder", "Atmospherish Technician", "Technical Assistant")
 var/list/medical_gimmicks = list("Medical Specialist", "Neurological Specialist", "Ophthalmic Specialist", "Thoracic Specialist", "Orthopaedic Specialist", "Maxillofacial Specialist",
 	  "Vascular Specialist", "Anaesthesiologist", "Acupuncturist", "Medical Director's Assistant", "Medical Assistant", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")


### PR DESCRIPTION
<!-- [input] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR delists Stowaway as a round-start trait, instead attaching it to a latejoin role. All other behaviors of Stowaway remain the same.

The new latejoin role:
**Stowaway:** 2 slots. Typical Stowaway container start, with nothing but a jumpsuit, headset, and makeshift tools for door hacking (crowbar, scissors, and screwdriver, so you don't get locked in maints)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Characters with the Stowaway trait are in this stupid position of having half a job. On one hand, you're clearly recognizable as whatever job you signed up for-- Scientist Stowaways show up garbed in gasmask and labcoat, Bartender Stowaways have their trusty break-action at their hip, Security Stowaways start with their official NT badges proving they're an officer, and Captain Stowaways start with the Nuclear Authentication disk. At the same time, though, they're totally unemployed-- they lack their ID and PDA for doing their job, and they aren't paid wages because NT didn't put them on the manifest. 

Because Stowaways have half a job, it makes it very easy to simply give the Stowaway whatever job their character would have had if they weren't Stowaways. It's a very, very common practice for Captains and HoPs to just completely ignore the fact that NT *did not want this person working today* and give them the ID, PDA, and whatever else they need. In a way, it gets interacted with in a similar way to Jailbird-- a character that consistently stows away will just get the ID they need, completely defeating the point of taking the trait. There's an argument here that Stowaways should be given the ID-- after all, the player needs it to actually play the game and do their job-- but, again, they took the trait. This is such an accepted practice that I've experienced goon-2-esque conflicts where a secoff threatens to throw the HoP across the room because they won't give a Stowaway secass an ID with sec access.

And, tangentially, this status quo makes Stowaway a powergamer trait for antag rounds. Because you aren't deprived of your PDA, ID, or job title thanks to the ennui of whoever's behind the ID console, the trait becomes a +1 that scrubs your name from the sec records that'd be used to set you to arrest. Even when you're not antag, the trait's core concept can invite characters that are "rebellious punks who Aren't With You People," which is never fun to deal with.

Stowaways, in their current state as a thing you can do every round, don't make sense for any job. Secoffs with shiny badges shouldn't be ignoring the wishes of whoever schedules shifts at NT to break into their workplaces and hang out. Stowaway Captains shouldn't be issued nuclear authentication disks, or be respected as an authority by the crew when NT didn't even schedule them. (If they aren't issued IDs or PDAs, why the heck do they get the rest of this stuff?) People who have valuable labor to contribute shouldn't be repeatedly putting in the extra effort to sneak into a space station just to work for free. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mintyphresh
(*)Stowaway can no longer be taken as a trait, and is instead a latejoin role.
```
