### PR TITLE
Fix genebooth still opening menu when depowered

### DIFF
--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -409,7 +409,7 @@
 
 	checkRequirements(atom/target, mob/user)
 		. = FALSE
-		if(!can_act(user) || !in_interact_range(target, user))
+		if(!can_act(user) || !in_interact_range(target, user) || GB.status & (NOPOWER | BROKEN))
 			return FALSE
 		if (GBP && GB && (BOUNDS_DIST(target, user) == 0 && isliving(user)) && !GB?.occupant)
 			. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds status check in genebooth product context menu `checkRequirements` because context actions don't give a fuck about `attack_hand` until after this runs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19459 
