### PR TITLE
Return of "OH SHIT, ANTS!!!!!!"

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1706,7 +1706,7 @@ datum
 					return
 				if (method == TOUCH)
 					. = 0 // for depleting fluid pools
-				if (!ON_COOLDOWN(M, "ants_scream", 15 SECONDS)) //lets make it less spammy
+				if (!ON_COOLDOWN(M, "ants_scream", 10 SECONDS)) //lets make it less spammy
 					M.emote("scream")
 					if (method == INGEST || method == INJECT)
 						boutput(M, SPAN_ALERT("<b>OH SHIT, ANTS [pick("", "IN MY BLOOD", " IN MY VEINS")]![pick("", "!", "!!", "!!!", "!!!!")]</b>"))

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1713,7 +1713,6 @@ datum
 					else
 						boutput(M, SPAN_ALERT("<b>OH SHIT, ANTS![pick("", "!", "!!", "!!!", "!!!!")]</b>"))
 				random_brute_damage(M, 4)
-				return
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1706,8 +1706,6 @@ datum
 					return
 				if (method == TOUCH)
 					. = 0 // for depleting fluid pools
-				if(method == TOUCH)
-					. = 0 // for depleting fluid pools
 				if (!ON_COOLDOWN(M, "ants_scream", 15 SECONDS)) //lets make it less spammy
 					M.emote("scream")
 					if (method == INGEST || method == INJECT)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1706,7 +1706,16 @@ datum
 					return
 				if (method == TOUCH)
 					. = 0 // for depleting fluid pools
+				if(method == TOUCH)
+					. = 0 // for depleting fluid pools
+				if (!ON_COOLDOWN(M, "ants_scream", 15 SECONDS)) //lets make it less spammy
+					M.emote("scream")
+					if (method == INGEST || method == INJECT)
+						boutput(M, SPAN_ALERT("<b>OH SHIT, ANTS [pick("", "IN MY BLOOD", " IN MY VEINS")]![pick("", "!", "!!", "!!!", "!!!!")]</b>"))
+					else
+						boutput(M, SPAN_ALERT("<b>OH SHIT, ANTS![pick("", "!", "!!", "!!!", "!!!!")]</b>"))
 				random_brute_damage(M, 4)
+				return
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Returns "OH SHIT, ANTS!!!!" to its rightful place.
Makes ants cause you to scream again, with an extended cooldown to mitigate audible spam.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The "OH SHIT, ANTS!!!!!" message is both hilarious and a part of goonstation heritage, and it's a shame to lose it. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Carton171
(+) Players will once again lose their shit upon being filled with/covered in ants
```
