### PR TITLE
Add map to death events

### DIFF
--- a/code/modules/goonhub/event_recording/events/Death.dm
+++ b/code/modules/goonhub/event_recording/events/Death.dm
@@ -38,5 +38,5 @@
 			M.get_oxygen_deprivation(),
 			gibbed ? TRUE : FALSE,
 			html_decode(M.last_words),
-			map_setting
+			global.map_setting
 		)

--- a/code/modules/goonhub/event_recording/events/Death.dm
+++ b/code/modules/goonhub/event_recording/events/Death.dm
@@ -16,7 +16,8 @@
 		toxloss,
 		oxyloss,
 		gibbed,
-		last_words
+		last_words,
+		map
 	)
 		. = ..(args)
 
@@ -36,5 +37,6 @@
 			M.get_toxin_damage(),
 			M.get_oxygen_deprivation(),
 			gibbed ? TRUE : FALSE,
-			html_decode(M.last_words)
+			html_decode(M.last_words),
+			map_setting
 		)

--- a/code/modules/goonhub/event_recording/types/Death.dm
+++ b/code/modules/goonhub/event_recording/types/Death.dm
@@ -11,5 +11,6 @@
 		"toxloss", // int
 		"oxyloss", // int
 		"gibbed", // boolean
-		"last_words" // string
+		"last_words", // string
+		"map", // string
 	)

--- a/code/modules/goonhub/event_recording/types/Death.dm
+++ b/code/modules/goonhub/event_recording/types/Death.dm
@@ -12,5 +12,5 @@
 		"oxyloss", // int
 		"gibbed", // boolean
 		"last_words", // string
-		"map", // string
+		"map" // string
 	)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds current map to death events

# Unsure if we want to implement like this or send the map id instead, wire input needed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

important

https://github.com/goonstation/api/issues/30