### PR TITLE
Move Nukie field medic satchel supplies to the pouch

### DIFF
--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -178,8 +178,12 @@
 	w_class = W_CLASS_TINY
 	slots = 4
 	opens_if_worn = TRUE
+	can_hold = list(/obj/item/robodefibrillator,
+	/obj/item/extinguisher/large)
 	spawn_contents = list(/obj/item/reagent_containers/mender/brute/high_capacity,
-	/obj/item/reagent_containers/mender/burn/high_capacity)
+	/obj/item/reagent_containers/mender/burn/high_capacity,
+	/obj/item/robodefibrillator,
+	/obj/item/extinguisher/large)
 	prevent_holding = list(/obj/item/storage)
 
 /obj/item/storage/security_pouch

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -597,7 +597,6 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/device/analyzer/healthanalyzer/upgraded,
 		/obj/item/storage/medical_pouch,
 		/obj/item/storage/belt/syndicate_medic_belt,
-		/obj/item/storage/backpack/satchel/syndie/syndicate_medic_satchel,
 		/obj/item/clothing/suit/space/syndicate/specialist/medic,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/medic)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the field medic nuclear operative's medical satchel and puts the defibrillator and fire extinguisher into the pouch, also lets the pouch hold them


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The satchel is a straight downgrade to the bag you spawn with, essentially just making it a trap for new players

