### PR TITLE
Remove unused variable `override_attack_hand `

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -126,7 +126,6 @@ ABSTRACT_TYPE(/obj/item)
 	/*‾‾‾‾‾*/
 	var/arm_icon = "" //set to an icon state in human.dmi minus _s/_l and l_arm_/r_arm_ to allow use as an arm
 	var/over_clothes = 0 //draw over clothes when used as a limb
-	var/override_attack_hand = 1 //when used as an arm, attack with item rather than using attack_hand
 	var/limb_hit_bonus = 0 // attack bonus for when you have this item as a limb and hit someone with it
 	var/can_hold_items = 0 //when used as an arm, can it hold things?
 	/// Chance for this item to be replaced by a mimic disguised as it - note, setting this high here is a *really* bad idea

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -38,7 +38,6 @@ TYPEINFO(/obj/item/saw)
 	arm_icon = "chainsaw-D"
 	var/base_arm = "chainsaw"
 	over_clothes = 1
-	override_attack_hand = 1
 	can_hold_items = 0
 	stamina_damage = 30
 	stamina_cost = 15

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -6,7 +6,6 @@ ABSTRACT_TYPE(/obj/item/parts)
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "buildpipe"
 	c_flags = ONBELT
-	override_attack_hand = 0
 	var/skin_tone = "#FFFFFF"
 	/// which part of the person or robot suit does it go on???????
 	var/slot = null

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -306,7 +306,6 @@
 /obj/item/parts/human_parts/arm
 	name = "placeholder item (don't use this!)"
 	desc = "A human arm."
-	override_attack_hand = 0 //to hit with an item instead of hand when used empty handed
 	can_hold_items = 1
 	var/rebelliousness = 0
 	var/strangling = FALSE
@@ -452,7 +451,6 @@
 	limb_type = /datum/limb/item
 	streak_decal = /obj/decal/cleanable/oil
 	streak_descriptor = "oily"
-	override_attack_hand = 1
 	can_hold_items = 0
 	remove_object = null
 	handlistPart = null
@@ -515,7 +513,6 @@
 			//if(I.over_clothes) handlistPart += "l_arm_[I.arm_icon]"
 			//else partlistPart += "l_arm_[I.arm_icon]"
 			handlistPart += "l_arm_[I.arm_icon]"
-			override_attack_hand = I.override_attack_hand
 			can_hold_items = I.can_hold_items
 
 			if (I.cant_drop)
@@ -600,7 +597,6 @@
 	limb_type = /datum/limb/item
 	streak_decal = /obj/decal/cleanable/oil // what streaks everywhere when it's cut off?
 	streak_descriptor = "oily" //bloody, oily, etc
-	override_attack_hand = 1
 	can_hold_items = 0
 	remove_object = null
 	handlistPart = null
@@ -646,7 +642,6 @@
 			//if(I.over_clothes) handlistPart += "r_arm_[I.arm_icon]"
 			//else partlistPart += "r_arm_[I.arm_icon]"
 			handlistPart += "r_arm_[I.arm_icon]"
-			override_attack_hand = I.override_attack_hand
 			can_hold_items = I.can_hold_items
 
 			if (I.cant_drop)
@@ -729,7 +724,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "eerie"
-	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
 	handlistPart = "l_hand_brullbar"
 	partIconModifier = "brullbar"
@@ -756,7 +750,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "eerie"
-	override_attack_hand = 1
 	limb_type = /datum/limb/brullbar
 	handlistPart = "r_hand_brullbar"
 	partIconModifier = "brullbar"
@@ -783,7 +776,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "bloody"
-	override_attack_hand = 1
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_left"
 	show_on_examine = TRUE
@@ -803,7 +795,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "bloody"
-	override_attack_hand = 1
 	limb_type = /datum/limb/hot
 	handlistPart = "hand_right"
 	show_on_examine = TRUE
@@ -825,7 +816,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "bearly"
-	override_attack_hand = 1
 	limb_type = /datum/limb/bear
 	handlistPart = "l_hand_bear"
 	partIconModifier = "bear"
@@ -848,7 +838,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "bearly"
-	override_attack_hand = 1
 	limb_type = /datum/limb/bear
 	handlistPart = "r_hand_bear"
 	partIconModifier = "bear"
@@ -976,7 +965,6 @@
 	side = "left"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "l_hand_abomination"
 	partIconModifier = "abomination"
@@ -1016,7 +1004,6 @@
 	side = "right"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/abomination
 	handlistPart = "r_hand_abomination"
 	partIconModifier = "abomination"
@@ -1055,12 +1042,10 @@
 	slot = "l_arm"
 	side = "left"
 	decomp_affected = FALSE
-	override_attack_hand = 1
 	can_hold_items = 0
 	limb_type = /datum/limb/zombie //Basically zombie arms am I right?
 	skintoned = TRUE
 	streak_descriptor = "undeadly"
-	override_attack_hand = 1
 	/// Supernatural if not abnormally gross
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ZOMBIE)
@@ -1078,12 +1063,10 @@
 	slot = "r_arm"
 	side = "right"
 	decomp_affected = FALSE
-	override_attack_hand = 1
 	can_hold_items = 0
 	limb_type = /datum/limb/zombie //Basically zombie arms am I right?
 	skintoned = TRUE
 	streak_descriptor = "undeadly"
-	override_attack_hand = 1
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_ZOMBIE)
 
@@ -1101,7 +1084,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "eerie"
-	override_attack_hand = 1
 	limb_type = /datum/limb/claw
 	handlistPart = "l_hand_brullbar"
 	partIconModifier = "brullbar"
@@ -1123,7 +1105,6 @@
 	decomp_affected = FALSE
 	skintoned = FALSE
 	streak_descriptor = "eerie"
-	override_attack_hand = 1
 	limb_type = /datum/limb/claw
 	handlistPart = "r_hand_brullbar"
 	partIconModifier = "brullbar"
@@ -1685,7 +1666,6 @@
 	handlistPart = "hand_left"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
 	show_on_examine = TRUE
 
@@ -1703,7 +1683,6 @@
 	side = "right"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/abomination/werewolf
 	handlistPart = "hand_right"
 	show_on_examine = TRUE
@@ -2049,7 +2028,6 @@
 	side = "left"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_left"
 	show_on_examine = TRUE
@@ -2068,7 +2046,6 @@
 	side = "right"
 	decomp_affected = FALSE
 	skintoned = FALSE
-	override_attack_hand = 1
 	limb_type = /datum/limb/hunter
 	handlistPart = "hand_right"
 	show_on_examine = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove all assignments of `override_attack_hand` since it is no longer read anywhere.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Remove dead code