### PR TITLE
Fix contributor scream resetting constantly

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1517,7 +1517,9 @@
 	proc/sillyscream(mob/M)
 		var/mob/living/living = M
 		if(istype( living ))
-			living.sound_scream = pick('sound/voice/screams/sillyscream1.ogg','sound/voice/screams/sillyscream2.ogg')
+			M.bioHolder.mobAppearance.screamsounds["sillyscream"] = pick('sound/voice/screams/sillyscream1.ogg', 'sound/voice/screams/sillyscream2.ogg')
+			M.bioHolder.mobAppearance.screamsound = "sillyscream"
+			M.bioHolder.mobAppearance.UpdateMob()
 			M.playsound_local_not_inworld(living.sound_scream, 100)
 			return 1
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes contributor scream code to add sound to appearanceHolder list of screams and change `screamsound` to match, instead of setting `sound_scream` directly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Contributor scream was reverting every time `appearanceHolder.UpdateMob()` was called (which is often)
