### PR TITLE
Teas no longer inherently addictive

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2649,8 +2649,6 @@ datum
 			taste = "herbal"
 			bladder_value = 0.04
 			energy_value = 0.04
-			addiction_prob = 0.01
-			addiction_min = 10
 			minimum_reaction_temperature = -INFINITY
 			caffeine_content = 0.2
 			var/list/flushed_reagents = list("toxin","toxic_slurry")
@@ -2684,8 +2682,6 @@ datum
 			thirst_value = 0.75
 			bladder_value = 0.04
 			energy_value = 0.04
-			addiction_prob = 0.02
-			addiction_min = 10
 
 			on_mob_life(var/mob/living/M, var/mult = 1)
 				if (!M) M = holder.my_atom
@@ -4798,8 +4794,6 @@ datum
 			thirst_value = 1
 			bladder_value = 0.04
 			energy_value = 0.04
-			addiction_prob = 0.02
-			addiction_min = 10
 			var/list/flushed_reagents = list("cholesterol")
 
 			on_mob_life(var/mob/M, var/mult = 1)


### PR DESCRIPTION

## About the PR
All teas are of the subtype /fooddrink/caffeinated, which decays into the addictive chemical caffeine. I'm not sure why the addiction parts were never removed when caffeine was added, so I'm assuming oversight.


## Why's this needed?
leaf water is addictive because it has caffeine in it, not because it is leaves water 