### PR TITLE
Printing press stops you from inserting paper with stuff on it

### DIFF
--- a/code/obj/machinery/printing_press.dm
+++ b/code/obj/machinery/printing_press.dm
@@ -218,6 +218,10 @@
 			boutput(user, "\The [src] is already fully loaded with paper!")
 	else if (istype(W, /obj/item/paper) && !istype(W, /obj/item/paper/book)) //should also exclude all other weird paper subtypes, but i think books are the only one
 		if (src.paper_amt < src.paper_max)
+			var/obj/item/paper/sheet = W
+			if(length(sheet.info))
+				boutput(user, SPAN_ALERT("\The [src] only takes blank paper!"))
+				return
 			boutput(user, "You load \the [W] into \the [src].")
 			src.paper_amt ++
 			UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check to the printing press for if the paper being inserted has writing on it, rejecting it if so.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Someone thought you insert your writing into the printing press and print it that way and they lost everything they'd written on the paper.