### PR TITLE
Add new vars to corpse spawners

### DIFF
--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -96,11 +96,6 @@
 		..()
 		JobEquipSpawned("Chaplain")
 
-/mob/living/carbon/human/normal/artist
-	New()
-		..()
-		JobEquipSpawned("Artist")
-
 /mob/living/carbon/human/normal/bartender
 	New()
 		..()

--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -96,6 +96,11 @@
 		..()
 		JobEquipSpawned("Chaplain")
 
+/mob/living/carbon/human/normal/artist
+	New()
+		..()
+		JobEquipSpawned("Artist")
+
 /mob/living/carbon/human/normal/bartender
 	New()
 		..()

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -93,6 +93,8 @@
 	var/delete_id = TRUE
 	/// If TRUE we break the headset and make it unscannable after spawning
 	var/break_headset = TRUE
+	/// Can be used to override default mutant race
+	var/datum/mutantrace/muterace = null
 	/// Sent in if we are spawned by a human critter that drops a spawner
 	var/datum/bioHolder/appearance_override = null
 	/// Used to track the created corpse after setup
@@ -148,6 +150,9 @@
 				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
 				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
 				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+
+		if (istype(src.muterace))
+			src.corpse.set_mutantrace(src.muterace)
 
 		if (src.husked)
 			src.corpse.disfigured = TRUE

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -59,6 +59,16 @@
 
 	/// If TRUE we husk the corpse on spawn and disfigure face
 	var/husked = FALSE
+	/// If TRUE we skeletonize the corpse on spawn
+	var/skeletonized = FALSE
+	/// If TRUE we decapitate the corpse on spawn
+	var/headless = FALSE
+	/// If TRUE we sever the arms of the corpse on spawn
+	var/armless = FALSE
+	/// If TRUE we sever the legs of the corpse on spawn
+	var/legless = FALSE
+	/// If TRUE we buckle corpse to chair if there is one
+	var/try_buckle = TRUE
 	/// If TRUE randomise the decomp stage of the body after spawning
 	var/randomise_decomp_stage = FALSE
 	/// Override this if you want a specific decomp stage
@@ -72,108 +82,195 @@
 	var/do_damage = TRUE
 	/// If this has a value, remove a random number of organs between 0 and this max
 	var/max_organs_removed = 4
+	/// If this has a value, remove a random number of limbs between 0 and this max
+	var/max_limbs_removed = 1
 
 	/// If TRUE we delete the contents of the backpack after spawning
-	var/empty_bag = FALSE
+	var/empty_bag = TRUE
 	/// If TRUE delete the pocket contents if any
-	var/empty_pockets = FALSE
+	var/empty_pockets = TRUE
 	/// If TRUE we delete the ID slot contents after spawning
-	var/delete_id = FALSE
+	var/delete_id = TRUE
 	/// If TRUE we break the headset and make it unscannable after spawning
-	var/break_headset = FALSE
+	var/break_headset = TRUE
 	/// Sent in if we are spawned by a human critter that drops a spawner
 	var/datum/bioHolder/appearance_override = null
+	/// Used to track the created corpse after setup
+	var/mob/living/carbon/human/corpse = null
 
 	setup()
 		if (isnull(src.spawn_type))
 			CRASH("Spawner [src] at [src.x] [src.y] [src.z] had no type.")
 
-		var/mob/living/carbon/human/H = new spawn_type(src.loc)
+		src.corpse = new spawn_type(src.loc)
 
-		if (!istype(H))
+		if (!istype(src.corpse))
 			CRASH("Human corpse spawner [src] at [src.x] [src.y] [src.z] had non-human type.")
 
-		if (H.l_hand)
-			qdel(H.l_hand)
-		if (H.r_hand)
-			qdel(H.r_hand)
+		if (src.corpse.l_hand)
+			qdel(src.corpse.l_hand)
+		if (src.corpse.r_hand)
+			qdel(src.corpse.r_hand)
 
 		SPAWN(1)
-			for (var/obj/item/implant/health/implant as anything in H.implant)
+			for (var/obj/item/implant/health/implant as anything in src.corpse.implant)
 				qdel(implant)
-			H.implant = list()
-			for (var/obj/item/device/pda2/pda in H.contents)
+			src.corpse.implant = list()
+			for (var/obj/item/device/pda2/pda in src.corpse.contents)
 				pda.scannable = FALSE
 
-		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
-		APPLY_ATOM_PROPERTY(H, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
-		H.death(FALSE)
-		H.traitHolder.addTrait("puritan")
-		H.is_npc = TRUE
+		if (src.try_buckle)
+			var/obj/stool/S = (locate(/obj/stool) in src.corpse.loc)
+			if (S)
+				S.buckle_in(src.corpse, src.corpse, TRUE)
+				src.corpse.dir = S.dir // Face properly
+
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "corpse_spawn")
+		APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_SUPPRESS_DEATH_SOUND, "corpse_spawn")
+		src.corpse.traitHolder.addTrait("puritan")
+		src.corpse.death(FALSE)
+		src.corpse.is_npc = TRUE
 
 		if (src.no_decomp)
-			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_DECOMPOSITION, "corpse_spawn")
 		if (src.no_miasma)
-			APPLY_ATOM_PROPERTY(H, PROP_MOB_NO_MIASMA, "corpse_spawn")
+			APPLY_ATOM_PROPERTY(src.corpse, PROP_MOB_NO_MIASMA, "corpse_spawn")
 
 		if (src.randomise_decomp_stage)
-			H.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
+			src.corpse.decomp_stage = rand(DECOMP_STAGE_NO_ROT, DECOMP_STAGE_HIGHLY_DECAYED)
 		else
-			H.decomp_stage = src.decomp_stage
+			src.corpse.decomp_stage = src.decomp_stage
+
+		if (src.skeletonized)
+			src.corpse.decomp_stage = DECOMP_STAGE_SKELETONIZED
+			src.corpse.set_mutantrace(/datum/mutantrace/skeleton)
+			if (prob(90))
+				src.corpse.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
+				src.corpse.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
 
 		if (src.husked)
-			H.disfigured = TRUE
-			H.UpdateName()
-			H.bioHolder?.AddEffect("husk")
+			src.corpse.disfigured = TRUE
+			src.corpse.UpdateName()
+			src.corpse.bioHolder?.AddEffect("husk")
 
 		if (src.do_damage)
-			src.do_damage(H)
+			src.do_damage(src.corpse)
 
 		if (src.max_organs_removed)
 			for (var/i in 1 to rand(0, src.max_organs_removed))
-				var/obj/item/organ/organ = H.drop_organ(pick("left_eye","right_eye","left_lung","right_lung","butt","left_kidney","right_kidney","liver","stomach","intestines","spleen","pancreas","appendix"))
+				var/obj/item/organ/organ = src.corpse.drop_organ(pick("left_eye","right_eye","left_lung","right_lung","butt","left_kidney","right_kidney","liver","stomach","intestines","spleen","pancreas","appendix"))
 				qdel(organ)
 
+		if (src.max_limbs_removed)
+			var/list/obj/item/parts/limb_list = list(src.corpse.limbs.l_arm, src.corpse.limbs.r_arm, src.corpse.limbs.l_leg, src.corpse.limbs.r_leg)
+			for (var/i in 1 to rand(0, src.max_limbs_removed))
+				var/obj/item/parts/limb_to_delete = pick(limb_list)
+				limb_to_delete.delete()
+				limb_list -= limb_to_delete
+
+		if (src.headless)
+			var/obj/item/organ/head/noggin = src.corpse.organHolder.drop_organ("head")
+			qdel(noggin)
+
+		if (src.armless)
+			for (var/obj/item/parts/limb in list(src.corpse.limbs.l_arm, src.corpse.limbs.r_arm))
+				limb.delete()
+
+		if (src.legless)
+			for (var/obj/item/parts/limb in list(src.corpse.limbs.l_leg, src.corpse.limbs.r_leg))
+				limb.delete()
+
 		if (src.delete_id)
-			qdel(H.wear_id)
+			qdel(src.corpse.wear_id)
 
 		if (src.empty_bag)
-			if (istype(H.back, /obj/item/storage/backpack))
-				var/obj/item/storage/backpack/backpack = H.back
+			if (istype(src.corpse.back, /obj/item/storage/backpack))
+				var/obj/item/storage/backpack/backpack = src.corpse.back
 				for (var/obj/item as anything in backpack)
 					qdel(item)
-			else if (istype(H.belt, /obj/item/storage/fanny))
-				var/obj/item/storage/fanny/fanny = H.belt
+			else if (istype(src.corpse.belt, /obj/item/storage/fanny))
+				var/obj/item/storage/fanny/fanny = src.corpse.belt
 				for (var/obj/item as anything in fanny)
 					qdel(item)
 
 		if (src.empty_pockets)
-			if (H.l_store)
-				qdel(H.l_store)
-			if (H.r_store)
-				qdel(H.r_store)
+			if (src.corpse.l_store)
+				qdel(src.corpse.l_store)
+			if (src.corpse.r_store)
+				qdel(src.corpse.r_store)
 
 		if (src.break_headset)
-			if (istype(H.ears, /obj/item/device/radio/headset))
-				var/obj/item/device/radio/headset/headset = H.ears
+			if (istype(src.corpse.ears, /obj/item/device/radio/headset))
+				var/obj/item/device/radio/headset/headset = src.corpse.ears
 				headset.bricked = TRUE
 				headset.mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED // No getting smart
 
 		if (src.container_type)
 			var/obj/container = new container_type(src.loc)
-			H.set_loc(container)
+			src.corpse.set_loc(container)
 			container.UpdateIcon()
 
 		if (src.appearance_override)
-			H.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
+			src.corpse.bioHolder.CopyOther(src.appearance_override, TRUE, FALSE, FALSE, FALSE)
 
 	do_damage(var/mob/living/carbon/human/H) // Override if you want specific damage numbers / types
 		H.TakeDamage("all", brute = rand(100, 150), burn = rand(100, 150), tox = rand(40, 80), disallow_limb_loss = TRUE)
 		H.take_oxygen_deprivation(rand(250, 300))
 
+	clown
+		spawn_type = /mob/living/carbon/human/normal/clown
+
+	engineer
+		spawn_type = /mob/living/carbon/human/normal/engineer
+
+	miner
+		spawn_type = /mob/living/carbon/human/normal/miner
+
+	janitor
+		spawn_type = /mob/living/carbon/human/normal/janitor
+
+	chaplain
+		spawn_type = /mob/living/carbon/human/normal/chaplain
+
+	artist
+		spawn_type = /mob/living/carbon/human/normal/artist
+
+	botanist
+		spawn_type = /mob/living/carbon/human/normal/botanist
+
+	chef
+		spawn_type = /mob/living/carbon/human/normal/chef
+
+	bartender
+		spawn_type = /mob/living/carbon/human/normal/bartender
+
+	security_officer
+		spawn_type = /mob/living/carbon/human/normal/securityofficer
+
+	scientist
+		spawn_type = /mob/living/carbon/human/normal/scientist
+
+	roboticist
+		spawn_type = /mob/living/carbon/human/normal/roboticist
+
+	geneticist
+		spawn_type = /mob/living/carbon/human/normal/geneticist
+
+	medical_doctor
+		spawn_type = /mob/living/carbon/human/normal/medicaldoctor
+
+	captain
+		spawn_type = /mob/living/carbon/human/normal/captain
+
+	head_of_personnel
+		spawn_type = /mob/living/carbon/human/normal/headofpersonnel
+
 /obj/mapping_helper/mob_spawn/corpse/human/random
 	name = "Random Human Corpse Spawn"
 	icon_state = "corpse-human-rand"
+	randomise_decomp_stage = TRUE
+
 	var/static/list/spawns = list(
 		/mob/living/carbon/human/normal/assistant = 30,
 		/mob/living/carbon/human/normal/miner = 20,
@@ -187,9 +284,15 @@
 		/mob/living/carbon/human/normal/engineer = 30,
 		/mob/living/carbon/human/normal/clown = 25,
 		/mob/living/carbon/human/normal/medicaldoctor = 15,
-		/mob/living/carbon/human/normal/bartender = 5)
+		/mob/living/carbon/human/normal/bartender = 5,
+		/mob/living/carbon/human/normal/securityofficer = 1)
 
 	initialize()
+		if (prob(20))
+			src.max_limbs_removed = 4
+			src.max_organs_removed = 10
+		if (prob(5))
+			src.headless = TRUE
 		if (prob(5))
 			src.spawn_type = weighted_pick(rare_spawns)
 			src.delete_id = TRUE
@@ -222,7 +325,7 @@
 
 /obj/mapping_helper/mob_spawn/corpse/human/skeleton
 	spawn_type = /mob/living/carbon/human/normal
-	decomp_stage = DECOMP_STAGE_SKELETONIZED
+	skeletonized = TRUE
 
 /obj/mapping_helper/mob_spawn/corpse/human/syndicate/old
 	spawn_type = /mob/living/carbon/human/normal/syndicate_old
@@ -245,6 +348,24 @@
 
 	assistant
 		spawn_type = /mob/living/carbon/human/normal/securityassistant
+
+/obj/mapping_helper/mob_spawn/corpse/human/soviet
+	spawn_type = /mob/living/carbon/human/normal
+	skeletonized = TRUE
+
+	setup()
+		..()
+		src.corpse.equip_new_if_possible(/obj/item/clothing/suit/space/soviet, SLOT_W_UNIFORM)
+		src.corpse.equip_new_if_possible(/obj/item/clothing/head/helmet/space/soviet, SLOT_HEAD)
+
+/obj/mapping_helper/mob_spawn/corpse/human/hazmat
+	spawn_type = /mob/living/carbon/human/normal
+	skeletonized = TRUE
+
+	setup()
+		..()
+		src.corpse.equip_new_if_possible(/obj/item/clothing/suit/hazard/rad/iomoon, SLOT_W_UNIFORM)
+		src.corpse.equip_new_if_possible(/obj/item/clothing/head/rad_hood/iomoon, SLOT_HEAD)
 
 //////////////////////// Critter corpses ////////////////////////
 

--- a/code/modules/mapping/helpers/mob_spawn.dm
+++ b/code/modules/mapping/helpers/mob_spawn.dm
@@ -238,9 +238,6 @@
 	chaplain
 		spawn_type = /mob/living/carbon/human/normal/chaplain
 
-	artist
-		spawn_type = /mob/living/carbon/human/normal/artist
-
 	botanist
 		spawn_type = /mob/living/carbon/human/normal/botanist
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Internal]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Atomizes most new subtypes and extra vars from #18897

Changes the default values of `empty_pockets`, `empty_bag` and `delete_id` to TRUE.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Useful tools for future maps.