### PR TITLE
Set station name after map settings have loaded

### DIFF
--- a/code/world/initialization/0_preMapLoad.dm
+++ b/code/world/initialization/0_preMapLoad.dm
@@ -209,7 +209,6 @@
 		fluid_turf_setup(first_time=TRUE)
 
 		Z_LOG_DEBUG("Preload", "Preload stage complete")
-		station_name() // generate station name and set it
 		..()
 		global.current_state = GAME_STATE_MAP_LOAD
 

--- a/code/world/initialization/1_New.dm
+++ b/code/world/initialization/1_New.dm
@@ -23,6 +23,8 @@
 	antagWeighter = new()
 	if (!chui) chui = new()
 
+	station_name() // generate station name and set it
+
 	//This is also used pretty early
 	Z_LOG_DEBUG("World/New", "Setting up powernets...")
 	makepowernets()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the station name generation from map pre-load to world/New()

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map settings are saved to the global variable on the map landmark New(), , so we have to set the station name after map loading in order to use the name in map settings. This still sets the world/station name before the hub is notified of a new round.
Fixes #19839