### PR TITLE
Adds emote text to *udder command

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2246,6 +2246,7 @@ TYPEINFO(/datum/mutantrace/cow)
 				src.clothes_filters_active = !src.clothes_filters_active
 				boutput(src.mob, src.clothes_filters_active ? "Bovine-specific clothes filters activated." : "Disabled bovine-specific clothes filters.")
 				src.mob.update_clothing()
+				. = "<B>[src.mob]</B> readjusts [his_or_her(src.mob)] udders."
 			else
 				.= ..()
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an emote string to the *udder command which was missing one, and instead returned an error when used

Unusable emote 'udder'. 'Me help' for a list.
vs
![image](https://github.com/goonstation/goonstation/assets/142273065/22e3521f-1aa6-45c5-ae64-21de9b5884e5)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes  #17406

[bug][player actions][mutantraces]