### PR TITLE
Adds empty gas tanks to science fabricator

### DIFF
--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -274,6 +274,7 @@
 		/datum/manufacture/welder,
 		/datum/manufacture/patch,
 		/datum/manufacture/atmos_can,
+		/datum/manufacture/gastank,
 		/datum/manufacture/artifactforms,
 		/datum/manufacture/fluidcanister,
 		/datum/manufacture/chembarrel,


### PR DESCRIPTION
[game-objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the empty gas tanks from the general fabricator to the science fabricator as well

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Science uses them a lot and the nearest gen fab is usually very very far away
