### PR TITLE
Fix loudspeakers

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1009,6 +1009,7 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker)
 	anchored = ANCHORED
 	speaker_range = 0
 	chat_class = RADIOCL_INTERCOM
+	locked_frequency = TRUE
 	//Best I can figure, you need broadcasting and listening to both be TRUE for it to make a signal and send the words spoken next to it. Why? Fuck whoever named these, that's why.
 	broadcasting = 0
 	listening = 0		//maybe this doesn't need to be on. It shouldn't be relaying signals.
@@ -1017,10 +1018,6 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker)
 	desc = "A HAM radio transmitter...Basically...It only transmits to loudspeakers on a secure frequency."
 	frequency = R_FREQ_LOUDSPEAKERS
 	var/image/active_light = null
-
-/obj/item/device/radio/intercom/loudspeaker/New()
-	. = ..()
-	src.frequency = R_FREQ_LOUDSPEAKERS
 
 //Must be standing next to it to talk into it
 /obj/item/device/radio/intercom/loudspeaker/hear_talk(mob/M as mob, msgs, real_name, lang_id)
@@ -1067,13 +1064,13 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker/speaker)
 	listening = 1
 	chat_class = RADIOCL_INTERCOM
 	frequency = R_FREQ_LOUDSPEAKERS
+	locked_frequency = TRUE
 	rand_pos = 0
 	density = 0
 	desc = "A Loudspeaker."
 
 	New()
 		..()
-		src.frequency = R_FREQ_LOUDSPEAKERS
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			switch(src.dir)
 				if(NORTH)

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1018,6 +1018,10 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker)
 	frequency = R_FREQ_LOUDSPEAKERS
 	var/image/active_light = null
 
+/obj/item/device/radio/intercom/loudspeaker/New()
+	. = ..()
+	src.frequency = R_FREQ_LOUDSPEAKERS
+
 //Must be standing next to it to talk into it
 /obj/item/device/radio/intercom/loudspeaker/hear_talk(mob/M as mob, msgs, real_name, lang_id)
 	if (src.broadcasting)
@@ -1028,18 +1032,24 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker)
 	. = ..()
 	. += "[src] is[src.broadcasting ? " " : " not "]active!\nIt is tuned to [format_frequency(src.frequency)]Hz."
 
-/obj/item/device/radio/intercom/loudspeaker/attack_self(mob/user as mob)
+/obj/item/device/radio/intercom/loudspeaker/proc/toggle_broadcast_mode(mob/user)
 	if (!broadcasting)
 		broadcasting = 1
 		src.icon_state = "transmitter-on"
-		boutput(user, "Now transmitting.")
+		src.visible_message("The [src] clicks on and begins transmitting.")
 	else
 		broadcasting = 0
 		src.icon_state = "transmitter"
-		boutput(user, "No longer transmitting.")
+		src.visible_message("The [src] whirrs down and stops transmitting.")
+
+/obj/item/device/radio/intercom/loudspeaker/attack_hand(mob/user)
+	. = ..()
+	src.toggle_broadcast_mode(user)
+
+/obj/item/device/radio/intercom/loudspeaker/attack_self(mob/user as mob)
+	src.toggle_broadcast_mode(user)
 
 /obj/item/device/radio/intercom/loudspeaker/initialize()
-
 	set_frequency(frequency)
 	if(src.secure_frequencies)
 		set_secure_frequencies()
@@ -1063,6 +1073,7 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker/speaker)
 
 	New()
 		..()
+		src.frequency = R_FREQ_LOUDSPEAKERS
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			switch(src.dir)
 				if(NORTH)
@@ -1086,8 +1097,6 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker/speaker)
 //You can't talk into it to send a message
 /obj/item/device/radio/intercom/loudspeaker/speaker/hear_talk()
 	return
-
-	//listening seems to refer to the device listening to the signals, not listening to voice
 
 /obj/item/device/radio/intercom/loudspeaker/speaker/send_hear()
 	var/list/hear = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Make attack_self and attack_hand use a new toggle proc for switching on/off
* Lock the frequency so it's not sanitized 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19784
For testing, these exist on donut3, manta, decarabia