### PR TITLE
Parity for Oshan's derelict station n2o

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -14040,7 +14040,7 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "aWm" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/item/tank/anesthetic,
 /turf/simulated/floor/grime,
 /area/iss)
 "aWp" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In Oshan's derelict station, change the n2o can to a tank.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
parity with the debris field derliect station, which recently had this change