### PR TITLE
Fix Oshan Hos/Armory door AI access

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -42968,7 +42968,8 @@
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	req_access = null;
-	id = "quarters_hos"
+	id = "quarters_hos";
+	aiControlDisabled = 1
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the door between HoS/Armory on oshan require hacking by the AI


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accidental change when the door was changed from sec to command probably, also consistency


