### PR TITLE
Remove electronic debris from random trader pool

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -761,12 +761,6 @@
 	price = PAY_UNTRAINED/10
 	desc_buy = "We are interested in recycling ground metal scrap."
 
-/datum/commodity/salvage/electronic_debris
-	comname = "Electronic Debris"
-	comtype = /obj/item/electronics
-	price = PAY_UNTRAINED/10
-	desc_buy = "We will recover metals from resistors, fuses, and other electronic debris."
-
 /datum/commodity/salvage/robot_upgrades
 	comname = "Cyborg Upgrade"
 	desc = "A salvaged cyborg upgrade kit."

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -989,7 +989,6 @@ ABSTRACT_TYPE(/obj/npc/trader/robot/robuddy)
 		src.goods_sell += new /datum/commodity/podparts/goldarmor(src)
 
 		src.goods_buy += new /datum/commodity/salvage/scrap(src)
-		src.goods_buy += new /datum/commodity/salvage/electronic_debris(src)
 		src.goods_buy += new /datum/commodity/relics/gnome(src)
 		src.goods_buy += new /datum/commodity/goldbar(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [REMOVAL] [EVENTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Remove the electronic debris commodity type.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Commodity types like this go into both the buy and sell pools for random traders, and `/obj/item/electronics` is an abstract parent type, NPC trader code will just include the parent type and none of the subtypes for selling and the subtypes are also kind of useless garbage so lets just scrap it.

Fixes #19709 
Fixes #17082 