### PR TITLE
Update comments in jobs.dm to reflect wiki changes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2019,7 +2019,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_poc2 = list(/obj/item/pen/pencil)
 	slot_lhan = list(/obj/item/storage/toolbox/artistic)
 	items_in_backpack = list(/obj/item/canvas, /obj/item/canvas, /obj/item/storage/box/crayon/basic ,/obj/item/paint_can/random)
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 /datum/job/special/random/foodcritic
 	name = "Food Critic"
@@ -2030,7 +2030,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_poc2 = list(/obj/item/paper)
 	slot_lhan = list(/obj/item/clipboard/with_pen)
 	items_in_backpack = list(/obj/item/item_box/postit)
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 /datum/job/special/random/pestcontrol
 	name = "Pest Control Specialist"
@@ -2041,7 +2041,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_lhan = list(/obj/item/pet_carrier)
 	items_in_backpack = list(/obj/item/storage/box/mousetraps)
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 /datum/job/special/random/drugdealer
 	name = "Drug Dealer"
@@ -2052,7 +2052,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_poc1 = list(/obj/item/cigpacket/propuffs)
 	slot_poc2 = list(/obj/item/cigpacket)
 	items_in_backpack = list(/obj/item/storage/pill_bottle/cyberpunk, /obj/item/storage/pill_bottle/methamphetamine, /obj/item/storage/pill_bottle/catdrugs)
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 /datum/job/special/random/vehiclemechanic
 	name = "Vehicle Mechanic" // fallback name, gets changed later
@@ -2072,7 +2072,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	#else
 	items_in_backpack = list(/obj/item/preassembled_frame_box/putt, /obj/item/podarmor/armor_light, /obj/item/clothing/head/helmet/welding)
 	#endif
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 /datum/job/special/random/phonemerchant
 	name = "Phone Merchant"
@@ -2082,7 +2082,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_poc1 = list(/obj/item/electronics/soldering)
 	items_in_backpack = list(/obj/item/electronics/frame/phone, /obj/item/electronics/frame/phone, /obj/item/electronics/frame/phone, /obj/item/electronics/frame/phone)
-	// missing wiki link, does not have a mention on https://wiki.ss13.co/Jobs
+	// missing wiki link, parent fallback to https://wiki.ss13.co/Jobs#Gimmick_Jobs
 
 #ifdef HALLOWEEN
 /*


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Internal][Documentation]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just updates the documentation for several gimmick jobs (Artist, Food Critic, Pest Control Specialist, Drug Dealer, Vehicle Mechanic, and Phone Merchant) that now have entries on the Jobs page. Now the comments reflect that they fall back to the Gimmick Jobs section.

I have not tested this beyond making sure it compiles. If editing these comments causes something obvious to break that I would have discovered in a playtest, I will record a spoken apology at least sixty seconds long and publish it in #imcoder.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The jobs have entries on the Jobs page now!
