### PR TITLE
Fix racks turning invisible after explosion

### DIFF
--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -12,7 +12,7 @@
 	material_amt = 0.1
 
 	proc/rackbreak()
-		icon_state += "-broken"
+		src.icon_state = initial(src.icon_state) + "-broken"
 		src.set_density(0)
 
 /obj/rack/New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change `rackbreak` to append the broken state suffix to initial icon state instead of the current one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19446