### PR TITLE
Re adds the two pill bottles in different places

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6988,6 +6988,7 @@
 /area/station/storage/emergency)
 "aAG" = (
 /obj/machinery/drone_recharger,
+/obj/item/storage/pill_bottle/cyberpunk,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aAH" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -49505,6 +49505,10 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"wLi" = (
+/obj/item/storage/pill_bottle/cyberpunk,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "wLu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -92719,7 +92723,7 @@ vvh
 beM
 beM
 beM
-beM
+wLi
 beT
 cNv
 beT


### PR DESCRIPTION
[MAPPING] [QOL] [BALANCE] (allegedly)
## About the PR
The sequel to #19673

Puts the removed bottles somewhere nearby in the maints but not inside the brig.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
SOMEONE was complaining. Also there aren't that many of these so they probably shouldn't just get removed.