### PR TITLE
Capsule machines stand back up when they're fixed

### DIFF
--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -1120,13 +1120,15 @@ ABSTRACT_TYPE(/datum/figure_info/patreon)
 	icon_state = "machine1"
 	icon_panel = "machine-panel"
 	var/sound_vend = 'sound/machines/capsulebuy.ogg'
+	var/base_icon_state = "machine1"
 	var/image/capsule_image = null
 
 	create_products(restocked)
 		product_list += new/datum/data/vending_product(/obj/item/item_box/figure_capsule, 35, cost=PAY_UNTRAINED/5)
 		product_list += new/datum/data/vending_product(/obj/item/satchel/figurines, 2, cost=PAY_UNTRAINED*3)
 		product_list += new/datum/data/vending_product(/obj/item/item_box/figure_capsule/gaming_capsule, rand(4,10), cost=PAY_UNTRAINED/3, hidden=1)
-		src.icon_state = "machine[rand(1,6)]"
+		src.base_icon_state = "machine[rand(1,6)]"
+		src.icon_state = src.base_icon_state
 		src.capsule_image = image(src.icon, "m_caps26")
 		src.UpdateOverlays(src.capsule_image, "capsules")
 
@@ -1136,6 +1138,14 @@ ABSTRACT_TYPE(/datum/figure_info/patreon)
 			var/datum/data/vending_product/R = src.product_list[1]
 			src.capsule_image.icon_state = "m_caps[R.product_amount]"
 			src.UpdateOverlays(src.capsule_image, "capsules")
+
+	fall()
+		..()
+		src.icon_state = "[src.base_icon_state]-fallen"
+
+	right()
+		..()
+		src.icon_state = src.base_icon_state
 
 	powered()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add a base image state for capsule machines (since they set their icon state on `create_products`)
Then, on `fall()`/`right()` use that base icon state to set the correct standing/fallen state (since they don't use power and thus have `power_change()` no-opped).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18901