### PR TITLE
New pronoun proc + pronoun fixes for juggling

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2979,7 +2979,7 @@
 
 	if (!src.juggling())
 		return
-	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything they were juggling!"))
+	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything [he_or_she(src)] [were_or_was(src)] juggling!"))
 	for (var/atom/movable/A in src.juggling)
 		src.remove_juggle(A)
 		if(istype(A, /obj/item/device/light)) //i hate this
@@ -3033,7 +3033,7 @@
 				continue
 			items += ", [juggled]"
 		items = copytext(items, 3)
-		src.visible_message("<b>[src]</b> adds [thing] to the [items] [he_or_she(src)]'s already juggling!")
+		src.visible_message("<b>[src]</b> adds [thing] to the [items] [he_or_she(src)] [were_or_was(src)] already juggling!")
 	else
 		src.visible_message("<b>[src]</b> starts juggling [thing]!")
 	src.juggling += thing

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -532,6 +532,10 @@
 /proc/blank_or_es(mob/subject)
 	return subject.get_pronouns().pluralize ? "" : "es"
 
+/// 'they were' vs 'he was'
+/proc/were_or_was(var/mob/subject)
+	return subject.get_pronouns().pluralize ? "were" : "was"
+
 /mob/proc/get_explosion_resistance()
 	return min(GET_ATOM_PROPERTY(src, PROP_MOB_EXPLOPROT), 100) / 100
 


### PR DESCRIPTION
[ui][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new proc (they were/he was) for pronouns, and uses it to fix pronoun usage in juggling 
![image-1](https://github.com/goonstation/goonstation/assets/142273065/b83b7c88-6a2e-4eda-a979-7f3a1ca6afc5)
![image-1](https://github.com/goonstation/goonstation/assets/142273065/f4efc781-2b06-4bfb-8af4-c8571cb8c899)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
x adds y to the z they's already juggling is wack and the dropping items just didnt use pronouns at all. pronouns good


