### PR TITLE
Remove duplicate IR detector in mushroom AI upload

### DIFF
--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -8542,11 +8542,6 @@
 /area/station/turret_protected/ai_upload)
 "aTs" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
-/obj/machinery/networked/secdetector{
-	area_access = 99;
-	detector_id = "AI Core";
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "0-4"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes second IR detector stacked on tile in mushroom AI upload.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19055 