### PR TITLE
German Accent Fixes

### DIFF
--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -833,8 +833,8 @@ proc/random_accent()
 	S = lowertext(S)
 	switch(S)
 
-		if("w") //germans pronounce W like V
-			if(lowertext(R.next_char) != " " || lowertext(R.next_char) != null)
+		if("w") //germans pronounce W like V, but generally keep the "ow" sound at the end of words and such.
+			if (!is_null_or_space(lowertext(R.next_char)))
 				new_string = "v"
 				used = 1
 		if("t") //unlinke the stereotypical zat- it's more like dat, because both the t and the h are pronounced in german. Of course, the Z still does happen quite often.

--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -834,7 +834,7 @@ proc/random_accent()
 	switch(S)
 
 		if("w") //germans pronounce W like V
-			if(lowertext(R.next_char) == " " || lowertext(R.next_char) == null)
+			if(lowertext(R.next_char) != " " || lowertext(R.next_char) != null)
 				new_string = "v"
 				used = 1
 		if("t") //unlinke the stereotypical zat- it's more like dat, because both the t and the h are pronounced in german. Of course, the Z still does happen quite often.

--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -834,12 +834,17 @@ proc/random_accent()
 	switch(S)
 
 		if("w") //germans pronounce W like V
-			new_string = "v"
-			used = 1
-		if("t") //unlinke the stereotypical zat- it's more like dat, because both the t and the h are pronounced in german
+			if(lowertext(R.next_char) == " " || lowertext(R.next_char) == null)
+				new_string = "v"
+				used = 1
+		if("t") //unlinke the stereotypical zat- it's more like dat, because both the t and the h are pronounced in german. Of course, the Z still does happen quite often.
 			if(lowertext(R.next_char) == "h")
-				new_string = "d"
-				used = 2
+				if(prob(50))
+					new_string = "d"
+					used = 2
+				else
+					new_string = "z"
+					used = 2
 		if("z")//z acts like an english ts
 			new_string = "ts"
 			used = 1
@@ -870,10 +875,6 @@ proc/random_accent()
 			if(lowertext(R.next_char) == "u")
 				new_string = "oi"
 				used = 2
-		if("d")
-			if(prob(50))
-				new_string = "t"
-				used = 1
 
 		if("v")
 			new_string = "f"
@@ -939,7 +940,7 @@ proc/random_accent()
 		"too bad" = "schade",
 		"no problem" = "kein problem"
 	) //this list is seperate from the text document, as the current accent system does not support multi word phrases. This could use reworking.
-	
+
 	var/substitute = null
 	for(var/i=1,i <= length(phrase),i++)
 		substitute = phrase[i]

--- a/strings/language/german.txt
+++ b/strings/language/german.txt
@@ -162,6 +162,7 @@ stones@=steine
 strong@=stark
 sugar@=zucker
 sun@=sonne
+sweet@=suess
 tank@=panzer
 tastes@=schmekt
 tasty@=lecker

--- a/strings/language/german.txt
+++ b/strings/language/german.txt
@@ -106,7 +106,6 @@ meat@=fleish
 medic@=doktor
 medics@=doktors
 milk@=milch
-miss@=frau
 missus@=frau
 mister@=herr
 mother@=mutter


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TRAITS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> The two tweaks are as follows:
1) the letter D no longer has a 50% chance to turn into a T.

2) the letter W at the end of a word is left unchanged, so how isn't displayed as "hov"

3) "miss" is no longer replaced by frau, because "I miss you" would be turned to "I frau you," which means "I woman you." Makes no sense.

This, as an added side affect, makes the lawbringer fully functional with the accent.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A couple words said with the accent previously would raise some eyebrows, and make no sense at all. These small tweaks both make the accent more appealing, and less unintelligable.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Klushy225
(+)Tweaked the German accent to make more sense.
```
