### PR TITLE
Admin crusher-walls use no power

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2786,7 +2786,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 					if (W.z != 1) continue
 					var/obj/machinery/crusher/O = locate() in W.contents //in case someone presses it again
 					if (O) continue
-					new /obj/machinery/crusher(locate(W.x, W.y, W.z))
+					new /obj/machinery/crusher/walls(locate(W.x, W.y, W.z))
 					W.set_density(0)
 
 				logTheThing(LOG_ADMIN, src, "has turned every wall into a crusher! God damn.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2786,7 +2786,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 					if (W.z != 1) continue
 					var/obj/machinery/crusher/O = locate() in W.contents //in case someone presses it again
 					if (O) continue
-					new /obj/machinery/crusher/walls(locate(W.x, W.y, W.z))
+					new /obj/machinery/crusher/wall(locate(W.x, W.y, W.z))
 					W.set_density(0)
 
 				logTheThing(LOG_ADMIN, src, "has turned every wall into a crusher! God damn.")

--- a/code/modules/disposals/crusher.dm
+++ b/code/modules/disposals/crusher.dm
@@ -21,6 +21,9 @@ TYPEINFO(/obj/machinery/crusher)
 
 	var/last_sfx = 0
 
+/obj/machinery/crusher/walls
+	power_usage = 0
+
 /obj/machinery/crusher/Bumped(atom/movable/AM)
 	return_if_overlay_or_effect(AM)
 	if(AM.flags & UNCRUSHABLE || AM.anchored == 2)

--- a/code/modules/disposals/crusher.dm
+++ b/code/modules/disposals/crusher.dm
@@ -21,7 +21,7 @@ TYPEINFO(/obj/machinery/crusher)
 
 	var/last_sfx = 0
 
-/obj/machinery/crusher/walls
+/obj/machinery/crusher/wall
 	power_usage = 0
 
 /obj/machinery/crusher/Bumped(atom/movable/AM)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[admin][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a new subtype of crusher (/wall) that uses no power, and have the admin button to make every single wall a crusher use the subtype.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Walls don't use power! The challenge is walls, not the power. If an admin wants both, there are Other Buttons to do that :^)