### PR TITLE
DRAFT: Re-refactor manufacturing requirements to be Better

### DIFF
--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -36,7 +36,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement)
 	/// Checks whether or not the given material meets the requirements enforced by this proc.
 	proc/is_match(var/datum/material/M)
 		SHOULD_CALL_PARENT(TRUE)
-		return isnull(M)
+		return !isnull(M)
 
 /datum/manufacturing_requirement/not_null
 	name = "Any"

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -8,6 +8,13 @@
 var/global/list/requirement_cache
 
 /proc/getRequirement(var/R_id)
+	#ifdef CHECK_MORE_RUNTIMES
+	if (!istext(R_id))
+		CRASH("getRequirement() called with a non-text argument [R_id].")
+	if (!(R_id in requirement_cache))
+		CRASH("getRequirement() called with an invalid requirement id [R_id].")
+	#endif
+	// Sanity checks that all requirement IDs resolved to instances in the cache
 	return requirement_cache?[R_id]
 
 ABSTRACT_TYPE(/datum/manufacturing_requirement)
@@ -238,7 +245,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		if (!(istype(M, src.match_typepath))) return
 
 /datum/manufacturing_requirement/match_subtypes/gemstone
-	name = "Gemstone"
+	name = "gemstone_subtypes"
 	id = "gemstone_subtypes"
 	match_typepath = /datum/material/crystal/gemstone
 
@@ -267,7 +274,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		/datum/manufacturing_requirement/match_flags/metal,
 	)
 /datum/manufacturing_requirement/mixed/metal
-	name = "Tough Metal"
+	name = "Sturdy Metal"
 	id = "metal_tough"
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/metal,
@@ -285,6 +292,14 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/mixed/insulated
 	name = "Insulative"
 	id = "insulated"
+	requirements = list(
+		/datum/manufacturing_requirement/match_flags/insulated,
+		/datum/manufacturing_requirement/match_property/insulated,
+	)
+
+/datum/manufacturing_requirement/mixed/insulated
+	name = "Highly Insulative"
+	id = "insulated_high"
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/insulated,
 		/datum/manufacturing_requirement/match_property/insulated,

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -21,10 +21,6 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	var/material_id = null
 	/// Material flags of the material to check. None of null, can be made like MATERIAL_A | MATERIAL_B if needed to check for either.
 	var/material_flags = null
-	/// Property of the material to check. None if null, some string like "radioactive" if used
-	var/material_property = null
-	/// Context-dependent material threshold for an item. Use if you want to check a material property of something. Currently just checks if >=
-	var/material_threshold = null
 
 	// ID must be defined, or else we have a problem
 	#ifdef CHECK_MORE_RUNTIMES
@@ -46,7 +42,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 			return FALSE
 		return TRUE
 
-/datum/manufacturing_requirement/any
+/datum/manufacturing_requirement/not_null
 	name = "Any"
 	id = "any"
 
@@ -61,7 +57,8 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		. = ..()
 
 	is_match(var/datum/material/M)
-		if (!..())
+		. = ..()
+		if (!.)
 			return FALSE
 		if (src.material_id != M.getID())
 			return FALSE
@@ -69,34 +66,36 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /***************************************************************
                       MATERIAL PROPERTIES
 
-           Includes material flag checks with properties
+          Match for a specific threshold of a property
 
                     PLEASE ALPHABETIZE THANKS
 ***************************************************************/
 
 /datum/manufacturing_requirement/match_property
-	is_match(var/datum/material/M)
-		var/should_match_property = !isnull(src.material_property) || !isnull(src.material_threshold)
-		if (should_match_property && !src.matches_property(M))
-			return FALSE
-		if (!isnull(src.material_flags) && !src.matches_flags(M.getMaterialFlags()))
-			return FALSE
-		. = ..()
 
-	/// Returns whether the material property matches the given criterion. Default behavior is to check if >=, override w/o calling parent for diff behavior.
-	proc/matches_property(var/datum/material/M)
-		return M.getProperty(src.material_property) >= src.material_threshold
+	/// Material property to match by its string identifier
+	var/property_id
+	/// What threshold our property has to match or exceed in order to pass.
+	var/property_threshold = 0
+
+	is_match(var/datum/material/M)
+		. = ..()
+		if (!.)
+			return FALSE
+		if (M.getProperty(src.property_id) < property_threshold)
+			return FALSE
+		return TRUE
 
 /datum/manufacturing_requirement/match_property/conductive
 	name = "Conductive"
 	id = "conductive"
-	material_property = "electrical"
-	material_threshold = 6
+	property_id = "electrical"
+	property_threshold = 6
 
 /datum/manufacturing_requirement/match_property/conductive/high
 	name = "High Energy Conductor"
 	id = "conductive_high"
-	material_threshold = 8
+	property_threshold = 8
 
 /datum/manufacturing_requirement/match_property/crystal
 	name = "Crystal"
@@ -106,8 +105,8 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/match_property/crystal/dense
 	name = "Extraordinarily Dense Crystalline Matter"
 	id = "crystal_dense"
-	material_property = "density"
-	material_threshold = 7
+	property_id = "density"
+	property_threshold = 7
 
 /datum/manufacturing_requirement/match_property/crystal/gemstone
 	name = "Gemstone"
@@ -121,29 +120,29 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/match_property/dense
 	name = "High Density Matter"
 	id = "dense"
-	material_property = "density"
-	material_threshold = 4
+	property_id = "density"
+	property_threshold = 4
 
 /datum/manufacturing_requirement/match_property/dense/super
 	name = "Very High Density Matter"
 	id = "dense_super"
-	material_threshold = 6
+	property_threshold = 6
 
 /datum/manufacturing_requirement/match_property/energy
 	name = "Power Source"
 	id = "energy"
-	material_property = "radioactive"
+	property_id = "radioactive"
 	material_flags = MATERIAL_ENERGY
 
 /datum/manufacturing_requirement/match_property/energy/high
 	name = "Significant Power Source"
 	id = "energy_high"
-	material_threshold = 3
+	property_threshold = 3
 
 /datum/manufacturing_requirement/match_property/energy/extreme
 	name = "Extreme Power Source"
 	id = "energy_extreme"
-	material_threshold = 5
+	property_threshold = 5
 
 /datum/manufacturing_requirement/match_property/fabric
 	name = "Fabric"
@@ -154,40 +153,40 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	name = "Insulative"
 	id = "insulated"
 	material_flags = MATERIAL_CLOTH | MATERIAL_RUBBER
-	material_threshold = 4
+	property_threshold = 4
 
 	matches_property(datum/material/M)
-		if (!(M.getProperty("electrical") <= src.material_threshold))
+		if (!(M.getProperty("electrical") <= src.property_threshold))
 			return FALSE
 		return TRUE
 
 /datum/manufacturing_requirement/match_property/insulated/super
 	id = "insulative_high"
 	name = "Highly Insulative"
-	material_threshold = 2
+	property_threshold = 2
 
 /datum/manufacturing_requirement/match_property/metal
 	name = "Metal"
 	id = "metal"
 	material_flags = MATERIAL_METAL
-	material_threshold = 0 // So we try to match properties
+	property_threshold = 0 // So we try to match properties
 
 	matches_property(var/datum/material/M)
 		// This specific check is based off the hardness of mauxite and bohrum.
 		// Mauxite ends up being 10 in here, while bohrum ends up being 16.
-		if (((M.getProperty("hard") * 2) + M.getProperty("density")) >= src.material_threshold)
+		if (((M.getProperty("hard") * 2) + M.getProperty("density")) >= src.property_threshold)
 			return TRUE
 		return FALSE
 
 /datum/manufacturing_requirement/match_property/metal/dense
 	name = "Sturdy Metal"
 	id = "metal_dense"
-	material_threshold = 10
+	property_threshold = 10
 
 /datum/manufacturing_requirement/match_property/metal/superdense
 	name = "Extremely Tough Metal"
 	id = "metal_superdense"
-	material_threshold = 15
+	property_threshold = 15
 
 /datum/manufacturing_requirement/match_property/organic_or_rubber
 	name = "Organic or Rubber"
@@ -197,8 +196,8 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/match_property/reflective
 	name = "Reflective"
 	id = "reflective"
-	material_property = "reflective"
-	material_threshold = 6
+	property_id = "reflective"
+	property_threshold = 6
 
 /datum/manufacturing_requirement/match_property/rubber
 	name = "Rubber"

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -26,8 +26,8 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	#ifdef CHECK_MORE_RUNTIMES
 	New()
 		. = ..()
-		if (isnull(id))
-			CRASH("[src] created with a null id")
+		if (isnull(src.id))
+			CRASH("[src] created with null id")
 	#endif
 
 	proc/get_id()
@@ -74,7 +74,16 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	/// Material property to match by its string identifier
 	var/property_id
 	/// What threshold our property has to match or exceed in order to pass.
-	var/property_threshold = 0
+	var/property_threshold
+
+	#ifdef CHECK_MORE_RUNTIMES
+	New()
+		. = ..()
+		if (isnull(src.property_id))
+			CRASH("[src] created with null property_id")
+		if (isnull(src.property_threshold))
+			CRASH("[src] created with null property_threshold")
+	#endif
 
 	is_match(var/datum/material/M)
 		. = ..()

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -110,12 +110,13 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	property_id = "density"
 	property_threshold = 7
 
-/datum/manufacturing_requirement/match_property/energy/high
+/datum/manufacturing_requirement/match_property/energy
 	name = "Significant Power Source"
 	id = "energy_property_3"
+	property_id = "radioactive"
 	property_threshold = 3
 
-/datum/manufacturing_requirement/match_property/energy/extreme
+/datum/manufacturing_requirement/match_property/energy/high
 	name = "Extreme Power Source"
 	id = "energy_property_5"
 	property_threshold = 5
@@ -207,7 +208,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 
 /datum/manufacturing_requirement/match_flags/fabric
 	name = "Fabric"
-	id = "fabric_flags"
+	id = "fabric_flag"
 	material_flags = MATERIAL_CLOTH | MATERIAL_RUBBER | MATERIAL_ORGANIC
 
 /datum/manufacturing_requirement/match_flags/crystal
@@ -273,7 +274,8 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/metal,
 	)
-/datum/manufacturing_requirement/mixed/metal
+
+/datum/manufacturing_requirement/mixed/metal_tough
 	name = "Sturdy Metal"
 	id = "metal_tough"
 	requirements = list(
@@ -281,7 +283,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		/datum/manufacturing_requirement/match_property/tough,
 	)
 
-/datum/manufacturing_requirement/mixed/metal
+/datum/manufacturing_requirement/mixed/metal_tough_extreme
 	name = "Extremely Tough Metal"
 	id = "metal_tough_extreme"
 	requirements = list(
@@ -297,10 +299,25 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		/datum/manufacturing_requirement/match_property/insulated,
 	)
 
-/datum/manufacturing_requirement/mixed/insulated
+/datum/manufacturing_requirement/mixed/insulated_high
 	name = "Highly Insulative"
 	id = "insulated_high"
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/insulated,
 		/datum/manufacturing_requirement/match_property/insulated,
+	)
+
+/datum/manufacturing_requirement/mixed/energy_high
+	name = "Significant Power Source"
+	id = "energy_high"
+	requirements = list(
+		/datum/manufacturing_requirement/match_flags/energy,
+		/datum/manufacturing_requirement/match_property/energy,
+	)
+/datum/manufacturing_requirement/mixed/energy_extreme
+	name = "Extreme Power Source"
+	id = "energy_high"
+	requirements = list(
+		/datum/manufacturing_requirement/match_flags/energy,
+		/datum/manufacturing_requirement/match_property/energy/high,
 	)

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -18,7 +18,6 @@ var/global/list/requirement_cache
 	return requirement_cache?[R_id]
 
 ABSTRACT_TYPE(/datum/manufacturing_requirement)
-ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement
 	var/name = "Unknown" //! Player-facing name of the requirement.
 	var/id //! Internal, unique ID of the requirement to use for the cache list.
@@ -44,6 +43,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	id = "any"
 
 /// All instances of match_material are generated at runtime for the cache
+ABSTRACT_TYPE(/datum/manufacturing_requirement/match_material)
 /datum/manufacturing_requirement/match_material
 	var/material_id //! Material ID of the material to check. None if null, some string like "erebite" if used. Meant for exact material checks.
 	New(var/mat_id)
@@ -59,6 +59,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		if (src.material_id != M.getID()) return
 
 
+ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/match_property
 	var/property_id //! Material property to match by its string identifier
 	var/property_threshold //! What threshold our property has to match or exceed in order to pass.
@@ -160,6 +161,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 #define MATCH_ALL 2 //! Pass if every material flag being checked is set.
 #define MATCH_EXACT 3 //! Pass if every material flag being checked is set, and every material flag not checked is not set.
 
+ABSTRACT_TYPE(/datum/manufacturing_requirement/match_flags)
 /datum/manufacturing_requirement/match_flags
 	var/material_flags //! The flag(s) of the material to match. This can be just one flag, or several with FLAG_A | FLAG_B | ...
 	var/match_type = MATCH_ANY //! How we want to define a successful match. By default, pass as long as at least one flag is set.
@@ -230,6 +232,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 #undef MATCH_ALL
 #undef MATCH_EXACT
 
+ABSTRACT_TYPE(/datum/manufacturing_requirement/match_subtypes)
 /datum/manufacturing_requirement/match_subtypes
 	var/match_typepath //! The parent type to use for istype() checks
 
@@ -251,6 +254,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	match_typepath = /datum/material/crystal/gemstone
 
 /// Manufacturing requirements which check several conditions at once.
+ABSTRACT_TYPE(/datum/manufacturing_requirement/mixed)
 /datum/manufacturing_requirement/mixed
 	var/list/datum/manufacturing_requirement/requirements = list() //! A list of requirements which must all be satisfied for this to return TRUE
 
@@ -316,7 +320,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	)
 /datum/manufacturing_requirement/mixed/energy_extreme
 	name = "Extreme Power Source"
-	id = "energy_high"
+	id = "energy_extreme"
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/energy,
 		/datum/manufacturing_requirement/match_property/energy/high,

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -124,17 +124,22 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 /datum/manufacturing_requirement/match_property/insulated/super
 	name = "Highly Insulative"
 	id = "electrical_property_<=_2"
+	property_id = "density"
 	property_threshold = 2
 
-/datum/manufacturing_requirement/match_property/metal/dense
-	name = "Sturdy Metal"
-	id = "metal_property_10"
+/datum/manufacturing_requirement/match_property/tough
+	name = "Tough Material"
+	id = "tough_property_10"
 	property_threshold = 10
 
-/datum/manufacturing_requirement/match_property/metal/superdense
-	name = "Extremely Tough Metal"
-	id = "metal_property_15"
-	property_id = "dense"
+	match_property(datum/material/M)
+		// This specific check is based off the hardness of mauxite and bohrum.
+		// Mauxite ends up being 10 in here, while bohrum ends up being 16.
+		return ((M.getProperty("hard") * 2) + M.getProperty("density")) > src.property_threshold
+
+/datum/manufacturing_requirement/match_property/tough/extreme
+	name = "Extremely Tough Material"
+	id = "tough_property_15"
 	property_threshold = 15
 
 /datum/manufacturing_requirement/match_property/reflective
@@ -261,13 +266,21 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	requirements = list(
 		/datum/manufacturing_requirement/match_flags/metal,
 	)
+/datum/manufacturing_requirement/mixed/metal
+	name = "Tough Metal"
+	id = "metal_tough"
+	requirements = list(
+		/datum/manufacturing_requirement/match_flags/metal,
+		/datum/manufacturing_requirement/match_property/tough,
+	)
 
-	is_match(datum/material/M)
-		// This specific check is based off the hardness of mauxite and bohrum.
-		// Mauxite ends up being 10 in here, while bohrum ends up being 16.
-		. = ..()
-		if (!.) return
-		if (((M.getProperty("hard") * 2) + M.getProperty("density")) < src.property_threshold) return
+/datum/manufacturing_requirement/mixed/metal
+	name = "Extremely Tough Metal"
+	id = "metal_tough_extreme"
+	requirements = list(
+		/datum/manufacturing_requirement/match_flags/metal,
+		/datum/manufacturing_requirement/match_property/tough/extreme,
+	)
 
 /datum/manufacturing_requirement/mixed/insulated
 	name = "Insulative"

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -107,12 +107,6 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	id = "dense_super"
 	property_threshold = 6
 
-/datum/manufacturing_requirement/match_property/energy
-	name = "Power Source"
-	id = "energy"
-	property_id = "radioactive"
-	material_flags = MATERIAL_ENERGY
-
 /datum/manufacturing_requirement/match_property/energy/high
 	name = "Significant Power Source"
 	id = "energy_high"
@@ -123,34 +117,10 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	id = "energy_extreme"
 	property_threshold = 5
 
-/datum/manufacturing_requirement/match_property/insulated
-	name = "Insulative"
-	id = "insulated"
-	material_flags = MATERIAL_CLOTH | MATERIAL_RUBBER
-	property_threshold = 4
-
-	is_match(datum/material/M)
-		. = ..()
-		if (!.) return
-		if (!(M.getProperty("electrical") <= src.property_threshold)) return
-
 /datum/manufacturing_requirement/match_property/insulated/super
 	id = "insulative_high"
 	name = "Highly Insulative"
 	property_threshold = 2
-
-/datum/manufacturing_requirement/match_property/metal
-	name = "Metal"
-	id = "metal"
-	material_flags = MATERIAL_METAL
-	property_threshold = 0 // So we try to match properties
-
-	is_match(datum/material/M)
-		// This specific check is based off the hardness of mauxite and bohrum.
-		// Mauxite ends up being 10 in here, while bohrum ends up being 16.
-		. = ..()
-		if (!.) return
-		if (((M.getProperty("hard") * 2) + M.getProperty("density")) < src.property_threshold) return
 
 /datum/manufacturing_requirement/match_property/metal/dense
 	name = "Sturdy Metal"
@@ -227,6 +197,16 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 #undef MATCH_ALL
 #undef MATCH_EXACT
 
+/datum/manufacturing_requirement/match_subtypes
+	var/match_typepath //! The parent type to use for istype() checks
+
+	#ifdef CHECK_MORE_RUNTIMES
+	New()
+		. = ..()
+		if (isnull(src.match_typepath) || !ispath(src.match_typepath))
+			CRASH("[src] has invalid match_typepath [src.match_typepath], it must be non-null and a valid path (not an instance!)")
+	#endif
+
 /// Manufacturing requirements which check several conditions at once.
 /datum/manufacturing_requirement/mixed
 	var/list/datum/manufacturing_requirement/requirements = list() //! A list of requirements which must all be satisfied for this to return TRUE
@@ -236,3 +216,33 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		if (!.) return
 		for (var/datum/manufacturing_requirement/R as anything in src.requirements)
 			if (!R.is_match(M)) return
+
+/datum/manufacturing_requirement/match_property/metal
+	name = "Metal"
+	id = "metal"
+	material_flags = MATERIAL_METAL
+	property_threshold = 0 // So we try to match properties
+
+	is_match(datum/material/M)
+		// This specific check is based off the hardness of mauxite and bohrum.
+		// Mauxite ends up being 10 in here, while bohrum ends up being 16.
+		. = ..()
+		if (!.) return
+		if (((M.getProperty("hard") * 2) + M.getProperty("density")) < src.property_threshold) return
+
+/datum/manufacturing_requirement/match_property/insulated
+	name = "Insulative"
+	id = "insulated"
+	material_flags = MATERIAL_CLOTH | MATERIAL_RUBBER
+	property_threshold = 4
+
+	is_match(datum/material/M)
+		. = ..()
+		if (!.) return
+		if (!(M.getProperty("electrical") <= src.property_threshold)) return
+
+/datum/manufacturing_requirement/match_property/energy
+	name = "Power Source"
+	id = "energy"
+	property_id = "radioactive"
+	material_flags = MATERIAL_ENERGY

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -87,15 +87,6 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 	property_id = "density"
 	property_threshold = 7
 
-/datum/manufacturing_requirement/match_property/crystal/gemstone
-	name = "Gemstone"
-	id = "gemstone"
-
-	is_match(var/datum/material/M)
-		. = ..()
-		if (!.) return
-		if (!(istype(M, /datum/material/crystal/gemstone))) return
-
 /datum/manufacturing_requirement/match_property/dense
 	name = "High Density Matter"
 	id = "dense"
@@ -206,6 +197,16 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		if (isnull(src.match_typepath) || !ispath(src.match_typepath))
 			CRASH("[src] has invalid match_typepath [src.match_typepath], it must be non-null and a valid path (not an instance!)")
 	#endif
+
+	is_match(var/datum/material/M)
+		. = ..()
+		if (!.) return
+		if (!(istype(M, src.match_typepath))) return
+
+/datum/manufacturing_requirement/match_subtypes/gemstone
+	name = "Gemstone"
+	id = "gemstone"
+	match_typepath = /datum/material/crystal/gemstone
 
 /// Manufacturing requirements which check several conditions at once.
 /datum/manufacturing_requirement/mixed

--- a/code/datums/manufacturing_requirements.dm
+++ b/code/datums/manufacturing_requirements.dm
@@ -38,9 +38,7 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
 		// This should always be a sequence of checks which return FALSE if the material does not match a requirement.
 		// See the check in match_material for a good example on this.
 		SHOULD_CALL_PARENT(TRUE)
-		if (isnull(M))
-			return FALSE
-		return TRUE
+		return isnull(M)
 
 /datum/manufacturing_requirement/not_null
 	name = "Any"
@@ -217,15 +215,26 @@ ABSTRACT_TYPE(/datum/manufacturing_requirement/match_property)
                     PLEASE ALPHABETIZE THANKS
 ***************************************************************/
 
+#define MATCH_ANY 1 //! Pass as long as at least one flag is defined.
+#define MATCH_ALL 2 //! Pass if every material flag is defined.
 /datum/manufacturing_requirement/match_flag
 
+	/// The flag(s) of the material to match. This can be just one flag, or several with FLAG_A | FLAG_B | ...
+	var/material_flags
+	var/match_type = MATCH_ANY
+
 	is_match(datum/material/M)
+		. = ..()
+		if (!.)
+			return FALSE
 
 
 	/// Returns whether the material flags are matched. This will return true should any flag match.
 	proc/matches_flags(var/material_flags)
 		return material_flags & src.material_flags
 
+#undef MATCH_ANY
+#undef MATCH_ALL
 
 /// Manufacturing requirements which check several conditions at once.
 /datum/manufacturing_requirement/mixed

--- a/code/world/initialization/0_preMapLoad.dm
+++ b/code/world/initialization/0_preMapLoad.dm
@@ -231,7 +231,15 @@
 	var/requirementList = concrete_typesof(/datum/manufacturing_requirement) - /datum/manufacturing_requirement/match_material
 	for (var/datum/manufacturing_requirement/R_path as anything in requirementList)
 		var/datum/manufacturing_requirement/R = new R_path()
+		#ifdef CHECK_MORE_RUNTIMES
+		if (R.id in requirement_cache)
+			CRASH("ID conflict: [R.id] from [R]")
+		#endif
 		requirement_cache[R.id] = R
 	for (var/datum/material/mat as anything in material_cache)
 		var/datum/manufacturing_requirement/match_material/R = new /datum/manufacturing_requirement/match_material(mat)
+		#ifdef CHECK_MORE_RUNTIMES
+		if (R.id in requirement_cache)
+			CRASH("ID conflict: [R.id] from [R]")
+		#endif
 		requirement_cache[R.id] = R


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Internal] [Code-Quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds more subtype matches of manufacturing requirements to better split the functionality between children.
Protects the ID and name attributes, and provides getters (but not setters) for these values -- which should remain constant throughout
renames various requirement IDs to be more distinct from another given the splitting of certain requirement datums into more datums -- renames all the IDs appropriately (pain... but worth it)
adds some more checks for CHECK_MORE_RUNTIMES, as well as better logic checks for the is_match() procs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While these manufacturing datums have certainly been an improvement over the old system, they still had a long way to go -- this PR aims to bring it closer to its ideal state.