### PR TITLE
Cyborg docking station click-drag range buff

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -187,8 +187,12 @@ TYPEINFO(/obj/machinery/recharge_station)
 		. = ..()
 
 /obj/machinery/recharge_station/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
-	if (BOUNDS_DIST(AM, src) > 0 || BOUNDS_DIST(src, user) > 0)
-		return
+	if (ismob(AM))
+		if (BOUNDS_DIST(AM, src) > 0 || BOUNDS_DIST(src, user) > 0)
+			return
+	else
+		if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0)
+			return
 	if (!isturf(AM.loc) && !(AM in user))
 		return
 	if (!isliving(user) || isAI(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before running the distance check for click-drag validity check on the cyborg dock if whats being click-dragged is a mob, if it is use current range, if its not use old range


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change was made so you couldn't click-drag people at long distance into the conversion chamber, however it removed the ability to put clothes and upgrades in a dock at a further distance, which was nice QOL for borgs.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Objects can now be click-dragged into cyborg docks from further away. Mobs still require the shorter distance.
```
