### PR TITLE
Add additional janitor spawns to Oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -25575,6 +25575,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/landmark/start/job/janitor,
 /turf/simulated/floor,
 /area/station/janitor/supply)
 "bOQ" = (
@@ -42694,6 +42695,7 @@
 /area/station/bridge)
 "rIG" = (
 /obj/landmark/gps_waypoint,
+/obj/landmark/start/job/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "rJk" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two janitor spawn landmarks to oshan, one in the main office and one in the closet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce the chance of janitors spawning on top of each other, which can reveal e.g. gang rounds to non gang members on round-start.