### PR TITLE
Removes floorpills from the brig

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45200,7 +45200,6 @@
 /obj/item/storage/toilet{
 	dir = 4
 	},
-/obj/item/storage/pill_bottle/cyberpunk,
 /turf/simulated/floor/sanitary,
 /area/station/security/brig)
 "ipZ" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -37670,15 +37670,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"pmI" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = 6
-	},
-/obj/machinery/drainage,
-/obj/item/storage/pill_bottle/cyberpunk,
-/turf/simulated/floor/grime,
-/area/station/security/brig)
 "pmU" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -95740,7 +95731,7 @@ bpF
 lZM
 bgL
 bgL
-pmI
+qLw
 qLw
 bns
 bns


### PR DESCRIPTION
[MAPPING]
## About the PR
Removes floorpills bottles from the bathrooms of the donut2 and cogmap1 brigs.

## Why's this needed?
It's not present on the other maps and causes stirstir to think "yum yum" and go into anaphylactic shock. Not ideal.
