### PR TITLE
Makes chem request and request receiver consoles constructable

### DIFF
--- a/code/modules/chemistry/chem_requester.dm
+++ b/code/modules/chemistry/chem_requester.dm
@@ -22,6 +22,7 @@ var/list/datum/chem_request/chem_requests = list()
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "chemreq"
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
+	circuit_type = /obj/item/circuitboard/chem_request
 	var/datum/chem_request/request = new
 	var/obj/item/card/id/card = null
 	var/max_volume = 400
@@ -120,7 +121,8 @@ var/list/datum/chem_request/chem_requests = list()
 			boutput(user, SPAN_NOTICE("You swipe the ID card."))
 			src.card = id_card
 			tgui_process.try_update_ui(user, src)
-		else src.Attackhand(user)
+		else
+			..()
 
 	science
 		area_name = "Science"
@@ -135,6 +137,7 @@ var/list/datum/chem_request/chem_requests = list()
 	req_access = list(access_chemistry)
 	object_flags = CAN_REPROGRAM_ACCESS
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
+	circuit_type = /obj/item/circuitboard/chem_request_receiver
 
 	get_help_message(dist, mob/user)
 		return null

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -175,10 +175,15 @@ TYPEINFO(/obj/item/circuitboard)
 /obj/item/circuitboard/announcement
 	name = "Circuit board (Announcement Computer)"
 	computertype = "/obj/machinery/computer/announcement"
-
 /obj/item/circuitboard/siphon_control
 	name = "Circuit board (Siphon Control)"
 	computertype = /obj/machinery/computer/siphon_control
+/obj/item/circuitboard/chem_request
+	name = "Circuit board (Chemical Request Console)"
+	computertype = /obj/machinery/computer/chem_requester
+/obj/item/circuitboard/chem_request_receiver
+	name = "Circuit board (Chemical Request Receiver)"
+	computertype = /obj/machinery/computer/chem_request_receiver
 
 /obj/computerframe/meteorhit(obj/O as obj)
 	qdel(src)

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -223,6 +223,7 @@
 /// Technical Storage circuit board rack for engineering/supply
 /obj/rack/organized/techstorage_eng
 	items_to_spawn = list(
+		/obj/item/circuitboard/arcade,
 		/obj/item/circuitboard/qmorder,
 		/obj/item/circuitboard/qmsupply,
 		/obj/item/circuitboard/barcode,
@@ -241,11 +242,12 @@
 /// Technical Storage circuit board rack for medical/science/misc
 /obj/rack/organized/techstorage_med
 	items_to_spawn = list(
-		/obj/item/circuitboard/arcade,
 		/obj/item/circuitboard/card,
 		/obj/item/circuitboard/teleporter,
 		/obj/item/circuitboard/operating,
 		/obj/item/circuitboard/cloning,
 		/obj/item/circuitboard/genetics,
 		/obj/item/circuitboard/robot_module_rewriter,
+		/obj/item/circuitboard/chem_request,
+		/obj/item/circuitboard/chem_request_receiver,
 	)


### PR DESCRIPTION
[GAME OBJECTS][FEATURE][ADD TO WIKI]

## About the PR

- Adds circuitboards for chemical request consoles and chemical request receiver consoles.
- Allows construction/deconstruction of those consoles.
- Adds the circuitboards to the medical/science rack.
- Moves arcade circuitboard to engineering rack to better balance.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Fixes #12894.
- Consistency with other consoles.

## Changelog

```changelog
(u)Mordent
(+)Chemical request and request receiver consoles can now be (de)constructed.
```