### PR TITLE
Adds HoP's Bill, RD's Diploma and MD's Medical License to all maps currently in rotation

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -907,6 +907,7 @@
 /obj/item/device/analyzer/healthanalyzer/upgraded,
 /obj/item/remote/porter/port_a_nanomed,
 /obj/item/stamp/md,
+/obj/item/mdlicense,
 /turf/simulated/floor/white,
 /area/station/bridge/united_command)
 "adp" = (
@@ -5219,6 +5220,7 @@
 /obj/machinery/light{
 	layer = 3
 	},
+/obj/item/rddiploma,
 /turf/simulated/floor/purple,
 /area/station/bridge/united_command)
 "auY" = (
@@ -18286,6 +18288,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
+"pdS" = (
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = 27
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/heads)
 "peD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -81105,7 +81113,7 @@ aug
 auK
 avi
 aBK
-aYD
+pdS
 aYD
 ylz
 aCU

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27048,6 +27048,10 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = -3;
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fblue2"
@@ -28611,6 +28615,10 @@
 	switchon = 1
 	},
 /obj/machinery/firealarm/north,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = -3;
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
@@ -33005,6 +33013,10 @@
 	pixel_y = 21
 	},
 /obj/storage/closet/office,
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = -3;
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -15341,6 +15341,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/ATM,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = 27
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "aZU" = (
@@ -24615,6 +24618,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = 27
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bLr" = (
@@ -31722,6 +31728,9 @@
 	},
 /obj/item/matchbook,
 /obj/item/cigpacket/propuffs,
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = 27
+	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "cjy" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -23731,6 +23731,10 @@
 	broadcasting = 0
 	},
 /obj/storage/secure/closet/command/hop,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_x = 32;
+	pixel_y = -3
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bsY" = (
@@ -38846,6 +38850,9 @@
 "cjt" = (
 /obj/storage/secure/closet/command/research_director,
 /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake,
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = 27
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "cju" = (
@@ -48740,6 +48747,10 @@
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
 	pixel_x = -4
+	},
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = -3;
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/station/medical/head)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -848,6 +848,10 @@
 	desc = "Part of a matching set.";
 	name = "MD's Morty plush"
 	},
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = -3;
+	pixel_x = -32
+	},
 /turf/simulated/floor/purple/side{
 	dir = 9
 	},
@@ -30605,6 +30609,10 @@
 "lcp" = (
 /obj/machinery/light/incandescent,
 /mob/living/critter/small_animal/dog/george/orwell,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = -3;
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fgreen2"
@@ -37331,10 +37339,6 @@
 	},
 /area/station/crew_quarters/kitchen/freezer)
 "oXb" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -43324,6 +43328,10 @@
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "sMH" = (
+/obj/machinery/light_switch{
+	name = "E light switch";
+	pixel_x = 24
+	},
 /turf/simulated/floor/blueblack{
 	dir = 5
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -17147,6 +17147,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/disposalpipe/segment/morgue,
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = 27
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"
@@ -24028,6 +24031,9 @@
 /area/station/hallway/primary/east)
 "hge" = (
 /obj/storage/secure/closet/command/hop,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = 27
+	},
 /turf/simulated/floor/carpet/green/fancy/narrow/west,
 /area/station/crew_quarters/heads)
 "hgB" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -9305,6 +9305,7 @@
 /obj/machinery/door_control/bolter/new_walls/south{
 	id = "quarters_mdir"
 	},
+/obj/item/mdlicense,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/md)
 "aJI" = (
@@ -20750,6 +20751,10 @@
 	dir = 0;
 	name = "autoname - SS13";
 	pixel_y = 20
+	},
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = 27;
+	pixel_x = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/bridge/hos)
@@ -43986,6 +43991,10 @@
 	},
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = -3;
+	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/science/research_director)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -17610,6 +17610,10 @@
 "hAs" = (
 /obj/storage/closet/biohazard,
 /obj/item/reagent_containers/emergency_injector/spaceacillin,
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = -3;
+	pixel_x = 32
+	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
 "hAU" = (
@@ -21350,6 +21354,10 @@
 /obj/storage/secure/closet/command/medical_director,
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = -3;
+	pixel_x = 32
 	},
 /turf/simulated/floor/blueblack{
 	dir = 4

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -4750,6 +4750,9 @@
 	icon_state = "skeleton_stand";
 	name = "Jim"
 	},
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = 27
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"
@@ -5972,6 +5975,10 @@
 /obj/stool/bee_bed/heisenbee,
 /obj/critter/domestic_bee/heisenbee,
 /obj/machinery/light/incandescent/warm,
+/obj/decal/poster/wallsign/framed_award/rddiploma{
+	pixel_y = -3;
+	pixel_x = -32
+	},
 /turf/simulated/floor/wood,
 /area/station/science/research_director)
 "aua" = (
@@ -20561,6 +20568,9 @@
 /obj/item/device/gps,
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
+	},
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_y = 26
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the HoP's Bill, RD's Diploma and MD's Medical License to every map that is currently in rotation. All framed awards are located in their respective offices with the exception of Atlas, where the RD's Diploma and MD's License are inside the locker unframed, and Kondaru, where the MD's License is also inside their locker. This was done due to lack of proper space, but can be changed if there's feedback.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The framed awards can be rolled as Spief Bounties and Salvager Bounties regardless of map. In the past, this lead to cases where these items were attempted to be located but were unable to be found simply because they did not exist on specific maps. Adding these will allow for these items to be obtainable on ALL currently in rotation maps, and gameplay wise give more reasons for Antags to break into different head of staff offices for bounties or RP Gimmicks.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wrench
(+)Adds the HoP's First Bill, the RD's Diploma and the MD's Medical License to all maps currently in rotation.
```
