### PR TITLE
Fix duplicate message applying patch to self

### DIFF
--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -117,9 +117,6 @@
 			return
 
 		if (can_operate_on(user))
-			user.visible_message("[user] applies [src] to [himself_or_herself(user)].",\
-			SPAN_NOTICE("You apply [src] to yourself."))
-			logTheThing(LOG_CHEMISTRY, user, "applies a patch to themself [log_reagents(src)] at [log_loc(user)].")
 			user.Attackby(src, user)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Remove redundant messages and logging from patch `attack_self`, as it is all repeated in `attack`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19168 
