### PR TITLE
Fix no chairs for "Party Animal" check

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -429,7 +429,7 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 
 			logTheThing(LOG_STATION, src, "has the Party Animal trait and has finished iterating through spots.")
 
-			if(!joined_late) // We got special late-join handling
+			if(!joined_late && length(valid_stools) > 0) // We got special late-join handling
 				var/obj/stool/stool = pick(valid_stools)
 				if (stool)
 					var/list/spawn_range = orange(1, get_turf(stool)) // Skip the actual stool


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Internal] [Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When there's no chairs on the map, or precisely, no chairs in any area labelled as "bar", there's a runtime error, because the code tries to pick from an empty list.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad
