### PR TITLE
give VR sleepers the enter/exit noise + clickdrag to put yourself in

### DIFF
--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -293,7 +293,8 @@
 		return
 	src.log_in(usr)
 	src.add_fingerprint(usr)
-	playsound(src, 'sound/machines/sleeper_close.ogg', 50, 1)
+	if (!isobserver(usr))
+		playsound(src, 'sound/machines/sleeper_close.ogg', 50, 1)
 	return
 
 /obj/machinery/sim/vr_bed/MouseDrop_T(mob/living/target, mob/user)

--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -293,7 +293,12 @@
 		return
 	src.log_in(usr)
 	src.add_fingerprint(usr)
+	playsound(src, 'sound/machines/sleeper_close.ogg', 50, 1)
 	return
+
+/obj/machinery/sim/vr_bed/MouseDrop_T(mob/living/target, mob/user)
+	if (target == user)
+		move_inside()
 
 /obj/machinery/sim/vr_bed/verb/move_eject()
 	set src in oview(1)
@@ -345,6 +350,7 @@
 	src.active = 0
 	src.con_user = null
 	src.UpdateIcon()
+	playsound(src, 'sound/machines/sleeper_open.ogg', 50, 1)
 	return
 
 /obj/machinery/sim/vr_bed/Exited(atom/movable/thing, newloc)

--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -298,6 +298,7 @@
 	return
 
 /obj/machinery/sim/vr_bed/MouseDrop_T(mob/living/target, mob/user)
+	if (BOUNDS_DIST(user, src) > 0 || !in_interact_range(src,user)) return
 	if (target == user)
 		move_inside()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Objects] [Qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

gives vr sleepers the sound for exiting / entering that other sleepers do

add clickdrag support for putting yourself in a sleeper

this is done by copy pasting some code onto vr sleepers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

regular sleepers allow you to clickdrag yourself in, which seems more intuitive

vr sleepers dont let you clickdrag yourself in, forcing you to use a verb


