### PR TITLE
Fix locker-spawn AI status display runtime

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -169,10 +169,12 @@
 
 /datum/manufacture/mechanics/ai_status_display
 	name = "AI display"
+	item_requirements = list("metal" = 2,
+							"conductive" = 6,
+							"crystal" = 6,)
 	create = 1
 	time = 5 SECONDS
 	frame_path = /obj/machinery/ai_status_display
-	generate_costs = TRUE
 
 /******************** Laser beam things *******************/
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add explicit list of material requirements for ai status displays

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19381