### PR TITLE
Convert job creator to use cloudsaves

### DIFF
--- a/code/datums/cloud_saves.dm
+++ b/code/datums/cloud_saves.dm
@@ -102,6 +102,9 @@
 
 	/// Save new cloud data for this player
 	proc/putData(key, value)
+		if(value == src.data[key]) //don't bother sending data if we'd be making no change
+			return TRUE //but treat it as a success I guess
+
 		if (src.simulating)
 			// Local fallback, update JSON file
 			src.putSimulatedCloud("data", key, value)
@@ -126,6 +129,9 @@
 
 	/// Save a new cloud file for this player
 	proc/putSave(name, data)
+		if(data == src.saves[name]) //don't bother sending save if we'd be making no change
+			return TRUE //but treat it as a success I guess
+
 		if (src.simulating)
 			// Local fallback, update JSON file
 			src.putSimulatedCloud("saves", name, data)

--- a/code/datums/controllers/custom_job_savefile.dm
+++ b/code/datums/controllers/custom_job_savefile.dm
@@ -1,209 +1,160 @@
-//some of this stuff is shamelessly based from savefile.dm. yay!! blame MBC if it breaks.
-
-datum/job_controller/proc/savefile_path(key)
-	return "data/admin_custom_job_saves/[src.load_another_ckey ? src.load_another_ckey : ckey(key)].sav"
-
-datum/job_controller/proc/savefile_path_exists(key)
-	var/path = savefile_path(key)
+/datum/job_controller/proc/convert_to_cloudsave(client/user)
+	if(!user || IsGuestKey( user.key ))
+		return FALSE
+	var/path = "data/admin_custom_job_saves/[user.ckey].sav"
 	if (!fexists(path))
-		return 0
-	return path
-
-datum/job_controller/proc/savefile_delete(key, profileNum=1)
-	fdel(savefile_path(key))
-
-datum/job_controller/proc/savefile_unlock(client/user)
-	if (savefile_path_exists(user.ckey))
-		var/savefile/F = new /savefile(src.savefile_path(user.ckey), -1)
-		F.Unlock()
-
-datum/job_controller/proc/savefile_version_pass(client/user)
-	var/version = null
-	var/savefile/F = new /savefile(src.savefile_path(user.ckey), -1)
-	F["version"] >> version
-	if (isnull(version) || version < CUSTOMJOB_SAVEFILE_VERSION_MIN || version > CUSTOMJOB_SAVEFILE_VERSION_MAX)
-		if (!src.load_another_ckey)
-			src.savefile_delete(user)
-		return 0
-	return 1
-
-datum/job_controller/proc/savefile_save(client/user, profileNum=1)
-	profileNum = clamp(profileNum, 1, CUSTOMJOB_SAVEFILE_PROFILES_MAX)
-	var/savefile/F = new /savefile(src.savefile_path(user.ckey), -1)
-	F.Lock(-1)
-
-	F["version"] << CUSTOMJOB_SAVEFILE_VERSION_MAX
-	F["[profileNum]_saved"] << 1
-	F["[profileNum]_job_name"] << src.job_creator.name
-	F["[profileNum]_wages"] << src.job_creator.wages
-	F["[profileNum]_limit"] << src.job_creator.limit
-	F["[profileNum]_mob_type"] << src.job_creator.mob_type
-	F["[profileNum]_slot_head"] << src.job_creator.slot_head
-	F["[profileNum]_slot_mask"] << src.job_creator.slot_mask
-	F["[profileNum]_slot_ears"] << src.job_creator.slot_ears
-	F["[profileNum]_slot_eyes"] << src.job_creator.slot_eyes
-	F["[profileNum]_slot_glov"] << src.job_creator.slot_glov
-	F["[profileNum]_slot_foot"] << src.job_creator.slot_foot
-	F["[profileNum]_slot_card"] << src.job_creator.slot_card
-	F["[profileNum]_slot_jump"] << src.job_creator.slot_jump
-	F["[profileNum]_slot_suit"] << src.job_creator.slot_suit
-	F["[profileNum]_slot_back"] << src.job_creator.slot_back
-	F["[profileNum]_slot_belt"] << src.job_creator.slot_belt
-	F["[profileNum]_slot_poc1"] << src.job_creator.slot_poc1
-	F["[profileNum]_slot_poc2"] << src.job_creator.slot_poc2
-	F["[profileNum]_slot_lhan"] << src.job_creator.slot_lhan
-	F["[profileNum]_slot_rhan"] << src.job_creator.slot_rhan
-	F["[profileNum]_access"] << src.job_creator.access
-	F["[profileNum]_change_name_on_spawn"] << src.job_creator.change_name_on_spawn
-	if(istext(src.job_creator.special_spawn_location))
-		F["[profileNum]_special_spawn_location"] << src.job_creator.special_spawn_location
-	else if(ismovable(src.job_creator.special_spawn_location) || isturf(src.job_creator.special_spawn_location))
-		var/atom/A = src.job_creator.special_spawn_location
-		var/turf/T = get_turf(A)
-		F["[profileNum]_special_spawn_location_coords"] << list(T.x, T.y, T.z)
-	F["[profileNum]_bio_effects"] << src.job_creator.bio_effects
-	F["[profileNum]_objective"] << src.job_creator.objective
-	F["[profileNum]_receives_implants"] << src.job_creator.receives_implants
-	F["[profileNum]_items_in_backpack"] << src.job_creator.items_in_backpack
-	F["[profileNum]_items_in_belt"] << src.job_creator.items_in_belt
-	F["[profileNum]_announce_on_join"] << src.job_creator.announce_on_join
-	F["[profileNum]_add_to_manifest"] << src.job_creator.add_to_manifest
-	F["[profileNum]_radio_announcement"] << src.job_creator.radio_announcement
-	F["[profileNum]_spawn_id"] << src.job_creator.spawn_id
-	F["[profileNum]_starting_mutantrace"] << src.job_creator.starting_mutantrace
-
-	return 1
-
-datum/job_controller/proc/savefile_load(client/user, var/profileNum = 1)
-	if (!savefile_path_exists(user.ckey))
-		return 0
-
-	if (!src.savefile_version_pass(user))
-		return 0
-
-	var/path = savefile_path(user.ckey)
-
-	profileNum = clamp(profileNum, 1, CUSTOMJOB_SAVEFILE_PROFILES_MAX)
+		return FALSE
 
 	var/savefile/F = new /savefile(path, -1)
+	for(var/i in 1 to CUSTOMJOB_SAVEFILE_PROFILES_MAX)
+		var/saved = null
+		var/datum/job/created/converter = new()
+		F["[i]_saved"] >> saved
+		if(saved)//there's a job to convert here.
+			F["[i]_job_name"] >> converter.name
+			F["[i]_wages"] >> converter.wages
+			F["[i]_limit"] >> converter.limit
+			F["[i]_mob_type"] >> converter.mob_type
+			F["[i]_slot_head"] >> converter.slot_head
+			F["[i]_slot_mask"] >> converter.slot_mask
+			F["[i]_slot_ears"] >> converter.slot_ears
+			F["[i]_slot_eyes"] >> converter.slot_eyes
+			F["[i]_slot_glov"] >> converter.slot_glov
+			F["[i]_slot_foot"] >> converter.slot_foot
+			F["[i]_slot_card"] >> converter.slot_card
+			F["[i]_slot_jump"] >> converter.slot_jump
+			F["[i]_slot_suit"] >> converter.slot_suit
+			F["[i]_slot_back"] >> converter.slot_back
+			F["[i]_slot_belt"] >> converter.slot_belt
+			F["[i]_slot_poc1"] >> converter.slot_poc1
+			F["[i]_slot_poc2"] >> converter.slot_poc2
+			F["[i]_slot_lhan"] >> converter.slot_lhan
+			F["[i]_slot_rhan"] >> converter.slot_rhan
+			F["[i]_access"] >> converter.access
+			F["[i]_change_name_on_spawn"] >> converter.change_name_on_spawn
+			converter.special_spawn_location = null
+			var/maybe_spawn_loc = null
+			F["[i]_special_spawn_location"] >> maybe_spawn_loc
+			if(istext(maybe_spawn_loc))
+				converter.special_spawn_location = maybe_spawn_loc
+			else
+				var/list/maybe_coords = null
+				F["[i]_special_spawn_location_coords"] >> maybe_coords
+				if(islist(maybe_coords))
+					converter.special_spawn_location = locate(maybe_coords[1], maybe_coords[2], maybe_coords[3])
+				else
+					F["[i]_special_spawn_location"] << null
+			F["[i]_bio_effects"] >> converter.bio_effects
+			F["[i]_objective"] >> converter.objective
+			// backwards compatibility
+			if(F["[i]_receives_implant"])
+				var/obj/item/implant/I = null
+				F["[i]_receives_implant"] >> I
+				converter.receives_implants = list(I)
+			if(F["[i]_receives_implants"])
+				F["[i]_receives_implants"] >> converter.receives_implants
+			F["[i]_items_in_backpack"] >> converter.items_in_backpack
+			if(isnull(converter.items_in_backpack))
+				converter.items_in_backpack = list()
+			F["[i]_items_in_belt"] >> converter.items_in_belt
+			if(isnull(converter.items_in_belt))
+				converter.items_in_belt = list()
+			F["[i]_announce_on_join"] >> converter.announce_on_join
+			F["[i]_add_to_manifest"] >> converter.add_to_manifest
+			F["[i]_radio_announcement"] >> converter.radio_announcement
+			F["[i]_spawn_id"] >> converter.spawn_id
+			F["[i]_starting_mutantrace"] >> converter.starting_mutantrace
 
-	var/sanity_check = null
-	F["[profileNum]_saved"] >> sanity_check
-	if (isnull(sanity_check))
-		for (var/i=1, i <= CUSTOMJOB_SAVEFILE_PROFILES_MAX, i++)
-			F["[i]_saved"] >> sanity_check
-			if (!isnull(sanity_check))
-				break
-		if (isnull(sanity_check))
-			fdel(path)
-		return 0
+			//build new savefile
+			var/savefile/F2 = savefile_save(converter)
+			F2["profile_number"] << i
+			var/exported = F2.ExportText()
+			user.player.cloudSaves.putSave("custom_job_[i]", exported)
+	fdel(path) //once we're in cloudland, nuke it
 
-	F["[profileNum]_job_name"] >> src.job_creator.name
-	F["[profileNum]_wages"] >> src.job_creator.wages
-	F["[profileNum]_limit"] >> src.job_creator.limit
-	F["[profileNum]_mob_type"] >> src.job_creator.mob_type
-	F["[profileNum]_slot_head"] >> src.job_creator.slot_head
-	F["[profileNum]_slot_mask"] >> src.job_creator.slot_mask
-	F["[profileNum]_slot_ears"] >> src.job_creator.slot_ears
-	F["[profileNum]_slot_eyes"] >> src.job_creator.slot_eyes
-	F["[profileNum]_slot_glov"] >> src.job_creator.slot_glov
-	F["[profileNum]_slot_foot"] >> src.job_creator.slot_foot
-	F["[profileNum]_slot_card"] >> src.job_creator.slot_card
-	F["[profileNum]_slot_jump"] >> src.job_creator.slot_jump
-	F["[profileNum]_slot_suit"] >> src.job_creator.slot_suit
-	F["[profileNum]_slot_back"] >> src.job_creator.slot_back
-	F["[profileNum]_slot_belt"] >> src.job_creator.slot_belt
-	F["[profileNum]_slot_poc1"] >> src.job_creator.slot_poc1
-	F["[profileNum]_slot_poc2"] >> src.job_creator.slot_poc2
-	F["[profileNum]_slot_lhan"] >> src.job_creator.slot_lhan
-	F["[profileNum]_slot_rhan"] >> src.job_creator.slot_rhan
-	F["[profileNum]_access"] >> src.job_creator.access
-	F["[profileNum]_change_name_on_spawn"] >> src.job_creator.change_name_on_spawn
-	src.job_creator.special_spawn_location = null
-	var/maybe_spawn_loc = null
-	F["[profileNum]_special_spawn_location"] >> maybe_spawn_loc
-	if(istext(maybe_spawn_loc))
-		src.job_creator.special_spawn_location = maybe_spawn_loc
+
+
+/datum/job_controller/proc/savefile_save(datum/job/created/toSave)
+	RETURN_TYPE(/savefile)
+	var/savefile/out = new/savefile
+	out["version"] << CUSTOMJOB_SAVEFILE_VERSION_MAX
+	out["name"] << toSave.name
+	out["job"] << toSave
+	return out
+
+/datum/job_controller/proc/savefile_load(client/user, savefile/SF)
+	RETURN_TYPE(/datum/job/created)
+	var/datum/job/created/loaded = new
+	SF["job"] >> loaded
+	return loaded
+
+/datum/job_controller/proc/savefile_export(client/user)
+	var/savefile/message = src.savefile_save(src.job_creator)
+	var/fname
+	message["name"] >> fname
+	fname = "[user.ckey]_[fname].sav"
+	if(fexists(fname))
+		fdel(fname)
+	var/F = file(fname)
+	message.ExportText("/", F)
+	user << ftp(F, fname)
+	SPAWN(15 SECONDS)
+		var/tries = 0
+		while((fdel(fname) == 0) && tries++ < 10)
+			sleep(30 SECONDS)
+
+
+/datum/job_controller/proc/savefile_import(client/user)
+	var/F = input(user) as file|null
+	if(!F)
+		return FALSE
+	var/savefile/message = new()
+	message.ImportText("/", file2text(F))
+	job_creator = savefile_load(user, message)
+	return TRUE
+
+
+/datum/job_controller/proc/cloudsave_save(client/user, profileNum)
+	if (user)
+		if (IsGuestKey( user.key ))
+			return FALSE
+
+	var/savefile/save = src.savefile_save(src.job_creator)
+	save["profile_number"] << profileNum
+	var/exported = save.ExportText()
+
+	user.player.cloudSaves.putSave("custom_job_[profileNum]", exported)
+	return TRUE
+
+
+/datum/job_controller/proc/cloudsave_load(client/user, profileNum)
+	if (user)
+		if (IsGuestKey(user.key))
+			return FALSE
+
+	var/cloudSaveData = user.player.cloudSaves.getSave("custom_job_[profileNum]")
+
+	var/savefile/save = new
+	save.ImportText( "/", cloudSaveData )
+	var/datum/job/created/loaded = src.savefile_load(user, save)
+	if(loaded)
+		src.job_creator = loaded
+		return TRUE
 	else
-		var/list/maybe_coords = null
-		F["[profileNum]_special_spawn_location_coords"] >> maybe_coords
-		if(islist(maybe_coords))
-			src.job_creator.special_spawn_location = locate(maybe_coords[1], maybe_coords[2], maybe_coords[3])
-		else
-			F["[profileNum]_special_spawn_location"] << null
-	F["[profileNum]_bio_effects"] >> src.job_creator.bio_effects
-	F["[profileNum]_objective"] >> src.job_creator.objective
-	// backwards compatibility
-	if(F["[profileNum]_receives_implant"])
-		var/obj/item/implant/I = null
-		F["[profileNum]_receives_implant"] >> I
-		src.job_creator.receives_implants = list(I)
-	if(F["[profileNum]_receives_implants"])
-		F["[profileNum]_receives_implants"] >> src.job_creator.receives_implants
-	F["[profileNum]_items_in_backpack"] >> src.job_creator.items_in_backpack
-	if(isnull(src.job_creator.items_in_backpack))
-		src.job_creator.items_in_backpack = list()
-	F["[profileNum]_items_in_belt"] >> src.job_creator.items_in_belt
-	if(isnull(src.job_creator.items_in_belt))
-		src.job_creator.items_in_belt = list()
-	F["[profileNum]_announce_on_join"] >> src.job_creator.announce_on_join
-	F["[profileNum]_add_to_manifest"] >> src.job_creator.add_to_manifest
-	F["[profileNum]_radio_announcement"] >> src.job_creator.radio_announcement
-	F["[profileNum]_spawn_id"] >> src.job_creator.spawn_id
-	F["[profileNum]_starting_mutantrace"] >> src.job_creator.starting_mutantrace
+		return FALSE
 
-
-
-
-	return 1
-
-datum/job_controller/proc/savefile_get_job_name(client/user, var/profileNum = 1)
-
-	if (!savefile_path_exists(user.ckey))
-		return 0
-
-	var/path = savefile_path(user.ckey)
-	profileNum = clamp(profileNum, 1, CUSTOMJOB_SAVEFILE_PROFILES_MAX)
-
-	var/savefile/F = new /savefile(path, -1)
-
-	var/job_name = null
-	F["[profileNum]_job_name"] >> job_name
-
-	if (isnull(job_name))
-		return 0
-
-	return job_name
-
-datum/job_controller/proc/savefile_get_job_names(client/user)
+/datum/job_controller/proc/savefile_get_job_names(client/user)
 	RETURN_TYPE(/list)
-
-	if (!savefile_path_exists(user.ckey))
-		return null
-
-	var/path = savefile_path(user.ckey)
-
-	var/savefile/F = new /savefile(path, -1)
+	var/savefile/F = new /savefile
 
 	var/list/job_names = list()
 	for(var/i in 1 to CUSTOMJOB_SAVEFILE_PROFILES_MAX)
-		var/job_name = null
-		F["[i]_job_name"] >> job_name
-		job_names += job_name
-
-	return job_names
-
-
-datum/job_controller/proc/savefile_fix(client/user)
-	if (!savefile_path_exists(user.ckey))
-		return
-	var/savefile/F = new /savefile(src.savefile_path(user.ckey), -1)
-	for(var/i in 1 to CUSTOMJOB_SAVEFILE_PROFILES_MAX)
-		var/spawn_loc
-		F["[i]_special_spawn_location"] >> spawn_loc
-		if(istype(spawn_loc, /datum))
-			F["[i]_special_spawn_location"] << null
+		var/save = user.player.cloudSaves.getSave("custom_job_[i]")
+		if(save)
+			F.ImportText("/", save)
 			var/job_name = null
-			F["[i]_job_name"] >> job_name
-			message_admins("Fixing savefile for [user.ckey] - [job_name].")
-	F.Flush()
+			F["name"] >> job_name
+			job_names += job_name
+		else
+			job_names += null
+	return job_names

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -9,7 +9,6 @@ var/datum/job_controller/job_controls
 
 	var/loaded_save = 0
 	var/last_client = null
-	var/load_another_ckey = null
 
 	New()
 		..()
@@ -57,10 +56,8 @@ var/datum/job_controller/job_controls
 
 	proc/check_user_changed()//Since this is a 'public' window that everyone can get to, make sure we keep the user contained to their own savefile
 		if (last_client != usr.client)
-			src.savefile_unlock(usr)
 			src.last_client = usr.client
 			src.loaded_save = 0
-			src.load_another_ckey = null
 			return 1
 		return 0
 
@@ -212,6 +209,7 @@ var/datum/job_controller/job_controls
 		return fallback_job
 
 	proc/job_creator()
+		src.convert_to_cloudsave(usr.client)
 		src.check_user_changed()
 		var/list/dat = list("<html><body><title>Job Creation</title>")
 		dat += "<b><u>Job Creator</u></b><HR>"
@@ -276,24 +274,21 @@ var/datum/job_controller/job_controls
 
 		if (loaded_save)
 			dat += "<b>Saved Jobs:</b>"
-			if (src.load_another_ckey)
-				dat += "<b> (Showing [src.load_another_ckey]'s jobs)</b>"
 			dat += "<br><small>"
-			var/list/job_names = src.savefile_get_job_names(usr)
+			var/list/job_names = src.savefile_get_job_names(usr.client)
 			for (var/i in 1 to length(job_names))
-				dat += " <a href='?src=\ref[src];Load=[i]'>[job_names[i] || i]</a>"
+				if(job_names[i])
+					dat += " <a href='?src=\ref[src];Load=[i]'>[job_names[i]]</a>"
+				else
+					dat += " Empty slot ([i])"
 				dat += "&nbsp;"
-				if (!src.load_another_ckey)
-					dat += " <a href='?src=\ref[src];Save=[i]'>(Save here)</a>"
+				dat += " <a href='?src=\ref[src];Save=[i]'>(Save here)</a>"
 				dat += "<br>"
 			dat += "</small><br>"
-			if (src.load_another_ckey)
-				dat += "<A href='?src=\ref[src];SaveLoad=1'><b>Load your own jobs</b></A>"
-			else
-				dat += "<A href='?src=\ref[src];LoadDifKey=1'><b>Load another admin's jobs</b></A>"
 		else
 			dat += "<A href='?src=\ref[src];SaveLoad=1'>Save/Load</A>"
 
+		dat += "<br><A href='?src=\ref[src];Import=1'>Import</A> / <A href='?src=\ref[src];Export=1'>Export</A>"
 		dat += "</body></html>"
 
 		usr.Browse(dat.Join(),"window=jobcreator;size=500x650")
@@ -999,29 +994,30 @@ var/datum/job_controller/job_controls
 
 		if(href_list["Save"])
 			if (!src.check_user_changed())
-				src.savefile_save(usr.client, (isnum(text2num(href_list["Save"])) ? text2num(href_list["Save"]) : 1))
+				src.cloudsave_save(usr.client, (isnum(text2num(href_list["Save"])) ? text2num(href_list["Save"]) : 1))
 				boutput(usr, SPAN_NOTICE("<b>Job saved to Slot [text2num(href_list["Save"])].</b>"))
 			src.job_creator()
 
 		if(href_list["Load"])
 			if (!src.check_user_changed())
-				if (!src.savefile_load(usr.client, (isnum(text2num(href_list["Load"])) ? text2num(href_list["Load"]) : 1)))
-					alert(usr, "You do not have a job saved in this slot.")
+				if (!src.cloudsave_load(usr.client, (isnum(text2num(href_list["Load"])) ? text2num(href_list["Load"]) : 1)))
+					alert(usr, "Loading failed.")
 				else
 					boutput(usr, SPAN_NOTICE("<b>Job loaded from Slot [text2num(href_list["Load"])].</b>"))
 			src.job_creator()
 
 		if(href_list["SaveLoad"])
 			src.loaded_save = 1
-			src.load_another_ckey = null
 			src.job_creator()
 
-		if (href_list["LoadDifKey"])
-			var/key = input("Which admin's jobs? (Enter ckey)","Job Creator")
-			src.load_another_ckey = key
-			if (!src.savefile_path_exists(key))
-				src.load_another_ckey = null
-				alert(usr, "Could not find a savefile with that ckey!.")
+		if(href_list["Import"])
+			if(src.savefile_import(usr.client))
+				boutput(usr, SPAN_NOTICE("<b>Job imported from file.</b>"))
+			src.job_creator()
+
+		if(href_list["Export"])
+			src.savefile_export(usr.client)
+			boutput(usr, SPAN_NOTICE("<b>Job exporting.</b>"))
 			src.job_creator()
 
 ///create job datum from job-creator job datum. todo just add a clone method to jobs?

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -67,7 +67,7 @@
 	var/mob/living/mob_type = /mob/living/carbon/human
 	var/datum/mutantrace/starting_mutantrace = null
 	var/change_name_on_spawn = FALSE
-	var/special_spawn_location = null
+	var/tmp/special_spawn_location = null
 	var/bio_effects = null
 	var/objective = null
 	var/rounds_needed_to_play = 0 //0 by default, set to the amount of rounds they should have in order to play this
@@ -2859,3 +2859,25 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 	name = "Special Job"
 	job_category = JOB_CREATED
 
+	//handle special spawn location
+	Write(F)
+		. = ..()
+		if(istext(src.special_spawn_location))
+			F["special_spawn_location"] << src.special_spawn_location
+		else if(ismovable(src.special_spawn_location) || isturf(src.special_spawn_location))
+			var/atom/A = src.special_spawn_location
+			var/turf/T = get_turf(A)
+			F["special_spawn_location_coords"] << list(T.x, T.y, T.z)
+
+	Read(F)
+		. = ..()
+		src.special_spawn_location = null
+		var/maybe_spawn_loc = null
+		F["special_spawn_location"] >> maybe_spawn_loc
+		if(istext(maybe_spawn_loc))
+			src.special_spawn_location = maybe_spawn_loc
+		else
+			var/list/maybe_coords = null
+			F["special_spawn_location_coords"] >> maybe_coords
+			if(islist(maybe_coords))
+				src.special_spawn_location = locate(maybe_coords[1], maybe_coords[2], maybe_coords[3])

--- a/code/modules/admin/job_manager.dm
+++ b/code/modules/admin/job_manager.dm
@@ -51,7 +51,6 @@
 			var/datum/job/job = find_job_in_controller_by_string(params["job"])
 			// invoke the job creator through its accursed var edit proc call thing...
 			job_controls.job_creator = job
-			job_controls.savefile_fix(ui.user)
 			job_controls.job_creator()
 
 		if ("job_creator")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use cloudsaves instead of local savefiles for job creator
also add import/export feature for those who are chronically out of slots



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Old savefile system was clunky and also broken.
Cloudsaves are cool and cross-server


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

