### PR TITLE
DNA Scramblers now randomize foreniscs blood DNA and fingerprints

### DIFF
--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -254,6 +254,8 @@ ADMIN_INTERACT_PROCS(/obj/item/genetics_injector/dna_injector, proc/admin_comman
 			src.bioHolder.CopyOther(target.bioHolder)
 			stored_name = target.real_name
 			randomize_look(target)
+			target.bioHolder.Uid = target.bioHolder.CreateUid() // forensics stuff, new blood dna and fingerprints
+			target.bioHolder.build_fingerprints()
 			UpdateIcon()
 
 	proc/paste_identity(var/mob/living/carbon/user,var/mob/living/carbon/target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

DNA scramblers will now randomize the bioholders UID, giving them new forensics blood DNA and fingerprints, they already store the old UID and have it restored as intended, unsure if this affects anything other than forensics.

Was unsure whether to put this here or inside randomize_look, but nothing else that uses randomize_look really needs randomized fingerprints, so I opted for it here

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Seems unintended that the scramblers leave you with your old fingerprints and DNA, fixes #12680
