### PR TITLE
Fix duplicate hot loop pump name on Cogmap 1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -61762,7 +61762,7 @@
 	},
 /obj/machinery/atmospherics/binary/pump/active{
 	dir = 4;
-	id = "Hot Loop Gas Supply 2";
+	id = "Hot Loop Gas Supply 1";
 	target_pressure = 1000
 	},
 /turf/simulated/floor/black,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes one of the hot loop gas supply pumps to be 1 instead of 2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19388 