### PR TITLE
Make it more clear that obj/item/device is abstract

### DIFF
--- a/code/obj/item/device/device_parent.dm
+++ b/code/obj/item/device/device_parent.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/obj/item/device)
 /obj/item/device
 	icon = 'icons/obj/items/device.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'


### PR DESCRIPTION
[CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
see title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it isn't. obj/item/device/key is abstract and makes all its ancestor types abstract. but code clarity is nice