### PR TITLE
Add "Postal Service Training" and binds mail chute climbing to that

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1472,7 +1472,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	alias_names = "Mailman"
 	wages = PAY_TRADESMAN
 	limit = 1
-	slot_jump = list(/obj/item/clothing/under/misc/mail/syndicate)
+	slot_jump = list(/obj/item/clothing/under/misc/mail)
 	slot_head = list(/obj/item/clothing/head/mailcap)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_back = list(/obj/item/storage/backpack/satchel)
@@ -1487,6 +1487,12 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		..()
 		src.access = get_access("Mail Courier")
 		return
+
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("training_mail")
 
 // randomizd gimmick jobs
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -711,6 +711,11 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "Subject is trained at carving out asteroids."
 	id = "training_miner"
 
+/datum/trait/job/mail_courier
+	name = "Postal Service Training"
+	desc = "Subject is a master of delivery."
+	id = "training_mail"
+
 // Stats - Undetermined Border
 /datum/trait/athletic
 	name = "Athletic"

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3067,11 +3067,13 @@
 
 /mob/living/carbon/human/canRideMailchutes()
 	if (ismonkey(src)) // Why not, I guess?
-		return 1
+		return TRUE
+	else if (src.w_uniform && istype(src.w_uniform, /obj/item/clothing/under/misc/mail/syndicate))
+		return TRUE
 	else if (src.traitHolder.hasTrait("training_mail"))
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /mob/living/carbon/human/set_mutantrace(var/datum/mutantrace/mutantrace_type)
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3068,7 +3068,7 @@
 /mob/living/carbon/human/canRideMailchutes()
 	if (ismonkey(src)) // Why not, I guess?
 		return 1
-	else if (src.w_uniform && istype(src.w_uniform, /obj/item/clothing/under/misc/mail/syndicate))
+	else if (src.traitHolder.hasTrait("training_mail"))
 		return 1
 	else
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Respawning]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `/datum/trait/job/mail_courier` and makes the Mail Courier job start with it.
Removes the pseudo syndicate item from the Mail Courier which was used to facilitate this.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's weird that Mail Couriers were handed a pseudo-syndicate item to facilitate their main gimmick and if they were gibbed or otherwise lost it, couldn't easily traverse via mail chutes anymore. This alleviates that.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Mail Couriers are now professionally trained to ride mail chutes, no matter the cost.
```
