### PR TITLE
Add PDA message feedback for sold pressure crystals

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -556,7 +556,7 @@
 		if (sell && value > 0)
 			src.pressure_crystal_sales["[pc.pressure]"] = value
 
-		// give PDA group messages
+		// tell sci
 		var/datum/signal/pdaSignal = get_free_signal()
 		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] pressure. "
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"=message)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -559,7 +559,7 @@
 		// give PDA group messages
 		var/datum/signal/pdaSignal = get_free_signal()
 		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] pressure. "
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"=message)
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"=message)
 		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
 
 		return value

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -555,6 +555,13 @@
 		value = round(value)
 		if (sell && value > 0)
 			src.pressure_crystal_sales["[pc.pressure]"] = value
+
+		// give PDA group messages
+		var/datum/signal/pdaSignal = get_free_signal()
+		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] pressure. "
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGD_SCIENCE, MGA_SALES), "sender"="00000000", "message"=message)
+		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
+
 		return value
 
 	proc/handle_returns(obj/storage/crate/sold_crate,var/return_code)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -558,7 +558,7 @@
 
 		// tell sci
 		var/datum/signal/pdaSignal = get_free_signal()
-		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] pressure. "
+		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] kiloblast. "
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"=message)
 		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
 


### PR DESCRIPTION
[QOL][UI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets science know about outgoing pressure crystal sales.
![image-1](https://github.com/goonstation/goonstation/assets/142273065/e47eef01-61f2-4b1a-8b96-77f4af30b2ac)
(after taking this screenshot I changed it to say 12 kiloblast like the pressure sensor does)

Unlike the artifact response, only sending them to sci PDAs as pressure crystals are sold in crates so cargo already gets the commodity sales alert, and I don't believe they need to have the pressure info in the same way as knowing how artlab did is useful since there's not really a fail state for pressure crystals in the same way as for misidentifying artifacts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Selling pressure crystals is exciting, sitting there refreshing the bazaar to see when cargo got around to selling it less fun.  Also lets everyone else in the department know about your sales since we get to hear about artlabs. ^___^
I tested this and it seemed to work but I'm very new to coding so please let me know if any of this is goofy....
