### PR TITLE
Fix stun batons turning off with enough charge

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -148,7 +148,7 @@ TYPEINFO(/obj/item/baton)
 			if (user && ismob(user))
 				var/list/ret = list()
 				if(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE, ret) & CELL_RETURNED_LIST)
-					if (ret["charge"] > src.cost_normal)
+					if (ret["charge"] >= src.cost_normal)
 						user.show_text("The [src.name] now has [ret["charge"]]/[ret["max_charge"]] PUs remaining.", "blue")
 					else
 						user.show_text("The [src.name] is now out of charge!", "red")


### PR DESCRIPTION
[GAME OBJECTS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes regular stun batons turning off at 25 PU instead of 0.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #18478