### PR TITLE
Fix vampire bat sprinting

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1876,11 +1876,8 @@
 		return
 
 /mob/living/proc/do_sprint_boost()
-	if (!next_step_delay && world.time >= src.next_sprint_boost)
+	if (!src.special_sprint?.no_sprint_boost && !next_step_delay && src.next_sprint_boost && world.time >= src.next_sprint_boost)
 		if (!(HAS_ATOM_PROPERTY(src, PROP_MOB_CANTMOVE) || GET_COOLDOWN(src, "lying_bullet_dodge_cheese") || GET_COOLDOWN(src, "unlying_speed_cheesy")))
-			//if (src.hasStatus("blocking"))
-			//	for (var/obj/item/grab/block/G in src.equipped_list(check_for_magtractor = 0)) //instant break blocks when we start a sprint
-			//		qdel(G)
 
 			var/last = src.loc
 			var/force_puff = world.time < src.next_move + 0.5 SECONDS //assume we are still in a movement mindset even if we didnt change tiles
@@ -1889,8 +1886,6 @@
 			src.next_move = world.time
 			attempt_move(src)
 
-			if (src.special_sprint?.no_sprint_boost)
-				src.sprint_boost_mod = 1
 			src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * src.sprint_boost_mod
 
 			if ((src.loc != last || force_puff) && !HAS_ATOM_PROPERTY(src, PROP_MOB_NO_MOVEMENT_PUFFS)) //ugly check to prevent stationary sprint weirds

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1862,31 +1862,40 @@
 	var/stop_here = SEND_SIGNAL(src, COMSIG_MOB_SPRINT)
 	if (stop_here)
 		return
-	if (HAS_ATOM_PROPERTY(src, PROP_MOB_CANTSPRINT))
-		return
 	if (src.client && src.special_sprint?.can_sprint(src))
 		src.special_sprint.do_sprint(src)
+		src.do_sprint_boost()
+		return
 	if (src.special_sprint?.overrides_sprint)
 		return
+	if (HAS_ATOM_PROPERTY(src, PROP_MOB_CANTSPRINT))
+		return
 	else if (src.use_stamina)
-		if (!next_step_delay && world.time >= next_sprint_boost)
-			if (!(HAS_ATOM_PROPERTY(src, PROP_MOB_CANTMOVE) || GET_COOLDOWN(src, "lying_bullet_dodge_cheese") || GET_COOLDOWN(src, "unlying_speed_cheesy")))
-				//if (src.hasStatus("blocking"))
-				//	for (var/obj/item/grab/block/G in src.equipped_list(check_for_magtractor = 0)) //instant break blocks when we start a sprint
-				//		qdel(G)
+		src.do_sprint_boost()
+		return
 
-				var/last = src.loc
-				var/force_puff = world.time < src.next_move + 0.5 SECONDS //assume we are still in a movement mindset even if we didnt change tiles
+/mob/living/proc/do_sprint_boost()
+	if (!next_step_delay && world.time >= src.next_sprint_boost)
+		if (!(HAS_ATOM_PROPERTY(src, PROP_MOB_CANTMOVE) || GET_COOLDOWN(src, "lying_bullet_dodge_cheese") || GET_COOLDOWN(src, "unlying_speed_cheesy")))
+			//if (src.hasStatus("blocking"))
+			//	for (var/obj/item/grab/block/G in src.equipped_list(check_for_magtractor = 0)) //instant break blocks when we start a sprint
+			//		qdel(G)
 
-				next_step_delay = max(src.next_move - world.time,0) //slows us on the following step by the amount of movement we just skipped over with our instant-step
-				src.next_move = world.time
-				attempt_move(src)
-				next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * 2
+			var/last = src.loc
+			var/force_puff = world.time < src.next_move + 0.5 SECONDS //assume we are still in a movement mindset even if we didnt change tiles
 
-				if ((src.loc != last || force_puff) && !HAS_ATOM_PROPERTY(src, PROP_MOB_NO_MOVEMENT_PUFFS)) //ugly check to prevent stationary sprint weirds
-					sprint_particle(src, last)
-					if (!isFlying)
-						playsound(src.loc, 'sound/effects/sprint_puff.ogg', 29, 1,extrarange = -4)
+			next_step_delay = max(src.next_move - world.time,0) //slows us on the following step by the amount of movement we just skipped over with our instant-step
+			src.next_move = world.time
+			attempt_move(src)
+			if (src.special_sprint?.no_sprint_boost)
+				src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED)
+			else
+				src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * 2
+
+			if ((src.loc != last || force_puff) && !HAS_ATOM_PROPERTY(src, PROP_MOB_NO_MOVEMENT_PUFFS)) //ugly check to prevent stationary sprint weirds
+				sprint_particle(src, last)
+				if (!isFlying)
+					playsound(src.loc, 'sound/effects/sprint_puff.ogg', 29, 1,extrarange = -4)
 
 // cogwerks - fix for soulguard and revive
 /mob/living/proc/remove_ailments()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -89,7 +89,6 @@
 	var/datum/special_sprint/special_sprint = null
 	var/next_step_delay = 0
 	var/next_sprint_boost = 0
-	var/sprint_boost_mod = 2 // Modifier that determines how much faster sprinting makes you
 	var/sustained_moves = 0
 
 	var/metabolizes = 1
@@ -1876,7 +1875,7 @@
 		return
 
 /mob/living/proc/do_sprint_boost()
-	if (!src.special_sprint?.no_sprint_boost && !next_step_delay && src.next_sprint_boost && world.time >= src.next_sprint_boost)
+	if (!src.special_sprint?.no_sprint_boost && !next_step_delay && world.time >= src.next_sprint_boost)
 		if (!(HAS_ATOM_PROPERTY(src, PROP_MOB_CANTMOVE) || GET_COOLDOWN(src, "lying_bullet_dodge_cheese") || GET_COOLDOWN(src, "unlying_speed_cheesy")))
 
 			var/last = src.loc
@@ -1886,7 +1885,7 @@
 			src.next_move = world.time
 			attempt_move(src)
 
-			src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * src.sprint_boost_mod
+			src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * 2
 
 			if ((src.loc != last || force_puff) && !HAS_ATOM_PROPERTY(src, PROP_MOB_NO_MOVEMENT_PUFFS)) //ugly check to prevent stationary sprint weirds
 				sprint_particle(src, last)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -89,6 +89,7 @@
 	var/datum/special_sprint/special_sprint = null
 	var/next_step_delay = 0
 	var/next_sprint_boost = 0
+	var/sprint_boost_mod = 2 // Modifier that determines how much faster sprinting makes you
 	var/sustained_moves = 0
 
 	var/metabolizes = 1
@@ -1887,10 +1888,10 @@
 			next_step_delay = max(src.next_move - world.time,0) //slows us on the following step by the amount of movement we just skipped over with our instant-step
 			src.next_move = world.time
 			attempt_move(src)
+
 			if (src.special_sprint?.no_sprint_boost)
-				src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED)
-			else
-				src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * 2
+				src.sprint_boost_mod = 1
+			src.next_sprint_boost = world.time + max(src.next_move - world.time,BASE_SPEED) * src.sprint_boost_mod
 
 			if ((src.loc != last || force_puff) && !HAS_ATOM_PROPERTY(src, PROP_MOB_NO_MOVEMENT_PUFFS)) //ugly check to prevent stationary sprint weirds
 				sprint_particle(src, last)

--- a/code/mob/special_sprint.dm
+++ b/code/mob/special_sprint.dm
@@ -1,6 +1,7 @@
 /datum/special_sprint
 	///Disable regular sprinting behaviour
 	var/overrides_sprint = FALSE
+	var/no_sprint_boost = FALSE // For things that prevent sprinting speed, but don't prevent sprinting skills
 	proc/can_sprint(mob/M)
 		if (isliving(M))
 			var/mob/living/owner = M
@@ -32,6 +33,8 @@
 	var/cloak = FALSE
 
 	do_sprint(mob/M)
+		if (M.traitHolder.hasTrait("slowstrider"))
+			src.no_sprint_boost = TRUE
 		new /obj/dummy/spell_batpoof(get_turf(M), M, src.cloak)
 
 /datum/special_sprint/poof/bat/cloak


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Code Quality]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Introduces a new `no_sprint_boost` var under `/datum/special_sprint` that checks if a sprint boost should happen.

Moves the `PROP_MOB_CANTSPRINT` check in `/mob/living/proc/start_sprint()` down so that it checks for special sprinting first.

Moves the sprint boosting to its own separate function `/mob/living/proc/do_sprint_boost()`, and subsequently checks for `src.special_sprint?.no_sprint_boost` to determine if to boost or not to boost. This is now done via `sprint_boost_mod` that defaults to 2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#19030 

I felt that "bat form, but slow" is a better alternative than to just say "okay you can't sprint unless you're a bat".