### PR TITLE
Refactor /obj/artifact and add triggers for lighting

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,7 +30,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,7 +30,7 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 

--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -419,7 +419,7 @@
 					qdel(I)
 
 			for (var/atom/S in gunsim)
-				if(istype(S, /obj/storage) || istype(S, /obj/artifact) || istype(S, /obj/critter) || istype(S, /obj/machinery) || istype(S, /obj/decal) || istype(S, /obj/fluid) || istype(S, /mob/living/carbon/human/tdummy) || istype(S, /mob/living/critter))
+				if(istype(S, /obj/storage) || istype(S, /obj/machinery/artifact) || istype(S, /obj/critter) || istype(S, /obj/machinery) || istype(S, /obj/decal) || istype(S, /obj/fluid) || istype(S, /mob/living/carbon/human/tdummy) || istype(S, /mob/living/critter))
 					qdel(S)
 
 

--- a/code/datums/components/glue_ready.dm
+++ b/code/datums/components/glue_ready.dm
@@ -78,7 +78,7 @@ TYPEINFO(/datum/component/glue_ready)
 		if(user)
 			boutput(user, SPAN_ALERT("Your hand with [thing_glued] passes straight through \the [glued_to]."))
 		return FALSE
-	if(istype(thing_glued, /obj/artifact) || istype(thing_glued, /obj/machinery/artifact))
+	if(istype(thing_glued, /obj/machinery/artifact) || istype(thing_glued, /obj/machinery/artifact))
 		if(user)
 			boutput(user, SPAN_ALERT("The alien energies of [thing_glued] evaporate the glue."))
 		return FALSE

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -237,6 +237,7 @@ var/datum/artifact_controller/artifact_controls
 
 	proc/post_setup(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
+		AD.validtriggers = filtered_concrete_typesof(/datum/artifact_trigger/, GLOBAL_PROC_REF(filter_artifact_trigger))
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(100*rarityMod))
 			artifact.transform = matrix(artifact.transform, -1, 1, MATRIX_SCALE)

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -237,7 +237,6 @@ var/datum/artifact_controller/artifact_controls
 
 	proc/post_setup(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
-		AD.validtriggers = filtered_concrete_typesof(/datum/artifact_trigger/, GLOBAL_PROC_REF(filter_artifact_trigger))
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(100*rarityMod))
 			artifact.transform = matrix(artifact.transform, -1, 1, MATRIX_SCALE)

--- a/code/datums/gamemodes/construction.dm
+++ b/code/datums/gamemodes/construction.dm
@@ -124,7 +124,7 @@
 					new object(T)
 				else
 					if (prob(5))
-						var/obj/artifact/lamp/L = new /obj/artifact/lamp(T)
+						var/obj/machinery/artifact/lamp/L = new /obj/machinery/artifact/lamp(T)
 						SPAWN(1 SECOND)
 							L.ArtifactActivated()
 					if (prob(100 / (picks + 1)))

--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -299,7 +299,7 @@
 				qdel(I)
 			for (var/obj/item/I in gauntlet)
 				qdel(I)
-			for (var/obj/artifact/A in gauntlet)
+			for (var/obj/machinery/artifact/A in gauntlet)
 				qdel(A)
 			for (var/obj/critter/C in gauntlet)
 				qdel(C)
@@ -626,7 +626,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 	inactive_artifact
 		name = "An Artifact"
 		minimum_level = 20
-		supplies = list(/obj/machinery/artifact/bomb, /obj/artifact/darkness_field, /obj/artifact/healer_bio, /obj/artifact/forcefield_generator, /obj/artifact/power_giver)
+		supplies = list(/obj/machinery/artifact/bomb, /obj/machinery/artifact/darkness_field, /obj/machinery/artifact/healer_bio, /obj/machinery/artifact/forcefield_generator, /obj/machinery/artifact/power_giver)
 		max_amount = 1
 
 	hamburgers

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -353,7 +353,7 @@
 			var/obj/item/I = target
 			if (!I.anchored)
 				return 0
-		if (istype(target, /obj/artifact) || istype(target, /obj/item/artifact) || istype(target, /obj/machinery/artifact)) //boo
+		if (istype(target, /obj/machinery/artifact) || istype(target, /obj/item/artifact) || istype(target, /obj/machinery/artifact)) //boo
 			boutput(src, "<span class='combat bold'>Your internal safety subroutines kick in and prevent you from touching \the [target]!</span>")
 			return
 
@@ -528,7 +528,7 @@
 		if (isliving(target) && !isghostdrone(target))
 			boutput(src, "<span class='combat bold'>Your internal law subroutines kick in and prevent you from using [W] on [target]!</span>")
 			return
-		if (istype(target, /obj/artifact) || istype(target, /obj/item/artifact) || istype(target, /obj/machinery/artifact)) //boo
+		if (istype(target, /obj/machinery/artifact) || istype(target, /obj/item/artifact) || istype(target, /obj/machinery/artifact)) //boo
 			boutput(src, "<span class='combat bold'>Your internal safety subroutines kick in and prevent you from using [W] on \the [target]!</span>")
 			return
 		else

--- a/code/modules/antagonists/wizard/abilities/forcewall.dm
+++ b/code/modules/antagonists/wizard/abilities/forcewall.dm
@@ -101,9 +101,9 @@
 		user.lastattacked = src
 
 /obj/forcefield/artifact
-	var/obj/artifact/forcefield_generator/source = null
+	var/obj/machinery/artifact/forcefield_generator/source = null
 
-	New(var/obj/artifact/forcefield_generator/S)
+	New(var/obj/machinery/artifact/forcefield_generator/S)
 		. = ..()
 		source = S
 

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -984,7 +984,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			T.fluid_react_single(reagent_id, amount)
 		else switch(spawn_type)
 			if("artifact")
-				var/obj/artifact = Artifact_Spawn(src.loc)
+				var/obj/machinery/artifact = Artifact_Spawn(src.loc)
 				. = artifact
 				if(prob(25))
 					SPAWN(randfloat(0.1 SECONDS, 15 SECONDS))

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -142,7 +142,7 @@
 	var/list/acceptable = list(/obj/storage/crate,
 	/obj/storage/secure/crate,
 	/obj/machinery/artifact,
-	/obj/artifact,
+	/obj/machinery/artifact,
 	/obj/mopbucket,
 	/obj/beacon_deployer,
 	/obj/machinery/portable_atmospherics,

--- a/code/obj/artifacts/artifact_items/wall_wand.dm
+++ b/code/obj/artifacts/artifact_items/wall_wand.dm
@@ -59,9 +59,9 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shieldsparkles"
 	desc = "Some kind of strange energy barrier. You can't get past it."
-	var/obj/artifact/forcefield_generator/source = null
+	var/obj/machinery/artifact/forcefield_generator/source = null
 
-	New(var/loc,var/duration,var/wallsprite,var/obj/artifact/forcefield_generator/S = null)
+	New(var/loc,var/duration,var/wallsprite,var/obj/machinery/artifact/forcefield_generator/S = null)
 		..()
 		icon_state = wallsprite
 		source = S

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -1,16 +1,13 @@
-/obj/artifact/augmentor
+/obj/machinery/artifact/augmentor
 	name = "artifact augmentor"
 	associated_datum = /datum/artifact/augmentor
 
 /datum/artifact/augmentor
-	associated_object = /obj/artifact/augmentor
+	associated_object = /obj/machinery/artifact/augmentor
 	type_name = "Surgery machine (cyborg/synth)"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("ancient","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
-	/datum/artifact_trigger/cold)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "opens up, revealing an array of strange tools!"
 	deact_text = "closes itself up."
@@ -342,12 +339,12 @@
 	right_kidney = list(/obj/item/organ/kidney/synth/right)
 	appendix = list(/obj/item/organ/appendix/synth)
 
-/obj/artifact/augmentor/limb_augmentor
+/obj/machinery/artifact/augmentor/limb_augmentor
 	name = "artifact limb augmentor"
 	associated_datum = /datum/artifact/augmentor/limb_augmentor
 
 /datum/artifact/augmentor/limb_augmentor
-	associated_object = /obj/artifact/augmentor/limb_augmentor
+	associated_object = /obj/machinery/artifact/augmentor/limb_augmentor
 	type_name = "Surgery machine (artifact limbs)"
 	rarity_weight = 200
 	validtypes = list("eldritch", "martian", "precursor")

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -6,8 +6,6 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	associated_object = null
 	rarity_weight = 0
 	validtypes = list("ancient","eldritch","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/cold,/datum/artifact_trigger/radiation)
 	fault_blacklist = list(ITEM_ONLY_FAULTS, TOUCH_ONLY_FAULTS) // can't sting you at range
 	react_xray = list(12,75,30,11,"COMPLEX")
 	var/explode_delay = 600

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -6,6 +6,8 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	associated_object = null
 	rarity_weight = 0
 	validtypes = list("ancient","eldritch","precursor")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/cold,/datum/artifact_trigger/radiation, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS, TOUCH_ONLY_FAULTS) // can't sting you at range
 	react_xray = list(12,75,30,11,"COMPLEX")
 	var/explode_delay = 600

--- a/code/obj/artifacts/artifact_objects/borgifier.dm
+++ b/code/obj/artifacts/artifact_objects/borgifier.dm
@@ -1,9 +1,9 @@
-/obj/artifact/borgifier
+/obj/machinery/artifact/borgifier
 	name = "artifact human2cyborg converter"
 	associated_datum = /datum/artifact/borgifier
 
 /datum/artifact/borgifier
-	associated_object = /obj/artifact/borgifier
+	associated_object = /obj/machinery/artifact/borgifier
 	type_name = "Cyborg converter"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 200

--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -1,4 +1,4 @@
-/obj/artifact/cloner
+/obj/machinery/artifact/cloner
 	name = "artifact cloner"
 	associated_datum = /datum/artifact/cloner
 
@@ -13,7 +13,7 @@
 			REMOVE_ATOM_PROPERTY(AM, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "cloner art")
 
 /datum/artifact/cloner
-	associated_object = /obj/artifact/cloner
+	associated_object = /obj/machinery/artifact/cloner
 	type_name = "Cloner"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 90

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -8,6 +8,9 @@
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
+	/datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "seems like it has something inside of it..."
 	deact_text = "locks back up."

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -1,15 +1,13 @@
-/obj/artifact/container
+/obj/machinery/artifact/container
 	name = "artifact sealed container"
 	associated_datum = /datum/artifact/container
 
 /datum/artifact/container
-	associated_object = /obj/artifact/container
+	associated_object = /obj/machinery/artifact/container
 	type_name = "Container"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450
 	validtypes = list("ancient","martian","wizard","eldritch","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "seems like it has something inside of it..."
 	deact_text = "locks back up."

--- a/code/obj/artifacts/artifact_objects/curser.dm
+++ b/code/obj/artifacts/artifact_objects/curser.dm
@@ -1,4 +1,4 @@
-/*/obj/artifact/curser
+/*/obj/machinery/artifact/curser
 	name = "artifact curser"
 	associated_datum = /datum/artifact/curser
 
@@ -15,7 +15,7 @@
 		src.visible_message("<b>[src] seems like it has something inside it...</b>") //Left on purpose, I want to make people thing its the container artifact.
 
 /datum/artifact/curser
-	associated_object = /obj/artifact/curser
+	associated_object = /obj/machinery/artifact/curser
 	type_name = "Curser"
 	rarity_weight = 0
 	validtypes = list("eldritch")

--- a/code/obj/artifacts/artifact_objects/darkness_field.dm
+++ b/code/obj/artifacts/artifact_objects/darkness_field.dm
@@ -1,9 +1,9 @@
-/obj/artifact/darkness_field
+/obj/machinery/artifact/darkness_field
 	name = "artifact darkness field"
 	associated_datum = /datum/artifact/darkness_field
 
 /datum/artifact/darkness_field
-	associated_object = /obj/artifact/darkness_field
+	associated_object = /obj/machinery/artifact/darkness_field
 	type_name = "Darkness Generator"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350

--- a/code/obj/artifacts/artifact_objects/forcefield.dm
+++ b/code/obj/artifacts/artifact_objects/forcefield.dm
@@ -1,9 +1,9 @@
-/obj/artifact/forcefield_generator
+/obj/machinery/artifact/forcefield_generator
 	name = "artifact forcefield generator"
 	associated_datum = /datum/artifact/forcefield_gen
 
 /datum/artifact/forcefield_gen
-	associated_object = /obj/artifact/forcefield_generator
+	associated_object = /obj/machinery/artifact/forcefield_generator
 	type_name = "Forcefield Generator"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -1,9 +1,9 @@
-/obj/artifact/healer_bio
+/obj/machinery/artifact/healer_bio
 	name = "artifact carbon healer"
 	associated_datum = /datum/artifact/healer_bio
 
 /datum/artifact/healer_bio
-	associated_object = /obj/artifact/healer_bio
+	associated_object = /obj/machinery/artifact/healer_bio
 	type_name = "Single Target Healer"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -9,7 +9,7 @@
 	rarity_weight = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch)
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/lighting)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activated = 0
 	activ_text = "begins to pulse softly."

--- a/code/obj/artifacts/artifact_objects/heatwave.dm
+++ b/code/obj/artifacts/artifact_objects/heatwave.dm
@@ -1,15 +1,14 @@
 
-/obj/artifact/heatwave
+/obj/machinery/artifact/heatwave
 	name = "artifact heatwave"
 	associated_datum = /datum/artifact/heatwave
 
 /datum/artifact/heatwave
-	associated_object = /obj/artifact/heatwave
+	associated_object = /obj/machinery/artifact/heatwave
 	type_name = "Heat Surge"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 365
 	validtypes = list("ancient","eldritch","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,/datum/artifact_trigger/heat)
 	fault_blacklist = list(ITEM_ONLY_FAULTS,TOUCH_ONLY_FAULTS)
 	activ_text = "starts emitting HUGE flames!"
 	deact_text = "stops emitting flames."

--- a/code/obj/artifacts/artifact_objects/heatwave.dm
+++ b/code/obj/artifacts/artifact_objects/heatwave.dm
@@ -9,6 +9,8 @@
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 365
 	validtypes = list("ancient","eldritch","precursor")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,
+	/datum/artifact_trigger/silicon_touch,/datum/artifact_trigger/heat, /datum/artifact_trigger/lighting)
 	fault_blacklist = list(ITEM_ONLY_FAULTS,TOUCH_ONLY_FAULTS)
 	activ_text = "starts emitting HUGE flames!"
 	deact_text = "stops emitting flames."

--- a/code/obj/artifacts/artifact_objects/implanter.dm
+++ b/code/obj/artifacts/artifact_objects/implanter.dm
@@ -7,6 +7,9 @@
 	type_name = "Implanter"
 	rarity_weight = 250
 	validtypes = list("eldritch", "ancient", "wizard")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
+	/datum/artifact_trigger/cold, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "opens up, revealing a complex array of thin tubes!"
 	deact_text = "closes itself up."

--- a/code/obj/artifacts/artifact_objects/implanter.dm
+++ b/code/obj/artifacts/artifact_objects/implanter.dm
@@ -1,15 +1,12 @@
-/obj/artifact/implanter
+/obj/machinery/artifact/implanter
 	name = "artifact implanter"
 	associated_datum = /datum/artifact/implanter
 
 /datum/artifact/implanter
-	associated_object = /obj/artifact/implanter
+	associated_object = /obj/machinery/artifact/implanter
 	type_name = "Implanter"
 	rarity_weight = 250
 	validtypes = list("eldritch", "ancient", "wizard")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
-	/datum/artifact_trigger/cold)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "opens up, revealing a complex array of thin tubes!"
 	deact_text = "closes itself up."

--- a/code/obj/artifacts/artifact_objects/injector.dm
+++ b/code/obj/artifacts/artifact_objects/injector.dm
@@ -8,6 +8,9 @@
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("ancient","martian","eldritch","precursor")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
+	/datum/artifact_trigger/cold, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "opens up, revealing an array of strange needles!"
 	deact_text = "closes itself up."

--- a/code/obj/artifacts/artifact_objects/injector.dm
+++ b/code/obj/artifacts/artifact_objects/injector.dm
@@ -1,16 +1,13 @@
-/obj/artifact/injector
+/obj/machinery/artifact/injector
 	name = "artifact injector"
 	associated_datum = /datum/artifact/injector
 
 /datum/artifact/injector
-	associated_object = /obj/artifact/injector
+	associated_object = /obj/machinery/artifact/injector
 	type_name = "Injector"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("ancient","martian","eldritch","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
-	/datum/artifact_trigger/cold)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "opens up, revealing an array of strange needles!"
 	deact_text = "closes itself up."

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -1,4 +1,4 @@
-/obj/artifact/lamp
+/obj/machinery/artifact/lamp
 	name = "artifact lamp"
 	associated_datum = /datum/artifact/lamp
 	var/light_brightness = 1
@@ -19,14 +19,11 @@
 		light.attach(src)
 
 /datum/artifact/lamp
-	associated_object = /obj/artifact/lamp
+	associated_object = /obj/machinery/artifact/lamp
 	type_name = "Lamp"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450
 	validtypes = list("martian","wizard","precursor")
-	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
-	/datum/artifact_trigger/cold)
 	activ_text = "begins to emit a steady light!"
 	deact_text = "goes dark and quiet."
 	react_xray = list(10,90,90,11,"NONE")
@@ -34,13 +31,13 @@
 	effect_activate(var/obj/O)
 		if (..())
 			return
-		var/obj/artifact/lamp/L = O
+		var/obj/machinery/artifact/lamp/L = O
 		if (L.light)
 			L.light.enable()
 
 	effect_deactivate(var/obj/O)
 		if (..())
 			return
-		var/obj/artifact/lamp/L = O
+		var/obj/machinery/artifact/lamp/L = O
 		if (L.light)
 			L.light.disable()

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -24,6 +24,9 @@
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450
 	validtypes = list("martian","wizard","precursor")
+	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
+	/datum/artifact_trigger/cold, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	activ_text = "begins to emit a steady light!"
 	deact_text = "goes dark and quiet."
 	react_xray = list(10,90,90,11,"NONE")

--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -16,7 +16,8 @@
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 90
 	validtypes = list("ancient")
-	validtriggers = list(/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
+	validtriggers = list(/datum/artifact_trigger/electric,/datum/artifact_trigger/carbon_touch,
+	/datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/lighting)
 	fault_blacklist = list(ITEM_ONLY_FAULTS, TOUCH_ONLY_FAULTS)
 	activated = 0
 	activ_text = "begins to emit an electric hum!"

--- a/code/obj/artifacts/artifact_objects/power_giver.dm
+++ b/code/obj/artifacts/artifact_objects/power_giver.dm
@@ -1,9 +1,9 @@
-/obj/artifact/power_giver
+/obj/machinery/artifact/power_giver
 	name = "artifact power giver"
 	associated_datum = /datum/artifact/power_giver
 
 /datum/artifact/power_giver
-	associated_object = /obj/artifact/power_giver
+	associated_object = /obj/machinery/artifact/power_giver
 	type_name = "Mutator"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 200

--- a/code/obj/artifacts/artifact_objects/power_giver.dm
+++ b/code/obj/artifacts/artifact_objects/power_giver.dm
@@ -10,7 +10,7 @@
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
 	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,
-	/datum/artifact_trigger/cold)
+	/datum/artifact_trigger/cold, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "begins glowing with an eerie light!"
 	deact_text = "falls dark and quiet."

--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -1,9 +1,9 @@
-/obj/artifact/prison
+/obj/machinery/artifact/prison
 	name = "artifact imprisoner"
 	associated_datum = /datum/artifact/prison
 
 /datum/artifact/prison
-	associated_object = /obj/artifact/prison
+	associated_object = /obj/machinery/artifact/prison
 	type_name = "Prison"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -9,7 +9,7 @@
 	rarity_weight = 450
 	validtypes = list("wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch)
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activated = 0
 	react_xray = list(15,75,90,3,"ANOMALOUS")

--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -1,9 +1,9 @@
-/obj/artifact/teleport_recaller
+/obj/machinery/artifact/teleport_recaller
 	name = "artifact recaller"
 	associated_datum = /datum/artifact/recaller
 
 /datum/artifact/recaller
-	associated_object = /obj/artifact/teleport_recaller
+	associated_object = /obj/machinery/artifact/teleport_recaller
 	type_name = "Recaller"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -1,9 +1,9 @@
-/obj/artifact/wish_granter
+/obj/machinery/artifact/wish_granter
 	name = "artifact wish granter"
 	associated_datum = /datum/artifact/wish_granter
 
 /datum/artifact/wish_granter
-	associated_object = /obj/artifact/wish_granter
+	associated_object = /obj/machinery/artifact/wish_granter
 	type_name = "Wishgranter"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 90

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -9,7 +9,7 @@
 	rarity_weight = 90
 	validtypes = list("wizard","eldritch")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold)
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/cold, /datum/artifact_trigger/lighting, /datum/artifact_trigger/darkness)
 	fault_blacklist = list(ITEM_ONLY_FAULTS)
 	activ_text = "begins glowing with an enticing light!"
 	deact_text = "falls dark and quiet."

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -63,9 +63,8 @@ ABSTRACT_TYPE(/datum/artifact/)
 
 	/// Which stimuli will activate this artifact?
 	var/list/triggers = list()
-	/// List from which to pick the triggers
-	var/validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
-	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,/datum/artifact_trigger/data)
+	/// List from which to pick the triggers, gets set in New() via filtered_concrete_typesof because it's too many dang types
+	var/validtriggers = list()
 	/// minimum amount of triggers the artifact will have
 	var/min_triggers = 1
 	/// maximum amount of triggers the artifact will have
@@ -109,6 +108,10 @@ ABSTRACT_TYPE(/datum/artifact/)
 	/// It is based mainly on origin, but some artifact types add more descriptors.
 	/// It is based on the fake origin though, so it is no use for recognizing fake origins.
 	var/list/touch_descriptors = list()
+
+	New()
+		..()
+		src.validtriggers = filtered_concrete_typesof(/datum/artifact_trigger/, GLOBAL_PROC_REF(filter_artifact_trigger))
 
 	/// gets called after the artifact basics (origin, appearance, object, etc) are all set up, so the type can modify it further
 	proc/post_setup()

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -63,8 +63,10 @@ ABSTRACT_TYPE(/datum/artifact/)
 
 	/// Which stimuli will activate this artifact?
 	var/list/triggers = list()
-	/// List from which to pick the triggers, gets set in post_setup() via filtered_concrete_typesof because it's too many dang types
-	var/validtriggers = list()
+	/// List from which to pick the triggers
+	var/validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
+	/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch,/datum/artifact_trigger/silicon_touch,/datum/artifact_trigger/data,
+	/datum/artifact_trigger/lighting,/datum/artifact_trigger/darkness)
 	/// minimum amount of triggers the artifact will have
 	var/min_triggers = 1
 	/// maximum amount of triggers the artifact will have

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -63,7 +63,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 
 	/// Which stimuli will activate this artifact?
 	var/list/triggers = list()
-	/// List from which to pick the triggers, gets set in New() via filtered_concrete_typesof because it's too many dang types
+	/// List from which to pick the triggers, gets set in post_setup() via filtered_concrete_typesof because it's too many dang types
 	var/validtriggers = list()
 	/// minimum amount of triggers the artifact will have
 	var/min_triggers = 1
@@ -108,10 +108,6 @@ ABSTRACT_TYPE(/datum/artifact/)
 	/// It is based mainly on origin, but some artifact types add more descriptors.
 	/// It is based on the fake origin though, so it is no use for recognizing fake origins.
 	var/list/touch_descriptors = list()
-
-	New()
-		..()
-		src.validtriggers = filtered_concrete_typesof(/datum/artifact_trigger/, GLOBAL_PROC_REF(filter_artifact_trigger))
 
 	/// gets called after the artifact basics (origin, appearance, object, etc) are all set up, so the type can modify it further
 	proc/post_setup()

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -54,10 +54,6 @@
 	var/datum/artifact/A = src.artifact
 	A.holder = src
 
-	// Separate process for lighting checks
-	if(A.get_trigger_by_string("light") || A.get_trigger_by_string("dark"))
-		processing_items |= src
-
 	if (!artifact_controls) //Hasn't been init'd yet
 		sleep(2 SECONDS)
 
@@ -140,14 +136,19 @@
 			A.triggers += AT
 			valid_triggers -= selection
 
+	// Separate process for lighting checks
+	if(A.get_trigger_by_path(/datum/artifact_trigger/lighting) || A.get_trigger_by_path(/datum/artifact_trigger/darkness))
+		processing_items |= src
+
 	artifact_controls.artifacts += src
 	A.post_setup()
 
 /obj/proc/ArtifactProcess()
-	// This proc gets called in both /obj/artifact/process() as well as /obj/machinery/artifact/process()
+	// This proc gets called in both /obj/machinery/artifact/process() as well as /obj/item/artifact/process()
 	// Primarily used to hook in lighting checks but could be used for anything
-
 	var/datum/artifact/A = src.artifact
+	if (A.activated)
+		return
 	A.holder = src
 
 	// Lighting trigger

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -154,7 +154,7 @@
 	// Lighting trigger
 	var/datum/artifact_trigger/AT_L = A.get_trigger_by_string("light")
 	var/datum/artifact_trigger/AT_D = A.get_trigger_by_string("dark")
-	var/rl_threshold = 0.3
+	var/rl_threshold = 1
 	if (istype(AT_L) || istype(AT_D))
 		var/turf/T = get_turf(src)
 		if (istype(T))

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -106,6 +106,13 @@
 		src.ArtifactTakeDamage(rand(5,20))
 		boutput(user, SPAN_ALERT("It seems to be a bit more damaged!"))
 
+/obj/artifact/proc/process()
+	var/datum/artifact/A = src.artifact
+	src.ArtifactProcess()
+
+	if (A.activated)
+		processing_items -= src
+
 /obj/machinery/artifact
 	name = "artifact large art piece"
 	icon = 'icons/obj/artifacts/artifacts.dmi'
@@ -129,6 +136,7 @@
 			src.ArtifactSetup()
 
 	disposing()
+		processing_items -= src
 		artifact_controls.artifacts -= src
 		..()
 
@@ -149,7 +157,10 @@
 			return
 		var/datum/artifact/A = src.artifact
 
+		src.ArtifactProcess()
+
 		if (A.activated)
+			processing_items -= src
 			A.effect_process(src)
 
 	attack_hand(mob/user)

--- a/code/obj/artifacts/triggers.dm
+++ b/code/obj/artifacts/triggers.dm
@@ -11,11 +11,6 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 	var/hint_prob = 33
 	var/used = 1
 
-// Filters unused artifact triggers
-proc/filter_artifact_trigger(var/type)
-	var/datum/artifact_trigger/AT = type
-	return initial(AT.used)
-
 /datum/artifact_trigger/carbon_touch
 	// touched by a carbon lifeform
 	type_name = "Carbon Touch"

--- a/code/obj/artifacts/triggers.dm
+++ b/code/obj/artifacts/triggers.dm
@@ -11,6 +11,11 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 	var/hint_prob = 33
 	var/used = 1
 
+// Filters unused artifact triggers
+proc/filter_artifact_trigger(var/type)
+	var/datum/artifact_trigger/AT = type
+	return initial(AT.used)
+
 /datum/artifact_trigger/carbon_touch
 	// touched by a carbon lifeform
 	type_name = "Carbon Touch"

--- a/code/obj/artifacts/triggers.dm
+++ b/code/obj/artifacts/triggers.dm
@@ -123,4 +123,4 @@ proc/filter_artifact_trigger(var/type)
 
 	New()
 		..()
-		stimulus_amount = rand(0, 3) / 10
+		stimulus_amount = rand(0, 10) / 10

--- a/code/obj/artifacts/triggers.dm
+++ b/code/obj/artifacts/triggers.dm
@@ -4,7 +4,7 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 /datum/artifact_trigger
 	var/type_name = "bad artifact code"
 	var/stimulus_required = null
-	var/do_amount_check = 1
+	var/do_amount_check = TRUE
 	var/stimulus_amount = null
 	var/stimulus_type = ">="
 	var/hint_range = 0
@@ -15,13 +15,13 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 	// touched by a carbon lifeform
 	type_name = "Carbon Touch"
 	stimulus_required = "carbtouch"
-	do_amount_check = 0
+	do_amount_check = FALSE
 
 /datum/artifact_trigger/silicon_touch
 	// touched by a silicon lifeform
 	type_name = "Silicon Touch"
 	stimulus_required = "silitouch"
-	do_amount_check = 0
+	do_amount_check = FALSE
 
 /datum/artifact_trigger/force
 	type_name = "Physical Force"
@@ -96,4 +96,26 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 	// touched by something that contains data (circuit board, disks) etc.
 	type_name = "Data"
 	stimulus_required = "data"
-	do_amount_check = 0
+	do_amount_check = FALSE
+
+/datum/artifact_trigger/lighting
+	// activated by lighting
+	type_name = "Light"
+	stimulus_required = "light"
+	stimulus_type = ">="
+	hint_range = 2
+
+	New()
+		..()
+		stimulus_amount = rand(1, 10)
+
+/datum/artifact_trigger/darkness
+	// activated by lack of lighting
+	type_name = "Dark"
+	stimulus_required = "dark"
+	stimulus_type = "<="
+	hint_range = 1
+
+	New()
+		..()
+		stimulus_amount = rand(0, 3) / 10

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -210,13 +210,13 @@
 				unacceptable = TRUE
 				break
 
-			for (var/obj/artifact/A in T) // check if an artifact has someone inside
-				if (istype(A, /obj/artifact/prison))
+			for (var/obj/machinery/artifact/A in T) // check if an artifact has someone inside
+				if (istype(A, /obj/machinery/artifact/prison))
 					var/datum/artifact/prison/P = A.artifact
 					if(istype(P.prisoner))
 						unacceptable = TRUE
 						break
-				else if (istype(A, /obj/artifact/cloner))
+				else if (istype(A, /obj/machinery/artifact/cloner))
 					var/datum/artifact/cloner/C = A.artifact
 					if(istype(C.clone))
 						unacceptable = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [Internal] [Science]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes  every instance of `/obj/artifact` into `/obj/machinery/artifact` and removes `/obj/artifact`.
Adds `/obj/proc/ArtifactProcess()` which extends `/obj/machinery/artifact/process()` and `/obj/item/artifact/process()`.
Adds artifacts to `processing_items` if their trigger uses light in any way.

Adds `/datum/artifact_trigger/lighting` and `/datum/artifact_trigger/darkness` which activate via light level.
The lighting trigger checks the light level by comparing the brightness value of the light used, this was done so that artifacts don't randomly activate by regular simple lights.
The darkness trigger checks the light level of the turf via `turf/is_lit`, and if this check fails, it compares how dark the tile is. This was done because simple lights don't really have any kind of brightness associated with them and I wanted to avoid weird cases where a tile is technically lit but counts as dark.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Originally I just wanted to implement light-based triggers, however it turns out that half the artifact code was duplicated into machinery and non-machinery, and because light-based checks can only feasible be done via process() checks, I figured I kill two birds with one stone and merge the redundant code so that now everything's a machine and uses process.

Also, light-related checks could cause performance problems, but I made sure to only check for them when the artifact actually rolls it as a trigger, and the check is removed once the artifact does trigger.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(*)Latest scientific discoveries indicate that artifacts can respond to different levels of light.
```
