### PR TITLE
Makes poor hygiene less vile

### DIFF
--- a/code/modules/medical/genetics/bioEffects/non_genetic.dm
+++ b/code/modules/medical/genetics/bioEffects/non_genetic.dm
@@ -198,11 +198,6 @@ ABSTRACT_TYPE(/datum/bioEffect/hidden)
 	occur_in_genepools = 0
 	var/personalized_stink = null
 
-	New()
-		..()
-		if (prob(5))
-			src.personalized_stink = stinkString()
-
 	OnAdd()
 		. = ..()
 		holder.owner?.UpdateParticles(new/particles/stink_lines, "stink_lines", KEEP_APART | RESET_TRANSFORM)
@@ -215,10 +210,8 @@ ABSTRACT_TYPE(/datum/bioEffect/hidden)
 					continue
 				if (ispug(C))
 					boutput(C, SPAN_ALERT("Wow, [owner] sure [pick("stinks", "smells", "reeks")]!"), "stink_message")
-				else if (src.personalized_stink)
-					boutput(C, SPAN_ALERT("[src.personalized_stink]"), "stink_message")
 				else
-					boutput(C, SPAN_ALERT("[stinkString()]"), "stink_message")
+					boutput(C, SPAN_ALERT("[stinkStringHygiene(owner)]"), "stink_message")
 	OnRemove()
 		holder.owner?.ClearSpecificParticles("stink_lines")
 		. = ..()

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -33,7 +33,6 @@ var/list/stinkThingies = list("ass","armpit","excretions","leftovers","administr
 var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a hose","a new bottle of cologne")
 /proc/stinkStringHygiene(var/mob/stinker)
 	var/someone = "someone"
-	var/them = "them"
 	var/they = "it"
 	var/their = "their"
 	var/blank_or_s = "s"

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -55,7 +55,7 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		if(6)
 			return "[pick(stinkExclamations)], what you wouldn't give to be staffed on a station where people bathe..."
 		if(7)
-			return "You reckon [someone] has [their] very own locker room in [their] backpack, because, damn! It REEKS!"
+			return "You reckon [someone] has [their] very own locker room in [their] backpack, because, damn! [they] REEK[capitalize(blank_or_s)]!"
 		if(8)
 			return "[capitalize(someone)] must have skipped laundry day for the past month. At least, [they] smell[blank_or_s] like it."
 		if(9)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -30,6 +30,40 @@ var/list/stinkThingies = list("ass","armpit","excretions","leftovers","administr
 // TODO convert the above to use a file/string picker
 
 
+var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a hose","a new bottle of cologne")
+/proc/stinkStringHygiene(var/mob/stinker)
+	var/someone = "someone"
+	var/them = "them"
+	var/they = "it"
+	var/their = "their"
+	var/blank_or_s = "s"
+	if(stinker)
+		someone = stinker.name
+		them = "[him_or_her(stinker)]"
+		they = "[he_or_she(stinker)]"
+		their = "[his_or_her(stinker)]"
+		blank_or_s = "[blank_or_s(stinker)]"
+	switch(rand(1,9))
+		if(1)
+			return "Smells like [someone] needs [pick(stink_remedy)]."
+		if(2)
+			return "[pick(stinkExclamations)], has anyone here heard of a shower before?"
+		if(3)
+			return "[capitalize(someone)] smells positively vile."
+		if(4)
+			return "[capitalize(someone)]'s odor hangs the air. You get a whiff. Disgusting."
+		if(5) //You wonder if John Joe even notices how gross he smells anymore.
+			return "You wonder if people around here ever notice how gross they smell sometimes."
+		if(6)
+			return "[pick(stinkExclamations)], what you wouldn't give to be staffed on a station where people bathe..."
+		if(7)
+			return "You reckon [someone] has [their] very own locker room in [their] backpack, because, damn! It REEKS!"
+		if(8)
+			return "[capitalize(someone)] must have skipped laundry day for the past month. At least, [they] smell[blank_or_s] like it."
+		if(9)
+			return "Dirt and grime is practically airborne around you. [capitalize(someone)] must be responsible."
+
+
 /proc/get_local_apc(O)
 	var/turf/T = get_turf(O)
 	if (!T)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -38,7 +38,6 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 	var/blank_or_s = "s"
 	if(stinker)
 		someone = stinker.name
-		them = "[him_or_her(stinker)]"
 		they = "[he_or_she(stinker)]"
 		their = "[his_or_her(stinker)]"
 		blank_or_s = "[blank_or_s(stinker)]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, the proc "stinkString" handles stink from poor hygiene (and some others). This PR provides Hygiene with its own set of strings, targeted specifically at poor hygiene and toned down from the severity of language found in stinkString.

Here's a quick sampling of some of the 9 possible strings...

"smells like Judy Scusting needs a spraydown with a hose."
"Christ, what you wouldn't give to be staffed on a station where people bathe..."
"Unknown's odor hangs in the air. You get a whiff. Disgusting."
"You reckon Joe Yoder has his very own locker room in his backpack, because, damn! He REEKS!"


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
stinkString makes some positively vile sentences, such as: 
"Fuck, smells like a corpse took a shit in here!"
"Eww, there's a putrid miasma in here..."
"Christ, it smells like a toilet's ass in here!"

I fucking hate that this repulsive, extreme potty humor is so easy to see in the game. Especially for body odor, which isn't really that bad (especially for the accumulated grime of... 90 minutes).