### PR TITLE
Add magnetized subtype for arcfiend that ignores unionized trait

### DIFF
--- a/code/modules/antagonists/arcfiend/abilities/polarize.dm
+++ b/code/modules/antagonists/arcfiend/abilities/polarize.dm
@@ -16,4 +16,4 @@
 		for (var/mob/living/carbon/human/H in range(src.range, get_turf(src.holder.owner)))
 			if (H == src.holder.owner)
 				continue
-			H.changeStatus("magnetized", src.duration, charge)
+			H.changeStatus("magnetized_arcfiend", src.duration, charge)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1909,12 +1909,13 @@
 	maxDuration = 3 MINUTES
 	effect_quality = STATUS_QUALITY_NEGATIVE
 	var/charge = null
+	var/ignore_unionized = FALSE
 
 	onAdd(optional)
 		. = ..()
 		if (!ismob(owner)) return
 		var/mob/M = owner
-		if (!M.bioHolder || M.bioHolder.HasEffect("resist_electric") || M.traitHolder.hasTrait("unionized"))
+		if (!M.bioHolder || M.bioHolder.HasEffect("resist_electric") || (!ignore_unionized && M.traitHolder.hasTrait("unionized")))
 			SPAWN(0)
 				M.delStatus("magnetized")
 			return
@@ -1929,6 +1930,10 @@
 		if (QDELETED(owner) || !ismob(owner)) return
 		var/mob/M = owner
 		M.bioHolder.RemoveEffect(charge)
+
+/datum/statusEffect/magnetized/arcfiend
+	id = "magnetized_arcfiend"
+	ignore_unionized = TRUE
 
 //I call it regrow limb, but it can regrow any limb/organ that a changer can make a spider from. (apart from headspider obviously)
 /datum/statusEffect/changeling_regrow

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1917,7 +1917,7 @@
 		var/mob/M = owner
 		if (!M.bioHolder || M.bioHolder.HasEffect("resist_electric") || (!ignore_unionized && M.traitHolder.hasTrait("unionized")))
 			SPAWN(0)
-				M.delStatus("magnetized")
+				M.delStatus(src.id)
 			return
 		if (optional)
 			src.charge = optional


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[PLAYER ACTIONS] [BALANCE] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a subtype for the magnetized effect that ignores the presence of the "unionized" trait on targets

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Unionized is an incredibly common trait to take and it conferring immunity to an antag ability is unreasonable. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)People with the Unionized trait are no longer immune to arcfiend's polarize ability. Immunity to bio-magnetic random events remain unchanged.
```
