### PR TITLE
Add empty faded slot to unavailable jobs

### DIFF
--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -476,13 +476,14 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 
 		var/limit = J.limit
 		var/c = J.assigned
+		var/allowed = TRUE
 		if (limit == 0 && c == 0)
 			// 0 slots, nobody in it, don't show it
 			return
 
 		if (!job_controls.check_job_eligibility(src, J, STAPLE_JOBS | SPECIAL_JOBS))
 			// Show unavailable jobs, but no joining them
-			limit = 0
+			allowed = FALSE
 
 		//If it's Revolution time, lets show all command jobs as filled to (try to) prevent metagaming.
 		if(istype(J, /datum/job/command/) && istype(ticker.mode, /datum/game_mode/revolution))
@@ -507,6 +508,7 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 			// can you believe all these slot appendages were in one line before using nested ternaries? awful.
 			if (i <= c)
 				if (i == 1 && c > shown)
+					// display +X card
 					slots += {"
 					<div
 					class='latejoin-card latejoin-full'
@@ -516,6 +518,7 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 					</div>
 					"}
 				else
+					// display crossed out card
 					slots += {"
 					<div
 					class='latejoin-card latejoin-full'
@@ -525,18 +528,30 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 					</div>
 					"}
 			else
-				slots += {"
-				<a
-				href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=join'
-				class='latejoin-card' style='border-color: [J.linkcolor];'
-				title='[hover_text]'
-				>&#x2713;&#xFE0E;
-				</a>
-				"}
+				if(allowed)
+					// display joinable slot
+					slots += {"
+					<a
+					href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=join'
+					class='latejoin-card' style='border-color: [J.linkcolor];'
+					title='[hover_text]'
+					>&#x2713;&#xFE0E;
+					</a>
+					"}
+				else
+					// display faded empty slot
+					slots += {"
+					<div
+					class ='latejoin-card latejoin-full'
+					style='border-color: [J.linkcolor]; background-color: [J.linkcolor];'
+					title='Job unavailable.'
+					>&#xA0;
+					</div>
+					"}
 		return {"
 			<tr>
 				<td class='latejoin-link[J.is_highlighted() ? " highlighted" : ""]'>
-					[(limit == -1 || c < limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=prompt' style='color: [J.linkcolor];' title='[hover_text]'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
+					[((limit == -1 || c < limit) && allowed) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J];latejoin=prompt' style='color: [J.linkcolor];' title='[hover_text]'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is unavailable.'>[J.name]</span>"]
 				</td>
 				<td class='latejoin-cards'>[jointext(slots, " ")]</td>
 			</tr>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the latejoin menu so jobs that aren't available (whitelist, sous-chef before chef, etc.) show a faded box next to the name, like an occupied slot but without the X, instead of just showing the job name and no slots. Also adds some comments to the different if branches in the code there cause it sucks to read.

![image](https://github.com/goonstation/goonstation/assets/75404941/b01f8ea3-e428-4020-ba21-6eb7d9d1e873)
Comparison with MD full and HoS not available to me.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Just having the job name floating there with no boxes looks weird and messes up the alignment a bit. Closes #19353