### PR TITLE
Update syndicate_buylist.dm to price the syndicate hat at 11 TC

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -280,8 +280,8 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 /datum/syndicate_buylist/generic/bighat
 	name = "Syndicate Hat"
 	item = /obj/item/clothing/head/bighat/syndicate
-	cost = 12
-	desc = "Think you're tough shit buddy?"
+	cost = 11
+	desc = "Think you're tough shit buddy? Now priced to accommodate an equally evil mustache!"
 	not_in_crates = TRUE //see /datum/syndicate_buylist/surplus/bighat
 	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[A-Clothing] [A-Gamemodes] [C-QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the price of the Syndicate Hat by 1, and changes the description slightly

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The syndicate hat is really just a silly item to be a mustache twirling evil bad guy, but purchasing the hat would prevent the buyer from purchasing anything else. This change allows buyers to pick up another 1 TC item to go along with their evil hat, like a fake mustache or agent card. This shouldn't change balance, as the syndicate hat was never really meant to be balanced, it was mostly an item used for the aesthetic, which would be enhanced with the addition of a fake mustache or an agent card assigned to Dr. Badguy, Head of Evil.  

I can't have a cool evil mustache and have a cool evil hat at the same time ):<

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Spaghett Pasta
(+)Syndicate Hat price changed from 12 TC to 11 TC
```
