### PR TITLE
Add decomposition lifeprocess only on death

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -758,6 +758,7 @@
 		INVOKE_ASYNC(A, TYPE_PROC_REF(/obj/item/clothing/suit/armor/suicide_bomb, trigger), src)
 
 	src.time_until_decomposition = rand(4 MINUTES, 10 MINUTES)
+	add_lifeprocess(/datum/lifeprocess/decomposition)
 
 	if (src.mind) // I think this is kinda important (Convair880).
 		if (src.mind.ckey && !inafterlife(src))

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -157,7 +157,7 @@
 	add_lifeprocess(/datum/lifeprocess/breath)
 	add_lifeprocess(/datum/lifeprocess/chems)
 	add_lifeprocess(/datum/lifeprocess/critical)
-	add_lifeprocess(/datum/lifeprocess/decomposition)
+	remove_lifeprocess(/datum/lifeprocess/decomposition) // only happens when mob is dead
 	add_lifeprocess(/datum/lifeprocess/disability)
 	add_lifeprocess(/datum/lifeprocess/health_mon)
 	add_lifeprocess(/datum/lifeprocess/hud)


### PR DESCRIPTION
[INTERNAL][PERFORMANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes humans get the decomposition lifeprocess only on death, rather than while also alive


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minor performance