### PR TITLE
Increase Relay conversion radius to 50 tiles

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -1065,6 +1065,42 @@ proc/get_default_flock()
 			O.color = fancy_flock_matrix
 	return T
 
+/// only converts turf
+/proc/flock_convert_turf_turfonly(turf/T)
+	if(!T || !flockTurfAllowed(T))
+		return
+
+	if(istype(T, /turf/simulated/floor))
+		T.ReplaceWith(/turf/simulated/floor/feather, FALSE)
+		animate_flock_convert_complete(T)
+	else if(istype(T, /turf/simulated/wall))
+		T.ReplaceWith(/turf/simulated/wall/auto/feather, FALSE)
+		animate_flock_convert_complete(T)
+
+	// regular and flock lattices
+	var/obj/lattice/lat = locate(/obj/lattice) in T
+	if(lat)
+		if(istype(lat, /obj/lattice/flock))
+			qdel(lat)
+			T.ReplaceWith(/turf/simulated/floor/feather, FALSE)
+			animate_flock_convert_complete(T)
+		else
+			qdel(lat)
+			new /obj/lattice/flock(T)
+
+	var/obj/grille/catwalk/catw = locate(/obj/grille/catwalk) in T
+	if(catw)
+		qdel(catw)
+		T.ReplaceWith(/turf/simulated/floor/feather, FALSE)
+		animate_flock_convert_complete(T)
+
+	if(istype(T, /turf/space))
+		var/obj/lattice/flock/FL = locate(/obj/lattice/flock) in T
+		if(!FL)
+			FL = new /obj/lattice/flock(T)
+
+	return T
+
 /proc/mass_flock_convert_turf(var/turf/T, datum/flock/F, force=FALSE, radius=15, delay=0.2 SECONDS, fancy=FALSE)
 	if(!T)
 		T = get_turf(usr)

--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -31,7 +31,8 @@ TYPEINFO(/obj/flock_structure/relay)
 	plane = PLANE_NOSHADOW_ABOVE
 	passthrough = FALSE
 	var/conversion_radius = 1
-	var/max_conv_radius = 15 // increase back to 100 later if possible. 100 worked fine on local but not as much on live with a lot of people
+	var/next_conv_radius = 1
+	var/max_conv_radius = 50 // increase back to 100 later if possible. 100 worked fine on local but not as much on live with a lot of people
 	var/list/turfs_to_convert = null
 	var/last_time_sound_played_in_seconds = 0
 	var/sound_length_in_seconds = 27
@@ -109,9 +110,9 @@ TYPEINFO(/obj/flock_structure/relay)
 		return "<b><i>BROADCASTING IN PROGRESS</i></b>"
 
 /obj/flock_structure/relay/process()
-	if (src.conversion_radius <= length(src.turfs_to_convert))
+	if (src.conversion_radius <= length(src.turfs_to_convert) && src.conversion_radius == src.next_conv_radius)
 		src.convert_turfs()
-		src.conversion_radius++
+		src.next_conv_radius++
 
 	var/elapsed = getTimeInSecondsSinceTime(src.time_started)
 	if (!src.finished)
@@ -144,8 +145,9 @@ TYPEINFO(/obj/flock_structure/relay)
 	SPAWN(0)
 		for (var/turf/T as anything in src?.turfs_to_convert["[src.conversion_radius]"])
 			LAGCHECK(LAG_LOW)
-			if (istype(T, /turf/simulated) && !isfeathertile(T))
-				src?.flock?.claimTurf(flock_convert_turf(T))
+			if (!istype(T, /turf/unsimulated) && !isfeathertile(T))
+				src?.flock?.claimTurf(flock_convert_turf_turfonly(T))
+		src.conversion_radius++
 
 /obj/flock_structure/relay/proc/unleash_the_signal()
 	if(src.finished)


### PR DESCRIPTION
[GAME MODES][EXPERIMENTAL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases Relay conversion radius to 50 tiles

Adds some extra code to make it only convert turf, instead of objects, and a safety check to make sure conversions aren't over queued

Originally from #10871 and #11825, probably needs test merge to make sure it doesn't break the server like how it did last time


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Would be cool

Also, converting space tiles to flock lattices could help make space fights easier?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Increased Flock Relay conversion radius to 50 tiles
```
