### PR TITLE
Revert "stop a proc from updating a mob's scream if there's one there"

### DIFF
--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -331,6 +331,8 @@ var/list/datum/bioEffect/mutini_effects = list()
 			H.update_body()
 			H.update_clothing()
 
+			H.sound_scream = screamsounds[screamsound || "male"] || screamsounds["male"]
+			H.sound_fart = fartsounds[fartsound || "default"] || fartsounds["default"]
 			H.voice_type = voicetype || RANDOM_HUMAN_VOICE
 
 			if (H.mutantrace.voice_override)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RESPAWNING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reverts goonstation/goonstation#19449

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19524 
Fixes #19547 