### PR TITLE
Geodes can only be broken open once

### DIFF
--- a/code/obj/geodes.dm
+++ b/code/obj/geodes.dm
@@ -20,7 +20,7 @@ ADMIN_INTERACT_PROCS(/obj/geode, proc/break_open)
 			AM.set_loc(src.loc)
 
 	ex_act(severity, last_touched, power, datum/explosion/explosion)
-		if ((explosion?.power || power) >= src.break_power)
+		if (!src.broken && ((explosion?.power || power) >= src.break_power))
 			src.break_open()
 
 /obj/geode/crystal


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check if the geode is already broken open before calling break_open


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19629
