### PR TITLE
Add missing flavor text to The Cluwne poster

### DIFF
--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -801,6 +801,7 @@
 					if("contest-other12")
 						src.name = "The Cluwne"
 						src.icon_state = "the_cluwne"
+						src.desc = "\"This summer...things are getting...honked.\""
 					if("contest-other13")
 						src.name = "Cluwne XVII"
 						src.icon_state = "cluwnexvii"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives The Cluwne poster flavor text I forgot to add in #19883. As I said there, some posters entries from the June 2024 contest came with taglines, which I added as flavor text. The Cluwne one had a tagline, but I forgot to add it in. This PR rectifies that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It fixes an oversight made in #19883

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
