### PR TITLE
Allow speech pro to be used as an item arm

### DIFF
--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -2249,7 +2249,7 @@
 	checkRequirements(var/obj/item/device/speech_pro/sp, var/mob/user)
 		if(!can_act(user))
 			return FALSE
-		return sp in user
+		return sp == user.equipped()
 
 	greeting
 		name = "Greeting"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check if the speech pro is the currently equipped item instead of just checking if it's on the person, because items are inside item arms and not in the user's contents.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix  #19378