### PR TITLE
Fix verbiage in "X ignites!" messages

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -148,13 +148,13 @@
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		if (src.on == 0)
 			if (temperature > T0C+200)
-				src.visible_message(SPAN_ALERT("The [src] ignites!"), group = "cig_ignite")
+				src.visible_message(SPAN_ALERT("[src] ignites!"), group = "cig_ignite")
 				src.light()
 
 	ex_act(severity)
 		. = ..()
 		if (src.on == 0)
-			src.visible_message(SPAN_ALERT("The [src] ignites!"), group = "cig_ignite")
+			src.visible_message(SPAN_ALERT("[src] ignites!"), group = "cig_ignite")
 			src.light()
 
 	attackby(obj/item/W, mob/user)
@@ -984,7 +984,7 @@
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		if (src.on == MATCH_UNLIT)
 			if (temperature > T0C+200)
-				src.visible_message(SPAN_ALERT("The [src] ignites!"))
+				src.visible_message(SPAN_ALERT("[src] ignites!"))
 				src.light()
 
 	ex_act(severity)
@@ -992,7 +992,7 @@
 		if (QDELETED(src))
 			return
 		if (src.on == MATCH_UNLIT)
-			src.visible_message(SPAN_ALERT("The [src] ignites!"))
+			src.visible_message(SPAN_ALERT("[src] ignites!"))
 			src.light()
 
 	afterattack(atom/target, mob/user as mob)

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -360,7 +360,7 @@ ADMIN_INTERACT_PROCS(/obj/item/device/light/candle, proc/light, proc/put_out)
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		if (src.on == 0)
 			if (temperature > (T0C + 430))
-				src.visible_message(SPAN_ALERT(" [src] ignites!"), group = "candle_ignite")
+				src.visible_message(SPAN_ALERT("[src] ignites!"), group = "candle_ignite")
 				src.light()
 
 	process()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove redundant "The" from cig/match ignition messages. Remove an extra space from candle ignition message.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19776