### PR TITLE
Cherries can be sliced/cut into maraschino cherries

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -503,7 +503,14 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 
 	make_reagents()
 		..()
-		src.reagents.add_reagent("juice_grapefruit",10)
+		src.reagents.add_reagent("juice_cherry",10)
+
+	attackby(obj/item/W, mob/user)
+		. = ..()
+		if (iscuttingtool(W) || issnippingtool(W))
+			new /obj/item/cocktail_stuff/maraschino_cherry(get_turf(src))
+			new /obj/item/cocktail_stuff/maraschino_cherry(get_turf(src))
+			qdel(src)
 
 /obj/item/reagent_containers/food/snacks/plant/melon
 	name = "melon"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allow botany's grown cherries to be cut/sliced into two maraschino cherries. Also fixes a bug where cherries contained grapefruit juice instead of cherry juice.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Renewable cocktail flair.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Cherries can be sliced or cut into maraschino cherries.
```
