### PR TITLE
Only show computer disassemble help message when relevant

### DIFF
--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -20,7 +20,9 @@
 
 	///Set to TRUE to make multitools call connection_scan. For consoles with associated equipment (cloner, genetek etc)
 	var/can_reconnect = FALSE
+	///The related circuit board type for replacement/repairs
 	var/obj/item/circuitboard/circuit_type = null
+
 	Topic(href, href_list)
 		if (..(href, href_list))
 			return 1
@@ -51,11 +53,12 @@
 			src.Attackhand(user)
 
 	get_help_message(dist, mob/user)
-		. = "You can use a <b>screwdriver</b> to unscrew the screen"
+		if (src.circuit_type)
+			. = "Use a <b>screwdriver</b> to unscrew the screen."
 		if (src.can_reconnect)
-			. += ",\nor a <b>multitool</b> to re-scan for equipment."
-		else
-			. += "."
+			if (.)
+				.+= "\n"
+			. += "Use a <b>multitool</b> to re-scan for equipment."
 
 	proc/unscrew_monitor(obj/item/W as obj, mob/user as mob)
 		var/obj/computerframe/A = new /obj/computerframe(src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only show the help message for unscrewing a computer screen if the computer is unscrewable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #14587