### PR TITLE
Remove bullet "hit by" messages

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1563,7 +1563,7 @@
 		if (D_TOXIC)
 			src.take_toxin_damage(damage)
 	if (!P || !P.proj_data || !P.proj_data.silentshot)
-		src.visible_message(SPAN_ALERT("[src] is hit by the [P]!"))
+		boutput(src, SPAN_ALERT("You are hit by the [P]!"))
 
 	actions.interrupt(src, INTERRUPT_ATTACKED)
 	return

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2071,7 +2071,7 @@
 					src.take_toxin_damage(damage)
 
 	if (!P.proj_data.silentshot)
-		src.visible_message(SPAN_COMBAT("<b>[src] is hit by the [P.name]!</b>"), SPAN_COMBAT("<b>You are hit by the [P.name][armor_msg]</b>!"))
+		boutput(src, SPAN_COMBAT("<b>You are hit by the [P.name][armor_msg]</b>!"))
 
 	var/mob/M = null
 	if (ismob(P.shooter))

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -334,7 +334,7 @@
 				src.TakeDamage(null, 0, damage)
 
 		if(!P.proj_data.silentshot)
-			src.visible_message(SPAN_ALERT("[src] is hit by the [P]!"))
+			boutput(src, SPAN_ALERT("You are hit by the [P]!"))
 
 	ex_act(severity)
 		if (!src.density) return

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -184,7 +184,7 @@
 				src.TakeDamage(null, 0, damage)
 
 		if(!P.proj_data.silentshot)
-			src.visible_message(SPAN_ALERT("[src] is hit by the [P]!"))
+			boutput(src, SPAN_ALERT("You are hit by the [P]!"))
 
 	blob_act(var/power)
 		logTheThing(LOG_COMBAT, src, "is hit by a blob")

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -566,7 +566,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/hit_ground_chance = 0    // With what % do we hit mobs laying down
 	var/window_pass = 0          // Can we pass windows
 	var/obj/projectile/master = null // The projectile obj that we're associated with
-	var/silentshot = 0           // Standard visible message upon bullet_act.
+	var/silentshot = 0           // Standard hit message upon bullet_act.
 	var/implanted                // Path of "bullet" left behind in the mob on successful hit
 	var/disruption = 0           // planned thing to deal with pod electronics / etc
 	var/zone = null              // todo: if fired from a handheld gun, check the targeted zone --- this should be in the goddamn obj

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -228,8 +228,6 @@
 		damage = round((0.15*P.power*P.proj_data.ks_ratio), 1.0)
 		damage = damage - min(damage,3) //bullet resist
 		if (damage < 1 || istype(P.proj_data,/datum/projectile/laser/heavy/law_safe))
-			if(!P.proj_data.silentshot)
-				src.visible_message(SPAN_ALERT("[src] is hit by the [P] but it deflects harmlessly."))
 			return
 
 		src.material_trigger_on_bullet(src, P)
@@ -245,9 +243,6 @@
 				changeHealth(-damage*0.5,P.shooter)
 			if (D_ENERGY)
 				changeHealth(-damage*0.75,P.shooter)
-
-		if(!P.proj_data.silentshot)
-			src.visible_message(SPAN_ALERT("[src] is hit by the [P]!"))
 
 	update_icon()
 		var/image/circuit_image = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[PERFORMANCE] [QOL] [REMOVAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes all the "Person has been hit by the bullet" messages to only show to the person who was hit, instead of everyone in visual range.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've noticed client performance taking a real hit during high population firefights and I'm guessing some of it has to do with the sheer amount of chat spam. Grenades especially generate an absurd amount of rapid chat messages so enough of them going off in a crowd is bound to cause problems.
These kinds of messages are from an earlier era of the game when there were a lot less useful visual effects to convey this type of information.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Bullet hit by messages now only show to the person being hit.
```
