### PR TITLE
Remove Player Selected Traits from Salvagers

### DIFF
--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -15,7 +15,7 @@
 			return FALSE
 
 		var/mob/living/carbon/human/H = src.owner.current
-
+		H.traitHolder.removeAll()
 		// You are... no one...
 		randomize_look(H, change_gender=FALSE)
 		H.bioHolder.mobAppearance.flavor_text = null


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability for most traits to be correctly removed from a mob.
Remove all traits from Salvagers when applying antagonist status to them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lean more into them being random... not your selected character.
Can provide opportunities to have more themed Salvager operations that resolve around trait based bioeffects and mutant races.



```changelog
(u)Azrun
(*)Salvagers no longer receive selected character traits.  They are truly just someone else entirely.
```
