### PR TITLE
Fix blob Repair ability being cast on full health tiles

### DIFF
--- a/code/modules/antagonists/blob/abilities/blob_abilities.dm
+++ b/code/modules/antagonists/blob/abilities/blob_abilities.dm
@@ -533,6 +533,9 @@
 		var/obj/blob/B = T.get_blob_on_this_turf()
 
 		if (B)
+			if (B.health >= B.health_max)
+				boutput(owner, SPAN_ALERT("That blob tile is already at full health."))
+				return
 			if(ON_COOLDOWN(B, "manual_blob_heal", 6 SECONDS))
 				boutput(owner, SPAN_ALERT("That blob tile needs time before it can be repaired again."))
 				return


### PR DESCRIPTION
[GAME MODES][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes blob Repair ability being able to be cast on full health tiles


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix