### PR TITLE
Resolve missing property ID for conductive requirement

### DIFF
--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -94,6 +94,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		conductive
 			name = "Conductive"
 			id = "conductive"
+			material_property = "electrical"
 			material_threshold = 6
 
 			high


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I forgot this and it lets checks for copper/claretine pass for non-conductive materials

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #19215 

