### PR TITLE
Corrects name on Pod Wars Blaster Shotgun

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_weapons.dm
+++ b/code/datums/gamemodes/pod_wars/pw_weapons.dm
@@ -124,7 +124,7 @@ TYPEINFO(/obj/item/gun/energy/blaster_pod_wars)
 
 
 /obj/item/gun/energy/blaster_pod_wars/shotgun
-	name = "blaster smg"
+	name = "blaster shotgun"
 	desc = "A dangerous-looking blaster shotgun. It's self-charging by a radioactive power cell."
 	icon_state = "pw_shotgun"
 	item_state = "pw_shotgun"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Corrects the name of the blaster shotgun, which currently is called "blaster smg" in game.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Avoids confusion as there already is a Blaster SMG for the Pod Wars game mode.