### PR TITLE
Cap/HoS spawn with their eguns in their bags

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -257,7 +257,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_eyes = list(/obj/item/clothing/glasses/sunglasses)
 	slot_ears = list(/obj/item/device/radio/headset/command/captain)
 	slot_poc1 = list(/obj/item/disk/data/floppy/read_only/authentication)
-	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash)
+	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash,/obj/item/gun/energy/egun/captain)
 	rounds_needed_to_play = 30
 
 	derelict
@@ -331,7 +331,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	receives_security_disk = TRUE
 	receives_badge = TRUE
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
-	items_in_backpack = list(/obj/item/device/flash)
+	items_in_backpack = list(/obj/item/device/flash, /obj/item/gun/energy/egun/head_of_security,)
 	wiki_link = "https://wiki.ss13.co/Head_of_Security"
 
 #ifdef SUBMARINE_MAP

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -209,8 +209,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 /obj/storage/secure/closet/command/captain
 	name = "\improper Captain's locker"
 	req_access = list(access_captain)
-	spawn_contents = list(/obj/item/gun/energy/egun/captain,
-	/obj/item/storage/box/id_kit,
+	spawn_contents = list(/obj/item/storage/box/id_kit,
 	/obj/item/storage/box/clothing/captain,
 	/obj/item/clothing/suit/armor/capcoat,
 	/obj/item/clothing/shoes/brown,
@@ -252,7 +251,6 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	/obj/item/clothing/suit/armor/vest,
 	/obj/item/clothing/head/helmet/hardhat/security/hos,
 	/obj/item/clothing/glasses/sunglasses/sechud,
-	/obj/item/gun/energy/egun/head_of_security,
 	/obj/item/device/radio/headset/security,
 	/obj/item/clothing/glasses/thermal,
 	/obj/item/stamp/hos,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the Captain and HoS Energy gun spawns into their backpacks rather than their lockers

Just a sidenote that with Short-sighted + NT loyalist I spawned with a full backpack as HoS, may need to remove the flash if there are any trait combos that can give more items. Unless there is a way for those trait items to spawn in hands/glued to them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Captains / HoSes latejoining to their gun already stolen isn't great, if a role isn't in the game their gear shouldn't be, also allows HoS latejoiners to have something to deal with antagonists that are already in security, preventing them from redeeming their token. And in addition newer captains can forget their gun in their office (probably not knowing it exists), this gives it to them by default.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Captains and HoSes now spawn with their Energy guns
```
