### PR TITLE
Fix det_net breaking after using scuttlebot

### DIFF
--- a/code/datums/abilities/critter/scuttlebot.dm
+++ b/code/datums/abilities/critter/scuttlebot.dm
@@ -137,6 +137,7 @@
 				holder.owner.ghostize()
 				return 1
 			E.mind.transfer_to(E.controller)
+			E.controller.network_device = null
 			E.controller = null
 		else //In case this ability is put on another mob
 			boutput(holder.owner, SPAN_ALERT("You don't have a body to go back to!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The return to body ability never cleared the mob's network device, and the det_net goggles check for that before dropping the player into the vr office.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allow detectives to use both scuttlebots and det_net in the same round.
Fix #19498