### PR TITLE
Don't send pda message on appraising pressure crystal

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -555,12 +555,10 @@
 		value = round(value)
 		if (sell && value > 0)
 			src.pressure_crystal_sales["[pc.pressure]"] = value
-
-		// tell sci
-		var/datum/signal/pdaSignal = get_free_signal()
-		var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] kiloblast. "
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"=message)
-		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
+			var/datum/signal/pdaSignal = get_free_signal() // tell sciv
+			var/message = "Notification: [value] credits earned from outgoing pressure crystal at [pc.pressure] kiloblast. "
+			pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_SCIENCE), "sender"="00000000", "message"=message)
+			radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
 
 		return value
 


### PR DESCRIPTION
[Bug][UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only send PDA message notifying about pressure crystal sale to sci if pressure crystal is actually sold, and had value


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #19599 , as well as another thing I noticed in round earlier where someone spammed sci PDA group by selling lots of duplicate but worthless crystals
tested it and it seemed to fix both problems
