### PR TITLE
Fix preassembled pod kit using wrong sound effects in construction

### DIFF
--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -140,7 +140,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 		if(BUILD_STEP_WELD_1)
 			if (isscrewingtool(I))
 				user.visible_message("[user] begins screwing down the frame's circuit boards and its engine...")
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_screw_1
 				action_bar.end_message = "[user] finishes screwing the the frame's circuit boards and its engine."
 				actions.start(action_bar, user)
@@ -187,7 +187,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 		if(BUILD_STEP_WELD_2)
 			if (isscrewingtool(I))
 				user.visible_message("[user] begins screwing the pod's maintenance panels shut...")
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_screw_2
 				action_bar.end_message = "With the cockpit and exterior indicators secured, the control system automatically starts up."
 				actions.start(action_bar, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SOUND] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the two steps during pod kit assembly that use a screwdriver to use the screwdriver SFX instead of wrench ones.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19259