### PR TITLE
Prevent duplicate razor blades in candy deleting one

### DIFF
--- a/code/modules/food_and_drink/candy.dm
+++ b/code/modules/food_and_drink/candy.dm
@@ -8,7 +8,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy)
 	fill_amt = 0.3 //You can eat a lot of candy
 	real_name = "candy"
 	var/sugar_content = 50
-	var/razor_blade = 0 //Is this BOOBYTRAPPED CANDY?
+	var/has_razor_blade = FALSE //!Is this BOOBYTRAPPED CANDY?
 	festivity = 1
 
 	New()
@@ -18,9 +18,12 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy)
 
 	attackby(obj/item/W, mob/user)
 		if(istype(W, /obj/item/razor_blade))
-			boutput(user, "You add the razor blade to [src]")
+			if (src.has_razor_blade)
+				boutput(user, "There's already a razor blade in [src]!")
+				return
+			boutput(user, "You add the razor blade to [src].")
 			qdel(W)
-			src.razor_blade = 1
+			src.has_razor_blade = TRUE
 			return
 
 		else
@@ -28,13 +31,13 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy)
 		return
 
 	heal(var/mob/M)
-		if(src.razor_blade && ishuman(M))
+		if(src.has_razor_blade && ishuman(M))
 			var/mob/living/carbon/human/H = M
 			boutput(H, SPAN_ALERT("You bite down into a razor blade!"))
 			H.TakeDamage("head", 10, 0, 0, DAMAGE_STAB)
 			H.changeStatus("knockdown", 3 SECONDS)
 			H.UpdateDamageIcon()
-			src.razor_blade = 0
+			src.has_razor_blade = FALSE
 			new /obj/item/razor_blade( get_turf(src) )
 		..()
 

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -551,7 +551,7 @@
 			var/obj/item/reagent_containers/food/snacks/candy/newcandy = new newcandy_path
 			user.put_in_hand_or_drop(newcandy)
 			if (prob(5))
-				newcandy.razor_blade = 1
+				newcandy.has_razor_blade = TRUE
 			boutput(user, "You grab [newcandy] from the cauldron!")
 
 		/// subtype named "ephemeral" which only spawns on halloween

--- a/code/obj/item/storage/food.dm
+++ b/code/obj/item/storage/food.dm
@@ -140,7 +140,7 @@
 			var/obj/item/reagent_containers/food/snacks/candy/newcandy = new newcandy_path(src)
 			src.storage.add_contents(newcandy)
 			if (prob(5))
-				newcandy.razor_blade = 1
+				newcandy.has_razor_blade = TRUE
 
 /obj/item/storage/box/popsicles
 	name = "popsicles"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Rename variable `razor_blade` to `has_razor_blade` to make it clearer it's a boolean
* convert comment to doc-comment
* Add a check when inserting a razor blade to not insert a second one


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #19849