### PR TITLE
Status effects are paused in cryostorage

### DIFF
--- a/code/datums/controllers/process/statusEffects.dm
+++ b/code/datums/controllers/process/statusEffects.dm
@@ -28,6 +28,8 @@
 				stack_trace("statusEffect [S] with owner [identify_object(S.owner)] updating with negative duration [S.duration]. actual = [actual]")
 				globalStatusInstances -= S
 			if(S.owner)
+				if (istype(S.owner.loc, /obj/cryotron))
+					continue
 				S.onUpdate(actual)
 				if(!isnull(S.duration))
 					S.duration -= actual


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[status effects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When processing status effects, skip processing if they're on a mob in cryogenic crew storage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11118