### PR TITLE
Fix floorbot construction breaking in backpacks

### DIFF
--- a/code/modules/robotics/bot/floorbot.dm
+++ b/code/modules/robotics/bot/floorbot.dm
@@ -474,10 +474,7 @@
 	if(src.color_overlay)
 		A.UpdateOverlays(image(A.icon, icon_state = src.color_overlay), "coloroverlay")
 		A.color_overlay = src.color_overlay
-	if (user.r_hand == src || user.l_hand == src)
-		A.set_loc(user.loc)
-	else
-		A.set_loc(src.loc)
+	A.set_loc(get_turf(src))
 	A.on = 1 // let's just pretend they flipped the switch
 	A.update_power_overlay()
 	boutput(user, "You add the robot arm to the odd looking toolbox assembly! Boop beep!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replace weird hand workaround and `set_loc(src.loc)` with a `set_loc(get_turf(src))` so it properly places the finished floorbot on the ground.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19158 
