### PR TITLE
Snap a runtime in the mainframe's argument parsing out of existence

### DIFF
--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -223,11 +223,11 @@
 							echo_text = pipetemp
 
 						var/add_newline = TRUE
-						if (command_list[1] == "-n")
-							add_newline = FALSE
-							command_list.Cut(1,2)
 
 						if(istype(command_list) && (length(command_list) > 0))
+							if (command_list[1] == "-n")
+								add_newline = FALSE
+								command_list.Cut(1,2)
 							echo_text += jointext(command_list, " ")
 
 						if (piping && piped_list.len && (ckey(piped_list[1]) != "break") )


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- moves the check for the `-n` argument for `echo`
that would runtime if list being checked for arguments was empty

- this check has been moved into an if statement checking if there are arguments

this ***should*** fix that one mainframe runtime people are using on their medal spreadsheets



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i got reminded of this, also

runtimes bad
