### PR TITLE
fix parasites and non-specified diseases not progressing

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -495,7 +495,7 @@
 		AD.master = A
 		AD.affected_mob = src
 		src.ailments += AD
-
+		AD.on_infection()
 		return AD
 
 	else
@@ -511,6 +511,7 @@
 		AD.master = A
 		AD.affected_mob = src
 		src.ailments += AD
+		AD.on_infection()
 
 		return AD
 


### PR DESCRIPTION
[bug][Medical]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR causes `/datum/ailment/parasite` and non-malady/disease/parasite `/datum/ailment_data` to call `proc/on_infection` on the corresponding ailment_data

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Because the corresponding ailment_datas never called on_infection, the ailment-status effect was never added to the mob, causing these ailments to never progress.

This caused e.g. ingesting a bee egg to never make you vomit out a bee. It apparently was very comfortable in my stomach... 

i'm not sure that was the cause of #19344 , because toxoplasmosis is a disease, but i tested it with this change and couldn't replicate it. So i assume the toxoplasmosis in that issue was either asymptomatic or fixed by this PR.