### PR TITLE
Requisition extra_eval proc

### DIFF
--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -652,8 +652,10 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	feemod = PAY_IMPORTANT
 
 	extra_eval(atom/eval_item)
+		. = FALSE
 		var/obj/item/cell/cell = eval_item
-		return cell.maxcharge >= 15000
+		if(cell.maxcharge >= 15000)
+			return TRUE
 
 /datum/rc_entry/item/borgmodule
 	name = "cyborg module"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -651,10 +651,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	typepath = /obj/item/cell
 	feemod = PAY_IMPORTANT
 
-	rc_eval(atom/eval_item)
-		. = ..()
-		if(!.)
-			return
+	extra_eval(atom/eval_item)
 		var/obj/item/cell/cell = eval_item
 		return cell.maxcharge >= 15000
 

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -687,16 +687,12 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/rc_entry/stack/fancy_cloth
 	name = "high-grade cloth (carbon or bee wool)"
-	typepath = /obj/item/material_piece/cloth/carbon
-	typepath_alt = /obj/item/material_piece/cloth/beewool
+	typepath = /obj/item/material_piece/cloth
 
-	rc_eval(obj/item/eval_item)
-		. = ..()
-		if (.) return
-		if (istype(eval_item, /obj/item/material_piece/cloth))
-			if(eval_item.material?.getID() == "carbonfibre" || eval_item.material?.getID() == "beewool")
-				rollcount += eval_item.amount
-				. = TRUE
+	extra_eval(obj/item/eval_item)
+		. = FALSE
+		if(eval_item.material?.getID() == "carbonfibre" || eval_item.material?.getID() == "beewool")
+			return TRUE
 
 /datum/rc_entry/stack/uqill_minprice
 	name = "uqill"

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -78,7 +78,7 @@ ABSTRACT_TYPE(/datum/rc_entry)
 	 * This should ALWAYS be included in any entry variant, as late as possible in primary checks but before the rolling count is incremented.
 	 * It should return TRUE if additional checks pass, and FALSE if they do not.
 	 */
-	proc/extra_eval()
+	proc/extra_eval(atom/eval_item)
 		return TRUE
 
 ABSTRACT_TYPE(/datum/rc_entry/item)
@@ -111,7 +111,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item)
 		else // Regular type evaluation
 			if(istype(eval_item,typepath) || (typepath_alt && istype(eval_item,typepath_alt))) valid_item = TRUE
 		if(!valid_item) return
-		if(!extra_eval()) return
+		if(!extra_eval(eval_item)) return
 		src.rollcount++
 		. = TRUE
 
@@ -148,7 +148,7 @@ ABSTRACT_TYPE(/datum/rc_entry/food)
 		if(rollcount >= count) return // Standard skip-if-complete
 		if(src.exactpath && eval_item.type != typepath) return // More fussy type evaluation
 		else if(!istype(eval_item,typepath)) return // Regular type evaluation
-		if(!extra_eval()) return
+		if(!extra_eval(eval_item)) return
 		switch(food_integrity)
 			if(FOOD_REQ_INTACT)
 				if(eval_item.bites_left != eval_item.uneaten_bites_left) return
@@ -188,7 +188,7 @@ ABSTRACT_TYPE(/datum/rc_entry/stack)
 			if(!eval_item.material || eval_item.material.getID() != src.mat_id)
 				return
 		if(istype(eval_item,typepath) || (typepath_alt && istype(eval_item,typepath_alt)))
-			if(!extra_eval()) return
+			if(!extra_eval(eval_item)) return
 			rollcount += eval_item.amount
 			. = TRUE // Let manager know passed eval item is claimed by contract
 
@@ -209,7 +209,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent)
 		. = ..()
 		if(rollcount >= count) return //standard skip-if-complete
 		if(contained_in && !istype(eval_item,contained_in)) return // Do we have a required container type? If so, validate it
-		if(!extra_eval()) return
+		if(!extra_eval(eval_item)) return
 		if(eval_item.reagents)
 			var/C // Total count of matching reagents, by unit
 			if(islist(src.chem_ids)) // If there are multiple reagents to evaluate, iterate by chem IDs
@@ -260,7 +260,7 @@ ABSTRACT_TYPE(/datum/rc_entry/seed)
 		var/obj/item/seed/cultivar = eval_item
 		if(!cultivar.plantgenes) return // No genome? Skip it
 		if(cultivar.planttype.name != cropname) return // Wrong species? Skip it
-		if(!extra_eval()) return
+		if(!extra_eval(eval_item)) return
 
 		gene_count = 0
 		for(var/index in gene_reqs) // Iterate over each parameter to see if the genome meets it, or exceeds it in the right direction
@@ -311,7 +311,7 @@ ABSTRACT_TYPE(/datum/rc_entry/artifact)
 					is_acceptable_type = TRUE
 			if(!is_acceptable_type) return
 
-		if(!extra_eval()) return
+		if(!extra_eval(eval_item)) return
 		src.rollcount++
 		. = TRUE // Let manager know artifact passes muster and is claimed by contract
 

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -73,6 +73,14 @@ ABSTRACT_TYPE(/datum/rc_entry)
 	proc/rc_eval(atom/eval_item)
 		. = FALSE
 
+	/**
+	 * Hook point for slight modifications to a contract entry's fulfillment condition.
+	 * This should ALWAYS be included in any entry variant, as late as possible in primary checks but before the rolling count is incremented.
+	 * It should return TRUE if additional checks pass, and FALSE if they do not.
+	 */
+	proc/extra_eval()
+		return TRUE
+
 ABSTRACT_TYPE(/datum/rc_entry/item)
 ///Basic item entry. Use for items that can't stack, and whose properties outside of path aren't relevant.
 /datum/rc_entry/item
@@ -103,6 +111,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item)
 		else // Regular type evaluation
 			if(istype(eval_item,typepath) || (typepath_alt && istype(eval_item,typepath_alt))) valid_item = TRUE
 		if(!valid_item) return
+		if(!extra_eval()) return
 		src.rollcount++
 		. = TRUE
 
@@ -139,6 +148,7 @@ ABSTRACT_TYPE(/datum/rc_entry/food)
 		if(rollcount >= count) return // Standard skip-if-complete
 		if(src.exactpath && eval_item.type != typepath) return // More fussy type evaluation
 		else if(!istype(eval_item,typepath)) return // Regular type evaluation
+		if(!extra_eval()) return
 		switch(food_integrity)
 			if(FOOD_REQ_INTACT)
 				if(eval_item.bites_left != eval_item.uneaten_bites_left) return
@@ -174,10 +184,11 @@ ABSTRACT_TYPE(/datum/rc_entry/stack)
 		. = ..()
 		if(rollcount >= count) return // Standard skip-if-complete
 		if(!istype(eval_item)) return // If it's not an item, it's not a stackable
-		if(mat_id) // If we're checking for materials, do that here with a tag comparison
+		if(mat_id) // If we're checking for a material, do that here with a tag comparison
 			if(!eval_item.material || eval_item.material.getID() != src.mat_id)
 				return
 		if(istype(eval_item,typepath) || (typepath_alt && istype(eval_item,typepath_alt)))
+			if(!extra_eval()) return
 			rollcount += eval_item.amount
 			. = TRUE // Let manager know passed eval item is claimed by contract
 
@@ -198,6 +209,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent)
 		. = ..()
 		if(rollcount >= count) return //standard skip-if-complete
 		if(contained_in && !istype(eval_item,contained_in)) return // Do we have a required container type? If so, validate it
+		if(!extra_eval()) return
 		if(eval_item.reagents)
 			var/C // Total count of matching reagents, by unit
 			if(islist(src.chem_ids)) // If there are multiple reagents to evaluate, iterate by chem IDs
@@ -248,6 +260,7 @@ ABSTRACT_TYPE(/datum/rc_entry/seed)
 		var/obj/item/seed/cultivar = eval_item
 		if(!cultivar.plantgenes) return // No genome? Skip it
 		if(cultivar.planttype.name != cropname) return // Wrong species? Skip it
+		if(!extra_eval()) return
 
 		gene_count = 0
 		for(var/index in gene_reqs) // Iterate over each parameter to see if the genome meets it, or exceeds it in the right direction
@@ -298,6 +311,7 @@ ABSTRACT_TYPE(/datum/rc_entry/artifact)
 					is_acceptable_type = TRUE
 			if(!is_acceptable_type) return
 
+		if(!extra_eval()) return
 		src.rollcount++
 		. = TRUE // Let manager know artifact passes muster and is claimed by contract
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a small stub proc to requisition contract entry prototypes to let their fulfillment conditions be modified slightly by individual entry variants, and applies it to attempts to hook into rc_eval that weren't working correctly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should fix #19752 and a potential similar issue with a Prototypist requisition variant.