### PR TITLE
Trim whitespace on supply order comments

### DIFF
--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -425,7 +425,7 @@ var/global/datum/rockbox_globals/rockbox_globals = new /datum/rockbox_globals
 						if (isnull(O.comment))
 							shippingmarket.supply_requests += O
 							return .("list") // The user cancelled the order
-						O.comment = html_encode(O.comment)
+						O.comment = html_encode(trimtext(O.comment))
 						wagesystem.shipping_budget -= P.cost
 						if (O.address)
 							src.send_pda_message(O.address, "Your order of [P.name] has been approved.")
@@ -463,7 +463,7 @@ var/global/datum/rockbox_globals/rockbox_globals = new /datum/rockbox_globals
 							O.comment = tgui_input_text(usr, "Comment:", "Enter comment", default_comment, multiline = FALSE, max_length = ORDER_LABEL_MAX_LEN, allowEmpty = TRUE)
 							if (isnull(O.comment))
 								return .("list") // The user cancelled the order
-							O.comment = html_encode(O.comment)
+							O.comment = html_encode(trimtext(O.comment))
 							wagesystem.shipping_budget -= P.cost
 							var/obj/storage/S = O.create(usr)
 							shippingmarket.receive_crate(S)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add trimtext before html_encoding the comments to remove excess whitespace from comments applied to supply orders

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i don't like extra whitespace on these it looks weird