### PR TITLE
Swap number labels on cog2 engine mixer ports

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -67569,10 +67569,10 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
 	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
+/obj/decal/poster/wallsign/stencil/right/two{
+	pixel_x = 17;
+	pixel_y = 12;
+	layer = 2
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -68373,10 +68373,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
+/obj/decal/poster/wallsign/stencil/right/one{
+	pixel_y = 12;
+	pixel_x = 15;
+	layer = 2
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Swap the 1 and 2 labels on the input ports to the gas mixer in the hot loop

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19715 