### PR TITLE
Borg can read Arthints

### DIFF
--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -37,7 +37,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -31,7 +31,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr)))
+		if (istext(A.examine_hint) && (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -31,7 +31,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -27,7 +27,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) &&  (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -50,7 +50,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist")) || isrobot(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	ex_act(severity)
@@ -137,7 +137,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))) || isrobot(usr))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()
@@ -242,7 +242,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))) || isrobot(usr))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives borgs the ability to see arthints.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Borgs should be able to access a database with the relevant information to determine artifact traits. They also have a science module and do artsci anyway.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(+)Borgs can now see artifact hints in addition to scientists.
```
