### PR TITLE
Makes pressure sensor belt equippable

### DIFF
--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -628,6 +628,7 @@ TYPEINFO(/obj/item/device/transfer_valve/briefcase)
 	icon_state = "pressure_tester"
 	desc = "Put in a pressure crystal to determine the strength of the explosion."
 	w_class = W_CLASS_SMALL
+	c_flags = ONBELT
 
 	var/obj/item/pressure_crystal/crystal
 


### PR DESCRIPTION
[qol][gameobjects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes pressure sensor (toxins tool used to measure pressure crystal) belt equippable (can put it in belt slot like wrench and other tool)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
my swag tool
