### PR TITLE
Player Piano Increased Note Limit

### DIFF
--- a/code/modules/items/instruments/playable_piano.dm
+++ b/code/modules/items/instruments/playable_piano.dm
@@ -7,7 +7,7 @@
 
 #define MIN_TIMING 0.1
 #define MAX_TIMING 0.5
-#define MAX_NOTE_INPUT 15360
+#define MAX_NOTE_INPUT 30000
 
 TYPEINFO(/obj/player_piano)
 	mats = 20


### PR DESCRIPTION
[GAME OBJECTS] [BALANCE]

## About the PR

Changes `MAX_NOTE_INPUT` from `15360` to `30000`.

`30000` because that's the limit for the `input` proc.

## Why's this needed?

Some Player Piano songs on the [Piano Song Dump](https://wiki.ss13.co/Piano_Song_Dump) exceed the current limit.

## Changelog

```changelog
(u)Facsimil
(+)Increased Player Piano note cap from 15360 to 30000.
```
