### PR TITLE
Adjust pipes in cog1 tox storage

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -43940,8 +43940,9 @@
 	},
 /area/station/hallway/primary/south)
 "huq" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -45601,6 +45602,12 @@
 	dir = 10
 	},
 /area/station/quartermaster/office)
+"iIF" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "iIP" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -91750,7 +91757,7 @@ bOd
 bHW
 bYT
 huq
-cak
+iIF
 ite
 ced
 cfl


### PR DESCRIPTION
[mapping][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an extra pipe to the heating loop in cog1 toxins storage so you can access the other valves without having to start pulling things around
![image](https://github.com/goonstation/goonstation/assets/142273065/bf853b87-1567-484d-a213-65ae76715162)
-->
![image](https://github.com/goonstation/goonstation/assets/142273065/b7d7c642-0141-4a83-8bdf-cf4701299d83)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I hate having to start pulling things around

thank you batelite for the beautiful solution
