### PR TITLE
Support For Single State Reagent Overlays

### DIFF
--- a/code/datums/components/reagent_overlay.dm
+++ b/code/datums/components/reagent_overlay.dm
@@ -59,8 +59,8 @@ TYPEINFO(/datum/component/reagent_overlay)
 	if (reagents.total_volume <= 0)
 		return 0
 
-	// Show the last reagent state only if the container is full.
-	if (reagents.total_volume >= reagents.maximum_volume)
+	// Show the last reagent state if the container is full, or only one reagent overlay state is present and the container is not empty.
+	if ((reagents.total_volume >= reagents.maximum_volume) || (src.reagent_overlay_states == 1))
 		return src.reagent_overlay_states
 
 	var/normalised_reagent_height = 0


### PR DESCRIPTION
[Bug] [Internal]


## About The PR:
For a container, if only one reagent overlay state is defined, the reagent overlay component will now use that state unless the container is completely empty. Previously, if only one state was defined, the component would use the empty state if the container was less than half full. This is not ideal, as it does not effectively communicate when a container with a single reagent overlay state is empty, which is arguably more important than communicating it is full in that case.