### PR TITLE
Add 10 second cooldown to reciting Miranda rights

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -13,7 +13,6 @@ datum/mind
 	var/remembered_pin = null
 	var/last_memory_time = 0 //Give a small delay when adding memories to prevent spam. It could happen!
 	var/miranda // sec's miranda rights thingy.
-	var/last_miranda_time = 0 // this is different than last_memory_time, this is when the rights were last SAID, not last CHANGED
 
 	var/violated_hippocratic_oath = 0
 	var/soul = 100 // how much soul we have left

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1439,11 +1439,12 @@
 	set name = "Recite Miranda Rights"
 	if (isnull(src.mind))
 		return
-	var/miranda = src.mind.get_miranda()
-	if (isnull(miranda))
-		src.say_verb(DEFAULT_MIRANDA)
-		return
-	src.say_verb(miranda)
+	if(!ON_COOLDOWN(src, "recite_miranda", 10 SECONDS))
+		var/miranda = src.mind.get_miranda()
+		if (isnull(miranda))
+			src.say_verb(DEFAULT_MIRANDA)
+			return
+		src.say_verb(miranda)
 
 /mob/proc/add_miranda()
 	set name = "Set Miranda Rights"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add a 10 second cooldown to reciting miranda rights and removes an unused variable that was presumably going to be used to implement that cooldown however many years ago

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People spamming a giant block of text as fast as they can click is annoying

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(+) The "Recite Miranda Rights" verb now has a 10 second cooldown.
```
