### PR TITLE
Fix stg booster creating an abstact deck item

### DIFF
--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -1188,12 +1188,7 @@ ABSTRACT_TYPE(/obj/item/card_group)
 
 	New()
 		..()
-		stored_deck = new /obj/item/card_group(src)
-		stored_deck.desc = "A bunch of Spacemen the Griffening cards."
-		stored_deck.total_cards = 40
-		stored_deck.card_style = "stg"
-		stored_deck.card_name = "Spacemen the Griffening"
-		stored_deck.build_stg()
+		stored_deck = new /obj/item/card_group/stg(src)
 
 	attack_self(mob/user as mob)
 		if(icon_state == "stg-booster")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of creating an abstract deck and modifying it to be an STG deck, just create a new STG deck since we have that subtype.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
do not create abstract objects / duplicate code