### PR TITLE
Donut 3 Mining Staff Room gets mugs

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -74423,6 +74423,9 @@
 	dir = 6;
 	icon_state = "line2"
 	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "wwb" = (
@@ -78470,14 +78473,15 @@
 	name = "autoname  - SS13";
 	tag = ""
 	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /obj/table/auto,
 /obj/machinery/coffeemaker/engineering{
 	pixel_y = 6
 	},
 /obj/item/kitchen/food_box/sugar_box,
+/obj/drink_rack/mug{
+	pixel_x = -26;
+	pixel_y = 6
+	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "xAB" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Miners had a coffee machine but no mugs, moved the display up and placed mugs, miners can drink coffee now

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No mugs but coffee machine smells like oversight



