### PR TITLE
Transport chutes flush after people have finished entering, instead of right away

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -674,7 +674,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		if (!istype(target) || target.buckled || BOUNDS_DIST(user, src) > 0 || BOUNDS_DIST(user, target) > 0 || is_incapacitated(user) || isAI(user) || isAI(target) || isghostcritter(user))
 			return
 		..()
-		flush = 1
 
 		if (!is_processing)
 			SubscribeToProcess()
@@ -854,7 +853,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			if (msg)
 				chute.visible_message(msg)
 
-			chute.ui_interact(user)
+			if (istype(src.chute, /obj/machinery/disposal/transport))
+				src.chute.flush = TRUE
+			else
+				chute.ui_interact(user)
 
 			chute.update()
 		..()

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -670,6 +670,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 	attackby(var/obj/item/I, var/mob/user)
 		return
 
+	Entered()
+		. = ..()
+		flush = 1
+
 	MouseDrop_T(mob/target, mob/user)
 		if (!istype(target) || target.buckled || BOUNDS_DIST(user, src) > 0 || BOUNDS_DIST(user, target) > 0 || is_incapacitated(user) || isAI(user) || isAI(target) || isghostcritter(user))
 			return
@@ -853,10 +857,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			if (msg)
 				chute.visible_message(msg)
 
-			if (istype(src.chute, /obj/machinery/disposal/transport))
-				src.chute.flush = TRUE
-			else
-				chute.ui_interact(user)
+			chute.ui_interact(user)
 
 			chute.update()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Set transport chutes to flush at the end of the action bar for entering/shoving someone into a chute instead of immediately.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes transport chutes consistently send people after they've entered, instead of depending on machineloop process timing.
Not popping up a UI makes them feel more 'automatic'; you can still bring up the ui by slapping it with your hands before entering.