### PR TITLE
Make blob player left clicks automatically cast the spread ability

### DIFF
--- a/code/mob/living/intangible/blob_overmind.dm
+++ b/code/mob/living/intangible/blob_overmind.dm
@@ -310,7 +310,10 @@
 			src.update_buttons()
 			return
 		else
-			if(params["right"])
+			if(params["left"])
+				var/datum/blob_ability/spread_abil = src.get_ability(/datum/blob_ability/spread)
+				spread_abil?.onUse(T)
+			else if(params["right"])
 				if (T && (!isghostrestrictedz(T.z) || (isghostrestrictedz(T.z) && restricted_z_allowed(src, T)) || src.tutorial || (src.client && src.client.holder)))
 					if (src.tutorial)
 						if (!tutorial.PerformAction("clickmove", T))


### PR DESCRIPTION
[GAME MODES][PLAYER ACTIONS][FEATURE][QoL][ADD TO WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that when a blob player left clicks something, it will attempt to call the spread ability on the tile.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Allows easier use of main spammable ability without disrupting anything else intended
-Allows other abilities to be hotkeyed
-Hopefully reduces some of the hovering over tiles that is needed and skill gap required to play


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)As a blob, left clicking a tile will now attempt to spread to that tile, meaning you don't need to click or hotkey the ability button at all!
```
