### PR TITLE
Fix runtime going to afterlife as certain diplomat species

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -671,8 +671,9 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 		// if you dont have an id, you get one anyway
 		newbody.spawnId(new /datum/job/command/captain)
 
-	newbody.wear_id:assignment = bar_role_name
-	newbody.wear_id:update_name()
+	var/obj/item/card/id/newID = newbody.wear_id
+	newID?.assignment = bar_role_name
+	newID?.update_name()
 
 	if (!newbody.bioHolder)
 		newbody.bioHolder = new bioHolder(newbody)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIME] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes `:` operator usage to typecast and `?.` so blob/martian diplomats not wearing jumpsuits and IDs doesn't cause the whole proc to runtime and fail

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19187 
