### PR TITLE
Fixes antag objective medals not unlocking

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -94,11 +94,6 @@ ABSTRACT_TYPE(/datum/game_mode)
 		var/obj_count = 0
 		var/traitor_name
 
-		// This is a really hacky check to prevent traitors from being outputted twice if their primary antag role has an antagonist datum that could be used for data instead.
-		// Once antagonist datums are completed, this check should be removed entirely.
-		if (traitor.get_antagonist(traitor.special_role))
-			continue
-
 		if (traitor.current)
 			traitor_name = "[traitor.current.real_name] (played by [traitor.displayed_key])"
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MEDAL] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the hacky workaround in `declare_completion()` that was supposed to be removed when antag datumization was finished because it's breaking objective-based medal rewards.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #18325 
Fixes #17933
Fixes #17667 