### PR TITLE
Fix runtime when dropping a juggle with glowsticks

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2986,7 +2986,7 @@
 		src.remove_juggle(A)
 		if(istype(A, /obj/item/device/light)) //i hate this
 			var/obj/item/device/light/L = A
-			L.light.attach(L)
+			L.light?.attach(L)
 		if (istype(A, /obj/item/gun) && prob(80)) //prob(80)
 			var/obj/item/gun/gun = A
 			gun.shoot(get_turf(pick(view(10, src))), get_turf(src), src, 16, 16)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
glowsticks use their own bespoke `light_c` light datum var, so `light` is null and it runtimes when dropping.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19729