### PR TITLE
ass_explosion sets back_op_stage when it tears you a new one

### DIFF
--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -91,6 +91,7 @@
 			ThrowRandom(B, dist = 6, speed = 1)
 		H.visible_message(SPAN_ALERT("<b>[H]</b>'s [magical ? "arse" : "ass"] tears itself away from [his_or_her(H)] body[magical ? " in a magical explosion" : null]!"),\
 		SPAN_ALERT("[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!"))
+		H.organHolder.back_op_stage = BACK_SURGERY_OPENED
 
 	/// If that didn't work, try severing a limb or tail
 	else if (!is_bot && prob(limbloss_prob)) // It'll try to sever an arm, then a leg, then an arm, then a leg
@@ -109,6 +110,7 @@
 				H.visible_message(SPAN_ALERT("<b>[H]</b>'s [magical ? "tægl" : "tail"] is torn free from [his_or_her(H)] body[magical ? " in a magical explosion" : null]!"),\
 				SPAN_ALERT("[changer ? "Our" : "Your"] [magical ? "tægl" : "tail"] is torn free from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!"))
 				H.drop_and_throw_organ("tail", dist = 6, speed = 1, showtext = 1)
+				H.organHolder.back_op_stage = BACK_SURGERY_OPENED
 			for(var/obj/item/parts/L in possible_limbs)
 				if(length(possible_limbs) > 2) // Lets not remove both limbs unless that's all that's left
 					if(possible_limbs[L] == "arm" && (!H.limbs.l_arm || !H.limbs.l_arm))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Set the back_op_stage value appropriately when a mob has their butt or tail exploded off them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Your ass gets exploded off in a shower of gore, not daintily removed and resewn.
Fix #19838