### PR TITLE
Make matsci mining tool particles clickthrough

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -1000,7 +1000,7 @@ Returns:
 			qdel(src)
 		..()
 
-/obj/meleeeffect
+/obj/effect/melee
 	name = ""
 	desc = ""
 	icon = 'icons/effects/meleeeffects.dmi'
@@ -1045,7 +1045,7 @@ Returns:
 		icon = 'icons/effects/effects.dmi'
 		icon_state = "glowyline"
 
-/obj/meleeeffect/spearimage
+/obj/effect/melee/spearimage
 	name = ""
 	desc = ""
 	icon = null
@@ -1311,8 +1311,8 @@ Returns:
 		return
 
 	showEffect(var/mob/user, var/atom/target, var/direction, var/stabStrength = 0)
-		var/obj/meleeeffect/dagger/M
-		M = new/obj/meleeeffect/dagger(target)
+		var/obj/effect/melee/dagger/M
+		M = new/obj/effect/melee/dagger(target)
 		M.set_dir(direction)
 		M.color = (stabStrength < 1 ? "#FFFFFF" : "#FF4444")
 
@@ -1460,8 +1460,8 @@ Returns:
 
 		var/color_new = list(partred*2.5,0.30,0.30, 0.30,partgreen*2.5,0.30, 0.30,0.30,partblue*2.5, 0,0,0)
 		var/atom/effectLoc = null
-		var/obj/meleeeffect/spear/M
-		//var/obj/meleeeffect/spearimage/I
+		var/obj/effect/melee/spear/M
+
 		switch(direction)
 			if(NORTH)
 				effectLoc = locate(user.x, user.y + 1, user.z)
@@ -1470,7 +1470,7 @@ Returns:
 				I.set_dir(direction)
 				animate(I, pixel_y = 96, time = 6, alpha= 0)
 				*/
-				M = new/obj/meleeeffect/spear(effectLoc)
+				M = new/obj/effect/melee/spear(effectLoc)
 				M.pixel_x = -32
 				M.set_dir(direction)
 				M.color = color_new
@@ -1482,7 +1482,7 @@ Returns:
 				I.set_dir(direction)
 				animate(I, pixel_x = 96, time = 6, alpha= 0)
 				*/
-				M = new/obj/meleeeffect/spear(effectLoc)
+				M = new/obj/effect/melee/spear(effectLoc)
 				M.pixel_y = -32
 				M.set_dir(direction)
 				M.color = color_new
@@ -1494,7 +1494,7 @@ Returns:
 				I.set_dir(direction)
 				animate(I, pixel_y = -96, time = 6, alpha= 0)
 				*/
-				M = new/obj/meleeeffect/spear(effectLoc)
+				M = new/obj/effect/melee/spear(effectLoc)
 				M.pixel_x = -32
 				M.set_dir(direction)
 				M.color = color_new
@@ -1506,7 +1506,7 @@ Returns:
 				I.set_dir(direction)
 				animate(I, pixel_x = -96, time = 6, alpha= 0)
 				*/
-				M = new/obj/meleeeffect/spear(effectLoc)
+				M = new/obj/effect/melee/spear(effectLoc)
 				M.pixel_y = -32
 				M.set_dir(direction)
 				M.color = color_new
@@ -1547,29 +1547,29 @@ Returns:
 
 		var/color_new = list(partred*2.5,0.30,0.30, 0.30,partgreen*2.5,0.30, 0.30,0.3,partblue*2.5, 0,0,0)
 		var/atom/effectLoc = null
-		var/obj/meleeeffect/M
+		var/obj/effect/melee/M
 		switch(direction)
 			if(NORTH)
 				effectLoc = locate(user.x, user.y + 1, user.z)
-				M = new/obj/meleeeffect(effectLoc)
+				M = new/obj/effect/melee(effectLoc)
 				M.pixel_x = -32
 				M.set_dir(direction)
 				M.color = color_new
 			if(EAST)
 				effectLoc = locate(user.x + 1, user.y, user.z)
-				M = new/obj/meleeeffect(effectLoc)
+				M = new/obj/effect/melee(effectLoc)
 				M.pixel_y = -32
 				M.set_dir(direction)
 				M.color = color_new
 			if(SOUTH)
 				effectLoc = locate(user.x, user.y - 3, user.z)
-				M = new/obj/meleeeffect(effectLoc)
+				M = new/obj/effect/melee(effectLoc)
 				M.pixel_x = -32
 				M.set_dir(direction)
 				M.color = color_new
 			if(WEST)
 				effectLoc = locate(user.x - 3, user.y, user.z)
-				M = new/obj/meleeeffect(effectLoc)
+				M = new/obj/effect/melee(effectLoc)
 				M.pixel_y = -32
 				M.set_dir(direction)
 				M.color = color_new

--- a/code/modules/materials/Mat_Mining.dm
+++ b/code/modules/materials/Mat_Mining.dm
@@ -108,7 +108,7 @@
 
 		var/turf/start = get_step(user,attackDir)
 
-		var/obj/meleeeffect/pick/DA = new/obj/meleeeffect/pick(start)
+		var/obj/effect/melee/pick/DA = new/obj/effect/melee/pick(start)
 
 		SPAWN(2 SECONDS)
 			qdel(DA)
@@ -118,7 +118,7 @@
 			extra_dmg |= range(1,start)
 			for(var/turf/T in extra_dmg)
 				if(istype(T,/turf/simulated/wall/auto/asteroid))
-					var/obj/meleeeffect/conc/conc = new/obj/meleeeffect/conc(T)
+					var/obj/effect/melee/conc/conc = new/obj/effect/melee/conc(T)
 					SPAWN(1 SECOND) qdel(conc)
 					T:change_health(-(round(power/7)))
 
@@ -170,8 +170,8 @@
 		animate(color="#AA0000", time=2)
 		animate(color="#FFFFFF", time=4)
 
-		var/obj/meleeeffect/blasterline/EA = new/obj/meleeeffect/blasterline(user.loc)
-		var/obj/meleeeffect/blasterline/EB = new/obj/meleeeffect/blasterline(start)
+		var/obj/effect/melee/blasterline/EA = new/obj/effect/melee/blasterline(user.loc)
+		var/obj/effect/melee/blasterline/EB = new/obj/effect/melee/blasterline(start)
 
 		EA.set_dir(attackDir)
 		EB.set_dir(turn(attackDir, 180))
@@ -191,7 +191,7 @@
 			extra_dmg |= range(1,TC)
 			for(var/turf/T in extra_dmg)
 				if(istype(T,/turf/simulated/wall/auto/asteroid))
-					var/obj/meleeeffect/conc/conc = new/obj/meleeeffect/conc(T)
+					var/obj/effect/melee/conc/conc = new/obj/effect/melee/conc(T)
 					SPAWN(1 SECOND) qdel(conc)
 					T:change_health(-(round(power/7)))
 
@@ -235,9 +235,9 @@
 		var/turf/middle = get_step(start,turn(attackDir, 90))
 		var/turf/end = get_step(start,turn(attackDir, -90))
 
-		var/obj/meleeeffect/hammer/DA = new/obj/meleeeffect/hammer(start)
-		var/obj/meleeeffect/hammer/DB = new/obj/meleeeffect/hammer(middle)
-		var/obj/meleeeffect/hammer/DC = new/obj/meleeeffect/hammer(end)
+		var/obj/effect/melee/hammer/DA = new/obj/effect/melee/hammer(start)
+		var/obj/effect/melee/hammer/DB = new/obj/effect/melee/hammer(middle)
+		var/obj/effect/melee/hammer/DC = new/obj/effect/melee/hammer(end)
 
 		SPAWN(2 SECONDS)
 			qdel(DA)
@@ -251,7 +251,7 @@
 			extra_dmg |= range(1,end)
 			for(var/turf/T in extra_dmg)
 				if(istype(T,/turf/simulated/wall/auto/asteroid))
-					var/obj/meleeeffect/conc/conc = new/obj/meleeeffect/conc(T)
+					var/obj/effect/melee/conc/conc = new/obj/effect/melee/conc(T)
 					SPAWN(1 SECOND) qdel(conc)
 					T:change_health(-(round(power/7)))
 
@@ -308,7 +308,7 @@
 				anim_x = -64
 				anim_y = 0
 
-		var/obj/meleeeffect/drill/D = new/obj/meleeeffect/drill(start)
+		var/obj/effect/melee/drill/D = new/obj/effect/melee/drill(start)
 		D.set_dir(attackDir)
 
 		animate(D, pixel_x = anim_x, pixel_y = anim_y, time = 5, easing = QUAD_EASING)
@@ -321,7 +321,7 @@
 			extra_dmg |= range(1,end)
 			for(var/turf/T in extra_dmg)
 				if(istype(T,/turf/simulated/wall/auto/asteroid))
-					var/obj/meleeeffect/conc/conc = new/obj/meleeeffect/conc(T)
+					var/obj/effect/melee/conc/conc = new/obj/effect/melee/conc(T)
 					SPAWN(1 SECOND) qdel(conc)
 					T:change_health(-(round(power/7)))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Have the mining melee effects descend from `/obj/effect` to pick up mouse opacity and event handler flags

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19679