### PR TITLE
Adds new mechcomp controls to the PTL

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -56,12 +56,6 @@
 						terminal = term
 						break dir_loop
 
-		if(!terminal)
-			status |= BROKEN
-			return
-
-		terminal.master = src
-
 		AddComponent(/datum/component/mechanics_holder)
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Enable Power Input", PROC_REF(_enable_input_mechchomp))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Disable Power Input", PROC_REF(_disable_input_mechchomp))
@@ -69,6 +63,13 @@
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Enable Power Output", PROC_REF(_enable_output_mechchomp))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Disable Power Ouput", PROC_REF(_disable_output_mechchomp))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Power Output", PROC_REF(_set_output_mechchomp))
+
+		if(!terminal)
+			status |= BROKEN
+			return
+
+		terminal.master = src
+
 		UpdateIcon()
 
 /obj/machinery/power/pt_laser/disposing()

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -13,7 +13,7 @@
 	req_access = list(access_engineering_power)
 	var/output = 0		//power output of the beam
 	var/max_dial_value = 999 // limitation of what can be set on the ui dial.
-	var/capacity = 1e15
+	var/capacity = 200 MEGA // Under the gib amount to prevent players from pulsing a death laser.
 	var/charge = 0
 	var/charging = 0
 	var/load_last_tick = 0	//how much load did we put on the network last tick?

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -223,7 +223,6 @@
 	var/last_onln = online
 	var/last_llt = load_last_tick
 	var/last_firing = firing
-	// var/last_output = output_last_tick
 	var/dont_update = 0
 	var/adj_output = abs(output)
 	var/input_power = src.chargelevel * charging // We can fire a laser with more power than our battery capacity, but only if input is enabled.

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -92,7 +92,7 @@
 /obj/machinery/power/pt_laser/proc/_set_input_mechchomp(var/datum/mechanicsMessage/inp)
 	if(!length(inp.signal)) return
 	var/newinput = text2num(inp.signal)
-	if (/*isnum_safe(newinput) && */newinput != src.chargelevel && newinput > 0 && newinput < 999 * 1 TERA WATT)
+	if (newinput != src.chargelevel && isnum_safe(newinput) &&  newinput > 0)
 		src.chargelevel = newinput
 		// Working backwards to update the ui based on the power we've set up.
 		if(chargelevel < 1 KILO WATT)
@@ -121,7 +121,7 @@
 	if(!length(inp.signal)) return
 	var/newoutput = text2num(inp.signal)
 	// We check against the absolute value of the current charge level, in case the PTL has been emagged.
-	if (newoutput != abs(src.output) && /*isnum_safe(newoutput) && */ newoutput > 0)
+	if (newoutput != abs(src.output) && isnum_safe(newoutput) newoutput > 0)
 		src.output = src.emagged ? -newoutput : newoutput
 		// Working backwards to update the ui based on the power we've set up.
 		if(newoutput >= 1 TERA WATT)

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -57,11 +57,9 @@
 						break dir_loop
 
 		AddComponent(/datum/component/mechanics_holder)
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Enable Power Input", PROC_REF(_enable_input_mechchomp))
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Disable Power Input", PROC_REF(_disable_input_mechchomp))
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Toggle Power Input", PROC_REF(_toggle_input_mechchomp))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Power Input", PROC_REF(_set_input_mechchomp))
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Enable Power Output", PROC_REF(_enable_output_mechchomp))
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Disable Power Ouput", PROC_REF(_disable_output_mechchomp))
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Togle Power Output", PROC_REF(_toggle_output_mechchomp))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Power Output", PROC_REF(_set_output_mechchomp))
 
 		if(!terminal)
@@ -84,11 +82,8 @@
 
 	..()
 
-/obj/machinery/power/pt_laser/proc/_enable_input_mechchomp()
-	src.charging = TRUE
-
-/obj/machinery/power/pt_laser/proc/_disable_input_mechchomp()
-	src.charging = FALSE
+/obj/machinery/power/pt_laser/proc/_toggle_input_mechchomp()
+	src.charging = !src.charging
 
 /obj/machinery/power/pt_laser/proc/_set_input_mechchomp(var/datum/mechanicsMessage/inp)
 	if(!length(inp.signal)) return
@@ -108,15 +103,11 @@
 			src.input_multi = 1 TERA WATT
 		src.input_number = clamp((src.chargelevel/src.input_multi), 0, src.max_dial_value)
 
-/obj/machinery/power/pt_laser/proc/_enable_output_mechchomp()
-	src.online = TRUE
-	src.process(1)
-
-/obj/machinery/power/pt_laser/proc/_disable_output_mechchomp()
-	src.online = FALSE
+/obj/machinery/power/pt_laser/proc/_toggle_output_mechchomp()
+	src.online = !src.online
 	if (!src.online && src.firing)
 		src.stop_firing()
-	src.process(1)
+
 
 /obj/machinery/power/pt_laser/proc/_set_output_mechchomp(var/datum/mechanicsMessage/inp)
 	if(!length(inp.signal)) return

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -92,7 +92,7 @@
 /obj/machinery/power/pt_laser/proc/_set_input_mechchomp(var/datum/mechanicsMessage/inp)
 	if(!length(inp.signal)) return
 	var/newinput = text2num(inp.signal)
-	if (newinput != src.chargelevel && isnum_safe(newinput) &&  newinput > 0)
+	if (newinput != src.chargelevel && isnum_safe(newinput) && newinput > 0)
 		src.chargelevel = newinput
 		// Working backwards to update the ui based on the power we've set up.
 		if(chargelevel < 1 KILO WATT)
@@ -121,7 +121,7 @@
 	if(!length(inp.signal)) return
 	var/newoutput = text2num(inp.signal)
 	// We check against the absolute value of the current charge level, in case the PTL has been emagged.
-	if (newoutput != abs(src.output) && isnum_safe(newoutput) newoutput > 0)
+	if (newoutput != abs(src.output) && isnum_safe(newoutput) && newoutput > 0)
 		src.output = src.emagged ? -newoutput : newoutput
 		// Working backwards to update the ui based on the power we've set up.
 		if(newoutput >= 1 TERA WATT)
@@ -130,7 +130,8 @@
 			src.output_multi = 1 GIGA WATT
 		else
 			src.output_multi = 1 MEGA WATT
-		src.output_number = clamp((newoutput/src.output_multi), 0, src.max_dial_value)
+		var abs_output_number = clamp((newoutput/src.output_multi), 0, src.max_dial_value)
+		src.output_number = src.emagged ? -abs_output_number : abs_output_number
 		src.update_output()
 		src.update_laser_power()
 
@@ -270,7 +271,8 @@
 				melt_blocking_objects()
 			power_sold(adj_output)
 
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "[output * firing]") //sends 0 if not firing else give theoretical output
+
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "output=[src.output]&firing=[src.firing]&charge=[src.charge]&currentbalance=[src.current_balance]&lifetimeearnings=[src.lifetime_earnings]")
 
 	// only update icon if state changed
 	if(dont_update == 0 && (last_firing != firing || last_disp != chargedisplay() || last_onln != online || ((last_llt > 0 && load_last_tick == 0) || (last_llt == 0 && load_last_tick > 0))))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds mech comp controls for the PTL. The controls it adds are nearly one-to-one with the controls already available
on the ingame ui (with toggles converted to stop/start controls for convenience). They are:
- Toggle PTL input.
- Set PTL input.
- Toggle output.
- Set PTL output.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Automated engine setups are cool. This also givers players some options to leverage the PTL in interesting ways
that were not previously possible. A list of ideas off the top of my head:
- An engineer could set up a contraption that disables the ptl whenever whenever a player wants to walk through the path.
- An engineer could set up a controller that monitors an engines output and automatically adjusts the PTL along with it.
- An antagonist engineer could rig up something to charge up energy and fire a short, stronger pulse of the laser at souls foolish enough to cross it (under the gib threshold, of course).

[Station Systems]

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)KakoLookiyam
(+) Added new mechcomp inputs to the Power Transmission Laser.
```
