### PR TITLE
Kondaru Toxins Update!

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -14017,6 +14017,18 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
+"beJ" = (
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "tox_accessvent";
+	layer = 8;
+	name = "Buffer Vent"
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/space)
 "beK" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -23556,8 +23568,13 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "bQu" = (
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/white,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "bQv" = (
 /obj/item/storage/wall{
@@ -25409,25 +25426,27 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
 "bZv" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 21
+/obj/machinery/atmospherics/unary/outlet_injector/active{
+	dir = 4
 	},
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
+/obj/machinery/sparker{
+	id = "tox_ignition1";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_x = 24
 	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bZw" = (
+/obj/machinery/door_control{
+	id = "tox_accessvent";
+	name = "Access Buffer Vent";
+	pixel_y = 28
+	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -25445,18 +25464,12 @@
 	},
 /area/station/science/lab)
 "bZz" = (
-/obj/machinery/door_control{
-	id = "tox_accessvent";
-	name = "Access Buffer Vent";
-	pixel_y = 28
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
-	},
-/area/station/science/lab)
+/obj/grille/catwalk,
+/turf/space,
+/area/space)
 "bZA" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -25576,36 +25589,78 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
 "can" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/purplewhite{
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/airless/purple/side{
 	dir = 9
 	},
 /area/station/science/lab)
 "cao" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
 	},
-/turf/simulated/floor/purplewhite{
+/obj/table/reinforced/chemistry/auto/basicsup{
+	drawer_contents = ssss
+	},
+/obj/table/reinforced/chemistry/auto/basicsup{
+	drawer_contents = null
+	},
+/obj/table/reinforced/chemistry/auto/basicsup{
+	drawer_contents = null;
+	desc = null
+	},
+/obj/item/device/prox_sensor{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/device/prox_sensor{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/device/timer{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/device/timer{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/device/timer{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/turf/simulated/floor/airless/purple/side{
 	dir = 1
 	},
 /area/station/science/lab)
 "cap" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
+/obj/table/reinforced/chemistry/auto/basicsup{
+	drawer_contents = null;
+	desc = null
 	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/table/reinforced/chemistry/auto/basicsup{
+	drawer_contents = null;
+	desc = null
 	},
-/turf/simulated/floor/purplewhite{
+/obj/item/device/igniter{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/device/igniter{
+	pixel_x = -9;
+	pixel_y = -4
+	},
+/obj/item/device/igniter{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/device/audio_log{
+	pixel_y = 7
+	},
+/turf/simulated/floor/airless/purple/side{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -25613,12 +25668,8 @@
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 5
+/turf/simulated/floor/airless/purple/side{
+	dir = 1
 	},
 /area/station/science/lab)
 "cas" = (
@@ -25718,11 +25769,8 @@
 /turf/space,
 /area/space)
 "cbe" = (
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 4;
-	id = "tox_vent";
-	layer = 8;
-	name = "Chamber Exhaust"
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -25733,64 +25781,81 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "cbg" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
-"cbh" = (
-/obj/machinery/atmospherics/unary/outlet_injector/active{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
-"cbi" = (
 /obj/machinery/atmospherics/binary/pump/active{
 	dir = 8;
 	frequency = 1229;
-	id = "Toxin Chamber Inlet";
+	id = "Chamber Two Inlet";
 	target_pressure = 1000
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lab)
-"cbl" = (
-/obj/cable{
-	icon_state = "2-4"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
-"cbm" = (
+"cbh" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
+"cbi" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/white,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/science/lab)
+"cbl" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/space)
+"cbm" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/table/auto,
+/obj/item/extinguisher{
+	pixel_y = 14;
+	pixel_x = 4
+	},
+/obj/item/extinguisher{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/obj/item/chem_grenade/firefighting{
+	pixel_y = -3;
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/chem_grenade/firefighting{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "cbn" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/purplewhite{
+/obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "cbp" = (
 /obj/cable{
@@ -26030,59 +26095,47 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "cce" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/machinery/door/firedoor/pyro{
+	dir = 4
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "ccf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/test_apparatus/gas_sensor{
-	setup_tag = "TOXCHMB"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/obj/cable,
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "ccg" = (
-/obj/machinery/atmospherics/unary/vent_pump/toxlab_chamber_to_tank{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/obj/machinery/sparker{
-	id = "tox_ignition";
-	layer = 7;
-	name = "Mounted Igniter";
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/turf/simulated/floor/engine/vacuum,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cch" = (
-/obj/machinery/atmospherics/binary/pump/active{
-	dir = 4;
-	frequency = 1229;
-	id = "Toxin Chamber Outlet";
-	target_pressure = 1000
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "ccm" = (
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/bomb_tester{
-	bank_id = "Mixer"
-	},
 /obj/item/device/radio/intercom/science{
 	dir = 8
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/machinery/networked/storage/bomb_tester{
+	bank_id = "Mixer"
 	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "ccn" = (
 /obj/rack,
@@ -26198,58 +26251,73 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "ccU" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 4;
-	id = "oh_boy_fire";
-	name = "Burn Chamber Heat Shield"
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/airless/purple/side{
+	dir = 10
 	},
-/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "ccV" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 8
+/obj/cable{
+	icon_state = "2-8"
 	},
+/obj/machinery/firealarm/north,
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "ccW" = (
-/turf/simulated/floor/white,
+/obj/stool/chair/office{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "ccX" = (
 /obj/table/auto,
-/obj/item/device/prox_sensor{
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/device/prox_sensor{
-	pixel_x = 2;
-	pixel_y = -8
-	},
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 8;
+	pixel_y = 10
 	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/device/analyzer/atmospheric,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/vr{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	network = "bombtest";
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "ccZ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -26471,45 +26539,71 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "cdH" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
+/obj/machinery/door_control{
+	id = "tox_mix";
+	name = "Mixing Vent Control";
+	pixel_x = -24
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/atmosphere/pumpcontrol{
+	dir = 4;
+	frequency = 1229
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cdI" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/pyro/shutters{
-	id = "oh_boy_fire";
-	name = "Burn Chamber Heat Shield"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine/vacuum,
+/obj/stool/chair/purple{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cdJ" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 6;
-	id = "oh_boy_fire";
-	name = "Burn Chamber Heat Shield"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine/vacuum,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cdK" = (
-/turf/simulated/floor/purplewhite{
+/turf/simulated/floor/airless/purple/side{
 	dir = 8
 	},
 /area/station/science/lab)
 "cdL" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/rack,
+/obj/item/clothing/suit/space/emerg/science,
+/obj/item/clothing/head/emerg/science,
+/obj/item/tank/air,
+/obj/machinery/light/incandescent/harsh{
+	dir = 1
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cdM" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 6
-	},
-/turf/simulated/floor/white,
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor,
 /area/station/science/lab)
 "cdP" = (
 /obj/machinery/manufacturer/gas,
@@ -26774,34 +26868,24 @@
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "ceN" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/purplewhite{
-	dir = 9
-	},
-/area/station/science/lab)
-"ceS" = (
-/obj/machinery/atmospherics/pipe/manifold/overfloor{
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
 	dir = 4
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/white,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
+"ceS" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "ceT" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating,
 /area/station/science/lab)
 "ceW" = (
 /obj/cable{
@@ -26911,72 +26995,60 @@
 /turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/crew_quarters/quarters_south)
 "cfy" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "cfz" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "cfB" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
+"cfD" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10;
+	can_rupture = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10;
+	can_rupture = 0
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
+"cfE" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor,
+/area/station/science/lab)
+"cfF" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/white,
-/area/station/science/lab)
-"cfD" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/atmosphere/pumpcontrol{
-	frequency = 1229
-	},
-/turf/simulated/floor/purplewhite,
-/area/station/science/lab)
-"cfE" = (
-/obj/machinery/light/small/floor,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/science/lab)
-"cfF" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/meter,
-/turf/simulated/floor/white,
+/turf/simulated/floor,
 /area/station/science/lab)
 "cfG" = (
-/obj/table/auto,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/device/analyzer/atmospheric,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/timer,
-/obj/item/device/timer,
-/obj/item/device/timer,
-/obj/item/wrench,
-/obj/item/wrench,
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cfH" = (
 /obj/machinery/light/small{
@@ -27139,46 +27211,45 @@
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "cgn" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
+/obj/machinery/atmospherics/binary/pump/active{
+	dir = 8;
+	frequency = 1229;
+	id = "Chamber One Inlet";
+	target_pressure = 1000
 	},
-/obj/stool/chair/office{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/turf/simulated/floor/purplewhite/corner{
-	dir = 4
-	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cgo" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 9
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cgq" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
-/turf/simulated/floor/white,
-/area/station/science/lab)
-"cgs" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/blue,
+/area/station/science/lab)
+"cgs" = (
+/turf/simulated/floor/airless/purple/corner{
+	dir = 4
+	},
 /area/station/science/lab)
 "cgt" = (
-/obj/stool/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/white,
+/turf/simulated/floor,
 /area/station/science/lab)
 "cgv" = (
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -27333,12 +27404,11 @@
 /turf/space,
 /area/space)
 "cgT" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/table/auto,
-/obj/item/device/audio_log,
-/obj/item/storage/firstaid/fire,
-/obj/item/screwdriver,
-/turf/simulated/floor/purplewhite,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor,
 /area/station/science/lab)
 "cgU" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -27388,12 +27458,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/science)
 "chf" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 1
+/obj/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/obj/stool/chair/office{
+	dir = 8
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "chj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -29543,22 +29614,21 @@
 /area/station/maintenance/west)
 "coj" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
 /obj/item/wrench,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
-/obj/item/clothing/mask/gas/emergency,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/item/wrench{
+	pixel_y = 4;
+	pixel_x = -3
 	},
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/item/wrench{
+	pixel_x = 7;
+	pixel_y = 0
 	},
+/obj/item/screwdriver{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor,
 /area/station/science/lab)
 "cok" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -29617,6 +29687,15 @@
 	dir = 1
 	},
 /area/station/security/main)
+"cos" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/obj/grille/catwalk,
+/turf/space,
+/area/space)
 "cov" = (
 /obj/machinery/disposal/mail/autoname/security,
 /obj/disposalpipe/trunk/mail/east,
@@ -30294,6 +30373,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"cyc" = (
+/obj/machinery/atmospherics/unary/vent{
+	dir = 1
+	},
+/turf/space,
+/area/space)
 "cyi" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -30507,6 +30592,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"cFk" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "cFJ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -30764,10 +30857,14 @@
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "cNX" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	name = "Mixing Port"
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "TOP"
 	},
-/turf/simulated/floor/white,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "cOf" = (
 /obj/machinery/conveyor/NS{
@@ -31338,23 +31435,27 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
 "djU" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
 /obj/table/auto,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+/obj/item/assembly/time_ignite{
+	pixel_y = 6;
+	pixel_x = 1
 	},
-/obj/item/chem_grenade/firefighting,
-/obj/item/chem_grenade/firefighting,
-/turf/simulated/floor/purplewhite{
-	dir = 6
+/obj/item/assembly/time_ignite{
+	pixel_x = 14;
+	pixel_y = 4
 	},
+/obj/item/assembly/time_ignite{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "dkC" = (
 /obj/machinery/atmospherics/binary/valve{
@@ -32816,11 +32917,8 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/showers)
 "ehl" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/bluewhite,
+/obj/machinery/atmospherics/unary/portables_connector,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "ehC" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt{
@@ -33435,6 +33533,22 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"ezT" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/activation_button/ignition_switch{
+	id = "tox_ignition";
+	name = "Chamber Ignition Switch";
+	pixel_x = -26;
+	pixel_y = 8
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "ezW" = (
 /obj/pool/perspective{
 	dir = 4;
@@ -33768,12 +33882,9 @@
 	},
 /area/station/hallway/secondary/south)
 "eMF" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 6
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/light/small/floor/netural,
+/obj/machinery/atmospherics/pipe/manifold,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "eMP" = (
 /obj/table/wood/auto,
@@ -34333,12 +34444,11 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
 "fhZ" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 6
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/bluewhite,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "fig" = (
 /obj/machinery/conveyor/EW{
@@ -34982,12 +35092,16 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "fGV" = (
-/obj/machinery/atmospherics/unary/vent{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "BOTTOM"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "fIi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35071,23 +35185,14 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "fNe" = (
-/obj/decal/tile_edge/line/red{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/atmospherics/binary/valve{
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
 	dir = 4;
-	name = "Chamber Outlet"
+	id = "tox_vent2";
+	layer = 8;
+	name = "Exhaust Vent"
 	},
-/obj/machinery/activation_button/ignition_switch{
-	id = "tox_ignition";
-	name = "Chamber Ignition Switch";
-	pixel_x = -26;
-	pixel_y = 8
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 8
-	},
+/turf/simulated/floor/plating/airless,
 /area/station/science/lab)
 "fNj" = (
 /obj/lattice{
@@ -35126,6 +35231,21 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"fPU" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "fQi" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/bluewhite{
@@ -35251,27 +35371,20 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "fVI" = (
-/obj/grille/steel,
-/obj/machinery/door/poddoor/pyro/shutters{
-	dir = 4;
-	id = "tox_accessvent";
-	layer = 8;
-	name = "Buffer Vent"
+/obj/securearea{
+	desc = "A warning sign which reads 'Fire Hazard'";
+	icon_state = "fire";
+	layer = 3;
+	name = "FIRE HAZARD"
 	},
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "fVK" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4;
 	layer = 2.9
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/bluewhite{
+/turf/simulated/floor/airless/purple/side{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -35489,14 +35602,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "gcU" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor,
 /area/station/science/lab)
 "gda" = (
 /turf/simulated/floor/specialroom/bar,
@@ -35713,13 +35819,9 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "gjB" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "Heat Sink Purge"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 8
-	},
+/obj/decal/cleanable/dirt,
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
 /area/station/science/lab)
 "gjD" = (
 /obj/cable{
@@ -36109,12 +36211,18 @@
 /area/station/security/secwing)
 "gwG" = (
 /obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4;
-	name = "Mixing Port"
+	dir = 8
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/red,
 /area/station/science/lab)
 "gwU" = (
 /obj/cable{
@@ -36268,6 +36376,18 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor,
 /area/station/crew_quarters/radio/news_office)
+"gDh" = (
+/obj/machinery/atmospherics/unary/outlet_injector/active{
+	dir = 4
+	},
+/obj/machinery/sparker{
+	id = "tox_ignition2";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_x = 24
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "gDk" = (
 /obj/rack,
 /obj/item/sponge{
@@ -36432,8 +36552,17 @@
 	},
 /obj/mapping_helper/access/tox_storage,
 /obj/mapping_helper/firedoor_spawn,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
 /turf/simulated/floor/purple,
 /area/station/science/storage)
+"gIG" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "gII" = (
 /obj/machinery/computer/operating/small{
 	id = "robotics"
@@ -36978,12 +37107,16 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "haB" = (
-/obj/machinery/atmospherics/unary/tank{
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
 	dir = 4
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 10
+/obj/machinery/door_control{
+	id = "tox_vent1";
+	name = "Chamber One Exhaust";
+	pixel_y = -24
 	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "haG" = (
 /obj/cable{
@@ -37615,6 +37748,17 @@
 /obj/mapping_helper/access/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
+"hyt" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/obj/grille/catwalk,
+/turf/space,
+/area/space)
 "hyJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37756,6 +37900,14 @@
 	},
 /turf/space,
 /area/station/com_dish/comdish)
+"hGD" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/obj/grille/catwalk,
+/turf/space,
+/area/space)
 "hHf" = (
 /obj/stool/bar,
 /obj/machinery/light/small/floor,
@@ -38429,6 +38581,12 @@
 "inI" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/armory_outside)
+"inL" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "iod" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -38607,17 +38765,16 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "iwp" = (
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line1"
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	name = "Mixing Port"
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lab)
+/turf/space,
+/area/space)
 "iwq" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -39904,14 +40061,10 @@
 /turf/simulated/floor/yellow/side,
 /area/station/engine/monitoring)
 "jmJ" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/tile_edge/line/blue{
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor,
 /area/station/science/lab)
 "jmK" = (
 /obj/cable/blue{
@@ -39986,6 +40139,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
+"jpv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "jpy" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Plasma Containment"
@@ -40671,13 +40833,13 @@
 /turf/space,
 /area/space)
 "jPF" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "Waste Gas Venting"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "jQd" = (
 /obj/disposalpipe/segment/vertical,
@@ -42295,13 +42457,14 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
 "kZW" = (
-/obj/machinery/atmospherics/unary/vent{
-	dir = 1
-	},
 /obj/lattice{
-	dir = 4;
 	icon_state = "lattice-dir"
 	},
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/grille/catwalk,
 /turf/space,
 /area/space)
 "kZX" = (
@@ -42317,6 +42480,11 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/grey,
 /area/station/bridge)
+"lax" = (
+/obj/lattice,
+/obj/grille/catwalk,
+/turf/space,
+/area/space)
 "laJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
@@ -42931,11 +43099,20 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
+"lxk" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "lya" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "Heat Sink Hookup"
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
+	dir = 4;
+	id = "tox_vent1";
+	layer = 8;
+	name = "Exhaust Vent"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/plating/airless,
 /area/station/science/lab)
 "lyi" = (
 /obj/item/storage/box/evidence,
@@ -43810,6 +43987,12 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/plating/damaged1,
 /area/station/security/beepsky)
+"meh" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -45592,6 +45775,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"nEr" = (
+/obj/decal/poster/wallsign/biohazard,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "nEE" = (
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
@@ -46315,14 +46502,12 @@
 /area/station/hallway/secondary/exit)
 "oce" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "oco" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -47045,6 +47230,12 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"oFr" = (
+/obj/machinery/atmospherics/unary/tank{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "oFt" = (
 /turf/simulated/floor/orangeblack/corner{
 	dir = 8
@@ -48281,6 +48472,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"pCz" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "pCI" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
@@ -49152,6 +49346,17 @@
 	},
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
+"qhk" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/blue,
+/area/station/science/lab)
 "qhy" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -49208,12 +49413,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "qjF" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "Intermix Valve"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/purplewhite/corner{
-	dir = 1
+/turf/simulated/floor/airless/purple/side{
+	dir = 8
 	},
 /area/station/science/lab)
 "qjT" = (
@@ -49253,6 +49457,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"qmu" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "qmz" = (
 /obj/noticeboard/persistent{
 	name = "Brig persistent notice board";
@@ -49459,6 +49669,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"qtq" = (
+/obj/grille/steel,
+/obj/machinery/door/poddoor/pyro/shutters{
+	id = "tox_mix";
+	layer = 8;
+	name = "Mixing Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "qtt" = (
 /obj/shrub{
 	dir = 1
@@ -49581,6 +49800,18 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/west)
+"qwR" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "tox_vent2";
+	name = "Chamber Two Exhaust";
+	pixel_y = 24
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "qwW" = (
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -49711,6 +49942,18 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
+"qBV" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "qCz" = (
 /obj/overlay{
 	icon = 'icons/misc/beach2.dmi';
@@ -49980,6 +50223,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"qMC" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "qNo" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/cable{
@@ -50208,6 +50457,26 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"qXG" = (
+/obj/machinery/activation_button/ignition_switch{
+	id = "tox_ignition2";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/binary/pump/active{
+	dir = 4;
+	frequency = 1229;
+	id = "Chamber Two Outlet";
+	target_pressure = 1000
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "qYs" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -50396,13 +50665,8 @@
 /turf/space,
 /area/station/mining/magnet)
 "rew" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/white,
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/airless/purple/side,
 /area/station/science/lab)
 "reM" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -50524,18 +50788,30 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rhS" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8;
-	name = "Waste Gas Venting"
-	},
 /obj/machinery/door_control{
 	id = "oh_boy_fire";
 	name = "Burn Chamber Heat Shields";
 	pixel_x = 24
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
+/obj/table/auto,
+/obj/item/device/transfer_valve{
+	pixel_x = 8
 	},
+/obj/item/device/transfer_valve{
+	pixel_x = -8
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/transfer_valve{
+	pixel_y = 3
+	},
+/turf/simulated/floor,
 /area/station/science/lab)
 "riw" = (
 /obj/grille/catwalk{
@@ -50790,6 +51066,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"rsQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/purple/side{
+	dir = 8
+	},
+/area/station/science/lab)
 "rsS" = (
 /obj/machinery/disposal/brig{
 	name = "mercantile checkpoint chute"
@@ -51086,6 +51373,10 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen/freezer)
+"rBz" = (
+/obj/decal/poster,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
 "rBS" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -53245,6 +53536,13 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/interrogation)
+"thF" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "thR" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -53460,26 +53758,24 @@
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "tqS" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line1"
+/obj/machinery/activation_button/ignition_switch{
+	id = "tox_ignition1";
+	pixel_x = -24;
+	pixel_y = -8
 	},
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line1"
+/obj/machinery/atmospherics/binary/pump/active{
+	dir = 4;
+	frequency = 1229;
+	id = "Chamber One Outlet";
+	target_pressure = 1000
 	},
-/obj/machinery/atmospherics/binary/valve{
-	name = "Heat Sink Loop"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door_control{
-	id = "oh_boy_fire";
-	name = "Burn Chamber Heat Shields";
-	pixel_x = 9;
-	pixel_y = 24
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "tqZ" = (
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -53507,6 +53803,13 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
+"tsr" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "tsS" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
@@ -53633,6 +53936,12 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/showers)
+"txe" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "txs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/caution/corner/se,
@@ -53861,6 +54170,15 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"tGJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "Waste Gas Venting"
+	},
+/turf/simulated/floor/airless/black,
+/area/station/science/lab)
 "tHm" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -54641,12 +54959,13 @@
 	},
 /area/station/hallway/primary/east)
 "ujQ" = (
-/obj/machinery/computer3/terminal/zeta{
-	setup_os_string = "ZETA_MAINFRAME"
+/obj/machinery/light/small/floor/netural,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/purplewhite,
+/turf/simulated/floor/airless/purple/side{
+	dir = 8
+	},
 /area/station/science/lab)
 "ujW" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -55395,6 +55714,14 @@
 	dir = 4
 	},
 /area/station/medical/medbay/psychiatrist)
+"uNS" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor/airless/purple/side{
+	dir = 10
+	},
+/area/station/science/lab)
 "uNX" = (
 /obj/stool/chair/red{
 	dir = 4
@@ -55914,11 +56241,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "vgR" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "Vacuum Cooling Hookup"
+/obj/machinery/atmospherics/pipe/simple/overfloor{
+	dir = 4
 	},
-/turf/simulated/floor/bluewhite,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "vgY" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -56316,6 +56642,14 @@
 	dir = 8
 	},
 /area/station/hangar/main)
+"vtv" = (
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/machinery/computer3/terminal/zeta{
+	setup_os_string = "ZETA_MAINFRAME"
+	},
+/turf/simulated/floor/airless/purple/side,
+/area/station/science/lab)
 "vtN" = (
 /obj/machinery/vending/snack,
 /obj/machinery/firealarm/east,
@@ -56328,11 +56662,13 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "vuC" = (
-/obj/machinery/light/small,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/purplewhite{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/overfloor{
+	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "vuD" = (
 /obj/machinery/recharge_station,
@@ -56714,6 +57050,20 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/storage/hydroponics)
+"vJZ" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/space)
 "vKH" = (
 /mob/living/carbon/human/npc/monkey/mrs_muggles,
 /turf/simulated/floor,
@@ -57338,6 +57688,11 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
+"wnV" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "woi" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/grey,
@@ -57743,12 +58098,13 @@
 	},
 /area/station/engine/core)
 "wDM" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-	level = 2
+/obj/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4
+	},
+/turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "wDO" = (
 /obj/stool/chair/yellow{
@@ -57937,10 +58293,11 @@
 	},
 /area/station/bridge)
 "wLG" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "Intermix Valve"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/white,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
 /area/station/science/lab)
 "wLP" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -58360,6 +58717,15 @@
 /obj/structure/woodwall,
 /turf/simulated/floor/plating/damaged1,
 /area/station/garden/aviary)
+"wXr" = (
+/obj/table/auto,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/storage/firstaid/fire{
+	pixel_y = 0
+	},
+/turf/simulated/floor/airless/purple/side,
+/area/station/science/lab)
 "wXw" = (
 /obj/machinery/atmospherics/unary/vent{
 	dir = 8
@@ -59891,20 +60257,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "xXa" = (
-/obj/decal/tile_edge/line/blue{
-	icon_state = "line1"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "Chamber Inlet"
+/obj/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/door_control{
-	id = "tox_vent";
-	name = "Chamber Exhaust";
-	pixel_x = -25;
-	pixel_y = 9
-	},
-/turf/simulated/floor/purplewhite{
+/turf/simulated/floor/airless/purple/side{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -91265,19 +91624,19 @@ bTG
 qtQ
 qtQ
 aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-acb
+iwp
+ceS
 abZ
-aay
-abZ
-aaf
-abZ
-abZ
+bZz
+hyt
+bZz
+bZz
+bZz
+hGD
+bZz
+lax
+bZz
+kZW
 abZ
 abZ
 abZ
@@ -91567,19 +91926,19 @@ xOY
 bvo
 jRG
 aaa
-aci
+pCz
+beJ
+bYG
+fNe
+fNe
+fNe
+fVI
+lya
+lya
+lya
+bYG
 aaa
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
-aci
-aaa
-aci
-aaa
-aaa
+cos
 aaa
 aaa
 aaa
@@ -91869,19 +92228,19 @@ bUM
 khr
 jRG
 aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-ach
-abZ
+pCz
+cbl
+bYG
+ccT
+cNX
+ccT
+bYG
+cbf
 fGV
-abZ
-acO
+ccS
+cdG
 aaa
-aaa
+cos
 aaa
 aaa
 aaa
@@ -92171,20 +92530,20 @@ bUM
 pht
 jRG
 aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
-aaa
+pCz
+vJZ
+lFD
+ccT
+cbe
+ccT
+qtq
+inL
 cfy
-aaa
-aci
-aaa
-aaa
-aaa
+ccS
+gIG
+bYG
+txe
+bYG
 aaa
 aaa
 aaa
@@ -92474,19 +92833,19 @@ bvo
 bvo
 bvo
 bYG
-fVI
+bZx
 bYG
+gDh
 cbe
-cbe
-cbe
+qBV
 bYG
-ceM
+fPU
 cfz
-ceM
-ceM
-aaa
-aaa
-aaa
+bZv
+vgR
+cdL
+ccg
+bYG
 aaa
 aaa
 aaa
@@ -92776,19 +93135,19 @@ bvo
 bXP
 vuD
 bYG
-bZv
+jKV
 bYG
-cbf
+qwR
 cce
-ccS
-cdG
 ceN
-gjB
+bYG
+ceN
+cce
 haB
-ceM
-ceM
-aaa
-aaa
+vgR
+bYG
+cfG
+bYG
 aaa
 aaa
 aaa
@@ -93079,21 +93438,21 @@ bWW
 bXN
 bYG
 bZw
-lFD
+ezT
 cbg
 ccf
-ccS
+qXG
 cdH
 tqS
 cfB
 cgn
 vuC
-ceM
-aaa
-aaa
-aaa
-aaa
-aaa
+oFr
+qMC
+thF
+rKr
+pCp
+hbu
 aaa
 aci
 aaa
@@ -93380,22 +93739,22 @@ bvo
 bWX
 bzR
 bYG
-bZx
-bYG
+bZA
 cbh
+cgo
 ccg
-ccT
+cgo
 cdI
-iwp
-lya
+cgo
+ccg
 cgo
 cfD
 eMF
+tsr
+cFk
 rKr
-pCp
 hbu
-aaa
-aaa
+meh
 aaa
 aci
 aaa
@@ -93681,23 +94040,23 @@ bSt
 bQU
 bQU
 bzR
+gjB
 bYG
-jKV
-bYG
+ccV
 cbi
 cch
-ccU
+cgq
 cdJ
 gwG
 bQu
 cgq
 fhZ
 wDM
-rKr
-pCp
+qhk
+ceM
+aaa
+bhJ
 aBi
-aaa
-aaa
 aaa
 aci
 aaa
@@ -93983,20 +94342,20 @@ bUO
 nzn
 bQU
 yhe
+ceT
 bYG
-bZz
 can
 xXa
-fNe
-ccV
+cdK
+cdK
 cdK
 qjF
-ccW
-cgq
-vgR
+cdK
+ccU
+ccg
+jpv
+ccg
 ceM
-abZ
-aay
 abZ
 abZ
 abZ
@@ -94285,22 +94644,22 @@ bUP
 hbg
 bQU
 bzR
+ceT
 bYG
-bZA
 cao
 jmJ
 gcU
-cNX
-wLG
-ceS
+gcU
+gcU
+jmJ
 wLG
 rew
 ehl
-ceM
-aaa
-aci
-aaa
-aaa
+tGJ
+lxk
+wnV
+chn
+cyc
 aaa
 aaa
 aci
@@ -94587,20 +94946,20 @@ bUQ
 bXa
 bQU
 bzR
-bAP
-bYG
+bAQ
+rBz
 cap
-cbl
+jmJ
 cfE
-cdL
-cdL
-ceT
-cfE
+gcU
+gcU
+jmJ
+qmu
 cgs
 ujQ
+rsQ
+uNS
 ceM
-aaa
-aci
 aaa
 aaa
 aaa
@@ -94892,8 +95251,8 @@ bzR
 bAQ
 bYG
 fVK
-cbm
-ccW
+jmJ
+gcU
 ccW
 cdM
 jPF
@@ -94901,8 +95260,8 @@ cfF
 cgt
 cgT
 chf
-chn
-kZW
+vtv
+ceM
 aaa
 aaa
 aaa
@@ -95199,12 +95558,12 @@ ccm
 ccX
 rhS
 cbn
-cfG
+gcU
 coj
 djU
+cbm
+wXr
 ceM
-abZ
-aad
 abZ
 abZ
 abZ
@@ -95494,7 +95853,7 @@ bWa
 bAU
 bzR
 bAQ
-bYG
+nEr
 bYG
 jfL
 bYG
@@ -95505,8 +95864,8 @@ bZD
 bZD
 bZD
 bZD
-aaa
-aaa
+bYG
+bYG
 aaa
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -27006,13 +27006,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
-"cfG" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/door/airlock/pyro/external{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/science/lab)
 "cfH" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -93096,7 +93089,7 @@ cce
 haB
 vgR
 bYG
-cfG
+txe
 bYG
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -25602,16 +25602,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/table/reinforced/chemistry/auto/basicsup{
-	drawer_contents = ssss
-	},
-/obj/table/reinforced/chemistry/auto/basicsup{
-	drawer_contents = null
-	},
-/obj/table/reinforced/chemistry/auto/basicsup{
-	drawer_contents = null;
-	desc = null
-	},
+/obj/table/reinforced/chemistry/auto/basicsup,
 /obj/item/device/prox_sensor{
 	pixel_x = -2;
 	pixel_y = -4
@@ -25637,10 +25628,6 @@
 	},
 /area/station/science/lab)
 "cap" = (
-/obj/table/reinforced/chemistry/auto/basicsup{
-	drawer_contents = null;
-	desc = null
-	},
 /obj/table/reinforced/chemistry/auto/basicsup{
 	drawer_contents = null;
 	desc = null

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -25593,7 +25593,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 9
 	},
 /area/station/science/lab)
@@ -25623,7 +25623,7 @@
 	pixel_x = 10;
 	pixel_y = 8
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -25647,7 +25647,7 @@
 /obj/item/device/audio_log{
 	pixel_y = 7
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -25655,7 +25655,7 @@
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 8
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -25833,7 +25833,7 @@
 	pixel_y = 9;
 	pixel_x = -8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cbn" = (
 /obj/cable{
@@ -25842,7 +25842,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cbp" = (
 /obj/cable{
@@ -26122,7 +26122,7 @@
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "ccn" = (
 /obj/rack,
@@ -26239,7 +26239,7 @@
 /area/station/science/lab)
 "ccU" = (
 /obj/decal/tile_edge/stripe/big,
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 10
 	},
 /area/station/science/lab)
@@ -26263,7 +26263,7 @@
 /obj/stool/chair/office{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "ccX" = (
 /obj/table/auto,
@@ -26304,7 +26304,7 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "ccZ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -26573,7 +26573,7 @@
 /turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cdK" = (
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -26590,7 +26590,7 @@
 "cdM" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cdP" = (
 /obj/machinery/manufacturer/gas,
@@ -27021,14 +27021,14 @@
 /area/station/science/lab)
 "cfE" = (
 /obj/machinery/light/small/floor/netural,
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cfF" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cfG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -27228,7 +27228,7 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "cgs" = (
-/turf/simulated/floor/airless/purple/corner{
+/turf/simulated/floor/purplewhite/corner{
 	dir = 4
 	},
 /area/station/science/lab)
@@ -27236,7 +27236,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cgv" = (
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -27395,7 +27395,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cgU" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -27451,7 +27451,7 @@
 /obj/stool/chair/office{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "chj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -29615,7 +29615,7 @@
 	pixel_x = -2
 	},
 /obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "cok" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -31442,7 +31442,7 @@
 	pixel_x = -7;
 	pixel_y = -3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "dkC" = (
 /obj/machinery/atmospherics/binary/valve{
@@ -35371,7 +35371,7 @@
 	dir = 4;
 	layer = 2.9
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/lab)
@@ -35589,7 +35589,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "gcU" = (
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "gda" = (
 /turf/simulated/floor/specialroom/bar,
@@ -40051,7 +40051,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "jmK" = (
 /obj/cable/blue{
@@ -40581,6 +40581,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"jGx" = (
+/turf/simulated/floor/purplewhite/corner{
+	dir = 4
+	},
+/area/space)
 "jHf" = (
 /obj/machinery/conveyor/EW{
 	id = "garbage";
@@ -40826,7 +40831,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "jQd" = (
 /obj/disposalpipe/segment/vertical,
@@ -46494,7 +46499,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "oco" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -49403,7 +49408,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -49448,7 +49453,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "qmz" = (
 /obj/noticeboard/persistent{
@@ -50653,7 +50658,7 @@
 /area/station/mining/magnet)
 "rew" = (
 /obj/decal/tile_edge/stripe/big,
-/turf/simulated/floor/airless/purple/side,
+/turf/simulated/floor/purplewhite,
 /area/station/science/lab)
 "reM" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -50798,7 +50803,7 @@
 /obj/item/device/transfer_valve{
 	pixel_y = 3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "riw" = (
 /obj/grille/catwalk{
@@ -51060,7 +51065,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -54950,7 +54955,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -55705,7 +55710,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 10
 	},
 /area/station/science/lab)
@@ -56635,7 +56640,7 @@
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
 	},
-/turf/simulated/floor/airless/purple/side,
+/turf/simulated/floor/purplewhite,
 /area/station/science/lab)
 "vtN" = (
 /obj/machinery/vending/snack,
@@ -58284,7 +58289,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor,
+/turf/simulated/floor/white,
 /area/station/science/lab)
 "wLP" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -58711,7 +58716,7 @@
 /obj/item/storage/firstaid/fire{
 	pixel_y = 0
 	},
-/turf/simulated/floor/airless/purple/side,
+/turf/simulated/floor/purplewhite,
 /area/station/science/lab)
 "wXw" = (
 /obj/machinery/atmospherics/unary/vent{
@@ -60250,7 +60255,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless/purple/side{
+/turf/simulated/floor/purplewhite{
 	dir = 8
 	},
 /area/station/science/lab)
@@ -88890,7 +88895,7 @@ aaa
 aci
 aaa
 aaa
-aaa
+jGx
 aaa
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -25776,7 +25776,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/science/lab)
 "cbl" = (
 /obj/machinery/light/small{
@@ -38717,6 +38717,18 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"iwr" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/science/lab)
 "iwQ" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple{
@@ -93988,7 +94000,7 @@ bYG
 ccV
 cbi
 cch
-cgq
+iwr
 cdJ
 gwG
 bQu
@@ -97313,7 +97325,7 @@ cau
 ccZ
 cdS
 ceY
-cfL
+cdR
 cfL
 cfL
 ccZ
@@ -97615,7 +97627,7 @@ cav
 cav
 cav
 cav
-cfL
+cdR
 cgz
 cfL
 bZD

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -23574,7 +23574,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "bQv" = (
 /obj/item/storage/wall{
@@ -25764,7 +25764,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cbi" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -26076,10 +26076,10 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ccg" = (
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cch" = (
 /obj/cable{
@@ -26089,7 +26089,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ccm" = (
 /obj/item/device/radio/intercom/science{
@@ -26232,7 +26232,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ccW" = (
 /obj/stool/chair/office{
@@ -26242,10 +26242,6 @@
 /area/station/science/lab)
 "ccX" = (
 /obj/table/auto,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
 	network = "bombtest";
@@ -26278,6 +26274,10 @@
 	network = "bombtest";
 	pixel_x = -8;
 	pixel_y = 7
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -26524,7 +26524,7 @@
 	name = "Mixing Vent Control";
 	pixel_x = -24
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cdI" = (
 /obj/cable{
@@ -26533,7 +26533,7 @@
 /obj/stool/chair/purple{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cdJ" = (
 /obj/cable{
@@ -26545,7 +26545,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cdK" = (
 /turf/simulated/floor/purplewhite{
@@ -26981,7 +26981,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cfD" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -26993,7 +26993,7 @@
 	can_rupture = 0
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cfE" = (
 /obj/machinery/light/small/floor/netural,
@@ -27011,7 +27011,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cfH" = (
 /obj/machinery/light/small{
@@ -27183,13 +27183,13 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cgo" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "cgq" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -32882,7 +32882,7 @@
 /area/station/crew_quarters/showers)
 "ehl" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ehC" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt{
@@ -33508,7 +33508,7 @@
 	pixel_x = -26;
 	pixel_y = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "ezW" = (
 /obj/pool/perspective{
@@ -33843,9 +33843,11 @@
 	},
 /area/station/hallway/secondary/south)
 "eMF" = (
-/obj/machinery/light/small/floor/netural,
-/obj/machinery/atmospherics/pipe/manifold,
-/turf/simulated/floor/airless/black,
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "eMP" = (
 /obj/table/wood/auto,
@@ -34409,7 +34411,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "fig" = (
 /obj/machinery/conveyor/EW{
@@ -40089,7 +40091,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "jpy" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -43055,7 +43057,7 @@
 "lxk" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "lya" = (
 /obj/grille/steel,
@@ -47184,7 +47186,7 @@
 /obj/machinery/atmospherics/unary/tank{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "oFt" = (
 /turf/simulated/floor/orangeblack/corner{
@@ -50169,7 +50171,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "qNo" = (
 /obj/machinery/atmospherics/binary/valve,
@@ -50417,7 +50419,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "qYs" = (
 /obj/machinery/conveyor/WE{
@@ -52009,6 +52011,13 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"sdW" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
 "set" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/wood,
@@ -53717,7 +53726,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "tqZ" = (
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -53750,7 +53759,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "tsS" = (
 /obj/disposalpipe/segment/bent/west,
@@ -53882,7 +53891,7 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "txs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -54119,7 +54128,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	name = "Waste Gas Venting"
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "tHm" = (
 /obj/machinery/power/apc/autoname_east,
@@ -55660,6 +55669,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/purplewhite{
 	dir = 10
 	},
@@ -56611,7 +56621,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "vuD" = (
 /obj/machinery/recharge_station,
@@ -58044,7 +58054,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/station/science/lab)
 "wDO" = (
 /obj/stool/chair/yellow{
@@ -95498,7 +95508,7 @@ ccm
 ccX
 rhS
 cbn
-gcU
+sdW
 coj
 djU
 cbm

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -14028,7 +14028,7 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/space)
+/area/station/science/lab)
 "beK" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -25443,9 +25443,6 @@
 	name = "Access Buffer Vent";
 	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -25456,20 +25453,10 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
 /area/station/science/lab)
-"bZz" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/grille/catwalk,
-/turf/space,
-/area/space)
 "bZA" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -25779,18 +25766,9 @@
 	},
 /turf/simulated/floor/airless/black,
 /area/station/science/lab)
-"cbh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless/black,
-/area/station/science/lab)
 "cbi" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -25809,7 +25787,7 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/space)
+/area/station/science/lab)
 "cbm" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -26250,9 +26228,6 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/firealarm/north,
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
@@ -26526,11 +26501,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "cdH" = (
-/obj/machinery/door_control{
-	id = "tox_mix";
-	name = "Mixing Vent Control";
-	pixel_x = -24
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
@@ -26548,6 +26518,11 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/machinery/door_control{
+	id = "tox_mix";
+	name = "Mixing Vent Control";
+	pixel_x = -24
 	},
 /turf/simulated/floor/airless/black,
 /area/station/science/lab)
@@ -27017,6 +26992,7 @@
 	dir = 10;
 	can_rupture = 0
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/airless/black,
 /area/station/science/lab)
 "cfE" = (
@@ -27228,6 +27204,9 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "cgs" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 10
+	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 4
 	},
@@ -29680,7 +29659,6 @@
 	icon_state = "lattice-dir";
 	tag = "icon-lattice-dir (EAST)"
 	},
-/obj/grille/catwalk,
 /turf/space,
 /area/space)
 "cov" = (
@@ -30581,8 +30559,7 @@
 /area/station/hallway/primary/west)
 "cFk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
@@ -33524,9 +33501,6 @@
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/activation_button/ignition_switch{
 	id = "tox_ignition";
@@ -37101,7 +37075,8 @@
 /obj/machinery/door_control{
 	id = "tox_vent1";
 	name = "Chamber One Exhaust";
-	pixel_y = -24
+	pixel_x = 9;
+	pixel_y = 9
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
@@ -37735,17 +37710,6 @@
 /obj/mapping_helper/access/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
-"hyt" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
-	},
-/obj/grille/catwalk,
-/turf/space,
-/area/space)
 "hyJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37887,14 +37851,6 @@
 	},
 /turf/space,
 /area/station/com_dish/comdish)
-"hGD" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
-	},
-/obj/grille/catwalk,
-/turf/space,
-/area/space)
 "hHf" = (
 /obj/stool/bar,
 /obj/machinery/light/small/floor,
@@ -40581,11 +40537,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"jGx" = (
-/turf/simulated/floor/purplewhite/corner{
-	dir = 4
-	},
-/area/space)
 "jHf" = (
 /obj/machinery/conveyor/EW{
 	id = "garbage";
@@ -42456,7 +42407,6 @@
 	dir = 9;
 	icon_state = "lattice-dir"
 	},
-/obj/grille/catwalk,
 /turf/space,
 /area/space)
 "kZX" = (
@@ -42473,10 +42423,21 @@
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "lax" = (
-/obj/lattice,
-/obj/grille/catwalk,
-/turf/space,
-/area/space)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/machinery/door/firedoor/pyro{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "tox_vent2";
+	name = "Chamber Two Exhaust";
+	pixel_y = 22;
+	pixel_x = 8
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "laJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
@@ -43349,9 +43310,6 @@
 	icon_state = "research_locked";
 	name = "Toxin Chamber";
 	req_access = null
-	},
-/obj/cable{
-	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/tox,
 /obj/mapping_helper/firedoor_spawn,
@@ -48464,9 +48422,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
-"pCz" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "pCI" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
@@ -49797,11 +49752,6 @@
 	can_rupture = 0;
 	dir = 4
 	},
-/obj/machinery/door_control{
-	id = "tox_vent2";
-	name = "Chamber Two Exhaust";
-	pixel_y = 24
-	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "qwW" = (
@@ -50216,7 +50166,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "qMC" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
 /turf/simulated/floor/airless/black,
@@ -56658,7 +56608,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/airless/black,
 /area/station/science/lab)
@@ -57043,9 +56994,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/hydroponics)
 "vJZ" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -57055,7 +57003,7 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/space)
+/area/station/science/lab)
 "vKH" = (
 /mob/living/carbon/human/npc/monkey/mrs_muggles,
 /turf/simulated/floor,
@@ -88895,7 +88843,7 @@ aaa
 aci
 aaa
 aaa
-jGx
+aaa
 aaa
 aaa
 aaa
@@ -91619,15 +91567,15 @@ aaa
 iwp
 ceS
 abZ
-bZz
-hyt
-bZz
-bZz
-bZz
-hGD
-bZz
-lax
-bZz
+abZ
+ceS
+abZ
+abZ
+abZ
+aay
+abZ
+aaf
+abZ
 kZW
 abZ
 abZ
@@ -91918,7 +91866,7 @@ xOY
 bvo
 jRG
 aaa
-pCz
+bYG
 beJ
 bYG
 fNe
@@ -92220,7 +92168,7 @@ bUM
 khr
 jRG
 aaa
-pCz
+bYG
 cbl
 bYG
 ccT
@@ -92522,7 +92470,7 @@ bUM
 pht
 jRG
 aaa
-pCz
+bYG
 vJZ
 lFD
 ccT
@@ -93130,7 +93078,7 @@ bYG
 jKV
 bYG
 qwR
-cce
+lax
 ceN
 bYG
 ceN
@@ -93732,7 +93680,7 @@ bWX
 bzR
 bYG
 bZA
-cbh
+ccg
 cgo
 ccg
 cgo


### PR DESCRIPTION
# I hope I made this PR correctly :) 
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This just makes a few changes to Kondaru's toxins to make it more in line with other maps' toxins!
 ping me on the goonstation discord @thebee03 if anything has to be changed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, toxins is almost unplayable on Kondaru. It's a pain in the ass to do anything with just one burn chamber, plus the layout is a bit cramped, and generally it's just not the best to look at. 

## Changes
Moved things around to make room for a second burn chamber
Im gonna be honest, this is a pretty close ripoff of donut 3's toxins, but why mess with greatness? 
Added some lab tables, cause those look cool 

## Before and After!
Before:
![image_2024-07-03_123035276](https://github.com/goonstation/goonstation/assets/170150086/1bf42c3c-fee4-4860-a552-22a74c9cada3)
After: Now Matching With The Rest Of Science!
![image](https://github.com/goonstation/goonstation/assets/170150086/9a19b4b0-6f87-4c58-8a93-7e05409fb310)


