### PR TITLE
Fix cannabis changing plant singletons

### DIFF
--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -200,16 +200,18 @@ proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/pare
 	//Now the seed it created and we can release it upon the world
 	return child
 
-proc/HYPgenerateplanttypecopy(var/obj/applied_object ,var/datum/plant/parent_planttype)
+proc/HYPgenerateplanttypecopy(var/obj/applied_object ,var/datum/plant/parent_planttype, var/force_new_datum = FALSE)
 	// this proc returns a copy of a planttype
 	// for basic plants, it just returns the planttype, since they are singletons.
 	// for spliced plants, since they run on instanced copies, it creates a new instance inside applied_object.
-	if (parent_planttype.hybrid)
+	// If we want to generate a new plant datum out one of our singletons, because we want to modify it (e.g. weed), set force_new_datum to TRUE
+	if (parent_planttype.hybrid || force_new_datum)
 		var/plantType = parent_planttype.type
 		var/datum/plant/hybrid = new plantType(applied_object)
 		for (var/transfered_variables in parent_planttype.vars)
 			if (issaved(parent_planttype.vars[transfered_variables]) && transfered_variables != "holder")
 				hybrid.vars[transfered_variables] = parent_planttype.vars[transfered_variables]
+		hybrid.hybrid = TRUE // That's cursed, but i'm here for it
 		return hybrid
 	else
 		return parent_planttype

--- a/code/modules/hydroponics/plants_herb.dm
+++ b/code/modules/hydroponics/plants_herb.dm
@@ -160,23 +160,32 @@ ABSTRACT_TYPE(/datum/plant/herb)
 
 	HYPharvested_proc(obj/machinery/plantpot/POT, mob/user)
 		// check if we need to add a suffix
+		var/new_weed_suffix = null
 		if (!src.weed_suffix && POT.plantgenes?.get_effective_value("potency") > INITIAL_REQUIRED_POTENCY)
-			src.weed_suffix = pick_string("chemistry_tools.txt", "WEED_suffixes")
+			new_weed_suffix = pick_string("chemistry_tools.txt", "WEED_suffixes")
 
-		if (src.weed_suffix)
+		if (src.weed_suffix || new_weed_suffix)
 			// if we have a suffix, check if we need to generate more prefixes
 			var/target_prefix_num = min(MAX_PREFIXES, round(POT.plantgenes?.get_effective_value("potency") / POTENCY_PER_PREFIX))
+			var/list/new_weed_prefix = src.weed_prefixes
 			if (length(src.weed_prefixes) < target_prefix_num)
 				var/prefixes_to_add = target_prefix_num - length(src.weed_prefixes)
 				for (var/i in 1 to prefixes_to_add)
-					weed_prefixes += pick_string("chemistry_tools.txt", "WEED_prefixes")
-
+					new_weed_prefix += pick_string("chemistry_tools.txt", "WEED_prefixes")
+			// we don't want to modify the cannabis singleton, so we force the generation of a new "hybrid" cannabis plant datum
+			var/datum/plant/herb/cannabis/new_cannabis_datum = HYPgenerateplanttypecopy(POT, src, TRUE)
 			// actually build the name
-			src.name = ""
-			for (var/prefix in src.weed_prefixes)
+			new_cannabis_datum.name = ""
+			if(new_weed_suffix)
+				new_cannabis_datum.weed_suffix = new_weed_suffix
+			new_cannabis_datum.weed_prefixes = new_weed_prefix
+			for (var/prefix in new_cannabis_datum.weed_prefixes)
 				// add in reverse order so newer prefixes are near the start
-				src.name = prefix + " [src.name]"
-			src.name += src.weed_suffix
+				new_cannabis_datum.name = prefix + " [new_cannabis_datum.name]"
+			new_cannabis_datum.name += new_cannabis_datum.weed_suffix
+			//now we are set and can insert our new cannabis datum into the plantpot
+			POT.current = new_cannabis_datum
+
 
 #undef INITIAL_REQUIRED_POTENCY
 #undef POTENCY_PER_PREFIX

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -883,10 +883,12 @@ TYPEINFO(/obj/machinery/plantpot)
 		return
 
 	if(growing.harvested_proc)
-		if(growing.HYPharvested_proc(src,user)) return
-		if(MUT?.HYPharvested_proc_M(src,user)) return
 		// Does this plant react to being harvested? If so, do it - it also functions as
 		// a check since harvesting will stop here if this returns anything other than 0.
+		if(growing.HYPharvested_proc(src,user)) return
+		if(MUT?.HYPharvested_proc_M(src,user)) return
+		//it can happen during HYPharvested_proc that the planttype in the pot gets replaced, we account for that here
+		growing = src.current
 
 	if(hydro_controls)
 		src.recently_harvested = 1


### PR DESCRIPTION
[hydroponics][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adjust `HYPgenerateplanttypecopy` with `var/force_new_datum`. If set to true, the return type of this proc will always be a new copy of `parent_planttype` with hybrid set to true, independant if the parent was a singleton or not.

This proc is used in `HYPharvested_proc` of cannabis to force it to create a new planttype if it adds new prefixes to its name.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

High potency cannabis was fucking around with singletons. This shouldn't happen and thus is getting fixed. The baseline cannabis seeds from the vendor shouldn't be worthy such awesome names :pensivefrog:.

This fixes #17796 
