### PR TITLE
Bible compatibility range-check optimization

### DIFF
--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -117,8 +117,10 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		return TRUE
 	if(BOUNDS_DIST(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
 		return TRUE
-	else if ((source in bible_contents) && locate(/obj/item/bible) in range(1, user)) // whoever added the global bibles, fuck you
-		return TRUE
+	else if ((source in bible_contents) && locate(/obj/item/bible) in range(1, user))
+		for_by_tcl(B, /obj/item/bible) // o coder past, quieten your rage
+			if(IN_RANGE(user,B,1))
+				return TRUE
 	else
 		if (iscarbon(user))
 			var/mob/living/carbon/C = user
@@ -199,7 +201,11 @@ proc/reachable_in_n_steps(turf/from, turf/target, n_steps, use_gas_cross=FALSE)
 	if(user.client?.holder?.ghost_interaction)
 		return TRUE
 	if (target in bible_contents)
-		target = locate(/obj/item/bible) in range(1, user) // fuck bibles
+		target = null
+		for_by_tcl(B, /obj/item/bible)
+			if(IN_RANGE(user,B,1))
+				target = B
+				break
 		if (!target)
 			return 0
 	var/turf/UT = get_turf(user)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -117,7 +117,7 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		return TRUE
 	if(BOUNDS_DIST(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
 		return TRUE
-	else if ((source in bible_contents) && locate(/obj/item/bible) in range(1, user))
+	else if (source in bible_contents)
 		for_by_tcl(B, /obj/item/bible) // o coder past, quieten your rage
 			if(IN_RANGE(user,B,1))
 				return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL][CLEAN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters in_interact_range() and can_reach() code that accommodates bible_contents.

Instead of using locate() in range 1 and iterating over (up to) every object in a 3x3 area to check for a proximate bible, simply iterates over each bible using for_by_tcl (maps usually have one or two bibles total) to check if it's in range.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should be a small but notable improvement to these commonly-used procs.