### PR TITLE
Switch up some Nadir nukie plant sites

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -859,10 +859,10 @@ var/global/list/mapNames = list(
 		"the courtroom" = list(/area/station/crew_quarters/courtroom),
 		"the engineering staff room" = list(/area/station/engine/engineering),
 		"the medical bay's central room" = list(/area/station/medical/medbay),
-		"the east crew quarters" = list(/area/station/crew_quarters/quarters_east),
-		"the nerd dungeon" = list(/area/station/crew_quarters/arcade/dungeon),
+		"the extraction nexus" = list(/area/station/science/construction),
+		"the cafeteria" = list(/area/station/crew_quarters/cafeteria, /area/station/crew_quarters/bar),
 		"the chapel" = list(/area/station/chapel/sanctuary),
-		"the radio lab" = list(/area/station/crew_quarters/radio/lab),
+		"the hydroponics bay" = list(/area/station/hydroponics),
 		"the derelict southeast 'Warrens'" = list(/area/station/hallway/secondary/construction))
 
 	job_limits_from_landmarks = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sites removed:
- nerd dungeon
- east crew quarters
- radio lab

Sites added:
- hydroponics
- cafeteria
- extraction nexus (the siphon room)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nukies already have a natural advantage on Nadir due to being immune to acid and some of the current plant sites are very enclosed and easy to fortify. These should be a little less cramped and hopefully lead to some better fights.
The extraction nexus is a pretty bad plant site buut we give them two anyway and they can always teleport to it via the diner if they fancy a challenge.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Removed Nadir nuke plant sites: nerd dungeon, east crew quarters, radio lab.
(+)Added Nadir nuke plant sites: hydroponics, cafeteria, extraction nexus.
```
