### PR TITLE
Clown announcement tweak

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -230,6 +230,7 @@
 	var/emagged = FALSE
 	sound_to_play = 'sound/machines/announcement_clown.ogg'
 	override_font = "Comic Sans MS"
+	desc = "A bootleg announcement computer. Only accepts official Chips Ahoy brand clown IDs."
 
 	send_message(mob/user, message)
 		. = ..()

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -261,7 +261,7 @@
 	attackby(obj/item/W, mob/user)
 		..()
 		if (istype(W, /obj/item/card/id))
-			if (!istype (W, /obj/item/card/id/clown))
+			if ( W.icon_state != "id_clown")
 				src.unlocked = 0
 				update_status()
 
@@ -269,7 +269,7 @@
 		..()
 		switch(action)
 			if ("id")
-				if(  !istype (src.ID, /obj/item/card/id/clown))
+				if ( ID.icon_state != "id_clown")
 					src.unlocked = 0 // clowns ONLY
 					update_status()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Very small change suggested by pali. The clown computer will now check if an ID has the clown ID sprite, rather than if it is the clown ID type. This makes something like an agent card (with the clown style chosen) work in the computer. 

Also adds a description to the computer hinting that its the style that matters. (The clown ID itself also mentions Chips Ahoy :p ) 

The HoP's computer can't assign the clown style, so I don't think this affects much else. Unless I forgot something!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A bit more consistent that two IDs which look exactly the same should both work. If a traitor wants to impersonate the clown this way, go for it! 

Could technically allow for a gimmick like agent card + emag to weaponize the computer without actually needing a clown to be on station.

[feature]

