### PR TITLE
Try to spread nukeops spawns

### DIFF
--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -92,7 +92,17 @@
 		if (src.id == ROLE_NUKEOP_COMMANDER)
 			M.set_loc(pick_landmark(LANDMARK_SYNDICATE_BOSS))
 		else
-			M.set_loc(pick_landmark(LANDMARK_SYNDICATE))
+			//copied from /mob/living/proc/Equip_Rank - try to find an unoccupied chair but not for too long.
+			var/tries = 8
+			var/turf/T
+			do
+				T = pick_landmark(LANDMARK_SYNDICATE)
+			while((locate(/mob) in T) && tries--)
+			M.set_loc(T)
+			//for completeness' sake, make em sit properly
+			var/obj/stool/an_chair = locate() in T
+			if(an_chair)
+				M.set_dir(an_chair.dir)
 
 	assign_objectives()
 		ticker.mode.bestow_objective(src.owner, /datum/objective/specialist/nuclear, src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Copies a little bit of code to nukeops that tries to spread operative spawns into unoccupied spaces. I also made them face towards the table via chairmancy.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I just observed a 6 man nuke team, 3 of which spawned in the same chair when there were 6 empty chairs around the table. It looks silly.