### PR TITLE
Projectiles have a chance to  pass through girders

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -7,6 +7,7 @@ obj/structure
 		density = 1
 		material_amt = 0.2
 		var/state = 0
+		var/projectile_passthrough_chance = 50
 		desc = "A metal support for an incomplete wall."
 		HELP_MESSAGE_OVERRIDE({"
 			You can use a <b>crowbar</b> to displace it,
@@ -18,6 +19,7 @@ obj/structure
 			name = "displaced girder"
 			icon_state = "displaced"
 			anchored = UNANCHORED
+			projectile_passthrough_chance = 30
 			desc = "An unsecured support for an incomplete wall."
 			HELP_MESSAGE_OVERRIDE({"
 				You can use a <b>screwdriver</b> to seperate the metal into sheets,
@@ -28,6 +30,7 @@ obj/structure
 			name = "reinforced girder"
 			icon_state = "reinforced"
 			state = 2
+			projectile_passthrough_chance = 70
 			desc = "A reinforced metal support for an incomplete wall."
 			get_help_message(dist, mob/user)
 				if (src.state == 2)
@@ -58,19 +61,7 @@ obj/structure/ex_act(severity)
 
 /obj/structure/girder/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
-		if (prob(50))
-			return TRUE
-	return (!density)
-
-/obj/structure/girder/displaced/Cross(atom/movable/mover)
-	if (istype(mover, /obj/projectile))
-		if (prob(70))
-			return TRUE
-	return (!density)
-
-/obj/structure/girder/reinforced/Cross(atom/movable/mover)
-	if (istype(mover, /obj/projectile))
-		if (prob(30))
+		if (prob(projectile_passthrough_chance))
 			return TRUE
 	return (!density)
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -19,7 +19,7 @@ obj/structure
 			name = "displaced girder"
 			icon_state = "displaced"
 			anchored = UNANCHORED
-			projectile_passthrough_chance = 30
+			projectile_passthrough_chance = 70
 			desc = "An unsecured support for an incomplete wall."
 			HELP_MESSAGE_OVERRIDE({"
 				You can use a <b>screwdriver</b> to seperate the metal into sheets,
@@ -30,7 +30,7 @@ obj/structure
 			name = "reinforced girder"
 			icon_state = "reinforced"
 			state = 2
-			projectile_passthrough_chance = 70
+			projectile_passthrough_chance = 30
 			desc = "A reinforced metal support for an incomplete wall."
 			get_help_message(dist, mob/user)
 				if (src.state == 2)
@@ -60,9 +60,8 @@ obj/structure/ex_act(severity)
 	return
 
 /obj/structure/girder/Cross(atom/movable/mover)
-	if (istype(mover, /obj/projectile))
-		if (prob(projectile_passthrough_chance))
-			return TRUE
+	if (istype(mover, /obj/projectile) && prob(projectile_passthrough_chance))
+		return TRUE
 	return (!density)
 
 /obj/structure/girder/attack_hand(mob/user)

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -60,16 +60,19 @@ obj/structure/ex_act(severity)
 	if (istype(mover, /obj/projectile))
 		if (prob(50))
 			return TRUE
+	return (!density)
 
 /obj/structure/girder/displaced/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
 		if (prob(70))
 			return TRUE
+	return (!density)
 
 /obj/structure/girder/reinforced/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
 		if (prob(30))
 			return TRUE
+	return (!density)
 
 /obj/structure/girder/attack_hand(mob/user)
 	if (user.is_hulk())

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -60,7 +60,7 @@ obj/structure/ex_act(severity)
 	return
 
 /obj/structure/girder/Cross(atom/movable/mover)
-	if (istype(mover, /obj/projectile) && prob(projectile_passthrough_chance))
+	if (istype(mover, /obj/projectile) && prob(src.projectile_passthrough_chance))
 		return TRUE
 	return (!density)
 

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -56,6 +56,21 @@ obj/structure/ex_act(severity)
 			return
 	return
 
+/obj/structure/girder/Cross(atom/movable/mover)
+	if (istype(mover, /obj/projectile))
+		if (prob(50))
+			return TRUE
+
+/obj/structure/girder/displaced/Cross(atom/movable/mover)
+	if (istype(mover, /obj/projectile))
+		if (prob(70))
+			return TRUE
+
+/obj/structure/girder/reinforced/Cross(atom/movable/mover)
+	if (istype(mover, /obj/projectile))
+		if (prob(30))
+			return TRUE
+
 /obj/structure/girder/attack_hand(mob/user)
 	if (user.is_hulk())
 		if (prob(50))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Give girders a chance to let projectiles pass right through them, with the rate dependent on how secure the girder is (displaced girder > girder > reinforced girder).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Girders can be used as a bullet-proof shield, which feels a bit wrong because you can literally see through them.

## Demo
Firing test with the Antares LMG (Nukies heavy machine gun). From left to right: Displaced Girders, Girders, and Reinforced Girders. Fired 1 LMG Belt behind the center test dummy for each set of girders.
https://github.com/goonstation/goonstation/assets/91498627/e43d83e1-4e3c-4593-a9c1-1bc78a0b8fb4


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Projectiles have a chance to pass through girders. The more secure a girder is, the less likely projectiles can travel through them.
```
