### PR TITLE
Fix atmos analyzer inhand

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -720,7 +720,6 @@ TYPEINFO(/obj/item/device/analyzer/atmosanalyzer_upgrade)
 			var/obj/item/device/analyzer/atmospheric/a = src
 			a.analyzer_upgrade = 1
 			a.icon_state = "atmos"
-			a.item_state = "atmosphericnalyzer"
 
 		else
 			boutput(user, SPAN_ALERT("That cartridge won't fit in there!"))


### PR DESCRIPTION
[bug][sprites]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the line that updates atmos analyzer inhand when distance upgrade is added, coz there's only one inhand icon and it looks about as much like both the upgraded and unupgraded version that I don't think it's worth adding a distinct sprite for an upgraded atmos analyzer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
currently when you upgrade the analyzer it just vanishes coz there is no upgraded sprite at least not one I was able to find in my digging

