### PR TITLE
Skeletons drop torsos on death and their limbs fly off 

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1162,34 +1162,29 @@ TYPEINFO(/datum/mutantrace/skeleton)
 			var/obj/itemspecialeffect/poof/P = new /obj/itemspecialeffect/poof
 			P.setup(src.mob.loc)
 			var/obj/item/I
-			//this should be done in like, a loop but by god the only way to do that is with vars[]
-			I = src.mob.limbs.l_arm?.remove(FALSE)
-			I?.pixel_x += rand(-8, 8)
-			I?.pixel_y += rand(-8, 8)
-			I = src.mob.limbs.r_arm?.remove(FALSE)
-			I?.pixel_x += rand(-8, 8)
-			I?.pixel_y += rand(-8, 8)
-			I = src.mob.limbs.l_leg?.remove(FALSE)
-			I?.pixel_x += rand(-8, 8)
-			I?.pixel_y += rand(-8, 8)
-			I = src.mob.limbs.r_leg?.remove(FALSE)
-			I?.pixel_x += rand(-8, 8)
-			I?.pixel_y += rand(-8, 8)
-			I = src.mob.organHolder.drop_organ("head")
-			I?.pixel_x += rand(-8, 8)
-			I?.pixel_y += rand(-8, 8)
+			I = src.mob.organHolder.drop_organ("head", src.mob)
+			var/list/limbs = list()
+			limbs += src.mob.limbs.l_arm?.remove(FALSE)
+			limbs += src.mob.limbs.r_arm?.remove(FALSE)
+			limbs += src.mob.limbs.l_leg?.remove(FALSE)
+			limbs += src.mob.limbs.r_leg?.remove(FALSE)
+
+			for (var/limb in limbs)
+				ThrowRandom(limb, rand(2, 4))
 
 			//good fucking god i hate skeletons
 			var/obj/item/organ/head/H = I || src.head_tracker
 			if(H)
 				H.brain = src.mob.organHolder?.drop_organ("brain", H)
+				ThrowRandom(H, 1)
 			else
 				qdel(src.mob.organHolder?.drop_organ("brain", null)) //perish
 
 			for(var/i in 1 to rand(2, 5))
 				I = new/obj/item/material_piece/bone(src.mob.loc)
-				I?.pixel_x += rand(-8, 8)
-				I?.pixel_y += rand(-8, 8)
+				ThrowRandom(I, rand(1, 3))
+
+			ThrowRandom(src.mob, rand(2, 3))
 
 			src.mob.dump_contents_chance = 100
 			var/list/organlist = list()
@@ -1203,10 +1198,8 @@ TYPEINFO(/datum/mutantrace/skeleton)
 
 			playsound(src.mob, 'sound/effects/skeleton_break.ogg', 66, 1)
 			src.mob.visible_message("<span 'class=alert'>[src.mob] falls apart into a pile of bones!</span>", "<span 'class=alert'>You fall apart into a pile of bones!</span>", "<span 'class=notice'>You hear a clattering noise.</span>")
-			var/mob/dead/observer/newmob = src.mob.ghostize()
-			newmob?.corpse = null
 
-			return MUTRACE_ONDEATH_DEFER_DELETE
+			return MUTRACE_ONDEATH_NOTHING
 
 /obj/item/joint_wax
 	name = "joint wax"

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1169,8 +1169,10 @@ TYPEINFO(/datum/mutantrace/skeleton)
 			limbs += src.mob.limbs.l_leg?.remove(FALSE)
 			limbs += src.mob.limbs.r_leg?.remove(FALSE)
 
-			for (var/limb in limbs)
-				ThrowRandom(limb, rand(2, 4))
+			for (var/obj/limb in limbs) // You do not know my pain.
+				ThrowRandom(limb, 1)
+
+			ThrowRandom(src.mob, 1)
 
 			//good fucking god i hate skeletons
 			var/obj/item/organ/head/H = I || src.head_tracker
@@ -1182,9 +1184,7 @@ TYPEINFO(/datum/mutantrace/skeleton)
 
 			for(var/i in 1 to rand(2, 5))
 				I = new/obj/item/material_piece/bone(src.mob.loc)
-				ThrowRandom(I, rand(1, 3))
-
-			ThrowRandom(src.mob, rand(2, 3))
+				ThrowRandom(I, 1)
 
 			src.mob.dump_contents_chance = 100
 			var/list/organlist = list()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1172,8 +1172,6 @@ TYPEINFO(/datum/mutantrace/skeleton)
 			for (var/obj/limb in limbs) // You do not know my pain.
 				ThrowRandom(limb, 1)
 
-			ThrowRandom(src.mob, 1)
-
 			//good fucking god i hate skeletons
 			var/obj/item/organ/head/H = I || src.head_tracker
 			if(H)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2856,6 +2856,7 @@
 	else if(limb == "r_arm" && src.limbs.r_arm) src.limbs.r_arm.sever()
 	else if(limb == "l_leg" && src.limbs.l_leg) src.limbs.l_leg.sever()
 	else if(limb == "r_leg" && src.limbs.r_leg) src.limbs.r_leg.sever()
+	else if(limb == "all") src.limbs.sever("all")
 
 /mob/living/carbon/human/proc/has_limb(var/limb)
 	if (!src.limbs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remake of a previous PR, without the additional fluff, that causes a skeleton's limbs, head and torso to fly off in random directions a couple tiles on death. A skeleton can be rebuilt after, but attempting to clone them will still result in a puritan explosion.


https://github.com/goonstation/goonstation/assets/102558507/cc443f8c-4f3f-44d0-b228-7bdd0d350d4a



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Skeletons don't drop their torso on death, which means that antags have to keep them alive while they absorb, eat or drink from them. This was discussed on the forums here (https://forum.ss13.co/showthread.php?tid=22763).


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Skeletons drop their torso on death as a tasty snack for antags.
```