### PR TITLE
Adds minimum addictive doses to 4 reagents

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -27,7 +27,7 @@ datum
 		var/fluid_b = 0
 		var/fluid_g = 255
 		var/addiction_prob = 0 // per-tick chance that addiction will surface
-		var/addiction_min = 0 // how high the tally for this addiction needs to be before addiction_prob starts rolling
+		var/addiction_min = 10 // how high the tally for this addiction needs to be before addiction_prob starts rolling
 		var/max_addiction_severity = "HIGH" // HIGH = barfing, stuns, etc, LOW = twitching, getting tired
 		var/dispersal = 4 // The range at which this disperses from a grenade. Should be lower for heavier particles (and powerful stuff).
 		var/volatility = 0 // Volatility determines effectiveness in pipebomb. This is 0 for a bad additive, otherwise a positive number which linerally affects explosive power.

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4319,6 +4319,7 @@ datum
 			fluid_b = 220
 			transparency = 160
 			addiction_prob = 100
+			addiction_min = 0
 			overdose = 35
 			taste = "bone-rattling"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR
Changes the default "addiction_min" for a reagent to 10 (up from the previous value of 0), meaning that, at minimum, 10 units of the reagent needs to be metabolized before a human starts making addiction rolls.

This change affects the following reagents, which all had no addiciton_min specified:
- Solipsizine
- Energy Drink
- Fleur-de-lys
- Robustissin

The Satisfaction of Making Spaghetti also had no addiction_min specified, but a value of 0 was assigned to it since it appeared to be intended behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Very few chemicals in the game immediately start rolling for addiction; those that have been intentionally marked to do so are highly addictive already and aren't the sorts of things you'd just stumble upon (enriched MSG and triple meth are the only two examples available to me). 

Meting out proper doses of reagents to yourself or others to prevent addiction should be rewarded. I think having a small zone of guaranteed no-addiction makes sense and makes these reagents more rewarding to use smartly, rather than getting owned by an unlucky prob(6) on your first lifetick of robustissin.