### PR TITLE
Fix double filling on hydroponics mister

### DIFF
--- a/code/obj/machinery/hydroponic_machines.dm
+++ b/code/obj/machinery/hydroponic_machines.dm
@@ -190,17 +190,6 @@ TYPEINFO(/obj/machinery/hydro_mister)
 			user.visible_message("<b>[user]</b> unbolts the [src] from the floor!")
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		src.anchored = !src.anchored
-	if(istype(W, /obj/item/reagent_containers/glass/) && W.is_open_container(FALSE))
-		// Not just watering cans - any kind of glass can be used to pour stuff in.
-		if(!W.reagents.total_volume)
-			boutput(user, SPAN_ALERT("There is nothing in [W] to pour!"))
-			return
-		else
-			user.visible_message(SPAN_NOTICE("[user] pours [W:amount_per_transfer_from_this] units of [W]'s contents into [src]."))
-			playsound(src.loc, 'sound/impact_sounds/Liquid_Slosh_1.ogg', 25, 1)
-			W.reagents.trans_to(src, W:amount_per_transfer_from_this)
-			if(!W.reagents.total_volume) boutput(user, SPAN_ALERT("<b>[W] is now empty.</b>"))
-
 
 /obj/machinery/hydro_mister/attack_hand(var/mob/user)
 	src.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Remove the code in `attackby` of the hydroponics mister to handle being clicked with reagent containers because all of that behavior exists in `/obj/item/reagent_containers/glass/afterattack`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently clicking on the mister with a reagent container transfers 20 units into it, because first the `afterattack` code runs and then the `attackby` code runs, producing two separate messages and generally being very confusing.