### PR TITLE
Adds gas extractors to toxins storage on most rotation maps

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7651,7 +7651,6 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "aYy" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -7659,6 +7658,7 @@
 	pixel_x = -10
 	},
 /obj/decal/stripe_caution,
+/obj/machinery/manufacturer/gas,
 /turf/simulated/floor,
 /area/station/science/lab)
 "aYz" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -28536,10 +28536,10 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bYT" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/manufacturer/gas,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "bYV" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -50868,7 +50868,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "cUW" = (
@@ -51876,7 +51876,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "cYD" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
@@ -51884,6 +51883,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/machinery/manufacturer/gas,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "cYE" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1306,7 +1306,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agQ" = (
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/manufacturer/gas,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agT" = (
@@ -28501,8 +28501,8 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "jIt" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/light/small/sticky/frostedred,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "jIC" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7257,6 +7257,7 @@
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
+/obj/machinery/manufacturer/gas,
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
 "cbm" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -39844,6 +39844,10 @@
 	},
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/clown)
+"nsC" = (
+/obj/machinery/manufacturer/gas,
+/turf/simulated/floor,
+/area/research_outpost/toxins)
 "ntg" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -130706,7 +130710,7 @@ eYr
 dBL
 wxZ
 aTq
-bbP
+nsC
 bcV
 bdl
 beh


### PR DESCRIPTION
[QOL] [mapping] [science]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a gas extractor to the canister storage area for plasma research on all rotation maps bar 2 (Kondaru already has one, and atlas toxins is itty bitty anyways, you can just go talk to QM)

For most maps, I removed one of the empty canisters from storage to make room, as gas extractors can print as many empty canisters as you need if you feed it metal.  Clarion I removed an oxygen canister instead, but that means there's still five by default which is more than cog1 so should be fine.

If the placements need to be adjusted, let me know  --  I dunno what the best spot would be, just kinda went based on vibes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Asked around in the discord about thoughts on this and the general feedback was that it would be a fine change, as "access to plasma canisters" is not really a measure of balance for antag actions  --  if you're making big TTVs, one plasma canister will fill as many TTVs as you want, generally.  If you're plasma flooding, you can already use the extractors in engineering (or QM on some maps), or just... use the existing plasma canisters.  There's a fair handful, generally.

However, having access to a gas extractor is a huge boon/QOL for non-antag toxins use, especially when dealing with the crystal bazaars bounty system which encourages experimenting with different temperatures of gas beyond just "what will make a maxcap."  Also, you still need mining inter-departmental cooperation to be able to use it to begin with  --  it comes unstocked, like in engineering/QM.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)joeled
(+)Plasma Research has been outfitted with their own gas extractor on nearly all stations.
```

We have mapdiffbot at home 
![d02lpCO](https://github.com/goonstation/goonstation/assets/142273065/db27756e-ffc6-4657-b355-771829e26225)

