### PR TITLE
Give syndicate cyborgs listening post access

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -563,6 +563,7 @@ var/global/list/module_editors = list()
 
 	if (src.syndicate || src.syndicate_possible)
 		if (src.mind.add_antagonist(ROLE_SYNDICATE_ROBOT, respect_mutual_exclusives = FALSE, source = ANTAGONIST_SOURCE_CONVERTED))
+			src.botcard.access += access_syndicate_shuttle
 			logTheThing(LOG_STATION, src, "[src] was made a Syndicate robot at [log_loc(src)]. [cause ? " Source: [constructTarget(cause,"combat")]" : ""]")
 			logTheThing(LOG_STATION, src, "[src.name] is connected to the default Syndicate rack [constructName(src.law_rack_connection)] [cause ? " Source: [constructTarget(cause,"combat")]" : ""]")
 			return TRUE

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -213,6 +213,9 @@
 					break
 
 			src.botcard.access = get_all_accesses()
+			if (src.syndicate)
+				src.botcard.access += access_syndicate_shuttle
+
 			src.botcard.registered = "Cyborg"
 			src.botcard.assignment = "Cyborg"
 			src.default_radio = new /obj/item/device/radio/headset(src)

--- a/code/obj/machinery/door/airlock_other.dm
+++ b/code/obj/machinery/door/airlock_other.dm
@@ -48,7 +48,6 @@ TYPEINFO(/obj/machinery/door/airlock/syndicate)
 	icon = 'icons/obj/doors/Doorext.dmi'
 	req_access_txt = "52"
 	cant_emag = TRUE
-	cyborgBumpAccess = FALSE
 	hardened = TRUE
 	aiControlDisabled = TRUE
 	object_flags = BOTS_DIRBLOCK

--- a/code/obj/machinery/door/airlock_pyro.dm
+++ b/code/obj/machinery/door/airlock_pyro.dm
@@ -210,7 +210,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/reinforced)
 
 /obj/machinery/door/airlock/pyro/reinforced/syndicate
 	req_access_txt = "52"
-	cyborgBumpAccess = FALSE
 	explosion_resistance = 999999
 	anchored = ANCHORED_ALWAYS //haha fuk u
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives syndicate cyborgs access_syndicate_shuttle so they can access the listening post
Note that adding cyborg bump access to the doors does **NOT** let normal borgs in, they just run the ID check like a normal crewmember would instead of skipping it and not even making the no access sound.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I keep trapping my borgs in the post :(
Also considering this is exclusive to the syndicate roboticist I dont think the 1tc saved is too big, considering you either have to wait for a latejoin, kill someone, or convince a borg to change frames.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Syndicate Cyborgs now have access to the Listening Post
```
