### PR TITLE
Do not autocapitalize agent card names

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -359,11 +359,7 @@ TYPEINFO(/obj/item/card/emag)
 	input = strip_html(input, MAX_MESSAGE_LEN, 1)
 	if (strip_bad_stuff_only)
 		return input
-	var/list/namecheck = splittext(trimtext(input), " ")
-	for(var/i = 1, i <= namecheck.len, i++)
-		namecheck[i] = capitalize(namecheck[i])
-	input = jointext(namecheck, " ")
-	return input
+	return trimtext(input)
 
 /obj/item/card/id/syndicate/get_help_message(dist, mob/user)
 	if (src.name == "agent card") //It's probably unmodified, should be fine to show the help message


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the Auto-capitalization Of Every Word from agent card name/job assignment.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19751