### PR TITLE
Add blob context menu actions for upgrading tiles

### DIFF
--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -78,6 +78,9 @@
 
 	var/admin_override = FALSE //for sudo blobs
 
+	/// context upgrades available for left clicking tiles
+	var/list/datum/contextAction/tile_upgrade_contexts
+
 	proc/start_tutorial()
 		if (tutorial)
 			return
@@ -110,6 +113,15 @@
 		src.nucleus_overlay = image('icons/mob/blob.dmi', null, "reflective_overlay")
 		src.nucleus_overlay.alpha = 0
 		src.nucleus_overlay.appearance_flags = RESET_COLOR | PIXEL_SCALE
+
+		// stored on blob overmind, otherwise contexts would need to be created for every tile clicked
+		src.tile_upgrade_contexts = list()
+		var/datum/contextLayout/experimentalcircle/context_menu = new
+		context_menu.center = TRUE
+		src.contextLayout = context_menu
+		for(var/datum/contextAction/blob_tile_upgrade/actionType as anything in childrentypesof(/datum/contextAction/blob_tile_upgrade))
+			if (!initial(actionType.requires_unlock))
+				src.tile_upgrade_contexts += new actionType()
 
 		SPAWN(0)
 			while (src)
@@ -222,6 +234,10 @@
 		else
 			src.remove_all_abilities()
 			src.remove_all_upgrades()
+
+			for (var/context in src.tile_upgrade_contexts)
+				qdel(context)
+				src.tile_upgrade_contexts = null
 
 			boutput(src, SPAN_ALERT("<b>With no nuclei to bind it to your biomass, your consciousness slips away into nothingness...</b>"))
 			src.ghostize()

--- a/code/modules/antagonists/blob/abilities/blob_abilities.dm
+++ b/code/modules/antagonists/blob/abilities/blob_abilities.dm
@@ -1142,6 +1142,7 @@
 		if (..())
 			return 1
 		owner.add_ability(/datum/blob_ability/build/launcher)
+		owner.tile_upgrade_contexts += new /datum/contextAction/blob_tile_upgrade/slime_launcher
 
 /datum/blob_upgrade/plasmaphyll
 	name = "Structural: Plasmaphyll"
@@ -1178,4 +1179,5 @@
 		if (..())
 			return 1
 		owner.add_ability(/datum/blob_ability/build/reflective)
+		owner.tile_upgrade_contexts += new /datum/contextAction/blob_tile_upgrade/reflective
 

--- a/code/modules/interface/multiContext/context_layouts.dm
+++ b/code/modules/interface/multiContext/context_layouts.dm
@@ -47,6 +47,9 @@ var/list/datum/contextAction/globalContextActions = null
 		var/mob/living/intangible/flock/flock_entity = target
 		flock_entity.render_special.add_screen(C)
 
+	else if (istype(target, /mob/living/intangible/blob_overmind))
+		var/mob/living/intangible/blob_overmind/overmind = target
+		overmind.render_special.add_screen(C)
 
 /datum/contextLayout/flexdefault
 	var/width = 2

--- a/code/modules/interface/multiContext/multiContext.dm
+++ b/code/modules/interface/multiContext/multiContext.dm
@@ -97,6 +97,10 @@
 			var/mob/living/intangible/flock/flock_entity = src
 			flock_entity.render_special.remove_screen(C)
 
+		else if (istype(src, /mob/living/intangible/blob_overmind))
+			var/mob/living/intangible/blob_overmind/overmind = src
+			overmind.render_special.remove_screen(C)
+
 		contextButtons.Remove(C)
 		if(C.overlays)
 			C.overlays = list()

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -121,17 +121,9 @@
 		if ("right" in pa)
 			right_click_action()
 		else if (src.type == /obj/blob && !(("alt" in pa) || ("shift" in pa) || ("ctrl" in pa)))
-			if (!src.contexts)
-				src.contexts = list()
-				var/datum/contextLayout/experimentalcircle/context_menu = new
-				context_menu.center = TRUE
-				src.contextLayout = context_menu
-				for(var/actionType in childrentypesof(/datum/contextAction/blob_tile_upgrade))
-					var/datum/contextAction/blob_tile_upgrade/upgrade = new actionType()
-					src.contexts += upgrade
-			var/mob/user = usr
+			var/mob/living/intangible/blob_overmind/user = usr
 			user.closeContextActions()
-			user.showContextActions(src.contexts, src, src.contextLayout)
+			user.showContextActions(user.tile_upgrade_contexts, src, user.contextLayout)
 		else
 			..()
 
@@ -1086,10 +1078,10 @@
 		return
 
 /datum/contextAction/blob_tile_upgrade
-	icon = 'icons/ui/context16x16.dmi'
+	icon = 'icons/mob/blob_ui.dmi'
 	desc = ""
-	icon_state = "wrench"
 	var/associated_ability
+	var/requires_unlock = FALSE
 
 	execute(obj/blob/blob_tile, mob/user)
 		if (QDELETED(blob_tile) || QDELETED(user))
@@ -1101,20 +1093,34 @@
 	checkRequirements()
 		return TRUE
 
+	cancel
+		name = "Cancel"
+		icon_state = "blob-exit"
+
+		execute()
+			return
+
 	thick_membrane
 		name = "Build Thick Membrane"
-		icon_state = "flag"
+		icon_state = "blob-wall"
 		associated_ability = /datum/blob_ability/build/wall
 
 	fire_membrane
 		name = "Build Fire-Resistant Membrane"
-		icon_state = "incarcerated"
+		icon_state = "blob-firewall"
 		associated_ability = /datum/blob_ability/build/firewall
 
 	slime_launcher
 		name = "Build Slime Launcher"
-		icon_state = "paroled"
+		icon_state = "blob-cannon"
 		associated_ability = /datum/blob_ability/build/launcher
+		requires_unlock = TRUE
+
+	reflective
+		name = "Build Reflective Membrane"
+		icon_state = "blob-reflective"
+		associated_ability = /datum/blob_ability/build/reflective
+		requires_unlock = TRUE
 
 /////////////////////////
 /// BLOB RELATED PROCS //


### PR DESCRIPTION
[GAME MODES][FEATURE][QoL][BALANCE][ADD TO WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds context menu upgrade actions for blobs upgrading tiles.

When a blob player left clicks one of their tiles, they will be given a context menu with what they want to upgrade it to, with allowed upgrades being thick membrane, fire resistant membrane, slime launcher, and reflective cell.

![image](https://github.com/goonstation/goonstation/assets/53062374/841daa7e-8a4f-430a-8c10-979f2826ebd0)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hopefully faster gameplay

Reduces some of the "clunkiness" in needing to hover over tiles to upgrade them, with hotkey'ing more common abilities in mind


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Blobs can now left click basic blob tiles to open a context menu for what they want to upgrade the tile to.
```
