### PR TITLE
Add 1TC version of wiretap that only gives access to syndicate channel

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -977,6 +977,14 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
+/datum/syndicate_buylist/traitor/syndicate_radio_upgrade
+	name = "Syndicate Radio Upgrade"
+	item = /obj/item/device/radio_upgrade/syndicatechannel
+	cost = 1
+	desc = "A small device that may be installed in a headset to grant access to a radio channel reserved for Syndicate operatives."
+	vr_allowed = FALSE
+	can_buy = UPLINK_TRAITOR
+
 /datum/syndicate_buylist/traitor/tape
 	name = "Ducktape"
 	item = /obj/item/handcuffs/tape_roll


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the syndicate channel only upgrade presently only used for syndieborgs to the generic buylist.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is already a 1TC way to get syndicate channel access in the form of agent card+listening post, this just lets you store more stuff in pockets and is a cheaper alternative to the wiretap if you dont care about departmental channels.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The syndicate now offers a cheaper version of the radio upgrade granting access to the syndicate frequency.
```
