### PR TITLE
Lets Wraiths point at things

### DIFF
--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -408,7 +408,7 @@
 	click(atom/target, params)
 		if (src.targeting_ability)
 			return ..()
-		if (src.client && src.client.check_key(KEY_POINT))
+		if (src.client?.check_key(KEY_POINT))
 			src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
 
 		else if (!density)

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -477,7 +477,7 @@
 
 			. = src.say_dead(message, 1)
 
-	emote(var/act, var/voluntary = 0)
+	emote(var/act)
 		if (!density)
 			return
 		..()
@@ -495,10 +495,6 @@
 				acts = "grustles"
 			if ("rattle")
 				acts = "rattles"
-			if ("flip")
-				if (src.emote_check(voluntary, 50))
-					acts = "<b>[src]</B> does a flip!"
-					animate_spin(src, pick("L", "R"), 1, 0)
 
 		if (acts)
 			for (var/mob/M in hearers(src, null))


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets wraiths point at things, the point is invisible to normal people while the wraith is invisible, and visible when the wraith is visible(corporeal).
Also lets wraith turn their mob in different directions by clicking like all other directional mobs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lets wraiths point at things, I'm fairly sure this was always an oversight, especially since we added ghost pointing.
