### PR TITLE
Prevents attacking space bees with items if you're on help intent

### DIFF
--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -410,6 +410,9 @@ ADMIN_INTERACT_PROCS(/obj/critter/domestic_bee, proc/dance, proc/puke_honey)
 			if (W.reagents.has_reagent("menthol") && length(W.reagents.reagent_list) == 1)
 				src.visible_message("<b>[src]</b> sniffles a bit.")
 				src.health = min(initial(src.health), src.health+5)
+		else if(user.a_intent == INTENT_HELP)
+			user.visible_message(SPAN_NOTICE("<b>[user]</b> harmlessly baps [src] with [W]!"), SPAN_NOTICE("You harmlessly bap [src] with [W]."))
+			user.lastattacked = src
 		else
 			src.lastattacker = user
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check just before the parent call on `attackby` for if you're on help intent, to harmlessly bap the bee with whatever object you're holding instead of jumping straight to beating them with it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A single misclick in a bee-heavy room can spell your brutal demise and it's called help intent isn't it
