### PR TITLE
Reduce number of blood bags in blood bank supply pack

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1010,7 +1010,8 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	name = "Blood Bank"
 	desc = "An emergency supply of blood."
 	category = "Medical Department"
-	contains = list (/obj/item/reagent_containers/iv_drip/blood = 2)
+	contains = list (/obj/item/reagent_containers/iv_drip/blood = 2,
+					/obj/item/reagent_containers/iv_drip/saline = 2)
 	cost = PAY_DOCTORATE*2
 	containertype = /obj/storage/crate/medical
 	containername = "Blood Bank"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1010,7 +1010,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	name = "Blood Bank"
 	desc = "An emergency supply of blood."
 	category = "Medical Department"
-	contains = list (/obj/item/reagent_containers/iv_drip/blood = 4)
+	contains = list (/obj/item/reagent_containers/iv_drip/blood = 2)
 	cost = PAY_DOCTORATE*2
 	containertype = /obj/storage/crate/medical
 	containername = "Blood Bank"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Blood Bank supply pack from 4 Blood IV Bags to 2 Blood IV bags and 2 Saline IV Bags.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Multiple regular 'protien' requisitions can be fulfilled with a single blood bank crate purchase. This still makes them profitable, but reduces the total number you can fill off one purchase.
* Nerf passive buy-their-blood vampires. Still possible, but requires more hassle/purchases.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Blood Bank supply backs come with two blood IV bags and two saline IV bags.
```
