### PR TITLE
Allow directly swapping out a cyborg's head

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1463,19 +1463,6 @@
 					playsound(src, 'sound/items/Ratchet.ogg', 40, TRUE)
 					swap_heads(held_head, user)
 					return //swap_heads handles all the rest
-					//Borgs die to parts now the moment they cease having a head, so none of the code below is relevant anymore
-					/*
-					if(src.part_head)
-						boutput(user, SPAN_ALERT("[src] already has a head part."))
-						return
-					src.part_head = RP
-					if (src.part_head.brain)
-						if(src.part_head.brain.owner)
-							if(src.part_head.brain.owner.current)
-								src.gender = src.part_head.brain.owner.current.gender
-								if(src.part_head.brain.owner.current.client)
-									src.lastKnownIP = src.part_head.brain.owner.current.client.address
-							src.part_head.brain.owner.transfer_to(src)*/
 				if("l_arm")
 					if(src.part_arm_l)
 						boutput(user, SPAN_ALERT("[src] already has a left arm part."))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1340,6 +1340,8 @@
 				actions.Add("Remove Left Leg")
 			if (src.part_head)
 				actions.Add("Remove Head")
+				if (user.find_type_in_hand(/obj/item/parts/robot_parts/head))
+					actions.Add("Swap Head With Held Head")
 			if (src.part_chest)
 				actions.Add("Remove Chest")
 
@@ -1369,6 +1371,14 @@
 			if(action == "Remove Head" && !src.part_head)
 				boutput(user, SPAN_ALERT("There's no head to remove!"))
 				return
+			if(action == "Swap Head With Held Head")
+				var/obj/item/parts/robot_parts/head/held_head = user.find_type_in_hand(/obj/item/parts/robot_parts/head)
+				if (!held_head)
+					boutput(user, SPAN_ALERT("You're not holding a replacement head anymore!"))
+					return
+				if (held_head.brain || held_head.ai_interface)
+					boutput(user, SPAN_ALERT("The replacement head needs to be empty!"))
+					return
 
 			playsound(src, 'sound/items/Ratchet.ogg', 40, TRUE)
 			switch(action)
@@ -1386,6 +1396,9 @@
 					src.part_head.holder = null
 					src.part_head = null
 					update_bodypart("head")
+				if("Swap Head With Held Head")
+					var/new_head = user.find_type_in_hand(/obj/item/parts/robot_parts/head) //should be guaranteed and empty after checks above
+					swap_heads(new_head, user)
 				if("Remove Right Arm")
 					if(src.part_arm_r.robot_movement_modifier)
 						REMOVE_MOVEMENT_MODIFIER(src, src.part_arm_r.robot_movement_modifier, src.part_arm_r.type)
@@ -1443,6 +1456,15 @@
 					boutput(user, SPAN_ALERT("You can't attach a chest piece to a constructed cyborg. You'll need to put it on a frame."))
 					return
 				if("head")
+					var/obj/item/parts/robot_parts/head/held_head = W
+					if (held_head.brain || held_head.ai_interface)
+						boutput(user, SPAN_ALERT("The replacement head needs to be empty!"))
+						return
+					playsound(src, 'sound/items/Ratchet.ogg', 40, TRUE)
+					swap_heads(held_head, user)
+					return //swap_heads handles all the rest
+					//Borgs die to parts now the moment they cease having a head, so none of the code below is relevant anymore
+					/*
 					if(src.part_head)
 						boutput(user, SPAN_ALERT("[src] already has a head part."))
 						return
@@ -1453,7 +1475,7 @@
 								src.gender = src.part_head.brain.owner.current.gender
 								if(src.part_head.brain.owner.current.client)
 									src.lastKnownIP = src.part_head.brain.owner.current.client.address
-							src.part_head.brain.owner.transfer_to(src)
+							src.part_head.brain.owner.transfer_to(src)*/
 				if("l_arm")
 					if(src.part_arm_l)
 						boutput(user, SPAN_ALERT("[src] already has a left arm part."))
@@ -1687,6 +1709,37 @@
 
 		src.part_head.brain = null
 		src.update_appearance()
+
+	//There's really nothing technical stopping us from swapping out filled heads for one another, and have players switch out accordingly.
+	//Except I'm not ready to deal with mind swapping bugs, so not for now. This is just a shortcut for borg vanity.
+	///Take new_head from user, put whatever's in the current head and slap it in, equip new_head and give the empty old one to user.
+	proc/swap_heads(obj/item/parts/robot_parts/head/new_head, mob/user)
+		if (!istype(new_head) || !user)
+			return
+		var/obj/item/parts/robot_parts/head/old_head = src.part_head
+		//update movement speed
+		if(old_head.robot_movement_modifier)
+			REMOVE_MOVEMENT_MODIFIER(src, old_head.robot_movement_modifier, old_head.type)
+		if(new_head.robot_movement_modifier)
+			REMOVE_MOVEMENT_MODIFIER(src, new_head.robot_movement_modifier, new_head.type)
+		//transfer head contents
+		if (old_head.brain)
+			old_head.brain.set_loc(new_head)
+			new_head.brain = old_head.brain
+			old_head.brain = null
+		else if (old_head.ai_interface) //note we may also swap two empty heads for each other and that's fine too
+			old_head.ai_interface.set_loc(new_head)
+			new_head.ai_interface = old_head.ai_interface
+			old_head.ai_interface = null
+		//transfer head references
+		old_head.holder = null
+		new_head.holder = src
+		user.drop_item(new_head)
+		new_head.set_loc(src)
+		src.part_head = new_head //since we're not doing mind swaps, I don't think the mob's mind/client needs to know what happened here
+		user.put_in_hand_or_drop(old_head)
+		boutput(user, SPAN_NOTICE("You swap out [src]'s [old_head] for [new_head]."))
+		update_bodypart("head")
 
 	Topic(href, href_list)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows roboticists to swap heads on a cyborg with an empty one they're holding. With a cyborg's wiring exposed (as for other part swaps), you can either use a wrench with the replacement head in your offhand or use the head directly on the borg. This swap automatically transfers the brain or interface over, so the cyborg's player doesn't lose control of their mob at any point in the process.

The held/replacement head needs to be empty for now, which is just to make it easy on myself. Given the persistence of mind transfer bugs, I'm not willing to mess with that stuff. It does mean that you can't swap out an empty-headed borg's head for one with a brain in it though, which I don't think is good.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Outfitting a roundstart borg with a screen head* currently involves complete dis- and reassembly. Given that the roboticist job has one of the higher knowledge floors for basic functioning, this should make what is one of the more fraught requests safer. Especially since I've seen borg players walk new roboticists through the steps to service them quite often.

(*Although I'd also love to see someone request a heavy head on their otherwise light body)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)BatElite
(+)You can now swap out heads on cyborgs by using an empty head on a cyborg with its wiring exposed, or using a wrench with the replacement in your other hand.
(+)The brain/interface inside the borg transfers to the new head automatically. This way you don't have to de-brain or take apart a cyborg just to change their head.
```
