### PR TITLE
Adds plasma research counter subtypes

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -886,7 +886,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 
 /obj/table/reinforced/chemistry/auto/firesafety
 	name = "fire safety lab counter"
-	desc = "These drawers have sooty marks on their handles. Hopefully you won't be adding to them."
+	desc = "These drawers have sooty scorch marks on their handles. Hopefully you won't be adding to them."
 	drawer_contents = list(/obj/item/storage/firstaid/fire,
 				/obj/item/extinguisher = 2,
 				/obj/item/chem_grenade/firefighting = 3,
@@ -894,7 +894,7 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 
 /obj/table/reinforced/chemistry/auto/toxins
 	name = "plasma research lab counter"
-	desc = "These drawers are full of all the special doodas an aspiring bomb-maker could hope for."
+	desc = "These drawers are full of all the special doodads an aspiring bomb-maker could hope for."
 	drawer_contents = list(/obj/item/device/analyzer/atmospheric = 2,
 				/obj/item/device/timer = 3,
 				/obj/item/device/igniter = 3,

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -884,6 +884,23 @@ TYPEINFO_NEW(/obj/table/reinforced/chemistry)
 				/obj/item/clothing/glasses/spectro,
 				/obj/item/device/reagentscanner)
 
+/obj/table/reinforced/chemistry/auto/firesafety
+	name = "fire safety lab counter"
+	desc = "These drawers have sooty marks on their handles. Hopefully you won't be adding to them."
+	drawer_contents = list(/obj/item/storage/firstaid/fire,
+				/obj/item/extinguisher = 2,
+				/obj/item/chem_grenade/firefighting = 3,
+				/obj/item/clothing/mask/gas = 2)
+
+/obj/table/reinforced/chemistry/auto/toxins
+	name = "plasma research lab counter"
+	desc = "These drawers are full of all the special doodas an aspiring bomb-maker could hope for."
+	drawer_contents = list(/obj/item/device/analyzer/atmospheric = 2,
+				/obj/item/device/timer = 3,
+				/obj/item/device/igniter = 3,
+				/obj/item/assembly/time_ignite = 3,
+				/obj/item/device/prox_sensor = 2)
+
 
 TYPEINFO(/obj/table/reinforced/industrial)
 TYPEINFO_NEW(/obj/table/reinforced/industrial)


### PR DESCRIPTION
[mapping][science][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two new subtypes of the chemistry pre-filled counters for use in plasma research labs: 

### Plasma Research
2x Atmospheric Analyzer
3x Timer
3x Igniter
3x Timer/Igniter Assembly
2x Proximity Sensor

### Fire safety 
2x Fire Extinguisher
3x Fire fighting grenade
1x Fire first aid
2x Gas mask

I wrote a list of the clutter on counters/tables in toxins in all rotation maps and this is a good median of all of it, with the exception of items I believe should stay visible (VR goggles, the valves themselves of course, and mechanical toolboxes/wrenches) and of the misc "office supply" type items, of which there is already a counter subtype for.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I tire of these mystery piles
![image](https://github.com/goonstation/goonstation/assets/142273065/cd84de56-4221-4eb7-97ce-cd477bf1ad54)
![image](https://github.com/goonstation/goonstation/assets/142273065/25b6fb14-c6f1-44ca-bdfd-02261c181ea1)
