### PR TITLE
Standardize nuclear engine starter material crate

### DIFF
--- a/assets/maps/engine_rooms/cogmap/nuclear_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/nuclear_100.dmm
@@ -297,13 +297,7 @@
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/inner)
 "OH" = (
-/obj/storage/secure/crate/eng,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
+/obj/storage/secure/crate/eng/nuclearfuel,
 /turf/simulated/floor/engine/caution/east,
 /area/station/engine/inner)
 "PB" = (

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -180,6 +180,11 @@
 				B5.pixel_y = 1
 				return 1
 
+	nuclearfuel
+		name = "Fissile Materials Crate"
+		desc = "Contains the resources required to construct nuclear fuel rods."
+		spawn_contents = list(/obj/item/raw_material/cerenkite = 6)
+
 /obj/storage/secure/crate/medical
 	desc = "A secure medical crate."
 	name = "medical crate"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18168,14 +18168,7 @@
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/crew_quarters/bar)
 "fyI" = (
-/obj/rack,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
+/obj/storage/secure/crate/eng/nuclearfuel,
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "fyY" = (
@@ -28335,6 +28328,10 @@
 	dir = 8
 	},
 /area/station/chapel/funeral_parlor)
+"nfh" = (
+/obj/storage/secure/crate/eng/nuclearfuel,
+/turf/space,
+/area/space)
 "nfy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -44587,7 +44584,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+nfh
 aaa
 aaa
 aaa

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -28328,10 +28328,6 @@
 	dir = 8
 	},
 /area/station/chapel/funeral_parlor)
-"nfh" = (
-/obj/storage/secure/crate/eng/nuclearfuel,
-/turf/space,
-/area/space)
 "nfy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -44584,7 +44580,7 @@ aaa
 aaa
 aaa
 aaa
-nfh
+aaa
 aaa
 aaa
 aaa

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7311,6 +7311,10 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
+"dpV" = (
+/obj/storage/secure/crate/eng/nuclearfuel,
+/turf/unsimulated/wall/trench,
+/area/space)
 "dqn" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/se{
@@ -15448,16 +15452,7 @@
 	name = "South Catalytic Substation"
 	})
 "gLf" = (
-/obj/storage/secure/crate/eng{
-	name = "Fissile Materials Crate"
-	},
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/item/raw_material/cerenkite,
-/obj/mapping_helper/access/engineering_engine,
+/obj/storage/secure/crate/eng/nuclearfuel,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
@@ -57041,7 +57036,7 @@ oeA
 oeA
 oeA
 oeA
-oeA
+dpV
 oeA
 oeA
 oeA

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7311,10 +7311,6 @@
 /area/iss{
 	name = "Drop Capsule"
 	})
-"dpV" = (
-/obj/storage/secure/crate/eng/nuclearfuel,
-/turf/unsimulated/wall/trench,
-/area/space)
 "dqn" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/se{
@@ -57036,7 +57032,7 @@ oeA
 oeA
 oeA
 oeA
-dpV
+oeA
 oeA
 oeA
 oeA


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Create a standard nuclear fuel crate for nuclear engines and implement where appropriate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
less copy/paste between maps and future additions