### PR TITLE
Changes the max stack for pipeshot from 4 to 8

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -827,26 +827,26 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/special/spreader/buckshot_burst
 	icon_state = "makeshiftscrap"
 	amount_left = 4
-	max_amount = 4
+	max_amount = 8
 	ammo_cat = AMMO_SHOTGUN_HIGH
 	delete_on_reload = TRUE
 	sound_load = 'sound/weapons/gunload_heavy.ogg'
 
 /obj/item/ammo/bullets/pipeshot/plasglass // plasmaglass handmade shells
 	sname = "plasmaglass load"
-	desc = "Some mean-looking plasmaglass shards that are jammed into a few cut open pipe frames."
+	desc = "Some mean-looking plasmaglass crystals that have been jammed into cut open pipe frames."
 	ammo_type = new/datum/projectile/special/spreader/buckshot_burst/plasglass
 	icon_state = "makeshiftplasglass"
 
 /obj/item/ammo/bullets/pipeshot/glass // glass handmade shells
 	sname = "glass load"
-	desc = "This appears to be some glass shards haphazardly shoved into a few cut open pipe frames."
+	desc = "Some broken glass that's been jammed into cut open pipe frames."
 	ammo_type = new/datum/projectile/special/spreader/buckshot_burst/glass
 	icon_state = "makeshiftglass"
 
 /obj/item/ammo/bullets/pipeshot/scrap // scrap handmade shells
 	sname = "scrap load"
-	desc = "This appears to be some metal bits haphazardly shoved into a few cut open pipe frames."
+	desc = "Some metal bits that have been jammed into cut open pipe frames."
 	ammo_type = new/datum/projectile/special/spreader/buckshot_burst/scrap
 
 /obj/item/ammo/bullets/pipeshot/scrap/five
@@ -855,7 +855,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 
 /obj/item/ammo/bullets/pipeshot/bone // scrap handmade bone shells
 	sname = "bone load"
-	desc = "This appears to be some bone fragments haphazardly shoved into a few cut open pipe frames - grotesque!"
+	desc = "Chunks of bone that have been jammed into cut open pipe frames - grotesque!"
 	ammo_type = new/datum/projectile/special/spreader/buckshot_burst/bone
 
 /obj/item/ammo/bullets/nails // oh god oh fuck


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Quite literally a one-line change that makes it so you can bunch two pipeshot stacks together. Since I was in there I also made the descriptions a little less clunky and it's not really worth atomizing out. (I still can if need be)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Honestly, this is a QoL change more than anything. Every other shotgun shell type starts out as a stack of either 7 or 8 shells, and since you can already use the unload-reload trick to make stacks of 8 pipeshot, there's no real point in not having it be an intentional feature.  

The only issue I can think of is balance reasons, but I doubt it's that big of a concern; anyone with access to a shotgun that isn't a slamgun or double-barrel is already capable of stacking pipeshot beyond 4.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NightmarechaMillian
(+)Max pipeshot stack 4 -> 8
```
