### PR TITLE
Use a process controller to handle shipping market refreshes

### DIFF
--- a/code/datums/controllers/process/shipping_market.dm
+++ b/code/datums/controllers/process/shipping_market.dm
@@ -1,0 +1,13 @@
+/// Handles updating the shipping market
+/datum/controller/process/shipping_market
+	setup()
+		name = "Shipping Market Update"
+		schedule_interval = 7.5 MINUTES
+		schedule_jitter = 90 SECONDS
+
+	doWork()
+		shippingmarket?.market_shift()
+
+	queued()
+		. = ..()
+		shippingmarket.time_until_shift = TIME + src.schedule_interval + src.schedule_jitter

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -74,6 +74,7 @@
 
 		SPAWN(300)
 			market_shift()
+			auto_market_refresh()
 
 		var/list/unique_traders = list(/datum/trader/gragg,/datum/trader/josh,/datum/trader/pianzi_hundan,
 		/datum/trader/vurdalak,/datum/trader/buford)
@@ -315,6 +316,12 @@
 
 			update_shipping_data()
 			update_buy_prices()
+
+	///Ensure market refresh / mail delivery happens regularly, even if no one checks the console
+	proc/auto_market_refresh()
+		src.timeleft()
+		SPAWN(5 MINUTES)
+			src.auto_market_refresh()
 
 	proc/generate_mail(time_since_previous)
 		var/adjustment = max(time_since_previous, 2 MINUTES)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -335,6 +335,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\controllers\process\random_events.dm"
 #include "code\datums\controllers\process\respawn.dm"
 #include "code\datums\controllers\process\sea_hotspots.dm"
+#include "code\datums\controllers\process\shipping_market.dm"
 #include "code\datums\controllers\process\stamina_updates.dm"
 #include "code\datums\controllers\process\statusEffects.dm"
 #include "code\datums\controllers\process\stock_market.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move shipping market refresh handling to a process controller.

Note: This will cause mail deliveries to occur even when there are no QMs/Mail Couriers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mail couriers do not have QM console access, and thus cannot recieve more mail until the market has refreshed. If there is no active QMs for whatever reason, then the mail courier can be SOL with their one job.
Stifle some small cheese where you can keep hot items hot indefinitely if no one ever checks the console.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Market refreshes and mail deliveries will now occur automatically.
```
