### PR TITLE
Syndicate Announcement Computer changes

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -214,13 +214,18 @@
 	icon = 'icons/obj/computerpanel.dmi'
 	icon_state = "announcement2"
 
-/obj/machinery/computer/announcement/syndie
+/obj/machinery/computer/announcement/syndicate
+	name = "Syndicate Announcement computer"
+	theme = "syndicate"
+	req_access = list(access_syndicate_shuttle)
+
+	commander
+		req_access = list(access_syndicate_commander)
+
+	console
 		icon_state = "syndiepc14"
 		icon = 'icons/obj/decoration.dmi'
 		req_access = null
-		name = "Syndicate Announcement computer"
-		voice_name = "Syndicate Announcement Computer"
-		theme = "syndicate"
 
 /obj/machinery/computer/announcement/clown
 	req_access = null

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10485,13 +10485,14 @@
 /turf/space,
 /area/space)
 "aOh" = (
-/obj/table/auto,
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/item/pinpointer/disk,
+/obj/machinery/computer/announcement/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/airless/circuit/red,
 /area/listeningpost)
 "aOi" = (
@@ -19062,6 +19063,11 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/purple,
 /area/station/janitor/office)
+"rkG" = (
+/obj/table/auto,
+/obj/item/pinpointer/disk,
+/turf/simulated/floor/circuit/red,
+/area/listeningpost)
 "rlI" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/machinery/light/incandescent/purpleish{
@@ -94843,7 +94849,7 @@ aNG
 aNQ
 aUH
 aOv
-aNG
+rkG
 ohq
 aaa
 aaa

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -12869,13 +12869,13 @@
 	dir = 1;
 	pixel_x = -1
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/listeningpost)
 "bKS" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -36431,8 +36431,7 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "czS" = (
-/obj/table/wood/auto,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "czT" = (
@@ -65207,6 +65206,7 @@
 	pixel_x = -2;
 	pixel_y = 10
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "xZQ" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -55933,13 +55933,13 @@
 	dir = 1;
 	pixel_x = -1
 	},
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/listeningpost)
 "dnI" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},

--- a/maps/cogwip/kappa.dmm
+++ b/maps/cogwip/kappa.dmm
@@ -242,7 +242,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -250,7 +250,7 @@
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -282,7 +282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -297,21 +297,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/engine/caution/north,
 /area/space)
 "bb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /obj/pool/perspective{
 	tag = "icon-pool (WEST)";
@@ -581,14 +581,14 @@
 "bT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -624,11 +624,11 @@
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -650,11 +650,11 @@
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -689,14 +689,14 @@
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -885,7 +885,7 @@
 /obj/machinery/door/airlock/pyro,
 /obj/cable{
 	icon_state = "1-2";
-	
+
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -1809,14 +1809,14 @@
 /obj/grille/catwalk,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/wall/auto/asteroid/comet/ice_dense,
 /area/space)
@@ -1827,7 +1827,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -1893,7 +1893,7 @@
 /obj/grille/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -1904,7 +1904,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 1;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -1917,14 +1917,14 @@
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
@@ -1968,7 +1968,7 @@
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -1982,7 +1982,7 @@
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
@@ -2049,14 +2049,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2066,11 +2066,11 @@
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2089,7 +2089,7 @@
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -2097,7 +2097,7 @@
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -2110,18 +2110,18 @@
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2184,11 +2184,11 @@
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2239,11 +2239,11 @@
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2960,18 +2960,18 @@
 "iT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3353,7 +3353,7 @@
 /obj/disposalpipe/trunk/east,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3531,7 +3531,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3543,7 +3543,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3555,36 +3555,36 @@
 /obj/disposalpipe/trunk/west,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3592,18 +3592,18 @@
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -5491,7 +5491,7 @@
 /turf/simulated/floor/grey,
 /area/space)
 "qb" = (
-/obj/machinery/computer/announcement/syndie,
+/obj/machinery/computer/announcement/syndicate/console,
 /turf/simulated/floor/wood/eight{
 	icon_state = "wooden-8";
 	dir = 4

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -7334,7 +7334,7 @@
 /turf/unsimulated/floor/black,
 /area/space)
 "tl" = (
-/obj/machinery/computer/announcement/syndie,
+/obj/machinery/computer/announcement/syndicate/console,
 /turf/unsimulated/floor/black,
 /area/space)
 "tm" = (
@@ -10006,7 +10006,7 @@
 "zQ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 2;
-	
+
 	},
 /turf/simulated/floor/caution/north,
 /area/space)
@@ -10390,7 +10390,7 @@
 "AT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	
+
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4;

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -264,13 +264,11 @@
 	dir = 1
 	},
 /obj/item/peripheral/network/radio/locked,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "abd" = (
-/obj/table/wood/auto{
-	dir = 6
-	},
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "abe" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -78014,6 +78014,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/computer/announcement/syndicate{
+	dir = 4
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -28853,7 +28853,7 @@
 	},
 /area/listeningpost)
 "clY" = (
-/obj/machinery/vending/standard,
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/black,
 /area/listeningpost)
 "clZ" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -44815,12 +44815,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "tdf" = (
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	pixel_x = -7
-	},
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/redblack,
 /area/listeningpost)
 "tdj" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -11928,6 +11928,7 @@
 /obj/machinery/light/incandescent/greenish{
 	dir = 4
 	},
+/obj/machinery/computer/announcement/syndicate,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -3028,7 +3028,7 @@
 	},
 /area/listeningpost/syndicateassaultvessel)
 "akN" = (
-/obj/machinery/computer/announcement/syndie,
+/obj/machinery/computer/announcement/syndicate/console,
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "akO" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -27687,13 +27687,8 @@
 	},
 /area/afterlife/heaven)
 "cgj" = (
-/obj/table/wood/auto,
-/obj/machinery/computer/announcement{
-	dir = 4;
-	icon_state = "datasec";
-	name = "Commander's Announcement Computer";
-	req_access_txt = "76";
-	theme = "syndicate"
+/obj/machinery/computer/announcement/syndicate/commander{
+	dir = 4
 	},
 /turf/unsimulated/floor/carpet/red/fancy/edge/sw,
 /area/syndicate_station/battlecruiser)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add syndicate announcement computers to the listening post
Make the current syndie and commander announcement computers subtypes of the syndicate announcement computer 
May require secret changes (repath /obj/machinery/computer/announcement/syndie -> /obj/machinery/computer/announcement/syndicate/console)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Become the supervillian by announcing your evildoings (pairs well with syndicate operative headset)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The listening post has been outfitted with an announcement computer. Agents only!
```
