### PR TITLE
Cog2 Ranch expansion

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6473,10 +6473,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aut" = (
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plating,
@@ -13192,23 +13190,32 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNd" = (
-/obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor{
 	icon_state = "carpetW"
 	},
 /area/station/crew_quarters/arcade)
 "aNe" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/carpet,
-/area/station/crew_quarters/arcade)
-"aNf" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor{
-	icon_state = "carpetE"
+/obj/table/reinforced/auto,
+/obj/item/satchel/hydro,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
 	},
-/area/station/crew_quarters/arcade)
+/obj/mapping_helper/access/rancher,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
+"aNf" = (
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/snacks/ranch_feed_bag,
+/obj/item/reagent_containers/food/snacks/ranch_feed_bag,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "aNg" = (
-/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNh" = (
@@ -13646,11 +13653,15 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOr" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor{
-	icon_state = "carpetW"
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "aOs" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet,
@@ -15091,7 +15102,7 @@
 "aSk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/arcade)
+/area/station/ranch)
 "aSl" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -15400,14 +15411,15 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/vending/cigarette,
 /obj/railing/orange/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/green/side{
-	dir = 9
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "aTl" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "xtra_bigstripe-edge2"
@@ -15421,8 +15433,9 @@
 /obj/disposalpipe/trunk/produce{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/arcade)
+/obj/item/device/radio/intercom/catering,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aTn" = (
 /obj/railing/orange/reinforced{
 	dir = 8
@@ -15436,59 +15449,56 @@
 /obj/disposalpipe/segment/produce{
 	dir = 4
 	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aTo" = (
-/obj/decal/poster/wallsign/poster_mining{
-	pixel_y = 30
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/green/side{
-	dir = 1
+/obj/potted_plant{
+	dir = 1;
+	pixel_y = 28
 	},
-/area/station/crew_quarters/arcade)
-"aTp" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aTq" = (
 /obj/machinery/light_switch/north,
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/mapping_helper/access/rancher,
+/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "Stairs_wide"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/ranch)
 "aTs" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aTt" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aTu" = (
-/obj/disposalpipe/segment/mail/bent/west,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -15961,23 +15971,20 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
-"aUI" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/green/corner,
-/area/station/crew_quarters/arcade)
 "aUM" = (
 /obj/potted_plant,
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/green/side,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aUN" = (
-/turf/simulated/floor/stairs{
+/obj/disposalpipe/segment{
 	dir = 4;
-	icon_state = "Stairs2_wide"
+	icon_state = "pipe-c"
 	},
-/area/station/crew_quarters/arcade)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aUP" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -16421,15 +16428,15 @@
 /turf/space,
 /area/space)
 "aWd" = (
-/turf/simulated/floor/green/side{
-	dir = 4
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
 	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aWh" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "aWi" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade/dungeon)
@@ -16837,18 +16844,12 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "aXB" = (
-/turf/simulated/floor/green/side{
-	dir = 8
+/obj/railing/orange/reinforced,
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
-/area/station/crew_quarters/arcade)
-"aXC" = (
-/obj/potted_plant{
-	dir = 4
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "aXD" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -16871,21 +16872,21 @@
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "aXG" = (
-/obj/machinery/disposal/mail/autoname/public/arcade,
-/obj/machinery/light_switch/north,
-/obj/disposalpipe/trunk/mail/north{
-	dir = 8
+/obj/table/reinforced/auto,
+/obj/item/plate,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/rancher,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue5"
+/turf/simulated/floor/grasstodirt{
+	dir = 4
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/ranch)
 "aXH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16908,10 +16909,16 @@
 /area/station/maintenance/northwest)
 "aXJ" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "Arcade";
+	dir = 8;
+	name = "Arcade APC";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
@@ -17496,50 +17503,34 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/arrivals)
 "aZm" = (
-/obj/stool/chair/couch{
+/obj/table/reinforced/auto,
+/obj/mapping_helper/access/rancher,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue5"
+/turf/simulated/floor/grasstodirt{
+	dir = 4
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/ranch)
 "aZn" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/crew_quarters/arcade)
-"aZo" = (
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/green/corner{
 	dir = 4
 	},
-/area/station/crew_quarters/arcade)
-"aZp" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
+/obj/mapping_helper/access/maint,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
+"aZp" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/stairs{
-	dir = 8;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "aZq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18050,25 +18041,27 @@
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "baJ" = (
-/obj/shrub{
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"baK" = (
+/obj/railing/orange/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/crew_quarters/arcade)
-"baK" = (
-/turf/simulated/floor/green/side,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "baL" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/stairs{
-	dir = 8;
-	icon_state = "Stairs_wide"
+/obj/shrub{
+	dir = 1
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "baM" = (
 /obj/shrub{
 	dir = 1
@@ -58293,16 +58286,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/inner)
-"fyz" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/window/eastright,
-/obj/mapping_helper/access/rancher,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/grasstodirt{
-	dir = 4
-	},
-/area/station/ranch)
 "fyC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58390,13 +58373,12 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/engine/substation/west)
 "fHh" = (
-/obj/machinery/light_switch/west,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/railing/orange/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
 /area/station/ranch)
 "fHk" = (
 /obj/submachine/laundry_machine,
@@ -59062,11 +59044,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/grasstodirt{
+	dir = 1
+	},
 /area/station/ranch)
 "guo" = (
 /obj/machinery/power/data_terminal,
@@ -59880,7 +59863,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/arcade)
+/area/station/ranch)
 "hoV" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -60410,15 +60393,9 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "hNZ" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/window/eastright,
-/obj/mapping_helper/access/rancher,
-/obj/mapping_helper/firedoor_spawn,
-/obj/item/plate,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget,
-/turf/simulated/floor/grasstodirt{
-	dir = 4
-	},
+/obj/machinery/light_switch/north,
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "hOD" = (
 /obj/table/auto,
@@ -60490,9 +60467,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "hRE" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/green/side,
-/area/station/crew_quarters/arcade)
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/chips,
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "hRR" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
@@ -61032,7 +61015,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/grasstodirt{
+	dir = 5
+	},
 /area/station/ranch)
 "isr" = (
 /obj/machinery/atmospherics/binary/valve{
@@ -61422,13 +61407,14 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/science)
 "iQD" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/window/eastright,
-/obj/item/satchel/hydro,
-/obj/mapping_helper/access/rancher,
-/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt{
-	dir = 4
+	dir = 8
 	},
 /area/station/ranch)
 "iRa" = (
@@ -61670,14 +61656,18 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "jcc" = (
-/obj/item/device/radio/intercom/catering,
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/dirt,
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 1
+	},
 /area/station/ranch)
 "jci" = (
 /turf/simulated/floor/plating,
@@ -62046,20 +62036,9 @@
 /turf/simulated/floor/black,
 /area/station/medical/head)
 "jsm" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/turf/simulated/floor/grasstodirt{
+	dir = 9
 	},
-/obj/machinery/disposal/small{
-	dir = 1;
-	layer = 32;
-	pixel_y = 32
-	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/dirt,
 /area/station/ranch)
 "jtY" = (
 /obj/grille/catwalk{
@@ -64030,16 +64009,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"lit" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 1
-	},
-/obj/mapping_helper/access/rancher,
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment,
-/obj/decal/tile_edge/stripe,
-/turf/simulated/floor/wood,
-/area/station/ranch)
 "liE" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -64235,19 +64204,11 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/power)
 "luy" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/potted_plant{
-	dir = 1;
-	pixel_y = 28
-	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "luz" = (
 /obj/machinery/atmospherics/binary/valve{
@@ -64333,17 +64294,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
-"lAy" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/ranch_feed_bag,
-/obj/item/reagent_containers/food/snacks/ranch_feed_bag,
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
 "lBA" = (
 /obj/machinery/arc_electroplater,
 /turf/simulated/floor/shuttlebay{
@@ -69473,7 +69423,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/tile_edge/stripe,
 /turf/simulated/floor/wood,
-/area/station/hydroponics/bay)
+/area/station/ranch)
 "qXj" = (
 /obj/stool/chair,
 /obj/cable{
@@ -70146,7 +70096,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "rBI" = (
-/obj/stool/chair/green{
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
 /turf/simulated/floor/dirt,
@@ -71022,7 +70972,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/arcade)
+/area/station/ranch)
 "sxL" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
@@ -72233,8 +72183,10 @@
 /turf/simulated/floor/purple,
 /area/station/teleporter)
 "tGv" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -72750,17 +72702,6 @@
 /obj/random_item_spawner/organs/one_to_three,
 /turf/simulated/floor/plating,
 /area/station/medical/maintenance)
-"upY" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/maint,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade/dungeon)
 "uqA" = (
 /obj/machinery/light,
 /turf/simulated/floor/purple/side,
@@ -73265,6 +73206,8 @@
 /area/station/routing/depot)
 "uOl" = (
 /obj/machinery/firealarm/east,
+/obj/machinery/disposal/mail/autoname/public/arcade,
+/obj/disposalpipe/trunk/mail/north,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "uOW" = (
@@ -74210,16 +74153,18 @@
 /turf/simulated/floor/engine,
 /area/station/hallway/primary/west)
 "wcj" = (
+/obj/machinery/light_switch/north,
 /obj/machinery/light{
-	dir = 4;
+	dir = 1;
 	layer = 9.1;
-	pixel_x = 10
+	pixel_y = 21
 	},
-/obj/potted_plant{
-	dir = 4
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue5"
 	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/area/station/crew_quarters/arcade/dungeon)
 "wcA" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/firealarm/west,
@@ -74337,17 +74282,9 @@
 	},
 /area/station/medical/dome)
 "wmO" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "Arcade";
-	dir = 8;
-	name = "Arcade APC";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "wor" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/atmospherics/binary/valve/purge{
@@ -75769,11 +75706,10 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "ybe" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "yby" = (
 /turf/simulated/wall/auto/supernorn,
@@ -100337,8 +100273,8 @@ azn
 aAH
 aPA
 aED
-aED
-aaa
+xfw
+xfw
 xfw
 iRa
 qfX
@@ -100639,10 +100575,10 @@ aCb
 aAH
 azn
 aQT
-awd
-nbd
 xfw
-lAy
+aNf
+aOr
+qBq
 qBq
 qBq
 qBq
@@ -100942,13 +100878,13 @@ aAH
 azn
 azn
 qXg
-eQI
 fHh
-tTd
+fHh
+fHh
 rBI
-tTd
-wcj
-tTd
+fHh
+fHh
+fHh
 ism
 gcY
 xfw
@@ -101243,15 +101179,15 @@ azn
 aAH
 azn
 aQV
-awd
 xfw
-xfw
-fyz
 hNZ
-iQD
-xfw
-xfw
-tGv
+qfX
+idv
+aXB
+qfX
+qfX
+luy
+gtQ
 rOo
 fji
 vdM
@@ -101545,15 +101481,15 @@ azn
 azn
 azn
 rqR
-aKy
+aWh
 aTk
+qfX
+qfX
 aXB
-aXB
-aXB
-aZn
-baJ
-xfw
-luy
+qfX
+qfX
+wmO
+gtQ
 rOo
 qfX
 qfX
@@ -101847,14 +101783,14 @@ azn
 azn
 azn
 aQW
-aKy
+aWh
 aTl
-aUI
-aWd
-aXC
-aZo
-hRE
-lit
+baK
+qfX
+aXB
+qfX
+qfX
+qfX
 gtQ
 thz
 qfX
@@ -102152,8 +102088,8 @@ aQX
 aSk
 aTn
 baK
-pFR
-pFR
+qfX
+aXB
 aZp
 baL
 ybe
@@ -102453,12 +102389,12 @@ yfB
 aQY
 swB
 aur
-baK
-pFR
-aXE
-aZq
-baM
-nbd
+qBq
+qBq
+baJ
+iQD
+qBq
+qBq
 jsm
 nnj
 trh
@@ -102753,14 +102689,14 @@ aJa
 azn
 azn
 aPA
-aKy
+aWh
 aTo
-baK
-pFR
-aXF
-vlP
-baN
-xfw
+tTd
+tGv
+tTd
+aUN
+aWd
+eQI
 rGQ
 xfw
 xfw
@@ -103055,13 +102991,13 @@ aNa
 aOo
 aPB
 aQZ
-aKy
-aTp
+aWh
+tTd
 aUM
 aWh
 aZm
-baI
-bbt
+aXG
+aNe
 xfw
 xfw
 xfw
@@ -103359,14 +103295,14 @@ aLK
 aLK
 hoU
 aTq
-aUN
+aWh
 aWi
-aXG
-aXH
-aQx
-ilw
-pJZ
-aXD
+aXE
+aZq
+baM
+qmv
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103663,12 +103599,12 @@ aKy
 aTs
 aUP
 aWi
-pVe
-kBU
-tlM
-maP
-tWh
-aXD
+aXF
+vlP
+baN
+qmv
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103965,12 +103901,12 @@ aSl
 aTt
 etE
 iYX
-sGY
-qXj
-ptb
-hJC
-oKC
-aXD
+hRE
+baI
+bbt
+qmv
+qmv
+qmv
 aaa
 aaa
 bfD
@@ -104260,18 +104196,18 @@ awh
 awh
 aLL
 aNd
-aOr
-aOr
-aOr
-aOr
+aNd
+aNd
+aNd
+aNd
 aTu
 aWO
 pFR
-xZN
-hlQ
-ucI
-vlg
-snI
+wcj
+aXH
+aQx
+ilw
+pJZ
 aXD
 aaa
 aaa
@@ -104561,7 +104497,7 @@ aHz
 gAZ
 aKy
 aLM
-aNe
+aSm
 aOs
 aPE
 aRb
@@ -104569,11 +104505,11 @@ aSm
 aTv
 aUR
 pFR
-eZn
-jRr
-nne
-kSZ
-sLX
+pVe
+kBU
+tlM
+maP
+tWh
 aXD
 aaa
 aaa
@@ -104863,7 +104799,7 @@ aHA
 aJe
 aKy
 aLN
-aNf
+aOt
 aOt
 aOt
 aOt
@@ -104871,11 +104807,11 @@ aOt
 aTw
 aUS
 aWi
-upY
-aWi
-qmv
-aXD
-aXD
+sGY
+qXj
+ptb
+hJC
+oKC
 aXD
 aaa
 abB
@@ -105172,13 +105108,13 @@ aRc
 aRc
 aTx
 aRc
-aKy
-bah
-wmO
-akw
-aaI
-aaa
-aaa
+aWi
+xZN
+hlQ
+ucI
+vlg
+snI
+aXD
 aaa
 aam
 kHc
@@ -105474,13 +105410,13 @@ aKy
 aKy
 aTy
 aKy
-aKy
-dsQ
-aXI
-akw
-aaI
-aaa
-aaa
+aWi
+eZn
+jRr
+nne
+kSZ
+sLX
+aXD
 aaa
 aam
 eNc
@@ -105776,13 +105712,13 @@ afm
 aEv
 omC
 aUT
-aKC
-bah
-nOi
-akw
-aaI
-aaa
-aaa
+aWi
+aZn
+aWi
+qmv
+aXD
+aXD
+aXD
 aaa
 aam
 eNc
@@ -106381,8 +106317,8 @@ aSp
 aTB
 aUV
 aKC
-bah
-aYI
+dsQ
+aXI
 akw
 aaI
 aaa
@@ -106986,7 +106922,7 @@ aTC
 aKC
 aRd
 aSE
-aYI
+nOi
 bbI
 bag
 auh

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6473,6 +6473,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/camera/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "aut" = (
@@ -13210,6 +13211,11 @@
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/snacks/ranch_feed_bag,
 /obj/item/reagent_containers/food/snacks/ranch_feed_bag,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -13653,11 +13659,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOr" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
+/obj/machinery/interdictor/unlocked,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -14670,10 +14672,16 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aRb" = (
-/obj/stool/chair{
-	dir = 8
+/obj/table/wood/auto,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
 	},
-/obj/landmark/pest,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/arcade)
 "aRc" = (
@@ -15104,6 +15112,7 @@
 /turf/simulated/floor/black,
 /area/station/ranch)
 "aSl" = (
+/obj/landmark/bill_spawn,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aSm" = (
@@ -15433,7 +15442,9 @@
 /obj/disposalpipe/trunk/produce{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/catering,
+/obj/item/device/radio/intercom/catering{
+	pixel_x = -7
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "aTn" = (
@@ -15491,9 +15502,6 @@
 /area/station/crew_quarters/arcade)
 "aTt" = (
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -15507,9 +15515,11 @@
 	},
 /area/station/crew_quarters/arcade)
 "aTv" = (
-/obj/stool/chair,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/arcade)
@@ -16003,24 +16013,14 @@
 	},
 /area/shuttle/arrival/station)
 "aUR" = (
-/obj/table/wood/auto,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
 	},
 /area/station/crew_quarters/arcade)
 "aUS" = (
-/obj/stool/chair{
-	dir = 8
-	},
 /turf/simulated/floor{
 	icon_state = "carpetSE"
 	},
@@ -16428,10 +16428,7 @@
 /turf/space,
 /area/space)
 "aWd" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "aWh" = (
@@ -16611,10 +16608,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/garden/owlery)
 "aWO" = (
-/obj/stool/chair{
-	dir = 4
-	},
-/obj/landmark/bill_spawn,
 /turf/simulated/floor{
 	icon_state = "carpetSW"
 	},
@@ -16866,6 +16859,9 @@
 	dir = 8
 	},
 /obj/item/storage/goodybag,
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "blue5"
@@ -18081,6 +18077,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
+/obj/machinery/light,
 /turf/simulated/floor/carpet{
 	icon_state = "blue5"
 	},
@@ -56553,9 +56550,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "dyM" = (
-/obj/machinery/interdictor/unlocked,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "carpetW"
+	},
+/area/station/crew_quarters/arcade)
 "dzT" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -57304,15 +57305,12 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "etE" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
+/obj/stool/chair{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor{
+	icon_state = "carpetE"
 	},
-/turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "etY" = (
 /obj/lattice{
@@ -57767,6 +57765,10 @@
 "eQI" = (
 /obj/item/device/radio/intercom/catering{
 	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -60152,6 +60154,10 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/central)
+"hGE" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "hHJ" = (
 /obj/stool/chair/dining/wood{
 	dir = 8
@@ -61607,11 +61613,11 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "iYX" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/landmark/pest,
+/turf/simulated/floor{
+	icon_state = "carpetW"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "iZs" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -63282,11 +63288,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "kBU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -68403,8 +68409,11 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "pVe" = (
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -69426,9 +69435,6 @@
 /area/station/ranch)
 "qXj" = (
 /obj/stool/chair,
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -70099,6 +70105,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/landmark/start/job/rancher,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "rCm" = (
@@ -70172,6 +70179,11 @@
 /area/research_outpost)
 "rGQ" = (
 /obj/storage/secure/closet/civilian/ranch,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "rHQ" = (
@@ -71155,14 +71167,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "sGY" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -72000,6 +72010,14 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"tyw" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
 "tzF" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -75676,6 +75694,10 @@
 "xZN" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -99674,7 +99696,7 @@ aaa
 nbd
 nbd
 oxp
-dyM
+qfX
 vNO
 nbd
 nbd
@@ -101487,7 +101509,7 @@ qfX
 qfX
 aXB
 qfX
-qfX
+hGE
 wmO
 gtQ
 rOo
@@ -103899,8 +103921,8 @@ aPD
 aOq
 aSl
 aTt
-etE
-iYX
+aUP
+aWi
 hRE
 baI
 bbt
@@ -104197,9 +104219,9 @@ awh
 aLL
 aNd
 aNd
-aNd
-aNd
-aNd
+dyM
+dyM
+iYX
 aTu
 aWO
 pFR
@@ -104504,7 +104526,7 @@ aRb
 aSm
 aTv
 aUR
-pFR
+tyw
 pVe
 kBU
 tlM
@@ -104801,8 +104823,8 @@ aKy
 aLN
 aOt
 aOt
-aOt
-aOt
+etE
+etE
 aOt
 aTw
 aUS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expands the cog2 ranch by adding 2 new pens, moves the nerd dungeon right a bit to make space
![image](https://github.com/goonstation/goonstation/assets/159719201/8668224c-a9b2-4c73-a838-c90d6d857e06)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cog2 ranch is really small and sad really


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Cogmap2 ranch expanded significantly
```
