### PR TITLE
Status Display Market Timer & Ship Alert integration

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -104,6 +104,7 @@
 #include "defines\spacebee_extension.dm"
 #include "defines\speed.dm"
 #include "defines\stamina.dm"
+#include "defines\status_display.dm"
 #include "defines\status_effects.dm"
 #include "defines\storage.dm"
 #include "defines\surgery.dm"

--- a/_std/defines/status_display.dm
+++ b/_std/defines/status_display.dm
@@ -1,0 +1,44 @@
+/// Nothing Displayed
+#define STATUS_DISPLAY_BLANK	0
+/// Shuttle ETA/ETD/ETC timer
+#define STATUS_DISPLAY_SHUTTLE	1
+/// Custom text message
+#define STATUS_DISPLAY_MESSAGE	2
+/// Alert image
+#define STATUS_DISPLAY_PICTURE	3
+/// Shipping Market timer
+#define STATUS_DISPLAY_MARKET	4
+/// Zeta station self-destruct
+#define STATUS_DISPLAY_SELFDES	5
+/// Mining score (unimplemented)
+#define STATUS_DISPLAY_ROCKBOX	6
+/// Nuclear Operatives Nuke timer
+#define STATUS_DISPLAY_NUCLEAR	7
+
+/// Default status display message, dependent on type
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT "default"
+
+/// Blank/NT Logo
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_BLANK "blank"
+
+/// Shuttle ETA/ETD/ETC timer
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_SHUTTLE "shuttle"
+
+/// Custom Text Message
+#define STATUS_DISPLAY_PACKET_MODE_MESSAGE "message"
+#define STATUS_DISPLAY_PACKET_MESSAGE_TEXT_1 "setmsg1"
+#define STATUS_DISPLAY_PACKET_MESSAGE_TEXT_2 "setmsg2"
+
+/// Shipping Market timer
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_MARKET "market"
+
+/// Selectable images
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT "alert"
+#define STATUS_DISPLAY_PACKET_ALERT_REDALERT "redalert"
+#define STATUS_DISPLAY_PACKET_ALERT_LOCKDOWN "lockdown"
+#define STATUS_DISPLAY_PACKET_ALERT_BIOHAZ "biohazard"
+
+/// Zeta station self destruct
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_SELFDES "destruct"
+/// Nuclear Operatives mode nuclear bomb timer
+#define STATUS_DISPLAY_PACKET_MODE_DISPLAY_NUCLEAR "nuclear"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -82,17 +82,16 @@
 
 		dat += "<h4>Station Status Display Interlink</h4>"
 
-		dat += "\[ <A HREF='?src=\ref[src];statdisp=blank'>Clear</A> \]<BR>"
-		dat += "\[ <A HREF='?src=\ref[src];statdisp=shuttle'>Shuttle ETA</A> \]<BR>"
-		dat += "\[ <A HREF='?src=\ref[src];statdisp=message'>Message</A> \]"
+		dat += "\[ <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT]'>Default</A> \]<BR>"
+		dat += "\[ <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_DISPLAY_SHUTTLE]'>Shuttle ETA</A> \]<BR>"
+		dat += "\[ <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_MESSAGE]'>Message</A> \]"
 
-		dat += "<ul><li> Line 1: <A HREF='?src=\ref[src];statdisp=setmsg1'>[ message1 ? message1 : "(none)"]</A>"
-		dat += "<li> Line 2: <A HREF='?src=\ref[src];statdisp=setmsg2'>[ message2 ? message2 : "(none)"]</A></ul><br>"
-		dat += "\[ Alert: <A HREF='?src=\ref[src];statdisp=alert;alert=default'>None</A> |"
-
-		dat += " <A HREF='?src=\ref[src];statdisp=alert;alert=redalert'>Red Alert</A> |"
-		dat += " <A HREF='?src=\ref[src];statdisp=alert;alert=lockdown'>Lockdown</A> |"
-		dat += " <A HREF='?src=\ref[src];statdisp=alert;alert=biohazard'>Biohazard</A> \]<BR>"
+		dat += "<ul><li> Line 1: <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MESSAGE_TEXT_1]'>[ message1 ? message1 : "(none)"]</A>"
+		dat += "<li> Line 2: <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MESSAGE_TEXT_2]'>[ message2 ? message2 : "(none)"]</A></ul><br>"
+		dat += "\[ Alert: "
+		dat += " <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT];alert=[STATUS_DISPLAY_PACKET_ALERT_REDALERT]'>Red Alert</A> |"
+		dat += " <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT];alert=[STATUS_DISPLAY_PACKET_ALERT_LOCKDOWN]'>Lockdown</A> |"
+		dat += " <A HREF='?src=\ref[src];statdisp=[STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT];alert=[STATUS_DISPLAY_PACKET_ALERT_BIOHAZ]'>Biohazard</A> \]<BR>"
 
 		return dat
 
@@ -103,12 +102,15 @@
 
 		if(href_list["statdisp"])
 			switch(href_list["statdisp"])
-				if("message")
-					post_status("message", message1, message2)
-				if("alert")
-					post_status("alert", href_list["alert"])
+				if(STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT)
+					post_status(STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT)
+				if(STATUS_DISPLAY_PACKET_MODE_MESSAGE)
+					post_status(STATUS_DISPLAY_PACKET_MODE_MESSAGE, message1, message2)
 
-				if("setmsg1")
+				if(STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT)
+					post_status(STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT, href_list["alert"])
+
+				if(STATUS_DISPLAY_PACKET_MESSAGE_TEXT_1)
 					if (!src.master?.is_user_in_interact_range(usr))
 						return
 
@@ -119,7 +121,7 @@
 					message1 = copytext(adminscrub(message1), 1, MAX_MESSAGE_LEN)
 					src.master.updateSelfDialog()
 
-				if("setmsg2")
+				if(STATUS_DISPLAY_PACKET_MESSAGE_TEXT_2)
 					if (!src.master?.is_user_in_interact_range(usr))
 						return
 

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -124,18 +124,18 @@
 		// Status display stuff
 		if("setstat")
 			switch(href_list["statdisp"])
-				if("message")
-					post_status("message", stat_msg1, stat_msg2)
-				if("alert")
-					post_status("alert", href_list["alert"])
+				if(STATUS_DISPLAY_PACKET_MODE_MESSAGE)
+					post_status(STATUS_DISPLAY_PACKET_MODE_MESSAGE, stat_msg1, stat_msg2)
+				if(STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT)
+					post_status(STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT, href_list["alert"])
 				else
 					post_status(href_list["statdisp"])
 
-		if("setmsg1")
+		if(STATUS_DISPLAY_PACKET_MESSAGE_TEXT_1)
 			stat_msg1 = input("Line 1", "Enter Message Text", stat_msg1) as text|null
 			stat_msg1 = copytext(adminscrub(stat_msg1), 1, MAX_MESSAGE_LEN)
 			src.updateDialog()
-		if("setmsg2")
+		if(STATUS_DISPLAY_PACKET_MESSAGE_TEXT_2)
 			stat_msg2 = input("Line 2", "Enter Message Text", stat_msg2) as text|null
 			stat_msg2 = copytext(adminscrub(stat_msg2), 1, MAX_MESSAGE_LEN)
 			src.updateDialog()

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -105,6 +105,13 @@ TYPEINFO(/obj/machinery/shipalert)
 			//toggle off
 			shipAlertState = SHIP_ALERT_GOOD
 
+			// set status displays to default
+			var/datum/signal/status_signal = get_free_signal()
+			status_signal.data["sender"] = "00000000"
+			status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT
+			status_signal.data["address_tag"] = "STATDISPLAY"
+			radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
+
 			src.update_lights()
 
 			ON_COOLDOWN(src, "alert_cooldown", src.cooldownPeriod)
@@ -125,6 +132,15 @@ TYPEINFO(/obj/machinery/shipalert)
 		playsound_global(world, soundGeneralQuarters, 100, pitch = 0.9) //lower pitch = more serious or something idk
 		//toggle on
 		shipAlertState = SHIP_ALERT_BAD
+
+		// status display red alert
+		var/datum/signal/status_signal = get_free_signal()
+		status_signal.data["sender"] = "00000000"
+		status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT
+		status_signal.data["address_tag"] = "STATDISPLAY"
+		status_signal.data["picture_state"] = STATUS_DISPLAY_PACKET_ALERT_REDALERT
+		radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
+
 		ON_COOLDOWN(src, "deactivate_cooldown", src.deactivateCooldown)
 		src.update_lights()
 		src.do_lockdown(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][station systems][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Feature: `/market` subtype that displays the time until market shift (not yet added to maps)
* Feature: Ship alert button sets status displays to red alert, and back to their default setting afterwards
* QoL: Status displays can now revert back to their initial setting
* QoL: Tweaked Status Controller smallprog to use new default functionality
* Internal: Use defines for status controller modes, commands, and alert images
* Internal: More doccomments for status display vars
* Internal: Convert `display_type` into `zeta_selfdestruct` a boolean variable for  related messages
* Internal: `src.` code consistency

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make status displays feel more integrated into the station's ongoing situation.

Now that the shipping market timer has been moved to the scheduler, status displays can now reliably show the remaining time left until the next shift. NOTE: Adding the shipping market status displays to maps will be done in a follow-up PR, or added to this PR if preferred on review.

Make the ship alert button even more alert-y.

## Screenshot
Here's the market timer:
![image](https://github.com/goonstation/goonstation/assets/91498627/f077f87f-bf14-4ef7-86ce-dbf8276c5ce8)