### PR TITLE
Make health scanners/operating computers report synthetic organs

### DIFF
--- a/code/obj/machinery/computer/operating.dm
+++ b/code/obj/machinery/computer/operating.dm
@@ -170,6 +170,8 @@
 		else
 			if (O.robotic)
 				special = "Cybernetic"
+			if (O.synthetic)
+				special = "Synthetic"
 			if (O.unusual)
 				special = "Unusual"
 			var/list/organ_calc = calc_organ_damage_severity(O)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -289,10 +289,12 @@
 		ret += "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
 	else if (damage > 0)
 		ret += "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
-	else if (O.robotic || O.unusual)
+	else if (O.robotic || O.unusual || O.synthetic)
 		ret += "<br><span style='color:purple'><b>[O.name]</b></span>"
 	if (O.robotic)
 		ret += "<span style='color:purple'> - Robotic organ detected</span>"
+	else if (O.synthetic)
+		ret += "<span style='color:purple'> - Synthetic organ detected</span>"
 	else if (O.unusual)
 		ret += "<span style='color:purple'> - Unknown organ detected</span>"
 	return ret.Join()

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -289,12 +289,10 @@
 		ret += "<br><span style='color:purple'><b>[O.name]</b> - Moderate</span>"
 	else if (damage > 0)
 		ret += "<br><span style='color:purple'><b>[O.name]</b> - Minor</span>"
-	else if (O.robotic || O.unusual || O.synthetic)
+	else if (O.robotic || O.unusual)
 		ret += "<br><span style='color:purple'><b>[O.name]</b></span>"
 	if (O.robotic)
 		ret += "<span style='color:purple'> - Robotic organ detected</span>"
-	else if (O.synthetic)
-		ret += "<span style='color:purple'> - Synthetic organ detected</span>"
 	else if (O.unusual)
 		ret += "<span style='color:purple'> - Unknown organ detected</span>"
 	return ret.Join()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds support for health scanners/operating computers to report when an organ is the synthetic version.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19560 (cyborg ones work)