### PR TITLE
Reshuffle oshan engineering lights

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -131,10 +131,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aaH" = (
-/obj/reagent_dispensers/fueltank,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
+/obj/table/auto,
+/obj/item/shipcomponent/secondary_system/gps,
+/obj/item/crowbar,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaI" = (
@@ -152,17 +154,16 @@
 	},
 /area/station/medical/medbay/surgery/storage)
 "aaJ" = (
-/obj/table/auto,
-/obj/item/shipcomponent/secondary_system/gps,
-/obj/item/crowbar,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /obj/machinery/light_switch/auto,
+/obj/table/auto,
+/obj/item/device/gps,
+/obj/item/weldingtool,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaK" = (
-/obj/machinery/manufacturer/hangar,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
@@ -187,10 +188,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaO" = (
-/obj/item/cigbutt,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/item/cigbutt,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaQ" = (
@@ -211,6 +212,11 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/item/match,
+/obj/item/cigbutt,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaT" = (
@@ -531,9 +537,6 @@
 	},
 /area/station/engine/engineering)
 "abJ" = (
-/obj/item/cigbutt,
-/obj/stool/chair/yellow,
-/obj/item/match,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
 	},
@@ -544,6 +547,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "abK" = (
@@ -33848,13 +33852,11 @@
 /turf/simulated/floor,
 /area/research_outpost/toxins)
 "eSK" = (
-/obj/table/auto,
 /obj/machinery/firealarm/north,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/item/weldingtool,
-/obj/item/device/gps,
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "eSX" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -183,6 +183,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "aaO" = (
@@ -312,6 +313,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
+/obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "abi" = (
@@ -2096,10 +2098,6 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
-"ahg" = (
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/engineering)
 "ahh" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	dir = 4;
@@ -11074,6 +11072,9 @@
 /obj/table/auto,
 /obj/item/tank/air,
 /obj/item/paper/book/from_file/ggcsftm,
+/obj/item/device/radio/intercom/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "aKL" = (
@@ -30225,9 +30226,7 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "ceL" = (
@@ -107932,7 +107931,7 @@ beP
 aAy
 aAy
 aAy
-ahg
+aAy
 aTm
 bkx
 bhr


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reshuffle oshan engineering lights to remove the one in the wall 
![image](https://github.com/goonstation/goonstation/assets/142273065/b74ed809-be17-49ed-bbcb-6ac8295c97c0)
vs
![image](https://github.com/goonstation/goonstation/assets/142273065/5df95439-b020-41a4-a983-765f6f7eb446)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #18937

[mapping][bug]



