### PR TITLE
Syndicate omnitool no longer goes into cigarette

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -242,7 +242,7 @@
 			if(!(get_fuel() > 0))
 				src.change_mode(OMNI_MODE_WELDING, user, /obj/item/weldingtool)
 
-		if (O.loc == user && O != src && istype(O, /obj/item/clothing))
+		if (O.loc == user && O != src && istype(O, /obj/item/clothing) && !istype(O, /obj/item/clothing/mask/cigarette))
 			boutput(user, SPAN_HINT("You hide the set of tools inside \the [O]. (Use the flex emote while wearing the clothing item to retrieve it.)"))
 			user.u_equip(src)
 			src.set_loc(O)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cigarettes no long accept syndicate omnitools, so you can light your cigarette with your 'badass' red tool.

I tried making this only happen when you light the cig, but because this is in afterattack I couldn't see a way to do so without some rank & questionable assumptions i.e. checking `numpuffs` against the initial setting.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11293