### PR TITLE
fix station namer bug

### DIFF
--- a/code/procs/station_name.dm
+++ b/code/procs/station_name.dm
@@ -141,7 +141,7 @@ var/global/lastStationNameChange = 0 //timestamp
 		station_name_whitelist_sectioned += list(whitelist_lists[section] = sortList(words, /proc/cmp_text_asc))
 
 		for (var/word in words)
-			station_name_whitelist[ckey(word)] = word
+			station_name_whitelist[lowertext(word)] = word
 
 
 //Verifies the given name matches a whitelist of words, only run on a manual setting of station name


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
 [bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug that prevented non-admins from using whitelisted words that contain non-alphanumeric characters such as `deep-fried` or `wire's` in the station namer
