### PR TITLE
Add landing pad to Kondaru listening post

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -37919,6 +37919,14 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"hMe" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/space)
 "hMD" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -39796,6 +39804,10 @@
 /obj/storage/closet/law,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
+"jhj" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/airless/engine,
+/area/space)
 "jhE" = (
 /obj/machinery/chem_master,
 /obj/item/storage/wall{
@@ -55756,6 +55768,9 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
+"uSs" = (
+/turf/simulated/floor/airless/engine,
+/area/space)
 "uSI" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/access/chemistry,
@@ -57217,6 +57232,14 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/south)
+"vWU" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space,
+/area/space)
 "vXe" = (
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -139301,11 +139324,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hMe
+aaS
+aaS
+aaS
+vWU
 aaa
 aaa
 aaa
@@ -139603,11 +139626,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+uSs
+uSs
+uSs
+aaS
 aaa
 aaa
 aab
@@ -139905,11 +139928,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+uSs
+jhj
+uSs
+aaS
 aaa
 aaa
 aaa
@@ -140207,11 +140230,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+uSs
+uSs
+uSs
+aaS
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a landing pad to the kondaru listening post
![image](https://github.com/user-attachments/assets/e374b8e7-0695-4613-83be-96de49300b2f)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Space hurts and the other listening posts have them


