### PR TITLE
Fix different-colored swimsuits all being called white

### DIFF
--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -994,22 +994,27 @@ TYPEINFO(/obj/item/clothing/under/shorts/luchador)
 	item_state = "fswimW"
 
 	red
+		name = "red swimsuit"
 		icon_state = "fswimR"
 		item_state = "fswimR"
 
 	green
+		name = "green swimsuit"
 		icon_state = "fswimG"
 		item_state = "fswimG"
 
 	blue
+		name = "blue swimsuit"
 		icon_state = "fswimBl"
 		item_state = "fswimBl"
 
 	purple
+		name = "purple swimsuit"
 		icon_state = "fswimP"
 		item_state = "fswimP"
 
 	black
+		name = "black swimsuit"
 		icon_state = "fswimB"
 		item_state = "fswimB"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives names to the different subtypes of the one-piece swimsuit that properly reflect their color

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19918
