### PR TITLE
Latejoining folk with Background traits no longer get announced

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -207,7 +207,7 @@
 			var/datum/trait/T = traits[id]
 			for (var/heldcat in T.category)
 				if (heldcat == cat)
-					. = T
+					return T
 
 //Yes these are objs because grid control. Shut up. I don't like it either.
 /datum/trait

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -205,8 +205,9 @@
 	proc/getTraitWithCategory(var/cat)
 		for(var/id in traits)
 			var/datum/trait/T = traits[id]
-			if (T.category == cat)
-				. = T
+			for (var/heldcat in T.category)
+				if (heldcat == cat)
+					. = T
 
 //Yes these are objs because grid control. Shut up. I don't like it either.
 /datum/trait


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The code from #15240 was changed to use a concise and readable proc! Unfortunately that proc tried to compare a list to a string directly and was nonfunctional. This PR fixes that proc (and should also fix the issues it was likely having during pod wars).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stowaways and heavy sleepers were getting announced again. 