### PR TITLE
Adds a new random room with firefighting supplies

### DIFF
--- a/assets/maps/random_rooms/3x3/firefighting.dmm
+++ b/assets/maps/random_rooms/3x3/firefighting.dmm
@@ -1,0 +1,70 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
+"d" = (
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/obj/table/auto{
+	icon_state = "1"
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/extinguisher{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
+"E" = (
+/obj/reagent_dispensers/foamtank,
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
+"M" = (
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
+"U" = (
+/obj/rack,
+/obj/item/tank/air{
+	pixel_x = -5
+	},
+/obj/item/tank/air{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 5
+	},
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+d
+M
+a
+"}
+(2,1,1) = {"
+M
+M
+M
+"}
+(3,1,1) = {"
+E
+M
+U
+"}

--- a/assets/maps/random_rooms/3x3/firefighting.dmm
+++ b/assets/maps/random_rooms/3x3/firefighting.dmm
@@ -24,6 +24,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
+"l" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/plating,
+/area/dmm_suite/clear_area)
 "E" = (
 /obj/reagent_dispensers/foamtank,
 /obj/item/storage/wall/fire{
@@ -60,7 +64,7 @@ a
 "}
 (2,1,1) = {"
 M
-M
+l
 M
 "}
 (3,1,1) = {"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a 3x3 room with firefighting supplies to the random room list. This is my first attempt at mapping, and contributing in general. Let me know if I'm doing stuff wrong.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wanted an easy project to start learning mapping stuff, and didn't see anything firefighting related in the existing random rooms.
