### PR TITLE
Door/airlock operation rework (better open/close & door-linked forcefield integration)

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -855,8 +855,9 @@ var/global/list/cycling_airlocks = list()
 					D.close()
 
 /obj/machinery/door/airlock/close(var/manual_actuation = FALSE)
-	if (src.welded || src.locked || src.operating)
-		return
+	if(!manual_actuation)
+		if (src.welded || src.locked || src.operating || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
+			return
 
 	var/already_closed = ..(!src.safety)
 

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1,9 +1,8 @@
 // how many possible network verification codes are there (i.e. how hard is it to bruteforce)
 #define NET_ACCESS_OPTIONS 32
 
-// power usage defines
+// power usage define
 #define OPEN_CLOSE_POWER_USAGE 50
-#define LINKED_FORCEFIELD_POWER_USAGE 100
 
 /// a global associative list of all airlocks linked together by cycling mechanisms. Indexed by ID
 var/global/list/cycling_airlocks = list()
@@ -804,33 +803,10 @@ var/global/list/cycling_airlocks = list()
 		return
 
 	if ((src.density) && (!( src.welded ) && !( src.operating ) && ((!src.arePowerSystemsOn()) || (src.status & NOPOWER)) && !( src.locked )))
-		SPAWN( 0 )
-			src.operating = 1
-			play_animation("opening")
-			src.UpdateIcon(1)
-
-			sleep(src.operation_time)
-
-			src.set_density(0)
-
-			if (!istype(src, /obj/machinery/door/airlock/glass))
-				src.set_opacity(0)
-			src.operating = 0
-			src.UpdateIcon()
+		src.open(TRUE)
 
 	else if ((!src.density) && (!( src.welded ) && !( src.operating ) && !( src.locked )))
-		SPAWN( 0 )
-			src.operating = 1
-			play_animation("closing")
-			src.UpdateIcon(1)
-
-			src.set_density(1)
-			sleep(1.5 SECONDS)
-
-			if (src.visible)
-				src.set_opacity(1)
-			src.operating = 0
-			src.UpdateIcon()
+		src.close(TRUE)
 
 	else if (src.operating == -1) //broken
 		boutput(usr, SPAN_ALERT("You try to pry [src]  [src.density ? "open" : "closed"], but it won't budge! It seems completely broken!"))
@@ -857,44 +833,41 @@ var/global/list/cycling_airlocks = list()
 		if (!(src in cycling_airlocks[src.cycle_id]))
 			cycling_airlocks[src.cycle_id] += src
 
-/obj/machinery/door/airlock/open()
-	if (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
-		return 0
-	src.use_power(OPEN_CLOSE_POWER_USAGE)
-	if (src.linked_forcefield)
-		power_usage += LINKED_FORCEFIELD_POWER_USAGE
-	.= ..()
+/obj/machinery/door/airlock/open(var/manual_actuation = FALSE)
+	if (!manual_actuation)
+		if (!src.density || src.welded || src.locked || src.operating == 1 || (!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
+			return 0
+	if(!(src.status & NOPOWER))
+		src.use_power(OPEN_CLOSE_POWER_USAGE)
+	. = ..()
+	if(!manual_actuation)
+		playsound(src.loc, src.sound_airlock, 25, 1)
 
-	playsound(src.loc, src.sound_airlock, 25, 1)
-
-	if (src.cycle_id)
-		for (var/obj/machinery/door/airlock/D in cycling_airlocks[src.cycle_id])
-			// if they share entry id, don't close, e.g. double doors facing space.
-			if (src.cycle_enter_id && src.cycle_enter_id == D.cycle_enter_id)
-				continue
-			if (D.operating) //can happen with really short airlocks, see atlas south maint
-				SPAWN(0.5 SECONDS)
+		if (src.cycle_id)
+			for (var/obj/machinery/door/airlock/D in cycling_airlocks[src.cycle_id])
+				// if they share entry id, don't close, e.g. double doors facing space.
+				if (src.cycle_enter_id && src.cycle_enter_id == D.cycle_enter_id)
+					continue
+				if (D.operating) //can happen with really short airlocks, see atlas south maint
+					SPAWN(0.5 SECONDS)
+						D.close()
+				else
 					D.close()
-			else
-				D.close()
 
-/obj/machinery/door/airlock/close()
-	//split into two sets of checks so failures to close due to lacking power will cause linked shields to deactivate
-	if ((!src.arePowerSystemsOn()) || (src.status & NOPOWER) || src.isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
-		if (src.linked_forcefield)
-			src.linked_forcefield.setactive(0)
-			power_usage -= LINKED_FORCEFIELD_POWER_USAGE
-		return
+/obj/machinery/door/airlock/close(var/manual_actuation = FALSE)
 	if (src.welded || src.locked || src.operating)
 		return
-	src.use_power(OPEN_CLOSE_POWER_USAGE)
-	if (src.linked_forcefield)
-		power_usage -= LINKED_FORCEFIELD_POWER_USAGE
-	if(!..(!src.safety))
-		if (src.sound_close_airlock)
-			playsound(src.loc, src.sound_close_airlock, 25, 1)
-		else
-			playsound(src.loc, src.sound_airlock, 25, 1)
+
+	var/already_closed = ..(!src.safety)
+
+	if (!already_closed)
+		if (!manual_actuation)
+			if (src.sound_close_airlock)
+				playsound(src.loc, src.sound_close_airlock, 25, 1)
+			else
+				playsound(src.loc, src.sound_airlock, 25, 1)
+		if(!(src.status & NOPOWER))
+			src.use_power(OPEN_CLOSE_POWER_USAGE)
 
 	return
 
@@ -1517,5 +1490,4 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door/airlock, proc/play_deny, proc/toggle_bo
 
 // undefining stuff
 #undef NET_ACCESS_OPTIONS
-#undef LINKED_FORCEFIELD_POWER_USAGE
 #undef OPEN_CLOSE_POWER_USAGE

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -45,6 +45,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 
 	var/ignore_light_or_cam_opacity = FALSE
 
+	var/obj/forcefield/energyshield/linked_forcefield = null
+
 	/// Set before calling open() for handling COMSIG_DOOR_OPENED. Can be null. This gets immediately set to null after the signal calls.
 	var/atom/movable/bumper = null
 

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -1,5 +1,4 @@
 #define KNOCK_DELAY 1 SECOND
-#define LINKED_FORCEFIELD_POWER_USAGE 100
 
 ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_complitely)
 /obj/machinery/door
@@ -508,15 +507,13 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	if (src.linked_forcefield && (src.powered() || !src.linked_forcefield.powered_locally))
 		src.linked_forcefield.setactive(TRUE)
 		if(src.linked_forcefield.powered_locally)
-			src.power_usage += LINKED_FORCEFIELD_POWER_USAGE
+			SubscribeToProcess()
 
 	SPAWN(-1)
 		play_animation("opening")
 		next_timeofday_opened = world.timeofday + (src.operation_time)
 		SPAWN(-1)
 			src.set_opacity(0)
-		if(!(src.status & NOPOWER))
-			src.use_power(100)
 		sleep(src.operation_time / 2)
 		src.set_density(0)
 		src.UpdateIcon(/*/toggling*/ 0)
@@ -557,7 +554,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	if (src.linked_forcefield?.isactive)
 		src.linked_forcefield.setactive(FALSE)
 		if(src.linked_forcefield.powered_locally)
-			src.power_usage -= LINKED_FORCEFIELD_POWER_USAGE
+			UnsubscribeProcess()
 
 	src.operating = 1
 	close_trys = 0
@@ -646,14 +643,14 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 		if (src.linked_forcefield.isactive && !powered() && src.linked_forcefield.powered_locally)
 			//forcefield active, we don't have local power, field isn't from a generator? deactivate, and door is no longer using field power
 			src.linked_forcefield.setactive(FALSE)
-			power_usage -= LINKED_FORCEFIELD_POWER_USAGE
+			UnsubscribeProcess()
 			src.update_nearby_tiles()
 		else if(!src.linked_forcefield.isactive && !density && (powered() || !src.linked_forcefield.powered_locally))
 			//forcefield inactive - if we have local power, or field is from a generator, bring it online if our airlock's open
 			src.linked_forcefield.setactive(TRUE)
-			//and only increment our power usage if door is providing field power
+			//and only start using power if door is providing field power
 			if(src.linked_forcefield.powered_locally)
-				power_usage += LINKED_FORCEFIELD_POWER_USAGE
+				SubscribeToProcess()
 
 /obj/machinery/door/proc/knockOnDoor(mob/user)
 	if(!ON_COOLDOWN(user, "knocking_cooldown", KNOCK_DELAY)) //slow the fuck down cowboy
@@ -913,4 +910,3 @@ TYPEINFO(/obj/machinery/door/unpowered/wood)
 	var/broken = 0
 
 #undef KNOCK_DELAY
-#undef LINKED_FORCEFIELD_POWER_USAGE

--- a/code/obj/machinery/door/poddoor.dm
+++ b/code/obj/machinery/door/poddoor.dm
@@ -966,14 +966,7 @@
 	if (ispryingtool(C) && src.density && (src.status & NOPOWER) && !( src.operating ))
 		if(!ON_COOLDOWN(src, "prying_sound", 1.5 SECONDS))
 			playsound(src, 'sound/machines/airlock_pry.ogg', 35, TRUE)
-		src.operating = TRUE
-		flick("[icon_base]c0", src)
-		src.icon_state = "[icon_base]0"
-		sleep(1.5 SECONDS)
-		src.set_density(0)
-		src.set_opacity(0)
-		src.operating = FALSE
-		src.update_nearby_tiles()
+		src.open()
 	else if (C && src.density && !src.operating)
 		user.lastattacked = src
 		attack_particle(user,src)
@@ -983,53 +976,18 @@
 /obj/machinery/door/poddoor/bumpopen(atom/movable/AM)
 	return 0
 
-/obj/machinery/door/poddoor/open()
-	if (src.operating == 1) //doors can still open when emag-disabled
-		return
-	if (!src.density)
-		return 0
-	if (src.linked_forcefield) //mbc : oh gosh why is this not calling door parent
-		src.linked_forcefield.setactive(1)
-
-	if(!src.operating) //in case of emag
-		src.operating = 1
-
-	SPAWN(-1)
-		flick("[icon_base]c0", src)
-		src.icon_state = "[icon_base]0"
-		sleep(1 SECOND)
-		src.set_density(0)
-		src.set_opacity(0)
-		src.update_nearby_tiles()
-
-		if(src.operating == 1) //emag again
-			src.operating = 0
-		if(src.autoclose)
-			SPAWN(15 SECONDS)
-				src.autoclose()
-	return 1
+/obj/machinery/door/poddoor/play_animation(animation)
+	switch(animation)
+		if("opening")
+			flick("[icon_base]c0", src)
+			src.icon_state = "[icon_base]0"
+		if("closing")
+			flick("[icon_base]c1", src)
+			src.icon_state = "[icon_base]1"
+	return
 
 /obj/machinery/door/poddoor/close()
-	if (src.operating)
-		return
-	if (src.density)
-		return
-	if (src.linked_forcefield) //mbc : oh gosh why is this not calling door parent
-		src.linked_forcefield.setactive(0)
-
-	SPAWN(0)
-		src.operating = 1
-		flick("[icon_base]c1", src)
-		src.icon_state = "[icon_base]1"
-		src.set_density(1)
-		if (src.visible)
-			src.set_opacity(1)
-		src.update_nearby_tiles()
-
-		sleep(1 SECOND)
-		src.operating = 0
-
-	return
+	. = ..(TRUE)
 
 /obj/machinery/door/poddoor/buff
 	name = "buff blast door"
@@ -1068,63 +1026,29 @@
 	if (!ispryingtool(C))
 		return
 	if ((src.density && (src.status & NOPOWER) && !( src.operating )))
-		SPAWN( 0 )
-			src.operating = 1
-			flick("[icon_base][doordir]c0", src)
-			src.icon_state = "[icon_base][doordir]0"
-			sleep(1.5 SECONDS)
-			src.set_density(0)
-			src.set_opacity(0)
-			src.operating = 0
-			src.update_nearby_tiles()
-			return
+		if(!ON_COOLDOWN(src, "prying_sound", 1.5 SECONDS))
+			playsound(src, 'sound/machines/airlock_pry.ogg', 35, TRUE)
+		src.open()
 	return
 
 /obj/machinery/door/poddoor/blast/bumpopen(atom/movable/AM)
 	return 0
 
-/obj/machinery/door/poddoor/blast/open()
-	if (src.operating == 1) //doors can still open when emag-disabled
-		return
-	if (!density)
-		return 0
-	if(!src.operating) //in case of emag
-		src.operating = 1
-	if (src.linked_forcefield) //mbc : SAVE ME FROM THIS HELL WHERE PARENTS ARENT CALLED
-		src.linked_forcefield.setactive(1)
+/obj/machinery/door/poddoor/blast/play_animation(animation)
+	switch(animation)
+		if("opening")
+			flick("[icon_base][doordir]c0", src)
+			src.icon_state = "[icon_base][doordir]0"
+		if("closing")
+			flick("[icon_base][doordir]c1", src)
+			src.icon_state = "[icon_base][doordir]1"
+	return
 
-	SPAWN(-1)
-		flick("[icon_base][doordir]c0", src)
-		src.icon_state = "[icon_base][doordir]0"
-		sleep(1 SECOND)
-		src.set_density(0)
-		src.set_opacity(0)
-		src.update_nearby_tiles()
-
-		if(operating == 1) //emag again
-			src.operating = 0
-		if(autoclose)
-			SPAWN(15 SECONDS)
-				autoclose()
-	return 1
-
-/obj/machinery/door/poddoor/blast/close()
-	if (src.operating || src.density)
-		return
-	if (src.linked_forcefield) //mbc : SAVE ME FROM THIS HELL WHERE PARENTS ARENT CALLED
-		src.linked_forcefield.setactive(0)
-	src.operating = 1
-
-	SPAWN(0)
-		flick("[icon_base][doordir]c1", src)
-		src.icon_state = "[icon_base][doordir]1"
-		src.set_density(1)
-		if (src.visible)
-			src.set_opacity(1)
-		src.update_nearby_tiles()
-
-		sleep(1 SECOND)
-		src.operating = 0
+/obj/machinery/door/poddoor/blast/update_icon(var/toggling = 0)
+	if(toggling? !density : density)
+		icon_state = "[icon_base][doordir]1"
+	else
+		icon_state = "[icon_base][doordir]0"
 	return
 
 /obj/machinery/door/poddoor/isblocked()

--- a/code/obj/machinery/shield_generators/energy_shield.dm
+++ b/code/obj/machinery/shield_generators/energy_shield.dm
@@ -225,6 +225,7 @@
 
 		S.layer = 2
 		S.set_dir(D.dir)
+		S.powered_locally = FALSE
 		if(!src.emagged)
 			S.linked_door = D
 			D.linked_forcefield = S

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -338,6 +338,11 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 		for(var/obj/forcefield/S in src.deployed_shields)
 			src.deployed_shields -= S
 			S:deployer = null	//There is no parent forcefield object and I'm not gonna be the one to make it so ":"
+			if(istype(S,/obj/forcefield/energyshield))
+				var/obj/forcefield/energyshield/checkedshield = S
+				if(checkedshield.linked_door)
+					checkedshield.linked_door.UnsubscribeProcess()
+					checkedshield.linked_door.linked_forcefield = null
 			qdel(S)
 
 		if(!connected)
@@ -457,6 +462,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 	var/sound/sound_shieldhit = 'sound/impact_sounds/Energy_Hit_1.ogg'
 	var/obj/machinery/shieldgenerator/deployer = null
 	var/obj/machinery/door/linked_door = null
+
+	///Special variable, set to FALSE for shields created by door-shield generators so doors won't inherently power them off when the area loses power
+	var/powered_locally = TRUE
 
 	flags = 0
 
@@ -627,7 +635,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 
 
 //sealab arrivalss
-/obj/machinery/door/var/obj/forcefield/energyshield/linked_forcefield = 0
+/obj/machinery/door/var/obj/forcefield/energyshield/linked_forcefield = null
 
 /obj/forcefield/energyshield/perma
 	name = "Permanent Atmospheric/Liquid Forcefield"
@@ -665,6 +673,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 			var/obj/machinery/door/door = (locate() in src.loc)
 			if(door)
 				door.linked_forcefield = src
+				door.SubscribeToProcess() //necessary for power consumption while open
 				src.linked_door = door
 				src.set_dir(door.dir)
 

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -658,6 +658,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 	Cross(atom/A)
 		return ..() && !istype(A,/obj/machinery/vehicle)
 
+#define LINKED_FORCEFIELD_POWER_USAGE 100
+
 /obj/forcefield/energyshield/perma/doorlink
 	name = "Door-linked Atmospheric/Liquid Forcefield"
 	desc = "A door-linked force field that prevents gas and liquids from passing through it."
@@ -668,9 +670,11 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 			var/obj/machinery/door/door = (locate() in src.loc)
 			if(door)
 				door.linked_forcefield = src
-				door.SubscribeToProcess() //necessary for power consumption while open
+				door.power_usage += LINKED_FORCEFIELD_POWER_USAGE
 				src.linked_door = door
 				src.set_dir(door.dir)
+
+#undef LINKED_FORCEFIELD_POWER_USAGE
 
 /obj/machinery/door/disposing()
 	if(linked_forcefield)

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -632,11 +632,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/shieldgenerator, proc/turn_on, proc/turn_off
 			playsound(src.loc, src.sound_shieldhit, 50, 1)
 			return
 
-
-
-//sealab arrivalss
-/obj/machinery/door/var/obj/forcefield/energyshield/linked_forcefield = null
-
 /obj/forcefield/energyshield/perma
 	name = "Permanent Atmospheric/Liquid Forcefield"
 	desc = "A permanent force field that prevents gas and liquids from passing through it."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX][STATION SYSTEMS][CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Reworks unpowered_open_close() (the proc for airlock prying) to use the airlock's regular open() and close() procs. These procs now have a manual_actuation variable that, when set, alters them to behave correctly with prying (no checking for power, no airlock operation sound, et cetera).
- Also removes duplicate open and close behavior from pod doors. These now instead have overridden icon/animation procs as necessary (what the previous duplicate behavior was attempting to account for).
- Door-linked forcefield power usage management has been moved to the base door type (since all doors can have linked forcefields), and doors will now be subscribed to process when open if they have a force field that isn't being powered by a door-link shield generator.
- Door-linked forcefields now respond reliably to changes in power; if powered by the door, they will now deactivate if equipment power is lost while the door is open (and reactivate if equipment power is regained), while door-linked shields provided by a shield generator will consistently operate even when area power has failed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes doors and their forcefields operate in a more cohesive manner (notably including updating adjacent tiles when they're supposed to) and reduces a bit of janky reimplementation.