### PR TITLE
Add air shields to bomb test range airlocks

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -28404,6 +28404,11 @@
 	cycle_id = "toxins";
 	name = "Toxins"
 	},
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "jEE" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -28404,7 +28404,7 @@
 	cycle_id = "toxins";
 	name = "Toxins"
 	},
-/obj/forcefield/energyshield/perma{
+/obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -16786,6 +16786,11 @@
 	cycle_id = "toxins";
 	name = "Toxin Storage"
 	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/black,
 /area/station/science/storage)
 "eWZ" = (
@@ -34302,6 +34307,11 @@
 /obj/mapping_helper/airlock/cycler{
 	cycle_id = "bombtest";
 	name = "Bomb Testing Chamber"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber/bombchamber)


### PR DESCRIPTION
[mapping][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds air shields to the external doors in toxin lab that lead to the bomb testing ranges on Donut 2 and Donut 3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Other external airlocks have them and after a good round of going in and out to pick up the crystals from the bomb testing range there's usually no air at all in toxins which is annoying