### PR TITLE
Adds "Mails Delivered / Frauded" to credits

### DIFF
--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -26,7 +26,6 @@
 
 	New()
 		..()
-		game_stats.Increment("mail_sent")
 		if (src.random_icons)
 			src.icon_state = "mail-[rand(1,3)]"
 

--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -26,6 +26,7 @@
 
 	New()
 		..()
+		game_stats.Increment("mail_sent")
 		if (src.random_icons)
 			src.icon_state = "mail-[rand(1,3)]"
 
@@ -131,6 +132,7 @@
 		cleanable.add_fingerprint(owner)
 		src.the_mail.open(owner, crime = TRUE)
 		playsound(src.the_mail, 'sound/items/Screwdriver2.ogg', 50, 1)
+		game_stats.Increment("mail_fraud")
 
 		if (!ON_COOLDOWN(global, "mail_fraud_alert", 10 MINUTES)) // no spamming this
 			var/mob/living/ourselves = owner
@@ -155,6 +157,7 @@
 			if(sec_record && sec_record["criminal"] != "*Arrest*")
 				sec_record["criminal"] = "*Arrest*"
 				sec_record["mi_crim"] = "Mail fraud."
+
 
 /obj/decal/cleanable/mail_fraud
 	name = "torn package"

--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -1231,6 +1231,12 @@
 			monitored_var = "mail_opened"
 			maptext_prefix = "<span class='c pixel sh'>Mail opened:\n<span class='vga'>"
 
+		frauded_mail
+			name = "frauded mail counter"
+			desc = "The number of times someone has frauded someone's mail."
+			monitored_var = "mail_fraud"
+			maptext_prefix = "<span class='c pixel sh'>Mail frauded:\n<span class='vga'>"
+
 		last_death
 			name = "last death monitor"
 			desc = "RIP this idiot. Hope it wasn't you!"

--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -398,6 +398,10 @@
 			"value" = round(score_tracker.score_expenses),
 		),
 		list(
+			"name" = "Mail Delivery Score",
+			"value" = "[round(score_tracker.score_mailing)]% (Sent: [score_tracker.mail_sent] | Opened: [score_tracker.mail_received] | Frauded: [score_tracker.mail_fraud])"
+		),
+		list(
 			"name" = "Total Department Score",
 			"type" = "colorPercent",
 			"value" = round(score_tracker.final_score_civ),

--- a/code/datums/crew_credits/crew_credits.dm
+++ b/code/datums/crew_credits/crew_credits.dm
@@ -398,8 +398,8 @@
 			"value" = round(score_tracker.score_expenses),
 		),
 		list(
-			"name" = "Mail Delivery Score",
-			"value" = "[round(score_tracker.score_mailing)]% (Sent: [score_tracker.mail_sent] | Opened: [score_tracker.mail_received] | Frauded: [score_tracker.mail_fraud])"
+			"name" = "Mails Delivered / Frauded",
+			"value" = "[score_tracker.mail_opened] / [score_tracker.mail_fraud]"
 		),
 		list(
 			"name" = "Total Department Score",

--- a/code/datums/datalogger.dm
+++ b/code/datums/datalogger.dm
@@ -40,7 +40,6 @@ var/global/datum/datalogger/game_stats
 		stats["slips"] = 0
 		stats["hydro_harvests"] = 0
 		stats["hydro_produce"] = 0
-		stats["mail_sent"] = 0
 		stats["mail_opened"] = 0
 		stats["mail_fraud"] = 0
 	proc

--- a/code/datums/datalogger.dm
+++ b/code/datums/datalogger.dm
@@ -40,7 +40,9 @@ var/global/datum/datalogger/game_stats
 		stats["slips"] = 0
 		stats["hydro_harvests"] = 0
 		stats["hydro_produce"] = 0
+		stats["mail_sent"] = 0
 		stats["mail_opened"] = 0
+		stats["mail_fraud"] = 0
 	proc
 		Increment(var/p)
 			if(!(p in stats))

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -25,9 +25,7 @@ var/datum/score_tracker/score_tracker
 	// CIVILIAN DEPARTMENT
 	var/score_cleanliness = 0
 	var/score_expenses = 0
-	var/score_mailing = 0
-	var/mail_sent = 0
-	var/mail_received = 0
+	var/mail_opened = 0
 	var/mail_fraud = 0
 	var/final_score_civ = 0
 	var/most_xp = "OH NO THIS IS BROKEN"
@@ -181,11 +179,9 @@ var/datum/score_tracker/score_tracker
 		score_expenses = clamp(score_expenses,0,100)
 		score_cleanliness = clamp(score_cleanliness,0,100)
 
-		mail_sent = game_stats.GetStat("mail_sent")
-		mail_received = game_stats.GetStat("mail_opened")
+		mail_opened = game_stats.GetStat("mail_opened")
 		mail_fraud = game_stats.GetStat("mail_fraud")
-		if (mail_sent)
-			score_mailing = (mail_received / mail_sent) * 100 - (mail_fraud / mail_sent) * 100
+
 		final_score_civ = (score_expenses + score_cleanliness) * 0.5
 
 		var/xp_winner = null

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -25,6 +25,10 @@ var/datum/score_tracker/score_tracker
 	// CIVILIAN DEPARTMENT
 	var/score_cleanliness = 0
 	var/score_expenses = 0
+	var/score_mailing = 0
+	var/mail_sent = 0
+	var/mail_received = 0
+	var/mail_fraud = 0
 	var/final_score_civ = 0
 	var/most_xp = "OH NO THIS IS BROKEN"
 	var/score_text = null
@@ -176,6 +180,12 @@ var/datum/score_tracker/score_tracker
 
 		score_expenses = clamp(score_expenses,0,100)
 		score_cleanliness = clamp(score_cleanliness,0,100)
+
+		mail_sent = game_stats.GetStat("mail_sent")
+		mail_received = game_stats.GetStat("mail_opened")
+		mail_fraud = game_stats.GetStat("mail_fraud")
+		if (mail_sent)
+			score_mailing = (mail_received / mail_sent) * 100 - (mail_fraud / mail_sent) * 100
 		final_score_civ = (score_expenses + score_cleanliness) * 0.5
 
 		var/xp_winner = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `mail_opened` and `mail_fraud` to both crew credits and game stats.

Adds a "Mails Delivered / Frauded" at the end of credits which displays them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny mail stuff


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Mail Delivery Score is now tracked at the end of credits.
```
