### PR TITLE
Stowaway trait cleanup

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1229,7 +1229,9 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	limit = 2
 	wages = 0
 	trait_list = list("stowaway")
+	add_to_manifest = FALSE
 	low_priority_job = TRUE
+	slot_card = null
 	slot_head = list(\
 	/obj/item/clothing/head/green = 1,
 	/obj/item/clothing/head/red = 1,

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2837,34 +2837,33 @@
 				continue
 			else
 				if (force_instead || tgui_alert(src, "Use the name [newname]?", newname, list("Yes", "No")) == "Yes")
-					if(!src.traitHolder.hasTrait("stowaway"))// stowaway entertainers shouldn't be on the manifest
-						for (var/datum/record_database/DB in list(data_core.bank, data_core.security, data_core.general, data_core.medical))
-							var/datum/db_record/R = DB.find_record("id", src.datacore_id)
-							if (R)
-								R["name"] = newname
-								if (R["full_name"])
-									R["full_name"] = newname
-						for (var/obj/item/I in src.contents)
-							var/obj/item/card/id/ID = get_id_card(I)
-							if (!ID)
-								if(length(I.contents)>0)
-									for(var/obj/item/J in I.contents)
-										var/obj/item/card/id/ID_maybe = get_id_card(J)
-										if(!ID_maybe)
-											continue
-										if(ID_maybe && ID_maybe.registered == src.real_name)
-											ID = ID_maybe
-							if(ID)
-								ID.registered = newname
-								ID.update_name()
-						for (var/obj/item/device/pda2/PDA in src.contents)
-							PDA.registered = newname
-							PDA.owner = newname
-							PDA.name = "PDA-[newname]"
-							if(PDA.ID_card)
-								var/obj/item/card/id/ID = PDA.ID_card
-								ID.registered = newname
-								ID.update_name()
+					for (var/datum/record_database/DB in list(data_core.bank, data_core.security, data_core.general, data_core.medical))
+						var/datum/db_record/R = DB.find_record("id", src.datacore_id)
+						if (R)
+							R["name"] = newname
+							if (R["full_name"])
+								R["full_name"] = newname
+					for (var/obj/item/I in src.contents)
+						var/obj/item/card/id/ID = get_id_card(I)
+						if (!ID)
+							if(length(I.contents)>0)
+								for(var/obj/item/J in I.contents)
+									var/obj/item/card/id/ID_maybe = get_id_card(J)
+									if(!ID_maybe)
+										continue
+									if(ID_maybe && ID_maybe.registered == src.real_name)
+										ID = ID_maybe
+						if(ID)
+							ID.registered = newname
+							ID.update_name()
+					for (var/obj/item/device/pda2/PDA in src.contents)
+						PDA.registered = newname
+						PDA.owner = newname
+						PDA.name = "PDA-[newname]"
+						if(PDA.ID_card)
+							var/obj/item/card/id/ID = PDA.ID_card
+							ID.registered = newname
+							ID.update_name()
 					src.real_name = newname
 					src.UpdateName()
 					return 1

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -337,8 +337,16 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 				if (!isnull(location))
 					character.set_loc(location)
 			else if (istype(JOB, /datum/job/special/stowaway))
-				boutput(character.mind.current,"<h3 class='notice'>You've arrived in a nondescript container! Good luck!</h3>")
-				//So the location setting is handled in EquipRank in jobprocs.dm. I assume cause that is run all the time as opposed to this.
+				var/list/obj/storage/SL = get_random_station_storage_list(closed=TRUE, breathable=TRUE)
+				if(length(SL) > 0)
+					boutput(character.mind.current,"<h3 class='notice'>You've arrived in a nondescript container! Good luck!</h3>")
+					character.set_loc(pick(SL))
+					logTheThing(LOG_STATION, src, "has the Stowaway job and spawns in storage at [log_loc(src)]")
+				else
+					var/starting_loc = null
+					starting_loc = pick_landmark(LANDMARK_LATEJOIN, locate(round(world.maxx / 2), round(world.maxy / 2), 1))
+					character.set_loc(starting_loc)
+					logTheThing(LOG_STATION, src, "has the Stowaway job but there were no valid containers to stow into!")
 			else if (character.traitHolder && character.traitHolder.hasTrait("pilot"))
 				if (istype(character.loc, /obj/machinery/vehicle))
 					boutput(character.mind.current,"<h3 class='notice'>You've become lost on your way to the station! Good luck!</h3>")

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -329,7 +329,7 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		src = possible_new_mob // let's hope this breaks nothing
 
 
-	if (!skip_manifest && ishuman(src) && JOB.add_to_manifest && !src.traitHolder.hasTrait("stowaway"))
+	if (!skip_manifest && ishuman(src) && JOB.add_to_manifest)
 		// Manifest stuff
 		var/sec_note = ""
 		var/med_note = ""
@@ -343,16 +343,7 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 
 	if (ishuman(src))
 		var/mob/living/carbon/human/H = src
-		if (src.traitHolder && !src.traitHolder.hasTrait("stowaway"))
-			H.spawnId(JOB)
-		if (src.traitHolder && src.traitHolder.hasTrait("stowaway"))
-			//Has the stowaway trait - they're hiding in a random locker
-			var/list/obj/storage/SL = get_random_station_storage_list(closed=TRUE, breathable=TRUE)
-
-			if(length(SL) > 0)
-				src.set_loc(pick(SL))
-				logTheThing(LOG_STATION, src, "has the Stowaway trait and spawns in storage at [log_loc(src)]")
-
+		H.spawnId(JOB)
 		if (src.traitHolder && src.traitHolder.hasTrait("pilot"))		//Has the Pilot trait - they're drifting off-station in a pod. Note that environmental checks are not needed here.
 			SPAWN(0) //pod creation sleeps for... reasons
 				#define MAX_ALLOWED_ITERATIONS 300
@@ -576,7 +567,7 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 				B.badge_owner_name = src.real_name
 				B.badge_owner_job = src.job
 
-	if (src.traitHolder && src.traitHolder.hasTrait("pilot"))
+	if (src.traitHolder?.hasTrait("pilot"))
 		var/obj/item/tank/mini_oxygen/E = new /obj/item/tank/mini_oxygen(src.loc)
 		src.force_equip(E, SLOT_IN_BACKPACK, TRUE)
 		#ifdef UNDERWATER_MAP
@@ -593,8 +584,6 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		src.equip_new_if_possible(/obj/item/clothing/mask/breath, SLOT_WEAR_MASK)
 		var/obj/item/device/gps/GPSDEVICE = new /obj/item/device/gps(src.loc)
 		src.force_equip(GPSDEVICE, SLOT_IN_BACKPACK, TRUE)
-
-	if (src.traitHolder?.hasTrait("stowaway") || src.traitHolder?.hasTrait("pilot"))
 		var/obj/item/device/pda2/pda = locate() in src
 		src.u_equip(pda)
 		qdel(pda)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Remove unneeded stowaway trait check for choosing a name
* Move spawning for stowaway job into latejoin code area & add fallback
* Use existing ID/manifest vars on job instead of checking for stowaway trait and removing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
stowaway isnt a trait anymore; use job stuff because its a job now.

i can't completely remove the trait because of the jailbird interaction (which itself breaks the 'rules' of arrest status vOv)