### PR TITLE
Increase sale price of identified artifacts

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -399,7 +399,7 @@
 
 
 	proc/calculate_artifact_price(var/modifier, var/correctness)
-		return ((modifier**2) * PAY_EMBEZZLED * correctness)
+		return ((modifier**1.5) * PAY_EMBEZZLED * correctness)
 
 	proc/sell_artifact(obj/sell_art, var/datum/artifact/sell_art_datum)
 		var/price = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the formula for calculating artifact prices by reducing the rarity modifier coefficient from 2 to 1.5. This increases the total sale price as it's raisng the power of a value less than one.

Comparison graph:
https://www.desmos.com/calculator/fe8s3bb7vf

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Several people have lamented on artifact sale prices. Sucks to have cargo spend 8k on artifacts and potentially get back <1k on four correct artifact IDs.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Artifacts sell for slightly more on the market.
```
