### PR TITLE
Prevent resisting while paralyzed

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1497,6 +1497,10 @@
 	if (!isalive(src)) //can't resist when dead or unconscious
 		return
 
+	if (src.hasStatus("paralysis"))
+		src.show_text("You are completely paralysed and can't resist!", "red")
+		return
+
 	if (src.last_resist > world.time)
 		return
 	src.last_resist = world.time + 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
While under the paralysis status effect, you are prevented from using resist.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Paralysis should stop most player actions.
Fix #19136