### PR TITLE
Rebalance addiction probabilities for benign chems

### DIFF
--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -134,7 +134,7 @@
 	fluid_g = 255
 	transparency = 5
 	addiction_prob = 1
-	addiction_min = 10
+	addiction_min = 50
 	depletion_rate = 0.05 // ethanol depletes slower but is formed in smaller quantities
 	overdose = 100 // ethanol poisoning
 	thirst_value = -0.02

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -433,7 +433,7 @@ datum
 			fluid_r = 230
 			fluid_g = 220
 			fluid_b = 230
-			addiction_prob = 2 //Less addictive than ethanol due to its higher depletion rate
+			addiction_prob = 1 //Less addictive than ethanol due to its higher depletion rate
 			addiction_min = 50
 			max_addiction_severity = "LOW"
 			stun_resist = 3

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -16,7 +16,7 @@ datum
 			fluid_g = 250
 			fluid_b = 250
 			transparency = 100
-			addiction_prob = 15//80
+			addiction_prob = 15
 			addiction_min = 5
 			overdose = 20
 			depletion_rate = 0.6
@@ -179,7 +179,7 @@ datum
 			fluid_b = 0
 			fluid_g = 200
 			transparency = 40
-			addiction_prob = 10//50
+			addiction_prob = 10
 			addiction_min = 5
 			overdose = 20
 			value = 20 // 10 2 1 3 1 heat explosion :v
@@ -400,8 +400,8 @@ datum
 			fluid_r = 200
 			fluid_g = 185
 			fluid_b = 230
-			addiction_prob = 15//65
-			addiction_min = 10
+			addiction_prob = 15
+			addiction_min = 25
 			depletion_rate = 0.2
 			value = 3 // 1c + 1c + 1c
 			viscosity = 0.2
@@ -433,8 +433,8 @@ datum
 			fluid_r = 230
 			fluid_g = 220
 			fluid_b = 230
-			addiction_prob = 1 //It lasts a while, it's not as low as it seems
-			addiction_min = 100
+			addiction_prob = 2 //Less addictive than ethanol due to its higher depletion rate
+			addiction_min = 50
 			max_addiction_severity = "LOW"
 			stun_resist = 3
 			depletion_rate = 0.1
@@ -742,7 +742,7 @@ datum
 			fluid_b = 0
 			viscosity = 0.2
 			transparency = 190
-			addiction_prob = 15//70
+			addiction_prob = 15
 			addiction_min = 10
 			max_addiction_severity = "LOW"
 			overdose = 35 // raise if too low - trying to aim for one sleepypen load being problematic, two being deadlyish
@@ -965,7 +965,7 @@ datum
 			fluid_g = 100
 			fluid_b = 180
 			transparency = 250
-			addiction_prob = 10//50
+			addiction_prob = 10
 			addiction_min = 10
 			overdose = 20
 			hunger_value = -0.1
@@ -1160,7 +1160,7 @@ datum
 			fluid_g = 250
 			fluid_b = 250
 			transparency = 220
-			addiction_prob = 10//60
+			addiction_prob = 10
 			addiction_min = 5
 			overdose = 20
 			depletion_rate = 0.6

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2259,7 +2259,7 @@ datum
 			transparency = 77
 			taste = "hot"
 			addiction_prob = 0.1 // heh
-			addiction_min = 2
+			addiction_min = 7.5
 			max_addiction_severity = "LOW"
 			//penetrates_skin = 1
 			viscosity = 0.2

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -71,7 +71,7 @@ datum
 			fluid_g = 251
 			fluid_b = 251
 			transparency = 30
-			addiction_prob = 10//50
+			addiction_prob = 10
 			addiction_min = 15
 			overdose = 15
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
@@ -127,7 +127,7 @@ datum
 			fluid_g = 251
 			fluid_b = 251
 			transparency = 30
-			addiction_prob = 10//50
+			addiction_prob = 10
 			addiction_min = 15
 			depletion_rate = 0.2
 			overdose = 40   //Ether is known for having a big difference in effective to toxic dosage
@@ -1271,7 +1271,7 @@ datum
 			fluid_b = 255
 			fluid_g = 230
 			transparency = 220
-			addiction_prob = 1//10
+			addiction_prob = 1
 			addiction_min = 10
 			value = 10 // 4 3 1 1 1
 			threshold = THRESHOLD_INIT

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2491,7 +2491,7 @@ datum
 			fluid_g = 16
 			fluid_b = 94
 			transparency = 200
-			addiction_prob = 1//20
+			addiction_prob = 1
 			addiction_min = 5
 			overdose = 11
 			depletion_rate = 0.1


### PR DESCRIPTION
## About the PR
Rebalances the addiction_mins of some chemicals, changing the amount metabolized before addiction rolls start.
- Ethanol: 10 -> 50
- Space Drugs: 10 -> 25
- Caffeine: 100 -> 50
- Capsaicin: 2 -> 7.5

Also removes comments that had old values for addiction probabilities, because those irked the hell out of me.

## Why's this needed? 
A single 50u glass of Bloody Mary has a 40% chance to addict you to ethanol with current numbers. 40%!!! What the hell!
Meanwhile it takes 9 glasses of espresso before addiction even starts rolling...

This change should help players order alcoholic drinks for once, instead of being afraid that a single glass of anything stronger than a Daiquiri will debilitate them for the rest of the round.


## Changelog
```changelog
(u)mintyphresh
(+)Ethanol is five times harder to get addicted to. 
```
