### PR TITLE
stop a proc from updating a mob's scream if there's one there

### DIFF
--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -331,8 +331,11 @@ var/list/datum/bioEffect/mutini_effects = list()
 			H.update_body()
 			H.update_clothing()
 
-			H.sound_scream = screamsounds[screamsound || "male"] || screamsounds["male"]
-			H.sound_fart = fartsounds[fartsound || "default"] || fartsounds["default"]
+			// if something changed our scream, instead of overwriting it go yell at whoever did it instead
+			H.sound_scream = H.sound_scream || screamsounds[screamsound || "male"]
+			// if something changed our fart, instead of overwriting it go yell at whoever did it instead
+			H.sound_fart = H.sound_fart || fartsounds[fartsound || "default"]
+
 			H.voice_type = voicetype || RANDOM_HUMAN_VOICE
 
 			if (H.mutantrace.voice_override)

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -331,11 +331,6 @@ var/list/datum/bioEffect/mutini_effects = list()
 			H.update_body()
 			H.update_clothing()
 
-			// if something changed our scream, instead of overwriting it go yell at whoever did it instead
-			H.sound_scream = H.sound_scream || screamsounds[screamsound || "male"]
-			// if something changed our fart, instead of overwriting it go yell at whoever did it instead
-			H.sound_fart = H.sound_fart || fartsounds[fartsound || "default"]
-
 			H.voice_type = voicetype || RANDOM_HUMAN_VOICE
 
 			if (H.mutantrace.voice_override)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug] [player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

deletes the two lines that force reset scream and fart sounds to default in updatemob

this probably will break atleast something

i do not know the reasoning behind why the current check resets your sounds so often, but it doesnt play nice with things

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

screams reverting to default bad

