### PR TITLE
Add market status screens to maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -15155,9 +15155,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
@@ -17984,6 +17981,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"odD" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "ofD" = (
 /turf/simulated/floor/white/side{
 	dir = 5
@@ -18055,6 +18056,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"ovj" = (
+/obj/machinery/status_display/market,
+/turf/space,
+/area/shuttle/merchant_shuttle/right_station/cogmap)
 "oCM" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -20895,6 +20900,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"wwf" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/quartermaster/office)
 "wwW" = (
 /obj/table/auto,
 /obj/item/device/matanalyzer{
@@ -61148,7 +61157,7 @@ aaE
 aaE
 aaE
 aaE
-aaE
+ovj
 aaE
 aBp
 afV
@@ -63265,7 +63274,7 @@ aAr
 abD
 abN
 abD
-abN
+odD
 bie
 adX
 aeI
@@ -64785,7 +64794,7 @@ akY
 abH
 abH
 uUE
-abH
+wwf
 aca
 alU
 akl

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18056,10 +18056,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"ovj" = (
-/obj/machinery/status_display/market,
-/turf/space,
-/area/shuttle/merchant_shuttle/right_station/cogmap)
 "oCM" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -18165,6 +18161,10 @@
 /obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"oSa" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/storage/tools)
 "oSG" = (
 /obj/machinery/microwave{
 	pixel_y = 6;
@@ -20900,10 +20900,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"wwf" = (
-/obj/machinery/status_display/market,
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
 "wwW" = (
 /obj/table/auto,
 /obj/item/device/matanalyzer{
@@ -61157,7 +61153,7 @@ aaE
 aaE
 aaE
 aaE
-ovj
+aaE
 aaE
 aBp
 afV
@@ -64794,7 +64790,7 @@ akY
 abH
 abH
 uUE
-wwf
+abH
 aca
 alU
 akl
@@ -66001,7 +65997,7 @@ aco
 ahA
 ahA
 ahA
-ahA
+oSa
 ahA
 aca
 alU

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16527,6 +16527,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"ega" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "ege" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -26074,9 +26078,6 @@
 /area/station/quartermaster/office)
 "lsP" = (
 /obj/machinery/vending/paint/broken,
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "lsX" = (
@@ -40659,6 +40660,10 @@
 	dir = 8
 	},
 /area/station/science/chemistry)
+"wvO" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/garden/aviary)
 "wwE" = (
 /obj/machinery/computer/airbr/emergency_shuttle{
 	density = 0;
@@ -82399,7 +82404,7 @@ abe
 aaw
 aap
 aap
-acl
+wvO
 lsP
 ovf
 bxj
@@ -86325,7 +86330,7 @@ aaa
 sqY
 plf
 bzy
-bzy
+ega
 aar
 lqn
 bsu

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -23531,6 +23531,7 @@
 /area/station/quartermaster/office)
 "bGX" = (
 /obj/grille/steel,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bGY" = (
@@ -50348,6 +50349,7 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/supplylobby)
 "mDt" = (
@@ -57433,6 +57435,10 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
+"rYg" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/cargooffice)
 "rYi" = (
 /obj/decal/stripe_caution,
 /obj/cable{
@@ -123133,7 +123139,7 @@ adC
 iWf
 mSG
 mwn
-smf
+rYg
 fRt
 bGX
 pNt

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -46906,9 +46906,6 @@
 /obj/machinery/computer/ordercomp{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
 /turf/simulated/floor/orangeblack,
 /area/station/crew_quarters/market)
 "cHi" = (
@@ -72632,6 +72629,11 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/east)
+"ueL" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "uiJ" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -73383,6 +73385,10 @@
 "uZB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/southwest)
+"vas" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market)
 "vbz" = (
 /obj/cable/orange{
 	icon_state = "2-4"
@@ -121205,7 +121211,7 @@ cwH
 cCv
 cDZ
 cFP
-cHc
+vas
 cIs
 cIs
 cIs
@@ -123626,7 +123632,7 @@ sEJ
 cJS
 cLw
 mtx
-cIu
+ueL
 cPO
 cRp
 cSS

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -23153,17 +23153,6 @@
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"giu" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/north)
 "giG" = (
 /obj/disposalpipe/switch_junction{
 	dir = 4;
@@ -25822,6 +25811,11 @@
 	dir = 1
 	},
 /area/station/security/processing)
+"hVG" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "hWa" = (
 /obj/table/glass/reinforced/auto,
 /turf/simulated/floor/escape{
@@ -30809,6 +30803,10 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"lhI" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/quartermaster/office)
 "lif" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -84492,8 +84490,8 @@ hjc
 qEL
 ugn
 avd
-auD
-giu
+lhI
+bvD
 axc
 eFT
 ayW
@@ -84783,7 +84781,7 @@ aoN
 aoN
 aoN
 aoO
-aoO
+hVG
 aqo
 aqR
 arx

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -31367,6 +31367,11 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen,
 /area/station/library)
+"juA" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east)
 "juB" = (
 /obj/cable,
 /obj/cable{
@@ -35059,6 +35064,14 @@
 	},
 /turf/space,
 /area/space)
+"kBA" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
+	},
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/jen/yellow,
+/area/station/quartermaster/office)
 "kBH" = (
 /obj/grille/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -132215,7 +132228,7 @@ mhe
 mhe
 mXS
 fiL
-jnN
+kBA
 uEF
 gNg
 wyb
@@ -136439,7 +136452,7 @@ dOa
 xPd
 jPR
 ffz
-heB
+juA
 pkd
 xnW
 buq

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20312,9 +20312,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/status_display{
-	pixel_y = -30
-	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/hallway/primary/south)
 "bFw" = (
@@ -33655,6 +33652,12 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
+"eFQ" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/cargobay)
 "eGc" = (
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
@@ -51492,6 +51495,10 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"rJk" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/south)
 "rJL" = (
 /obj/grille/catwalk{
 	icon_state = "catwalk_cross"
@@ -105758,7 +105765,7 @@ bCm
 bCq
 bDA
 bFv
-bBv
+rJk
 bJr
 oqr
 cnQ
@@ -107885,7 +107892,7 @@ bSW
 bJr
 cnU
 cnV
-dJV
+eFQ
 rPO
 hzL
 jEa

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -43204,6 +43204,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/southwest)
+"stG" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/quartermaster/cargooffice)
 "stQ" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47982,6 +47986,13 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/northeast)
+"usV" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/storage{
+	name = "Cargo Auxiliary Endpoint"
+	})
 "uti" = (
 /obj/surgery_tray,
 /obj/machinery/light/small/floor/netural,
@@ -103140,7 +103151,7 @@ kqZ
 wbj
 wmh
 cqc
-oxJ
+stG
 mIV
 mIV
 qTA
@@ -104355,7 +104366,7 @@ ktm
 bHE
 wxe
 cLn
-oUb
+usV
 jkd
 pAd
 qcD

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -35371,6 +35371,12 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/sea_elevator_room)
+"gNY" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "gOv" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -40986,6 +40992,10 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"oVt" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "oWf" = (
 /obj/rack,
 /obj/item/clothing/suit/space/syndicate,
@@ -44475,9 +44485,6 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
@@ -77141,7 +77148,7 @@ bJw
 bJw
 bJw
 bJw
-bJw
+oVt
 bJw
 pPq
 bNZ
@@ -81062,7 +81069,7 @@ vhK
 bDa
 bEp
 bDa
-bDa
+gNY
 bGV
 bHU
 bII

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -20234,6 +20234,7 @@
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/supplylobby)
 "aVl" = (
@@ -21942,6 +21943,7 @@
 /area/station/hallway/primary/central)
 "ban" = (
 /obj/grille/steel,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "bao" = (
@@ -53930,6 +53932,10 @@
 /obj/mapping_helper/access/chapel_office,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
+"dwm" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/cargooffice)
 "dwR" = (
 /obj/table/auto,
 /obj/item/clothing/glasses/toggleable/meson{
@@ -99337,7 +99343,7 @@ cCO
 tXA
 flf
 oBU
-cLr
+dwm
 buF
 ban
 buA

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -19489,7 +19489,6 @@
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
 	},
-/obj/machinery/status_display/market,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "dEi" = (

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -19489,6 +19489,7 @@
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line1"
 	},
+/obj/machinery/status_display/market,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "dEi" = (
@@ -21744,6 +21745,10 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"eBx" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/construction)
 "eBK" = (
 /obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/line/yellow{
@@ -29001,6 +29006,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
+"hXN" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/artifact)
 "hXP" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
@@ -44039,16 +44048,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"pOY" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/yellow,
-/area/station/hallway/secondary/construction)
 "pPB" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
@@ -49542,7 +49541,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "sMG" = (
-/obj/fakeobject/pathology_computer{
+/obj/fakeobject/pathogen_computer{
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
@@ -50831,6 +50830,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
+"ttu" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/engine/elect)
 "ttC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54570,6 +54573,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "vgU" = (
+/obj/machinery/status_display/market,
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "vgX" = (
@@ -56976,9 +56980,6 @@
 	},
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/primary/east)
@@ -113216,7 +113217,7 @@ dsA
 mub
 sPw
 nOV
-nYu
+ttu
 wsT
 psH
 tDL
@@ -115948,8 +115949,8 @@ kmN
 bil
 xQd
 uCi
-qPl
-pOY
+eBx
+pMQ
 pBg
 pMQ
 qPl
@@ -117449,7 +117450,7 @@ mAZ
 wXo
 wXo
 wXo
-wXo
+hXN
 gvb
 brW
 xQd

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -44808,7 +44808,9 @@
 	})
 "czu" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
-/area/supply/delivery_point)
+/area/station/science/artifact{
+	name = "Artifact Lounge"
+	})
 "czv" = (
 /obj/table/wood/auto,
 /obj/machinery/networked/storage/scanner{
@@ -44988,7 +44990,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/status_display,
 /turf/simulated/floor/black,
 /area/station/science/artifact{
 	name = "Artifact Lounge"

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -13240,6 +13240,10 @@
 /obj/item/storage/wall/fire,
 /turf/simulated/shuttle/wall/escape,
 /area/station/hallway/secondary/exit)
+"aNn" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "aNo" = (
 /obj/stool/chair/comfy/shuttle/brown{
 	dir = 4
@@ -28977,9 +28981,6 @@
 "bFs" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
-/obj/machinery/status_display{
-	pixel_y = -30
-	},
 /turf/simulated/floor/yellowblack{
 	dir = 6
 	},
@@ -44987,6 +44988,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/status_display,
 /turf/simulated/floor/black,
 /area/station/science/artifact{
 	name = "Artifact Lounge"
@@ -49892,6 +49894,10 @@
 /obj/mapping_helper/access/syndie_shuttle,
 /turf/simulated/floor/black/grime,
 /area/listeningpost)
+"irf" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/engineering)
 "irt" = (
 /obj/table/wood/auto,
 /obj/disposalpipe/segment/morgue{
@@ -53106,6 +53112,11 @@
 	},
 /turf/space,
 /area/space)
+"nCz" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/east)
 "nCW" = (
 /obj/item/currency/spacecash/ten,
 /turf/simulated/floor/plating/random,
@@ -128810,7 +128821,7 @@ mha
 bzG
 bCt
 bFs
-bzU
+irf
 bLe
 bOq
 bRa
@@ -129107,7 +129118,7 @@ cBx
 bmE
 mhW
 xFm
-bmE
+nCz
 oqk
 bdT
 fRr
@@ -132425,7 +132436,7 @@ wWH
 aAk
 aAk
 bkk
-bkk
+aNn
 bmP
 bpV
 clg

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -4814,6 +4814,10 @@
 	dir = 8
 	},
 /area/station/security/equipment)
+"bpt" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/qm)
 "bpF" = (
 /obj/decal/poster/wallsign/hazard_electrical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -41889,6 +41893,11 @@
 /obj/disposalpipe/trunk/north,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
+"lay" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/status_display/market,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/cargooffice)
 "laJ" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/cable{
@@ -44739,9 +44748,6 @@
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /obj/item/cargotele,
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /obj/machinery/light/emergency{
 	dir = 4;
 	pixel_x = 12
@@ -78260,6 +78266,10 @@
 /area/station/crew_quarters/juryroom{
 	name = "Jury Sequestration"
 	})
+"ulD" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/quartermaster/office)
 "ulQ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -152205,7 +152215,7 @@ yiE
 slB
 cHy
 btR
-tyo
+lay
 aSp
 hMN
 bre
@@ -155228,7 +155238,7 @@ qsO
 paa
 xNq
 iVE
-qMZ
+ulD
 lKS
 jAu
 vZF
@@ -155546,7 +155556,7 @@ xXN
 xXN
 huA
 gIn
-ycV
+bpt
 cwn
 cwn
 cwn

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -19374,7 +19374,6 @@
 	rand_pos = 0
 	},
 /obj/disposalpipe/segment/mail,
-/obj/mapping_helper/access/medical,
 /obj/table/reinforced/auto,
 /obj/item/stamp{
 	pixel_y = 6;
@@ -31301,7 +31300,6 @@
 	name = "Corpse Tunnel"
 	})
 "nNJ" = (
-/obj/mapping_helper/access/medical,
 /obj/table/reinforced/auto,
 /obj/item/clipboard{
 	pixel_x = 14;
@@ -44508,6 +44506,10 @@
 /obj/table/reinforced/bar/auto,
 /turf/simulated/floor/carpet/green/fancy/narrow/eastwest,
 /area/station/engine/monitoring)
+"tCN" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/south)
 "tCO" = (
 /obj/table/reinforced/auto,
 /obj/item/weldingtool{
@@ -51294,6 +51296,10 @@
 /area/station/security/brig{
 	name = "Brig Bathroom"
 	})
+"wBj" = (
+/obj/machinery/status_display/market,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/office)
 "wBp" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -102103,7 +102109,7 @@ tvO
 tvO
 tvO
 oEt
-ldM
+tCN
 wXJ
 bna
 bna
@@ -106036,7 +106042,7 @@ uKe
 hwm
 lIC
 vSC
-tnb
+wBj
 uDO
 uDO
 uDO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][game objects][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add 2-3 market shift status displays to QM offices across all maps that use status displays. Generally speaking, one is placed near the order request console, and one is placed closer to the import/export belts. Some existing status displays have been replaced with the market timer versions where appropriate.

Note, some of these are placed on windows. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See at a glance when the next market shift occurs without having to hover over the console.