### PR TITLE
Fix revheads not having a revhead arrest icon when dead

### DIFF
--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -21,9 +21,10 @@
 
 			if (arrestState != "*Arrest*") // Contraband overrides non-arrest statuses, now check for contraband
 				if (locate(/obj/item/implant/counterrev) in H.implant)
-					if (H.mind?.get_antagonist(ROLE_HEAD_REVOLUTIONARY))
+					var/mob/M = ckey_to_mob_maybe_disconnected(H.last_ckey)
+					if (M?.mind?.get_antagonist(ROLE_HEAD_REVOLUTIONARY))
 						arrestState = "RevHead"
-					else if (H.mind?.get_antagonist(ROLE_REVOLUTIONARY))
+					else if (M?.mind?.get_antagonist(ROLE_REVOLUTIONARY))
 						arrestState = "Loyal_Progress"
 					else
 						arrestState = "Loyal"


### PR DESCRIPTION
[GAME MODES][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes dead headrevs showing as loyal when implanted with a counter rev implant, rather than headrev


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix
