### PR TITLE
Major changes to cloth rag chokehold behavior

### DIFF
--- a/code/obj/item/cloths.dm
+++ b/code/obj/item/cloths.dm
@@ -43,7 +43,7 @@ ABSTRACT_TYPE(/obj/item/cloth)
 
 /obj/item/cloth/New()
 	..()
-	src.create_reagents(10)
+	src.create_reagents(20)
 
 /obj/item/cloth/disposing()
 	..()
@@ -52,9 +52,14 @@ ABSTRACT_TYPE(/obj/item/cloth)
 
 /obj/item/cloth/process_grab(var/mult = 1)
 	..()
-	if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state == GRAB_CHOKE && iscarbon(src.chokehold.affecting))
-		src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult)
-		src.reagents.trans_to(chokehold.affecting, 0.5 * mult)
+	if (chokehold.transfering_chemicals)
+		if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
+			//src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult) // No more ingesting means no stacking damage horribly and instantly
+			src.reagents.trans_to(chokehold.affecting, 1 * mult)
+		else
+			chokehold.transfering_chemicals = FALSE
+	else if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state > GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
+		src.reagents.trans_to(chokehold.affecting, 1 * mult) // Having more than an aggressive grab will transfer the chemicals anyway
 
 /obj/item/cloth/is_open_container()
 	.= 1

--- a/code/obj/item/cloths.dm
+++ b/code/obj/item/cloths.dm
@@ -55,7 +55,7 @@ ABSTRACT_TYPE(/obj/item/cloth)
 	if (chokehold.transfering_chemicals || chokehold.state > GRAB_AGGRESSIVE) // Having more than an aggressive grab will transfer the chemicals anyway
 		if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
 			//src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult) // No more ingesting means no stacking damage horribly and instantly
-			src.reagents.trans_to(chokehold.affecting, 1 * mult)
+			src.reagents.trans_to(chokehold.affecting, 2 * mult)
 		else
 			chokehold.transfering_chemicals = FALSE
 

--- a/code/obj/item/cloths.dm
+++ b/code/obj/item/cloths.dm
@@ -52,14 +52,12 @@ ABSTRACT_TYPE(/obj/item/cloth)
 
 /obj/item/cloth/process_grab(var/mult = 1)
 	..()
-	if (chokehold.transfering_chemicals)
+	if (chokehold.transfering_chemicals || chokehold.state > GRAB_AGGRESSIVE) // Having more than an aggressive grab will transfer the chemicals anyway
 		if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
 			//src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult) // No more ingesting means no stacking damage horribly and instantly
 			src.reagents.trans_to(chokehold.affecting, 1 * mult)
 		else
 			chokehold.transfering_chemicals = FALSE
-	else if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state > GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
-		src.reagents.trans_to(chokehold.affecting, 1 * mult) // Having more than an aggressive grab will transfer the chemicals anyway
 
 /obj/item/cloth/is_open_container()
 	.= 1

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -1014,7 +1014,7 @@ ABSTRACT_TYPE(/obj/item/grab/threat)
 		if (chokehold.transfering_chemicals || chokehold.state > GRAB_AGGRESSIVE) // Having more than an aggressive grab will transfer the chemicals anyway
 			if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
 				//src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult) // No more ingesting means no stacking damage horribly and instantly
-				src.reagents.trans_to(chokehold.affecting, 1 * mult)
+				src.reagents.trans_to(chokehold.affecting, 1.5 * mult)
 			else
 				chokehold.transfering_chemicals = FALSE
 

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -997,7 +997,7 @@ ABSTRACT_TYPE(/obj/item/grab/threat)
 ////////////////////////////
 
 /obj/item/material_piece/cloth
-	event_handler_flags = USE_GRAB_CHOKE | USE_FLUID_ENTER //here
+	event_handler_flags = USE_GRAB_CHOKE | USE_FLUID_ENTER
 	special_grab = /obj/item/grab/rag_muffle
 
 	New()

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -229,9 +229,10 @@
 						var/obj/item/cloth = src.loc
 						if (cloth.reagents && cloth.reagents.total_volume > 0 && iscarbon(src.affecting))
 							logTheThing(LOG_COMBAT, src.assailant, "tries to force [constructTarget(src.affecting)] to breathe from [cloth] [log_reagents(cloth.reagents)]")
-							SETUP_GENERIC_PRIVATE_ACTIONBAR(src.assailant, src.affecting, 2 SECONDS, /obj/item/grab/proc/resolve_chem_transfer, src, cloth.icon, cloth.icon_state,\
-							"[src.assailant] presses [cloth] onto [src.affecting]'s face!", INTERRUPT_STUNNED)
-
+							boutput(src.affecting, SPAN_BOLD("[src.assailant] presses the [cloth] in your face to force you to breathe in chemicals!"))
+							SPAWN(2 SECONDS) // When it actually begins passing chemicals through
+								if (src.state >= GRAB_AGGRESSIVE)
+									transfering_chemicals = TRUE
 					icon_state = "reinforce"
 					src.state = GRAB_AGGRESSIVE //used to be '1'. SKIP LEVEL 1
 					set_affected_loc()
@@ -354,10 +355,6 @@
 			return 1
 
 		return 0
-
-	proc/resolve_chem_transfer(var/obj/item/grab/chokehold)
-		if (chokehold.state >= GRAB_AGGRESSIVE)
-			chokehold.transfering_chemicals = TRUE
 
 	update_icon()
 

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -1011,14 +1011,12 @@ ABSTRACT_TYPE(/obj/item/grab/threat)
 
 	process_grab(var/mult = 1)
 		..()
-		if (chokehold.transfering_chemicals)
+		if (chokehold.transfering_chemicals || chokehold.state > GRAB_AGGRESSIVE) // Having more than an aggressive grab will transfer the chemicals anyway
 			if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
 				//src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult) // No more ingesting means no stacking damage horribly and instantly
 				src.reagents.trans_to(chokehold.affecting, 1 * mult)
 			else
 				chokehold.transfering_chemicals = FALSE
-		else if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state > GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
-			src.reagents.trans_to(chokehold.affecting, 1 * mult) // Having more than an aggressive grab will transfer the chemicals anyway
 
 	is_open_container()
 		.= 1


### PR DESCRIPTION
[LABEL][balance][chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR alters the behavior of cloth rags and handkerchiefs in 3 distinct ways:
- Increases the maximum held volume from 10 to 20, and the grab chemical output from 0.5 to 1.5(ripped cloth pieces) or 2(bartender handkerchiefs).
- Removes the ingest effects of chemicals inhaled through the grab.
- Makes it so getting someone on an aggressive grab causes you to transfer chemicals after a 2 second delay.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't remember ever seeing anyone use the cloth rags besides very few and far between moments, since their chemical transfer requires a chokehold, an action that both kills your target, and is pretty much a win condition anyways.

In pretty much all situations, rags are just not worth it even when compared to just hand grabbing your opponent, besides the honestly kinda janky stacking of ingest effects(looking at you, phlog and bath salts hellspam). This PR also removes the aforementioned ingest effects from the rags, to incentivise their use as a way to put chems in people, and not just deal 10 damage per cycle to them.

As it stands, these changes actually allow you to nonlethaly tackle targets in a way that requires more commitment and is more interesting to go against than something instant and unavoidable like scalpel dipping, but cuts down on some of the more jank and overly damaging effects like phlog ingest spam.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Colossusqw
(+)Changed cloth rag grabs to begin transfering chems on aggressive grabs, after a two second delay.
(+)Cloth rags now can hold up to 20 units of chems, and transfer 1.5(ripped cloth rags) or 2(bartender handkerchiefs) per cycle, but don't cause ingest effects anymore.
```
