### PR TITLE
Adds Forensics Carts with items to Clarion and Donut2's Detective Offices

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2563,6 +2563,21 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/audio_log,
+/obj/item/device/detective_scanner,
+/obj/item/body_bag,
+/obj/item/body_bag,
+/obj/item/body_bag,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "avv" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -24728,6 +24728,22 @@
 /obj/item/device/radio/intercom/detnet/security{
 	dir = 8
 	},
+/obj/storage/cart/forensic,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/audio_log,
+/obj/item/device/detective_scanner,
+/obj/item/body_bag,
+/obj/item/body_bag,
+/obj/item/body_bag,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "hjn" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a Forensics Cart with items to both Clarion & Donut2's Detective Offices. The carts contain the same items that are in the Forensics Carts on most other maps that are currently in rotation.

Made in response to the following Bug Report: https://github.com/goonstation/goonstation/issues/19875#issue-2393795966


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More map parity = Good! Detectives should be able to get whatever they need from said carts no matter what map they're on, and shouldn't have to go scouring the map for Bodybags, Evidence Boxes, etc.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wrench
(+)Adds Forensics Carts with items to both Clarion & Donut2's Detective Offices.
```
