### PR TITLE
Fix Clarion and Kondaru non-perspective post doors

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13136,9 +13136,9 @@
 	},
 /area/listeningpost)
 "bLL" = (
-/obj/machinery/door/airlock/syndicate{
-	desc = "This looks like a perfectly innocent weather satellite. It's locked up pretty tight to keep bath salts junkies from breaking in to steal the equipment.";
-	name = "Weather Satellite"
+/obj/machinery/door/airlock/pyro/reinforced/syndicate{
+	dir = 4;
+	name = "Listening Post"
 	},
 /turf/unsimulated/floor/shuttle/red{
 	dir = 4
@@ -20180,8 +20180,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass,
 /obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/listeningpost)
 "gYz" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -28947,7 +28947,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/listeningpost)
 "cmq" = (
@@ -29153,8 +29155,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/listeningpost)
 "cmZ" = (
-/obj/machinery/door/airlock/syndicate{
-	desc = "Seems to be a pretty sturdy door.";
+/obj/machinery/door/airlock/pyro/reinforced/syndicate{
+	dir = 4;
 	name = "Listening Post"
 	},
 /turf/unsimulated/floor/shuttle/red{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clarion and kondaru had a couple non-perspective interior doors, makes them the perspective ones


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They shouldn't be flat silly syndies