### PR TITLE
Fixes to "Breaker" airlock helpers

### DIFF
--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -82,5 +82,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 			F.icon = D.icon
 			F.icon_state = F.icon_state
 			// final touches
-			F.name = "Rusted " + D.name
+			F.name = D.name
+			F.desc = D.desc
+			F.density = D.density
 			qdel(D)


### PR DESCRIPTION
[INTERNAL] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Using a 'Breaker' type mapping helper on an airlock will now make it match:
- Name
- Description
- Density
- Icon (including `icon`, `icon_state` and Welding overlay)

If you want to make the fake airlock be called "Rusted airlock" then var editing the base airlock should transfer the name over. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Previously it would only match icon, icon_state, and it would prepend "Rusted " to the airlock name, which I'm realising now is not flexible enough for the wide variety of broken airlocks in the game. Now it will match description and density too, allowing fake doors to be rusted open instead of just shut, and more control over the maps.