### PR TITLE
Warns players when they're eligible for addiction

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -328,6 +328,8 @@ datum
 			holder.addiction_tally[src.id] += rate
 			var/current_tally = holder.addiction_tally[src.id]
 			//DEBUG_MESSAGE("current_tally [current_tally], min [addiction_min]")
+			if (addiction_min < current_tally + 3 && !ON_COOLDOWN(M, "addiction_warn_[src.id]", 5 MINUTES))
+				boutput(M, SPAN_ALERT("You think it might be time to hold back on the [src.name] for a bit..."))
 			if (addiction_min < current_tally && isliving(M) && prob(addProb) && prob(addiction_prob2))
 				boutput(M, SPAN_ALERT("<b>You suddenly feel invigorated and guilty...</b>"))
 				AD = new

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -327,8 +327,6 @@ datum
 			holder.addiction_tally[src.id] += rate
 			var/current_tally = holder.addiction_tally[src.id]
 			//DEBUG_MESSAGE("current_tally [current_tally], min [addiction_min]")
-			if (addiction_min < current_tally + 3 && !ON_COOLDOWN(M, "addiction_warn_[src.id]", 5 MINUTES))
-				boutput(M, SPAN_ALERT("You think it might be time to hold back on the [src.name] for a bit..."))
 			if (addiction_min < current_tally && isliving(M) && prob(addProb))
 				boutput(M, SPAN_ALERT("<b>You suddenly feel invigorated and guilty...</b>"))
 				AD = new
@@ -340,6 +338,8 @@ datum
 				M.ailments += AD
 				//DEBUG_MESSAGE("became addicted: [AD.name]")
 				return AD
+			if (addiction_min < current_tally + 3 && !ON_COOLDOWN(M, "addiction_warn_[src.id]", 5 MINUTES))
+				boutput(M, SPAN_ALERT("You think it might be time to hold back on [src.name] for a bit..."))
 			return
 
 		proc/flush(var/datum/reagents/holder, var/amount, var/list/flush_specific_reagents)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Addiction rolls a probability to addict every tick, but only after a reagent-specific addiction resistance variable gets worn down. This PR adds a warning ("You think it might be time to hold back on the [reagent name] for a bit...") a little before this resistance is completely overcome, so that players know they are nearly at risk for addiction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's pretty easy for addiction to take you by surprise, which makes it feel really cheap (especially if you're doing something innocuous like drinking coffee, tea, or ethanol). This change should hopefully make addiction feel a bit fairer.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)mintyphresh
(+)Players about to be eligible for addiction are now warned of it.
```
