### PR TITLE
Fleet gas mixer fix

### DIFF
--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -17448,7 +17448,7 @@
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
 	id = "engine_combust_control";
-	mixerid = "engine_combust";
+	mixerid = s;
 	name = "Gas Mixer Control (Combustion Chamber)";
 	dir = 4
 	},
@@ -22818,7 +22818,7 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 1;
 	frequency = 1225;
-	id_tag = s;
+	id_tag = "engine_combust";
 	master_id = "engine_combust_control";
 	name = "Gas Mixer (Combustion Chamber)"
 	},

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -17448,7 +17448,7 @@
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
 	id = "engine_combust_control";
-	mixerid = s;
+	mixerid = "engine_combust";
 	name = "Gas Mixer Control (Combustion Chamber)";
 	dir = 4
 	},
@@ -22818,7 +22818,7 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 1;
 	frequency = 1225;
-	id_tag = "engine_combust";
+	id_tag = s;
 	master_id = "engine_combust_control";
 	name = "Gas Mixer (Combustion Chamber)"
 	},

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -17446,8 +17446,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/computer/atmosphere/mixercontrol{
-	dir = 4;
-	frequency = 1225
+	frequency = 1225;
+	id = "engine_combust_control";
+	mixerid = "engine_combust";
+	name = "Gas Mixer Control (Combustion Chamber)";
+	dir = 4
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/power{
@@ -22815,7 +22818,7 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 1;
 	frequency = 1225;
-	id_tag = "engine_combust";
+	id_tag = s;
 	master_id = "engine_combust_control";
 	name = "Gas Mixer (Combustion Chamber)"
 	},

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -22818,7 +22818,7 @@
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 1;
 	frequency = 1225;
-	id_tag = s;
+	id_tag = "engine_combust";
 	master_id = "engine_combust_control";
 	name = "Gas Mixer (Combustion Chamber)"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Corrects a missing tag on the Erebus' gas mixer computer in Fleet, allowing it to link to the mixer. No idea when that happened, but there you go. Validated ingame that it now connects.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #14312. Makes Fleet's TEG ship work, in the event the map gets rolled out for a gimmick.