### PR TITLE
Limbs that cannot pickup items don't try to do so with kleptomaniac trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1132,6 +1132,14 @@ TYPEINFO(/datum/trait/partyanimal)
 
 	onLife(var/mob/owner, var/mult)
 		if(!owner.stat && !owner.lying && can_act(owner) && !owner.equipped() && probmult(6))
+			if(istype(owner, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = owner
+				if (H.hand)
+					if (H.limbs?.l_arm && !H.limbs.l_arm.can_hold_items)
+						return
+				else
+					if (H.limbs?.r_arm && !H.limbs.r_arm.can_hold_items)
+						return
 			for(var/obj/item/I in oview(1, owner))
 				if(!I.anchored && !I.cant_drop && isturf(I.loc) && can_reach(owner, I) && !HAS_ATOM_PROPERTY(I, PROP_MOVABLE_KLEPTO_IGNORE))
 					I.Attackhand(owner)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1134,7 +1134,7 @@ TYPEINFO(/datum/trait/partyanimal)
 		if(!owner.stat && !owner.lying && can_act(owner) && !owner.equipped() && probmult(6))
 			if(istype(owner, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = owner
-				if (H.hand)
+				if (H.hand == LEFT_HAND)
 					if (H.limbs?.l_arm && !H.limbs.l_arm.can_hold_items)
 						return
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check the current active limb's ability to hold items when running the kleptomaniac trait onLife check.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19816
