### PR TITLE
Orderable clothing restocks

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1383,6 +1383,18 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Electronics Vending Machine Restocking Pack"
 
+/datum/supply_packs/clothing_vending_restock
+	name = "Clothing Vending Machine Restock Pack"
+	desc = "Various Vending Machine Restock Cartridges for departmental apparel vendors"
+	contains = list(/obj/item/vending/restock_cartridge/jobclothing/security,
+					/obj/item/vending/restock_cartridge/jobclothing/medical,
+					/obj/item/vending/restock_cartridge/jobclothing/engineering,
+					/obj/item/vending/restock_cartridge/jobclothing/catering,
+					/obj/item/vending/restock_cartridge/jobclothing/research,)
+	cost = PAY_TRADESMAN*5
+	containertype = /obj/storage/crate
+	containername = "Clothing Vending Machine Restocking Pack"
+
 /*
 	Umm, apparently the packs below never get added? What's up with that. Construction mode :S -ZeWaka
 */

--- a/code/obj/item/vending_restock.dm
+++ b/code/obj/item/vending_restock.dm
@@ -155,6 +155,31 @@
 	icon_state = "clothing"
 	vendingType =  "jobclothing"
 
+/obj/item/vending/restock_cartridge/jobclothing/security
+	name = "security clothing restock cartridge"
+	desc = "A cartridge that restocks security clothing vending machines."
+	vendingType = "jobclothing/security"
+
+/obj/item/vending/restock_cartridge/jobclothing/medical
+	name = "medical clothing restock cartridge"
+	desc = "A cartridge that restocks medical clothing vending machines."
+	vendingType = "jobclothing/medical"
+
+/obj/item/vending/restock_cartridge/jobclothing/engineering
+	name = "engineering clothing restock cartridge"
+	desc = "A cartridge that restocks engineering clothing vending machines."
+	vendingType = "jobclothing/engineering"
+
+/obj/item/vending/restock_cartridge/jobclothing/catering
+	name = "catering clothing restock cartridge"
+	desc = "A cartridge that restocks catering clothing vending machines."
+	vendingType = "jobclothing/catering"
+
+/obj/item/vending/restock_cartridge/jobclothing/research
+	name = "research clothing restock cartridge"
+	desc = "A cartridge that restocks research clothing vending machines."
+	vendingType = "jobclothing/research"
+
 /obj/item/vending/restock_cartridge/jobclothing/syndicate
 	name = "syndicate clothing restock cartridge"
 	desc = "A cartridge that restocks syndicate clothing vending machines."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add departmental clothing restock cartridges that can be bought by cargo


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More people may want the style than there are amounts of that item available.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Cargo can now order a crate full of departmental clothing vendor restock cartridges.
```
