### PR TITLE
Engineeering power access cleanup

### DIFF
--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -121,11 +121,6 @@
 	req_access = list(access_engineering_engine)
 	color = ENGINEERING
 
-/obj/mapping_helper/access/engineering_power
-	name = "engineering power access spawn"
-	req_access = list(access_engineering_power)
-	color = ENGINEERING
-
 /obj/mapping_helper/access/engineering_mechanic
 	name = "engineering mechanics access spawn"
 	req_access = list(access_engineering_mechanic)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -31727,6 +31727,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "pEu" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -38537,7 +38537,7 @@
 	name = "Power Room"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/grime,
 /area/station/engine/power)
 "dvn" = (
@@ -54294,7 +54294,6 @@
 	dir = 4;
 	name = "Electrical Substation"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4
@@ -54313,6 +54312,7 @@
 	enter_id = "outer";
 	name = "AI Power"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "pCg" = (
@@ -63439,12 +63439,6 @@
 /obj/mapping_helper/access/engineering_engine,
 /obj/disposalpipe/segment{
 	dir = 4
-	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
 	},
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -27290,7 +27290,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "iUh" = (
@@ -28828,10 +28828,10 @@
 /obj/machinery/door/airlock/pyro/engineering/alt{
 	dir = 4
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor,
 /area/station/engine/substation/north)
 "jXF" = (
@@ -29394,10 +29394,10 @@
 /obj/machinery/door/airlock/pyro/engineering/alt{
 	dir = 4
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "kpN" = (
@@ -32737,12 +32737,9 @@
 /turf/simulated/floor/plating,
 /area/station/science/testchamber/bombchamber)
 "mqk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/sci_alt,
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/access/research,
+/obj/mapping_helper/access/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "mqD" = (
@@ -37274,7 +37271,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "oWl" = (
@@ -44911,12 +44908,12 @@
 /obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/airlock/cycler{
 	cycle_id = "aisat";
 	enter_id = "inner";
 	name = "AI Satellite"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "tLf" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -18222,7 +18222,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/access/engineering_power,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/airlock/cycler{
@@ -18230,6 +18229,7 @@
 	enter_id = "outer";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/inner)
 "cWz" = (
@@ -26559,7 +26559,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -26570,6 +26569,7 @@
 	cycle_id = "innereng2";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/inner)
 "ixk" = (
@@ -28923,7 +28923,6 @@
 /area/station/crew_quarters/pool)
 "jZS" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/access/engineering_power,
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
@@ -28934,6 +28933,7 @@
 	enter_id = "outer";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/inner)
 "kaC" = (
@@ -35000,7 +35000,6 @@
 /area/station/chapel/sanctuary)
 "nMF" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
 /obj/cable/orange{
@@ -35011,6 +35010,7 @@
 	enter_id = "inner";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "nMK" = (
@@ -38624,7 +38624,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -38635,6 +38634,7 @@
 	cycle_id = "innereng3";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/inner)
 "pMZ" = (
@@ -48104,7 +48104,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/airlock/cycler{
@@ -48112,6 +48111,7 @@
 	enter_id = "inner";
 	name = "Inner Engineering"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "vQH" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6362,11 +6362,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/access/engineering,
 /obj/mapping_helper/airlock/cycler{
 	cycle_id = "westsolar";
 	name = "West Solar Maintenance"
 	},
+/obj/mapping_helper/access/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "bMe" = (
@@ -32704,7 +32704,6 @@
 /obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/access/engineering,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -32714,6 +32713,7 @@
 	cycle_id = "westsolar";
 	name = "West Solar Maintenance"
 	},
+/obj/mapping_helper/access/engineering_power,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/west)
 "jOU" = (
@@ -73799,7 +73799,6 @@
 /obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/access/engineering,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 8;
@@ -73810,6 +73809,7 @@
 	cycle_id = "eastsolar";
 	name = "East Solar Maintenance"
 	},
+/obj/mapping_helper/access/engineering_power,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
 "wmQ" = (
@@ -77651,7 +77651,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
 	},
-/obj/mapping_helper/access/engineering,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -77659,6 +77658,7 @@
 	cycle_id = "eastsolar";
 	name = "East Solar Maintenance"
 	},
+/obj/mapping_helper/access/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "xon" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39786,8 +39786,8 @@
 	name = "Power Room";
 	req_access = null
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "jjV" = (
@@ -48594,7 +48594,6 @@
 	dir = 4;
 	name = "Power Room"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/access/engineering_engine,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/yellow,
@@ -52384,8 +52383,8 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Power Transmission Laser"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/ptl)
 "sEX" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -35335,7 +35335,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "fXD" = (
@@ -36988,7 +36988,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "haB" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -6453,12 +6453,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 8;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/hotloop)
 "aol" = (
@@ -55354,7 +55348,6 @@
 	dir = 8;
 	name = "Electrical Substation"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 8
@@ -55373,6 +55366,7 @@
 	enter_id = "outer";
 	name = "AI Power"
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "fqT" = (
@@ -59484,7 +59478,7 @@
 	req_access = null
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/engineering_power,
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/grime,
 /area/station/engine/power)
 "maK" = (
@@ -59635,7 +59629,6 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Electrical Substation"
 	},
-/obj/mapping_helper/access/engineering_power,
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -59645,6 +59638,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/mapping_helper/access/engineering_control,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "mmN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a room is *just* access to solars controls, make it use `engineering_power`, otherwise use a more appropriate engineering access spawner. Commit messages have detailed changes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19691
