### PR TITLE
Nerf Prairie Fire's capsaicin content

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1507,8 +1507,8 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				if(prob(20))
-					M.reagents.add_reagent("capsaicin", rand(10,20) * mult)
+				if(prob(5))
+					M.reagents.add_reagent("capsaicin", rand(4,12) * mult)
 				if(prob(10))
 					M.reagents.add_reagent("histamine", rand(1,5) * mult)
 				..()


### PR DESCRIPTION
## About the PR
Reduces the probability and volume of Capsaicin surges, from a 20% chance for 10-20 units per tick to a 5% chance of 4-12 units per tick. This changes Prairie Fire's average Capsaicin-by-volume content from being 750% CPV to just 100%, which still allows for capsaicin-duping without making the drink unreasonably spicy.


## Why's this needed? 
7.5 units of capsaicin per 1 unit of prairie fire was simply too much.