### PR TITLE
Change mail delivered objective from quartermaster to mail courier

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -266,7 +266,8 @@ ABSTRACT_TYPE(/datum/objective/crew/quartermaster)
 	check_completion()
 		return length(shippingmarket.complete_orders)
 
-/datum/objective/crew/quartermaster/maildelivery
+ABSTRACT_TYPE(/datum/objective/crew/mailcourier)
+/datum/objective/crew/mailcourier/maildelivery
 	explanation_text = "Ensure 30 pieces of mail are opened by their addressees."
 	check_completion()
 		return game_stats.GetStat("mail_opened") >= 30


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rework]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the mail delivery objective from Quartermaster job to Mail Courier job.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mail Courier is now a roundstart job

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Mail Couriers can roll the deliver mail crew objective.
```
