### PR TITLE
Add flock floors to EFIF-1 wall/repair forbidden types list

### DIFF
--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -736,7 +736,7 @@ TYPEINFO(/obj/item/shipcomponent/mainweapon/constructor)
 		//walls can be built on most floors. avoid some types that are unsuitable
 		if (mode == EFIF_MODE_WALLS || mode == EFIF_MODE_REPAIR)
 			if(istype(T,/turf/simulated/floor) && !istype(T,/turf/simulated/floor/airbridge) && !istype(T,/turf/simulated/floor/shuttle)\
-				&& !istype(T,/turf/simulated/floor/setpieces) && !istype(T,/turf/simulated/floor/martian))
+				&& !istype(T,/turf/simulated/floor/setpieces) && !istype(T,/turf/simulated/floor/martian) && !istype(T,/turf/simulated/floor/feather))
 				return TRUE
 		//fallback: space is good
 		if (istype(T,/turf/space))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds flock's feather floors to the list of tile types the EFIF-1 is not permitted to repair (replace with original path) or build walls on top of. Did a quick check for other instances of ReplaceWith that create floors, and flock appears to be the only one that affects pertinent non-space tiles, so I *think* the list should be good now?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19835