### PR TITLE
Matsci space helmets are blocked from petasusaphilic trait

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -117,6 +117,7 @@
 	name = "bespoke space helmet"
 	desc = "A custom built helmet with a fancy visor!"
 	icon_state = "spacemat"
+	blocked_from_petasusaphilic = TRUE
 
 	var/image/fabrItemImg = null
 	var/image/fabrWornImg = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mark custom matsci helmets as incompatible with the petasusaphilic trait


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #10497