### PR TITLE
New fishing locale: Deep hole

### DIFF
--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -916,3 +916,14 @@ datum/fishing_spot/golden_toilet
 	/obj/item/parts/human_parts/arm/mutant/monkey/right = 5,\
 	/obj/item/parts/human_parts/leg/mutant/monkey/left = 5,\
 	/obj/item/parts/human_parts/leg/mutant/monkey/right =5)
+
+//trench hole
+/datum/fishing_spot/deephole
+	fishing_atom_type = /turf/space/fluid/warp_z5
+	rod_tier_required = 3
+	fish_available = list(/obj/item/raw_material/rock = 10,
+	/obj/item/seashell = 10,
+	/obj/item/clothing/shoes/flippers = 5, //like fishing up a boot (cartoonstyle)
+	/mob/living/critter/small_animal/pikaia = 5,
+	/mob/living/critter/small_animal/trilobite = 5,
+	/mob/living/critter/small_animal/hallucigenia = 5)


### PR DESCRIPTION
[feature][gameobjects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds deep hole (like trench holes, oshan/nadir style) as fishable location which has fun stuff (rock, seashell, flipper) and even funner stuff (evil fish that want to kill you)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We need more stupid fishing spots that try to hurt you
![image](https://github.com/goonstation/goonstation/assets/142273065/70612a64-564e-4fd6-9b5f-f7bde51bb0fc)
(I tried to get a picture of one of the actual mobs I fished up but he threw himself back into the trench immediately and died)
