### PR TITLE
Add system for automatically adding/removing mutantrace-associated abilities

### DIFF
--- a/code/datums/abilities/lizard.dm
+++ b/code/datums/abilities/lizard.dm
@@ -1,24 +1,3 @@
-/mob/living/carbon/human/proc/give_lizard_powers()
-	if (ishuman(src)) // not4long
-		var/datum/abilityHolder/lizard/A = src.get_ability_holder(/datum/abilityHolder/lizard)
-		if (A && istype(A))
-			return
-		var/datum/abilityHolder/lizard/W = src.add_ability_holder(/datum/abilityHolder/lizard)
-		W.addAbility(/datum/targetable/lizardAbility/colorshift)
-		W.addAbility(/datum/targetable/lizardAbility/colorchange)
-		W.addAbility(/datum/targetable/lizardAbility/regrow_tail)
-	else return
-
-/mob/living/carbon/human/proc/remove_lizard_powers()
-	if (ishuman(src))
-		var/datum/abilityHolder/lizard/W = src.get_ability_holder(/datum/abilityHolder/lizard)
-		if (W && istype(W))
-			W.removeAbility(/datum/targetable/lizardAbility/colorshift)
-			W.removeAbility(/datum/targetable/lizardAbility/colorchange)
-			W.removeAbility(/datum/targetable/lizardAbility/regrow_tail)
-			src.remove_ability_holder(/datum/abilityHolder/lizard)
-	else return
-
 /mob/living/carbon/human/proc/update_lizard_parts()
 	if (ishuman(src))
 		var/mob/living/carbon/human/liz = src

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -858,10 +858,16 @@ TYPEINFO_NEW(/datum/mutantrace/lizard)
 
 	ghost_icon_state = "ghost-lizard"
 
+	mutant_abilityholder = /datum/abilityHolder/lizard
+	mutant_abilities = list(
+		/datum/targetable/lizardAbility/colorshift,
+		/datum/targetable/lizardAbility/colorchange,
+		/datum/targetable/lizardAbility/regrow_tail
+	)
+
 	on_attach(var/mob/living/carbon/human/H)
 		..()
 		if(ishuman(H))
-			H.give_lizard_powers()
 			H.AddComponent(/datum/component/consume/organpoints, /datum/abilityHolder/lizard)
 			H.AddComponent(/datum/component/consume/can_eat_inedible_organs)
 			H.mob_flags |= SHOULD_HAVE_A_TAIL
@@ -895,7 +901,6 @@ TYPEINFO_NEW(/datum/mutantrace/lizard)
 			C?.RemoveComponent(/datum/component/consume/organpoints)
 			var/datum/component/D = L.GetComponent(/datum/component/consume/can_eat_inedible_organs)
 			D?.RemoveComponent(/datum/component/consume/can_eat_inedible_organs)
-			L.remove_lizard_powers()
 			src.mob.mob_flags &= ~SHOULD_HAVE_A_TAIL
 			src.mob.thermoregulation_mult = initial(src.mob.thermoregulation_mult)
 			src.mob.base_body_temp = initial(src.mob.base_body_temp)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -232,6 +232,11 @@ ABSTRACT_TYPE(/datum/mutantrace)
 
 	var/self_click_fluff //used when clicking self on help intent
 
+	/// Abilityholder associated with this mutantrace, will be automatically given to mobs on spawn
+	var/datum/abilityHolder/mutant_abilityholder = null
+	/// List of abilities associated with this mutantrace, requires mutant_abilityholder to be set
+	var/list/datum/targetable/mutant_abilities = list()
+
 	/// Called by /mob/living/carbon/human/update_clothing()'s slot-specific sub-procs.
 	/// Each sub-proc passes its obj to this proc, which you can then operate on.
 	/// Should return a filter or list of filters, to be added to the obj's wear_image.filters
@@ -316,6 +321,14 @@ ABSTRACT_TYPE(/datum/mutantrace)
 		M.set_face_icon_dirty()
 		M.set_body_icon_dirty()
 
+		if(src.mutant_abilityholder)
+			var/datum/abilityHolder/mutantHolder = M.get_ability_holder(src.mutant_abilityholder)
+			if(!mutantHolder)
+				mutantHolder = M.add_ability_holder(src.mutant_abilityholder)
+			for(var/ability in src.mutant_abilities)
+				mutantHolder.addAbility(ability)
+
+
 		SPAWN(2.5 SECONDS) // Don't remove.
 			if (M?.organHolder?.skull)
 				M.assign_gimmick_skull() // For hunters (Convair880).
@@ -364,6 +377,13 @@ ABSTRACT_TYPE(/datum/mutantrace)
 				var/mob/living/carbon/human/H = src.mob
 				organ_mutator(H, "reset")
 				LimbSetter(H, "reset")
+
+				if(src.mutant_abilityholder)
+					var/datum/abilityHolder/mutantHolder = src.mob.get_ability_holder(src.mutant_abilityholder)
+					if(mutantHolder)
+						for(var/ability in src.mutant_abilities)
+							mutantHolder.removeAbility(ability)
+						src.mob.remove_ability_holder(src.mutant_abilityholder)
 
 				H.set_face_icon_dirty()
 				H.set_body_icon_dirty()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2043,6 +2043,17 @@ TYPEINFO(/datum/mutantrace/kudzu)
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_SKINTONE | TORSO_HAS_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | HAS_SPECIAL_HAIR | HAS_EXTRA_DETAILS | BUILT_FROM_PIECES)
 	override_attack = 1
 
+	mutant_abilityholder = /datum/abilityHolder/kudzu
+	mutant_abilities = list(
+		/datum/targetable/kudzu/guide,
+		/datum/targetable/kudzu/growth,
+		/datum/targetable/kudzu/seed,
+		/datum/targetable/kudzu/heal_other,
+		/datum/targetable/kudzu/stealth,
+		/datum/targetable/kudzu/kudzusay,
+		/datum/targetable/kudzu/vine_appendage
+	)
+
 	custom_attack(atom/target)
 		if(ishuman(target))
 			src.mob.visible_message(SPAN_ALERT("<B>[src.mob]</B> waves its limbs at [target] threateningly!"))
@@ -2060,28 +2071,11 @@ TYPEINFO(/datum/mutantrace/kudzu)
 				H.add_stam_mod_max("kudzu", -100)
 				APPLY_ATOM_PROPERTY(H, PROP_MOB_STAMINA_REGEN_BONUS, "kudzu", -5)
 				H.bioHolder.AddEffect("xray", power = 2, magical=1)
-				H.abilityHolder = new /datum/abilityHolder/kudzu(H)
-				H.abilityHolder.owner = H
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/guide)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/growth)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/seed)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/heal_other)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/stealth)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/kudzusay)
-				H.abilityHolder.addAbility(/datum/targetable/kudzu/vine_appendage)
 
 
 	disposing()
 		if(ishuman(src.mob))
 			var/mob/living/carbon/human/H = src.mob
-			if(H.abilityHolder)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/guide)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/growth)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/seed)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/heal_other)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/stealth)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/kudzusay)
-				H.abilityHolder.removeAbility(/datum/targetable/kudzu/vine_appendage)
 			H.remove_stam_mod_max("kudzu")
 			REMOVE_ATOM_PROPERTY(H, PROP_MOB_STAMINA_REGEN_BONUS, "kudzu")
 		return ..()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -772,18 +772,15 @@ TYPEINFO(/datum/mutantrace/virtual)
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/virtual/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | BUILT_FROM_PIECES)
 
+	mutant_abilityholder = /datum/abilityHolder/virtual
+	mutant_abilities = list(/datum/targetable/virtual/logout)
+
 	on_attach(var/mob/living/carbon/human/H)
 		..()
 		if(ishuman(src.mob))
 			var/color = pick("#FF0000","#FFFF00","#00FF00","#00FFFF","#0000FF","#FF00FF")
 			src.mob.blood_color = color
 			src.mob.bioHolder.bloodColor = color
-			var/datum/abilityHolder/virtual/A = H.get_ability_holder(/datum/abilityHolder/virtual)
-			if (A && istype(A))
-				return
-			var/datum/abilityHolder/virtual/W = H.add_ability_holder(/datum/abilityHolder/virtual)
-			W.addAbility(/datum/targetable/virtual/logout)
-//for sure didnt steal code from ww. no siree
 
 /datum/mutantrace/blank
 	name = "blank"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MUTANTRACES] [CODE QUALITY] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add two new variables to `/datum/mutantrace`, `mutant_abilityholder` and `mutant_abilities`. The former holds an abilityHolder type that will be automatically added when the mob gains the mutantrace, the latter holds a list of abilities to be added to the new abilityHolder. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A couple different mutantraces implement abilities tied to the mutrace, and each one implements it separately which is no good. One way to do it means less duplicate code.
