### PR TITLE
Fix ship alert button closing all shutters

### DIFF
--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -150,7 +150,7 @@ TYPEINFO(/obj/machinery/shipalert)
 			continue
 		if (shutter.z != Z_LEVEL_STATION)
 			continue
-		if (shutter.id != "lockdown" && shutter.id != "ai_core" && shutter.id != "armory")
+		if ((shutter.id != "lockdown") && (shutter.id != "ai_core") && (shutter.id != "armory"))
 			continue
 		shutter.close()
 

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -150,7 +150,7 @@ TYPEINFO(/obj/machinery/shipalert)
 			continue
 		if (shutter.z != Z_LEVEL_STATION)
 			continue
-		if (shutter.id != "lockdown" && shutter.id != "ai_core" && shutter.id == "armory")
+		if (shutter.id != "lockdown" && shutter.id != "ai_core" && shutter.id != "armory")
 			continue
 		shutter.close()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
"not `lockdown` AND not `ai_core` AND `armory`" means ship alert locks down *everything but armory*

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ship alert should close the lockdown, core, and armory shutters, not the bar/kitchen/public market/entire station... 
i am doofus and make bug :( please let me fix bug :)?