### PR TITLE
Adds withdraw cash verb to PDAs

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -784,7 +784,7 @@
 
 /obj/item/device/pda2/verb/ejectCash()
 	set name = "Withdraw Cash"
-	set desc = "withdraw Cash from this PDA."
+	set desc = "Withdraw Cash from this PDA."
 	set category = "Local"
 	set src in usr
 

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -782,6 +782,14 @@
 	eject_pen(usr)
 	src.updateSelfDialog()
 
+/obj/item/device/pda2/verb/ejectCash()
+	set name = "Withdraw Cash"
+	set desc = "withdraw Cash from this PDA."
+	set category = "Local"
+	set src in usr
+
+	eject_cash(usr)
+
 /obj/item/device/pda2
 
 	proc/update_colors(bg, linkbg)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[objects][qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://github.com/goonstation/goonstation/assets/30974789/11d5b5e4-717b-4e3d-bb78-f0cc3a7a9ad9)
Works exactly the same as the withdraw button in the pda's ui

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
would be nice.
Other basic functionality of the pda is already in verbs and at least i use them