### PR TITLE
Code documentation and cleanup on manufacturers

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -293,7 +293,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 					status |= NOPOWER
 					src.build_icon()
 
-	// Overriden to not disable if no power, wire maintenence to restore power is on the GUI which creates catch-22 situation
+	/// Overriden to not disable if no power, wire maintenence to restore power is on the GUI which creates catch-22 situation
 	broken_state_topic(mob/user)
 		. = user.shared_ui_interaction(src)
 		if (src.is_broken())
@@ -419,7 +419,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 
 	/// Converts list of manufacture datums to list keyed by category containing listified manufacture datums of said category.
-	proc/blueprints_as_list	(var/list/L, mob/user, var/static_elements = FALSE)
+	proc/blueprints_as_list(var/list/L, mob/user, var/static_elements = FALSE)
 		var/list/as_list = list()
 		for (var/datum/manufacture/M as anything in L)
 			if (isnull(M.category) || !(M.category in src.categories)) // fix for not displaying blueprints/manudrives
@@ -490,7 +490,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 	proc/is_electrified()
 		return src.time_left_electrified > 0
 
-	proc/validate_disp(datum/manufacture/M)
+	/// Returns whether or not a blueprint is able to be used for printing
+	proc/blueprint_is_available(datum/manufacture/M)
 		. = FALSE
 		if(src.available && (M in src.available))
 			return TRUE
@@ -505,9 +506,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 			return TRUE
 
 	/// Clear src.queue but not the current working print if it exists
+	/// Functionally does nothing special, but allows for future changes to be mirrored easier
 	proc/clear_queue()
-		if (!length(src.queue))
-			return
 		src.queue = list()
 
 	/// Try to shock the target if the machine is electrified, returns whether or not the target got shocked
@@ -592,7 +592,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 				if (!istype(I,/datum/manufacture/))
 					return
 				// Verify that there is no href fuckery abound
-				if(!validate_disp(I))
+				if(!blueprint_is_available(I))
 					// Since a manufacturer may get unhacked or a downloaded item could get deleted between someone
 					// opening the window and clicking the button we can't assume intent here, so no cluwne
 					return

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -27,6 +27,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	density = TRUE
 	anchored = ANCHORED
 	power_usage = 200
+
 	/// req_access is used to lock out specific featurs and not limit deconstruciton therefore DECON_NO_ACCESS is required
 	req_access = list(access_heads)
 	event_handler_flags = NO_MOUSEDROP_QOL
@@ -98,9 +99,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	var/should_update_static = TRUE //! true by default to update first time around, set to true whenever something is done that invalidates static data
 	var/list/material_patterns_by_ref = list() //! Helper list which stores all the material patterns each loaded material satisfies, by ref to the piece
 
-	// Production options
-	var/search = null
-	var/category = null
+	/* Production options */
 	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Medicine", "Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE
 	var/list/available = list() //! A list of every option available in this unit subtype by default

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1040,6 +1040,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		storage[index_2] = temp_hold
 		src.should_update_static = TRUE
 
+	/// Handles allowing the user to eject integer amounts of material
 	proc/eject_material(var/mat_ref, mob/user)
 		var/obj/item/material_piece/P = src.get_material_by_ref(mat_ref)
 		if (!src.can_eject_material(P, user))
@@ -1510,81 +1511,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 			if (ispath(X))
 				src.add_schematic(X,"hidden")
 				src.hidden -= X
-
-	proc/match_material_pattern(pattern, datum/material/mat)
-		if (!mat) // Marq fix for various cannot read null. runtimes
-			return FALSE
-
-		if (pattern == "ALL") // anything at all
-			return TRUE
-		if (pattern == "ORG|RUB")
-			return mat.getMaterialFlags() & MATERIAL_RUBBER || mat.getMaterialFlags() & MATERIAL_ORGANIC
-		if (pattern == "RUB")
-			return mat.getMaterialFlags() & MATERIAL_RUBBER
-		if (pattern == "WOOD")
-			return mat.getMaterialFlags() & MATERIAL_WOOD
-		else if (copytext(pattern, 4, 5) == "-") // wildcard
-			var/firstpart = copytext(pattern, 1, 4)
-			var/secondpart = text2num_safe(copytext(pattern, 5))
-			switch(firstpart)
-				// this was kind of thrown together in a panic when i felt shitty so if its horrible
-				// go ahead and clean it up a bit
-				if ("MET")
-
-					if (mat.getMaterialFlags() & MATERIAL_METAL)
-						// maux hardness = 15
-						// bohr hardness = 33
-						switch(secondpart)
-							if(2)
-								return mat.getProperty("hard") * 2 + mat.getProperty("density") >= 10
-							if(3 to INFINITY)
-								return mat.getProperty("hard") * 2 + mat.getProperty("density") >= 15
-							else
-								return TRUE
-				if ("CRY")
-					if (mat.getMaterialFlags() & MATERIAL_CRYSTAL)
-
-						switch(secondpart)
-							if(2)
-								return mat.getProperty("density") >= 7
-							else
-								return TRUE
-				if ("REF")
-					return (mat.getProperty("reflective") >= 6)
-				if ("CON")
-					switch(secondpart)
-						if(2)
-							return (mat.getProperty("electrical") >= 8)
-						else
-							return (mat.getProperty("electrical") >= 6)
-				if ("INS")
-					switch(secondpart)
-						if(2)
-							return mat.getProperty("electrical") <= 2 && (mat.getMaterialFlags() & (MATERIAL_CLOTH | MATERIAL_RUBBER))
-						else
-							return mat.getProperty("electrical") <= 4 && (mat.getMaterialFlags() & (MATERIAL_CLOTH | MATERIAL_RUBBER))
-				if ("DEN")
-					switch(secondpart)
-						if(2)
-							return mat.getProperty("density") >= 6
-						else
-							return mat.getProperty("density") >= 4
-				if ("POW")
-					if (mat.getMaterialFlags() & MATERIAL_ENERGY)
-						switch(secondpart)
-							if(3)
-								return mat.getProperty("radioactive") >= 5 //soulsteel and erebite basically
-							if(2)
-								return mat.getProperty("radioactive") >= 2
-							else
-								return TRUE
-				if ("FAB")
-					return mat.getMaterialFlags() & (MATERIAL_CLOTH | MATERIAL_RUBBER | MATERIAL_ORGANIC)
-				if ("GEM")
-					return istype(mat, /datum/material/crystal/gemstone)
-		else if (pattern == mat.getID()) // specific material id
-			return TRUE
-		return FALSE
 
 	/// Get a list of the patterns a material satisfies. Does not include "ALL" in list, as it is assumed such a requirement is handled separately.
 	/// Includes all previous material tier strings for simple "x in y" checks, as well as material ID for those recipies which need exact mat.

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -95,17 +95,25 @@ TYPEINFO(/obj/machinery/manufacturer)
 	/// The types of material pieces of which the manufacturer will be spawned with.
 	/// The amount of each resource is defined on free_resource_amt
 	var/list/obj/item/material_piece/free_resources = list()
+	/// Supposedly used by podwards manufacturers, but not really
+	var/list/resource_amounts = list()
 	var/obj/item/disk/data/floppy/manudrive/manudrive = null
 	var/should_update_static = TRUE //! true by default to update first time around, set to true whenever something is done that invalidates static data
-	var/list/material_patterns_by_ref = list() //! Helper list which stores all the material patterns each loaded material satisfies, by ref to the piece
+	/// Helper list which stores all the material patterns each loaded material satisfies, by ref to the piece
+	var/list/material_patterns_by_ref = list()
 
 	/* Production options */
+	/// A list of valid categories the manufacturer will use. Any invalid provided categories are assigned "Miscellaneous".
 	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Medicine", "Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE
-	var/list/available = list() //! A list of every option available in this unit subtype by default
-	var/list/download = list() //! Options gained from scanned blueprints
-	var/list/drive_recipes = list() //! Options provided by an inserted manudrive
-	var/list/hidden = list() //! These options are available by default, but can't be printed unless the machine is hacked
+	/// A list of every option available in this unit subtype by default
+	var/list/available = list()
+	/// Options gained from scanned blueprints
+	var/list/download = list()
+	/// Options provided by an inserted manudrive
+	var/list/drive_recipes = list()
+	/// These options are available by default, but can't be printed or seen unless the machine is hacked
+	var/list/hidden = list()
 
 	// Unsorted stuff. The names for these should (hopefully!) be self-explanatory
 	var/image/work_display = null

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1758,7 +1758,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 		return
 
-	proc/dispense_product(product, datum/manufacture/M var/list/materials_used)
+	proc/dispense_product(product, datum/manufacture/M,  var/list/materials_used)
 		if (ispath(product))
 			if (istype(M,/datum/manufacture/))
 				var/atom/movable/A = new product(src)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -230,21 +230,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 		if (src.time_left_electrified > 0)
 			src.time_left_electrified--
-		/*
-		if (src.mode == MODE_WORKING)
-			if (src.malfunction && prob(8))
-				src.flip_out()
-			src.time_left -= src.speed * 4.4 * mult
-			use_power(src.active_power_consumption)
-			if (src.time_left < 1)
-				src.output_loop(src.queue[1])
-				SPAWN(0)
-					if (length(src.queue) < 1)
-						playsound(src.loc, src.sound_happy, 50, 1)
-						src.visible_message(SPAN_NOTICE("[src] finishes its production queue."))
-						src.mode = MODE_READY
-						src.build_icon()
-		*/
 
 	proc/finish_work()
 		if(length(src.queue))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Converts most //! formatted comments to /// comments, as the documentation for same-line doc comments does not work with hovers in VSCode.
Adds, removes, and renames certain parts of comments as well.
Adds some new documentation for variables which should realistically have them.
Removes some unused variables. 
Removes a block of commented out code.
Removes match_material_pattern(), which has been replaced and is getting doubly replaced with #19057 
Renames validate_disp to blueprint_is_available to reflect its usage in the code. Once.
Pass around the materials used on dispensing to avoid a object-wide scoped materials_in_use var, which is only relevant at the time of dispensing where we fetch identical values anyways

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves the code quality of the manufacturer code in my continued effort to improve the internal and external QoL of the manufacturer.
