### PR TITLE
Auto-disable AI control of armory airlocks

### DIFF
--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -274,6 +274,11 @@
 	req_access = list(access_armory)
 	color = SECURITY
 
+	setup()
+		. = ..()
+		for (var/obj/machinery/door/airlock/secure_airlock in src.loc)
+			secure_airlock.aiControlDisabled = TRUE
+
 /obj/mapping_helper/access/engineering_chief
 	name = "CE access spawn"
 	req_access = list(access_engineering_chief)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -20682,7 +20682,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
 	name = "Armory"
 	},
 /obj/mapping_helper/access/armory,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -19732,9 +19732,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
 	name = "Armory";
-	req_access = null
+	
 	},
 /obj/machinery/secscanner{
 	pixel_y = -10

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -40971,7 +40971,6 @@
 /area/station/routing/medsci)
 "ffc" = (
 /obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
 	name = "Armory"
 	},
 /obj/mapping_helper/firedoor_spawn,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -66861,7 +66861,6 @@
 /area/station/com_dish/auxdish)
 "owh" = (
 /obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
 	dir = 4;
 	name = "Armory"
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -22720,9 +22720,7 @@
 /area/station/quartermaster/magnet)
 "fSk" = (
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/security/alt{
-	aiHacking = 1
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
 /obj/mapping_helper/access/armory,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -19859,9 +19859,8 @@
 /area/station/crew_quarters/courtroom)
 "fUg" = (
 /obj/machinery/door/airlock/pyro/glass/security{
-	aiControlDisabled = 1;
 	dir = 4;
-	req_access = null
+	
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
@@ -29159,9 +29158,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "iOl" = (
-/obj/machinery/door/airlock/pyro/security/alt{
-	aiControlDisabled = 1
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner,
 /obj/cable{
@@ -50893,10 +50890,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "psu" = (
-/obj/machinery/door/airlock/pyro/glass/security{
-	aiControlDisabled = 1;
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/glass/security,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner,
 /obj/decal/stripe_delivery,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -52694,9 +52694,8 @@
 /area/station/engine/core)
 "sNE" = (
 /obj/machinery/door/airlock/pyro/command{
-	aiControlDisabled = 1;
 	name = "Armory";
-	req_access = null
+	
 	},
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -38367,7 +38367,6 @@
 	})
 "qih" = (
 /obj/machinery/door/airlock/pyro/security/alt{
-	aiControlDisabled = 1;
 	dir = 4
 	},
 /obj/cable{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -34479,9 +34479,8 @@
 /area/station/security/checkpoint/medical)
 "fGB" = (
 /obj/machinery/door/airlock/pyro/security/alt{
-	aiControlDisabled = 1;
 	name = "Armory";
-	req_access_txt = "37"
+	
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner{

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -54484,11 +54484,10 @@
 /area/station/maintenance/northwest)
 "enP" = (
 /obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
 	name = "Armory";
-	req_access = null
+	
 	},
-/obj/mapping_helper/access/hos,
+/obj/mapping_helper/access/armory,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/secscanner{
 	pixel_y = 10
@@ -62084,12 +62083,11 @@
 /area/station/engine/coldloop)
 "rdk" = (
 /obj/machinery/door/airlock/pyro/security{
-	aiControlDisabled = 1;
 	name = "Armory";
-	req_access = null
+	
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/hos,
+/obj/mapping_helper/access/armory,
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The armory access spawner will automatically disable AI control of any airlocks found on the same tile. This removes the need for var-editing each door, and as such those var edits have been removed here.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map consistency with less var-editing
Fix  #19993