### PR TITLE
Fix foil StG cards losing prefix on flipping

### DIFF
--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -327,6 +327,7 @@
 		UpdateOverlays(image(icon,"stg-foil"),"foil")
 		foiled = TRUE
 		name = "Foil [name]"
+		src.update_stored_info()
 
 /obj/item/playing_card/expensive //(¬‿¬)
 	desc = "Tap this card and sacrifice one of yourselves to win the game."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [UI] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Call `update_stored_info` after "foil" is added to card name so it persists between flipping the card face up/down.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flipping the card face down and then back up causes the item name to lose the foil prefix.