### PR TITLE
Fix sec camera console giving you duplicate exit buttons

### DIFF
--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -329,9 +329,10 @@ chui/window/security_cameras
 					C.connect_viewer(user)
 				owner.current = C
 				owner.last_viewer = user
-				user.item_abilities += new /obj/ability_button/reset_view/console()
-				user.need_update_item_abilities = 1
-				user.update_item_abilities()
+				if(!(locate(/obj/ability_button/reset_view/console) in user.item_abilities))
+					user.item_abilities += new /obj/ability_button/reset_view/console()
+					user.need_update_item_abilities = 1
+					user.update_item_abilities()
 
 		else if (href_list["save"])
 			var/obj/machinery/camera/C = locate(href_list["save"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Check if the user has the exit camera ability before giving one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19185 