### PR TITLE
Fix (seemingly) forced middle names in character creation

### DIFF
--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -443,9 +443,9 @@ var/list/removed_jobs = list(
 					return TRUE
 
 			if ("update-nameMiddle")
-				var/new_name = tgui_input_text(usr, "Please select a middle name:", "Character Generation", src.name_middle)
+				var/new_name = tgui_input_text(usr, "Please select a middle name:", "Character Generation", src.name_middle, allowEmpty = TRUE)
 				if (isnull(new_name))
-					return
+					new_name = ""
 				new_name = trimtext(new_name)
 				for (var/c in bad_name_characters)
 					new_name = replacetext(new_name, c, "")
@@ -453,8 +453,7 @@ var/list/removed_jobs = list(
 					tgui_alert(usr, "Your middle name is too long. It must be no more than [NAME_CHAR_MAX] characters long.", "Name too long")
 					return
 				else if (is_blank_string(new_name) && new_name != "")
-					tgui_alert(usr, "Your middle name cannot contain only spaces.", "Blank name")
-					return
+					new_name = ""
 				new_name = capitalize(new_name)
 				src.name_middle = new_name // don't need to check if there is one in case someone wants no middle name I guess
 				src.profile_modified = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes middle names to use `allowEmpty = TRUE`, changes any null names to `""`.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was weird how the game made it seem like you needed a middle name, but actually supports a lack of middle names just fine. This is a streamlining of the feature, because you can already force a `None` middle name by simply picking a character found in `bad_name_characters` such as `_` and making this your middle name, but that's clearly an exploit.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)You can now choose not to have a middle name in character creation by leaving it empty.
```
