### PR TITLE
Cluwneshot

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1383,12 +1383,12 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				if (sound)
 					playsound(M, 'sound/vox/detain.ogg', 50)
 				src.toggle_recoil(FALSE)
-			if ("execute", "exterminate")
+			if ("execute", "exterminate", "cluwneshot") //heh
 				set_current_projectile(projectiles["execute"])
 				current_projectile.cost = 30
 				item_state = "lawg-execute"
 				if (sound)
-					playsound(M, 'sound/vox/exterminate.ogg', 50)
+					playsound(M, "sound/vox/[text == "cluwneshot" ? "cluwne" : "exterminate"].ogg", 50)
 				src.toggle_recoil(TRUE)
 			if ("smokeshot","fog")
 				set_current_projectile(projectiles["smokeshot"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR "adds" a cluwneshot mode to the Lawbringer. In reality, it's a version of the lethal kinetic mode with a different VOX line.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The appropriate response to a cluwne is putting them out of their misery. But mostly, I think this is funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The Lawbringer has been given a new (?) mode for use against the cluwne
```
