### PR TITLE
moves map votes to the end of the round

### DIFF
--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -16,7 +16,7 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 	var/playersVoting = 0 //are players currently voting on the map?
 	var/voteStartedAt = 0 //timestamp when the map vote was started
 	var/autoVoteDelay = 0 //how long should we delay the auto vote starting?
-	var/autoVoteDuration = 60 SECONDS //how long (in byond deciseconds) the automatic map vote should last
+	var/autoVoteDuration = 30 SECONDS //how long (in byond deciseconds) the automatic map vote should last
 	var/voteCurrentDuration = 0 //how long is the current vote set to last?
 	var/voteChosenMap = "" //the map that the players voted to switch to
 	var/nextMapIsVotedFor = 0 //is the next map a result of player voting?

--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -15,8 +15,8 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 	var/votingAllowed = 1 //is map voting allowed?
 	var/playersVoting = 0 //are players currently voting on the map?
 	var/voteStartedAt = 0 //timestamp when the map vote was started
-	var/autoVoteDelay = 30 SECONDS //how long should we wait after round start to trigger to automatic map vote?
-	var/autoVoteDuration = 7 MINUTES //how long (in byond deciseconds) the automatic map vote should last (1200 = 2 mins)
+	var/autoVoteDelay = 0 //how long should we delay the auto vote starting?
+	var/autoVoteDuration = 60 SECONDS //how long (in byond deciseconds) the automatic map vote should last
 	var/voteCurrentDuration = 0 //how long is the current vote set to last?
 	var/voteChosenMap = "" //the map that the players voted to switch to
 	var/nextMapIsVotedFor = 0 //is the next map a result of player voting?
@@ -131,13 +131,10 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 				src.passiveVotes[C.ckey] = C.preferences.preferred_map
 
 		//announce vote
-		var/msg = "<br><span class='bold notice'>"
-		msg += "A vote for next round's map has started! Click here: [mapVoteLinkStat.chat_link()] or on the 'Map Vote' button in your status window."
+		var/sound_to_play = 'sound/misc/announcement_1.ogg'
+		var/msg = "A vote for the next map has started! You can vote by clicking the 'Map Vote' button in your Status window or by clicking here:<div style='text-align: center; font-size: 250%;'>[mapVoteLinkStat.chat_link()]</div>[duration ? "<b>The vote will end in [duration / 10] seconds.</b>" : ""]"
 
-		if (duration)
-			msg += " It will end in [duration / 10] seconds."
-		msg += "</span><br><br>"
-		boutput(world, msg)
+		command_alert(msg, "Map Vote Started", sound_to_play, alert_origin = "Civic Duty Alert");
 
 		//if the vote was triggered with a duration, wait that long and end it
 		if (duration)


### PR DESCRIPTION
## About the PR

this PR does the following things:
* the automated map vote is __moved from pre-round to the end of the round__.
* the map vote time is shortened from 7 minutes (420 sec) to 60 seconds.
* the end-of-round countdown time is increased from 60 to 120.
* the map vote link in chat is now a command alert with a much larger link.

in addition, if the next map has already been set (`mapSwitcher.next` non-null), the map vote will be skipped. this allows an admin (or other event?...) to set the map without worrying that the map vote will end up overriding it.

----

**note**: this change is based on an assumption that the build server can build and deploy the next round's code within a bit over a minute; current estimates are that it generally finishes within 30 seconds, though this is also dependent on if other servers are active.

a future improvement involves delaying the end of a round until receiving a "build ready" signal from the build server (or running out of time and going ahead anyway)


## Why's this needed?

map votes typically have low turnout, and determine the fate of a round anywhere from 50 to 100 minutes (or more) in the future. this allows votes to happen by people who will likely be around for the next round, and also makes the vote more visible.


## Changelog
```changelog
(u)Zamujasa
(*)Map votes now happen after the round is over, when the countdown starts.
(*)Map votes are now 60 seconds.
(*)End-of-round time is now 120.
```
