### PR TITLE
Makes traitor bowling balls able to bowl multiple people over in a row

### DIFF
--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -18,7 +18,8 @@
 				if (!L.throws_can_hit_me) continue
 				if (L.lying) continue
 				src.throw_impact(A, thr)
-				. = TRUE
+				if (thr.stops_on_mob_hit)
+					. = TRUE
 			// **TODO: Better behaviour for windows
 			// which are dense, but shouldn't always stop movement
 			if(isobj(A))

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -24,6 +24,7 @@
 	var/dist_travelled = 0
 	var/speed_error = 0
 	var/throw_type
+	var/stops_on_mob_hit = TRUE
 
 	New(atom/movable/thing, atom/target, error, speed, dx, dy, dist_x, dist_y, range,
 			target_x, target_y, matrix/transform_original, list/params, turf/thrown_from, mob/thrown_by, atom/return_target,

--- a/code/obj/item/bowling.dm
+++ b/code/obj/item/bowling.dm
@@ -31,8 +31,7 @@
 		if(user.w_uniform && istype(user.w_uniform, /obj/item/clothing/under/gimmick/bowling))
 			hitMob.stuttering = max(damMax-5, hitMob.stuttering)
 			if (damMax-10 > 0)
-				hitMob.changeStatus("stunned", 4 SECONDS)
-				hitMob.changeStatus("knockdown", 4 SECONDS)
+				hitMob.changeStatus("knockdown", 5 SECONDS)
 				hitMob.force_laydown_standup()
 			hitMob.TakeDamageAccountArmor("chest", rand(damMin, damMax), 0)
 		else

--- a/code/obj/item/bowling.dm
+++ b/code/obj/item/bowling.dm
@@ -43,7 +43,8 @@
 			allow_anchored = UNANCHORED, bonus_throwforce = 0, end_throw_callback = null)
 		throw_unlimited = 1
 		src.icon_state = "bowling_ball_spin"
-		..()
+		var/datum/thrown_thing/thr = ..()
+		thr.stops_on_mob_hit = FALSE
 
 	attack_hand(mob/user)
 		..()
@@ -63,8 +64,9 @@
 						if (istype(user))
 							if (user.w_uniform && istype(user.w_uniform, /obj/item/clothing/under/gimmick/bowling))
 								src.hitHard(hitMob, user)
-
-								if(!(hitMob == user))
+								var/turf/new_target = get_steps(hitMob, get_dir(thr.thrown_from, get_turf(hitMob)), 8)
+								hitMob.throw_at(new_target, 8, thr.speed, thr.params, thr.thrown_from, thr.thrown_by, thr.throw_type)
+								if(!(hitMob == user) && !ON_COOLDOWN(user, "bowling_speak", 1 SECOND))
 									user.say(pick("Who's the kingpin now, baby?", "STRIIIKE!", "Watch it, pinhead!", "Ten points!"))
 							else
 								src.hitWeak(hitMob, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Traitor bowling balls now throw mobs they hit along their trajectory and continue flying after hitting a mob. This effect only applies when the thrower is wearing the bowling suit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny, someone suggested it, #19521 motivated me to add something cool too.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Traitor bowling balls thrown while wearing the bowling suit now throw people flying and can continue through multiple targets.
```
