### PR TITLE
The Authentication Disk can be used to alter the escape shuttle depature time

### DIFF
--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -320,6 +320,9 @@ TYPEINFO(/obj/item/disk/data/floppy/read_only/authentication)
 	w_class = W_CLASS_TINY
 	random_color = 0
 	file_amount = 32
+	HELP_MESSAGE_OVERRIDE({"Use on an armed nuclear bomb to alter the time remaining until detonation.
+	Use on an armory authorization computer to issue an emergency authorization or unauthorization.
+	Use on an escape shuttle launch computer to alter the time until departure."})
 
 	New()
 		. = ..()

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -319,6 +319,13 @@ var/bombini_saved
 		return
 
 	if (istype(W, /obj/item/disk/data/floppy/read_only/authentication))
+		if(emergency_shuttle.location != SHUTTLE_LOC_STATION)
+			return
+		for (var/datum/flock/flock in flocks)
+			if (flock.relay_in_progress)
+				boutput(user, SPAN_ALERT("[src] emits a pained burst of static, but nothing happens!"))
+				return
+
 		if (user)
 			var/choice = tgui_alert(user, "Would you like to launch the shuttle?", "Shuttle control", list("Launch", "Cancel"))
 			if(BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -314,28 +314,21 @@ var/bombini_saved
 	icon = 'icons/obj/decoration.dmi'
 	icon_state = "syndiepc4"
 
-/obj/machinery/computer/shuttle/emag_act(var/mob/user, var/obj/item/card/emag/E)
-	if(emergency_shuttle.location != SHUTTLE_LOC_STATION)
-		return
-	for (var/datum/flock/flock in flocks)
-		if (flock.relay_in_progress)
-			boutput(user, SPAN_ALERT("[src] emits a pained burst of static, but nothing happens!"))
-			return
-
-	if (user)
-		var/choice = tgui_alert(user, "Would you like to launch the shuttle?", "Shuttle control", list("Launch", "Cancel"))
-		if(BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
-		if (choice == "Launch")
-			boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
-			emergency_shuttle.settimeleft( 10 )
-			logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
-	else
-		boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
-		emergency_shuttle.settimeleft( 10 )
-	return TRUE
-
 /obj/machinery/computer/shuttle/attackby(var/obj/item/W, var/mob/user)
 	if(status & (BROKEN|NOPOWER))
+		return
+
+	if (istype(W, /obj/item/disk/data/floppy/read_only/authentication))
+		if (user)
+			var/choice = tgui_alert(user, "Would you like to launch the shuttle?", "Shuttle control", list("Launch", "Cancel"))
+			if(BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
+			if (choice == "Launch")
+				boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
+				emergency_shuttle.settimeleft( 10 )
+				logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
+		else
+			boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
+			emergency_shuttle.settimeleft( 10 )
 		return
 
 	var/obj/item/card/id/id_card = get_id_card(W)
@@ -390,7 +383,7 @@ var/bombini_saved
 				boutput(world, SPAN_NOTICE("<B>All authorizations to shorting time for shuttle launch have been revoked!</B>"))
 				src.authorized.len = 0
 				src.authorized = list(  )
-	return
+
 
 ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 /obj/machinery/computer/elevator

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -327,16 +327,24 @@ var/bombini_saved
 				return
 
 		if (user)
-			var/choice = tgui_alert(user, "Would you like to launch the shuttle?", "Shuttle control", list("Launch", "Cancel"))
-			if(BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
-			if (choice == "Launch")
-				boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
-				emergency_shuttle.settimeleft( 10 )
-				logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
-		else
-			boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
-			emergency_shuttle.settimeleft( 10 )
-		return
+			var/choice = ""
+			if (user.mind?.is_antagonist())
+				choice = tgui_alert(user, "Would you like to launch the escape shuttle early?", "Shuttle control", list("Launch", "Cancel"))
+			else
+				choice = tgui_alert(user, "Would you like to delay the escape shuttle depature for one minute?", "Shuttle control", list("Delay", "Cancel"))
+
+			if (BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
+
+			switch(choice)
+				if ("Launch")
+					boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
+					emergency_shuttle.settimeleft( 10 )
+					logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
+				if ("Delay")
+					boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time inceased by 1 minute!</B>"))
+					emergency_shuttle.settimeleft( emergency_shuttle.timeleft() + 60 )
+					logTheThing(LOG_ADMIN, user, "increases Emergency Shuttle launch time by 1 minute.")
+
 
 	var/obj/item/card/id/id_card = get_id_card(W)
 	if (istype(id_card))

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -315,7 +315,7 @@ var/bombini_saved
 	icon_state = "syndiepc4"
 
 /obj/machinery/computer/shuttle/attackby(var/obj/item/W, var/mob/user)
-	if(!(istype(W, /obj/item/disk/data/floppy/read_only/authentication) || istype(W, /obj/item/card/id)) && (status & (BROKEN|NOPOWER)))
+	if(!(istype(W, /obj/item/disk/data/floppy/read_only/authentication) || istype(W, /obj/item/card/id)) || (status & (BROKEN|NOPOWER)))
 		return ..()
 
 	if (istype(W, /obj/item/disk/data/floppy/read_only/authentication))

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -327,23 +327,14 @@ var/bombini_saved
 				return
 
 		if (user)
-			var/choice = ""
-			if (user.mind?.is_antagonist())
-				choice = tgui_alert(user, "Would you like to launch the escape shuttle early?", "Shuttle control", list("Launch", "Cancel"))
-			else
-				choice = tgui_alert(user, "Would you like to delay the escape shuttle depature for one minute?", "Shuttle control", list("Delay", "Cancel"))
+			var/choice = tgui_alert(user, "Would you like to launch the escape shuttle early?", "Shuttle control", list("Launch", "Cancel"))
 
 			if (BOUNDS_DIST(user, src) > 0 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
 
-			switch(choice)
-				if ("Launch")
-					boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
-					emergency_shuttle.settimeleft( 10 )
-					logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
-				if ("Delay")
-					boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time inceased by 1 minute!</B>"))
-					emergency_shuttle.settimeleft( emergency_shuttle.timeleft() + 60 )
-					logTheThing(LOG_ADMIN, user, "increases Emergency Shuttle launch time by 1 minute.")
+			if (choice == "Launch")
+				boutput(world, SPAN_NOTICE("<B>Alert: Shuttle launch time shortened to 10 seconds!</B>"))
+				emergency_shuttle.settimeleft( 10 )
+				logTheThing(LOG_ADMIN, user, "shortens Emergency Shuttle launch time to 10 seconds.")
 
 
 	var/obj/item/card/id/id_card = get_id_card(W)

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -315,8 +315,8 @@ var/bombini_saved
 	icon_state = "syndiepc4"
 
 /obj/machinery/computer/shuttle/attackby(var/obj/item/W, var/mob/user)
-	if(status & (BROKEN|NOPOWER))
-		return
+	if(!(istype(W, /obj/item/disk/data/floppy/read_only/authentication) || istype(W, /obj/item/card/id)) && (status & (BROKEN|NOPOWER)))
+		return ..()
 
 	if (istype(W, /obj/item/disk/data/floppy/read_only/authentication))
 		if(emergency_shuttle.location != SHUTTLE_LOC_STATION)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rework][game objects][add to wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the early shuttle launch trigger from`emag_act` to `attackby` with the authentication disk as the trigger.

Add help text to the auth disk for its three current uses:
1. armed nuclear bomb detonation timer
2. armory emergency auth/unauth
3. escape shuttle launch timer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More value to the auth disk in non-nukie rounds. Require antags doing early shuttle launches to engage with at least one (1) other crew member (the captain). 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)The authentication disk can be used on the escape shuttle console to immediately launch it.
```
