### PR TITLE
Fix VR scream and fart sounds not working

### DIFF
--- a/code/mob/living/carbon/human/virtual.dm
+++ b/code/mob/living/carbon/human/virtual.dm
@@ -9,8 +9,10 @@
 		..()
 		sound_burp = 'sound/voice/virtual_gassy.ogg'
 		//sound_malescream = 'sound/voice/virtual_scream.ogg'
-		sound_scream = 'sound/voice/virtual_scream.ogg'
-		sound_fart = 'sound/voice/virtual_gassy.ogg'
+		src.bioHolder.mobAppearance.screamsounds["virtual"] = 'sound/voice/virtual_scream.ogg'
+		src.bioHolder.mobAppearance.screamsound = "virtual"
+		src.bioHolder.mobAppearance.fartsounds["virtual"] = 'sound/voice/virtual_gassy.ogg'
+		src.bioHolder.mobAppearance.fartsound = "virtual"
 		sound_snap = 'sound/voice/virtual_snap.ogg'
 		sound_fingersnap = 'sound/voice/virtual_snap.ogg'
 		SPAWN(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change `New()` on virtual mob to set fart and scream sounds in bioHolder instead of directly on mob.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Scream and fart sounds for these were just resetting to the defaults.
