### PR TITLE
Computers die when you shoot them

### DIFF
--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -248,7 +248,6 @@ TYPEINFO(/obj/item/motherboard)
 			if (prob(P.power))
 				switch(state)
 					if(0)
-						src.visible_message(SPAN_COMBAT("The empty frame crumples from the impact!"))
 						new /obj/item/scrap(src.loc)
 						qdel(src)
 					if(1)
@@ -264,12 +263,10 @@ TYPEINFO(/obj/item/motherboard)
 							src.eject_mainboard()
 					if(3)
 						if (src.hd)
-							src.visible_message(SPAN_COMBAT("The disk drive is hit and flung out!"))
 							src.hd.set_loc(src)
 							src.hd.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 							src.hd = null
 						else
-							src.visible_message(SPAN_COMBAT("The internal wiring snaps and is flung out!"))
 							var/obj/item/cable_coil/debris = new /obj/item/cable_coil(src.loc)
 							debris.amount = 1
 							debris.UpdateIcon()
@@ -277,7 +274,6 @@ TYPEINFO(/obj/item/motherboard)
 							src.state = 2
 							src.icon_state = "2"
 					if(4)
-						src.visible_message(SPAN_COMBAT("The screen shatters and a glass shard flies out!"))
 						var/obj/item/raw_material/shard/glass/debris = new /obj/item/raw_material/shard/glass(src.loc)
 						debris.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 						src.state = 3
@@ -285,7 +281,6 @@ TYPEINFO(/obj/item/motherboard)
 
 /obj/computer3frame/proc/eject_mainboard()
 	if(isnull(src.mainboard)) return
-	src.visible_message("The mainboard is knocked loose!")
 	src.mainboard.set_loc(get_turf(src))
 	src.mainboard.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 	src.mainboard = null
@@ -294,7 +289,6 @@ TYPEINFO(/obj/item/motherboard)
 
 /obj/computer3frame/proc/eject_peripherals()
 	if (length(src.peripherals) == 0) return
-	src.visible_message("The installed components [pick("fly out", "are launched", "go flying")]!")
 	for(var/obj/item/peripheral/peripheral in src.peripherals)
 		peripheral.set_loc(get_turf(src))
 		peripheral.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -240,3 +240,63 @@ TYPEINFO(/obj/item/motherboard)
 				P.change_stack_amount(-glass_needed)
 				src.state = 4
 				src.icon_state = "4"
+
+/obj/computer3frame/bullet_act(obj/projectile/P)
+	. = ..()
+	switch (P.proj_data.damage_type)
+		if (D_KINETIC, D_PIERCING, D_SLASHING)
+			if (prob(P.power))
+				switch(state)
+					if(0)
+						src.visible_message(SPAN_COMBAT("The empty frame crumples from the impact!"))
+						new /obj/item/scrap(src.loc)
+						qdel(src)
+					if(1)
+						if(src.mainboard)
+							src.eject_mainboard()
+						else
+							src.anchored = UNANCHORED
+							src.state = 0
+					if(2)
+						if(length(src.peripherals))
+							src.eject_peripherals()
+						else if(src.mainboard)
+							src.eject_mainboard()
+
+					if(3)
+						if (src.hd)
+							src.visible_message(SPAN_COMBAT("The disk drive is hit and flung out!"))
+							src.hd.set_loc(src)
+							src.hd.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
+							src.hd = null
+						else
+							src.visible_message(SPAN_COMBAT("The internal wiring snaps and is flung out!"))
+							var/obj/item/cable_coil/debris = new /obj/item/cable_coil(src.loc)
+							debris.amount = 1
+							debris.UpdateIcon()
+							debris.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
+							src.state = 2
+							src.icon_state = "2"
+					if(4)
+						src.visible_message(SPAN_COMBAT("The screen shatters and a glass shard flies out!"))
+						var/obj/item/raw_material/shard/glass/debris = new /obj/item/raw_material/shard/glass(src.loc)
+						debris.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
+						src.state = 3
+						src.icon_state = "3"
+
+/obj/computer3frame/proc/eject_mainboard()
+	if(isnull(src.mainboard)) return
+	src.mainboard.set_loc(get_turf(src))
+	src.mainboard.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
+	src.mainboard = null
+	src.state = 1
+	src.icon_state = "1"
+
+/obj/computer3frame/proc/eject_peripherals()
+	if (length(src.peripherals) == 0) return
+	src.visible_message("The installed components [pick("fly out", "are launched", "go flying")]!")
+	for(var/obj/item/peripheral/peripheral in src.peripherals)
+		peripheral.set_loc(get_turf(src))
+		peripheral.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
+		src.peripherals.Remove(peripheral)
+		peripheral.uninstalled()

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -262,7 +262,6 @@ TYPEINFO(/obj/item/motherboard)
 							src.eject_peripherals()
 						else if(src.mainboard)
 							src.eject_mainboard()
-
 					if(3)
 						if (src.hd)
 							src.visible_message(SPAN_COMBAT("The disk drive is hit and flung out!"))
@@ -286,6 +285,7 @@ TYPEINFO(/obj/item/motherboard)
 
 /obj/computer3frame/proc/eject_mainboard()
 	if(isnull(src.mainboard)) return
+	src.visible_message("The mainboard is knocked loose!")
 	src.mainboard.set_loc(get_turf(src))
 	src.mainboard.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 	src.mainboard = null

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -565,13 +565,13 @@
 	A.created_icon_state = src.base_icon_state
 	A.set_dir(src.dir)
 	if (src.status & BROKEN)
-		boutput(user, SPAN_NOTICE("The broken glass falls out."))
+		user?.show_text("The broken glass falls out.", "blue")
 		var/obj/item/raw_material/shard/glass/G = new /obj/item/raw_material/shard/glass
 		G.set_loc( src.loc )
 		A.state = 3
 		A.icon_state = "3"
 	else
-		boutput(user, SPAN_NOTICE("You disconnect the monitor."))
+		user?.show_text("You disconnect the monitor.", "blue")
 		A.state = 4
 		A.icon_state = "4"
 
@@ -631,6 +631,22 @@
 	if (prob(power * 2.5))
 		set_broken()
 		src.set_density(0)
+
+/obj/machinery/computer3/bullet_act(obj/projectile/P)
+	. = ..()
+	switch (P.proj_data.damage_type)
+		if (D_KINETIC, D_PIERCING, D_SLASHING)
+			if (prob(P.power))
+				if (status & BROKEN)
+					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"))
+					src.unscrew_monitor()
+				else
+					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
+					src.set_broken()
+		if (D_ENERGY)
+			if (!(status & BROKEN) && prob(P.power))
+				src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
+				src.set_broken()
 
 /obj/machinery/computer3/disposing()
 	if (hd)

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -638,7 +638,8 @@
 		if (D_KINETIC, D_PIERCING, D_SLASHING)
 			if (prob(P.power))
 				if (status & BROKEN)
-					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"))
+					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"));
+					playsound(src, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 50, TRUE)
 					src.unscrew_monitor()
 				else
 					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -638,15 +638,12 @@
 		if (D_KINETIC, D_PIERCING, D_SLASHING)
 			if (prob(P.power))
 				if (status & BROKEN)
-					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"));
 					playsound(src, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 50, TRUE)
 					src.unscrew_monitor()
 				else
-					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
 					src.set_broken()
 		if (D_ENERGY)
 			if (!(status & BROKEN) && prob(P.power))
-				src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
 				src.set_broken()
 
 /obj/machinery/computer3/disposing()

--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -221,6 +221,7 @@
 			if (prob(P.power))
 				if (status & BROKEN)
 					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"))
+					playsound(src, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 50, TRUE)
 					src.unscrew_monitor()
 				else
 					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))

--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -63,13 +63,13 @@
 	proc/unscrew_monitor(obj/item/W as obj, mob/user as mob)
 		var/obj/computerframe/A = new /obj/computerframe(src.loc)
 		if (src.status & BROKEN)
-			user.show_text("The broken glass falls out.", "blue")
+			user?.show_text("The broken glass falls out.", "blue")
 			var/obj/item/raw_material/shard/glass/G = new /obj/item/raw_material/shard/glass
 			G.set_loc(src.loc)
 			A.state = 3
 			A.icon_state = "3"
 		else
-			user.show_text("You disconnect the monitor.", "blue")
+			user?.show_text("You disconnect the monitor.", "blue")
 			A.state = 4
 			A.icon_state = "4"
 		var/obj/item/circuitboard/M = new src.circuit_type(A)
@@ -213,3 +213,19 @@
 	icon_state = "[src.base_icon_state]b"
 	light.disable()
 	status |= BROKEN
+
+/obj/machinery/computer/bullet_act(obj/projectile/P)
+	. = ..()
+	switch (P.proj_data.damage_type)
+		if (D_KINETIC, D_PIERCING, D_SLASHING)
+			if (prob(P.power))
+				if (status & BROKEN)
+					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"))
+					src.unscrew_monitor()
+				else
+					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
+					src.set_broken()
+		if (D_ENERGY)
+			if (!(status & BROKEN) && prob(P.power))
+				src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
+				src.set_broken()

--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -220,13 +220,10 @@
 		if (D_KINETIC, D_PIERCING, D_SLASHING)
 			if (prob(P.power))
 				if (status & BROKEN)
-					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and shatters!"))
 					playsound(src, "sound/impact_sounds/Glass_Shatter_[rand(1,3)].ogg", 50, TRUE)
 					src.unscrew_monitor()
 				else
-					src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
 					src.set_broken()
 		if (D_ENERGY)
 			if (!(status & BROKEN) && prob(P.power))
-				src.visible_message(SPAN_COMBAT("The [src] is struck by [P] and breaks!"))
 				src.set_broken()

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -363,7 +363,7 @@ TYPEINFO(/obj/item/circuitboard)
 
 /obj/computerframe/proc/eject_board()
 		if (!src.circuit) return
-		src.visible_message("The installed circuit board is struck and [pick("flies out", "is launched", "goes flying")]!")
+		src.visible_message("The installed circuit board [pick("flies out", "is launched", "goes flying")]!")
 		src.circuit.set_loc(get_turf(src))
 		src.circuit.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 		src.state = STATE_ANCHORED

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -334,20 +334,17 @@ TYPEINFO(/obj/item/circuitboard)
 			if (prob(P.power))
 				switch(state)
 					if(STATE_UNANCHORED)
-						src.visible_message(SPAN_COMBAT("The empty frame crumples from the impact!"))
 						new /obj/item/scrap(src.loc)
 						qdel(src)
 					if(STATE_ANCHORED)
 						if (src.circuit)
 							src.eject_board()
 						else
-							src.visible_message(SPAN_COMBAT("The [src] is dislodged from the the impact!"))
 							src.anchored = UNANCHORED
 							src.state = STATE_UNANCHORED
 					if(STATE_HAS_BOARD)
 						src.eject_board()
 					if(STATE_HAS_CABLES)
-						src.visible_message(SPAN_COMBAT("The internal wiring snaps and is flung out!"))
 						var/obj/item/cable_coil/debris = new /obj/item/cable_coil(src.loc)
 						debris.amount = 1
 						debris.UpdateIcon()
@@ -355,7 +352,6 @@ TYPEINFO(/obj/item/circuitboard)
 						src.state = STATE_HAS_BOARD
 						src.icon_state = "2"
 					if(STATE_HAS_GLASS)
-						src.visible_message(SPAN_COMBAT("The screen shatters and a glass shard flies out!"))
 						var/obj/item/raw_material/shard/glass/debris = new /obj/item/raw_material/shard/glass(src.loc)
 						debris.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 						src.state = STATE_HAS_CABLES
@@ -363,7 +359,6 @@ TYPEINFO(/obj/item/circuitboard)
 
 /obj/computerframe/proc/eject_board()
 		if (!src.circuit) return
-		src.visible_message("The installed circuit board [pick("flies out", "is launched", "goes flying")]!")
 		src.circuit.set_loc(get_turf(src))
 		src.circuit.throw_at(get_offset_target_turf(src, rand(5)-rand(5), rand(5)-rand(5)), rand(2,4), 2)
 		src.state = STATE_ANCHORED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add `bullet_act` definitions for computer, computer3, computerframe, and computer3frame. Based on the projectile's power (i.e. with distance falloff applied), Kinetic/slashing/piercing projectiles will move computers/computerframes in reverse through their build steps, slowly becoming more and more broken before eventually breaking apart into scrap. Energy projectiles can cause the screen to break, but cannot further break down frames.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* projectiles have more interaction with game objects
* computers shouldn't be infinite shields
* Fix #9122 :^)

## Demo
https://github.com/goonstation/goonstation/assets/91498627/cb5a43d4-bb7c-49cc-b30a-eb602a9c7846


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Kinetic projectiles progressively break computers/consoles to scrap.
(+)Energy projectiles, including tasers, have a chance to break computer/console screens.
```