### PR TITLE
Hygiene behavior tweaks

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -268,7 +268,7 @@
 			if (value < SIMS_HYGIENE_THRESHOLD_FILTHY && prob(33))
 				if (holder.owner.bioHolder && !(holder.owner.bioHolder.HasEffect("sims_stinky")) && !holder.owner.hasStatus("filthy"))
 					holder.owner.setStatus("filthy", 3 MINUTES)
-			else if ((value >= SIMS_HYGIENE_THRESHOLD_CLEAN ) && holder.owner.hasStatus("rancid"))
+			else if ((value >= SIMS_HYGIENE_THRESHOLD_FILTHY) && holder.owner.hasStatus("rancid"))
 				holder.owner.delStatus("rancid")
 			/*
 			if (value < 10 && prob((10 - value) * 1.5))

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -175,12 +175,14 @@ datum
 								var/hygiene_restore = hygiene_value
 								var/hygiene_cap = 100 - H.get_chem_protection() * 4 // Hygiene will not restore above this cap; typical minimum of 40%
 								var/hygiene_distance_from_cap = hygiene_cap - hygiene
-								var/hygiene_change = min(volume * hygiene_restore * (H.get_chem_protection() / 100), max(hygiene_distance_from_cap, 0))
+								var/hygiene_change = min(volume * hygiene_restore * (1 - (H.get_chem_protection() / 100)), max(hygiene_distance_from_cap, 0))
+
 								if (H.mutantrace.aquaphobic)
 									if (istype(src, /datum/reagent/oil))
 										hygiene_restore = 3
 									else if (istype(src, /datum/reagent/water))
 										hygiene_restore = -3
+								boutput(M, SPAN_ALERT("hyg [hygiene] || resto [hygiene_restore] || cap [hygiene_cap] || dist frm cap [hygiene_distance_from_cap] || change [hygiene_change]"))
 								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 0) && hygiene_change == 0)
 									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
 										boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -182,7 +182,6 @@ datum
 										hygiene_restore = 3
 									else if (istype(src, /datum/reagent/water))
 										hygiene_restore = -3
-								boutput(M, SPAN_ALERT("hyg [hygiene] || resto [hygiene_restore] || cap [hygiene_cap] || dist frm cap [hygiene_distance_from_cap] || change [hygiene_change]"))
 								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 0) && hygiene_change == 0)
 									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
 										boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -183,7 +183,7 @@ datum
 										hygiene_restore = -3
 								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 0) && hygiene_change == 0)
 									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
-										boutput(M, SPAN_NOTICE("Your clothes prevent you from getting any cleaner!"))
+										boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))
 								H.sims.affectMotive("Hygiene", hygiene_change)
 
 				if(INGEST)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -182,7 +182,7 @@ datum
 										hygiene_restore = 3
 									else if (istype(src, /datum/reagent/water))
 										hygiene_restore = -3
-								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 0) && hygiene_change == 0)
+								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 100) && hygiene_change == 0)
 									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
 										boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))
 								H.sims.affectMotive("Hygiene", hygiene_change)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -170,14 +170,21 @@ datum
 							if (!ON_COOLDOWN(H, "bingus_damage", 3 SECONDS))
 								random_burn_damage(H, clamp(0.3 * volume, 4, 20))
 						if (H.sims)
-							if ((hygiene_value > 0 && !(H.wear_suit || H.w_uniform)) || hygiene_value < 0)
+							if (hygiene_value)
+								var/hygiene = H.sims.getValue("Hygiene")
 								var/hygiene_restore = hygiene_value
+								var/hygiene_cap = 100 - H.get_chem_protection() * 4 // Hygiene will not restore above this cap; typical minimum of 40%
+								var/hygiene_distance_from_cap = hygiene_cap - hygiene
+								var/hygiene_change = min(volume * hygiene_restore * (H.get_chem_protection() / 100), max(hygiene_distance_from_cap, 0))
 								if (H.mutantrace.aquaphobic)
 									if (istype(src, /datum/reagent/oil))
 										hygiene_restore = 3
 									else if (istype(src, /datum/reagent/water))
 										hygiene_restore = -3
-								H.sims.affectMotive("Hygiene", volume * hygiene_restore)
+								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 0) && hygiene_change == 0)
+									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
+										boutput(M, SPAN_NOTICE("Your clothes prevent you from getting any cleaner!"))
+								H.sims.affectMotive("Hygiene", hygiene_change)
 
 				if(INGEST)
 					var/datum/ailment_data/addiction/AD = M.addicted_to_reagent(src)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2291,9 +2291,8 @@
 
 	onUpdate(timePassed)
 		. = ..()
-		if (H?.sims?.getValue("Hygiene") > SIMS_HYGIENE_THRESHOLD_CLEAN)
+		if (H?.sims?.getValue("Hygiene") > SIMS_HYGIENE_THRESHOLD_FILTHY)
 			H.delStatus("filthy")
-
 
 	onRemove()
 		. = ..()


### PR DESCRIPTION
## About the PR

- You no longer need to take off clothes to restore hygiene with chem splashes (e.g. showers, baths, flopping in puddles). Instead, the maximum hygiene you can reach is limited by 4x the chemical protection (chemprot) of your equipped items.
--  Players are notified in chat if their clothes are preventing them from getting any cleaner.
--  A default Staff Assistant wearing a jumpsuit and shoes will have their maximum decreased by 60% (that's 15% * 4), so a shower can only get them up to 40% unless they take off clothes.
--  Chemprot also reduces the effectiveness of chemical splashes for both restoring and reducing hygiene.

- The stink-lines effect can be removed by getting above 15% hygiene, rather than 85%. This means that a clothed shower will still cure stinkiness. 
-- This means that a character will not emanate a "fetid stench" (or similar) at 80% hygiene because they were below 15% at some point.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We get a lot of Mhelps about bathing on RP, because the system isn't intuitive. Clothes permeable enough to let a blood puddle soil your skin should probably also be permeable enough that showers make you a little cleaner... especially if you're so fucking rancid that you make the room "smell like a corpse took a shit in here." (Jesus fuck, the language used in those notifications can get nasty...) This PR is designed to get new players clean, while guiding them along to intended gameplay paths to maximize cleanliness.


## Changelog
```changelog
(u)mintyphresh
(+)Showering with clothes on now restores the hygiene motive, with higher chemprot limiting the maximum cleanliness you can achieve.
```
