### PR TITLE
Spare command PDAs in their lockers

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -220,7 +220,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/stamp/cap,
 	/obj/item/device/radio/headset/command/captain,
 	/obj/item/megaphone,
-	/obj/item/pet_carrier)
+	/obj/item/pet_carrier,
+	/obj/item/device/pda2/captain)
 
 	make_my_stuff()
 		if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
@@ -257,7 +258,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/stamp/hos,
 	/obj/item/device/radio/headset/command/hos,
 	/obj/item/clothing/shoes/swat/heavy,
-	/obj/item/barrier)
+	/obj/item/barrier,
+	/obj/item/device/pda2/hos)
 
 /obj/storage/secure/closet/command/hop
 	name = "\improper Head of Personnel's locker"
@@ -272,7 +274,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/device/accessgun,
 	/obj/item/clipboard,
 	/obj/item/clothing/suit/hopjacket,
-	/obj/item/pet_carrier)
+	/obj/item/pet_carrier,
+	/obj/item/device/pda2/hop)
 
 /obj/storage/secure/closet/command/research_director
 	name = "\improper Research Director's locker"
@@ -290,7 +293,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/stamp/rd,
 	/obj/item/clothing/suit/labcoat,
 	/obj/item/device/radio/headset/command/rd,
-	/obj/item/pet_carrier)
+	/obj/item/pet_carrier,
+	/obj/item/device/pda2/research_director)
 
 	make_my_stuff()
 		if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
@@ -316,7 +320,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/device/flash,
 	/obj/item/stamp/md,
 	/obj/item/device/radio/headset/command/md,
-	/obj/item/pet_carrier)
+	/obj/item/pet_carrier,
+	/obj/item/device/pda2/medical_director)
 
 	make_my_stuff()
 		if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
@@ -343,6 +348,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 		/obj/item/storage/toolbox/mechanical/yellow_tools,
 		/obj/item/storage/box/misctools,
 		/obj/item/extinguisher,
+		/obj/item/device/pda2/chiefengineer,
 	#ifdef MAP_OVERRIDE_OSHAN
 		/obj/item/clothing/shoes/stomp_boots,
 	#endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a spare command PDA to all command lockers
![image](https://github.com/goonstation/goonstation/assets/159719201/6ef9315d-15f6-4228-82e4-c2591e9f8c1f)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For a couple reasons really mainly being these cannot ever be obtained outside of joining as that role, and it automatically gives the PDA the name of the owner when they join so anyone attempting to impersonate a head of staff is obvious by lack of command PDA (and the worldwide "George Khouri is the Medical Director!" message but that is very possible to miss).

In addition there is no way to replace these if you happen to lose them as command so like the headsets a spare would be nice to have in their locker.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Replacement command PDAs can now be found in their lockers. Helpful for impersonating heads of staff.
```
