### PR TITLE
fix sawfly remote mechscan

### DIFF
--- a/_std/defines/materials.dm
+++ b/_std/defines/materials.dm
@@ -22,32 +22,6 @@
 /// Global static list of rarity color associations
 var/global/static/list/RARITY_COLOR = list("#9d9d9d", "#ffffff", "#1eff00", "#0070dd", "#a335ee", "#ff8000", "#ff0000")
 
-/// Material category names as displayed in fabricators
-/// see match_material_pattern() for exact definitions
-var/global/list/material_category_names = list(
-	"ALL"   = "Any Material",
-	"CON-1" = "Conductive Material",
-	"CON-2" = "High Energy Conductor",
-	"CRY-1" = "Crystal",
-	"DEN-1" = "High Density Matter",
-	"DEN-2" = "Very High Density Matter",
-	"CRY-2" = "Extraordinarily Dense Crystalline Matter",
-	"FAB-1" = "Fabric",
-	"INS-1" = "Insulative Material",
-	"INS-2" = "Highly Insulative Material",
-	"MET-1" = "Metal",
-	"MET-2" = "Sturdy Metal",
-	"MET-3" = "Extremely Tough Metal",
-	"POW-1" = "Power Source",
-	"POW-2" = "Significant Power Source",
-	"POW-3" = "Extreme Power Source",
-	"REF-1" = "Reflective Material",
-	"ORG|RUB" = "Organic or Rubber Material",
-	"RUB" = "Rubber Material",
-	"WOOD" = "Wood",
-	"GEM-1" = "Any Gemstone"
-)
-
 #define TRIGGERS_ON_BULLET "triggersOnBullet"
 #define TRIGGERS_ON_EAT "triggersOnEat"
 #define TRIGGERS_ON_TEMP "triggersTemp"

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -475,8 +475,8 @@ TYPEINFO(/atom)
 	..()
 
 TYPEINFO(/atom/movable)
-	/// Either a number or a list of the form list("MET-1"=5, "erebite"=3)
-	/// See the `match_material_pattern` proc for an explanation of what "CRY-2" is supposed to mean
+	/// A key-value list of match property or material IDs and an amount required to construct the item
+	/// See `/datum/manufacturing_requirement/match_property` for match properties
 	var/list/mats = null
 
 /atom/movable

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -96,7 +96,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 			icon_state_armed = "clusterflyB1"
 
 // -------------------controller---------------
-TYPEINFO(/obj/item/old_grenade/sawfly)
+TYPEINFO(/obj/item/remote/sawflyremote)
 	mats = list("conductive"=2)
 /obj/item/remote/sawflyremote
 	name = "Sawfly remote"

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -97,7 +97,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 
 // -------------------controller---------------
 TYPEINFO(/obj/item/old_grenade/sawfly)
-	mats = list("CON-1"=2)
+	mats = list("conductive"=2)
 /obj/item/remote/sawflyremote
 	name = "Sawfly remote"
 	desc = "A small device that can be used to fold or deploy sawflies in range."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use "conductive" instead of "CON-1" for sawfly remotes
Removes a global list of material properties to stop future confusion (hopefully nothing in secret uses this???)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Follow up to #19681 using current material definition system