### PR TITLE
Raise a glass to freedom

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -976,8 +976,13 @@
 
 			if ("raisehand")
 				if (!src.restrained())
-					message = "<B>[src]</B> raises a hand."
-					maptext_out = "<I>raises a hand</I>"
+					var/obj/item/thing = src.equipped()
+					if (thing)
+						message = "<B>[src]</B> raises [thing]."
+						maptext_out = "<I>raises [thing]</I>"
+					else
+						message = "<B>[src]</B> raises a hand."
+						maptext_out = "<I>raises a hand</I>"
 				else
 					message = "<B>[src]</B> tries to move [his_or_her(src)] arm."
 					maptext_out = "<I>tries to move [his_or_her(src)] arm</I>"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -391,21 +391,9 @@
 								message = "<B>[src]</b> points finger guns at... [himself_or_herself(src)]?"
 								maptext_out = "<I> points finger guns at... [himself_or_herself(src)]?</I>"
 							else
-								if ("wave" && I)
-									if (I.reagents && I.reagents.total_volume > 0)
-										if (I.reagents) I.reagents.physical_shock(rand(2, 6))
-										if (I.is_open_container())
-											message = "<B>[src]</b> gently rocks [I] in the air."
-											maptext_out = "<I>gently rocks [I] in the air</I>"
-										else
-											message = "<B>[src]</b> waves [I] around."
-											maptext_out = "<I>waves [I] around</I>"
-									else if (istype(I, /obj/item/cloth/handkerchief))
-										message = "<B>[src]</b> waves [I]."
-										maptext_out = "<I>waves [I]</I>"
-									else
-										message = "<B>[src]</b> waves [I] around."
-										maptext_out = "<I>waves [I] around</I>"
+								if ("wave" && istype(I, /obj/item/cloth/handkerchief))
+									message = "<B>[src]</b> waves [I]."
+									maptext_out = "<I>waves [I]</I>"
 								else
 									message = "<B>[src]</b> [act]s."
 									maptext_out = "<I>[act]s</I>"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -391,9 +391,21 @@
 								message = "<B>[src]</b> points finger guns at... [himself_or_herself(src)]?"
 								maptext_out = "<I> points finger guns at... [himself_or_herself(src)]?</I>"
 							else
-								if ("wave" && istype(I, /obj/item/cloth/handkerchief))
-									message = "<B>[src]</b> waves [I]."
-									maptext_out = "<I>waves [I]</I>"
+								if ("wave" && I)
+									if (I.reagents && I.reagents.total_volume > 0)
+										if (I.reagents) I.reagents.physical_shock(rand(2, 6))
+										if (I.is_open_container())
+											message = "<B>[src]</b> gently rocks [I] in the air."
+											maptext_out = "<I>gently rocks [I] in the air</I>"
+										else
+											message = "<B>[src]</b> waves [I] around."
+											maptext_out = "<I>waves [I] around</I>"
+									else if (istype(I, /obj/item/cloth/handkerchief))
+										message = "<B>[src]</b> waves [I]."
+										maptext_out = "<I>waves [I]</I>"
+									else
+										message = "<B>[src]</b> waves [I] around."
+										maptext_out = "<I>waves [I] around</I>"
 								else
 									message = "<B>[src]</b> [act]s."
 									maptext_out = "<I>[act]s</I>"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If there's an item in your active hand when you do the raise hand emote (CTRL-H), it'll raise that item instead. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cool way to do toasts or cheerses withhout having to custom emote it.

