### PR TITLE
Reagent Overlay Documentation Fix

### DIFF
--- a/code/datums/components/reagent_overlay.dm
+++ b/code/datums/components/reagent_overlay.dm
@@ -71,7 +71,7 @@ TYPEINFO(/datum/component/reagent_overlay)
 			normalised_reagent_height = normalised_volume
 
 		// Vₛ = volume of sphere, r = radius of sphere, Vₗ = volume of liquid inside of sphere, h = height of liquid.
-		// `Vₗ = ∫ π(r² - (z - r)²) dx` with lower and upper limits of 0 and h respectively gives the equation `Vₗ = πh²(r - h/3)`.
+		// `Vₗ = ∫ π(r² - (z - r)²) dz` with lower and upper limits of 0 and h respectively gives the equation `Vₗ = πh²(r - h/3)`.
 		// `Vₗ = πh²(r - h/3)` is very closely approximated by `Vₗ = -0.5Vₛ(cos(h(π / 2r)) - 1)` for 0 <= h <= 2r.
 		// This permits us to efficiently solve for h without the need for the cubic formula: `h = (2r / π) * arccos(1 - 2(Vₗ / Vₛ))`
 		// Setting Vₛ = 1 and normalising h to a range of 0-1 gives: `h = arccos(1 - 2Vₗ) / π`


### PR DESCRIPTION
[Trivial]


## About The PR:
Fixes the variable of integration being stated as `x` instead of `z` in the volume of a liquid in a sphere formula.