### PR TITLE
manufacturer now prints chembarrels properly

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -700,13 +700,16 @@
 	name = "Chemical Barrel"
 	item_requirements = list("metal_dense" = 6,
 							 "cobryl" = 9)
-	item_outputs = list(/obj/reagent_dispensers/chemicalbarrel/yellow)
+	item_outputs = list(/obj/reagent_dispensers/chemicalbarrel)
 	create = 1
 	time = 30 SECONDS
 	category = "Machinery"
 
 	red
+		item_outputs = list(/obj/reagent_dispensers/chemicalbarrel/red)
+		
 	yellow
+		item_outputs = list(/obj/reagent_dispensers/chemicalbarrel/yellow)
 
 /datum/manufacture/shieldgen
 	name = "Energy-Shield Gen."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
aeiou
Blueprint output was misconfigured, now it isnt

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #19266