### PR TITLE
Built zone / area inherit rework to use "unconnected zone"

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -4133,7 +4133,7 @@ ABSTRACT_TYPE(/area/mining)
 
 		for (var/obj/machinery/M in trans_turf)
 			if(M in src.machines)
-				if(istype(M),/obj/machinery/power/apc)
+				if(istype(M,/obj/machinery/power/apc))
 					var/obj/machinery/power/apc/yoink_apc = M
 					yoink_apc.area = new_owner
 					yoink_apc.name = "[new_owner.name] APC"
@@ -4143,8 +4143,8 @@ ABSTRACT_TYPE(/area/mining)
 				src.machines -= M
 				new_owner.machines += M
 				if (istype(M,/obj/machinery/light)) // steal all the lights
-					A.remove_light(M)
-					TargA.add_light(M)
+					src.remove_light(M)
+					new_owner.add_light(M)
 
 		src.contents -= trans_turf
 		new_owner.contents += trans_turf
@@ -4162,6 +4162,13 @@ ABSTRACT_TYPE(/area/mining)
 	power_equip = 0
 	power_light = 0
 	power_environ = 0
+
+	proc/SetName(var/name)
+		src.name = name
+		global.area_list_is_up_to_date = FALSE // our area cache could no longer be accurate!
+		for(var/obj/machinery/power/apc/apc in src)
+			apc.name = "[name] APC"
+			apc.area = src
 
 /// adhara setpiece
 /area/janitor_setpiece

--- a/code/area.dm
+++ b/code/area.dm
@@ -4131,7 +4131,7 @@ ABSTRACT_TYPE(/area/mining)
 		if(istype(new_owner,/area/unconnected_zone)) //this should never happen, and now it extra will never happen
 			return
 
-		if(make_built_zone)
+		if(!new_owner && make_built_zone)
 			new_owner = new /area/built_zone()
 
 		for (var/obj/machinery/M in trans_turf)

--- a/code/area.dm
+++ b/code/area.dm
@@ -4091,7 +4091,7 @@ ABSTRACT_TYPE(/area/mining)
 	CanEnter()
 		return 1
 
-/** When building a zone in space, unconnected to anywhere else, this is the zone that gets created.
+/** When building in space, unconnected to anywhere else, this is the zone the turf will be allocated to.
  *  Turfs within it will cede themselves to built zones (created by APC installation) or other existing zones.
  *  Only one of these should exist at any given time, assigned to the unconnected_zone global variable.
  */
@@ -4110,7 +4110,7 @@ ABSTRACT_TYPE(/area/mining)
 		LAGCHECK(LAG_LOW)
 		var/list/propagation_targets = list()
 		var/area/connectable_area = null
-		///Usually, this will be true because someone built an APC in an unconnected zone
+		///Usually, this will be true because someone built an APC in an unconnected zone.
 		var/apc_already_for_some_reason = FALSE
 		if (locate(/obj/machinery/power/apc) in target_turf)
 			apc_already_for_some_reason = TRUE

--- a/code/area.dm
+++ b/code/area.dm
@@ -4156,8 +4156,6 @@ ABSTRACT_TYPE(/area/mining)
 			new_owner.area_apc.request_update()
 		return TRUE
 
-	New()
-		. = ..()
 
 ///Created when an APC is installed in an unconnected zone.
 /area/built_zone

--- a/code/area.dm
+++ b/code/area.dm
@@ -4092,25 +4092,76 @@ ABSTRACT_TYPE(/area/mining)
 		return 1
 
 /** When building a zone in space, unconnected to anywhere else, this is the zone that gets created.
- *  If an APC existed in the zone upon creation, will rename the APC as well.
+ *  Turfs within it will cede themselves to built zones (created by APC installation) or other existing zones.
+ *  Only one of these should exist at any given time. If this is not the case,
  */
+/area/unconnected_zone
+	name = "Unconnected Zone"
+	requires_power = 1
+	power_equip = 0
+	power_light = 0
+	power_environ = 0
+	expandable = FALSE
+
+	proc/propagate_zone(var/turf/target_turf)
+		LAGCHECK(LAG_LOW)
+		var/list/propagation_targets = list()
+		var/area/connectable_area
+		//why did you build the APC before the floor. i do not know. but it must be accounted for.
+		var/apc_already_for_some_reason = FALSE
+		if (locate(/obj/machinery/power/apc) in target_turf)
+			apc_already_for_some_reason = TRUE
+
+		for (var/dir in cardinal)
+			var/turf/polled_turf = get_step(target_turf,dir)
+			var/area/polled_area = polled_turf?.loc
+			if(!connectable_area && polled_area.expandable)
+				connectable_area = polled_area
+			if(!apc_already_for_some_reason && istype(polled_area,/area/unconnected_zone))
+				propagation_targets += polled_turf
+		if(connectable_area || apc_already_for_some_reason)
+			if(transfer_ownership(target_turf,connectable_area,apc_already_for_some_reason))
+				for(var/turf/T in propagation_targets)
+					propagate_zone(T)
+
+	proc/transfer_ownership(var/turf/trans_turf,var/area/new_owner,var/make_built_zone = FALSE)
+		if(istype(new_owner,/area/unconnected_zone)) //this should never happen, and now it extra will never happen
+			return
+
+		if(make_built_zone)
+			new_owner = new /area/built_zone()
+
+		for (var/obj/machinery/M in trans_turf)
+			if(M in src.machines)
+				if(istype(M),/obj/machinery/power/apc)
+					var/obj/machinery/power/apc/yoink_apc = M
+					yoink_apc.area = new_owner
+					yoink_apc.name = "[new_owner.name] APC"
+					if (!new_owner.area_apc)
+						new_owner.area_apc = yoink_apc
+
+				src.machines -= M
+				new_owner.machines += M
+				if (istype(M,/obj/machinery/light)) // steal all the lights
+					A.remove_light(M)
+					TargA.add_light(M)
+
+		src.contents -= trans_turf
+		new_owner.contents += trans_turf
+
+		if(new_owner.area_apc)
+			new_owner.area_apc.request_update()
+
+	New()
+		. = ..()
+
+///Created when an APC is installed in an unconnected zone.
 /area/built_zone
 	name = "Built Zone"
 	requires_power = 1
 	power_equip = 0
 	power_light = 0
 	power_environ = 0
-
-	proc/SetName(var/name)
-		src.name = name
-		global.area_list_is_up_to_date = FALSE // our area cache could no longer be accurate!
-		for(var/obj/machinery/power/apc/apc in src)
-			apc.name = "[name] APC"
-			apc.area = src
-
-	New()
-		.=..()
-		SetName(name) //because the jerk built an APC first, because WHY NOT JERKO?!
 
 /// adhara setpiece
 /area/janitor_setpiece

--- a/code/area.dm
+++ b/code/area.dm
@@ -4103,7 +4103,7 @@ ABSTRACT_TYPE(/area/mining)
 	power_environ = 0
 	expandable = FALSE
 
-	proc/propagate_zone(var/turf/target_turf,var/propagate_from_self = FALSE)
+	proc/propagate_zone(var/turf/target_turf)
 		if(target_turf.transfer_evaluation)
 			return
 		target_turf.transfer_evaluation = TRUE

--- a/code/global.dm
+++ b/code/global.dm
@@ -96,6 +96,8 @@ var/global
 	list/station_areas = list()
 	/// The station_areas list is up to date. If something changes an area, make sure to set this to 0
 	area_list_is_up_to_date = FALSE
+	/// Areas built anew belong to a single unconnected zone, which gives its turfs over to other expandable areas when contacting them
+	area/unconnected_zone/unconnected_zone = new
 
 	/// Contains objects in ID-based switched object groups, such as blinds and their switches
 	list/switched_objs = list()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -203,7 +203,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 			src.name = "[area.name] APC"
 	if (!QDELETED(src.area))
 		if(istype(src.area,/area/unconnected_zone)) //if we built in an as-yet APCless zone, we've created a new built zone as a consequence
-			unconnected_zone.transfer_ownership(get_turf(src), null, TRUE)
+			unconnected_zone.propagate_zone(get_turf(src))
 		else
 			src.area.area_apc = src
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -75,7 +75,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 	var/timeout = 60 //The time until we auto disconnect (if we don't get a refresh ping)
 	var/timeout_alert = 0 //Have we sent a timeout refresh alert?
 	var/hardened = 0 // azone/listening post apcs that you dont want fucked with. immune to explosions, blobs, meteors
-	var/update_requested = FALSE
+	var/update_requested = FALSE // Whether the next APC process should include an update (set after turfs are reallocated to this APC's area)
 
 //	luminosity = 1
 	var/debug = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -75,6 +75,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 	var/timeout = 60 //The time until we auto disconnect (if we don't get a refresh ping)
 	var/timeout_alert = 0 //Have we sent a timeout refresh alert?
 	var/hardened = 0 // azone/listening post apcs that you dont want fucked with. immune to explosions, blobs, meteors
+	var/update_requested = FALSE
 
 //	luminosity = 1
 	var/debug = 0
@@ -201,7 +202,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 		if (src.autoname_on_spawn == 1 || (name == "N APC" || name == "E APC" || name == "S APC" || name == "W APC"))
 			src.name = "[area.name] APC"
 	if (!QDELETED(src.area))
-		src.area.area_apc = src
+		if(istype(src.area,/area/unconnected_zone)) //if we built in an as-yet APCless zone, we've created a new built zone as a consequence
+			unconnected_zone.transfer_ownership(get_turf(src), null, TRUE)
+		else
+			src.area.area_apc = src
 
 	src.UpdateIcon()
 
@@ -905,6 +909,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 /obj/machinery/power/apc/proc/report()
 	return "[area.name] : [equipment]/[lighting]/[environ] ([lastused_equip+lastused_light+lastused_environ]) : [cell? cell.percent() : "N/C"] ([charging])"
 
+/obj/machinery/power/apc/proc/request_update()
+	src.update_requested = TRUE
+
 /obj/machinery/power/apc/proc/update()
 	if (!QDELETED(src.area))
 
@@ -1304,7 +1311,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 
 	// update icon & area power if anything changed
 
-	if(last_lt != lighting || last_eq != equipment || last_en != environ || last_ch != charging)
+	if(last_lt != lighting || last_eq != equipment || last_en != environ || last_ch != charging || update_requested)
+		if(update_requested)
+			update_requested = FALSE
 		UpdateIcon()
 		update()
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -47,6 +47,9 @@
 	var/step_material = 0
 	var/step_priority = 0 //compare vs. shoe for step sounds
 
+	/// Whether this turf is currently being evaluated for changing hands from the "unconnected zone" area (constructed) to a "real" area
+	var/tmp/transfer_evaluation = FALSE
+
 	// Vars used for breaking and burning turfs, only used for floors at the moment
 	var/can_burn = FALSE
 	var/can_break = FALSE

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -132,15 +132,8 @@
 
 	proc/inherit_area() //jerko built a thing
 		if(!loc:expandable) return
-		for(var/dir in (cardinal + 0))
-			var/turf/thing = get_step(src, dir)
-			var/area/fuck_everything = thing?.loc
-			if(fuck_everything?.expandable && (fuck_everything.type != /area/space))
-				fuck_everything.contents += src
-				return
-
-		var/area/built_zone/zone = new//TODO: cache a list of these bad boys because they don't get GC'd because WHY WOULD THEY?!
-		zone.contents += src//get in the ZONE
+		unconnected_zone.contents += src
+		unconnected_zone.propagate_zone(src)
 
 	proc/break_tile(var/force)
 		if (!src.can_break && !force)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[REWORK][INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Overhauls the behavior of turf area allocation to use a new global unconnected zone.

When a turf attempts to inherit area, instead of only polling adjacent areas, it will be added to the unconnected zone, a global area that holds constructed turfs that don't belong to any particular "real" area, and then prompt the unconnected zone to evaluate it for area propagation using propagate_zone().

The unconnected zone, through propagate_zone(), handles propagation as follows.

- First: the turf being evaluated is marked as undergoing transfer evaluation, so other propagation doesn't attempt to work on the turf at the same time. A lagcheck is included immediately thereafter, as the propagation process isn't rate-limited otherwise.
- Second: check for the presence of an APC in the given turf. If there is one (either because an APC was built in the unconnected zone, or an unconnected zone was built onto an APC), a new Built Zone likely needs to be prepared for it, and the proc makes note of this.
- Third: evaluate adjacent turfs in cardinal directions. If there's at least one adjacent expandable area, the first one found is selected - adjacent turfs belonging to the unconnected zone are also enumerated in this phase, and placed in the "propagation_targets" list.
- Fourth: if there is a suitable recipient of the turf being evaluated (either an adjacent expandable area or a to-be-created Built Zone for a found APC), the turf will be transferred to that recipient using transfer_ownership, and propagate_zone() is then called targeting adjacent unconnected zone turfs in order to fully propagate any found area. If there is no suitable recipient, the turf will remain in the unconnected zone.
- Lastly, the turf is marked as no longer undergoing transfer evaluation, so further attempts at propagation will work.

APCs now prompt a zone propagation when they are constructed, and have a variable that can be poked by transfer_ownership to instruct them to refresh their member tiles the next time they process (avoids refreshing once for each newly-transferred tile).

*Before APC installation.*
![image](https://github.com/goonstation/goonstation/assets/12454065/5b74269e-2989-4f1f-b618-0a0cbc3270d0)

*After APC installation.*
![image](https://github.com/goonstation/goonstation/assets/12454065/ceeaf223-e789-4042-894f-2b0e65acc76c)

*Worst case scenario under current built zone system.*
![image](https://github.com/goonstation/goonstation/assets/12454065/bcc216df-134d-4ccb-8b87-4df46192a426)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Current built-zone behavior is unresponsive, unintuitive and can create a significant amount of tiny new areas that never get cleaned up. With this change, all disconnected built tiles use a single shared area so there are no new areas being created until an APC installation prompts it, connecting new construction to the station works consistently, and space construction without a room designator works reliably.

Changelog entry included as this is very relevant to construction enjoyers.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Tiles constructed outside of an area will now use a single "unconnected zone" area by default, making it much easier to connect these areas to station areas or turn them into a single built zone using an APC.
```
