### PR TITLE
Rusted airlock fake object unification

### DIFF
--- a/assets/maps/prefabs/planet/prefab_planet_random_ship1.dmm
+++ b/assets/maps/prefabs/planet/prefab_planet_random_ship1.dmm
@@ -60,7 +60,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/assets/maps/prefabs/planet/prefab_planet_random_ship2.dmm
+++ b/assets/maps/prefabs/planet/prefab_planet_random_ship2.dmm
@@ -50,7 +50,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/assets/maps/prefabs/planet/prefab_planet_random_ship3.dmm
+++ b/assets/maps/prefabs/planet/prefab_planet_random_ship3.dmm
@@ -75,7 +75,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/assets/maps/prefabs/space/prefab_beesanctuary.dmm
+++ b/assets/maps/prefabs/space/prefab_beesanctuary.dmm
@@ -1617,7 +1617,7 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "UT" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/assets/maps/prefabs/space/prefab_clown_nest.dmm
+++ b/assets/maps/prefabs/space/prefab_clown_nest.dmm
@@ -5,7 +5,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "airlock_open";

--- a/assets/maps/prefabs/space/prefab_dans_asteroid.dmm
+++ b/assets/maps/prefabs/space/prefab_dans_asteroid.dmm
@@ -28,7 +28,7 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "aZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "com_open";
@@ -625,7 +625,7 @@
 /turf/unsimulated/floor/arctic/snow/ice,
 /area/prefab/discount_dans_asteroid)
 "xV" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/decal/cleanable/blood/tracks{
 	dir = 8;
 	icon_state = "tracks"
@@ -750,7 +750,7 @@
 /turf/unsimulated/floor/arctic/snow/ice,
 /area/prefab/discount_dans_asteroid)
 "DW" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";

--- a/assets/maps/prefabs/space/prefab_drug_den.dmm
+++ b/assets/maps/prefabs/space/prefab_drug_den.dmm
@@ -93,7 +93,7 @@
 /turf/variableTurf/clear,
 /area/noGenerate)
 "eN" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "airlock_open";

--- a/assets/maps/prefabs/space/prefab_ksol.dmm
+++ b/assets/maps/prefabs/space/prefab_ksol.dmm
@@ -249,7 +249,7 @@
 	dir = 8;
 	icon_state = "tracks"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";
@@ -420,7 +420,7 @@
 	dir = 4;
 	icon_state = "tracks"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";
@@ -1038,7 +1038,7 @@
 /turf/variableTurf/floor,
 /area/noGenerate)
 "cH" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1049,7 +1049,7 @@
 /turf/simulated/floor/airless/engine,
 /area/noGenerate)
 "cI" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 2;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1059,7 +1059,7 @@
 /turf/simulated/floor/airless/engine,
 /area/noGenerate)
 "cJ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 6;
 	icon = 'icons/obj/doors/blastdoor.dmi';

--- a/assets/maps/prefabs/space/prefab_space_casino.dmm
+++ b/assets/maps/prefabs/space/prefab_space_casino.dmm
@@ -128,7 +128,7 @@
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/prefab/space_casino)
 "oD" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/Doormaint.dmi';

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_beesanctuary.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_beesanctuary.dmm
@@ -650,7 +650,7 @@
 /turf/unsimulated/floor/white,
 /area/prefab/bee_sanctuary)
 "Dn" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_crashed.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_crashed.dmm
@@ -356,7 +356,7 @@
 	},
 /area/station/turret_protected/sea_crashed)
 "bs" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 10;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -426,7 +426,7 @@
 "bM" = (
 /mob/living/critter/robotic/gunbot{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/black/grime,
 /area/station/turret_protected/sea_crashed)
@@ -449,7 +449,7 @@
 "bQ" = (
 /mob/living/critter/robotic/gunbot{
 	dir = 8;
-	
+
 	},
 /turf/simulated/floor/black/grime,
 /area/station/turret_protected/sea_crashed)
@@ -1289,7 +1289,7 @@
 "sR" = (
 /mob/living/critter/robotic/gunbot{
 	dir = 4;
-	
+
 	},
 /obj/item/implantcase/robust,
 /turf/simulated/floor/black/grime,

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -282,12 +282,6 @@
 
 // setpiece decals
 
-/obj/fakeobject/sealed_door/owlery
-	name = "Busted Airlock"
-	desc = "This airlock is all shot up. The control panel seems to have taken several hits and is beyond repair."
-	icon = 'icons/misc/Owlzone.dmi'
-	icon_state = "airlock_broken"
-
 /obj/fakeobject/pipe/radioactive
 	desc = "This pipe is kinda warm. Huh."
 	interesting = "Radiological decay detected."

--- a/code/obj/fakeobject.dm
+++ b/code/obj/fakeobject.dm
@@ -187,13 +187,6 @@
 	icon_state = "firex"
 	anchored = ANCHORED
 
-/obj/fakeobject/firelock_broken
-	name = "rusted firelock"
-	desc = "Rust has rendered this firelock useless."
-	icon = 'icons/obj/doors/door_fire2.dmi'
-	icon_state = "door0"
-	anchored = ANCHORED_ALWAYS
-
 /obj/fakeobject/airlock_broken
 	name = "rusted airlock"
 	desc = "Rust has rendered this airlock useless."
@@ -215,6 +208,12 @@
 			desc = "This airlock is all shot up. The control panel seems to have taken several hits and is beyond repair."
 			icon = 'icons/misc/Owlzone.dmi'
 			icon_state = "airlock_broken"
+
+	firelock // what used to be /obj/fakeobject/airlock_broken/firelock
+		name = "rusted firelock"
+		desc = "Rust has rendered this firelock useless."
+		icon = 'icons/obj/doors/door_fire2.dmi'
+		icon_state = "door0"
 
 /obj/fakeobject/lighttube_broken
 	name = "shattered light tube"

--- a/code/obj/fakeobject.dm
+++ b/code/obj/fakeobject.dm
@@ -192,16 +192,29 @@
 	desc = "Rust has rendered this firelock useless."
 	icon = 'icons/obj/doors/door_fire2.dmi'
 	icon_state = "door0"
-	anchored = ANCHORED
+	anchored = ANCHORED_ALWAYS
 
 /obj/fakeobject/airlock_broken
 	name = "rusted airlock"
 	desc = "Rust has rendered this airlock useless."
 	icon = 'icons/obj/doors/Door1.dmi';
 	icon_state = "doorl";
-	anchored = ANCHORED
+	anchored = ANCHORED_ALWAYS
 	density = 1
 	opacity = 1
+
+	sealed // used in dojozone
+		name = "laboratory door"
+		desc = "It appears to be sealed."
+		icon = 'icons/obj/dojo.dmi'
+		icon_state = "sealed_door"
+		anchored = ANCHORED_ALWAYS
+
+		owlery // used in owlery
+			name = "Busted Airlock"
+			desc = "This airlock is all shot up. The control panel seems to have taken several hits and is beyond repair."
+			icon = 'icons/misc/Owlzone.dmi'
+			icon_state = "airlock_broken"
 
 /obj/fakeobject/lighttube_broken
 	name = "shattered light tube"

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -552,15 +552,6 @@ Contents:
 	icon = 'icons/obj/dojo.dmi'
 	icon_state = "rake"
 
-/obj/fakeobject/sealed_door
-	name = "laboratory door"
-	desc = "It appears to be sealed."
-	icon = 'icons/obj/dojo.dmi'
-	icon_state = "sealed_door"
-	density = 1
-	anchored = ANCHORED_ALWAYS
-	opacity = 1
-
 /obj/fakeobject/katana_fake
 	name = "katana sheath"
 	desc = "It can clean a bloodied katana, and also allows for easier storage of a katana"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -23934,7 +23934,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -36997,7 +36997,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles3"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -37025,7 +37025,7 @@
 /turf/simulated/floor/airless/plating/scorched,
 /area/abandonedship)
 "cBL" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -57220,7 +57220,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
 	icon = 'icons/obj/junk.dmi';

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -5121,7 +5121,7 @@
 /turf/simulated/floor/airless/plating/scorched,
 /area/space)
 "nO" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -5700,7 +5700,7 @@
 /turf/simulated/floor/airless/plating/damaged2,
 /area/space)
 "pt" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/Doorext.dmi';
@@ -10577,7 +10577,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -33686,7 +33686,7 @@
 /turf/simulated/floor/plating,
 /area/tech_outpost)
 "eKD" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	icon_state = "door1";

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -11385,7 +11385,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "azM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -11539,7 +11539,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -11558,7 +11558,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles3"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -55450,7 +55450,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	dir = 8;
 	icon = 'icons/obj/junk.dmi';

--- a/maps/setpieces/lunaport.dmm
+++ b/maps/setpieces/lunaport.dmm
@@ -468,7 +468,7 @@
 	name = "Concourse D"
 	})
 "bX" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;
@@ -3829,7 +3829,7 @@
 	},
 /area/moon/underground)
 "oQ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;
@@ -5169,7 +5169,7 @@
 /turf/unsimulated/floor/wood/five,
 /area/moon/underground)
 "tF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -6346,7 +6346,7 @@
 	},
 /area/moon/underground)
 "xy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's bolted as heck. You're not gonna be able to unbolt this.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -6363,7 +6363,7 @@
 /turf/unsimulated/iomoon/floor,
 /area/space)
 "xB" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's bolted as heck. You're not gonna be able to unbolt this.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -6475,7 +6475,7 @@
 	name = "Concourse B"
 	})
 "xZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -8514,7 +8514,7 @@
 	name = "Concourse B"
 	})
 "FW" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's bolted as heck. You're not gonna be able to unbolt this.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -10144,7 +10144,7 @@
 	name = "Concourse D"
 	})
 "Mv" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -11464,7 +11464,7 @@
 	name = "SPECTRE Showroom"
 	})
 "RR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Just a door. A door that's not for you.";
 	dir = 4;
@@ -12332,7 +12332,7 @@
 	name = "Concourse B"
 	})
 "UQ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -12976,7 +12976,7 @@
 /turf/unsimulated/floor/industrial,
 /area/moon/underground)
 "Xf" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -13710,7 +13710,7 @@
 /turf/unsimulated/wall/setpieces/leadwall/white/lunar,
 /area/moon/underground)
 "ZF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -54723,7 +54723,7 @@
 	},
 /area/russian/radiation)
 "mXd" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -2305,7 +2305,7 @@
 /turf/simulated/wall/auto/asteroid/lighted,
 /area/station/engine/substation/pylon)
 "agp" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/maps/unused/setpieces/AIBM_lunar.dmm
+++ b/maps/unused/setpieces/AIBM_lunar.dmm
@@ -604,7 +604,7 @@
 	name = "Security Checkpoint";
 	req_access_txt = "255"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this firelock useless.  Well I mean actually it doesnt have much at all, but it's probably in key areas or something.  Get off my back."
 	},
 /turf/unsimulated/floor/red,
@@ -712,7 +712,7 @@
 	},
 /area/moon/underground)
 "ck" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -1407,7 +1407,7 @@
 /turf/unsimulated/floor,
 /area/moon/underground)
 "dX" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -1565,7 +1565,7 @@
 /turf/unsimulated/floor,
 /area/moon/underground)
 "es" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "It's jammed, apparently.  Or just really locked.";
 	name = "sealed airlock"
 	},
@@ -2350,7 +2350,7 @@
 /turf/unsimulated/floor/lunar,
 /area/moon)
 "gG" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -2749,7 +2749,7 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -4111,7 +4111,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "kb" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4123,7 +4123,7 @@
 	},
 /area/moon/museum/west)
 "kc" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4135,7 +4135,7 @@
 	},
 /area/moon/museum/west)
 "kd" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4172,7 +4172,7 @@
 	},
 /area/moon/museum)
 "kh" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4184,7 +4184,7 @@
 	},
 /area/moon/museum)
 "ki" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4673,7 +4673,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "lf" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -5128,7 +5128,7 @@
 /turf/unsimulated/floor/grey/checker,
 /area/moon/museum/giftshop)
 "mh" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -5141,7 +5141,7 @@
 	},
 /area/moon/museum)
 "mi" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -5159,7 +5159,7 @@
 	},
 /area/moon/museum/giftshop)
 "mk" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/Doormaint.dmi';
@@ -5606,7 +5606,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "nf" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';

--- a/maps/unused/setpieces/APH_mars2.dmm
+++ b/maps/unused/setpieces/APH_mars2.dmm
@@ -562,7 +562,7 @@
 	},
 /area/mars)
 "bz" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	tag = "icon-bdoorbroken (EAST)";
 	name = "rusty blastdoor";
 	desc = "This blast door looks rusted over.  Junk.";
@@ -612,7 +612,7 @@
 	},
 /area/mars)
 "bF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	tag = "icon-bdoorbroken";
 	name = "rusty blastdoor";
 	desc = "This blast door looks rusted over.  Junk.";
@@ -1241,7 +1241,7 @@
 	},
 /area/mars)
 "dD" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	tag = "icon-bdoorbroken (SOUTHEAST)";
 	name = "rusty blastdoor";
 	desc = "This blast door looks rusted over.  Junk.";

--- a/maps/unused/setpieces/SHARED_biodomeExpanded.dmm
+++ b/maps/unused/setpieces/SHARED_biodomeExpanded.dmm
@@ -609,7 +609,7 @@
 	},
 /area/swampzone/interiors)
 "aKR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock is jammed.";
 	icon = 'icons/obj/doors/doormed.dmi';
@@ -1531,11 +1531,11 @@
 /turf/unsimulated/floor/auto/grass/leafy,
 /area/swampzone/deeps)
 "bPF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/map/light/graveyard,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/Doorext.dmi';
@@ -3688,7 +3688,7 @@
 /turf/unsimulated/floor/auto/grass/swamp_grass,
 /area/swampzone/ground)
 "eve" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/machinery/door/airlock/glass,
 /obj/decal/stripe_delivery,
 /turf/unsimulated/floor,
@@ -5068,7 +5068,7 @@
 /turf/unsimulated/floor/auto/swamp,
 /area/swampzone/interiors/bonktek)
 "fSY" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/Doorext.dmi';
@@ -5613,7 +5613,7 @@
 /turf/unsimulated/greek/water,
 /area/swampzone/ground)
 "gzr" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/machinery/door/airlock/medical,
@@ -5630,7 +5630,7 @@
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "gCg" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock is jammed.";
 	icon = 'icons/obj/doors/doormed.dmi';
@@ -10106,7 +10106,7 @@
 /turf/unsimulated/floor/caution/west,
 /area/crater/biodome/research)
 "lXB" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/machinery/door/airlock/medical{
@@ -11055,7 +11055,7 @@
 /turf/unsimulated/floor/auto/grass/leafy,
 /area/crater/biodome/north)
 "ndF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1
 	},
 /obj/machinery/door/airlock/glass,
@@ -15176,7 +15176,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/crater/biodome/maint)
 "snk" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass,
@@ -16848,7 +16848,7 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/crypt/sigma/rd)
 "ukq" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/decal/stripe_delivery,
 /turf/unsimulated/floor,
 /area/crypt/sigma/kitchen)
@@ -19414,7 +19414,7 @@
 /turf/space/fluid/cenote,
 /area/swampzone/interiors/quarry)
 "xbB" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock is jammed.";
 	icon = 'icons/obj/doors/doormed.dmi';

--- a/maps/unused/setpieces/silo.dmm
+++ b/maps/unused/setpieces/silo.dmm
@@ -177,7 +177,7 @@
 	},
 /area/space)
 "aB" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	tag = "icon-door0 (WEST)";
 	icon_state = "door0";
 	dir = 8
@@ -233,7 +233,7 @@
 /turf/unsimulated/floor/setpieces/ancient_pit/shaft,
 /area/space)
 "aK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	tag = "icon-door0 (EAST)";
 	icon_state = "door0";
 	dir = 4
@@ -559,7 +559,7 @@
 	},
 /area/space)
 "bC" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1375,7 +1375,7 @@
 /area/space)
 "dh" = (
 /obj/stomachacid,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -1770,7 +1770,7 @@
 /turf/simulated/floor/plating,
 /area/russian)
 "aeV" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /turf/simulated/floor,
 /area/russian)
 "aeY" = (
@@ -1885,7 +1885,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "afp" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/cable{
 	icon_state = "4-8"
 	},

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -16640,7 +16640,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "hsK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -30036,7 +30036,7 @@
 /area/owlery/staffhall)
 "cnr" = (
 /obj/decal/cleanable/blood/tracks,
-/obj/fakeobject/sealed_door/owlery,
+/obj/fakeobject/airlock_broken/sealed/owlery,
 /turf/unsimulated/floor/orangeblack,
 /area/owlery/staffhall)
 "cns" = (
@@ -31113,7 +31113,7 @@
 /turf/unsimulated/floor/black,
 /area/dojo)
 "crq" = (
-/obj/fakeobject/sealed_door,
+/obj/fakeobject/airlock_broken/sealed,
 /turf/unsimulated/floor/black,
 /area/dojo)
 "crr" = (
@@ -42062,7 +42062,7 @@
 	},
 /area/owlery/owleryhall)
 "cXn" = (
-/obj/fakeobject/sealed_door{
+/obj/fakeobject/airlock_broken/sealed{
 	name = "office door"
 	},
 /turf/unsimulated/wall/auto/reinforced/gannets,

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -339,7 +339,7 @@
 	},
 /area/hospital)
 "adk" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This window is broken.  Impressively broken, as the surrounding bulkhead is all torn up too.  Maybe there was a....space....quake.";
 	icon = 'icons/misc/hospital.dmi';
 	icon_state = "brokenup";
@@ -540,7 +540,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
 "adR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorright0";
@@ -609,7 +609,7 @@
 	},
 /area/hospital/samostrel)
 "aec" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorleft0";
@@ -625,7 +625,7 @@
 /area/hospital)
 "aee" = (
 /obj/chaser/hospital_trigger,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -678,7 +678,7 @@
 /turf/unsimulated/floor/white,
 /area/hospital)
 "aep" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -822,7 +822,7 @@
 	},
 /area/hospital/samostrel)
 "aeV" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -832,7 +832,7 @@
 /turf/unsimulated/floor/white,
 /area/hospital)
 "aeW" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -1074,7 +1074,7 @@
 /turf/unsimulated/wall/auto/lead/gray,
 /area/crypt/sigma/mainhall)
 "afX" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -2675,7 +2675,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "ans" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -2953,7 +2953,7 @@
 /turf/unsimulated/floor/carpet/red/decal/innercross,
 /area/syndicate_station/battlecruiser)
 "aoE" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A pod door.  One that might be stuck, who knows.";
 	dir = 4;
 	icon = 'icons/obj/doors/sovblastdoor.dmi';
@@ -3398,7 +3398,7 @@
 /turf/unsimulated/floor/engine,
 /area/hospital/samostrel)
 "aqy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A pod door.  One that is definitely stuck.";
 	dir = 8;
 	icon = 'icons/obj/doors/sovblastdoor.dmi';
@@ -4136,7 +4136,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
 "atI" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorright0";
@@ -4150,7 +4150,7 @@
 	},
 /area/hospital)
 "atK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0";
@@ -4240,7 +4240,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
 "auo" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate compartments.";
 	icon = 'icons/obj/doors/blastdoor.dmi';
 	icon_state = "bdoorleft0";
@@ -4833,7 +4833,7 @@
 /turf/unsimulated/floor/black,
 /area/hospital/samostrel)
 "axL" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4845,7 +4845,7 @@
 	},
 /area/moon/museum/west)
 "axM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4855,7 +4855,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum/west)
 "axN" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4886,7 +4886,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "axR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -4896,7 +4896,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "axS" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -5770,7 +5770,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "aCo" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -5896,7 +5896,7 @@
 /turf/unsimulated/floor/grey/checker,
 /area/moon/museum/giftshop)
 "aCR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -5907,7 +5907,7 @@
 /turf/unsimulated/floor,
 /area/moon/museum)
 "aCS" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -6471,7 +6471,7 @@
 	},
 /area/hospital/underground)
 "aFU" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "A security door used to separate museum compartments.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -6672,7 +6672,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -7996,7 +7996,7 @@
 	},
 /area/marsoutpost)
 "aMS" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -8004,7 +8004,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor1";
@@ -8447,7 +8447,7 @@
 	},
 /area/marsoutpost)
 "aOp" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -9007,7 +9007,7 @@
 	},
 /area/marsoutpost)
 "aPV" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";
@@ -9213,7 +9213,7 @@
 /turf/unsimulated/floor/cave,
 /area/crater/cave)
 "aQJ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -9222,7 +9222,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -9543,7 +9543,7 @@
 	},
 /area/upper_arctic/exterior/surface)
 "aRM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";
@@ -9713,7 +9713,7 @@
 	},
 /area/marsoutpost)
 "aSy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -11367,7 +11367,7 @@
 	},
 /area/marsoutpost/duststorm)
 "aXT" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -11377,7 +11377,7 @@
 /turf/unsimulated/floor/engine,
 /area/marsoutpost)
 "aXU" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 6;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -13697,7 +13697,7 @@
 	layer = 2.5;
 	name = "power conduit"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -13706,7 +13706,7 @@
 	},
 /area/marsoutpost)
 "bfw" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -13723,7 +13723,7 @@
 	name = "mysterious computer";
 	pixel_x = 32
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -13877,7 +13877,7 @@
 	},
 /area/marsoutpost)
 "bga" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -14005,7 +14005,7 @@
 	},
 /area/marsoutpost)
 "bgy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_open";
@@ -14014,7 +14014,7 @@
 /turf/unsimulated/floor/grime,
 /area/marsoutpost)
 "bgz" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -14391,7 +14391,7 @@
 /turf/unsimulated/floor/arctic/snow/ice,
 /area/lower_arctic/lower)
 "bia" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -15546,7 +15546,7 @@
 /turf/unsimulated/floor/cave,
 /area/crater/cave/lower)
 "bkZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -15556,7 +15556,7 @@
 	},
 /area/marsoutpost)
 "bla" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -15775,7 +15775,7 @@
 /turf/unsimulated/floor/grime,
 /area/marsoutpost)
 "blE" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -16012,7 +16012,7 @@
 /turf/unsimulated/floor/grime,
 /area/marsoutpost)
 "bmm" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -16149,7 +16149,7 @@
 /turf/unsimulated/wall/solidcolor/white,
 /area/afterlife/heaven)
 "bmM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -18591,7 +18591,7 @@
 /turf/unsimulated/floor/lava,
 /area/iomoon)
 "bvR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -19158,8 +19158,8 @@
 /turf/unsimulated/floor/lava,
 /area/iomoon)
 "bzm" = (
-/obj/fakeobject/firelock_broken,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock,
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -19575,7 +19575,7 @@
 /turf/space,
 /area/space)
 "bBp" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -19585,11 +19585,11 @@
 /turf/unsimulated/floor,
 /area/iomoon/base)
 "bBs" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -22375,7 +22375,7 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/crunch)
 "bLD" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -22489,7 +22489,7 @@
 	},
 /area/crunch)
 "bLV" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -24426,7 +24426,7 @@
 /area/gauntlet)
 "bSz" = (
 /obj/creepy_sound_trigger,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -26991,7 +26991,7 @@
 	},
 /area/meat_derelict/main)
 "ccJ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "com2_open";
@@ -27000,7 +27000,7 @@
 /turf/unsimulated/floor,
 /area/meat_derelict/guts)
 "ccK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -27473,7 +27473,7 @@
 /turf/simulated/wall/auto/reinforced/old,
 /area/crunch)
 "ceP" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -27512,7 +27512,7 @@
 /turf/unsimulated/floor/setpieces/gauntlet,
 /area/afterlife/heaven)
 "ceZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -28433,7 +28433,7 @@
 /turf/unsimulated/floor/grime,
 /area/meat_derelict/entry)
 "ciq" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -46616,8 +46616,8 @@
 	},
 /area/centcom)
 "dnj" = (
-/obj/fakeobject/firelock_broken,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock,
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -46729,7 +46729,7 @@
 /turf/unsimulated/iomoon/floor,
 /area/iomoon)
 "doL" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 6;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -47196,7 +47196,7 @@
 	},
 /area/shuttle/merchant_shuttle/right_centcom/donut2)
 "dtA" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -47541,7 +47541,7 @@
 	},
 /area/shuttle/merchant_shuttle/right_centcom/cogmap2)
 "dvf" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -47559,7 +47559,7 @@
 	},
 /area/shuttle/merchant_shuttle/left_centcom/cogmap2)
 "dvj" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -55374,7 +55374,7 @@
 	},
 /area/crunch/wtc)
 "esa" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -56261,7 +56261,7 @@
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/shuttle/merchant_shuttle/left_centcom/donut2)
 "fjj" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0";
@@ -56462,7 +56462,7 @@
 /turf/space,
 /area/syndicate_station_space)
 "fuR" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	dir = 4;
@@ -56679,7 +56679,7 @@
 	},
 /area/owlery/staffhall)
 "fDB" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -56822,7 +56822,7 @@
 /turf/unsimulated/floor/plating,
 /area/upper_arctic/hall)
 "fLm" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock is jammed.";
 	dir = 4;
@@ -58313,7 +58313,7 @@
 	icon_state = "1-2"
 	},
 /obj/grille/catwalk,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -58875,7 +58875,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/upper_arctic/pod2)
 "huI" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -58930,7 +58930,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/sovexe)
 "hxi" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -59170,7 +59170,7 @@
 	},
 /area/centcom)
 "hIZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -59590,7 +59590,7 @@
 /obj/cable/green{
 	icon_state = "5-10"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -60826,7 +60826,7 @@
 /turf/unsimulated/floor/blackwhite/whitegrime/other,
 /area/observatory)
 "jaS" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -61059,7 +61059,7 @@
 /turf/unsimulated/floor/wood/six,
 /area/centcom/offices/janantilles)
 "jir" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -61149,7 +61149,7 @@
 /turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "jle" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/machinery/door/airlock/pyro/maintenance,
 /turf/unsimulated/floor/plating,
 /area/iomoon/base)
@@ -61483,7 +61483,7 @@
 /turf/unsimulated/floor/caution/east,
 /area/iomoon/base/underground)
 "jxy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "maint_open";
@@ -61802,7 +61802,7 @@
 	},
 /area/owlery/gangzone)
 "jNF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -61811,7 +61811,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -61955,7 +61955,7 @@
 /turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
 "jUW" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 1;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -62622,7 +62622,7 @@
 	},
 /area/titlescreen)
 "kvy" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -63714,7 +63714,7 @@
 	layer = 6;
 	name = "broken door"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -64581,7 +64581,7 @@
 	},
 /area/meat_derelict/guts)
 "mgq" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;
@@ -64814,7 +64814,7 @@
 /turf/unsimulated/floor/sanitary/white,
 /area/owlery/owleryhall)
 "msq" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -64944,7 +64944,7 @@
 /turf/unsimulated/floor/black,
 /area/centcom/offices/kyle)
 "mwF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -68173,7 +68173,7 @@
 /turf/unsimulated/floor/plating,
 /area/owlery/Owlopen)
 "phv" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -68414,7 +68414,7 @@
 /turf/unsimulated/floor/pool/no_animate,
 /area/centcom/garden)
 "por" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;
@@ -68588,7 +68588,7 @@
 /turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
 "pxZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -68787,7 +68787,7 @@
 /turf/unsimulated/floor/black,
 /area/owlery/Owlmait2)
 "pDK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	dir = 8;
 	icon = 'icons/obj/doors/shuttle.dmi';
@@ -68907,7 +68907,7 @@
 	name = "grimy pipe";
 	pixel_y = -6
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "It's jammed, apparently.  Or just really locked.";
 	dir = 4;
@@ -69604,7 +69604,7 @@
 /obj/cable{
 	icon_state = "5-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	dir = 4;
@@ -69833,7 +69833,7 @@
 /turf/unsimulated/floor,
 /area/watchful_eye_sensor)
 "qvf" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -70959,7 +70959,7 @@
 /area/centcom/offices/pali)
 "rrt" = (
 /obj/machinery/door/airlock/pyro/glass,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -71881,7 +71881,7 @@
 /turf/unsimulated/floor/lava,
 /area/iomoon/caves)
 "sad" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 8;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -72316,7 +72316,7 @@
 	name = "power conduit";
 	tag = "icon-conduit (EAST)"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0";
@@ -72724,7 +72724,7 @@
 	name = "broken door";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -72906,7 +72906,7 @@
 	},
 /area/iomoon/base)
 "sQU" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  What's the point of it then?  WHAT IS THE POINT";
 	dir = 8;
 	icon = 'icons/obj/doors/shuttle.dmi';
@@ -73084,7 +73084,7 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/owlery/gangzone)
 "tfF" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -73322,7 +73322,7 @@
 /turf/unsimulated/wall/auto/adventure/mars,
 /area/marsoutpost)
 "trc" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -74125,7 +74125,7 @@
 /turf/unsimulated/floor/plating,
 /area/moon/museum)
 "ueV" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -74134,7 +74134,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -74159,7 +74159,7 @@
 /turf/unsimulated/floor,
 /area/crunch)
 "ugt" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -74918,7 +74918,7 @@
 	},
 /area/titlescreen)
 "uOZ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This blast door looks rusted over.  Junk.";
 	dir = 4;
 	icon = 'icons/obj/doors/blastdoor.dmi';
@@ -75900,7 +75900,7 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/hospital/underground)
 "vGz" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -75909,7 +75909,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -76607,7 +76607,7 @@
 /turf/space,
 /area/watchful_eye_sensor)
 "wfP" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -77088,7 +77088,7 @@
 /turf/space,
 /area/watchful_eye_sensor)
 "wya" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	dir = 4;
@@ -77199,7 +77199,7 @@
 /turf/simulated/floor/sanitary,
 /area/shuttle/centcom_elevator/lower)
 "wDz" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
@@ -77207,16 +77207,16 @@
 /turf/unsimulated/floor/plating,
 /area/meat_derelict/entry)
 "wDM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/map/light/graveyard,
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	dir = 4;
@@ -77575,7 +77575,7 @@
 	dir = 4;
 	name = "Surface Airlock"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor0"
@@ -77925,7 +77925,7 @@
 /turf/unsimulated/wall/auto/lead/blue,
 /area/upper_arctic/pod1)
 "xkk" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  What's the point of it then?  WHAT IS THE POINT";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	name = "rusted hatch"
@@ -78581,7 +78581,7 @@
 /turf/unsimulated/floor/white,
 /area/centcom/garden)
 "xDP" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/obj/doors/SL_doors.dmi';
@@ -78589,7 +78589,7 @@
 	name = "rusted airlock";
 	opacity = 1
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "fdoor1";
@@ -79099,7 +79099,7 @@
 /turf/space,
 /area/watchful_eye_sensor)
 "xYe" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	dir = 4;

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -5284,7 +5284,7 @@
 /obj/decal/floatingtiles{
 	icon_state = "floattiles2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -6779,7 +6779,7 @@
 /turf/simulated/floor/orangeblack,
 /area/h7/storage)
 "aJG" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1
 	},
 /obj/cable{
@@ -6792,7 +6792,7 @@
 /turf/simulated/floor,
 /area/h7/control)
 "aJH" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1
 	},
 /obj/cable{
@@ -7537,7 +7537,7 @@
 /turf/space,
 /area/space)
 "aMe" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -7619,7 +7619,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/overlay{
@@ -9028,7 +9028,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/machinery/door/airlock/pyro{
 	name = "Storage"
 	},
@@ -9433,7 +9433,7 @@
 /turf/simulated/floor/airless/plating/damaged2,
 /area/abandonedship)
 "aSh" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	desc = "This airlock seems to be badly damaged.";
 	icon = 'icons/obj/doors/Doorext.dmi';
@@ -9842,7 +9842,7 @@
 	},
 /area/h7)
 "aTp" = (
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -10341,7 +10341,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/overlay{
@@ -10354,7 +10354,7 @@
 /turf/simulated/floor,
 /area/h7)
 "aUM" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 8
 	},
 /obj/cable{
@@ -10411,7 +10411,7 @@
 	},
 /area/fermid_hive)
 "aUU" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/cable{
@@ -10858,7 +10858,7 @@
 /turf/simulated/floor/plating,
 /area/h7)
 "aWj" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -10949,7 +10949,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -11835,7 +11835,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/security{
@@ -12234,7 +12234,7 @@
 	},
 /area/h7/lab)
 "baY" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 4
 	},
 /obj/cable{
@@ -12707,7 +12707,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1
 	},
 /obj/machinery/door/airlock/pyro/medical{
@@ -12750,7 +12750,7 @@
 /turf/simulated/floor/airless/plating/damaged3,
 /area/abandonedship)
 "bcQ" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	dir = 1
 	},
 /obj/cable{
@@ -12933,7 +12933,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/fakeobject/firelock_broken,
+/obj/fakeobject/airlock_broken/firelock,
 /turf/simulated/floor/plating,
 /area/h7/lab)
 "bdz" = (
@@ -13370,7 +13370,7 @@
 	},
 /area/hollowasteroid)
 "bfP" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	density = 1;
 	icon = 'icons/obj/doors/Doorclassic.dmi';
 	icon_state = "door_closed";
@@ -14139,7 +14139,7 @@
 /turf/simulated/floor/yellow/side,
 /area/derelict_ai_sat/core)
 "biz" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -15635,7 +15635,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/diner/motel)
 "bGL" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	name = "rusted hatch"
@@ -18247,7 +18247,7 @@
 	},
 /area/diner/jucer_trader)
 "jcK" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	name = "rusted hatch"
@@ -19860,7 +19860,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/abandonedship)
 "nuL" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "Rust has rendered this airlock useless.";
 	icon = 'icons/misc/hstation.dmi';
 	icon_state = "bloodydoor";
@@ -20654,7 +20654,7 @@
 	},
 /area/space)
 "pIn" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	name = "rusted hatch"
@@ -20671,7 +20671,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/diner/motel)
 "pKb" = (
-/obj/fakeobject/firelock_broken{
+/obj/fakeobject/airlock_broken/firelock{
 	desc = "This shuttle door is really jammed.  It might as well not even be a door.  What a lousy door.  Fuck this door, man, just... just...  FUCK YOU, DOOR.";
 	icon = 'icons/obj/doors/shuttle.dmi';
 	name = "rusted hatch"

--- a/tools/UpdatePaths/Scripts/fake_doors_unification.txt
+++ b/tools/UpdatePaths/Scripts/fake_doors_unification.txt
@@ -1,2 +1,3 @@
 /obj/fakeobject/sealed_door : /obj/fakeobject/airlock_broken/sealed
 /obj/fakeobject/sealed_door/owlery : /obj/fakeobject/airlock_broken/sealed/owlery
+/obj/fakeobject/airlock_broken/firelock : /obj/fakeobject/airlock_broken/firelock

--- a/tools/UpdatePaths/Scripts/fake_doors_unification.txt
+++ b/tools/UpdatePaths/Scripts/fake_doors_unification.txt
@@ -1,0 +1,2 @@
+/obj/fakeobject/sealed_door : /obj/fakeobject/airlock_broken/sealed
+/obj/fakeobject/sealed_door/owlery : /obj/fakeobject/airlock_broken/sealed/owlery


### PR DESCRIPTION
[CODE QUALITY] [MAPPING] [SECRET]
## About the PR
The sequel to the palindrome pr #19491.

The way fake airlocks is implemented is that... there isn't a unified way of doing it. Some var edit a regular decal, some var edit `obj/fakeobject/airlock_broken`, and worse, some var edit `obj/fakeobject/firelock_broken`. Those aren't even airlocks. There's also `obj/fakeobject/sealed_door`, `obj/fakeobject/sealed_door/owlery`, and a whole host of other implementations.

This PR aims to repath as many of these as possible to be `obj/fakeobject/airlock_broken`, or a subtype. It also introduces variants for custom use in different airlock styles, for mapping convenience. There is also an updatepaths script provided as well.

## Why's this needed?
Code quality, and convenience for future mappers in creating false airlocks.
