### PR TITLE
Replaces the syndicate's Sawfly purchase with the pouch containing three

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -203,11 +203,11 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	desc = "A pack of Syndicool Lights exploding trick cigarettes. Due to the use of a military-grade explosive, please do not attempt to smoke these after lighting."
 
 /datum/syndicate_buylist/generic/sawfly
-	name = "Compact Sawfly"
-	item = /obj/item/old_grenade/sawfly/firsttime/withremote
+	name = "Sawfly Pouch"
+	item = /obj/item/storage/sawfly_pouch
 	cost = 2
 	vr_allowed = FALSE
-	desc = "A small antipersonnel robot that will not attack anyone of syndicate affiliation. It can be folded up after use."
+	desc = "Three small antipersonnel robots that will not attack anyone of syndicate affiliation. They can be folded up after use."
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/generic/sawflymany


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See title- changes the buylist purchase. 

If need be, I'm fine with changing it to be a 1 TC purchase per drone, but thought I'd see what folks think of the pouch idea first.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There's been some talk in RP-chat about how sawflies are a little underwhelming for 2 TC, especially since all the other grenades you can purchase are 1 TC and give a whole pouch of them. 

When sawflies were first added, 2 TC made sense. They pierced armor, had considerably faster attacks, and had shorter fuze times. I definitely think the changes were merited, but since then, I feel like they've dropped out of the 2 TC price bracket.

The purchase giving a pouch of sawflies instead of one and a remote is more in-line with the other grenades, and should hopefully legitimize their use outside of the "let's make an army in mechlab" niche.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NightmarechaMillian
(*)The 2 TC sawfly purchase will now provide a pouch of 3 drones. Yes, this is the one nukies get.
```
