### PR TITLE
Fix more critter arms damaging borgs.

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -1142,6 +1142,7 @@
 // A replacement for the awful custom_attack() overrides in mutantraces.dm, which consisted of two
 // entire copies of pre-stamina melee attack code (Convair880).
 /datum/limb/abomination
+	can_beat_up_robots = TRUE
 	var/weak = 0
 
 	werewolf

--- a/code/modules/antagonists/wraith/critters/skeleton_commander.dm
+++ b/code/modules/antagonists/wraith/critters/skeleton_commander.dm
@@ -70,6 +70,7 @@
 		HH.can_range_attack = 1
 
 /datum/limb/halberd
+	can_beat_up_robots = TRUE
 	attack_range(atom/target, var/mob/user, params)
 		switch (user.a_intent)
 			if (INTENT_HELP)


### PR DESCRIPTION
[balance][critters]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes skeleton halberds and abomination arms doing damage against borgs, which was previously fixed here https://github.com/goonstation/goonstation/commit/e7ee4dc04e33204e6bfa155b08a3ac0424f9cc85 but was broken by whatever broke a bunch of other critter limb code.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It doesn't make a lot of sense for skeletons to take damage when swinging halberds against borgs, even if their halberd is technically coded as a limb. Also a bit weird how the combat oriented wrath has no answer against borgs, while a plaguerat can at least use slam. Fixes https://github.com/goonstation/goonstation/issues/20007 and https://github.com/goonstation/goonstation/issues/19755.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)KakoLookiyam
(+)Skeleton halberds are once again effective against borgs.
```
