### PR TITLE
use clear/update overlay procs for obj/vehicles

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -245,7 +245,7 @@ TYPEINFO(/obj/vehicle/tug)
 				rider.throw_at(target, 5, 1)
 				rider.buckled = null
 				rider = null
-				overlays = null
+				src.ClearSpecificOverlays("rider")
 				return
 			if (selfdismount)
 				boutput(rider, SPAN_NOTICE("You dismount from [src]."))
@@ -256,7 +256,7 @@ TYPEINFO(/obj/vehicle/tug)
 			if (rider)
 				rider.buckled = null
 			rider = null
-			overlays = null
+			src.ClearSpecificOverlays("rider")
 			return
 
 	MouseDrop_T(var/atom/movable/C, mob/user)
@@ -301,7 +301,7 @@ TYPEINFO(/obj/vehicle/tug)
 		target.set_loc(src)
 		rider = target
 		rider.pixel_y = 6
-		overlays += rider
+		src.UpdateOverlays(rider, "rider")
 		if (rider.restrained() || rider.stat)
 			rider.buckled = src
 

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -186,7 +186,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 	relaymove(mob/user as mob, dir)
 		// we reset the overlays to null in case the relaymove() call was initiated by a
 		// passenger rather than the driver (we shouldn't have a rider overlay if there is no rider!)
-		src.overlays = null
+		src.ClearSpecificOverlays("rider")
 
 		if(!src.rider || user != src.rider)
 			return
@@ -194,12 +194,13 @@ ABSTRACT_TYPE(/obj/vehicle)
 		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
 
 		if(src.rider_visible)
-			src.overlays += src.rider
+			src.UpdateOverlays(src.rider, "rider")
 
 		// You can't move in space without the booster upgrade
 		if (src.booster_upgrade)
-			src.overlays += booster_image
+			src.UpdateOverlays(booster_image, "booster_image")
 		else
+			src.ClearSpecificOverlays("booster_image")
 			var/turf/T = get_turf(src)
 
 			if(T.throw_unlimited && istype(T, /turf/space))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[vehicles][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
use ClearSpecificOverlays and UpdateOverlays instead of directly nuking `src.overlays`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #19888