### PR TITLE
Remove redundant "The" from failing to sword sheathe an item

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1555,7 +1555,7 @@ TYPEINFO(/obj/item/swords/captain)
 
 	attackby(obj/item/W, mob/user)
 		if (!istype(W, sword_path))
-			boutput(user, SPAN_ALERT("The [W] can't fit into [src]."))
+			boutput(user, SPAN_ALERT("[W] can't fit into [src]."))
 			return
 		if (istype(W, /obj/item/swords) && !src.sword_inside && !W.cant_drop == 1)
 			icon_state = sheathed_state


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove redundant the


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Typo
![image](https://github.com/goonstation/goonstation/assets/91498627/7e36af9f-8603-45a8-94d2-dd70aca514a3)
