### PR TITLE
Replaces toxins camera monitors with ones that work

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -10704,10 +10704,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bdz" = (
-/obj/item/device/camera_viewer{
-	network = "Zeta"
-	},
 /obj/table/reinforced/chemistry/auto,
+/obj/item/device/camera_viewer/public,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "bdB" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -22239,6 +22239,7 @@
 /obj/machinery/light/lamp/green,
 /obj/disposalpipe/trunk/west,
 /obj/machinery/disposal/small/west,
+/obj/item/device/camera_viewer/outpost/science,
 /turf/simulated/floor/purple/side{
 	dir = 5
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -77394,9 +77394,7 @@
 /area/station/chapel/sanctuary)
 "xli" = (
 /obj/table/auto,
-/obj/item/device/camera_viewer{
-	network = "Zeta"
-	},
+/obj/item/device/camera_viewer/public,
 /turf/simulated/floor/black,
 /area/station/science/storage)
 "xlw" = (


### PR DESCRIPTION
[bug] [mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the blank camera monitors in toxins on donut 2 and donut 3 with public ones, because the bomb testing sites are on the public network and I think they should stay public.  Let staffies watch bombs. But also let me watch the bombs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
they currently still have the camera monitors that dont work coz everything got repathed or whatever
