### PR TITLE
Block ants on restrict Z levels

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -44,6 +44,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	proc/ant_safe()
 		if (!isturf(src.loc))
 			return FALSE
+		if (isrestrictedz(src.loc.z))
+			return TRUE // there are no ants in deep space...
 		if (locate(/obj/table) in src.loc) // locate is faster than typechecking each movable
 			return TRUE
 		if (locate(/obj/surgery_tray) in src.loc) // includes kitchen islands


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Prevents ants from appearing in restricted z foods


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes https://github.com/goonstation/goonstation-secret/issues/626


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Ants will no longer spawn in food located on restricted Z levels
```
