### PR TITLE
make tomato splats use create_reagents

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -294,7 +294,7 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 		if(!target) return
 
 		if (isnull(target.reagents))
-			target.reagents = new
+			target.create_reagents()
 
 		var/datum/reagents/target_reagents = target.reagents
 		amount = min(amount, target_reagents.maximum_volume - target_reagents.total_volume)
@@ -1223,6 +1223,6 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 
 /// Convenience proc to create a reagents holder for an atom
 /// Max vol is maximum volume of holder
-atom/proc/create_reagents(var/max_vol)
+atom/proc/create_reagents(var/max_vol = 100)
 	reagents = new/datum/reagents(max_vol)
 	reagents.my_atom = src

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -172,7 +172,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 			var/obj/decal/cleanable/tomatosplat/splat = new
 			if(src.reagents)
 				src.reagents.handle_reactions()
-				splat.reagents = new(10000)
+				splat.reagents = create_reagents(10000)
 				src.reagents.trans_to(splat, src.reagents.total_volume)
 			splat.set_loc(T)
 			splat.setup(T)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -172,7 +172,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 			var/obj/decal/cleanable/tomatosplat/splat = new
 			if(src.reagents)
 				src.reagents.handle_reactions()
-				splat.reagents = create_reagents(10000)
+				splat.create_reagents(10000)
 				src.reagents.trans_to(splat, src.reagents.total_volume)
 			splat.set_loc(T)
 			splat.setup(T)

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -172,7 +172,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 			var/obj/decal/cleanable/tomatosplat/splat = new
 			if(src.reagents)
 				src.reagents.handle_reactions()
-				splat.create_reagents(10000)
+				splat.create_reagents(src.reagents.total_volume)
 				src.reagents.trans_to(splat, src.reagents.total_volume)
 			splat.set_loc(T)
 			splat.setup(T)


### PR DESCRIPTION
[hydroponics]bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the creation of tomato splats properly use create_reagents instead of creating a improperly set up reagent container in them

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

someone in the discord found a bug where tomato splats of tomatoes filled with black powder were unable to be ignited. this was because the reagent container of the tomato splat was improperly configurated and hadn't `.my_atom` set properly. This fixes this and probably other inconsistencies that this would cause.