### PR TITLE
Unsimmulated Asteroid Flooring for MapGen

### DIFF
--- a/code/modules/worldgen/mapgen/CaveGenerator.dm
+++ b/code/modules/worldgen/mapgen/CaveGenerator.dm
@@ -210,9 +210,9 @@
 	nitrogen = MOLES_N2STANDARD
 	temperature = 330
 	default_ore = null
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/cave
+	replace_type = /turf/unsimulated/floor/plating/asteroid/cave
 
-/turf/simulated/floor/plating/airless/asteroid/cave
+/turf/unsimulated/floor/plating/asteroid/cave
 	name = "cave"
 	desc = "cave floor"
 	color = "#7c5855"

--- a/code/modules/worldgen/mapgen/DesertGenerator.dm
+++ b/code/modules/worldgen/mapgen/DesertGenerator.dm
@@ -31,7 +31,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 65
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain/desert
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/desert
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/desert
 
 ///Seeds the rust-g perlin noise with a random number.
 /datum/map_generator/desert_generator/generate_terrain(list/turfs, reuse_seed, flags)
@@ -97,9 +97,9 @@
 	nitrogen = MOLES_N2STANDARD
 	temperature = 330
 	default_ore = null
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/desert
+	replace_type = /turf/unsimulated/floor/plating/asteroid/desert
 
-/turf/simulated/floor/plating/airless/asteroid/desert
+/turf/unsimulated/floor/plating/asteroid/desert
 	name = "mountain"
 	desc = "a sandy mountain"
 	color = "#957a59"

--- a/code/modules/worldgen/mapgen/ForestGenerator.dm
+++ b/code/modules/worldgen/mapgen/ForestGenerator.dm
@@ -32,7 +32,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 65
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/mountain
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/mountain
 
 ///Seeds the rust-g perlin noise with a random number.
 /datum/map_generator/forest_generator/generate_terrain(list/turfs, reuse_seed, flags)

--- a/code/modules/worldgen/mapgen/IceMoonGenerator.dm
+++ b/code/modules/worldgen/mapgen/IceMoonGenerator.dm
@@ -56,7 +56,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 65
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain/icemoon
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/icemoon
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/icemoon
 
 ///Seeds the rust-g perlin noise with a random number.
 /datum/map_generator/icemoon_generator/generate_terrain(list/turfs, reuse_seed, flags)
@@ -117,7 +117,7 @@
 	name = "ice wall"
 	desc = "You're inside a glacier. Wow."
 	fullbright = 0
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/icemoon
+	replace_type = /turf/unsimulated/floor/plating/asteroid/icemoon
 	default_material = "ice"
 	color = "#8df"
 	stone_color = "#8df"
@@ -131,7 +131,7 @@
 			default_ore = /obj/item/raw_material/ice
 		. = ..()
 
-/turf/simulated/floor/plating/airless/asteroid/icemoon
+/turf/unsimulated/floor/plating/asteroid/icemoon
 	name = "floor"
 	desc = "A tunnel through the glacier. This doesn't seem to be water ice..."
 	carbon_dioxide = 100

--- a/code/modules/worldgen/mapgen/JungleGenerator.dm
+++ b/code/modules/worldgen/mapgen/JungleGenerator.dm
@@ -32,7 +32,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 65
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/mountain
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/mountain
 
 ///Seeds the rust-g perlin noise with a random number.
 /datum/map_generator/jungle_generator/generate_terrain(list/turfs, reuse_seed, flags)
@@ -92,7 +92,7 @@
 	desc = "a rocky mountain"
 	fullbright = 0
 	default_ore = null
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/mountain
+	replace_type = /turf/unsimulated/floor/plating/asteroid/mountain
 
 	destroy_asteroid(var/dropOre=1)
 		var/image/weather = GetOverlayImage("weather")
@@ -101,22 +101,25 @@
 		if(src.ore || prob(8)) // provide less rock
 			default_ore = /obj/item/raw_material/rock
 		. = ..()
+		for (var/turf/unsimulated/floor/plating/asteroid/A in range(src,1))
+			A.UpdateIcon()
 
 		if(weather)
 			src.AddOverlays(weather, "weather")
 		if(ambient)
 			src.AddOverlays(ambient, "ambient")
 
-		if(air) // force reverting air to floor turf as this is post replace
+		if(istype(src, /turf/simulated))
+			if(air) // force reverting air to floor turf as this is post replace
 #define _TRANSFER_GAS_TO_AIR(GAS, ...) air.GAS = GAS;
-			APPLY_TO_GASES(_TRANSFER_GAS_TO_AIR)
+				APPLY_TO_GASES(_TRANSFER_GAS_TO_AIR)
 #undef _TRANSFER_GAS_TO_AIR
 
-			air.temperature = temperature
+				air.temperature = temperature
 
 		return src
 
-/turf/simulated/floor/plating/airless/asteroid/mountain
+/turf/unsimulated/floor/plating/asteroid/mountain
 	name = "mountain"
 	desc = "a rocky mountain"
 	oxygen = MOLES_O2STANDARD

--- a/code/modules/worldgen/mapgen/LavaMoonGenerator.dm
+++ b/code/modules/worldgen/mapgen/LavaMoonGenerator.dm
@@ -121,7 +121,7 @@
 	var/perlin_zoom = 65
 	var/lava_percent = 40
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain/lavamoon
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/lavamoon
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/lavamoon
 
 	var/lava_noise = null
 	var/datum/spatial_hashmap/manual/near_station
@@ -218,12 +218,10 @@
 	name = "silicate wall"
 	desc = "You're inside a matrix of silicate. Neat."
 	fullbright = 0
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/lavamoon
+	replace_type = /turf/unsimulated/floor/plating/asteroid/lavamoon
 	color = "#998E4E"
 	stone_color = "#998E4E"
 	carbon_dioxide = 20
-	nitrogen = 0
-	oxygen = 0
 	temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST-1
 
 	destroy_asteroid(var/dropOre=1)
@@ -231,11 +229,11 @@
 			default_ore = /datum/material/crystal/gemstone
 		. = ..()
 
-/turf/simulated/floor/plating/airless/asteroid/lavamoon
+/turf/unsimulated/floor/plating/asteroid/lavamoon
 	name = "floor"
 	desc = "A tunnel through the silicate. This doesn't seem to be water ice..."
 	carbon_dioxide = 20
-	nitrogen = 0
-	oxygen = 0
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
 	temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST-1
 	fullbright = 0

--- a/code/modules/worldgen/mapgen/MarsGenerator.dm
+++ b/code/modules/worldgen/mapgen/MarsGenerator.dm
@@ -57,7 +57,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 65
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mars
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/mars
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/mars
 
 /datum/map_generator/mars_generator/duststorm
 	///2D list of all biomes based on heat and humidity combos.
@@ -160,8 +160,7 @@
 						playsound(src, 'sound/impact_sounds/Flesh_Stab_2.ogg', 50, TRUE)
 						boutput(jerk, pick("Dust gets caught in your eyes!","The wind blows you off course!","Debris pierces through your skin!"))
 
-
-/turf/simulated/floor/plating/airless/asteroid/mars
+/turf/unsimulated/floor/plating/asteroid/mars
 	stone_color = "#c96433"
 	color = "#c96433"
 	carbon_dioxide = 500
@@ -177,7 +176,7 @@
 	fullbright = 0
 	color = "#c96433"
 	stone_color = "#c96433"
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/mars
+	replace_type = /turf/unsimulated/floor/plating/asteroid/mars
 
 	destroy_asteroid(var/dropOre=1)
 		var/image/ambient_light = src.GetOverlayImage("ambient")

--- a/code/modules/worldgen/mapgen/SnowGenerator.dm
+++ b/code/modules/worldgen/mapgen/SnowGenerator.dm
@@ -33,7 +33,7 @@
 	///Used to select "zoom" level into the perlin noise, higher numbers result in slower transitions
 	var/perlin_zoom = 85
 	wall_turf_type	= /turf/simulated/wall/auto/asteroid/mountain
-	floor_turf_type = /turf/simulated/floor/plating/airless/asteroid/mountain
+	floor_turf_type = /turf/unsimulated/floor/plating/asteroid/mountain
 
 ///Seeds the rust-g perlin noise with a random number.
 /datum/map_generator/snow_generator/generate_terrain(list/turfs, reuse_seed, flags)
@@ -90,10 +90,9 @@
 
 
 /turf/simulated/wall/auto/asteroid/mountain/snow
-	replace_type = /turf/simulated/floor/plating/airless/asteroid/desert
+	replace_type = /turf/unsimulated/floor/plating/asteroid/mountain/snow
 
-/turf/simulated/floor/plating/airless/asteroid/mountain/snow
+/turf/unsimulated/floor/plating/asteroid/mountain/snow
 	temperature = 235
-
 
 #undef BIOME_RANDOM_SQUARE_DRIFT


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I don't see the need to continue have random swaths of simulated turfs when areas of mined for MapGen Z1 or planetary events.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce Atmos burden