### PR TITLE
Fix material application for manufacturers

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1546,8 +1546,11 @@ TYPEINFO(/obj/machinery/manufacturer)
 			return P_ref
 
 	/// Check if a blueprint can be manufactured with the current materials.
-	proc/check_enough_materials(datum/manufacture/M)
-		return length(get_materials_needed(M)) == length(M.item_requirements)
+	/// mats_used - a list from get_materials_needed to avoid calling the proc twice
+	proc/check_enough_materials(datum/manufacture/M, var/list/mats_used = null)
+		if (isnull(mats_used))
+			mats_used = get_materials_needed(M)
+		return length(mats_used) == length(M.item_requirements)
 
 	/// Go through the material requirements of a blueprint, removing the respective used materials
 	proc/remove_materials(datum/manufacture/M)
@@ -1655,8 +1658,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 		if (length(M.item_outputs) <= 0)
 			return
-		var/materials_used = check_enough_materials(M)
-		if(materials_used)
+		var/list/materials_used = src.get_materials_needed(M)
+		if(src.check_enough_materials(M, materials_used))
 			var/make = clamp(M.create, 0, src.output_cap)
 			switch(M.randomise_output)
 				if(1) // pick a new item each loop


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I could have sworn I pushed this change
Anyway it fixes passing a bool instead of the materials req list like it *should*.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #19461

