### PR TITLE
Close context buttons when dropping t-ray scanner

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -41,6 +41,10 @@ TYPEINFO(/obj/item/device/t_scanner)
 			var/datum/contextAction/t_scanner/action = new actionType(src)
 			actions += action
 
+	dropped(mob/user)
+		. = ..()
+		user.closeContextActions()
+
 	/// Update the inventory, ability, and context buttons
 	proc/set_on(new_on, mob/user=null)
 		on = new_on


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Close the context buttons when dropping the t-ray scanner


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19853