### PR TITLE
Provide user feedback when attempting to cut leg holes in port-a-sci

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -305,7 +305,10 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 							return
 						src._health = src._max_health
 						src.visible_message(SPAN_ALERT("[user] repairs [src] with [I]."))
-					else if (!src.is_short && !src.legholes && src.can_leghole)
+					else if (!src.is_short && !src.legholes)
+						if (!src.can_leghole)
+							boutput(user, SPAN_ALERT("You can't cut holes in that!"))
+							return
 						if (!weldingtool.try_weld(user, 1))
 							return
 						src.legholes = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Separate out the can_legholes check and boutput to user telling them they can't cut it instead of silently denying them cheese. Generic message as this could var is used elsewhere.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20012