### PR TITLE
Makes cameras in bomb testing chambers explosion immune

### DIFF
--- a/code/modules/camera/television.dm
+++ b/code/modules/camera/television.dm
@@ -75,3 +75,8 @@
 	name = "mobile television - science"
 	c_tag = "science mobile"
 	network = "telesci"
+
+/obj/machinery/camera/television/bombtest
+	name = "television camera - bomb testing range"
+	desc = "A bulky stationary camera for wireless broadcasting of live bomb tests."
+	invuln = TRUE

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17199,10 +17199,8 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/wreckage)
 "cpz" = (
-/obj/machinery/camera/television{
-	c_tag = "test chamber 2";
-	dir = 8;
-	name = "camera - test chamber 2"
+/obj/machinery/camera/television/bombtest{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/science/testchamber/bombchamber)
@@ -21697,10 +21695,8 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "ffp" = (
-/obj/machinery/camera/television{
-	c_tag = "test chamber";
-	dir = 4;
-	name = "camera - test chamber"
+/obj/machinery/camera/television/bombtest{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/testchamber/bombchamber)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -26933,7 +26933,7 @@
 	icon_state = "line2"
 	},
 /obj/machinery/light/incandescent/cool/very,
-/obj/machinery/camera/television/auto{
+/obj/machinery/camera/television/bombtest{
 	dir = 8
 	},
 /turf/simulated/floor/white,
@@ -43426,7 +43426,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "ndT" = (
-/obj/machinery/camera/television/auto,
+/obj/machinery/camera/television/bombtest,
 /turf/simulated/floor/carpet/grime,
 /area/station/science/testchamber/bombchamber)
 "ndX" = (


### PR DESCRIPTION
[mapping][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new variant of the stationary cameras used in the bomb testing ranges, which are named as such and will not be destroyed by explosions

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The regular ones blow up really easily and I believe it is enriching for staff assistants to watch ttvs going off on the TV

I'm not fully sure this is the best way to make them explosion resistant (ideally I'd like them to be explosion Resistant but not Immune) but roxy said this is how it's handled currently and this is the best option.  If you have a better idea pleaase let me know
I'm also not sure if it should be a variant of the regular television cam or of the auto version because donut 2 uses the regular ones and donut 3 uses the auto ones so I just went with the regular one. I dunno
