### PR TITLE
Alcohol Resistance also grants resistance to ethanol addiction

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -322,7 +322,7 @@ datum
 					addProb = round(addProb * 2)
 					rate *= 2
 					//DEBUG_MESSAGE("addictive_personality: addProb [addProb], rate [rate]")
-				if (src.id == "ethanol" || isalcoholresistant(H))
+				if (src.id == "ethanol" && isalcoholresistant(H))
 					addProb /= 4
 					rate /= 4
 			if (!holder.addiction_tally)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -253,7 +253,8 @@ datum
 						H.sims.affectMotive("Energy", energy_value)
 			deplRate = deplRate * mult
 			if (addiction_prob)
-				src.handle_addiction(M, deplRate)
+				var/addProb = addiction_prob
+				src.handle_addiction(M, deplRate, addProb)
 
 			if (src.volume - deplRate <= 0)
 				src.on_mob_life_complete(M)
@@ -303,13 +304,12 @@ datum
 
 
 
-		proc/handle_addiction(var/mob/M, var/rate)
+		proc/handle_addiction(var/mob/M, var/rate, var/addProb)
 			//DEBUG_MESSAGE("[src.id].handle_addiction([M],[rate])")
 			var/datum/ailment_data/addiction/AD = M.addicted_to_reagent(src)
 			if (AD)
 				//DEBUG_MESSAGE("already have [AD.name]")
 				return AD
-			var/addProb = addiction_prob
 			//DEBUG_MESSAGE("addProb [addProb]")
 			if (isliving(M))
 				var/mob/living/H = M
@@ -321,9 +321,6 @@ datum
 					addProb *= 2
 					rate *= 2
 					//DEBUG_MESSAGE("addictive_personality: addProb [addProb], rate [rate]")
-				if (src.id == "ethanol" && isalcoholresistant(H))
-					addProb /= 4
-					rate /= 4
 			if (!holder.addiction_tally)
 				holder.addiction_tally = list()
 			//DEBUG_MESSAGE("holder.addiction_tally\[src.id\] = [holder.addiction_tally[src.id]]")

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -323,8 +323,8 @@ datum
 					rate *= 2
 					//DEBUG_MESSAGE("addictive_personality: addProb [addProb], rate [rate]")
 				if (src.id == "ethanol" || isalcoholresistant(H))
-					addProb = 0
-					rate = 0
+					addProb /= 4
+					rate /= 4
 			if (!holder.addiction_tally)
 				holder.addiction_tally = list()
 			//DEBUG_MESSAGE("holder.addiction_tally\[src.id\] = [holder.addiction_tally[src.id]]")

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -322,6 +322,9 @@ datum
 					addProb = round(addProb * 2)
 					rate *= 2
 					//DEBUG_MESSAGE("addictive_personality: addProb [addProb], rate [rate]")
+				if (src.id == "ethanol" || isalcoholresistant(H))
+					addProb = 0
+					rate = 0
 			if (!holder.addiction_tally)
 				holder.addiction_tally = list()
 			//DEBUG_MESSAGE("holder.addiction_tally\[src.id\] = [holder.addiction_tally[src.id]]")

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -253,8 +253,7 @@ datum
 						H.sims.affectMotive("Energy", energy_value)
 			deplRate = deplRate * mult
 			if (addiction_prob)
-				var/addProb = addiction_prob
-				src.handle_addiction(M, deplRate, addProb)
+				src.handle_addiction(M, deplRate, addiction_prob)
 
 			if (src.volume - deplRate <= 0)
 				src.on_mob_life_complete(M)

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -251,6 +251,14 @@
 				H.contract_disease(/datum/ailment/malady/heartdisease,null,null,1)
 			..()
 
+	handle_addiction(var/mob/M, var/rate, var/addProb)
+		if (isliving(M))
+			var/mob/living/H = M
+			if (isalcoholresistant(H))
+				addProb /= 4
+				rate /= 4
+		..()
+
 /datum/reagent/hydrogen
 	name = "hydrogen"
 	id = "hydrogen"

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -257,7 +257,7 @@
 			if (isalcoholresistant(H))
 				addProb /= 4
 				rate /= 4
-		..()
+		..(M, rate, addProb)
 
 /datum/reagent/hydrogen
 	name = "hydrogen"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The alcohol resistance effect, which can be gotten either through genetics, the career alcoholic trait, or by being a certain job, already grants full immunity to ethanol's effects (so long as there's no moonshine in there). This PR grants them a greater resistance to ethanol addiction, too; quartering the chance it happens and making it take four times as long to start rolling.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've taken the gene that grants alcohol resistance before, expecting it to have this behavior, since it's the hardest symptom of ethanol to treat and the most persistent. What's the point of alcohol resistance if you can't resist taking more of it?


## Changelog
```changelog
(u)mintyphresh
(+)Alcohol resistance from genetics, jobs, and traits now helps stave off addiction, too.
```
