### PR TITLE
Adds Tanning Sunglasses to the Kondaru and Nadir Pools.

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -9592,6 +9592,7 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/stool/chair/pool,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aLf" = (
@@ -44323,6 +44324,7 @@
 "mvx" = (
 /obj/landmark/start/job/assistant,
 /obj/stool/chair/pool,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "mwi" = (
@@ -59517,6 +59519,7 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/stool/chair/pool,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "xCW" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -22785,6 +22785,7 @@
 /obj/landmark/start/job/assistant,
 /obj/item/device/radio/intercom,
 /obj/stool/chair/pool,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},
@@ -33999,6 +34000,7 @@
 "omm" = (
 /obj/landmark/start/job/assistant,
 /obj/stool/chair/pool,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[mapping][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds Tanning Sunglasses to the Pools on both Kondaru and Nadir.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Those were the only two maps currently in rotation that lacked Tanning Sunglasses at the Pools.
Tiny change, but good for Map Parity and extra fashion choice for those that like to wear sunglasses and dont want to search the station for a hidden pair.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wrench
(+)Adds Tanning Sunglasses to the Kondaru and Nadir Pools.
```
