### PR TITLE
Prevents mechscanned sawflies from producing remotes

### DIFF
--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -51,7 +51,8 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 			heldfly.ai = new /datum/aiHolder/aggressive(heldfly)
 
 		qdel(src)
-/obj/item/old_grenade/sawfly/firsttime//super important- traitor uplinks and sawfly pouches use this specific version
+
+/obj/item/old_grenade/sawfly/firsttime //super important- traitor uplinks and sawfly pouches use this specific version
 	New()
 
 		heldfly = new /mob/living/critter/robotic/sawfly(src.loc)
@@ -60,6 +61,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 		..()
 
 /obj/item/old_grenade/sawfly/firsttime/withremote // for traitor menu
+	mechanics_type_override = /obj/item/old_grenade/sawfly/firsttime //prevents remote clutter if you're making an army
 	New()
 		new /obj/item/remote/sawflyremote(src.loc)
 		..()
@@ -93,7 +95,8 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 			icon_state_armed = "clusterflyB1"
 
 // -------------------controller---------------
-
+TYPEINFO(/obj/item/old_grenade/sawfly)
+	mats = list("CON-1"=2)
 /obj/item/remote/sawflyremote
 	name = "Sawfly remote"
 	desc = "A small device that can be used to fold or deploy sawflies in range."
@@ -103,6 +106,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 	w_class = W_CLASS_TINY
 	flags = FPRINT | TABLEPASS
 	object_flags = NO_GHOSTCRITTER
+	is_syndicate = TRUE
 
 	HELP_MESSAGE_OVERRIDE({"Use the remote in hand to activate/deactivate any sawflies within a 5 tile radius."})
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Tiny change that prevents mechscanned sawflies from producing remotes. Makes it syndie-scannable instead, in case you need to make any new remotes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Quality of life! Any time I've seen anyone do a sawfly army gimmick, there's always an annoying and screen-clogging massive pile of sawfly remotes at the end. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NightmarechaMillian
(+)Mechscanned sawflies will no longer produce a remote on deployment.
(+)The sawfly remote is separately mechscannable.
```
